### PR TITLE
feat(deploy) add initContainer to wait for DB state

### DIFF
--- a/deploy/manifests/ingress-controller.yaml
+++ b/deploy/manifests/ingress-controller.yaml
@@ -42,6 +42,25 @@ spec:
         app: ingress-kong
     spec:
       serviceAccountName: kong-serviceaccount
+      initContainers:
+      # hack to verify that the DB is up to date or not
+      # TODO remove this for Kong >= 0.15.0
+      - name: wait-for-db
+        image: kong:0.14.1-centos
+        command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
+        env:
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
       containers:
       - name: admin-api
         image: kong:0.14.1-centos

--- a/deploy/manifests/kong.yaml
+++ b/deploy/manifests/kong.yaml
@@ -14,6 +14,25 @@ spec:
         name: kong
         app: kong
     spec:
+      initContainers:
+      # hack to verify that the DB is up to date or not
+      # TODO remove this for Kong >= 0.15.0
+      - name: wait-for-db
+        image: kong:0.14.1-centos
+        command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
+        env:
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
       containers:
       - name: kong-proxy
         image: kong:0.14.1-centos

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -322,6 +322,25 @@ spec:
         app: ingress-kong
     spec:
       serviceAccountName: kong-serviceaccount
+      initContainers:
+      # hack to verify that the DB is up to date or not
+      # TODO remove this for Kong >= 0.15.0
+      - name: wait-for-db
+        image: kong:0.14.1-centos
+        command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
+        env:
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
       containers:
       - name: admin-api
         image: kong:0.14.1-centos
@@ -438,6 +457,25 @@ spec:
         name: kong
         app: kong
     spec:
+      initContainers:
+      # hack to verify that the DB is up to date or not
+      # TODO remove this for Kong >= 0.15.0
+      - name: wait-for-db
+        image: kong:0.14.1-centos
+        command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
+        env:
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
       containers:
       - name: kong-proxy
         image: kong:0.14.1-centos


### PR DESCRIPTION
Kong can startup only if the DB schema is up to date.
If Postgres is not up or the schema is not up to date, then Kong
will fail to start, resulting in Pod restarts.

This change will wait for Postgres to be up and migrations to finish
running, avoiding restarts and failures in Kubernetes.

There is currently no way to verify if DB state is at the correct
version and hence we resort to a hack of actualling starting Kong and
stopping it in the init container.

With Kong >= 0.15.0, Kong will have a CLI command to check if migrations
are up to date or not.