### PR TITLE
feat(admission) implement validation for secret-based credentials

### DIFF
--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	admission "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var decoder = codecs.UniversalDeserializer()
@@ -27,6 +28,11 @@ func (v KongFakeValidator) ValidateConsumer(
 
 func (v KongFakeValidator) ValidatePlugin(
 	k8sPlugin configuration.KongPlugin) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
+func (v KongFakeValidator) ValidateCredential(
+	secret corev1.Secret) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -1,0 +1,91 @@
+package admission
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
+	type args struct {
+		secret corev1.Secret
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantOK      bool
+		wantMessage string
+		wantErr     bool
+	}{
+		{
+			name: "valid key-auth credential",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						"key":      []byte("foo"),
+						"credType": []byte("key-auth"),
+					},
+				},
+			},
+			wantOK:      true,
+			wantMessage: "",
+			wantErr:     false,
+		},
+		{
+			name: "invalid key-auth credential",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						"key-wrong": []byte("foo"),
+						"credType":  []byte("key-auth"),
+					},
+				},
+			},
+			wantOK:      false,
+			wantMessage: "missing required field(s): key",
+			wantErr:     false,
+		},
+		{
+			name: "invalid credential type",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						"credType": []byte("foo"),
+					},
+				},
+			},
+			wantOK:      false,
+			wantMessage: "invalid credential type: foo",
+			wantErr:     false,
+		},
+		{
+			name: "non-kong secrets are passed",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						"key": []byte("foo"),
+					},
+				},
+			},
+			wantOK:      true,
+			wantMessage: "",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := KongHTTPValidator{}
+			got, got1, err := validator.ValidateCredential(tt.args.secret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KongHTTPValidator.ValidateCredential() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.wantOK {
+				t.Errorf("KongHTTPValidator.ValidateCredential() got = %v, want %v", got, tt.wantOK)
+			}
+			if got1 != tt.wantMessage {
+				t.Errorf("KongHTTPValidator.ValidateCredential() got1 = %v, want %v", got1, tt.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The validation currently consists of verifying if each and every
required field is provided by the user or not.

In future, the validation can be made smarter to include an Admin API
call to Kong to verify if the creation of such a credential will succeed
or not (see TODO in code).