### PR TITLE
fix: create multiple SNIs when same certificate is reused

### DIFF
--- a/internal/apis/admin/sni.go
+++ b/internal/apis/admin/sni.go
@@ -15,6 +15,7 @@ type SNIInterface interface {
 	List(url.Values) (*adminv1.SNIList, error)
 	Get(string) (*adminv1.SNI, *APIResponse)
 	Create(*adminv1.SNI) (*adminv1.SNI, *APIResponse)
+	Patch(string, *adminv1.SNI) (*adminv1.SNI, *APIResponse)
 	Delete(string) error
 }
 
@@ -25,6 +26,12 @@ type sniAPI struct {
 func (a *sniAPI) Create(target *adminv1.SNI) (*adminv1.SNI, *APIResponse) {
 	out := &adminv1.SNI{}
 	err := a.client.Create(target, out)
+	return out, err
+}
+
+func (a *sniAPI) Patch(id string, sni *adminv1.SNI) (*adminv1.SNI, *APIResponse) {
+	out := &adminv1.SNI{}
+	err := a.client.Patch(id, sni, out)
 	return out, err
 }
 


### PR DESCRIPTION
As seen in #75, if multiple Host reference the same certificate, only
one host is added as SNI in Kong. This was a bug due to early exit when
a GET request for a certificate succeded.
There were also edge-cases around change certificate for a Host or
updating SNI name. This commit covers those.

Fixes #75 