### PR TITLE
deploy: introduce host_header property in KongIngress

### DIFF
--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -209,6 +209,8 @@ spec:
               - "round-robin"
               - "consistent-hashing"
               - "least-connections"
+            host_header:
+              type: string
             hash_on:
               type: string
             hash_on_cookie:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -243,6 +243,8 @@ spec:
                       type: object
                   type: object
               type: object
+            host_header:
+              type: string
             slots:
               minimum: 10
               type: integer

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -243,6 +243,8 @@ spec:
                       type: object
                   type: object
               type: object
+            host_header:
+              type: string
             slots:
               minimum: 10
               type: integer

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -243,6 +243,8 @@ spec:
                       type: object
                   type: object
               type: object
+            host_header:
+              type: string
             slots:
               minimum: 10
               type: integer

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -243,6 +243,8 @@ spec:
                       type: object
                   type: object
               type: object
+            host_header:
+              type: string
             slots:
               minimum: 10
               type: integer


### PR DESCRIPTION
Kong 1.4 ships with the capability to change the host header sent to the
upstream service. This commit adds the property to the CRD.
deck 0.6 adds the capability to configure the property in Kong.