### PR TITLE
feat: drop --default-backend-service CLI flag

### DIFF
--- a/cli/ingress-controller/flag_test.go
+++ b/cli/ingress-controller/flag_test.go
@@ -36,7 +36,7 @@ func TestDefaults(t *testing.T) {
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"cmd", "--default-backend-service", "namespace/test"}
+	os.Args = []string{"cmd", "--publish-service", "namespace/test"}
 
 	showVersion, conf, err := parseFlags()
 	if err != nil {

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -19,7 +19,6 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -57,11 +56,6 @@ protocol://address:port, e.g., "http://localhost:8080.
 If not specified, the assumption is that the binary runs inside a 
 Kubernetes cluster and local discovery is attempted.`)
 		kubeConfigFile = flags.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
-
-		defaultSvc = flags.String("default-backend-service", "",
-			`Service used to serve a 404 page for the default backend. Takes the form
-		namespace/name. The controller uses the first node port of this Service for
-		the default backend.`)
 
 		ingressClass = flags.String("ingress-class", "",
 			`Name of the ingress class to route through this controller.`)
@@ -130,10 +124,6 @@ The controller will set the endpoint records on the ingress using this address.`
 		return true, nil, nil
 	}
 
-	if *defaultSvc == "" {
-		return false, nil, fmt.Errorf("Please specify --default-backend-service")
-	}
-
 	if *ingressClass != "" {
 		glog.Infof("Watching for ingress class: %s", *ingressClass)
 
@@ -159,7 +149,6 @@ The controller will set the endpoint records on the ingress using this address.`
 		ElectionID:             *electionID,
 		EnableProfiling:        *profiling,
 		ResyncPeriod:           *resyncPeriod,
-		DefaultService:         *defaultSvc,
 		Namespace:              *watchNamespace,
 		PublishService:         *publishSvc,
 		PublishStatusAddress:   *publishStatusAddress,

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -27,7 +27,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -75,25 +74,11 @@ func main() {
 	pluginintscheme.AddToScheme(scheme.Scheme)
 	consumerintscheme.AddToScheme(scheme.Scheme)
 
-	ns, name, err := k8s.ParseNameNS(conf.DefaultService)
-	if err != nil {
-		glog.Fatal(err)
-	}
-
-	_, err = kubeClient.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
-	if err != nil {
-		if strings.Contains(err.Error(), "cannot get services in the namespace") {
-			glog.Fatalf("✖ It seems the cluster it is running with Authorization enabled (like RBAC) and there is no permissions for the ingress controller. Please check the configuration")
-		}
-		glog.Fatalf("no service with name %v found: %v", conf.DefaultService, err)
-	}
-	glog.Infof("validated %v as the default backend", conf.DefaultService)
-
 	if conf.PublishService == "" {
 		glog.Fatal("flag --publish-address is mandatory")
 	}
 
-	ns, name, err = k8s.ParseNameNS(conf.PublishService)
+	ns, name, err := k8s.ParseNameNS(conf.PublishService)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -62,8 +62,6 @@ type Configuration struct {
 
 	ResyncPeriod time.Duration
 
-	DefaultService string
-
 	Namespace string
 
 	DefaultHealthzURL     string


### PR DESCRIPTION
The flag comes in from the era of NGINX ingress controller.

The default service is selected from the Ingress rules if any of the
Ingress rules contain a backend at the root level, meaning a service
which is the fallback is none of the Ingress rules actually match.

While this flag was present, it is not being used anywhere in the
codebase and will not be used in future.

This is a breaking change and users are advised to update their
YAML deployments to remove the flag, else the controller will fail to
boot up.