### PR TITLE
updating README to reflect correct service name

### DIFF
--- a/deploy/gke.md
+++ b/deploy/gke.md
@@ -208,6 +208,6 @@ spec:
         paths:
           - path: "/"
             backend:
-              serviceName: kong-admin
+              serviceName: kong-ingress-controller
               servicePort: 8001" | kubectl apply -f -
 ```

--- a/deploy/gke.md
+++ b/deploy/gke.md
@@ -30,7 +30,7 @@ This command will create  followings files:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kong-admin
+  name: kong-ingress-controller
   namespace: kong
 spec:
   type: ClusterIP


### PR DESCRIPTION
the svc name from wget is kong-ingress-controller, not kong-admin

**What this PR does / why we need it**:
updates the correct service name from the README.md
