### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
   - [Architecture](#architecture)
   - [Custom Resources](#custom-resources)
   - [Deployment methods](#deployment-methods)
-  - [High-availability and scalling](#high-availability-and-scalling)
+  - [High-availability and scaling](#high-availability-and-scaling)
   - [Security](#security)
 - [Guides and Tutorials](#guides-and-tutorials)
 - [Configuration reference](#configuration-reference)
@@ -46,11 +46,11 @@ involved and different ways of deploying them based on the use-case.
 The Kong Ingress Controller is designed to scale with your traffic
 and infrastructure.
 Please refer to [this document](concepts/ha-and-scaling.md) to understand
-failures scenarios, recovery methods, as well scaling considerations.
+failures scenarios, recovery methods, as well as scaling considerations.
 
 ### Security
 
-Please refere to [this document](concepts/security.md) to understand the
+Please refer to [this document](concepts/security.md) to understand the
 default security settings and how to further secure the Ingress Controller.
 
 ## Guides and Tutorials

--- a/docs/concepts/deployment.md
+++ b/docs/concepts/deployment.md
@@ -34,7 +34,7 @@ they are used, so that they can be tweaked as necessary for a specific use-case.
 
 Kong Ingress Controller can be deployed in any [namespace][k8s-namespace].  
 If Kong Ingress Controller is being used to proxy traffic for all namespaces
-in a Kubernetes cluster, which is generaly the case,
+in a Kubernetes cluster, which is generally the case,
 it is recommended that it is installed in a dedicated
 `kong` namespace but it is not required to do so.
 
@@ -54,7 +54,7 @@ A few custom resources are bundled with Kong Ingress Controller to configure
 settings that are specific to Kong and provide fine-grained control over
 the proxying behavior.
 
-Please refer to [custom resources][custom-resources.md]
+Please refer to [custom resources](custom-resources.md)
 concept document for details.
 
 ### RBAC permissions
@@ -124,7 +124,7 @@ See the [database](#database) section below for details.
 
 Once Kong Ingress Controller is deployed, one service is needed to
 expose Kong outside the Kubernetes cluster so that it can receive all traffic
-that is destinted for the cluster and route it appropriately.
+that is destined for the cluster and route it appropriately.
 `kong-proxy` is a Kubernetes service which points to the Kong pods which are
 capable of proxying request traffic. This service will be usually of type
 `LoadBalancer`, however it is not required to be such.
@@ -208,8 +208,8 @@ and a controller container which configures Kong.
 `kong-proxy` service would point to the ports of the Kong container in the
 above deployment.
 
-Since each pod contains a controller and a Kong container, scalling out
-simply requires horizontally scalling this deployment to handle more traffic
+Since each pod contains a controller and a Kong container, scaling out
+simply requires horizontally scaling this deployment to handle more traffic
 or to add redundancy in the infrastructure.
 
 #### With a Database
@@ -232,7 +232,7 @@ separating the control and data flow:
   that only one of the pods is configuring Kong's database at a time.
 - **Data-plane**: This deployment consists of pods running a
   single Kong container which can proxy traffic based on the configuration
-  it loads from the database. This deployment should be scalled to respond
+  it loads from the database. This deployment should be scaled to respond
   to change in traffic profiles and add redundancy to safeguard from node
   failures.
 - **Database**: The database is used to store Kong's configuration and propagate

--- a/docs/concepts/design.md
+++ b/docs/concepts/design.md
@@ -46,13 +46,13 @@ configuration:
 - A [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
   inside Kubernetes is a way to abstract an application that is
   running on a set of pods.
-  This maps to two object in Kong: Service and Upstream.
+  This maps to two objects in Kong: Service and Upstream.
   The service object in Kong holds the information on the protocol
   to use to talk to the upstream service and various other protocol
   specific settings. The Upstream object defines load balancing
   and healthchecking behavior.
 - Pods associated to a Service in Kubernetes map as a Target belonging
-  to the Upstream (the upsteram correspondign to the Kubenrete
+  to the Upstream (the upstream corresponding to the Kubernetes
   Service) in Kong. Kong load balances across the Pods of your service.
   This means that all requests flowing through Kong are not directed via
   kube-proxy but directly to the pod.

--- a/docs/concepts/ha-and-scaling.md
+++ b/docs/concepts/ha-and-scaling.md
@@ -1,4 +1,4 @@
-# High-availability and Scalling
+# High-availability and Scaling
 
 ## High availability
 
@@ -54,7 +54,7 @@ namespace that the controller is deployed in.
 
 ## Scaling
 
-Kong is designed to be horizontally scallable, meaning as traffic increases,
+Kong is designed to be horizontally scalable, meaning as traffic increases,
 multiple instances of Kong can be deployed to handle the increase in load.
 
 The configuration is either pumped into Kong directly via the Ingress

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -30,7 +30,7 @@ ensures that the likelihood of this happening is as small as possible.
 
 In the example deployements, the Controller and Kong's Admin API communicate
 over the loopback (`lo`) interface of the pod.
-Kong is no performing any kind of authorization or
+Kong is not performing any kind of authorization or
 authentication on the Admin API, hence the API is accessible only
 on the loopback interface to limit the attack surface.
 Although not ideal, this setup requires fewer steps

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -7,7 +7,7 @@ Kong Ingress Controller onto your Kubernetes cluster.
 
 ## Testing connectivity to Kong
 
-This guide assumes that `PROXY_IP` environment varialbe is
+This guide assumes that `PROXY_IP` environment variable is
 set to contain the IP address or URL pointing to Kong.
 If you've not done so, please follow one of the
 [deployment guides](../deployment) to configure this environment variable.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,7 +152,7 @@ $ kubectl exec test-701078429-s5kca -- curl --cacert /var/run/secrets/kubernetes
 If it is not working, there are two possible reasons:
 
 1. The contents of the tokens are invalid.
-   Find the secret name with `kubectl get secrets | grep service-account` and
+   Find the secret name with `kubectl get secrets --field-selector=type=kubernetes.io/service-account-token` and
   delete it with `kubectl delete secret <name>`.  
   It will automatically be recreated.
 1. You have a non-standard Kubernetes installation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Fixes a few miscellaneous typos in the documentation.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**:

I noticed that the repo's readme mentions:

`
⚠️ Kong Ingress Controller takes care of managing all entities in Kong's datastore as per the Ingress and custom resource definitions in k8s. Any entity created using Kong's Admin API will be deleted by the Ingress Controller.
`

however the [FAQ mentions that it is possible](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/faq.md#is-it-possible-to-create-consumers-using-the-admin-api) to create resources outside of the controller. I'm still looking into using Kong so I haven't yet tested it myself, but it would be great if these statements could be made consistent.