### PR TITLE
deploy: use non-root user in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,21 @@ ARG REPO_INFO
 ARG COMMIT
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kong-ingress-controller -ldflags "-s -w -X main.RELEASE=$TAG -X main.COMMIT=$COMMIT -X main.REPO=$REPO_INFO" ./cli/ingress-controller
 
+# Final stage: the running container.
 FROM alpine:3.9
 RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+
+# Create the user (ID 1000) and group that will be used in the running container to
+# run the process as an unprivileged user.
+RUN addgroup -S kong && \
+    adduser -S kong -G kong -u 1000
+
+# Import the compiled executable from the second stage.
 COPY --from=build /kong-ingress-controller/kong-ingress-controller .
-ENTRYPOINT ["./kong-ingress-controller"]
+
+# Perform any further action as an unprivileged user.
+USER 1000
+
+# Run the compiled binary.
+ENTRYPOINT ["/kong-ingress-controller"]
+


### PR DESCRIPTION
**What this PR does / why we need it**

This PR changes the user that is used for running Kong Ingress Controller in the container. It is considered a bad practice to use standard root user, especially if the app does not need root access.

**Special notes for your reviewer**

Tested the change in GKE cluster with enforced Pod Security Policy that does not permit running containers as root user. Container started successfully. No securityContext definition needed, as user ID is defined in Dockerfile.
