### PR TITLE
Set default value of PreserveHost for new routes to true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ a hosted k8s service like
 To setup Kong Ingress Controller in your k8s cluster, execute:
 
 ```shell
+helm install stable/kong --set ingressController.enabled=true
+```
+
+If you don't have helm installed on your k8s cluster, execute:
+
+```
 kubectl apply -f https://bit.ly/kong-ingress
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ Kubernetes version `1.8` through `1.10`.
 The following matrix lists supported versions of
 Kong for every release of the Kong Ingress Controller:
 
-| Kong Ingress Controller  | <= 0.0.4           | 0.0.5              | 0.1.x              | 0.2.x              |
-|--------------------------|:------------------:|:------------------:|:------------------:|:------------------:|
-| Kong 0.13.x              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| Kong 0.14.x              | :x:                | :x:                | :x:                | :white_check_mark: |
-| Kong Enterprise 0.32.x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| Kong Enterprise 0.33.x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| Kong Ingress Controller  | <= 0.0.4           | 0.0.5              | 0.1.x              | 0.2.x              | 0.3.x              |
+|--------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| Kong 0.13.x              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Kong 0.14.x              | :x:                | :x:                | :x:                | :white_check_mark: | :x:                |
+| Kong 1.0.x               | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
+| Kong Enterprise 0.32-x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Kong Enterprise 0.33-x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Kong Enterprise 0.34-x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ spin up.
 You now have set up Kong as your Ingress controller and
 all Ingress resources in your Kubernetes Cluster will be satisfied.
 
-Please refer to our [deployment documentation][deployment-doc]
+Please refer to our [deployment documentation][deployment]
 for a detailed introduction to Kong Ingress Controller
 and Ingress spec.
 
@@ -106,9 +106,9 @@ repository. Pull Requests are welcome for additions and corrections.
 
 Following are some helpful link:
 
-- [**Getting Started**][deployment-doc]:
+- [**Getting Started**][docs]:
   Get Kubernetes Ingress setup up and running.
-- [**Deployment**][deployment-doc]:
+- [**Deployment**][deployment]:
   Deployment guides for Minikube, GKE
   and other types of clusters.
 - [**Custom Resources Definitions (CRDs)**][crds]:
@@ -159,7 +159,8 @@ Please check the [roadmap][roadmap] document.
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [kong]: https://konghq.com/kong-community-edition/
 [kong-hub]: https://docs.konghq.com/hub/
-[deployment-doc]: deploy/README.md
+[docs]: docs/
+[deployment]: docs/deployment/
 [annotations]: docs/annotations.md
 [crds]: docs/custom-resources.md
 [roadmap]: docs/roadmap.md

--- a/deploy/manifests/ingress-controller.yaml
+++ b/deploy/manifests/ingress-controller.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: kong-serviceaccount
       initContainers:
       - name: wait-for-migrations
-        image: kong:1.0.0
+        image: kong:1.0
         command: [ "/bin/sh", "-c", "kong migrations list" ]
         env:
         - name: KONG_ADMIN_LISTEN
@@ -65,7 +65,7 @@ spec:
           value: kong
       containers:
       - name: admin-api
-        image: kong:1.0.0
+        image: kong:1.0
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/manifests/kong.yaml
+++ b/deploy/manifests/kong.yaml
@@ -18,7 +18,7 @@ spec:
       # hack to verify that the DB is up to date or not
       # TODO remove this for Kong >= 0.15.0
       - name: wait-for-migrations
-        image: kong:1.0.0
+        image: kong:1.0
         command: [ "/bin/sh", "-c", "kong migrations list" ]
         env:
         - name: KONG_ADMIN_LISTEN
@@ -39,7 +39,7 @@ spec:
           value: kong
       containers:
       - name: kong-proxy
-        image: kong:1.0.0
+        image: kong:1.0
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/manifests/migration.yaml
+++ b/deploy/manifests/migration.yaml
@@ -19,7 +19,7 @@ spec:
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
-        image: kong:1.0.0-centos
+        image: kong:1.0-centos
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -510,7 +510,7 @@ spec:
       serviceAccountName: kong-serviceaccount
       initContainers:
       - name: wait-for-migrations
-        image: kong:1.0.0
+        image: kong:1.0
         command: [ "/bin/sh", "-c", "kong migrations list" ]
         env:
         - name: KONG_ADMIN_LISTEN
@@ -531,7 +531,7 @@ spec:
           value: kong
       containers:
       - name: admin-api
-        image: kong:1.0.0
+        image: kong:1.0
         env:
         - name: KONG_PG_PASSWORD
           value: kong
@@ -650,7 +650,7 @@ spec:
       # hack to verify that the DB is up to date or not
       # TODO remove this for Kong >= 0.15.0
       - name: wait-for-migrations
-        image: kong:1.0.0
+        image: kong:1.0
         command: [ "/bin/sh", "-c", "kong migrations list" ]
         env:
         - name: KONG_ADMIN_LISTEN
@@ -671,7 +671,7 @@ spec:
           value: kong
       containers:
       - name: kong-proxy
-        image: kong:1.0.0
+        image: kong:1.0
         env:
         - name: KONG_PG_PASSWORD
           value: kong
@@ -713,7 +713,7 @@ spec:
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
-        image: kong:1.0.0-centos
+        image: kong:1.0-centos
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -31,7 +31,7 @@ On the other hand, an annotation such as
 metadata:
   name: foo
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 ```
 
 will target Kong Ingress controller, forcing the GCE controller to ignore it.

