### PR TITLE
Fix upstream/service collisions for multi-port Kubernetes Services

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -374,7 +374,7 @@ func (p *Parser) parseIngressRules(
 					service = Service{
 						Service: kong.Service{
 							Name:           kong.String(serviceName),
-							Host:           kong.String(rule.Backend.ServiceName + "." + ingress.Namespace + ".svc"),
+							Host:           kong.String(rule.Backend.ServiceName + "." + ingress.Namespace + "." + rule.Backend.ServicePort.String() + ".svc"),
 							Port:           kong.Int(80),
 							Protocol:       kong.String("http"),
 							Path:           kong.String("/"),
@@ -409,7 +409,7 @@ func (p *Parser) parseIngressRules(
 			service = Service{
 				Service: kong.Service{
 					Name: kong.String(serviceName),
-					Host: kong.String(defaultBackend.ServiceName + "." + ingress.Namespace + ".svc"),
+					Host: kong.String(defaultBackend.ServiceName + "." + ingress.Namespace + "." + defaultBackend.ServicePort.String() + ".svc"),
 					Port: kong.Int(80),
 				},
 				Namespace: ingress.Namespace,
@@ -555,7 +555,7 @@ func overrideUpstream(upstream *Upstream,
 func (p *Parser) getUpstreams(serviceMap map[string]Service) ([]Upstream, error) {
 	var upstreams []Upstream
 	for _, service := range serviceMap {
-		upstreamName := service.Backend.ServiceName + "." + service.Namespace + ".svc"
+		upstreamName := service.Backend.ServiceName + "." + service.Namespace + "." + service.Backend.ServicePort.String() + ".svc"
 		upstream := Upstream{
 			Upstream: kong.Upstream{
 				Name: kong.String(upstreamName),


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds port to Kong service hostnames, in turn adding the port to the associated upstream name.

This prevents collisions and/or misdirected traffic when a Kubernetes Service exposes multiple ports, and Ingress rules use two or more of those ports. Previously, rules for different ports on the same Service would attempt to use the same Kong service/upstream hostname.

**Which issue this PR fixes**
Fixes #335

**Special notes for your reviewer**:
Tests cover Kong service generation only. I reviewed whether it would be useful to separately test `Parser.getUpstreams()` for this, but determined it unnecessary--we do not pass Kubernetes Services to it directly, but rather generate Kong services first and then get upstreams for each Kong service.