### PR TITLE
Fixed broken link to Enterprise documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ helm install stable/kong
 ```
 
 If you are setting up Kong for Kubernetes Enterprise, please
-follow along [this guide](TODO).
+follow along [this guide](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment/k4k8s-enterprise.md).
 
 It takes a few minutes for all components to spin up.
 You now have set up Kong as your Ingress point and


### PR DESCRIPTION
This README had a broken link to the Enterprise installation description

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
