### PR TITLE
External kong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ TAG?=0.3.0
 REGISTRY?=kong-docker-kubernetes-ingress-controller.bintray.io
 GOOS?=linux
 DOCKER?=docker
+DOCKER_BUILD_EXTRA?=
 SED_I?=sed -i
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 
@@ -114,7 +115,7 @@ else
 	$(SED_I) "s/CROSS_BUILD_//g" $(DOCKERFILE)
 endif
 
-	$(DOCKER) build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)/rootfs
+	$(DOCKER) build -t $(MULTI_ARCH_IMG):$(TAG) $(DOCKER_BUILD_EXTRA) $(TEMP_DIR)/rootfs
 
 ifeq ($(ARCH), amd64)
 	# This is for to maintain the backward compatibility

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -78,6 +78,8 @@ Kubernetes cluster and local discovery is attempted.`)
 
 		profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
+		kongOutsideKubernetes = flags.Bool("kong-outside-kubernetes", false, `Kong lives outside the kubernetes cluster`)
+
 		updateStatus = flags.Bool("update-status", true, `Indicates if the
 		ingress controller should update the Ingress status IP/hostname. Default is true`)
 
@@ -158,6 +160,7 @@ The controller will set the endpoint records on the ingress using this address.`
 		UpdateStatus:           *updateStatus,
 		ElectionID:             *electionID,
 		EnableProfiling:        *profiling,
+		KongOutsideKubernetes:  *kongOutsideKubernetes,
 		ResyncPeriod:           *resyncPeriod,
 		DefaultService:         *defaultSvc,
 		Namespace:              *watchNamespace,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 
 	apiv1 "k8s.io/api/core/v1"
-	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -140,7 +139,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 }
 
 // getEndpoints returns a list of <endpoint ip>:<port> for a given service/target port combination.
-func (n *NGINXController) getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Protocol) []ingress.Endpoint {
+func (n *NGINXController) getEndpoints(s *apiv1.Service, port *apiv1.ServicePort, proto apiv1.Protocol) []ingress.Endpoint {
 	if n.cfg.KongOutsideKubernetes && port.NodePort != 0 {
 		return getEndpointsForExternalKong(s, port, n.store.ListNodeAddresses)
 	} else {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -141,7 +141,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 
 // getEndpoints returns a list of <endpoint ip>:<port> for a given service/target port combination.
 func (n *NGINXController) getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Protocol) []ingress.Endpoint {
-	if n.cfg.KongOutsideKubernetes {
+	if n.cfg.KongOutsideKubernetes && port.NodePort != 0 {
 		return getEndpointsForExternalKong(s, port, n.store.ListNodeAddresses)
 	} else {
 		return getEndpoints(s, port, proto, n.store.GetServiceEndpoints)

--- a/internal/ingress/controller/endpoints.go
+++ b/internal/ingress/controller/endpoints.go
@@ -27,6 +27,20 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress"
 )
 
+func getEndpointsForExternalKong(s *corev1.Service, port *corev1.ServicePort, getNodeAddresses func() []string) []ingress.Endpoint {
+	var result []ingress.Endpoint
+	if port.NodePort != 0 {
+		addresses := getNodeAddresses()
+		for _, address := range addresses {
+			result = append(result, ingress.Endpoint{
+				Address: address,
+				Port:    fmt.Sprintf("%v", port.NodePort),
+			})
+		}
+	}
+	return result
+}
+
 // getEndpoints returns a list of <endpoint ip>:<port> for a given service/target port combination.
 func getEndpoints(
 	s *corev1.Service,

--- a/internal/ingress/controller/store/node.go
+++ b/internal/ingress/controller/store/node.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NodeLister makes a Store that lists Nodes.
+type NodeLister struct {
+	cache.Store
+}
+
+// ByKey searches for a Node in the local secrets Store
+func (nl *NodeLister) ByKey(key string) (*apiv1.Node, error) {
+	n, exists, err := nl.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("Node %v was not found", key)
+	}
+	return n.(*apiv1.Node), nil
+}
+
+// GetNodes returns all nodes
+func (nl *NodeLister) GetNodes() ([]*apiv1.Node, error) {
+	var result []*apiv1.Node
+	for _, n := range nl.List() {
+		node, ok := n.(*apiv1.Node)
+		if ok {
+			result = append(result, node)
+		}
+	}
+	return result, nil
+}

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -382,7 +382,7 @@ func New(namespace string, configmap, tcp, udp, defaultSSLCertificate string,
 	store.listers.Service.Store = store.informers.Service.GetStore()
 
 	store.informers.Node = infFactory.Core().V1().Nodes().Informer()
-	store.listers.Node.Store = store.informers.Service.GetStore()
+	store.listers.Node.Store = store.informers.Node.GetStore()
 
 	store.informers.Ingress.AddEventHandler(ingEventHandler)
 	store.informers.Endpoint.AddEventHandler(epEventHandler)


### PR DESCRIPTION
**What this PR does / why we need it**:
https://discuss.konghq.com/t/feature-request-ingress-controller-to-support-kong-which-lives-outside-the-kubernetes-cluster/3218

**Special notes for your reviewer**:
This change adds a feature to support external kong servers. This feature is turned off by default.
I have created [a dedicated helm chart](https://github.com/trentzhou/external-kong-ingress-controller) to deploy the modified ingress controller. 

