### PR TITLE
feat(deploy) introduce a preStop hook for graceful shutdown of Kong

### DIFF
--- a/deploy/manifests/kong-ingress-dbless.yaml
+++ b/deploy/manifests/kong-ingress-dbless.yaml
@@ -76,6 +76,10 @@ spec:
           value: /dev/stderr
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sh", "-c", "kong quit" ]
         ports:
         - name: proxy
           containerPort: 8000

--- a/deploy/manifests/kong.yaml
+++ b/deploy/manifests/kong.yaml
@@ -58,5 +58,8 @@ spec:
         - name: proxy-ssl
           containerPort: 8443
           protocol: TCP
-
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sh", "-c", "kong quit" ]
 ---

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -493,6 +493,10 @@ spec:
           value: /dev/stderr
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sh", "-c", "kong quit" ]
         ports:
         - name: proxy
           containerPort: 8000

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -704,7 +704,10 @@ spec:
         - name: proxy-ssl
           containerPort: 8443
           protocol: TCP
-
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sh", "-c", "kong quit" ]
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
k8s sends SIGTERM to the containers to terminate which results in nginx
dropping requests.

This ensures that nginx gets a SIGQUIT to gracefully shutdown before
getting a SIGTERM.