### PR TITLE
feat: add support for path only based routing

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -706,10 +706,6 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 
 	// Routes
 	for _, server := range ingressCfg.Servers {
-		if server.Hostname == "_" {
-			// there is no catch all server in kong
-			continue
-		}
 
 		protos := []string{"http"}
 		if server.SSLCert != nil {
@@ -749,8 +745,10 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 			r := &kongadminv1.Route{
 				Paths:     []string{location.Path},
 				Protocols: []string{"http", "https"}, // default
-				Hosts:     []string{server.Hostname},
 				Service:   kongadminv1.InlineService{ID: svc.ID},
+			}
+			if server.Hostname != "_" {
+				r.Hosts = []string{server.Hostname}
 			}
 
 			if kongIngress != nil && kongIngress.Route != nil {
@@ -1182,9 +1180,15 @@ func buildName(backend string, location *ingress.Location) string {
 // getKongService returns a Route from a list using the path and hosts as filters
 func getKongRoute(hostname, path string, routes []kongadminv1.Route) *kongadminv1.Route {
 	for _, r := range routes {
-		if sets.NewString(r.Paths...).Has(path) &&
-			sets.NewString(r.Hosts...).Has(hostname) {
-			return &r
+		if hostname != "_" {
+			if sets.NewString(r.Paths...).Has(path) &&
+				sets.NewString(r.Hosts...).Has(hostname) {
+				return &r
+			}
+		} else {
+			if sets.NewString(r.Paths...).Has(path) {
+				return &r
+			}
 		}
 	}
 


### PR DESCRIPTION
Host is not a required field in Kubernetes Ingress Spec.
This is a small change which instantiates routes in Kong based on path
only.

Fix #84