### PR TITLE
fix: certificate and SNI sync when TLS secret is changed

### DIFF
--- a/internal/apis/admin/certificate.go
+++ b/internal/apis/admin/certificate.go
@@ -47,7 +47,7 @@ func (a *certificateAPI) List(params url.Values) (*adminv1.CertificateList, erro
 	}
 
 	list := &adminv1.CertificateList{}
-	request := a.client.RestClient().Get().Resource("consumers")
+	request := a.client.RestClient().Get().Resource("certificates")
 	for k, vals := range params {
 		for _, v := range vals {
 			request.Param(k, v)


### PR DESCRIPTION
This change addresses following issues:
- When a TLS secret is changed for a hostname(s), then updating the cert
  will result in errors in the reconsilation loop which will never
  resolve. This occurs due to Kong complaining that a hostname is already
  bound to another certificate.
  The SNI is now being populated during an SNI sync and not during a
  certificate creation.
- An unreferenced certificate is never deleted.
  At the end of certificate sync we delete any unused certificate.