### PR TITLE
Support disable service retry

### DIFF
--- a/internal/apis/configuration/v1/types.go
+++ b/internal/apis/configuration/v1/types.go
@@ -55,7 +55,7 @@ type Proxy struct {
 	Protocol       string `json:"protocol"`
 	Path           string `json:"path"`
 	ConnectTimeout int    `json:"connect_timeout"`
-	Retries        int    `json:"retries"`
+	Retries        *int   `json:"retries"`
 	ReadTimeout    int    `json:"read_timeout"`
 	WriteTimeout   int    `json:"write_timeout"`
 }

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -391,9 +391,8 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 							outOfSync = true
 						}
 
-						if kongIngress.Proxy.Retries >= 0 &&
-							(s.Retries == nil || *s.Retries != kongIngress.Proxy.Retries) {
-							s.Retries = kong.Int(kongIngress.Proxy.Retries)
+						if kongIngress.Proxy.Retries != nil && (s.Retries == nil || s.Retries != kongIngress.Proxy.Retries) {
+							s.Retries = kong.Int(*kongIngress.Proxy.Retries)
 							outOfSync = true
 						}
 					}

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -391,7 +391,7 @@ func (n *NGINXController) syncServices(ingressCfg *ingress.Configuration) (bool,
 							outOfSync = true
 						}
 
-						if kongIngress.Proxy.Retries > 0 &&
+						if kongIngress.Proxy.Retries >= 0 &&
 							(s.Retries == nil || *s.Retries != kongIngress.Proxy.Retries) {
 							s.Retries = kong.Int(kongIngress.Proxy.Retries)
 							outOfSync = true


### PR DESCRIPTION
I need to disable retry for service, but the proxy set retries to 0, it doesn't apply to kong and the DB doesn't update.

~~~
apiVersion: configuration.konghq.com/v1
kind: KongIngress
metadata:
  name: service1
proxy:
  path: /
  protocol: http
  retries: 0
route:
  preserve_host: true
~~~