### PR TITLE
feat(cli) implement new --kong-admin-concurrency flag

### DIFF
--- a/cli/ingress-controller/flag_test.go
+++ b/cli/ingress-controller/flag_test.go
@@ -50,6 +50,7 @@ func TestDefaults(t *testing.T) {
 		AdmissionWebhookKeyPath:  "/admission-webhook/tls.key",
 
 		KongAdminURL:           "http://localhost:8001",
+		KongAdminConcurrency:   10,
 		KongWorkspace:          "",
 		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
 		KongAdminHeaders:       []string{},
@@ -95,6 +96,7 @@ func TestOverrideViaCLIFlags(t *testing.T) {
 		"--admission-webhook-key-file", "/key-file",
 
 		"--kong-url", "https://kong.example.com",
+		"--kong-admin-concurrency", "1",
 		"--kong-workspace", "yolo",
 		"--kong-admin-filter-tag", "foo-tag",
 		"--admin-header", "foo:bar",
@@ -129,6 +131,7 @@ func TestOverrideViaCLIFlags(t *testing.T) {
 		AdmissionWebhookKeyPath:  "/key-file",
 
 		KongAdminURL:           "https://kong.example.com",
+		KongAdminConcurrency:   1,
 		KongWorkspace:          "yolo",
 		KongAdminFilterTags:    []string{"foo-tag"},
 		KongAdminHeaders:       []string{"foo:bar"},
@@ -172,6 +175,7 @@ func TestOverrideViaEnvVars(t *testing.T) {
 		"CONTROLLER_ADMISSION_WEBHOOK_CERT_FILE": "/new-cert-path",
 		"CONTROLLER_ADMISSION_WEBHOOK_KEY_FILE":  "/new-key-path",
 		"CONTROLLER_ANONYMOUS_REPORTS":           "false",
+		"CONTROLLER_KONG_ADMIN_CONCURRENCY":      "100",
 	}
 	for k, v := range envs {
 		os.Setenv(k, v)
@@ -187,6 +191,7 @@ func TestOverrideViaEnvVars(t *testing.T) {
 
 		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
 		KongAdminURL:           "http://localhost:8001",
+		KongAdminConcurrency:   100,
 		KongWorkspace:          "",
 		KongAdminHeaders:       []string{},
 		KongAdminTLSSkipVerify: false,
@@ -238,6 +243,7 @@ func TestDeprecatedFlags(t *testing.T) {
 	expectedConf := cliConfig{
 		KongAdminURL:           "https://kong.example.com",
 		KongWorkspace:          "yolo",
+		KongAdminConcurrency:   10,
 		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
 		KongAdminHeaders:       []string{"foo:bar"},
 		KongAdminTLSSkipVerify: true,
@@ -298,6 +304,7 @@ func TestDeprecatedFlagPrecedences(t *testing.T) {
 	expectedConf := cliConfig{
 		KongAdminURL:           "http://kong.yolo42.com",
 		KongWorkspace:          "yolo",
+		KongAdminConcurrency:   10,
 		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
 		KongAdminHeaders:       []string{"fuu:baz"},
 		KongAdminTLSSkipVerify: true,

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -45,6 +45,7 @@ type cliConfig struct {
 	// Kong connection details
 	KongAdminURL           string
 	KongWorkspace          string
+	KongAdminConcurrency   int
 	KongAdminFilterTags    []string
 	KongAdminHeaders       []string
 	KongAdminTLSSkipVerify bool
@@ -105,6 +106,9 @@ format of protocol://address:port`)
 
 	flags.String("kong-workspace", "",
 		"Workspace in Kong Enterprise to be configured")
+
+	flag.Int("kong-admin-concurrency", 10,
+		"Max number of concurrent requests sent to Kong's Admin API")
 
 	flags.StringSlice("kong-admin-filter-tag", []string{defaultKongFilterTag},
 		`add a header (key:value) to every Admin API call,
@@ -238,6 +242,7 @@ func parseFlags() (cliConfig, error) {
 	config.KongAdminURL = kongAdminURL
 
 	config.KongWorkspace = viper.GetString("kong-workspace")
+	config.KongAdminConcurrency = viper.GetInt("kong-admin-concurrency")
 	config.KongAdminFilterTags = viper.GetStringSlice("kong-admin-filter-tag")
 
 	config.KongAdminHeaders = viper.GetStringSlice("admin-header")

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -59,8 +59,9 @@ import (
 func controllerConfigFromCLIConfig(cliConfig cliConfig) controller.Configuration {
 	return controller.Configuration{
 		Kong: controller.Kong{
-			URL:        cliConfig.KongAdminURL,
-			FilterTags: cliConfig.KongAdminFilterTags,
+			URL:         cliConfig.KongAdminURL,
+			FilterTags:  cliConfig.KongAdminFilterTags,
+			Concurrency: cliConfig.KongAdminConcurrency,
 		},
 
 		ResyncPeriod:  cliConfig.SyncPeriod,
@@ -100,6 +101,11 @@ func main() {
 
 	if cliConfig.SyncPeriod.Seconds() < 10 {
 		glog.Fatalf("resync period (%vs) is too low", cliConfig.SyncPeriod.Seconds())
+	}
+
+	if cliConfig.KongAdminConcurrency < 1 {
+		glog.Fatalf("kong-admin-concurrency (%v) cannot be less than 1",
+			cliConfig.KongAdminConcurrency)
 	}
 
 	kubeCfg, kubeClient, err := createApiserverClient(cliConfig.APIServerHost,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -56,6 +56,8 @@ type Kong struct {
 	Enterprise    bool
 
 	Version semver.Version
+
+	Concurrency int
 }
 
 // Configuration contains all the settings required by an Ingress controller

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -168,9 +168,8 @@ func (n *KongController) onUpdateDBMode(parserState *parser.KongState) error {
 	if err != nil {
 		return errors.Wrap(err, "creating a new syncer")
 	}
-	// TODO configurable parallelism
 	//client.SetDebugMode(true)
-	errs := solver.Solve(nil, syncer, client, 10, false)
+	errs := solver.Solve(nil, syncer, client, n.cfg.Kong.Concurrency, false)
 	if errs != nil {
 		return utils.ErrArray{Errors: errs}
 	}


### PR DESCRIPTION
This flag can be used to control the maximum number of concurrent
requests that are sent to Kong's Admin API in the DB-mode.

This can be used in debugging and to slow down the controller when Kong
is being backed by Cassandra (not recommended).