### PR TITLE
fix(KongPlugin) compare CRD config and kongplugin config correctly

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -1184,7 +1184,7 @@ func pluginDeepEqual(config map[string]interface{}, kong *kongadminv1.Plugin) bo
 			return false
 		}
 
-		if fmt.Sprintf("%v", v) != fmt.Sprintf("%v", kv) {
+		if !reflect.DeepEqual(v, kv) {
 			return false
 		}
 	}

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -27,7 +27,7 @@ func TestPluginDeepEqual(t *testing.T) {
 
 	equal = pluginDeepEqual(map[string]interface{}{}, &kongadminv1.Plugin{Config: map[string]interface{}{}})
 	if !equal {
-		t.Errorf("Comparing empty maps failed on pluginDeepEqual")
+		t.Errorf("Comparing empty maps failed")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -40,7 +40,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key3": "value3",
 	}})
 	if !equal {
-		t.Errorf("Comparing maps with same keys and same order failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with same keys and same order failed")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -53,7 +53,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key1": "vaule1",
 	}})
 	if !equal {
-		t.Errorf("Comparing maps with same keys and different order failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with same keys and different order failed")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -70,7 +70,67 @@ func TestPluginDeepEqual(t *testing.T) {
 		},
 	}})
 	if !equal {
-		t.Errorf("Comparing maps with nested map failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with nested map failed")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": map[string]string{},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": map[string]string{},
+	}})
+	if !equal {
+		t.Errorf("Comparing maps with empty map failed")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": [3]string{
+			"arr1", "arr2", "arr3",
+		},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": [3]string{
+			"arr1", "arr2", "arr3",
+		},
+	}})
+	if !equal {
+		t.Errorf("Comparing maps with nested array failed")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": [3]string{
+			"arr1", "arr2", "arr3",
+		},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": [3]string{
+			"arr2", "arr3", "arr1",
+		},
+	}})
+	if equal {
+		t.Errorf("Comparing maps with nested array with different order failed")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": []string{},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": []string{},
+	}})
+	if !equal {
+		t.Errorf("Comparing maps with empty array failed")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -86,7 +146,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		},
 	}})
 	if equal {
-		t.Errorf("Comparing maps with missing keys failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with missing keys failed")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -103,6 +163,6 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key4": "value4",
 	}})
 	if equal {
-		t.Errorf("Comparing maps with unmatched keys failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with unmatched keys failed")
 	}
 }

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 Kong Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	kongadminv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/admin/v1"
+)
+
+func TestPluginDeepEqual(t *testing.T) {
+	var equal bool
+	equal = pluginDeepEqual(map[string]interface{}{}, &kongadminv1.Plugin{Config: map[string]interface{}{}})
+	if !equal {
+		t.Errorf("Comparation empty maps  failed on pluginDeepEqual")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": "vaule1",
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key1": "vaule1",
+		"key2": "value2",
+		"key3": "value3",
+	}})
+	if !equal {
+		t.Errorf("Comparation maps with same keys and same order failed on pluginDeepEqual")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": "vaule1",
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": "vaule1",
+	}})
+	if !equal {
+		t.Errorf("Comparation maps with same keys and different order failed on pluginDeepEqual")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key3": "value3",
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+	}})
+	if !equal {
+		t.Errorf("Comparation maps with nested map failed on pluginDeepEqual")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key2": "value2",
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+	}})
+	if equal {
+		t.Errorf("Comparation maps with missing keys failed on pluginDeepEqual")
+	}
+
+	equal = pluginDeepEqual(map[string]interface{}{
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+		"key2": "value2",
+		"key3": "value3",
+	}, &kongadminv1.Plugin{Config: map[string]interface{}{
+		"key3": "value3",
+		"key1": map[string]string{
+			"nestedkey1": "nestedvalue1",
+		},
+		"key4": "value4",
+	}})
+	if equal {
+		t.Errorf("Comparation maps with unmatched keys failed on pluginDeepEqual")
+	}
+}

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestPluginDeepEqual(t *testing.T) {
 	var equal bool
+
 	equal = pluginDeepEqual(map[string]interface{}{}, &kongadminv1.Plugin{Config: map[string]interface{}{}})
 	if !equal {
-		t.Errorf("Comparation empty maps  failed on pluginDeepEqual")
+		t.Errorf("Comparing empty maps failed on pluginDeepEqual")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -39,7 +40,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key3": "value3",
 	}})
 	if !equal {
-		t.Errorf("Comparation maps with same keys and same order failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with same keys and same order failed on pluginDeepEqual")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -52,7 +53,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key1": "vaule1",
 	}})
 	if !equal {
-		t.Errorf("Comparation maps with same keys and different order failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with same keys and different order failed on pluginDeepEqual")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -69,7 +70,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		},
 	}})
 	if !equal {
-		t.Errorf("Comparation maps with nested map failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with nested map failed on pluginDeepEqual")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -85,7 +86,7 @@ func TestPluginDeepEqual(t *testing.T) {
 		},
 	}})
 	if equal {
-		t.Errorf("Comparation maps with missing keys failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with missing keys failed on pluginDeepEqual")
 	}
 
 	equal = pluginDeepEqual(map[string]interface{}{
@@ -102,6 +103,6 @@ func TestPluginDeepEqual(t *testing.T) {
 		"key4": "value4",
 	}})
 	if equal {
-		t.Errorf("Comparation maps with unmatched keys failed on pluginDeepEqual")
+		t.Errorf("Comparing maps with unmatched keys failed on pluginDeepEqual")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Use `reflect.DeepEqual` to correctly compare CRD config and existing KongPlugin config

**Which issue this PR fixes** : fixes #102
