### PR TITLE
fix: set strip_path to false by default

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -760,6 +760,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 				Paths:     []*string{&location.Path},
 				Protocols: []*string{kong.String("http"), kong.String("https")}, // default
 				Service:   &kong.Service{ID: svc.ID},
+				StripPath: kong.Bool(false),
 			}
 			if server.Hostname != "_" {
 				r.Hosts = []*string{kong.String(server.Hostname)}


### PR DESCRIPTION
`strip_path` was set to false by default but was changed in 0.2.1
release to true.

See #193