### PR TITLE
fix: add / when Path in an Ingress is empty

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -188,6 +188,9 @@ func (p *Parser) parseIngressRules(
 
 				isACMEChallenge := strings.HasPrefix(path, "/.well-known/acme-challenge/")
 
+				if path == "" {
+					path = "/"
+				}
 				r := Route{
 					Ingress: ingress,
 					Route: kong.Route{


### PR DESCRIPTION
Ingress spec allows for an Empty Path in the rules, this results in a
schema violation in Kong.
When an empty path is found, Ingress Controller will add a harmless `/`
to it to avoid this schema violation.

See #298