### PR TITLE
fix: ensure multiple certs are created

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -268,7 +268,7 @@ func (n *KongController) toDeckKongState(k8sState *parser.KongState) (*state.Kon
 
 	for _, c := range k8sState.Certificates {
 		cert := state.Certificate{Certificate: c.Certificate}
-		c.ID = kong.String("placeholder-" +
+		cert.ID = kong.String("placeholder-" +
 			strconv.FormatUint(count.Inc(), 10))
 		err := targetState.Certificates.Add(cert)
 		if err != nil {


### PR DESCRIPTION
Not assigning a certificate ID to the cert being added to deck's
target state results in only the most recently updated cert to be
persisted in Kong.

While we fix this issue by correcting the typo, we are not able to add a
unit or integration test at this point. This is being addressed with the
on-going work to refactor parser and store out of the controller logic
and also with integration tests and simpler API in deck for using deck
as a library.

Fix #285