### PR TITLE
fix(KongService) only send PATCH request for services when necessary

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -262,8 +262,10 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 							outOfSync = true
 						}
 
-						if kongIngress.Proxy.ConnectTimeout > 0 {
+						if kongIngress.Proxy.ConnectTimeout > 0 &&
+							s.ConnectTimeout != kongIngress.Proxy.ConnectTimeout {
 							s.ConnectTimeout = kongIngress.Proxy.ConnectTimeout
+							outOfSync = true
 						}
 
 						if kongIngress.Proxy.ReadTimeout > 0 {

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -268,12 +268,16 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 							outOfSync = true
 						}
 
-						if kongIngress.Proxy.ReadTimeout > 0 {
+						if kongIngress.Proxy.ReadTimeout > 0 &&
+							s.ReadTimeout != kongIngress.Proxy.ReadTimeout {
 							s.ReadTimeout = kongIngress.Proxy.ReadTimeout
+							outOfSync = true
 						}
 
-						if kongIngress.Proxy.WriteTimeout > 0 {
+						if kongIngress.Proxy.WriteTimeout > 0 &&
+							s.WriteTimeout != kongIngress.Proxy.WriteTimeout {
 							s.WriteTimeout = kongIngress.Proxy.WriteTimeout
+							outOfSync = true
 						}
 
 						if kongIngress.Proxy.Retries > 0 && s.Retries != kongIngress.Proxy.Retries {


### PR DESCRIPTION
**What this PR does / why we need it**: only send PATCH request to Kong when the kongIngress changed, this will solve a problem that may result in high database pressure in Kong.

**Which issue this PR fixes** : fixes #104

