### PR TITLE
treat ipv6 addresses correctly

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"bytes"
 	"fmt"
+        "net"
 	"net/http"
 	"os"
 	"reflect"
@@ -140,7 +141,7 @@ func syncTargets(upstream string, ingressEndpopint *ingress.Backend, client *kon
 
 	newTargets := sets.NewString()
 	for _, endpoint := range ingressEndpopint.Endpoints {
-		nt := fmt.Sprintf("%v:%v", endpoint.Address, endpoint.Port)
+		nt := net.JoinHostPort(endpoint.Address, endpoint.Port)
 		if !newTargets.Has(nt) {
 			newTargets.Insert(nt)
 		}


### PR DESCRIPTION

When dealing with IPv6 addresses - Sprintf will not do the right thing i.e.

Host: fd00::7c46
Port: 80

Results in upstream target of:
~~~
POST /upstreams/myservice.http-svc.80/targets HTTP/1.1
{"target":"fd00::7c46:80","upstream_id":"2e0a4d5a-ed01-4858-ac12-9c3f11df7556"}
~~~

Which results in unreachable targets
~~~
2018/09/09 14:48:06 [error] 38#38: *22634 connect() failed (113: Host is unreachable) while connecting to upstream, client: fd00::1, server: kong, request: "GET / HTTP/1.1", upstream: "http://[fd00:0000:0000:0000:0000:0000:7c46:0080]:8000/", host: "foo.bar"
~~~

The correct API call is:
~~~
POST /upstreams/myservice.http-svc.80/targets HTTP/1.1
{"target":"[fd00::7c46]:80","upstream_id":"2e0a4d5a-ed01-4858-ac12-9c3f11df7556"}
~~~

golangs standard net.JoinHostPort will do the right thing for both IPv4 + IPv6

