### PR TITLE
feat: skip a sync call if config has not changed in dbless mode

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -215,7 +215,8 @@ type KongController struct {
 	updateCh *channels.RingChannel
 
 	// runningConfig contains the running configuration in the Backend
-	runningConfig *parser.KongState
+	runningConfig     *parser.KongState
+	runningConfigHash [32]byte
 
 	isShuttingDown bool
 


### PR DESCRIPTION
If the hash of the configuration is same, then it is safe to assume that
the configuration has not changed.
This is similar to `check_hash` feature that comes with Kong 1.2, only
that we avoid the API call itself.
