### PR TITLE
feat: introduce ingress.kubernetes.io/service-upstream annotation

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -94,3 +94,9 @@ func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 func ExtractConfigurationName(anns map[string]string) string {
 	return anns[configurationAnnotationKey]
 }
+
+// HasServiceUpstreamAnnotation returns true if the annotation
+// ingress.kubernetes.io/service-upstream is set to "true" in anns.
+func HasServiceUpstreamAnnotation(anns map[string]string) bool {
+	return anns["ingress.kubernetes.io/service-upstream"] == "true"
+}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -778,6 +778,13 @@ func getEndpoints(
 			Port:    fmt.Sprintf("%v", targetPort),
 		})
 	}
+	if annotations.HasServiceUpstreamAnnotation(s.Annotations) {
+		return append(upsServers, utils.Endpoint{
+			Address: s.Name + "." + s.Namespace + ".svc",
+			Port:    fmt.Sprintf("%v", port.Port),
+		})
+
+	}
 
 	glog.V(3).Infof("getting endpoints for service %v/%v and port %v", s.Namespace, s.Name, port.String())
 	ep, err := getEndpoints(s.Namespace, s.Name)

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -646,6 +646,41 @@ func TestGetEndpoints(t *testing.T) {
 			},
 		},
 		{
+			"a service with ingress.kubernetes.io/service-upstream annotation should return one endpoint",
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						"ingress.kubernetes.io/service-upstream": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "default",
+							TargetPort: intstr.FromInt(80),
+						},
+					},
+				},
+			},
+			&corev1.ServicePort{
+				Name:       "default",
+				TargetPort: intstr.FromInt(2080),
+			},
+			corev1.ProtocolTCP,
+			func(string, string) (*corev1.Endpoints, error) {
+				return &corev1.Endpoints{}, nil
+			},
+			[]utils.Endpoint{
+				{
+					Address: "foo.bar.svc",
+					Port:    "2080",
+				},
+			},
+		},
+		{
 			"should return no endpoints when there is an error searching for endpoints",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Problems
--------

1. Kong Ingress Controller configures targets in Kong based on the
   endpoints of the corresponding Kubernetes service. This allows Kong
   to be used a load-balancer, but Kong then by-passes kube-proxy.
   There are use-cases where kube-proxy should handle load-balancing
   and Kong should send traffic to kube-proxy instead of pods.
   This was not possible.
2. In Kong, the `host` header sent to upstream is set to the IP
   value of the target picked for the request (unless `preserve_host`
   is set to true in the route selected for routing the request).
   This breaks routing in certain cases(see #330) when the upstream
   routes or responds based on the `host` header it receives in the
   request.

Solution
--------

Both of these problems are being addressed by populating the target of
the service with the DNS entry of the Kubernetes service i.e.
`service.namespace.svc`. This means , if the
`ingress.kubernetes.io/service-upstream` annotation is set to `true`,
then Kong will send the traffic to the ClusterIP of the service and also
set the host header to `service.namespace.svc`.
In a future release of Kong, Kong will support setting an arbitrary
`host` header value when sending a request upstream, which will allow
for further customization as needed.

See #330 #48