### PR TITLE
fix(*) support enterprise versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: all-container
 BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG?=0.0.4
+TAG?=0.0.5
 REGISTRY?=kong-docker-kubernetes-ingress-controller.bintray.io
 GOOS?=linux
 DOCKER?=docker

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -144,7 +144,7 @@ func main() {
 		glog.Fatalf("%v", err)
 	}
 
-	if !(v.GTE(semver.MustParse("0.13.0") || v.GTE(semver.MustParse("0.32.0")) {
+	if !(v.GTE(semver.MustParse("0.13.0")) || v.GTE(semver.MustParse("0.32.0"))) {
 		glog.Fatalf("The version %s is not compatible with the Kong Ingress Controller. It requires Kong CE 0.13.0 or higher, or Kong EE 0.32 or higher.", v)
 	}
 

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -144,8 +144,8 @@ func main() {
 		glog.Fatalf("%v", err)
 	}
 
-	if !v.GTE(semver.MustParse("0.13.0")) {
-		glog.Fatalf("The version %s is not compatible with the Kong Ingress Controller. It requires Kong 0.13.0 or higher.", v)
+	if !(v.GTE(semver.MustParse("0.13.0") || v.GTE(semver.MustParse("0.32.0")) {
+		glog.Fatalf("The version %s is not compatible with the Kong Ingress Controller. It requires Kong CE 0.13.0 or higher, or Kong EE 0.32 or higher.", v)
 	}
 
 	glog.Infof("kong version: %s", v)

--- a/internal/apis/admin/kong_client.go
+++ b/internal/apis/admin/kong_client.go
@@ -138,8 +138,15 @@ func (c *RestClient) GetVersion() (semver.Version, error) {
 
 	if version, ok := info["version"]; ok {
 		v := version.(string)
+		
+		// fix enterprise edition semver adding patch number
+		re := regexp.MustCompile(`([\d\.]+)-enterprise-edition`)
+		if re.MatchString(v) {
+			v = re.ReplaceAllString(v, "$1.0-enterprise")
+		}
+
 		// fix bad version formats like 0.13.0preview1
-		re := regexp.MustCompile(`(.*\d)(preview.*|rc.*)`)
+		re = regexp.MustCompile(`(.*\d)(preview.*|rc.*)`)
 		if re.MatchString(v) {
 			v = re.ReplaceAllString(v, "$1-$2")
 		}

--- a/vendor/k8s.io/client-go/discovery/discovery_client.go
+++ b/vendor/k8s.io/client-go/discovery/discovery_client.go
@@ -335,7 +335,7 @@ func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
 func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	data, err := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do().Raw()
 	if err != nil {
-		if errors.IsForbidden(err) || errors.IsNotFound(err) {
+		if errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsNotAcceptable(err) {
 			// single endpoint not found/registered in old server, try to fetch old endpoint
 			// TODO(roycaihw): remove this in 1.11
 			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()

--- a/vendor/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/vendor/k8s.io/client-go/discovery/discovery_client_test.go
@@ -326,12 +326,12 @@ var returnedOpenAPI = openapi_v2.Document{
 	},
 }
 
-func openapiSchemaDeprecatedFakeServer() (*httptest.Server, error) {
+func openapiSchemaDeprecatedFakeServer(status int) (*httptest.Server, error) {
 	var sErr error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// old server returns 403 on new endpoint request
 		if req.URL.Path == "/openapi/v2" {
-			w.WriteHeader(http.StatusForbidden)
+			// write the error status for the new endpoint request
+			w.WriteHeader(status)
 			return
 		}
 		if req.URL.Path != "/swagger-2.0.0.pb-v1" {
@@ -398,8 +398,42 @@ func TestGetOpenAPISchema(t *testing.T) {
 	}
 }
 
-func TestGetOpenAPISchemaFallback(t *testing.T) {
-	server, err := openapiSchemaDeprecatedFakeServer()
+func TestGetOpenAPISchemaForbiddenFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusForbidden)
+	if err != nil {
+		t.Errorf("unexpected error starting fake server: %v", err)
+	}
+	defer server.Close()
+
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.OpenAPISchema()
+	if err != nil {
+		t.Fatalf("unexpected error getting openapi: %v", err)
+	}
+	if e, a := returnedOpenAPI, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetOpenAPISchemaNotFoundFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusNotFound)
+	if err != nil {
+		t.Errorf("unexpected error starting fake server: %v", err)
+	}
+	defer server.Close()
+
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.OpenAPISchema()
+	if err != nil {
+		t.Fatalf("unexpected error getting openapi: %v", err)
+	}
+	if e, a := returnedOpenAPI, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetOpenAPISchemaNotAcceptableFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusNotAcceptable)
 	if err != nil {
 		t.Errorf("unexpected error starting fake server: %v", err)
 	}

--- a/vendor/k8s.io/client-go/transport/cache.go
+++ b/vendor/k8s.io/client-go/transport/cache.go
@@ -44,6 +44,7 @@ type tlsCacheKey struct {
 	certData   string
 	keyData    string
 	serverName string
+	dial       string
 }
 
 func (t tlsCacheKey) String() string {
@@ -51,7 +52,7 @@ func (t tlsCacheKey) String() string {
 	if len(t.keyData) > 0 {
 		keyText = "<redacted>"
 	}
-	return fmt.Sprintf("insecure:%v, caData:%#v, certData:%#v, keyData:%s, serverName:%s", t.insecure, t.caData, t.certData, keyText, t.serverName)
+	return fmt.Sprintf("insecure:%v, caData:%#v, certData:%#v, keyData:%s, serverName:%s, dial:%s", t.insecure, t.caData, t.certData, keyText, t.serverName, t.dial)
 }
 
 func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
@@ -75,7 +76,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		return nil, err
 	}
 	// The options didn't require a custom TLS config
-	if tlsConfig == nil {
+	if tlsConfig == nil && config.Dial == nil {
 		return http.DefaultTransport, nil
 	}
 
@@ -109,5 +110,6 @@ func tlsConfigKey(c *Config) (tlsCacheKey, error) {
 		certData:   string(c.TLS.CertData),
 		keyData:    string(c.TLS.KeyData),
 		serverName: c.TLS.ServerName,
+		dial:       fmt.Sprintf("%p", c.Dial),
 	}, nil
 }

--- a/vendor/k8s.io/client-go/transport/transport.go
+++ b/vendor/k8s.io/client-go/transport/transport.go
@@ -52,7 +52,7 @@ func New(config *Config) (http.RoundTripper, error) {
 // TLSConfigFor returns a tls.Config that will provide the transport level security defined
 // by the provided Config. Will return nil if no transport level security is requested.
 func TLSConfigFor(c *Config) (*tls.Config, error) {
-	if !(c.HasCA() || c.HasCertAuth() || c.TLS.Insecure) {
+	if !(c.HasCA() || c.HasCertAuth() || c.TLS.Insecure || len(c.TLS.ServerName) > 0) {
 		return nil, nil
 	}
 	if c.HasCA() && c.TLS.Insecure {

--- a/vendor/k8s.io/client-go/transport/transport_test.go
+++ b/vendor/k8s.io/client-go/transport/transport_test.go
@@ -101,6 +101,13 @@ func TestNew(t *testing.T) {
 			Config:  &Config{},
 		},
 
+		"server name": {
+			TLS: true,
+			Config: &Config{TLS: TLSConfig{
+				ServerName: "foo",
+			}},
+		},
+
 		"ca transport": {
 			TLS: true,
 			Config: &Config{


### PR DESCRIPTION
This PR aims at adding support for EE versions of Kong which is currently broken. The version signature of EE versions of Kong is different than CE versions, and it's like: `0.32-enterprise-edition`.

This PR identifies an EE version of Kong, adds a patch number to the version (default `x.x.0`) and checks that the version of Kong is either greater than `0.13.0` or `0.32.0`.

To be sure this is working as intended, I would like to have another person test this patch.