### PR TITLE
feat(deploy) mount pvc correctly on the Postgres pod

### DIFF
--- a/deploy/manifests/postgres.yaml
+++ b/deploy/manifests/postgres.yaml
@@ -34,6 +34,10 @@ spec:
       containers:
       - name: postgres
         image: postgres:9.5
+        volumeMounts:
+          - name: datadir
+            mountPath: /var/lib/postgresql/data
+            subPath: pgdata
         env:
         - name: POSTGRES_USER
           value: kong
@@ -48,10 +52,6 @@ spec:
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60
-      volumes:
-      - name: datadir
-        persistentVolumeClaim:
-          claimName: datadir
   volumeClaimTemplates:
   - metadata:
       name: datadir

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -103,6 +103,10 @@ spec:
       containers:
       - name: postgres
         image: postgres:9.5
+        volumeMounts:
+          - name: datadir
+            mountPath: /var/lib/postgresql/data
+            subPath: pgdata
         env:
         - name: POSTGRES_USER
           value: kong
@@ -117,10 +121,6 @@ spec:
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60
-      volumes:
-      - name: datadir
-        persistentVolumeClaim:
-          claimName: datadir
   volumeClaimTemplates:
   - metadata:
       name: datadir


### PR DESCRIPTION
Currently, the Postgres pod does not persist data across restarts
because the mount is done incorrectly.

This change uses `volumeMounts` in the StatefulSet spec to mount the
persistent volume at the $PGDATA path.