### PR TITLE
fix: update plugins which are detected as out of sync

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -497,6 +497,7 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 							}
 							p.Consumer = fmt.Sprintf("%v", consumer.GetUID())
 						}
+						pluginsToUpdate = append(pluginsToUpdate, p)
 					}
 				}
 			}
@@ -908,6 +909,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 							}
 							p.Consumer = fmt.Sprintf("%v", consumer.GetUID())
 						}
+						pluginsToUpdate = append(pluginsToUpdate, p)
 					}
 					glog.Infof("plugin %v configuration in kong is up to date.", pluginInk8s.PluginName)
 


### PR DESCRIPTION
This is regression introduced in 25507588.
The plugins were being detected out of sync but not actually synced to
Kong.
No tests are added currently since this is due a refactor soon.