### PR TITLE
fix: --update-state=false cause panic

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -105,7 +105,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 		return nil
 	}
 
-	if !n.syncStatus.IsLeader() {
+	if !n.elector.IsLeader() {
 		glog.V(2).Infof("skipping synchronization of configuration because I am not the leader.")
 		return nil
 	}

--- a/internal/ingress/controller/run.go
+++ b/internal/ingress/controller/run.go
@@ -28,6 +28,7 @@ import (
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/filesystem"
@@ -35,6 +36,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations/class"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller/store"
+	"github.com/kong/kubernetes-ingress-controller/internal/ingress/election"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/status"
 	"github.com/kong/kubernetes-ingress-controller/internal/task"
 )
@@ -79,6 +81,13 @@ func NewNGINXController(config *Configuration) *NGINXController {
 
 	n.syncQueue = task.NewTaskQueue(n.syncIngress)
 
+	electionConfig := election.Config{
+		Client:              config.KubeClient,
+		ElectionID:          config.ElectionID,
+		IngressClass:        class.IngressClass,
+		DefaultIngressClass: class.DefaultClass,
+	}
+
 	if config.UpdateStatus {
 		n.syncStatus = status.NewStatusSyncer(status.Config{
 			Client:                 config.KubeClient,
@@ -94,9 +103,24 @@ func NewNGINXController(config *Configuration) *NGINXController {
 				n.syncQueue.Enqueue(&extensions.Ingress{})
 			},
 		})
+		electionConfig.Callbacks = n.syncStatus.Callbacks()
 	} else {
 		glog.Warning("Update of ingress status is disabled (flag --update-status=false was specified)")
+
+		electionConfig.Callbacks = leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(stop <-chan struct{}) {
+				glog.V(2).Infof("I am the new status update leader")
+			},
+			OnStoppedLeading: func() {
+				glog.V(2).Infof("I am not status update leader anymore")
+			},
+			OnNewLeader: func(identity string) {
+				glog.Infof("new leader elected: %v", identity)
+			},
+		}
 	}
+
+	n.elector = election.NewElector(electionConfig)
 
 	return n
 }
