### PR TITLE
feat: add support to inject headers into Admin API calls

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -30,6 +32,20 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations/class"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller"
 )
+
+type headers []string
+
+func (h *headers) String() string {
+	return "my string representation"
+}
+
+func (h *headers) Set(value string) error {
+	if len(strings.Split(value, ":")) < 2 {
+		return errors.New("header should be of form key:value")
+	}
+	*h = append(*h, value)
+	return nil
+}
 
 func parseFlags() (bool, *controller.Configuration, error) {
 	var (
@@ -94,7 +110,12 @@ The controller will set the endpoint records on the ingress using this address.`
 
 		kongURL = flags.String("kong-url", "http://localhost:8001",
 			"The address of the Kong Admin URL to connect to in the format of protocol://address:port")
+
+		kongHeaders headers
 	)
+
+	flag.Var(&kongHeaders, "admin-header",
+		"add a header (key:value) to every Admin API call, flag can be used multiple times")
 
 	flag.Set("logtostderr", "true")
 
@@ -133,7 +154,8 @@ The controller will set the endpoint records on the ingress using this address.`
 
 	config := &controller.Configuration{
 		Kong: controller.Kong{
-			URL: *kongURL,
+			URL:     *kongURL,
+			Headers: kongHeaders,
 		},
 		APIServerHost:            *apiserverHost,
 		KubeConfigFile:           *kubeConfigFile,

--- a/cli/ingress-controller/header_roundtripper.go
+++ b/cli/ingress-controller/header_roundtripper.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+// HeaderRoundTripper injects Headers into requests
+// made via RT.
+type HeaderRoundTripper struct {
+	headers []string
+	rt      http.RoundTripper
+}
+
+// RoundTrip satisfies the RoundTripper interface.
+func (t *HeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	newRequest := new(http.Request)
+	*newRequest = *req
+	newRequest.Header = make(http.Header, len(req.Header))
+	for k, s := range req.Header {
+		newRequest.Header[k] = append([]string(nil), s...)
+	}
+	for _, s := range t.headers {
+		split := strings.SplitN(s, ":", 2)
+		if len(split) >= 2 {
+			newRequest.Header[split[0]] = append([]string(nil), split[1])
+		}
+	}
+	return t.rt.RoundTrip(newRequest)
+}

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -117,11 +117,16 @@ func main() {
 	kongClient, err := kong.NewRESTClient(&rest.Config{
 		Host:    conf.Kong.URL,
 		Timeout: 0,
+		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
+			return &HeaderRoundTripper{
+				headers: conf.Kong.Headers,
+				rt:      rt,
+			}
+		},
 	})
 	if err != nil {
 		glog.Fatalf("Error creating Kong Rest client: %v", err)
 	}
-
 	v, err := kongClient.GetVersion()
 	if err != nil {
 		glog.Fatalf("%v", err)

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -42,8 +42,9 @@ const (
 )
 
 type Kong struct {
-	URL    string
-	Client *kong.RestClient
+	URL     string
+	Headers []string
+	Client  *kong.RestClient
 }
 
 // Configuration contains all the settings required by an Ingress controller


### PR DESCRIPTION
If Kong's control plane is protected behind Authentication or
Authorization, then Kong Ingress Controller cannot talk to Kong. This
change let's user specify flags to add any header(key:value) that will
be added in every call to Kong's Control Plane a.k.a Admin API.