### PR TITLE
Fix "New migrations available" at proxy sidecar

### DIFF
--- a/deploy/manifests/postgres/kong-ingress-postgres.yaml
+++ b/deploy/manifests/postgres/kong-ingress-postgres.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-migrations
-        image: kong:1.2
+        image: kong:1.3
         command:
         - "/bin/sh"
         - "-c"

--- a/deploy/manifests/postgres/migration.yaml
+++ b/deploy/manifests/postgres/migration.yaml
@@ -20,7 +20,7 @@ spec:
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
-        image: kong:1.2
+        image: kong:1.3
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -618,7 +618,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:1.2
+        image: kong:1.3
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -693,7 +693,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:1.2
+        image: kong:1.3
         name: kong-migrations
       initContainers:
       - command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Since 4a94cb3 when you try to apply all-in-one-postgres.yaml you'll get at
proxy sidecar log:
nginx: [error] init_by_lua error:
/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:25: New migrations
available; run 'kong migrations up' to proceed
stack traceback:
        [C]: in function 'error'
	/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:25:
	in function 'check_state'
	/usr/local/share/lua/5.1/kong/init.lua:358: in
	function 'init'
	init_by_lua:3: in main chunk

The reason behind this is that the migrations part of the manifest wasn't
bumped to 1.3

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR bumps these parts of the manifests and fixes that problem

**Special notes for your reviewer**:
