### PR TITLE
feat: create Kong Enterprise workspace when not present

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -173,6 +173,11 @@ func main() {
 
 	// setup workspace in Kong Enterprise
 	if conf.Kong.Workspace != "" {
+		// ensure the workspace exists or try creating it
+		err := ensureWorkspace(kongClient, conf.Kong.Workspace)
+		if err != nil {
+			glog.Fatalf("Error ensuring workspace: %v", err)
+		}
 		kongClient, err = kong.NewClient(kong.String(conf.Kong.URL+"/"+conf.Kong.Workspace), c)
 		if err != nil {
 			glog.Fatalf("Error creating Kong Rest client: %v", err)

--- a/cli/ingress-controller/util.go
+++ b/cli/ingress-controller/util.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/hbagdi/go-kong/kong"
+	"github.com/pkg/errors"
 )
 
 func getSemVerVer(v string) (semver.Version, error) {
@@ -25,4 +27,32 @@ func getSemVerVer(v string) (semver.Version, error) {
 	}
 	v = fmt.Sprintf("%s.%s%s", m[1], m[2], m[3])
 	return semver.Make(v)
+}
+
+func ensureWorkspace(client *kong.Client, workspace string) error {
+	req, err := client.NewRequest("GET", "/workspaces/"+workspace, nil, nil)
+	if err != nil {
+		return err
+	}
+	_, err = client.Do(nil, req, nil)
+	if err != nil {
+		if kong.IsNotFoundErr(err) {
+			if err := createWorkspace(client, workspace); err != nil {
+				return errors.Wrapf(err, "creating workspace '%v'", workspace)
+			}
+			return nil
+		}
+		return errors.Wrapf(err, "looking up workspace '%v'", workspace)
+	}
+	return nil
+}
+
+func createWorkspace(client *kong.Client, workspace string) error {
+	body := map[string]string{"name": workspace}
+	req, err := client.NewRequest("POST", "/workspaces", nil, body)
+	if err != nil {
+		return err
+	}
+	_, err = client.Do(nil, req, nil)
+	return err
 }


### PR DESCRIPTION
If Kong Enterprise workspace doesn't exist, the controller simply errors
out.
With this change, the controller tries to create a workspace before
erroring out.
If the creation is successful, then it proceeds as usual.