@@ -110,6 +134,8 @@ type NGINXController struct {
 	syncQueue *task.Queue
 
 	syncStatus status.Sync
+
+	elector election.Elector
 
 	syncRateLimiter flowcontrol.RateLimiter
 
@@ -139,6 +165,8 @@ func (n *NGINXController) Start() {
 	glog.Infof("starting Ingress controller")
 
 	n.store.Run(n.stopCh)
+
+	go n.elector.Run()
 
 	if n.syncStatus != nil {
 		go n.syncStatus.Run()
@@ -187,7 +215,7 @@ func (n *NGINXController) Stop() error {
 	close(n.stopCh)
 	go n.syncQueue.Shutdown()
 	if n.syncStatus != nil {
-		n.syncStatus.Shutdown()
+		n.syncStatus.Shutdown(n.elector.IsLeader())
 	}
 
 	return nil

--- a/internal/ingress/election/election.go
+++ b/internal/ingress/election/election.go
@@ -1,0 +1,98 @@
+package election
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+	"github.com/kong/kubernetes-ingress-controller/internal/k8s"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+)
+
+type Elector interface {
+	Run()
+	IsLeader() bool
+}
+
+type Config struct {
+	Client              clientset.Interface
+	ElectionID          string
+	IngressClass        string
+	DefaultIngressClass string
+	Callbacks           leaderelection.LeaderCallbacks
+}
+
+type electorStatus struct {
+	Config
+	electionID string
+	elector    *leaderelection.LeaderElector
+}
+
+func (e electorStatus) Run() {
+	e.elector.Run()
+}
+
+func (e electorStatus) IsLeader() bool {
+	return e.elector.IsLeader()
+}
+
+func NewElector(config Config) Elector {
+	pod, err := k8s.GetPodDetails(config.Client)
+	if err != nil {
+		glog.Fatalf("unexpected error obtaining pod information: %v", err)
+	}
+
+	es := electorStatus{
+		Config: config,
+	}
+
+	// we need to use the defined ingress class to allow multiple leaders
+	// in order to update information about ingress status
+	electionID := fmt.Sprintf("%v-%v", config.ElectionID, config.DefaultIngressClass)
+	if config.IngressClass != "" {
+		electionID = fmt.Sprintf("%v-%v", config.ElectionID, config.IngressClass)
+	}
+
+	es.electionID = electionID
+
+	broadcaster := record.NewBroadcaster()
+	hostname, _ := os.Hostname()
+
+	recorder := broadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{
+		Component: "ingress-leader-elector",
+		Host:      hostname,
+	})
+
+	lock := resourcelock.ConfigMapLock{
+		ConfigMapMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: electionID},
+		Client:        config.Client.CoreV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity:      pod.Name,
+			EventRecorder: recorder,
+		},
+	}
+
+	ttl := 30 * time.Second
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          &lock,
+		LeaseDuration: ttl,
+		RenewDeadline: ttl / 2,
+		RetryPeriod:   ttl / 4,
+		Callbacks:     config.Callbacks,
+	})
+
+	if err != nil {
+		glog.Fatalf("unexpected error starting leader election: %v", err)
+	}
+
+	es.elector = le
+	return es
+}

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -19,7 +19,6 @@ package status
 import (
 	"fmt"
 	"net"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -34,10 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
 
 	"github.com/kong/kubernetes-ingress-controller/internal/k8s"
@@ -51,9 +47,9 @@ const (
 // Sync ...
 type Sync interface {
 	Run()
-	Shutdown()
+	Shutdown(l bool)
 
-	IsLeader() bool
+	Callbacks() leaderelection.LeaderCallbacks
 }
 
 type ingressLister interface {
@@ -94,28 +90,26 @@ type statusSync struct {
 	pod *k8s.PodInfo
 
 	electionID string
-	elector    *leaderelection.LeaderElector
 	// workqueue used to keep in sync the status IP/s
 	// in the Ingress rules
 	syncQueue *task.Queue
+	callbacks leaderelection.LeaderCallbacks
 }
 
 // Run starts the loop to keep the status in sync
 func (s statusSync) Run() {
-	s.elector.Run()
 }
 
-// IsLeader returns if it is the current leader
-func (s statusSync) IsLeader() bool {
-	return s.elector.IsLeader()
+func (s statusSync) Callbacks() leaderelection.LeaderCallbacks {
+	return s.callbacks
 }
 
 // Shutdown stop the sync. In case the instance is the leader it will remove the current IP
 // if there is no other instances running.
-func (s statusSync) Shutdown() {
+func (s statusSync) Shutdown(isLeader bool) {
 	go s.syncQueue.Shutdown()
 	// remove IP from Ingress
-	if !s.elector.IsLeader() {
+	if !isLeader {
 		return
 	}
 
@@ -197,7 +191,7 @@ func NewStatusSyncer(config Config) Sync {
 
 	st.electionID = electionID
 
-	callbacks := leaderelection.LeaderCallbacks{
+	st.callbacks = leaderelection.LeaderCallbacks{
 		OnStartedLeading: func(stop <-chan struct{}) {
 			glog.V(2).Infof("I am the new status update leader")
 			if st.Config.OnStartedLeading != nil {
@@ -218,37 +212,6 @@ func NewStatusSyncer(config Config) Sync {
 		},
 	}
 
-	broadcaster := record.NewBroadcaster()
-	hostname, _ := os.Hostname()
-
-	recorder := broadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{
-		Component: "ingress-leader-elector",
-		Host:      hostname,
-	})
-
-	lock := resourcelock.ConfigMapLock{
-		ConfigMapMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: electionID},
-		Client:        config.Client.CoreV1(),
-		LockConfig: resourcelock.ResourceLockConfig{
-			Identity:      pod.Name,
-			EventRecorder: recorder,
-		},
-	}
-
-	ttl := 30 * time.Second
-	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
-		Lock:          &lock,
-		LeaseDuration: ttl,
-		RenewDeadline: ttl / 2,
-		RetryPeriod:   ttl / 4,
-		Callbacks:     callbacks,
-	})
-
-	if err != nil {
-		glog.Fatalf("unexpected error starting leader election: %v", err)
-	}
-
-	st.elector = le
 	return st
 }
 

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -318,7 +318,7 @@ func TestStatusActions(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// execute shutdown
-	fk.Shutdown()
+	fk.Shutdown(true)
 	// ingress should be empty
 	newIPs2 := []apiv1.LoadBalancerIngress{}
 	fooIngress2, err2 := fk.Client.ExtensionsV1beta1().Ingresses(apiv1.NamespaceDefault).Get("foo_ingress_1", metav1.GetOptions{})


### PR DESCRIPTION
Signed-off-by: lijiaocn <lijiaocn@foxmail.com>
(cherry picked from commit 8e7e4df6a9d1fedcd69ded6e0ded475f9d8217a7)

**What this PR does / why we need it**:  

Separate "Leader election" from statusSync (internal/ingress/status/status.go). 
This  imports an independent electoral mechanism and fix bug #232 at the same time.

**Which issue this PR fixes** *: 

fixes #232

**Special notes for your reviewer**:
