### PR TITLE
Feat/secret based credentials

### DIFF
--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -88,6 +88,10 @@ spec:
           type: string
         custom_id:
           type: string
+        credentials:
+          type: array
+          items:
+            type: string
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -27,6 +27,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        credentials:
+          items:
+            type: string
+          type: array
         custom_id:
           type: string
         username:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -27,6 +27,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        credentials:
+          items:
+            type: string
+          type: array
         custom_id:
           type: string
         username:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -27,6 +27,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        credentials:
+          items:
+            type: string
+          type: array
         custom_id:
           type: string
         username:

--- a/internal/apis/configuration/v1/types.go
+++ b/internal/apis/configuration/v1/types.go
@@ -125,6 +125,10 @@ type KongConsumer struct {
 	// CustomID existing unique ID for the consumer - useful for mapping
 	// Kong with users in your existing database
 	CustomID string `json:"custom_id,omitempty"`
+
+	// Credentials are references to secrets containing a credential to be
+	// provisioned in Kong.
+	Credentials []string `json:"credentials,omitempty"`
 }
 
 // KongConsumerList is a top-level list type. The client methods for

--- a/internal/apis/configuration/v1/zz_generated.deepcopy.go
+++ b/internal/apis/configuration/v1/zz_generated.deepcopy.go
@@ -30,6 +30,11 @@ func (in *KongConsumer) DeepCopyInto(out *KongConsumer) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Credentials != nil {
+		in, out := &in.Credentials, &out.Credentials
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1286,3 +1286,158 @@ func TestGetEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func Test_processCredential(t *testing.T) {
+	type args struct {
+		credType   string
+		consumer   *Consumer
+		credConfig interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		result  *Consumer
+		wantErr bool
+	}{
+		{
+			name: "invalid cred type errors",
+			args: args{
+				credType:   "invalid-type",
+				consumer:   &Consumer{},
+				credConfig: nil,
+			},
+			result:  &Consumer{},
+			wantErr: true,
+		},
+		{
+			name: "key-auth",
+			args: args{
+				credType:   "key-auth",
+				consumer:   &Consumer{},
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: &Consumer{
+				KeyAuths: []*kong.KeyAuth{
+					{
+						Key: kong.String("foo"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "basic-auth",
+			args: args{
+				credType: "basic-auth",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"username": "foo",
+					"password": "bar",
+				},
+			},
+			result: &Consumer{
+				BasicAuths: []*kong.BasicAuth{
+					{
+						Username: kong.String("foo"),
+						Password: kong.String("bar"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "hmac-auth",
+			args: args{
+				credType: "hmac-auth",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"username": "foo",
+					"secret":   "bar",
+				},
+			},
+			result: &Consumer{
+				HMACAuths: []*kong.HMACAuth{
+					{
+						Username: kong.String("foo"),
+						Secret:   kong.String("bar"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "oauth2",
+			args: args{
+				credType: "oauth2",
+				consumer: &Consumer{},
+				credConfig: map[string]interface{}{
+					"name":          "foo",
+					"client_id":     "bar",
+					"client_secret": "baz",
+					"redirect_uris": []string{"example.com"},
+				},
+			},
+			result: &Consumer{
+				Oauth2Creds: []*kong.Oauth2Credential{
+					{
+						Name:         kong.String("foo"),
+						ClientID:     kong.String("bar"),
+						ClientSecret: kong.String("baz"),
+						RedirectURIs: kong.StringSlice("example.com"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "jwt",
+			args: args{
+				credType: "jwt",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"key":            "foo",
+					"rsa_public_key": "bar",
+					"secret":         "baz",
+				},
+			},
+			result: &Consumer{
+				JWTAuths: []*kong.JWTAuth{
+					{
+						Key:          kong.String("foo"),
+						RSAPublicKey: kong.String("bar"),
+						Secret:       kong.String("baz"),
+						// set by default
+						Algorithm: kong.String("HS256"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "acl",
+			args: args{
+				credType:   "acl",
+				consumer:   &Consumer{},
+				credConfig: map[string]string{"group": "group-foo"},
+			},
+			result: &Consumer{
+				ACLGroups: []*kong.ACLGroup{
+					{
+						Group: kong.String("group-foo"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := processCredential(tt.args.credType, tt.args.consumer,
+				tt.args.credConfig); (err != nil) != tt.wantErr {
+				t.Errorf("processCredential() error = %v, wantErr %v",
+					err, tt.wantErr)
+			}
+			assert.Equal(t, tt.result, tt.args.consumer)
+		})
+	}
+}


### PR DESCRIPTION
Credentials can now be stored in Kubernetes Secrets in an encrypted
fashion. Credentials property in KongConsumer determines the secrets to
be referenced.

With this, KongCredential custom resource should be considered as
deprecated and will be removed in a future release.

Fixes #299