### PR TITLE
fix: populate algorithm of Upstream for Kong >= 1.3.0

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -239,6 +239,7 @@ func (n *KongController) toDeckContent(
 	}
 
 	for _, u := range k8sState.Upstreams {
+		n.fillUpstream(&u.Upstream)
 		upstream := file.FUpstream{Upstream: u.Upstream}
 		for _, t := range u.Targets {
 			target := file.FTarget{Target: t.Target}
@@ -275,10 +276,13 @@ func (n *KongController) toDeckContent(
 	return &content, nil
 }
 
-var kong110version = semver.MustParse("1.1.0")
+var (
+	kong110version = semver.MustParse("1.1.0")
+	kong120version = semver.MustParse("1.2.0")
+	kong130version = semver.MustParse("1.3.0")
 
-var kong120version = semver.MustParse("1.2.0")
-var kongEnterprise036version = semver.MustParse("0.36.0")
+	kongEnterprise036version = semver.MustParse("0.36.0")
+)
 
 func (n *KongController) fillRoute(route *kong.Route) {
 	if n.cfg.Kong.Version.GTE(kong120version) ||
@@ -286,6 +290,14 @@ func (n *KongController) fillRoute(route *kong.Route) {
 			n.cfg.Kong.Version.GTE(kongEnterprise036version)) {
 		if route.HTTPSRedirectStatusCode == nil {
 			route.HTTPSRedirectStatusCode = kong.Int(426)
+		}
+	}
+}
+
+func (n *KongController) fillUpstream(upstream *kong.Upstream) {
+	if n.cfg.Kong.Version.GTE(kong130version) {
+		if upstream.Algorithm == nil {
+			upstream.Algorithm = kong.String("round-robin")
 		}
 	}
 }


### PR DESCRIPTION
The `algorithm` in the `upstream` entity defaults to `round-robin`.
This field was introduced in Kong 1.3.0.

If this field is not set, decK finds a diff between the current state
and target state and issues a PUT request to Kong, updating the upstream
in Kong's database.

This leads to a cache invalidation and rebuilt of upstreams in Kong,
causing performance degradation.

The code now injects the algorithm based on the version of Kong (or Kong
Enterprise). Kong Enterprise 1.3.0.0 will also pick this change
correctly.