### PR TITLE
docs: use local policy for rate-limiting

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -211,6 +211,7 @@ metadata:
 config:
   minute: 5
   limit_by: ip
+  policy: local
 plugin: rate-limiting
 " | kubectl apply -f -
 kongplugin.configuration.konghq.com/rl-by-ip created


### PR DESCRIPTION
Some users deploy the in-memory version of Kong, which results in
errors if the storage policy is not set to `local`.