### PR TITLE
chore(deps) bump up decK to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.40.0 // indirect
-	github.com/blang/semver v3.5.1+incompatible
+	github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906
 	github.com/eapache/channels v1.1.0
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
@@ -15,8 +15,8 @@ require (
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/hashicorp/go-memdb v1.0.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hbagdi/deck v0.4.0
-	github.com/hbagdi/go-kong v0.5.0
+	github.com/hbagdi/deck v0.5.1
+	github.com/hbagdi/go-kong v0.9.0
 	github.com/imdario/mergo v0.3.7
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.4
 	github.com/spf13/pflag v1.0.3
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/gjson v1.2.1
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906 h1:KGe2go3VELJLcQfKBUlviUzERqg79dO6VYzCvQxF01w=
+github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -71,10 +71,10 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hbagdi/deck v0.4.0 h1:6D8/wBwS3cu3AOx0MXUdhdyeAQxjD+U4+0sUmKQnZO4=
-github.com/hbagdi/deck v0.4.0/go.mod h1:P4brDcc7E+D+HqfrwzJpQV7wLVJRAYGbNawgBinhSrg=
-github.com/hbagdi/go-kong v0.5.0 h1:1NVoG8VwoaEB9ix+mcE1s6y/IZEvjpWHoX+mzA+kQxM=
-github.com/hbagdi/go-kong v0.5.0/go.mod h1:JtNYtCEZoh6+Jr5qiZkccn2cUQuEIoBEdusM2uIrBeQ=
+github.com/hbagdi/deck v0.5.1 h1:WRSNtXBOegXqvFXtv91EZ9c7teuZT7q5Tc7uyNJFW10=
+github.com/hbagdi/deck v0.5.1/go.mod h1:C+4ec6eEsqpmEEcdKnb0JJ8XwRQojISzGWG0wVwvNf8=
+github.com/hbagdi/go-kong v0.9.0 h1:bztX/BSwFO1RtLGquWBkgt/JljQL7SqQvmr6ZbecIAI=
+github.com/hbagdi/go-kong v0.9.0/go.mod h1:NzIC8BWQK05XAHLZsXO931W1N6E1giEEt5xqRMEPlto=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
@@ -168,6 +168,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/gjson v1.2.1 h1:j0efZLrZUvNerEf6xqoi0NjWMK5YlLrR7Guo/dxY174=
 github.com/tidwall/gjson v1.2.1/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -146,7 +146,7 @@ func (n *KongController) onUpdateDBMode(state *parser.KongState) error {
 			SelectorTags: n.getIngressControllerTags(),
 		})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "loading configuration from kong")
 	}
 	targetState, err := n.toDeckKongState(state)
 	if err != nil {
@@ -250,7 +250,7 @@ func (n *KongController) toDeckKongState(
 	}
 
 	content.Info.SelectorTags = n.getIngressControllerTags()
-	targetState, _, err := file.GetStateFromContent(&content)
+	targetState, _, _, err := file.GetStateFromContent(&content)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating a valid state for Kong")
 	}


### PR DESCRIPTION
decK
----

Changelog:
https://github.com/hbagdi/deck/blob/master/CHANGELOG.md

go-kong
-------

Changelog:
https://github.com/hbagdi/go-kong/blob/master/CHANGELOG.md

go-kong bump is large because of multiple releases that happened while
preparing for this commit.

Noteworthy changes apart from additions:
- https://github.com/hbagdi/go-kong/issues/6
- String() method has been dropped from all types defined in the
  library.