### PR TITLE
docs(readme) add Enterprise 1.3 to matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Kong for every release of the Kong Ingress Controller:
 | Kong Enterprise 0.34-x   | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                |
 | Kong Enterprise 0.35-x   | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Kong Enterprise 0.36-x   | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
+| Kong Enterprise 1.3.x   | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
+
 
 ## Get started
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Kong Enterprise 1.3 compatibility information to matrix.

**Special notes for your reviewer**:
So far as I know, Enterprise 1.3 does not add any features from core 1.3 that would make it incompatible with 0.6.x, and I did not find any existing issues indicating otherwise.