### PR TITLE
Support setting the Proxy Port in a KongIngress

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -398,6 +398,9 @@ func overrideService(service *Service,
 	if s.Protocol != nil {
 		service.Protocol = kong.String(*s.Protocol)
 	}
+	if s.Port != nil {
+		service.Port = kong.Int(*s.Port)
+	}
 	if s.Path != nil {
 		service.Path = kong.String(*s.Path)
 	}

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -390,6 +390,32 @@ func TestOverrideService(t *testing.T) {
 				},
 			},
 		},
+		{
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("http"),
+					Path:     kong.String("/"),
+				},
+			},
+			configurationv1.KongIngress{
+				Proxy: &kong.Service{
+					Protocol: kong.String("https"),
+					Port:     kong.Int(443),
+				},
+			},
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(443),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("https"),
+					Path:     kong.String("/"),
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testTable {


### PR DESCRIPTION
**What this PR does / why we need it**:  Provides support for setting the Port value in KongIngress's

**Which issue this PR fixes**: fixes #336

**Special notes for your reviewer**:
Hello!  Let me know if you need anything else!