### PR TITLE
Tests/fake store

### DIFF
--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -475,7 +475,7 @@ func TestGetEndpoints(t *testing.T) {
 		svc    *corev1.Service
 		port   *corev1.ServicePort
 		proto  corev1.Protocol
-		fn     func(*corev1.Service) (*corev1.Endpoints, error)
+		fn     func(string, string) (*corev1.Endpoints, error)
 		result []utils.Endpoint
 	}{
 		{
@@ -483,7 +483,7 @@ func TestGetEndpoints(t *testing.T) {
 			nil,
 			nil,
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return nil, nil
 			},
 			[]utils.Endpoint{},
@@ -493,7 +493,7 @@ func TestGetEndpoints(t *testing.T) {
 			&corev1.Service{},
 			nil,
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return nil, nil
 			},
 			[]utils.Endpoint{},
@@ -503,7 +503,7 @@ func TestGetEndpoints(t *testing.T) {
 			&corev1.Service{},
 			&corev1.ServicePort{Name: "default"},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]utils.Endpoint{},
@@ -517,7 +517,7 @@ func TestGetEndpoints(t *testing.T) {
 			},
 			&corev1.ServicePort{Name: "default"},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]utils.Endpoint{},
@@ -541,7 +541,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]utils.Endpoint{
@@ -570,7 +570,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				return nil, fmt.Errorf("unexpected error")
 			},
 			[]utils.Endpoint{},
@@ -594,7 +594,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -635,7 +635,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -676,7 +676,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -719,7 +719,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromInt(80),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -767,7 +767,7 @@ func TestGetEndpoints(t *testing.T) {
 				TargetPort: intstr.FromString("port-1"),
 			},
 			corev1.ProtocolTCP,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string, string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"reflect"
