### PR TITLE
feat: implement Kong Enterprise workspace compatibility

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -100,6 +100,8 @@ The controller will set the endpoint records on the ingress using this address.`
 			"SNI name to use to verify the certificate presented by Kong in TLS.")
 		kongCACert = flag.String("admin-ca-cert-file", "",
 			"Path to PEM-encoded CA certificate file to verify the Kong's Admin SSL certificate.")
+		workspace = flag.String("kong-workspace", "",
+			"Workspace in Kong Enterprise to be configured")
 
 		kongHeaders headers
 	)
@@ -126,8 +128,9 @@ The controller will set the endpoint records on the ingress using this address.`
 
 	config := &controller.Configuration{
 		Kong: controller.Kong{
-			URL:     *kongURL,
-			Headers: kongHeaders,
+			URL:       *kongURL,
+			Headers:   kongHeaders,
+			Workspace: *workspace,
 
 			TLSServerName: *kongTLSServerName,
 			TLSSkipVerify: *kongTLSSkipVerify,

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -149,7 +149,7 @@ func main() {
 	kongConfiguration := root["configuration"].(map[string]interface{})
 	conf.Kong.Version = v
 	glog.Infof("Kong datastore: %s", kongConfiguration["database"].(string))
-	conf.Kong.Client = kongClient
+
 	if kongConfiguration["database"].(string) == "off" {
 		conf.Kong.InMemory = true
 	}
@@ -159,6 +159,15 @@ func main() {
 	if err == nil && res.StatusCode == 200 {
 		conf.Kong.HasTagSupport = true
 	}
+
+	// setup workspace in Kong Enterprise
+	if conf.Kong.Workspace != "" {
+		kongClient, err = kong.NewClient(kong.String(conf.Kong.URL+"/"+conf.Kong.Workspace), c)
+		if err != nil {
+			glog.Fatalf("Error creating Kong Rest client: %v", err)
+		}
+	}
+	conf.Kong.Client = kongClient
 
 	coreInformerFactory := informers.NewSharedInformerFactoryWithOptions(
 		kubeClient,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -57,6 +57,9 @@ type Kong struct {
 	InMemory      bool
 	HasTagSupport bool
 	Version       semver.Version
+
+	// Workspace is the Kong Enterprise workspace being synced.
+	Workspace string
 }
 
 // Configuration contains all the settings required by an Ingress controller


### PR DESCRIPTION
This commit adds the feature of configuring workspace to sync the
configuration to inside Kong Enterprise deployment model.

This opens up an array of possible deployment options for Kong
Enterprise:
- For each Ingress.class, configuration could be synced to separate
workspaces
- For each namespace, an Ingress Controller could be running, syncing
configuration of that particular namespace to a corresponding workspace
in Kong.