### PR TITLE
feat: ensure Kong Enterprise 0.36 compatiblity

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -27,6 +27,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -152,6 +153,11 @@ func main() {
 	glog.Infof("kong version: %s", v)
 	kongConfiguration := root["configuration"].(map[string]interface{})
 	conf.Kong.Version = v
+
+	if strings.Contains(root["version"].(string), "enterprise") {
+		conf.Kong.Enterprise = true
+	}
+
 	kongDB := kongConfiguration["database"].(string)
 	glog.Infof("Kong datastore: %s", kongDB)
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -59,7 +59,9 @@ type Kong struct {
 	InMemory      bool
 	Database      string
 	HasTagSupport bool
-	Version       semver.Version
+
+	Enterprise bool
+	Version    semver.Version
 
 	// Workspace is the Kong Enterprise workspace being synced.
 	Workspace string

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -261,9 +261,12 @@ func (n *KongController) toDeckKongState(
 var kong110version = semver.MustParse("1.1.0")
 
 var kong120version = semver.MustParse("1.2.0")
+var kongEnterprise036version = semver.MustParse("0.36.0")
 
 func (n *KongController) fillRoute(route *kong.Route) {
-	if n.cfg.Kong.Version.GTE(kong120version) {
+	if n.cfg.Kong.Version.GTE(kong120version) ||
+		(n.cfg.Kong.Enterprise &&
+			n.cfg.Kong.Version.GTE(kongEnterprise036version)) {
 		if route.HTTPSRedirectStatusCode == nil {
 			route.HTTPSRedirectStatusCode = kong.Int(426)
 		}


### PR DESCRIPTION
Kong Enterprise 0.36 is based on Kong 1.2 core:
https://docs.konghq.com/enterprise/changelog/#036

`https_redirect_status_code` property was introduced in Kong 1.2 and
this needs to injected when Kong Enterprise is running.
This ensures that decK detects no change in state and fires no
Admin API requests while performing a full-sync during idle conditions
i.e. when there are no changes in the k8s cluster.