### PR TITLE
[Docs] Fix wrong values for ingress class in azure ingress deployment docs

### DIFF
--- a/docs/deployment/aks.md
+++ b/docs/deployment/aks.md
@@ -97,7 +97,7 @@ IP address to the `kong-proxy` Service so please be patient.
     name: dummy
     namespace:  dummy
     annotations:
-      kubernetes.io/ingress.class: "nginx"
+      kubernetes.io/ingress.class: "kong"
   spec:
     rules:
       - host:
@@ -134,7 +134,7 @@ metadata:
   name: kong-admin
   namespace:  kong
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: dummy.kong.example


### PR DESCRIPTION
Signed-off-by: cbrgm <chris@cbrgm.net>

**What this PR does / why we need it**:

The `kubernetes.io/ingress.class` value in the example for the ingress deployment on Azure has a wrong value. This must be `kong` and not `nginx`. I had to debug for a long time until I found the error. Hopefully others won't have the problem in the future.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

none

**Special notes for your reviewer**:

none