### PR TITLE
Adds support for grpc and grpc(s) to services and routes

### DIFF
--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -171,6 +171,8 @@ spec:
                 enum:
                 - http
                 - https
+                - grpc
+                - grpcs
             https_redirect_status_code:
               type: integer
         proxy:
@@ -181,6 +183,8 @@ spec:
               enum:
               - http
               - https
+              - grpc
+              - grpcs
             path:
               type: string
               pattern: ^/.*$

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -540,8 +540,12 @@ func overrideService(service *Service,
 		return
 	}
 	s := kongIngress.Proxy
+	// grpc(s) doesn't accept a service_path
 	if s.Protocol != nil {
 		service.Protocol = kong.String(*s.Protocol)
+		if *service.Protocol == *kong.String("grpcs") || *service.Protocol == *kong.String("grpc") {
+			service.Path = nil
+		}
 	}
 	if s.Path != nil {
 		service.Path = kong.String(*s.Path)
@@ -573,8 +577,14 @@ func overrideRoute(route *Route,
 	if len(r.Headers) != 0 {
 		route.Headers = r.Headers
 	}
+	// grpc(s) doesn't accept strip_path
 	if len(r.Protocols) != 0 {
 		route.Protocols = cloneStringPointerSlice(r.Protocols...)
+		for _, val := range r.Protocols {
+			if *val == *kong.String("grpc") || *val == *kong.String("grpcs") {
+				route.StripPath = kong.Bool(false)
+			}
+		}
 	}
 	if r.RegexPriority != nil {
 		route.RegexPriority = kong.Int(*r.RegexPriority)

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -711,6 +711,56 @@ func TestOverrideService(t *testing.T) {
 				},
 			},
 		},
+		{
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("grpc"),
+					Path:     kong.String("/"),
+				},
+			},
+			configurationv1.KongIngress{
+				Proxy: &kong.Service{
+					Protocol: kong.String("grpc"),
+				},
+			},
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("grpc"),
+					Path:     nil,
+				},
+			},
+		},
+		{
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("https"),
+					Path:     kong.String("/"),
+				},
+			},
+			configurationv1.KongIngress{
+				Proxy: &kong.Service{
+					Protocol: kong.String("grpcs"),
+				},
+			},
+			Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("grpcs"),
+					Path:     nil,
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testTable {
@@ -827,6 +877,25 @@ func TestOverrideRoute(t *testing.T) {
 					Headers: map[string][]string{
 						"foo-header": {"bar-value"},
 					},
+				},
+			},
+		},
+		{
+			Route{
+				Route: kong.Route{
+					Hosts: kong.StringSlice("foo.com"),
+				},
+			},
+			configurationv1.KongIngress{
+				Route: &kong.Route{
+					Protocols: kong.StringSlice("grpc", "grpcs"),
+				},
+			},
+			Route{
+				Route: kong.Route{
+					Hosts:     kong.StringSlice("foo.com"),
+					Protocols: kong.StringSlice("grpc", "grpcs"),
+					StripPath: kong.Bool(false),
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for grpc and grpc(s) to services and routes, as well as unit tests

Update #387 