### PR TITLE
chore(ci) update to go 13 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go v0.40.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
Standardise go version in go.mod and .travis.yaml. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Currently, go.mod is still specifying 1.12, however, the CI build is running with go 13.

**Special notes for your reviewer**:
