### PR TITLE
docs(yaml) update http-svc to use NodePort

### DIFF
--- a/deploy/manifests/dummy-application-openshift.yaml
+++ b/deploy/manifests/dummy-application-openshift.yaml
@@ -54,6 +54,7 @@ metadata:
   labels:
     app: http-svc
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8080

--- a/deploy/manifests/dummy-application.yaml
+++ b/deploy/manifests/dummy-application.yaml
@@ -45,6 +45,7 @@ metadata:
   labels:
     app: http-svc
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8080


### PR DESCRIPTION
Exposing ports helps in having an endpoint directly accessible in
minikube which eases on boarding for users using Kong Ingress Controller.