### PR TITLE
Feat/credential enhancements

### DIFF
--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -128,7 +128,7 @@ func (a Server) handleValidation(request admission.AdmissionRequest) (
 		if err != nil {
 			return nil, err
 		}
-		if _, ok = secret.Data["credType"]; !ok {
+		if _, ok = secret.Data["kongCredType"]; !ok {
 			// secret does not look like a credential resource in Kong
 			ok = true
 			break

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -88,14 +88,23 @@ func (validator KongHTTPValidator) ValidatePlugin(
 }
 
 var (
+	keyAuthFields   = []string{"key"}
+	basicAuthFields = []string{"username", "password"}
+	hmacAuthFields  = []string{"username", "secret"}
+	jwtAuthFields   = []string{"algorithm", "rsa_public_key", "key", "redirect_uris"}
+
 	// TODO dynamically fetch these from Kong
 	credTypeToFields = map[string][]string{
-		"key-auth":   {"key"},
-		"basic-auth": {"username", "password"},
-		"hmac-auth":  {"username", "secret"},
-		"oauth2":     {"name", "client_id", "client_secret", "redirect_uris"},
-		"jwt":        {"algorithm", "rsa_public_key", "key", "secret"},
-		"acl":        {"group"},
+		"key-auth":             keyAuthFields,
+		"keyauth_credential":   keyAuthFields,
+		"basic-auth":           basicAuthFields,
+		"basicauth_credential": basicAuthFields,
+		"hmac-auth":            hmacAuthFields,
+		"hmacauth_credential":  hmacAuthFields,
+		"jwt":                  jwtAuthFields,
+		"jwt_secret":           jwtAuthFields,
+		"oauth2":               {"name", "client_id", "client_secret", "redirect_uris"},
+		"acl":                  {"group"},
 	}
 )
 

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -107,7 +107,7 @@ var (
 func (validator KongHTTPValidator) ValidateCredential(
 	secret corev1.Secret) (bool, string, error) {
 
-	credTypeBytes, ok := secret.Data["credType"]
+	credTypeBytes, ok := secret.Data["kongCredType"]
 	if !ok {
 		// doesn't look like a credential resource
 		return true, "", nil

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -32,6 +32,20 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name: "valid keyauth_credential",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						"key":          []byte("foo"),
+						"kongCredType": []byte("keyauth_credential"),
+					},
+				},
+			},
+			wantOK:      true,
+			wantMessage: "",
+			wantErr:     false,
+		},
+		{
 			name: "invalid key-auth credential",
 			args: args{
 				secret: corev1.Secret{

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -22,8 +22,8 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 			args: args{
 				secret: corev1.Secret{
 					Data: map[string][]byte{
-						"key":      []byte("foo"),
-						"credType": []byte("key-auth"),
+						"key":          []byte("foo"),
+						"kongCredType": []byte("key-auth"),
 					},
 				},
 			},
@@ -36,8 +36,8 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 			args: args{
 				secret: corev1.Secret{
 					Data: map[string][]byte{
-						"key-wrong": []byte("foo"),
-						"credType":  []byte("key-auth"),
+						"key-wrong":    []byte("foo"),
+						"kongCredType": []byte("key-auth"),
 					},
 				},
 			},
@@ -50,7 +50,7 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 			args: args{
 				secret: corev1.Secret{
 					Data: map[string][]byte{
-						"credType": []byte("foo"),
+						"kongCredType": []byte("foo"),
 					},
 				},
 			},

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -283,7 +283,7 @@ func (p *Parser) fillConsumersAndCredentials(state *KongState) error {
 				}
 				credConfig[k] = string(v)
 			}
-			credType, ok := credConfig["credType"].(string)
+			credType, ok := credConfig["kongCredType"].(string)
 			if !ok {
 				glog.Errorf("invalid credType in secret '%v/%v'",
 					consumer.Namespace, cred)

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -175,7 +175,7 @@ func (p *Parser) Build() (*KongState, error) {
 func processCredential(credType string, consumer *Consumer,
 	credConfig interface{}) error {
 	switch credType {
-	case "key-auth":
+	case "key-auth", "keyauth_credential":
 		var cred kong.KeyAuth
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
@@ -183,14 +183,14 @@ func processCredential(credType string, consumer *Consumer,
 
 		}
 		consumer.KeyAuths = append(consumer.KeyAuths, &cred)
-	case "basic-auth":
+	case "basic-auth", "basicauth_credential":
 		var cred kong.BasicAuth
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
 			return errors.Wrap(err, "failed to decode basic-auth credential")
 		}
 		consumer.BasicAuths = append(consumer.BasicAuths, &cred)
-	case "hmac-auth":
+	case "hmac-auth", "hmacauth_credential":
 		var cred kong.HMACAuth
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
@@ -204,7 +204,7 @@ func processCredential(credType string, consumer *Consumer,
 			return errors.Wrap(err, "failed to decode oauth2 credential")
 		}
 		consumer.Oauth2Creds = append(consumer.Oauth2Creds, &cred)
-	case "jwt":
+	case "jwt", "jwt_secret":
 		var cred kong.JWTAuth
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1326,6 +1326,22 @@ func Test_processCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "keyauth_credential",
+			args: args{
+				credType:   "keyauth_credential",
+				consumer:   &Consumer{},
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: &Consumer{
+				KeyAuths: []*kong.KeyAuth{
+					{
+						Key: kong.String("foo"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "basic-auth",
 			args: args{
 				credType: "basic-auth",
@@ -1346,9 +1362,49 @@ func Test_processCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "basicauth_credential",
+			args: args{
+				credType: "basicauth_credential",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"username": "foo",
+					"password": "bar",
+				},
+			},
+			result: &Consumer{
+				BasicAuths: []*kong.BasicAuth{
+					{
+						Username: kong.String("foo"),
+						Password: kong.String("bar"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "hmac-auth",
 			args: args{
 				credType: "hmac-auth",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"username": "foo",
+					"secret":   "bar",
+				},
+			},
+			result: &Consumer{
+				HMACAuths: []*kong.HMACAuth{
+					{
+						Username: kong.String("foo"),
+						Secret:   kong.String("bar"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "hmacauth_credential",
+			args: args{
+				credType: "hmacauth_credential",
 				consumer: &Consumer{},
 				credConfig: map[string]string{
 					"username": "foo",
@@ -1393,6 +1449,30 @@ func Test_processCredential(t *testing.T) {
 			name: "jwt",
 			args: args{
 				credType: "jwt",
+				consumer: &Consumer{},
+				credConfig: map[string]string{
+					"key":            "foo",
+					"rsa_public_key": "bar",
+					"secret":         "baz",
+				},
+			},
+			result: &Consumer{
+				JWTAuths: []*kong.JWTAuth{
+					{
+						Key:          kong.String("foo"),
+						RSAPublicKey: kong.String("bar"),
+						Secret:       kong.String("baz"),
+						// set by default
+						Algorithm: kong.String("HS256"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "jwt_secret",
+			args: args{
+				credType: "jwt_secret",
 				consumer: &Consumer{},
 				credConfig: map[string]string{
 					"key":            "foo",


### PR DESCRIPTION
- Previously, `credType` key was used to lookup the type of kong
credential that was defined.
This key can potentially collide with other use-cases of Secret resource
in Kubernetes.
Hence, this key is renamed to `kongCredType`, which also provides good
context to the end user that this secret has something to do with a
credential inside Kong.
- Allow Kong DAO names to appear in credential types
This helps when users come from a DB-less driven approach and want to use DAO names instead of Admin API names.