### PR TITLE
deploy: update apiVersion for Deployments to apps/v1

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/manifests/dummy-application.yaml
+++ b/deploy/manifests/dummy-application.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: http-svc

--- a/deploy/manifests/enterprise/kong-enterprise.yaml
+++ b/deploy/manifests/enterprise/kong-enterprise.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-kong

--- a/deploy/manifests/postgres/kong-ingress-postgres.yaml
+++ b/deploy/manifests/postgres/kong-ingress-postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-kong

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -472,7 +472,7 @@ spec:
   selector:
     app: ingress-kong
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -486,7 +486,7 @@ spec:
   selector:
     app: postgres
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -486,7 +486,7 @@ spec:
   selector:
     app: postgres
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Deployment is available under apps/v1 apiVersion since Kubernetes 1.9
(almost 2 years ago).

Deployments under extensions/v1beta1 apiVersion are no longer served by
default from kubernetes 1.16 onwards.