### PR TITLE
fix(deploy) fix dbless yaml with correct labels

### DIFF
--- a/deploy/manifests/kong-ingress-dbless.yaml
+++ b/deploy/manifests/kong-ingress-dbless.yaml
@@ -41,13 +41,13 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: ingress-kong
+    app: kong
   name: ingress-kong
   namespace: kong
 spec:
   selector:
     matchLabels:
-      app: ingress-kong
+      app: kong
   strategy:
     rollingUpdate:
       maxSurge: 3
@@ -59,7 +59,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
       labels:
-        app: ingress-kong
+        app: kong
     spec:
       serviceAccountName: kong-serviceaccount
       containers:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -458,13 +458,13 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: ingress-kong
+    app: kong
   name: ingress-kong
   namespace: kong
 spec:
   selector:
     matchLabels:
-      app: ingress-kong
+      app: kong
   strategy:
     rollingUpdate:
       maxSurge: 3
@@ -476,7 +476,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
       labels:
-        app: ingress-kong
+        app: kong
     spec:
       serviceAccountName: kong-serviceaccount
       containers:


### PR DESCRIPTION
Fix the deployment labels to be app=kong so that it will be
matched with kong-proxy service
