### PR TITLE
Fix secret cert names

### DIFF
--- a/docs/deployment/admission-webhook.md
+++ b/docs/deployment/admission-webhook.md
@@ -31,7 +31,7 @@ in the default case is `kong-validation-webhook.kong.svc`.
 Use openssl to generate a self-signed certificate:
 
 ```bash
-$ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365  \
+$ openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365  \
     -nodes -subj "/CN=kong-validation-webhook.kong.svc"
 Generating a 2048 bit RSA private key
 ..........................................................+++
@@ -52,7 +52,7 @@ on how to generate a certificate using the in-built CA.
 Next, create a Kubernetes secret object based on the key and certificate that
 was generatd in the previous steps.
 Here, we assume that the PEM-encoded certificate is stored in a file named
-`cert.pem` and private key is stored in `key.pem`.
+`tls.crt` and private key is stored in `tls.key`.
 
 ```bash
 $ kubectl create secret tls kong-validation-webhook -n kong \
@@ -103,7 +103,7 @@ webhooks:
     service:
       namespace: kong
       name: kong-validation-webhook
-    caBundle: $(cat cert.pem  | base64) " | kubectl apply -f -
+    caBundle: $(cat tls.crt  | base64) " | kubectl apply -f -
 ```
 
 ## Verify if it works

--- a/docs/deployment/admission-webhook.md
+++ b/docs/deployment/admission-webhook.md
@@ -56,7 +56,7 @@ Here, we assume that the PEM-encoded certificate is stored in a file named
 
 ```bash
 $ kubectl create secret tls kong-validation-webhook -n kong \
-    --key key.pem --cert cert.pem
+    --key tls.crt --cert tls.key
 secret/kong-validation-webhook created
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fix cert names when creating the secret for validation webhook

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Error saw before
```
E1024 15:00:41.568756       1 main.go:315] error running the admission controller server:open /admission-webhook/tls.crt: no such file or directory
```

It worked fine after my change