### PR TITLE
breakage on 32bit platforms

### DIFF
--- a/internal/apis/admin/v1/types.go
+++ b/internal/apis/admin/v1/types.go
@@ -19,8 +19,8 @@ type Required struct {
 
 	Tags []string `json:"tags,omitempty"`
 
-	CreatedAt int `json:"created_at,omitempty"`
-	UpdatedAt int `json:"updated_at,omitempty"`
+	CreatedAt int64 `json:"created_at,omitempty"`
+	UpdatedAt int64 `json:"updated_at,omitempty"`
 }
 
 // RequiredList ...


### PR DESCRIPTION

Running the code on a 32bit platform - in this case a armhf causes a unmarshaling failure due to int not being 64bit.

~~~
I0909 14:34:11.012422       8 controller.go:127] syncing Ingress configuration...
E0909 14:34:11.133679       8 controller.go:130] unexpected failure updating Kong configuration: 
syncing targets: json: cannot unmarshal number 1536503123429 into Go struct field Target.created_at of type int
W0909 14:34:11.133820       8 queue.go:113] requeuing openfaas-fn/hello-python, err syncing targets: json: cannot unmarshal number 1536503123429 into Go struct field Target.created_at of type int
~~~

Resolution is to explicitly define created/updated as 64 bit.



