### PR TITLE
feat: implement admission controller for configuration.konghq.com group

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -46,6 +46,12 @@ func (h *headers) Set(value string) error {
 	return nil
 }
 
+var (
+	admissionWebhookListen   string
+	admissionWebhookCertPath string
+	admissionWebhookKeyPath  string
+)
+
 func parseFlags() (bool, *controller.Configuration, error) {
 	var (
 		flags = pflag.NewFlagSet("", pflag.ExitOnError)
@@ -108,6 +114,16 @@ The controller will set the endpoint records on the ingress using this address.`
 
 	flag.Var(&kongHeaders, "admin-header",
 		"add a header (key:value) to every Admin API call, flag can be used multiple times")
+
+	flag.StringVar(&admissionWebhookListen, "admission-webhook-listen", ":8080",
+		"The address to start admission controller on (ip:port)."+
+			" Setting it to `off` disables the admission controller.")
+	flag.StringVar(&admissionWebhookCertPath, "admission-webhook-cert-file",
+		"/admission-webhook/tls.crt",
+		"Path to the PEM-encoded certificate file for TLS handshake")
+	flag.StringVar(&admissionWebhookKeyPath, "admission-webhook-key-file",
+		"/admission-webhook/tls.key",
+		"Path to the PEM-encoded private key file for TLS handshake")
 
 	flag.Set("logtostderr", "true")
 

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -1,0 +1,135 @@
+package admission
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/golang/glog"
+	configuration "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
+	"github.com/pkg/errors"
+	admission "k8s.io/api/admission/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+// Server is an HTTP server that can validate Kong Ingress Controllers'
+// Custom Resources using Kubernetes Admission Webhooks.
+type Server struct {
+	// Validator validates the entities that the k8s API-server asks
+	// it the server to validate.
+	Validator KongValidator
+}
+
+// ServeHTTP parses AdmissionReview requests and responds back
+// with the validation result of the entity.
+func (a Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		glog.Error("admission webhook: received request with empty body")
+		http.Error(w, "admission review object is missing",
+			http.StatusBadRequest)
+		return
+	}
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		glog.Error("admission webhook: reading request", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	review := admission.AdmissionReview{}
+	if err := json.Unmarshal(data, &review); err != nil {
+		glog.Error("admission webhook: parsing AdmissionReview", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	response, err := a.handleValidation(*review.Request)
+	if err != nil {
+		glog.Error("admission webhook: handling webhook", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	review.Response = response
+	data, err = json.Marshal(review)
+	if err != nil {
+		glog.Error("admission webhook: marshaling response", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, err = w.Write(data)
+	if err != nil {
+		glog.Error("admission webhook: writing response", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+var (
+	consumerGVResource = meta.GroupVersionResource{
+		Group:    configuration.SchemeGroupVersion.Group,
+		Version:  configuration.SchemeGroupVersion.Version,
+		Resource: "kongconsumers"}
+	pluginGVResource = meta.GroupVersionResource{
+		Group:    configuration.SchemeGroupVersion.Group,
+		Version:  configuration.SchemeGroupVersion.Version,
+		Resource: "kongplugins"}
+)
+
+func (a Server) handleValidation(request admission.AdmissionRequest) (
+	*admission.AdmissionResponse, error) {
+	var response admission.AdmissionResponse
+
+	var ok bool
+	var message string
+	var err error
+
+	switch request.Resource {
+	case consumerGVResource:
+		consumer := configuration.KongConsumer{}
+		deserializer := codecs.UniversalDeserializer()
+		_, _, err = deserializer.Decode(request.Object.Raw,
+			nil, &consumer)
+		if err != nil {
+			return nil, err
+		}
+
+		ok, message, err = a.Validator.ValidateConsumer(consumer)
+		if err != nil {
+			return nil, err
+		}
+	case pluginGVResource:
+		plugin := configuration.KongPlugin{}
+		deserializer := codecs.UniversalDeserializer()
+		_, _, err = deserializer.Decode(request.Object.Raw,
+			nil, &plugin)
+		if err != nil {
+			return nil, err
+		}
+
+		ok, message, err = a.Validator.ValidatePlugin(plugin)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.Errorf("unknown resource type to validate: %s/%s %s",
+			request.Resource.Group, request.Resource.Version,
+			request.Resource.Resource)
+	}
+	if err != nil {
+		return nil, err
+	}
+	response.UID = request.UID
+	response.Allowed = ok
+	response.Result = &meta.Status{
+		Message: message,
+	}
+	if !ok {
+		response.Result.Code = 400
+	}
+	return &response, nil
+}

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -1,0 +1,237 @@
+package admission
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	configuration "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	admission "k8s.io/api/admission/v1beta1"
+)
+
+var decoder = codecs.UniversalDeserializer()
+
+type KongFakeValidator struct {
+	Result  bool
+	Message string
+	Error   error
+}
+
+func (v KongFakeValidator) ValidateConsumer(
+	consumer configuration.KongConsumer) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
+func (v KongFakeValidator) ValidatePlugin(
+	k8sPlugin configuration.KongPlugin) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
+func TestServeHTTPBasic(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+
+	req, err := http.NewRequest("POST", "", nil)
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(400, res.Code)
+	assert.Equal("admission review object is missing\n",
+		res.Body.String())
+}
+
+func TestValidateKongConsumer(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{
+			Result: true,
+		},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+	// TODO how to marshal k8s object to correct JSON?
+	body := `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "b2df61dd-ab5b-4cb4-9be0-878533c83892",
+    "resource": {
+      "group": "configuration.konghq.com",
+      "version": "v1",
+      "resource": "kongconsumers"
+    },
+    "object": {
+      "apiVersion": "configuration.konghq.com/v1",
+      "kind": "KongConsumer"
+    }
+  }
+}
+	`
+	req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(body)))
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(200, res.Code)
+	var review admission.AdmissionReview
+	_, _, err = decoder.Decode([]byte(res.Body.String()), nil, &review)
+	assert.Nil(err)
+	assert.Equal("b2df61dd-ab5b-4cb4-9be0-878533c83892",
+		string(review.Response.UID))
+	assert.True(review.Response.Allowed)
+}
+
+func TestValidateKongConsumerInvalid(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{
+			Result:  false,
+			Message: "consumer is not valid",
+		},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+	body := `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "b2df61dd-ab5b-4cb4-9be0-878533c83892",
+    "resource": {
+      "group": "configuration.konghq.com",
+      "version": "v1",
+      "resource": "kongconsumers"
+    },
+    "object": {
+      "apiVersion": "configuration.konghq.com/v1",
+      "kind": "KongConsumer"
+    }
+  }
+}
+	`
+	req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(body)))
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(200, res.Code)
+	var review admission.AdmissionReview
+	_, _, err = decoder.Decode([]byte(res.Body.String()), nil, &review)
+	assert.Nil(err)
+	assert.Equal("b2df61dd-ab5b-4cb4-9be0-878533c83892",
+		string(review.Response.UID))
+	assert.False(review.Response.Allowed)
+	assert.Equal("consumer is not valid", review.Response.Result.Message)
+	assert.Equal(int32(400), review.Response.Result.Code)
+}
+
+func TestValidateKongConsumerOnError(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{
+			Error: errors.New("error making API call to kong"),
+		},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+	body := `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "b2df61dd-ab5b-4cb4-9be0-878533c83892",
+    "resource": {
+      "group": "configuration.konghq.com",
+      "version": "v1",
+      "resource": "kongconsumers"
+    },
+    "object": {
+      "apiVersion": "configuration.konghq.com/v1",
+      "kind": "KongConsumer"
+    }
+  }
+}
+	`
+	req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(body)))
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(500, res.Code)
+	assert.Equal("error making API call to kong\n", res.Body.String())
+}
+
+func TestUnknownResource(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{
+			Result:  false,
+			Message: "consumer is not valid",
+		},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+	body := `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "b2df61dd-ab5b-4cb4-9be0-878533c83892",
+    "resource": {
+      "group": "configuration.konghq.com",
+      "version": "v1",
+      "resource": "kongunknown"
+    },
+    "object": {
+      "apiVersion": "configuration.konghq.com/v1",
+      "kind": "KongConsumer"
+    }
+  }
+}
+	`
+	req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(body)))
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(500, res.Code)
+	assert.Equal("unknown resource type to validate: configuration.konghq.com/v1 kongunknown\n", res.Body.String())
+}
+
+func TestValidateKongPlugin(t *testing.T) {
+	assert := assert.New(t)
+	res := httptest.NewRecorder()
+	server := Server{
+		Validator: KongFakeValidator{
+			Result: true,
+		},
+	}
+	handler := http.HandlerFunc(server.ServeHTTP)
+	body := `
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "b2df61dd-ab5b-4cb4-9be0-878533c83892",
+    "resource": {
+      "group": "configuration.konghq.com",
+      "version": "v1",
+      "resource": "kongplugins"
+    },
+    "object": {
+      "apiVersion": "configuration.konghq.com/v1",
+      "kind": "KongPlugin"
+    }
+  }
+}
+	`
+	req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(body)))
+	assert.Nil(err)
+	handler.ServeHTTP(res, req)
+	assert.Equal(200, res.Code)
+	var review admission.AdmissionReview
+	_, _, err = decoder.Decode([]byte(res.Body.String()), nil, &review)
+	assert.Nil(err)
+	assert.Equal("b2df61dd-ab5b-4cb4-9be0-878533c83892",
+		string(review.Response.UID))
+	assert.True(review.Response.Allowed)
+}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -1,0 +1,88 @@
+package admission
+
+import (
+	"github.com/golang/glog"
+	"github.com/hbagdi/go-kong/kong"
+	configuration "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
+	"github.com/pkg/errors"
+)
+
+// KongValidator validates Kong entities.
+type KongValidator interface {
+	ValidateConsumer(consumer configuration.KongConsumer) (bool, string, error)
+	ValidatePlugin(consumer configuration.KongPlugin) (bool, string, error)
+}
+
+// KongHTTPValidator implements KongValidator interface to validate Kong
+// entities using the Admin API of Kong.
+type KongHTTPValidator struct {
+	Client *kong.Client
+}
+
+// ValidateConsumer checks if consumer has a Username and a consumer with
+// the same username doesn't exist in Kong.
+// If an error occurs during validation, it is returned as the last argument.
+// The first boolean communicates if the consumer is valid or not and string
+// holds a message if the entity is not valid.
+func (validator KongHTTPValidator) ValidateConsumer(
+	consumer configuration.KongConsumer) (bool, string, error) {
+	if consumer.Username == "" {
+		return false, "username cannot be empty", nil
+	}
+	c, err := validator.Client.Consumers.Get(nil, &consumer.Username)
+	if err != nil {
+		if kong.IsNotFoundErr(err) {
+			return true, "", nil
+		}
+		glog.Errorf("admission controller: "+
+			"error getting consumer from Kong: %v", err)
+		return false, "", errors.Wrap(err, "fetching consumer from Kong")
+	}
+	if c != nil {
+		return false, "consumer already exists", nil
+	}
+	return true, "", nil
+}
+
+// ValidatePlugin checks if k8sPlugin is valid. It does so by performing
+// an HTTP request to Kong's Admin API entity validation endpoints.
+// If an error occurs during validation, it is returned as the last argument.
+// The first boolean communicates if k8sPluign is valid or not and string
+// holds a message if the entity is not valid.
+func (validator KongHTTPValidator) ValidatePlugin(
+	k8sPlugin configuration.KongPlugin) (bool, string, error) {
+	if k8sPlugin.PluginName == "" {
+		return false, "plugin name cannot be empty", nil
+	}
+	var plugin kong.Plugin
+	plugin.Name = kong.String(k8sPlugin.PluginName)
+	if k8sPlugin.Config != nil {
+		plugin.Config = kong.Configuration(k8sPlugin.Config)
+	}
+	if k8sPlugin.RunOn != "" {
+		plugin.RunOn = kong.String(k8sPlugin.RunOn)
+	}
+	if len(k8sPlugin.Protocols) > 0 {
+		plugin.Protocols = kong.StringSlice(k8sPlugin.Protocols...)
+	}
+	req, err := validator.Client.NewRequest("POST", "/schemas/plugins/validate",
+		nil, &plugin)
+	if err != nil {
+		return false, "", err
+	}
+	resp, err := validator.Client.Do(nil, req, nil)
+	if err != nil {
+		return false, err.Error(), nil
+	}
+	if resp.StatusCode == 201 {
+		return true, "", nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	return true, "", nil
+}
+
+func empty(s *string) bool {
+	return s == nil && *s == ""
+}


### PR DESCRIPTION
Users frequently stumble onto situation where a misconfigured plugin
stops the entire controller from functioning.

It is now possible to setup an admission validation webhook to prevent
users from mis-configuring plugins and consumers.

Documentation on how to configure the controller will be published soon
and this controller will include KongCredentials in the future.

Fix #245 