### PR TITLE
fix(deploy) change kong-proxy to LB

### DIFF
--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -419,7 +419,7 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
   - name: kong-proxy
     port: 80

--- a/deploy/single/kong-resources-openshift.yaml
+++ b/deploy/single/kong-resources-openshift.yaml
@@ -294,7 +294,7 @@ kind: Service
 metadata:
   name: kong-proxy
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
   - name: kong-proxy
     port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:
As best I know, there's no case where the proxy service should be a NodePort. It must be publicly accessible on normal HTTP ports. I've changed it to LoadBalancer in most of the deployment examples. `deploy/provider/baremetal/kong-proxy-nodeport.yaml` has been left as-is since it explicitly says it's a NodePort in the name, and I'm not entirely sure of its original purpose (it only contains the service definition and we don't appear to reference it in docs).