### PR TITLE
deploy: use one worker process by default

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -29,6 +29,8 @@ spec:
         env:
         - name: KONG_DATABASE
           value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
         - name: KONG_NGINX_HTTP_INCLUDE
           value: "/kong/servers.conf"
         - name: KONG_ADMIN_ACCESS_LOG

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -497,6 +497,8 @@ spec:
       - env:
         - name: KONG_DATABASE
           value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
         - name: KONG_NGINX_HTTP_INCLUDE
           value: /kong/servers.conf
         - name: KONG_ADMIN_ACCESS_LOG

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -520,6 +520,8 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
         - name: KONG_NGINX_HTTP_INCLUDE
           value: /kong/servers.conf
         - name: KONG_ADMIN_ACCESS_LOG

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -515,6 +515,8 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
         - name: KONG_NGINX_HTTP_INCLUDE
           value: /kong/servers.conf
         - name: KONG_ADMIN_ACCESS_LOG


### PR DESCRIPTION
In a containerized environment, `get_nprocs()` returns the same number
of CPUs as in the underlying physical host or Virtual Machine.

In a Kubernetes environment, users run larger hosts and pack multiple
workloads, including Kong into a small number of machines.

In such situations, Kong's underlying Nginx spawns up a larger number of
worker assuming that it is indeed running on a box with all the cores
for itself. This leads to two problems:
- having more workers than necessary leads to scheduling and
context-switching overhead; this has a direct impact on the latency
introduced by Kong as the request is proxied via it.
- Each worker process also aggressively caches configuration at the
process level, which frequently leads to memory exhaustion.

Due to these reasons, a default setting of one worker process is being
introduced, which should be okay for most use cases to start with and
then can be tuned based on specific use-cases.

This is by no means a one size fits all solution and it is not possible
to device such a solution as of today. We would like to avoid people
getting puzzled on their Day 1 with Kong. As users gain more familiarity
with Kong, they are encouraged to tune this setting based on their
infrastructure and workload.