### PR TITLE
feat: new cli parsing and environment variable

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"errors"
 	"flag"
 	"os"
 	"strings"
@@ -25,146 +24,190 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
 	apiv1 "k8s.io/api/core/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
-	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller"
 )
 
-type headers []string
+type cliConfig struct {
+	// Admission controller server properties
+	AdmissionWebhookListen   string
+	AdmissionWebhookCertPath string
+	AdmissionWebhookKeyPath  string
 
-func (h *headers) String() string {
-	return "my string representation"
+	// Kong connection details
+	KongAdminURL           string
+	KongWorkspace          string
+	KongAdminHeaders       []string
+	KongAdminTLSSkipVerify bool
+	KongAdminTLSServerName string
+	KongAdminCACertPath    string
+
+	// Resource filtering
+	WatchNamespace string
+	IngressClass   string
+	ElectionID     string
+
+	// Ingress Status publish resource
+	PublishService         string
+	PublishStatusAddress   string
+	UpdateStatus           bool
+	UpdateStatusOnShutdown bool
+
+	// Rutnime behavior
+	SyncPeriod    time.Duration
+	SyncRateLimit float32
+
+	// k8s connection details
+	APIServerHost      string
+	KubeConfigFilePath string
+
+	// Performance
+	EnableProfiling bool
+
+	// Misc
+	ShowVersion bool
 }
 
-func (h *headers) Set(value string) error {
-	if len(strings.Split(value, ":")) < 2 {
-		return errors.New("header should be of form key:value")
-	}
-	*h = append(*h, value)
-	return nil
-}
+func flagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ExitOnError)
 
-var (
-	admissionWebhookListen   string
-	admissionWebhookCertPath string
-	admissionWebhookKeyPath  string
-)
+	// Admission controller server properties
+	flags.String("admission-webhook-listen", ":8080",
+		`The address to start admission controller on (ip:port).
+Setting it to 'off' disables the admission controller.`)
+	flags.String("admission-webhook-cert-file", "/admission-webhook/tls.crt",
+		`Path to the PEM-encoded certificate file for
+TLS handshake`)
+	flags.String("admission-webhook-key-file", "/admission-webhook/tls.key",
+		`Path to the PEM-encoded private key file for
+TLS handshake`)
 