+
+	configurationv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
+	apiv1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func keyFunc(obj interface{}) (string, error) {
+	v := reflect.Indirect(reflect.ValueOf(obj))
+	name := v.FieldByName("Name")
+	namespace := v.FieldByName("Namespace")
+	return namespace.String() + "/" + name.String(), nil
+}
+
+// FakeObjects can be used to populate a fake Store.
+type FakeObjects struct {
+	Ingresses       []*extensions.Ingress
+	Services        []*apiv1.Service
+	Endpoints       []*apiv1.Endpoints
+	Secrets         []*apiv1.Secret
+	KongPlugins     []*configurationv1.KongPlugin
+	KongIngresses   []*configurationv1.KongIngress
+	KongConsumers   []*configurationv1.KongConsumer
+	KongCredentials []*configurationv1.KongCredential
+}
+
+// NewFakeStore creates a store backed by the objects passed in as arguments.
+func NewFakeStore(
+	objects FakeObjects) (Storer, error) {
+	var s Storer
+
+	ingressStore := cache.NewStore(keyFunc)
+	for _, ingress := range objects.Ingresses {
+		err := ingressStore.Add(ingress)
+		if err != nil {
+			return nil, err
+		}
+	}
+	serviceStore := cache.NewStore(keyFunc)
+	for _, s := range objects.Services {
+		err := serviceStore.Add(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	secretsStore := cache.NewStore(keyFunc)
+	for _, s := range objects.Secrets {
+		err := secretsStore.Add(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	endpointStore := cache.NewStore(keyFunc)
+	for _, e := range objects.Endpoints {
+		err := endpointStore.Add(e)
+		if err != nil {
+			return nil, err
+		}
+	}
+	kongIngressStore := cache.NewStore(keyFunc)
+	for _, k := range objects.KongIngresses {
+		err := kongIngressStore.Add(k)
+		if err != nil {
+			return nil, err
+		}
+	}
+	consumerStore := cache.NewStore(keyFunc)
+	for _, c := range objects.KongConsumers {
+		err := consumerStore.Add(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+	kongCredentialsStore := cache.NewStore(keyFunc)
+	for _, c := range objects.KongCredentials {
+		err := kongCredentialsStore.Add(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+	kongPluginsStore := cache.NewStore(keyFunc)
+	for _, p := range objects.KongPlugins {
+		err := kongPluginsStore.Add(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	s = Store{
+		stores: CacheStores{
+			Ingress:  ingressStore,
+			Service:  serviceStore,
+			Endpoint: endpointStore,
+			Secret:   secretsStore,
+
+			Plugin:        kongPluginsStore,
+			Consumer:      consumerStore,
+			Credential:    kongCredentialsStore,
+			Configuration: kongIngressStore,
+		},
+		isValidIngresClass: annotations.IngressClassValidatorFuncFromObjectMeta("kong"),
+	}
+	return s, nil
+}

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -1,0 +1,348 @@
+package store
+
+import (
+	"testing"
+
+	configurationv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_keyFunc(t *testing.T) {
+	type args struct {
+		obj interface{}
+	}
+
+	type F struct {
+		Name      string
+		Namespace string
+	}
+	type B struct {
+		F
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			want: "Bar/Foo",
+			args: args{
+				obj: &F{
+					Name:      "Foo",
+					Namespace: "Bar",
+				},
+			},
+		},
+		{
+			want: "Bar/Fu",
+			args: args{
+				obj: B{
+					F: F{
+
+						Name:      "Fu",
+						Namespace: "Bar",
+					},
+				},
+			},
+		},
+		{
+			want: "default/foo",
+			args: args{
+				obj: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := keyFunc(tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("keyFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("keyFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFakeStoreEmpty(t *testing.T) {
+	assert := assert.New(t)
+	store, err := NewFakeStore(FakeObjects{})
+	assert.Nil(err)
+	assert.NotNil(store)
+}
+
+func TestFakeStoreIngress(t *testing.T) {
+	assert := assert.New(t)
+
+	ingresses := []*extensions.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: extensions.IngressRuleValue{
+							HTTP: &extensions.HTTPIngressRuleValue{
+								Paths: []extensions.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: extensions.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "not-kong",
+				},
+			},
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: extensions.IngressRuleValue{
+							HTTP: &extensions.HTTPIngressRuleValue{
+								Paths: []extensions.HTTPIngressPath{
+									{
+										Path: "/bar",
+										Backend: extensions.IngressBackend{
+											ServiceName: "bar-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{Ingresses: ingresses})
+	assert.Nil(err)
+	assert.NotNil(store)
+	assert.Len(store.ListIngresses(), 1)
+}
+
+func TestFakeStoreService(t *testing.T) {
+	assert := assert.New(t)
+
+	services := []*apiv1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{Services: services})
+	assert.Nil(err)
+	assert.NotNil(store)
+	service, err := store.GetService("default", "foo")
+	assert.NotNil(service)
+	assert.Nil(err)
+
+	service, err = store.GetService("default", "does-not-exists")
+	assert.NotNil(err)
+	assert.Nil(service)
+}
+
+func TestFakeStoreEndpiont(t *testing.T) {
+	assert := assert.New(t)
+
+	endpoints := []*apiv1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{Endpoints: endpoints})
+	assert.Nil(err)
+	assert.NotNil(store)
+	c, err := store.GetEndpointsForService("default", "foo")
+	assert.Nil(err)
+	assert.NotNil(c)
+
+	c, err = store.GetEndpointsForService("default", "does-not-exist")
+	assert.NotNil(err)
+	assert.Nil(c)
+}
+
+func TestFakeStoreConsumer(t *testing.T) {
+	assert := assert.New(t)
+
+	consumers := []*configurationv1.KongConsumer{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{KongConsumers: consumers})
+	assert.Nil(err)
+	assert.NotNil(store)
+	assert.Len(store.ListKongConsumers(), 1)
+	c, err := store.GetKongConsumer("default", "foo")
+	assert.Nil(err)
+	assert.NotNil(c)
+
+	c, err = store.GetKongConsumer("default", "does-not-exist")
+	assert.Nil(c)
+	assert.NotNil(err)
+}
+
+func TestFakeStorePlugins(t *testing.T) {
+	assert := assert.New(t)
+
+	plugins := []*configurationv1.KongPlugin{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{KongPlugins: plugins})
+	assert.Nil(err)
+	assert.NotNil(store)
+	plugins, err = store.ListGlobalKongPlugins()
+	assert.Len(plugins, 0)
+
+	plugins = []*configurationv1.KongPlugin{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+				Labels: map[string]string{
+					"global": "true",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Labels: map[string]string{
+					"global": "true",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "baz",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err = NewFakeStore(FakeObjects{KongPlugins: plugins})
+	assert.Nil(err)
+	assert.NotNil(store)
+	plugins, err = store.ListGlobalKongPlugins()
+	assert.Len(plugins, 2)
+
+	plugin, err := store.GetKongPlugin("default", "bar")
+	assert.NotNil(plugin)
+	assert.Nil(err)
+
+	plugin, err = store.GetKongPlugin("default", "does-not-exist")
+	assert.NotNil(err)
+	assert.Nil(plugin)
+}
+
+func TestFakeStoreCredentials(t *testing.T) {
+	assert := assert.New(t)
+
+	credentials := []*configurationv1.KongCredential{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "baz",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{KongCredentials: credentials})
+	assert.Nil(err)
+	assert.NotNil(store)
+	credentials = store.ListKongCredentials()
+	assert.Len(credentials, 2)
+}
+
+func TestFakeStoreSecret(t *testing.T) {
+	assert := assert.New(t)
+
+	secrets := []*apiv1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{Secrets: secrets})
+	assert.Nil(err)
+	assert.NotNil(store)
+	secret, err := store.GetSecret("default", "foo")
+	assert.Nil(err)
+	assert.NotNil(secret)
+
+	secret, err = store.GetSecret("default", "does-not-exist")
+	assert.Nil(secret)
+	assert.NotNil(err)
+}
+
+func TestFakeKongIngress(t *testing.T) {
+	assert := assert.New(t)
+
+	kongIngresses := []*configurationv1.KongIngress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{KongIngresses: kongIngresses})
+	assert.Nil(err)
+	assert.NotNil(store)
+	kingress, err := store.GetKongIngress("default", "foo")
+	assert.Nil(err)
+	assert.NotNil(kingress)
+
+	kingress, err = store.GetKongIngress("default", "does-not-exist")
+	assert.NotNil(err)
+	assert.Nil(kingress)
+}


### PR DESCRIPTION
A fake store implementation to ease integration tests for the `parser` package.
This will also help in doing an integration test of the controller with Kong but without k8s.
Objective here is to avoid testing k8s and kong as much as possible and only have Go tests for speed and simplicity.