### PR TITLE
Add TLS (HTTPS) section to gke.md

### DIFF
--- a/deploy/gke.md
+++ b/deploy/gke.md
@@ -216,13 +216,13 @@ spec:
 
 You need to set your API with HTTPS in order to expose your service securely. In this section, I will explain how to secure it with [Let’s Encrypt](https://letsencrypt.org/).
 
-1. Register your domain
+##### 1. Register fyour domain
 
 First of all, you must register your domain with any domain registration services such as [Google Domains](https://domains.google/).
 
-2. Follow instructions of [Let’s Encrypt on GKE](https://github.com/ahmetb/gke-letsencrypt)
+##### 2. Follow instructions of Let’s Encrypt on GKE
 
-[Let’s Encrypt on GKE](https://github.com/ahmetb/gke-letsencrypt) is a tutorial for installing `cert-manager` to get HTTPS certificates from Let’s Encrypt. There is an important things you need to configure, if you want to accomplish correctly. You should apply [KongIngress](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/custom-types.md#kongingress) and set `preserve_host` configuration `true` so that you could keep hostname in request headers.
+[Let’s Encrypt on GKE](https://github.com/ahmetb/gke-letsencrypt) is a tutorial for installing `cert-manager` to get HTTPS certificates from Let’s Encrypt. There is an important things you need to configure, if you want to accomplish correctly. You should apply [KongIngress](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/custom-types.md#kongingress) and set `preserve_host` configuration `true` at the [4th step](https://github.com/ahmetb/gke-letsencrypt/blob/master/40-deploy-an-app.md) so that you could keep hostname in request headers.
 
 [cert-manager](https://github.com/jetstack/cert-manager) checks equality of hostname and domain name when it creates HTTPS certificates. However, Kong remove hostname as default. I recommend you to create a `KongIngress` spec file to avoid the following error.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update gke.md in order to add the instruction of how to setup TLS (HTTPS) on GKE by using [Let's Encrypt](https://letsencrypt.org/).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Nothing.

**Special notes for your reviewer**:

Nothing.
