### PR TITLE
chore(ci) use GOPROXY to speed up module download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ cache:
   - $GOPATH/pkg/mod
 
 env:
-- GO111MODULE=on
+  global:
+  - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
 
 go:
   - "1.12"


### PR DESCRIPTION
Use GOPROXY=https://proxy.golang.org to speed up CI by a little bit.