### PR TITLE
feat(deploy) drop Role and RoleBinding resources

### DIFF
--- a/deploy/manifests/rbac.yaml
+++ b/deploy/manifests/rbac.yaml
@@ -1,12 +1,9 @@
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kong-serviceaccount
   namespace: kong
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -68,24 +65,6 @@ rules:
   - get
   - list
   - watch
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: kong-ingress-role
-  namespace: kong
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - secrets
-  - namespaces
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:
@@ -97,39 +76,10 @@ rules:
   # when launching the kong-ingress-controller.
   - "ingress-controller-leader-kong"
   verbs:
+  - create
   - get
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: kong-ingress-role-nisa-binding
-  namespace: kong
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: kong-ingress-role
-subjects:
-- kind: ServiceAccount
-  name: kong-serviceaccount
-  namespace: kong
-
----
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -142,5 +92,4 @@ subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
   namespace: kong
-
 ---

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -269,15 +269,12 @@ spec:
                     unhealthy: *unhealthy
 
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kong-serviceaccount
   namespace: kong
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -339,24 +336,6 @@ rules:
   - get
   - list
   - watch
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: kong-ingress-role
-  namespace: kong
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - secrets
-  - namespaces
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:
@@ -368,39 +347,10 @@ rules:
   # when launching the kong-ingress-controller.
   - "ingress-controller-leader-kong"
   verbs:
+  - create
   - get
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: kong-ingress-role-nisa-binding
-  namespace: kong
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: kong-ingress-role
-subjects:
-- kind: ServiceAccount
-  name: kong-serviceaccount
-  namespace: kong
-
----
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -413,7 +363,6 @@ subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
   namespace: kong
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -334,15 +334,12 @@ spec:
           storage: 1Gi
 
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kong-serviceaccount
   namespace: kong
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -404,24 +401,6 @@ rules:
   - get
   - list
   - watch
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: kong-ingress-role
-  namespace: kong
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - secrets
-  - namespaces
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:
@@ -433,39 +412,10 @@ rules:
   # when launching the kong-ingress-controller.
   - "ingress-controller-leader-kong"
   verbs:
+  - create
   - get
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: kong-ingress-role-nisa-binding
-  namespace: kong
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: kong-ingress-role
-subjects:
-- kind: ServiceAccount
-  name: kong-serviceaccount
-  namespace: kong
-
----
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -478,7 +428,6 @@ subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
   namespace: kong
-
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Role and RoleBinding resources are not needed if all ClusterRole
resource grants accesses to those resources at cluster level.

The ConfigMap resource used for leader election is now allowed
permission at the cluster level which shouldn't be a problem for most
installations.