### PR TITLE
feat(cli) implement --kong-admin-filter-tag flag

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -31,7 +31,10 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 )
 
-const defaultKongAdminURL = "http://localhost:8001"
+const (
+	defaultKongAdminURL  = "http://localhost:8001"
+	defaultKongFilterTag = "managed-by-ingress-controller"
+)
 
 type cliConfig struct {
 	// Admission controller server properties
@@ -42,6 +45,7 @@ type cliConfig struct {
 	// Kong connection details
 	KongAdminURL           string
 	KongWorkspace          string
+	KongAdminFilterTags    []string
 	KongAdminHeaders       []string
 	KongAdminTLSSkipVerify bool
 	KongAdminTLSServerName string
@@ -100,6 +104,10 @@ format of protocol://address:port`)
 
 	flags.String("kong-workspace", "",
 		"Workspace in Kong Enterprise to be configured")
+
+	flags.StringSlice("kong-admin-filter-tag", []string{defaultKongFilterTag},
+		`add a header (key:value) to every Admin API call,
+this flag can be used multiple times to specify multiple tags`)
 
 	// deprecated
 	flags.StringSlice("admin-header", nil,
@@ -227,6 +235,7 @@ func parseFlags() (cliConfig, error) {
 	config.KongAdminURL = kongAdminURL
 
 	config.KongWorkspace = viper.GetString("kong-workspace")
+	config.KongAdminFilterTags = viper.GetStringSlice("kong-admin-filter-tag")
 
 	config.KongAdminHeaders = viper.GetStringSlice("admin-header")
 	kongAdminHeaders := viper.GetStringSlice("kong-admin-header")

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -60,7 +60,8 @@ import (
 func controllerConfigFromCLIConfig(cliConfig cliConfig) controller.Configuration {
 	return controller.Configuration{
 		Kong: controller.Kong{
-			URL: cliConfig.KongAdminURL,
+			URL:        cliConfig.KongAdminURL,
+			FilterTags: cliConfig.KongAdminFilterTags,
 		},
 
 		ResyncPeriod:  cliConfig.SyncPeriod,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -45,7 +45,8 @@ import (
 
 // Kong Represents a Kong client and connection information
 type Kong struct {
-	URL string
+	URL        string
+	FilterTags []string
 	// Headers are injected into every request to Kong's Admin API
 	// to help with authorization/authentication.
 	Client *kong.Client

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -41,8 +41,6 @@ import (
 
 var count counter.Counter
 
-const ingressControllerTag = "managed-by-ingress-controller"
-
 var upstreamDefaults = kong.Upstream{
 	Slots: kong.Int(10000),
 	Healthchecks: &kong.Healthcheck{
@@ -166,7 +164,7 @@ func (n *KongController) onUpdateDBMode(state *parser.KongState) error {
 func (n *KongController) getIngressControllerTags() []string {
 	var res []string
 	if n.cfg.Kong.HasTagSupport {
-		res = append(res, ingressControllerTag)
+		res = append(res, n.cfg.Kong.FilterTags...)
 	}
 	return res
 }


### PR DESCRIPTION
The new flag can be used to tweak the tag that is used by the Ingress
controller to filter entities it manages and also tag entities it
creates.

This is configurable and should not be changed once the Ingress
Controller is deployed with a database. If the need be, then the
database should be truncated before changing this.