-func parseFlags() (bool, *controller.Configuration, error) {
-	var (
-		flags = pflag.NewFlagSet("", pflag.ExitOnError)
+	// Kong connection details
+	flags.String("kong-url", "http://localhost:8001",
+		`The address of the Kong Admin URL to connect to in the
+format of protocol://address:port`)
+	flags.String("kong-workspace", "",
+		"Workspace in Kong Enterprise to be configured")
+	flags.StringSlice("admin-header", nil,
+		"add a header (key:value) to every Admin API call, "+
+			"flag can be used multiple times")
+	flags.Bool("admin-tls-skip-verify", false,
+		"Disable verification of TLS certificate of Kong's Admin endpoint.")
+	flags.String("admin-tls-server-name", "",
+		"SNI name to use to verify the certificate presented by Kong in TLS.")
+	flags.String("admin-ca-cert-file", "",
+		`Path to PEM-encoded CA certificate file to verify the
+Kong's Admin SSL certificate.`)
 
-		apiserverHost = flags.String("apiserver-host", "",
-			`The address of the Kubernetes Apiserver to connect to in the format of 
+	// Resource filtering
+	flags.String("watch-namespace", apiv1.NamespaceAll,
+		`Namespace to watch for Ingress. Default is to watch all namespaces`)
+	flags.String("ingress-class", annotations.DefaultIngressClass,
+		`Name of the ingress class to route through this controller.`)
+	flags.String("election-id", "ingress-controller-leader",
+		`Election id to use for status update.`)
+
+	// Ingress Status publish resource
+	flags.String("publish-service", "",
+		`Service fronting the ingress controllers. Takes the form namespace/name.
+The controller will set the endpoint records on the ingress objects
+to reflect those on the service.`)
+	flags.String("publish-status-address", "",
+		`User customized address to be set in the status of ingress resources.
+The controller will set the endpoint records on the
+ingress using this address.`)
+	flags.Bool("update-status", true, `Indicates if the ingress controller
+should update the Ingress status IP/hostname.`)
+	flags.Bool("update-status-on-shutdown", true,
+		`Indicates if the ingress controller should update the Ingress status 
+IP/hostname when the controller is being stopped.`)
+
+	// Rutnime behavior
+	flags.Duration("sync-period", 600*time.Second,
+		`Relist and confirm cloud resources this often.`)
+	flags.Float32("sync-rate-limit", 0.3,
+		`Define the sync frequency upper limit`)
+
+	// k8s connection details
+	flags.String("apiserver-host", "",
+		`The address of the Kubernetes Apiserver to connect to in the format of 
 protocol://address:port, e.g., "http://localhost:8080.
 If not specified, the assumption is that the binary runs inside a 
 Kubernetes cluster and local discovery is attempted.`)
-		kubeConfigFile = flags.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
+	flags.String("kubeconfig", "", "Path to kubeconfig file with "+
+		"authorization and master location information.")
 
-		ingressClass = flags.String("ingress-class", annotations.DefaultIngressClass,
-			`Name of the ingress class to route through this controller.`)
+	// Misc
+	flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
+	flags.Bool("version", false,
+		`Shows release information about the Kong Ingress controller`)
 
-		publishSvc = flags.String("publish-service", "",
-			`Service fronting the ingress controllers. Takes the form namespace/name.
-		The controller will set the endpoint records on the ingress objects to reflect those on the service.`)
+	return flags
+}
 
-		resyncPeriod = flags.Duration("sync-period", 600*time.Second,
-			`Relist and confirm cloud resources this often. Default is 10 minutes`)
+func parseFlags() (cliConfig, error) {
 
-		watchNamespace = flags.String("watch-namespace", apiv1.NamespaceAll,
-			`Namespace to watch for Ingress. Default is to watch all namespaces`)
+	flagSet := flagSet()
 
-		profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
-
-		updateStatus = flags.Bool("update-status", true, `Indicates if the
-		ingress controller should update the Ingress status IP/hostname. Default is true`)
-
-		electionID = flags.String("election-id", "ingress-controller-leader", `Election id to use for status update.`)
-
-		updateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true,
-			`Indicates if the ingress controller should update the Ingress status 
-IP/hostname when the controller is being stopped. Default is true`)
-
-		showVersion = flags.Bool("version", false,
-			`Shows release information about the Kong Ingress controller`)
-
-		syncRateLimit = flags.Float32("sync-rate-limit", 0.3,
-			`Define the sync frequency upper limit`)
-
-		publishStatusAddress = flags.String("publish-status-address", "",
-			`User customized address to be set in the status of ingress resources.
-The controller will set the endpoint records on the ingress using this address.`)
-
-		kongURL = flags.String("kong-url", "http://localhost:8001",
-			"The address of the Kong Admin URL to connect to in the format of protocol://address:port")
-
-		kongTLSSkipVerify = flag.Bool("admin-tls-skip-verify", false,
-			"Disable verification of TLS certificate of Kong's Admin endpoint.")
-		kongTLSServerName = flag.String("admin-tls-server-name", "",
-			"SNI name to use to verify the certificate presented by Kong in TLS.")
-		kongCACert = flag.String("admin-ca-cert-file", "",
-			"Path to PEM-encoded CA certificate file to verify the Kong's Admin SSL certificate.")
-		workspace = flag.String("kong-workspace", "",
-			"Workspace in Kong Enterprise to be configured")
-
-		kongHeaders headers
-	)
-
-	flag.Var(&kongHeaders, "admin-header",
-		"add a header (key:value) to every Admin API call, flag can be used multiple times")
-
-	flag.StringVar(&admissionWebhookListen, "admission-webhook-listen", ":8080",
-		"The address to start admission controller on (ip:port)."+
-			" Setting it to `off` disables the admission controller.")
-	flag.StringVar(&admissionWebhookCertPath, "admission-webhook-cert-file",
-		"/admission-webhook/tls.crt",
-		"Path to the PEM-encoded certificate file for TLS handshake")
-	flag.StringVar(&admissionWebhookKeyPath, "admission-webhook-key-file",
-		"/admission-webhook/tls.key",
-		"Path to the PEM-encoded private key file for TLS handshake")
-
+	// glog
 	flag.Set("logtostderr", "true")
 
-	flags.AddGoFlagSet(flag.CommandLine)
-	flags.Parse(os.Args)
+	flagSet.AddGoFlagSet(flag.CommandLine)
+	flagSet.Parse(os.Args)
 
 	// Workaround for this issue:
 	// https://github.com/kubernetes/kubernetes/issues/17162
 	flag.CommandLine.Parse([]string{})
 
-	pflag.VisitAll(func(flag *pflag.Flag) {
-		glog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
-	})
+	viper.SetEnvPrefix("CONTROLLER")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	viper.BindPFlags(flagSet)
 
-	if *showVersion {
-		return true, nil, nil
+	for key, value := range viper.AllSettings() {
+		glog.V(2).Infof("FLAG: --%s=%q", key, value)
 	}
 
-	config := &controller.Configuration{
-		Kong: controller.Kong{
-			URL:       *kongURL,
-			Headers:   kongHeaders,
-			Workspace: *workspace,
+	var config cliConfig
+	// Admission controller server properties
+	config.AdmissionWebhookListen = viper.GetString("admission-webhook-listen")
+	config.AdmissionWebhookCertPath =
+		viper.GetString("admission-webhook-cert-file")
+	config.AdmissionWebhookKeyPath =
+		viper.GetString("admission-webhook-key-file")
 
-			TLSServerName: *kongTLSServerName,
-			TLSSkipVerify: *kongTLSSkipVerify,
-			CACert:        *kongCACert,
-		},
-		APIServerHost:          *apiserverHost,
-		KubeConfigFile:         *kubeConfigFile,
-		UpdateStatus:           *updateStatus,
-		ElectionID:             *electionID,
-		EnableProfiling:        *profiling,
-		ResyncPeriod:           *resyncPeriod,
-		IngressClass:           *ingressClass,
-		Namespace:              *watchNamespace,
-		PublishService:         *publishSvc,
-		PublishStatusAddress:   *publishStatusAddress,
-		UpdateStatusOnShutdown: *updateStatusOnShutdown,
-		SyncRateLimit:          *syncRateLimit,
-	}
+	// Kong connection details
+	config.KongAdminURL = viper.GetString("kong-url")
+	config.KongWorkspace = viper.GetString("kong-workspace")
+	config.KongAdminHeaders = viper.GetStringSlice("admin-header")
+	config.KongAdminTLSSkipVerify = viper.GetBool("admin-tls-skip-verify")
+	config.KongAdminTLSServerName = viper.GetString("admin-tls-server-name")
+	config.KongAdminCACertPath = viper.GetString("admin-ca-cert-file")
 
-	return false, config, nil
+	// Resource filtering
+	config.WatchNamespace = viper.GetString("watch-namespace")
+	config.IngressClass = viper.GetString("ingress-class")
+	config.ElectionID = viper.GetString("election-id")
+
+	// Ingress Status publish resource
+	config.PublishService = viper.GetString("publish-service")
+	config.PublishStatusAddress = viper.GetString("publish-status-address")
+	config.UpdateStatus = viper.GetBool("update-status")
+	config.UpdateStatusOnShutdown = viper.GetBool("update-status-on-shutdown")
+
+	// Rutnime behavior
+	config.SyncPeriod = viper.GetDuration("sync-period")
+	config.SyncRateLimit = (float32)(viper.GetFloat64("sync-rate-limit"))
+
+	// k8s connection details
+	config.APIServerHost = viper.GetString("apiserver-host")
+	config.KubeConfigFilePath = viper.GetString("kubeconfig")
+
+	// Misc
+	config.EnableProfiling = viper.GetBool("profiling")
+	config.ShowVersion = viper.GetBool("version")
+	return config, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.4
 	github.com/spf13/pflag v1.0.3
+	github.com/spf13/viper v1.2.1
 	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/gjson v1.2.1
 	github.com/tidwall/match v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.40.0 h1:FjSY7bOj+WzJe6TZRVtXI2b9kAYvtNg4lMbcH2+MUkk=
 cloud.google.com/go v0.40.0/go.mod h1:Tk58MuI9rbLMKlAjeO/bDnteAx7tX2gJIXw4T5Jwlro=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -38,7 +38,6 @@ import (
 	networking "k8s.io/api/networking/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
@@ -49,34 +48,23 @@ type Kong struct {
 	URL string
 	// Headers are injected into every request to Kong's Admin API
 	// to help with authorization/authentication.
-	Headers []string
-	Client  *kong.Client
-
-	TLSSkipVerify bool
-	TLSServerName string
-	CACert        string
+	Client *kong.Client
 
 	InMemory      bool
-	Database      string
 	HasTagSupport bool
+	Enterprise    bool
 
-	Enterprise bool
-	Version    semver.Version
-
-	// Workspace is the Kong Enterprise workspace being synced.
-	Workspace string
+	Version semver.Version
 }
 
 // Configuration contains all the settings required by an Ingress controller
 type Configuration struct {
 	Kong
 
-	APIServerHost  string
-	KubeConfigFile string
-	KubeClient     clientset.Interface
-	KubeConf       *rest.Config
+	KubeClient clientset.Interface
 
-	ResyncPeriod time.Duration
+	ResyncPeriod  time.Duration
+	SyncRateLimit float32
 
 	Namespace string
 
@@ -87,12 +75,8 @@ type Configuration struct {
 	PublishStatusAddress string
 
 	UpdateStatus           bool
-	ElectionID             string
 	UpdateStatusOnShutdown bool
-
-	EnableProfiling bool
-
-	SyncRateLimit float32
+	ElectionID             string
 
 	UseNetworkingV1beta1 bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Revamps the CLI configuration and flags of the controller.
The controller can now be configured using environment variables and certain flags are marked as deprecated.

This also enables users to use k8s secrets for sensitive values like authentication header to use against Kong's Admin API, which had to be stored in plain-text previously.