### PR TITLE
feat: add support for custom TLS certificate

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -111,6 +111,13 @@ The controller will set the endpoint records on the ingress using this address.`
 		kongURL = flags.String("kong-url", "http://localhost:8001",
 			"The address of the Kong Admin URL to connect to in the format of protocol://address:port")
 
+		kongTLSSkipVerify = flag.Bool("admin-tls-skip-verify", false,
+			"Disable verification of TLS certificate of Kong's Admin endpoint.")
+		kongTLSServerName = flag.String("admin-tls-server-name", "",
+			"SNI name to use to verify the certificate presented by Kong in TLS.")
+		kongCACert = flag.String("admin-ca-cert-file", "",
+			"Path to PEM-encoded CA certificate file to verify the Kong's Admin SSL certificate.")
+
 		kongHeaders headers
 	)
 
@@ -156,6 +163,10 @@ The controller will set the endpoint records on the ingress using this address.`
 		Kong: controller.Kong{
 			URL:     *kongURL,
 			Headers: kongHeaders,
+
+			TLSServerName: *kongTLSServerName,
+			TLSSkipVerify: *kongTLSSkipVerify,
+			CACert:        *kongCACert,
 		},
 		APIServerHost:            *apiserverHost,
 		KubeConfigFile:           *kubeConfigFile,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -42,9 +42,15 @@ const (
 )
 
 type Kong struct {
-	URL     string
+	URL string
+	// Headers are injected into every request to Kong's Admin API
+	// to help with authorization/authentication.
 	Headers []string
 	Client  *kong.Client
+
+	TLSSkipVerify bool
+	TLSServerName string
+	CACert        string
 }
 
 // Configuration contains all the settings required by an Ingress controller


### PR DESCRIPTION
Following options have been added to work with custom TLS certificates,
SNI names and to ignore a self-signed certificate:

- `--admin-tls-skip-verify`: to skip validation of a certificate, this
shouldn't be used in a production environment.
- `--admin-tls-server-name`: use this if the FQDN of Kong's Admin API
doesn't match the SNI name in the certificate.
- `--admin-ca-cert-file`: use this to specify a custom CA cert which is
not part of the bundled CA certs.