### PR TITLE
feat: upstream client certificate for each service

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -33,6 +33,8 @@ const (
 
 	protocolsAnnotationKey = "configuration.konghq.com/protocols"
 
+	clientCertAnnotationKey = "configuration.konghq.com/client-cert"
+
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
 	DefaultIngressClass = "kong"
@@ -106,6 +108,12 @@ func ExtractProtocolName(anns map[string]string) string {
 // ExtractProtocolNames extracts the protocols supplied in the annotation
 func ExtractProtocolNames(anns map[string]string) []string {
 	return strings.Split(anns[protocolsAnnotationKey], ",")
+}
+
+// ExtractClientCertificate extracts the secret name containing the
+// client-certificate to use.
+func ExtractClientCertificate(anns map[string]string) string {
+	return anns[clientCertAnnotationKey]
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -73,6 +73,18 @@ func TestExtractProtocolNames(t *testing.T) {
 		t.Errorf("expected grpc,grpcs as configuration name but got %v", pns)
 	}
 }
+
+func TestExtractClientCert(t *testing.T) {
+	data := map[string]string{
+		"configuration.konghq.com/client-cert": "secret1",
+	}
+
+	secret := ExtractClientCertificate(data)
+	if secret != "secret1" {
+		t.Errorf("expected secret as secret1 but got %v", secret)
+	}
+}
+
 func TestIngrssClassValidatorFunc(t *testing.T) {
 	tests := []struct {
 		ingress    string

--- a/internal/ingress/controller/kong/dbless/kong_inmemory.go
+++ b/internal/ingress/controller/kong/dbless/kong_inmemory.go
@@ -168,6 +168,9 @@ func KongNativeState(k8sState *parser.KongState) *KongDeclarativeConfig {
 			Key:  c.Key,
 			Cert: c.Cert,
 		}
+		if c.ID != nil {
+			cert.ID = kong.String(*c.ID)
+		}
 		for _, sni := range c.SNIs {
 			cert.SNIs = append(cert.SNIs, kong.SNI{Name: kong.String(*sni)})
 		}


### PR DESCRIPTION
Kong can present a client certificate during a TLS handshake to the
upstream service. This is configurable for each service in Kong (each
kubernetes service maps to a service in Kong).

Users can use `configuration.konghq.com/client-cert` annotation on the
service resource in k8s to specify the secret which should be used by
Kong for client authentication.

Fix #348