### PR TITLE
feat(KongIngress) allow upstream HTTPS

### DIFF
--- a/internal/apis/configuration/v1/types.go
+++ b/internal/apis/configuration/v1/types.go
@@ -49,6 +49,7 @@ type Upstream struct {
 }
 
 type Proxy struct {
+	Protocol       string `json:"protocol"`
 	Path           string `json:"path"`
 	ConnectTimeout int    `json:"connect_timeout"`
 	Retries        int    `json:"retries"`

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -232,12 +232,6 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 				proto := "http"
 				port := 80
 
-				// upstream servers require TLS
-				if upstream.Secure {
-					proto = "https"
-					port = 443
-				}
-
 				s, res := client.Services().Get(name)
 				if res.StatusCode == http.StatusNotFound {
 					s = &kongadminv1.Service{
@@ -254,6 +248,11 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 					if kongIngress != nil && kongIngress.Proxy != nil {
 						if kongIngress.Proxy.Path != "" {
 							s.Path = kongIngress.Proxy.Path
+						}
+
+						if kongIngress.Proxy.Protocol != "" &&
+							(kongIngress.Proxy.Protocol == "http" || kongIngress.Proxy.Protocol == "https") {
+							s.Protocol = kongIngress.Proxy.Protocol
 						}
 
 						if kongIngress.Proxy.ConnectTimeout > 0 {


### PR DESCRIPTION
This change allows specifying protocol (HTTP/HTTPS) to talk to upstream
via a KongIngress object.

Fixes #69