### PR TITLE
Support Service's Cluster IP based upstream target

### DIFF
--- a/internal/apis/configuration/v1/types.go
+++ b/internal/apis/configuration/v1/types.go
@@ -40,11 +40,12 @@ type Route struct {
 }
 
 type Upstream struct {
-	HashOn       string        `json:"hash_on"`
-	HashOnHeader string        `json:"hash_on_header"`
-	HashFallback string        `json:"hash_fallback"`
-	Healthchecks *Healthchecks `json:"healthchecks,omitempty"`
-	Slots        int           `json:"slots"`
+	HashOn          string        `json:"hash_on"`
+	HashOnHeader    string        `json:"hash_on_header"`
+	HashFallback    string        `json:"hash_fallback"`
+	Healthchecks    *Healthchecks `json:"healthchecks,omitempty"`
+	Slots           int           `json:"slots"`
+	ServiceUpstream bool          `json:"service_upstream"`
 }
 
 type Proxy struct {


### PR DESCRIPTION
Option for use service's Cluster IP and port, instead of endpoints.

https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md#service-upstream
