### PR TITLE
chore(Makefile) fix sed path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SED_I?=sed -i
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 
 ifeq ($(GOHOSTOS),darwin)
-  SED_I=sed -i ''
+  SED_I=/usr/bin/sed -i ''
 endif
 
 REPO_INFO=$(shell git config --get remote.origin.url)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR helps the build process be robust, by ensuring that the `sed` that ships with macOS is the `sed` that is used in the build process.

**Which issue this PR fixes** : 

**Special notes for your reviewer**: The prevents issues for users who have installed GNU `sed`, and have it in their path before the OS's BSD `sed`.