--- a/docs/deployment/gke.md
+++ b/docs/deployment/gke.md
@@ -231,7 +231,7 @@ IP address to the `kong-proxy` Service.
   
   ```bash
 
-  kubectl create namespace dummy && curl https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/master/deploy/manifests/dummy-application.yaml -n dummy
+  kubectl create namespace dummy && kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/master/deploy/manifests/dummy-application.yaml -n dummy
 
   ```
 

--- a/docs/deployment/gke.md
+++ b/docs/deployment/gke.md
@@ -246,7 +246,7 @@ IP address to the `kong-proxy` Service.
     name: dummy
     namespace:  dummy
     annotations:
-      kubernetes.io/ingress.class: "nginx"
+      kubernetes.io/ingress.class: "kong"
   spec:
     rules:
       - host: dummy.kong.example
@@ -283,7 +283,7 @@ metadata:
   name: kong-admin
   namespace:  kong
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: dummy.kong.example
@@ -361,7 +361,7 @@ metadata:
   name: dummy
   namespace:  dummy
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
     configuration.konghq.com: sample-kong-ingress
 spec:
   rules:

--- a/docs/external-service/externalname.md
+++ b/docs/external-service/externalname.md
@@ -39,6 +39,7 @@ metadata:
 config:
   remove:
     headers: host
+plugin: request-transformer
 " | kubectl create -f -
 ```
 
@@ -51,8 +52,7 @@ kind: Ingress
 metadata:
   name: proxy-from-k8s-to-mockbin
   annotations:
-    request-transformer.plugin.konghq.com: |
-      transform-request-to-mockbin
+    plugins.konghq.com: transform-request-to-mockbin
 spec:
   rules:
   - host: foo.bar

--- a/docs/external-service/externalnamejwt.md
+++ b/docs/external-service/externalnamejwt.md
@@ -36,6 +36,7 @@ metadata:
 config:
   remove:
     headers: host
+plugin: request-transformer
 " | kubectl create -f -
 ```
 
@@ -48,8 +49,7 @@ kind: Ingress
 metadata:
   name: proxy-from-k8s-to-mockbin
   annotations:
-    request-transformer.plugin.konghq.com: |
-      transform-request-to-mockbin
+    plugins.konghq.com: transform-request-to-mockbin
 spec:
   rules:
   - host: foo.bar
@@ -120,6 +120,7 @@ apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
   name: jwt
