### PR TITLE
Update annotations doc

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -16,6 +16,7 @@ The content of the annotation, in this case, `add-ratelimiting-to-route` indicat
 - the suffix must be `.plugin.konghq.com`
 - the end of the line must be `|` if we want to add multiple plugins.
 - each line should contain a valid `KongPlugin` in the Kubernetes cluster.
+- `KongPlugin` k8s resources must be unique to each service/ ingress that use any kong plugin
 
 Setting annotations in Ingress rules set ups plugins in `Kong Routes`. Sometimes, we could need to apply plugins in `Kong Services`. To achieve this, we can use the same annotations but applied to the Kubernetes service itself.
 

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -267,7 +267,7 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 			plugins := annotations.ExtractKongPluginAnnotations(location.Service.GetAnnotations())
 
 			if len(plugins) == 0 {
-				glog.Infof("service %v/%v does not contains any pluging. Checking if is required to remove plugins...",
+				glog.Infof("service %v/%v does not contain any plugins. Checking if it is required to remove plugins...",
 					location.Service.Namespace, location.Service.Name)
 				// remove all the plugins from the service.
 				plugins, err := client.Plugins().GetAllByService(svc.ID)
@@ -604,7 +604,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 			plugins := annotations.ExtractKongPluginAnnotations(location.Ingress.GetAnnotations())
 
 			if len(plugins) == 0 {
-				glog.Errorf("Route %v does not contains any pluging. Checking if is required to remove plugins...", route.ID)
+				glog.Errorf("Route %v does not contain any plugins. Checking if it is required to remove plugins...", route.ID)
 				plugins, err := client.Plugins().GetAllByRoute(route.ID)
 				if err != nil {
 					glog.Errorf("Unexpected error obtaining Kong plugins for route %v: %v", route.ID, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We had a stumbling block where plugins were not being added to routes if
we tried to reference the same `KongPlugin` k8s resource in more than
one service/ ingress annotation. Also fixed a few typos I noticed when debugging this problem.