### PR TITLE
Update deployment manifests with latest 0.2.x image tags

### DIFF
--- a/deploy/manifests/ingress-controller.yaml
+++ b/deploy/manifests/ingress-controller.yaml
@@ -119,7 +119,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -399,7 +399,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/kong-resources-openshift.yaml
+++ b/deploy/single/kong-resources-openshift.yaml
@@ -260,7 +260,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.2.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Manifests are still pointing at 0.2.0 even though 0.2.2 is latest release for the 0.2.x branch. 