### PR TITLE
feat: add CRD validations and additional printing columns

### DIFF
--- a/deploy/manifests/custom-types.yaml
+++ b/deploy/manifests/custom-types.yaml
@@ -12,6 +12,36 @@ spec:
     plural: kongplugins
     shortNames:
     - kp
+  additionalPrinterColumns:
+  - name: Plugin-Type
+    type: string
+    description: Name of the plugin
+    JSONPath: .plugin
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  - name: Disabled
+    type: boolean
+    description: Is the plugin disabled?
+    JSONPath: .disabled
+    priority: 1
+  - name: Config
+    type: string
+    description: configuration of the plugin
+    JSONPath: .config
+    priority: 1
+  validation:
+    openAPIV3Schema:
+      required:
+      - plugin
+      properties:
+        plugin:
+          type: string
+        disabled:
+          type: boolean
+        config:
+          type: object
 
 ---
 
@@ -28,6 +58,22 @@ spec:
     plural: kongconsumers
     shortNames:
     - kc
+  additionalPrinterColumns:
+  - name: Username
+    type: string
+    description: Username of a Kong Consumer
+    JSONPath: .username
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        username:
+          type: string
+        custom_id:
+          type: string
 
 ---
 
@@ -42,6 +88,29 @@ spec:
   names:
     kind: KongCredential
     plural: kongcredentials
+  additionalPrinterColumns:
+  - name: Credential-type
+    type: string
+    description: Type of credential
+    JSONPath: .type
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  - name: Consumer-Ref
+    type: string
+    description: Owner of the credential
+    JSONPath: .consumerRef
+  validation:
+    openAPIV3Schema:
+      required:
+      - consumerRef
+      - type
+      properties:
+        consumerRef:
+          type: string
+        type:
+          type: string
 
 ---
 
@@ -58,5 +127,122 @@ spec:
     plural: kongingresses
     shortNames:
     - ki
+  validation:
+    openAPIV3Schema:
+      properties:
+        upstream:
+          type: object
+        route:
+          properties:
+            methods:
+              type: array
+              items:
+                type: string
+            regex_priority:
+              type: integer
+            strip_path:
+              type: boolean
+            preserve_host:
+              type: boolean
+            protocols:
+              type: array
+              items:
+                type: string
+                enum:
+                - http
+                - https
+        proxy:
+          type: object
+          properties:
+            protocol:
+              type: string
+              enum:
+              - http
+              - https
+            path:
+              type: string
+              pattern: ^/.*$
+            retries:
+              type: integer
+              minimum: 0
+            connect_timeout:
+              type: integer
+              minimum: 0
+            read_timeout:
+              type: integer
+              minimum: 0
+            write_timeout:
+              type: integer
+              minimum: 0
+        upstream:
+          type: object
+          properties:
+            hash_on:
+              type: string
+            hash_on_cookie:
+              type: string
+            hash_on_cookie_path:
+              type: string
+            hash_on_header:
+              type: string
+            hash_fallback_header:
+              type: string
+            hash_fallback:
+              type: string
+            slots:
+              type: integer
+              minimum: 10
+            healthchecks:
+              type: object
+              properties:
+                active:
+                  type: object
+                  properties:
+                    concurrency:
+                      type: integer
+                      minimum: 1
+                    timeout:
+                      type: integer
+                      minimum: 0
+                    http_path:
+                      type: string
+                      pattern: ^/.*$
+                    healthy: &healthy
+                      type: object
+                      properties:
+                        http_statuses:
+                          type: array
+                          items:
+                            type: integer
+                        interval:
+                          type: integer
+                          minimum: 0
+                        successes:
+                          type: integer
+                          minimum: 0
+                    unhealthy: &unhealthy
+                      type: object
+                      properties:
+                        http_failures:
+                          type: integer
+                          minimum: 0
+                        http_statuses:
+                          type: array
+                          items:
+                            type: integer
+                        interval:
+                          type: integer
+                          minimum: 0
+                        tcp_failures:
+                          type: integer
+                          minimum: 0
+                        timeout:
+                          type: integer
+                          minimum: 0
+                passive:
+                  type: object
+                  properties:
+                    healthy: *healthy
+                    unhealthy: *unhealthy
 
 ---

--- a/deploy/manifests/custom-types.yaml
+++ b/deploy/manifests/custom-types.yaml
@@ -23,12 +23,12 @@ spec:
     JSONPath: .metadata.creationTimestamp
   - name: Disabled
     type: boolean
-    description: Is the plugin disabled?
+    description: Indicates if the plugin is disabled
     JSONPath: .disabled
     priority: 1
   - name: Config
     type: string
