### PR TITLE
docs(guides) correct ClusterIssuer example script

### DIFF
--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -163,12 +163,14 @@ metadata:
   namespace: cert-manager
 spec:
   acme:
-    email: user@example.com # please change this
-    http01: {}
+    email: user@example.com #please change this
     privateKeySecretRef:
       name: letsencrypt-prod
-    server: https://acme-v02.api.letsencrypt.org/directory" | kubectl apply -f -
-clusterissuer.certmanager.k8s.io/letsencrypt-prod created
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress: {}" | kubectl apply -f -
+clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
 *Note*: If you run into issues configuring this, be sure that the group (`cert-manager.io`) and version (`v1alpha2`) match those in the output of `kubectl describe crd clusterissuer`.


### PR DESCRIPTION
Example was using old version, updated with example from https://cert-manager.io/docs/configuration/acme/#creating-a-basic-acme-issuer

**What this PR does / why we need it**:
The cert-manager example is not doable without much investigation time.
https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides/cert-manager.md

**Special notes for your reviewer**:
PR requested by @rainest 
See discussion: https://kubernetes.slack.com/archives/CDCA87FRD/p1579287594005300