### PR TITLE
chore(docker) install ca-certificates package

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -17,7 +17,8 @@ FROM BASEIMAGE
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 RUN clean-install \
-  dumb-init
+  dumb-init \
+  ca-certificates
 
 COPY . /
 


### PR DESCRIPTION
The ingress controller verifies TLS certs before using them.
See #94 