### PR TITLE
fix(queue) do not log every item that is being queued

### DIFF
--- a/internal/ingress/task/queue.go
+++ b/internal/ingress/task/queue.go
@@ -67,7 +67,6 @@ func (t *Queue) Enqueue(obj interface{}) {
 	}
 
 	ts := time.Now().UnixNano()
-	glog.V(3).Infof("queuing item %v", obj)
 	key, err := t.fn(obj)
 	if err != nil {
 		glog.Errorf("%v", err)


### PR DESCRIPTION
This can potentially lead to leaking of secrets and other sensitive
information in the logs.