-    description: configuration of the plugin
+    description: Configuration of the plugin
     JSONPath: .config
     priority: 1
   validation:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -19,6 +19,36 @@ spec:
     plural: kongplugins
     shortNames:
     - kp
+  additionalPrinterColumns:
+  - name: Plugin-Type
+    type: string
+    description: Name of the plugin
+    JSONPath: .plugin
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  - name: Disabled
+    type: boolean
+    description: Is the plugin disabled?
+    JSONPath: .disabled
+    priority: 1
+  - name: Config
+    type: string
+    description: configuration of the plugin
+    JSONPath: .config
+    priority: 1
+  validation:
+    openAPIV3Schema:
+      required:
+      - plugin
+      properties:
+        plugin:
+          type: string
+        disabled:
+          type: boolean
+        config:
+          type: object
 
 ---
 
@@ -35,6 +65,22 @@ spec:
     plural: kongconsumers
     shortNames:
     - kc
+  additionalPrinterColumns:
+  - name: Username
+    type: string
+    description: Username of a Kong Consumer
+    JSONPath: .username
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        username:
+          type: string
+        custom_id:
+          type: string
 
 ---
 
@@ -49,6 +95,29 @@ spec:
   names:
     kind: KongCredential
     plural: kongcredentials
+  additionalPrinterColumns:
+  - name: Credential-type
+    type: string
+    description: Type of credential
+    JSONPath: .type
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  - name: Consumer-Ref
+    type: string
+    description: Owner of the credential
+    JSONPath: .consumerRef
+  validation:
+    openAPIV3Schema:
+      required:
+      - consumerRef
+      - type
+      properties:
+        consumerRef:
+          type: string
+        type:
+          type: string
 
 ---
 
@@ -65,6 +134,123 @@ spec:
     plural: kongingresses
     shortNames:
     - ki
+  validation:
+    openAPIV3Schema:
+      properties:
+        upstream:
+          type: object
+        route:
+          properties:
+            methods:
+              type: array
+              items:
+                type: string
+            regex_priority:
+              type: integer
+            strip_path:
+              type: boolean
+            preserve_host:
+              type: boolean
+            protocols:
+              type: array
+              items:
+                type: string
+                enum:
+                - http
+                - https
+        proxy:
+          type: object
+          properties:
+            protocol:
+              type: string
+              enum:
+              - http
+              - https
+            path:
+              type: string
+              pattern: ^/.*$
+            retries:
+              type: integer
+              minimum: 0
+            connect_timeout:
+              type: integer
+              minimum: 0
+            read_timeout:
+              type: integer
+              minimum: 0
+            write_timeout:
+              type: integer
+              minimum: 0
+        upstream:
+          type: object
+          properties:
+            hash_on:
+              type: string
+            hash_on_cookie:
+              type: string
+            hash_on_cookie_path:
+              type: string
+            hash_on_header:
+              type: string
+            hash_fallback_header:
+              type: string
+            hash_fallback:
+              type: string
+            slots:
+              type: integer
+              minimum: 10
+            healthchecks:
+              type: object
+              properties:
+                active:
+                  type: object
+                  properties:
+                    concurrency:
+                      type: integer
+                      minimum: 1
+                    timeout:
+                      type: integer
+                      minimum: 0
+                    http_path:
+                      type: string
+                      pattern: ^/.*$
+                    healthy: &healthy
+                      type: object
+                      properties:
+                        http_statuses:
+                          type: array
+                          items:
+                            type: integer
+                        interval:
+                          type: integer
+                          minimum: 0
+                        successes:
+                          type: integer
+                          minimum: 0
+                    unhealthy: &unhealthy
+                      type: object
+                      properties:
+                        http_failures:
+                          type: integer
+                          minimum: 0
+                        http_statuses:
+                          type: array
+                          items:
+                            type: integer
+                        interval:
+                          type: integer
+                          minimum: 0
+                        tcp_failures:
+                          type: integer
+                          minimum: 0
+                        timeout:
+                          type: integer
+                          minimum: 0
+                passive:
+                  type: object
+                  properties:
+                    healthy: *healthy
+                    unhealthy: *unhealthy
 
 ---
 

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -30,12 +30,12 @@ spec:
     JSONPath: .metadata.creationTimestamp
   - name: Disabled
     type: boolean
-    description: Is the plugin disabled?
+    description: Indicates if the plugin is disabled
     JSONPath: .disabled
     priority: 1
   - name: Config
     type: string
-    description: configuration of the plugin
+    description: Configuration of the plugin
     JSONPath: .config
     priority: 1
   validation:


### PR DESCRIPTION
Newer releases of Kubernetes supports validations of Custom Resources
via OpenAPI v3 schema, which uses JSON schema.

This change adds support for validations and additionally, if the k8s
server supports server-side printing, then additional columns are
printed for some of the custom resources.