### PR TITLE
feat: add support for networking.k8s.io/v1beta1 Ingress API

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/utils"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -27,7 +27,7 @@ import (
 type Route struct {
 	kong.Route
 	// Ingress object associated with this route
-	Ingress extensions.Ingress
+	Ingress networking.Ingress
 	Plugins []kong.Plugin
 }
 
@@ -35,7 +35,7 @@ type Route struct {
 // service and other k8s metadata.
 type Service struct {
 	kong.Service
-	Backend   extensions.IngressBackend
+	Backend   networking.IngressBackend
 	Namespace string
 	Routes    []Route
 	Plugins   []kong.Plugin
@@ -213,11 +213,11 @@ func (p *Parser) Build() (*KongState, error) {
 }
 
 func (p *Parser) parseIngressRules(
-	ingressList []*extensions.Ingress) (*parsedIngressRules, error) {
+	ingressList []*networking.Ingress) (*parsedIngressRules, error) {
 
 	// generate the following:
 	// Services and Routes
-	var allDefaultBackends []extensions.Ingress
+	var allDefaultBackends []networking.Ingress
 	secretNameToSNIs := make(map[string][]string)
 	serviceNameToServices := make(map[string]Service)
 
@@ -687,7 +687,7 @@ func (p *Parser) getKongIngressForService(namespace, serviceName string) (
 
 // getKongIngress checks if the Ingress contains an annotation for configuration
 // or if exists a KongIngress object with the same name than the Ingress
-func (p *Parser) getKongIngressFromIngress(ing *extensions.Ingress) (
+func (p *Parser) getKongIngressFromIngress(ing *networking.Ingress) (
 	*configurationv1.KongIngress, error) {
 	confName := annotations.ExtractConfigurationName(ing.Annotations)
 	if confName != "" {

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -17,23 +17,23 @@ import (
 func TestParseIngressRules(t *testing.T) {
 	assert := assert.New(t)
 	p := Parser{}
-	ingressList := []*extensions.Ingress{
+	ingressList := []*networking.Ingress{
 		// 0
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "foo-namespace",
 			},
-			Spec: extensions.IngressSpec{
-				Rules: []extensions.IngressRule{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -51,8 +51,8 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "ing-with-tls",
 				Namespace: "bar-namespace",
 			},
-			Spec: extensions.IngressSpec{
-				TLS: []extensions.IngressTLS{
+			Spec: networking.IngressSpec{
+				TLS: []networking.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",
@@ -68,15 +68,15 @@ func TestParseIngressRules(t *testing.T) {
 						SecretName: "sooper-secret2",
 					},
 				},
-				Rules: []extensions.IngressRule{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -94,8 +94,8 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "ing-with-default-backend",
 				Namespace: "bar-namespace",
 			},
-			Spec: extensions.IngressSpec{
-				Backend: &extensions.IngressBackend{
+			Spec: networking.IngressSpec{
+				Backend: &networking.IngressBackend{
 					ServiceName: "default-svc",
 					ServicePort: intstr.FromInt(80),
 				},
@@ -107,16 +107,16 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "foo",
 				Namespace: "foo-namespace",
 			},
-			Spec: extensions.IngressSpec{
-				Rules: []extensions.IngressRule{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
 										Path: "/.well-known/acme-challenge/yolo",
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "cert-manager-solver-pod",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -134,15 +134,15 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "foo",
 				Namespace: "foo-namespace",
 			},
-			Spec: extensions.IngressSpec{
-				Rules: []extensions.IngressRule{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -156,7 +156,7 @@ func TestParseIngressRules(t *testing.T) {
 		},
 	}
 	t.Run("no ingress returns empty info", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{})
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{})
 		assert.Equal(&parsedIngressRules{
 			ServiceNameToServices: make(map[string]Service),
 			SecretNameToSNIs:      make(map[string][]string),
@@ -164,7 +164,7 @@ func TestParseIngressRules(t *testing.T) {
 		assert.Nil(err)
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{
 			ingressList[0],
 		})
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -176,7 +176,7 @@ func TestParseIngressRules(t *testing.T) {
 		assert.Nil(err)
 	})
 	t.Run("ingress rule with default backend", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{
 			ingressList[0],
 			ingressList[2],
 		})
@@ -193,7 +193,7 @@ func TestParseIngressRules(t *testing.T) {
 		assert.Nil(err)
 	})
 	t.Run("ingress rule with TLS", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{
 			ingressList[1],
 		})
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -203,7 +203,7 @@ func TestParseIngressRules(t *testing.T) {
 		assert.Nil(err)
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{
 			ingressList[3],
 		})
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -217,7 +217,7 @@ func TestParseIngressRules(t *testing.T) {
 		assert.Nil(err)
 	})
 	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
-		parsedInfo, err := p.parseIngressRules([]*extensions.Ingress{
+		parsedInfo, err := p.parseIngressRules([]*networking.Ingress{
 			ingressList[4],
 		})
 		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -6,7 +6,7 @@ import (
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -19,7 +19,7 @@ func keyFunc(obj interface{}) (string, error) {
 
 // FakeObjects can be used to populate a fake Store.
 type FakeObjects struct {
-	Ingresses       []*extensions.Ingress
+	Ingresses       []*networking.Ingress
 	Services        []*apiv1.Service
 	Endpoints       []*apiv1.Endpoints
 	Secrets         []*apiv1.Secret

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -6,7 +6,7 @@ import (
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -53,7 +53,7 @@ func Test_keyFunc(t *testing.T) {
 		{
 			want: "default/foo",
 			args: args{
-				obj: extensions.Ingress{
+				obj: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -86,22 +86,22 @@ func TestFakeStoreEmpty(t *testing.T) {
 func TestFakeStoreIngress(t *testing.T) {
 	assert := assert.New(t)
 
-	ingresses := []*extensions.Ingress{
+	ingresses := []*networking.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "default",
 			},
-			Spec: extensions.IngressSpec{
-				Rules: []extensions.IngressRule{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -121,16 +121,16 @@ func TestFakeStoreIngress(t *testing.T) {
 					"kubernetes.io/ingress.class": "not-kong",
 				},
 			},
-			Spec: extensions.IngressSpec{
-				Rules: []extensions.IngressRule{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: extensions.IngressRuleValue{
-							HTTP: &extensions.HTTPIngressRuleValue{
-								Paths: []extensions.HTTPIngressPath{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
 									{
 										Path: "/bar",
-										Backend: extensions.IngressBackend{
+										Backend: networking.IngressBackend{
 											ServiceName: "bar-svc",
 											ServicePort: intstr.FromInt(80),
 										},

--- a/internal/ingress/store/store_test.go
+++ b/internal/ingress/store/store_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+
+	core "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_networkingIngressV1Beta1(t *testing.T) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *networking.Ingress
+	}{
+		{
+			name: "networking.Ingress is returned as is",
+			args: args{
+				obj: &networking.Ingress{},
+			},
+			want: &networking.Ingress{},
+		},
+		{
+			name: "returns nil if a non-ingress object is passed in",
+			args: args{
+				&core.Service{
+					Spec: core.ServiceSpec{
+						Type:      core.ServiceTypeClusterIP,
+						ClusterIP: "1.1.1.1",
+						Ports: []core.ServicePort{
+							{
+								Name:       "default",
+								TargetPort: intstr.FromString("port-1"),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "correctly transformers from extensions to networking group",
+			args: args{
+				obj: &extensions.Ingress{
+					Spec: extensions.IngressSpec{
+						Rules: []extensions.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: extensions.IngressRuleValue{
+									HTTP: &extensions.HTTPIngressRuleValue{
+										Paths: []extensions.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: extensions.IngressBackend{
+													ServiceName: "foo-svc",
+													ServicePort: intstr.FromInt(80),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &networking.Ingress{
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networking.IngressBackend{
+												ServiceName: "foo-svc",
+												ServicePort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkingIngressV1Beta1(tt.args.obj); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("networkingIngressV1Beta1() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ingress API is undergoing changes and finally moving to v1 [1].
This commit adds support for networking/v1beta1 Ingress resource,
which is same as extensions/v1beta1 resource, keeping the controller
compatible with future k8s releases.

1: https://github.com/kubernetes/enhancements/pull/749/files