### PR TITLE
Feat/kong 1.3

### DIFF
--- a/deploy/manifests/custom-types.yaml
+++ b/deploy/manifests/custom-types.yaml
@@ -150,6 +150,12 @@ spec:
               type: array
               items:
                 type: string
+            headers:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
             regex_priority:
               type: integer
             strip_path:

--- a/deploy/manifests/custom-types.yaml
+++ b/deploy/manifests/custom-types.yaml
@@ -142,8 +142,6 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        upstream:
-          type: object
         route:
           properties:
             methods:
@@ -197,6 +195,12 @@ spec:
         upstream:
           type: object
           properties:
+            algorithm:
+              type: string
+              enum:
+              - "round-robin"
+              - "consistent-hashing"
+              - "least-connections"
             hash_on:
               type: string
             hash_on_cookie:

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -509,7 +509,9 @@ func overrideRoute(route *Route,
 	if len(r.Methods) != 0 {
 		route.Methods = cloneStringPointerSlice(r.Methods...)
 	}
-
+	if len(r.Headers) != 0 {
+		route.Headers = r.Headers
+	}
 	if len(r.Protocols) != 0 {
 		route.Protocols = cloneStringPointerSlice(r.Protocols...)
 	}

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -485,6 +485,30 @@ func TestOverrideRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			Route{
+				Route: kong.Route{
+					Hosts:     kong.StringSlice("foo.com"),
+					Protocols: kong.StringSlice("http", "https"),
+				},
+			},
+			configurationv1.KongIngress{
+				Route: &kong.Route{
+					Headers: map[string][]string{
+						"foo-header": {"bar-value"},
+					},
+				},
+			},
+			Route{
+				Route: kong.Route{
+					Hosts:     kong.StringSlice("foo.com"),
+					Protocols: kong.StringSlice("http", "https"),
+					Headers: map[string][]string{
+						"foo-header": {"bar-value"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testTable {


### PR DESCRIPTION
Changelog:
- HTTP header based routing
- Load balancing algorithm selection per service; new `least-connections` load balancer

Fix #347 