+plugin: jwt
 " | kubectl create -f -
 ```
 9. Update the ingress with a reference to the JWT plugin:
@@ -133,9 +134,7 @@ kind: Ingress
 metadata:
   name: proxy-from-k8s-to-mockbin
   annotations:
-    jwt.plugin.konghq.com: jwt
-    request-transformer.plugin.konghq.com: |
-      transform-request-to-mockbin
+    jwt.plugin.konghq.com: transform-request-to-mockbin, jwt
 spec:
   rules:
   - host: foo.bar

--- a/docs/ingress-class.md
+++ b/docs/ingress-class.md
@@ -20,7 +20,7 @@ On the other hand, an annotation such as
 metadata:
   name: foo
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 ```
 
 will target Kong Ingress controller, forcing the GCE controller to ignore it.
@@ -29,8 +29,15 @@ __Note__: Deploying multiple ingress controller and not specifying the
 annotation will cause both controllers fighting to satisfy the Ingress
 and will lead to unknown behaviour.
 
-If you're running multiple ingress controllers, or running on a cloud provider that handles ingress, you need to specify the annotation `kubernetes.io/ingress.class: "nginx"` in all ingresses you would like this controller to claim. This mechanism also provides users the ability to run _multiple_ Kong ingress controllers (e.g. one which serves public traffic, one which serves "internal" traffic).
-When using this functionality the option `--ingress-class` should set a value unique for the cluster. Here is a partial example:
+If you're running multiple ingress controllers, or running on a
+cloud provider that handles ingress,
+you need to specify the annotation `kubernetes.io/ingress.class: "kong"`
+in all ingresses you would like this controller to claim.
+This mechanism also provides users the ability to run _multiple_
+Kong ingress controllers (e.g. one which serves public traffic,
+and another serving "internal" traffic).
+When using this functionality the option `--ingress-class`
+should set a value unique for the cluster. Here is a partial example:
 
 ```yaml
 spec:
@@ -44,5 +51,7 @@ spec:
              - '--ingress-class=kong-internal'
 ```
 
-Not specifying the annotation will lead to multiple ingress controllers claiming the same ingress.
-Setting a value which does not match the class of any existing ingress controllers will cause all ingress controllers ignoring the ingress.
+Not specifying the annotation will lead to multiple ingress controllers
+claiming the same ingress.
+Setting a value which does not match the class of any existing ingress
+controllers will cause all ingress controllers ignoring the ingress.

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -763,6 +763,7 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 				Protocols: []*string{kong.String("http"), kong.String("https")}, // default
 				Service:   &kong.Service{ID: svc.ID},
 				StripPath: kong.Bool(false),
+				PreserveHost: kong.Bool(true),
 			}
 			if server.Hostname != "_" {
 				r.Hosts = []*string{kong.String(server.Hostname)}

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -759,10 +759,10 @@ func (n *NGINXController) syncRoutes(ingressCfg *ingress.Configuration) (bool, e
 			}
 
 			r := &kong.Route{
-				Paths:     []*string{&location.Path},
-				Protocols: []*string{kong.String("http"), kong.String("https")}, // default
-				Service:   &kong.Service{ID: svc.ID},
-				StripPath: kong.Bool(false),
+				Paths:        []*string{&location.Path},
+				Protocols:    []*string{kong.String("http"), kong.String("https")}, // default
+				Service:      &kong.Service{ID: svc.ID},
+				StripPath:    kong.Bool(false),
 				PreserveHost: kong.Bool(true),
 			}
 			if server.Hostname != "_" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Currently it's impossible as far as I know to integrate with cert-manager due to the default value of PreserveHost being false.
By changing the default to true we align with the nginx ingress controller and enable seamless integration with cert-manager.

**Which issue this PR fixes**:
This PR doesn't fix any open issues, but here are some references to the discussion:
#162 
#163 
jetstack/cert-manager#958


**Special notes for your reviewer**:

I realise this may not be the ideal long term solution for this and it has been discussed in #162 that a default KongIngress resource would be a good solution.
Also cert-manager is exploring an ingress template solution in jetstack/cert-manager#1097.
However this is such a small change to enable interoperability in the mean time that I thought it worth proposing the pull request.