### PR TITLE
feat: implement consumer-level plugins

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -230,11 +230,11 @@ func (n *KongController) toDeckKongState(
 	}
 
 	for _, c := range k8sState.Consumers {
-		c := file.Consumer{Consumer: c.Consumer}
+		consumer := file.Consumer{Consumer: c.Consumer}
 		for _, p := range c.Plugins {
-			c.Plugins = append(c.Plugins, p)
+			consumer.Plugins = append(consumer.Plugins, &file.Plugin{Plugin: p})
 		}
-		content.Consumers = append(content.Consumers, c)
+		content.Consumers = append(content.Consumers, consumer)
 	}
 
 	content.Info.SelectorTags = n.getIngressControllerTags()

--- a/internal/ingress/controller/kong/dbless/kong_inmemory.go
+++ b/internal/ingress/controller/kong/dbless/kong_inmemory.go
@@ -139,11 +139,11 @@ func KongNativeState(k8sState *parser.KongState) *KongDeclarativeConfig {
 	}
 
 	for _, c := range k8sState.Consumers {
-		c := Consumer{Consumer: c.Consumer,
+		consumer := Consumer{Consumer: c.Consumer,
 			Plugins:     c.Plugins,
 			Credentials: c.Credentials,
 		}
-		result.Consumers = append(result.Consumers, c)
+		result.Consumers = append(result.Consumers, consumer)
 	}
 	return &result
 }


### PR DESCRIPTION
Consumer level plugins can be configured using plugins.konghq.com
annotation on the KongConsumer resource.

See #250 