### PR TITLE
Allow controller to associate plugins from other namespaces

### DIFF
--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -275,6 +275,10 @@ func TestFakeStorePlugins(t *testing.T) {
 	plugin, err = store.GetKongPlugin("default", "does-not-exist")
 	assert.NotNil(err)
 	assert.Nil(plugin)
+
+	plugin, err = store.GetKongPlugin("foo", "default/bar")
+	assert.NotNil(plugin)
+	assert.Nil(err)
 }
 
 func TestFakeStoreCredentials(t *testing.T) {

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/internal/apis/configuration/v1"
@@ -138,6 +139,9 @@ func (s Store) GetEndpointsForService(namespace, name string) (*apiv1.Endpoints,
 // GetKongPlugin returns the 'name' KongPlugin resource in namespace.
 func (s Store) GetKongPlugin(namespace, name string) (*configurationv1.KongPlugin, error) {
 	key := fmt.Sprintf("%v/%v", namespace, name)
+	if strings.Contains(name, "/") {
+		key = name
+	}
 	p, exists, err := s.stores.Plugin.GetByKey(key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is in relation to this issue I raised: https://discuss.konghq.com/t/use-kongplugin-from-a-different-kubernetes-namespace/4714. Basically, if you want to consume a plugin that is not defined in the same namespace, there is no way to do it. This change allows you to prefix the name of the plugin with `<namespace>/` and then it will find and use that plugin.

For example:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: kong
    plugins.konghq.com: ops/internal-only-ip
  name: echoserver
  namespace: dev
spec:
  rules:
  - host: echo.web.com
    http:
      paths:
      - backend:
          serviceName: echo
          servicePort: 80
```

I undertand this is just a starting point and there might be security issues we need to think about. Let me know if I can make any improvements.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
