### PR TITLE
0.3.0 release default Ingress class is now kong

### DIFF
--- a/docs/deployment/aks.md
+++ b/docs/deployment/aks.md
@@ -96,6 +96,8 @@ IP address to the `kong-proxy` Service so please be patient.
   metadata:
     name: dummy
     namespace:  dummy
+    annotations:
+    kubernetes.io/ingress.class: "kong"
   spec:
     rules:
       - host:
@@ -132,7 +134,7 @@ metadata:
   name: kong-admin
   namespace:  kong
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: dummy.kong.example

--- a/docs/deployment/aks.md
+++ b/docs/deployment/aks.md
@@ -96,8 +96,6 @@ IP address to the `kong-proxy` Service so please be patient.
   metadata:
     name: dummy
     namespace:  dummy
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
   spec:
     rules:
       - host:

--- a/docs/deployment/gke.md
+++ b/docs/deployment/gke.md
@@ -245,6 +245,8 @@ IP address to the `kong-proxy` Service.
   metadata:
     name: dummy
     namespace:  dummy
+    annotations:
+    kubernetes.io/ingress.class: "kong"
   spec:
     rules:
       - host: dummy.kong.example
@@ -281,7 +283,7 @@ metadata:
   name: kong-admin
   namespace:  kong
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: dummy.kong.example
@@ -359,7 +361,7 @@ metadata:
   name: dummy
   namespace:  dummy
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
     configuration.konghq.com: sample-kong-ingress
 spec:
   rules:

--- a/docs/deployment/gke.md
+++ b/docs/deployment/gke.md
@@ -245,8 +245,6 @@ IP address to the `kong-proxy` Service.
   metadata:
     name: dummy
     namespace:  dummy
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
   spec:
     rules:
       - host: dummy.kong.example


### PR DESCRIPTION
0.3.0 release default Ingress class is now kong 
Removed lines
annotations:
    kubernetes.io/ingress.class: "nginx"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
