### PR TITLE
feat(deploy) use Job to run Kong migration

### DIFF
--- a/deploy/manifests/ingress-controller.yaml
+++ b/deploy/manifests/ingress-controller.yaml
@@ -42,15 +42,6 @@ spec:
         app: ingress-kong
     spec:
       serviceAccountName: kong-serviceaccount
-      initContainers:
-      - name: kong-migration
-        image: kong:0.14.1-centos
-        env:
-          - name: KONG_PG_PASSWORD
-            value: kong
-          - name: KONG_PG_HOST
-            value: postgres
-        command: [ "/bin/sh", "-c", "kong migrations up" ]
       containers:
       - name: admin-api
         image: kong:0.14.1-centos

--- a/deploy/manifests/migration.yaml
+++ b/deploy/manifests/migration.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kong-migrations
+  namespace: kong
+spec:
+  template:
+    metadata:
+      name: kong-migrations
+    spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox
+        env:
+          - name: KONG_PG_HOST
+            value: postgres
+          - name: KONG_PG_PORT
+            value: "5432"
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      containers:
+      - name: kong-migrations
+        image: kong:0.14.1-centos
+        env:
+          - name: KONG_PG_PASSWORD
+            value: kong
+          - name: KONG_PG_HOST
+            value: postgres
+          - name: KONG_PG_PORT
+            value: "5432"
+        command: [ "/bin/sh", "-c", "kong migrations up" ]
+      restartPolicy: OnFailure

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -322,15 +322,6 @@ spec:
         app: ingress-kong
     spec:
       serviceAccountName: kong-serviceaccount
-      initContainers:
-      - name: kong-migration
-        image: kong:0.14.1-centos
-        env:
-          - name: KONG_PG_PASSWORD
-            value: kong
-          - name: KONG_PG_HOST
-            value: postgres
-        command: [ "/bin/sh", "-c", "kong migrations up" ]
       containers:
       - name: admin-api
         image: kong:0.14.1-centos
@@ -419,7 +410,7 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - name: kong-proxy
     port: 80
@@ -470,3 +461,34 @@ spec:
           protocol: TCP
 
 ---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kong-migrations
+  namespace: kong
+spec:
+  template:
+    metadata:
+      name: kong-migrations
+    spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox
+        env:
+          - name: KONG_PG_HOST
+            value: postgres
+          - name: KONG_PG_PORT
+            value: "5432"
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      containers:
+      - name: kong-migrations
+        image: kong:0.14.1-centos
+        env:
+          - name: KONG_PG_PASSWORD
+            value: kong
+          - name: KONG_PG_HOST
+            value: postgres
+          - name: KONG_PG_PORT
+            value: "5432"
+        command: [ "/bin/sh", "-c", "kong migrations up" ]
+      restartPolicy: OnFailure

--- a/hack/build-single-manifests.sh
+++ b/hack/build-single-manifests.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
-WITH_POSTGRESQL="manifests/namespace.yaml manifests/custom-types.yaml manifests/postgres.yaml manifests/rbac.yaml manifests/ingress-controller.yaml provider/baremetal/kong-proxy-nodeport.yaml manifests/kong.yaml"
+WITH_POSTGRESQL="manifests/namespace.yaml manifests/custom-types.yaml manifests/postgres.yaml manifests/rbac.yaml manifests/ingress-controller.yaml provider/baremetal/kong-proxy-nodeport.yaml manifests/kong.yaml manifests/migration.yaml"
 MANIFEST=$(cd ${SCRIPT_ROOT}/deploy; cat ${WITH_POSTGRESQL})
 
 echo "${MANIFEST}" > ${SCRIPT_ROOT}/deploy/single/all-in-one-postgres.yaml


### PR DESCRIPTION
Using InitContainer can result in two Kong nodes running migrations
concurrently.
Job is the right way to run migrations.