### PR TITLE
fix: rename name to plugin in KongPlugin resource

### DIFF
--- a/internal/apis/plugin/v1/types.go
+++ b/internal/apis/plugin/v1/types.go
@@ -28,8 +28,8 @@ type KongPlugin struct {
 	// Config contains the plugin configuration.
 	Config Configuration `json:"config,omitempty"`
 
-	// Name is the name of the plugin to which to apply the config
-	Name string `json:"name,omitempty"`
+	// PluginName is the name of the plugin to which to apply the config
+	PluginName string `json:"plugin,omitempty"`
 }
 
 // KongPluginList is a top-level list type. The client methods for lists are automatically created.

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -131,7 +131,7 @@ func (n *NGINXController) syncGlobalPlugins() error {
 	var duplicates []string // keep track of duplicate
 
 	for i := 0; i < len(targetGlobalPlugins); i++ {
-		name := targetGlobalPlugins[i].Name
+		name := targetGlobalPlugins[i].PluginName
 		// empty name skip it
 		if name == "" {
 			continue
@@ -482,7 +482,7 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 					// check the kong plugin configuration is up to date
 					if !pluginDeepEqual(k8sPlugin.Config, configuredPlugin) ||
 						(!k8sPlugin.Disabled != configuredPlugin.Enabled) {
-						glog.Infof("plugin %v configuration in kong is outdated. Updating...", k8sPlugin.Name)
+						glog.Infof("plugin %v configuration in kong is outdated. Updating...", k8sPlugin.PluginName)
 						p := &kongadminv1.Plugin{
 							Name:    configuredPlugin.Name,
 							Config:  kongadminv1.Configuration(k8sPlugin.Config),
@@ -509,7 +509,7 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 						continue
 					}
 
-					glog.Infof("plugin %v configuration in kong is up to date.", k8sPlugin.Name)
+					glog.Infof("plugin %v configuration in kong is up to date.", k8sPlugin.PluginName)
 				}
 			}
 		}
@@ -924,7 +924,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 					// check the kong plugin configuration is up to date
 					if !pluginDeepEqual(k8sPlugin.Config, configuredPlugin) ||
 						(!k8sPlugin.Disabled != configuredPlugin.Enabled) {
-						glog.Infof("plugin %v configuration in kong is outdated. Updating...", k8sPlugin.Name)
+						glog.Infof("plugin %v configuration in kong is outdated. Updating...", k8sPlugin.PluginName)
 						p := &kongadminv1.Plugin{
 							Name:    configuredPlugin.Name,
 							Config:  kongadminv1.Configuration(k8sPlugin.Config),
@@ -941,7 +941,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 						continue
 					}
 
-					glog.Infof("plugin %v configuration in kong is up to date.", k8sPlugin.Name)
+					glog.Infof("plugin %v configuration in kong is up to date.", k8sPlugin.PluginName)
 				}
 			}
 


### PR DESCRIPTION
This is a fix for the issue introduced in 32ca70f.
`name` is already a property defined for every resource in k8s, which is
unique across all objects of the same kind.
The `name` from metav1.objectMeta needs to be accessible in other parts
of code to correctly read the object.

This commit renames the `name` to `plugin` field.