### PR TITLE
docs(guides) update Deployment version to v1

### DIFF
--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -73,7 +73,7 @@ Any HTTP-based application can be used, for the purpose of the demo, install
 the following echo server:
 
 ```bash
-curl -sL bit.ly/echo-server | kubectl apply -f -
+curl -sL bit.ly/echo-service | kubectl apply -f -
 service/echo created
 deployment.apps/echo created
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -35,7 +35,7 @@ Setup an echo-server application to demonstrate how
 to use Kong Ingress Controller:
 
 ```bash
-curl -sL bit.ly/echo-server | kubectl apply -f -
+curl -sL bit.ly/echo-service | kubectl apply -f -
 service/echo created
 deployment.apps/echo created
 ```

--- a/docs/guides/using-kongingress-resource.md
+++ b/docs/guides/using-kongingress-resource.md
@@ -37,7 +37,7 @@ This is expected as Kong does not yet know how to proxy the request.
 We will start by installing the echo service.
 
 ```bash
-$ kubectl apply -f https://bit.ly/echo-server
+$ kubectl apply -f https://bit.ly/echo-service
 service/echo created
 deployment.apps/echo created
 ```

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -46,7 +46,7 @@ deployment.apps/httpbin created
 ```
 
 ```bash
-$ kubectl apply -f https://bit.ly/echo-server
+$ kubectl apply -f https://bit.ly/echo-service
 service/echo created
 deployment.apps/echo created
 ```


### PR DESCRIPTION
bit.ly/echo-server has Deployment/v1beta1 which has been deprecated and
removed from new Kubernetes versions.

bit.ly/echo-service has Deployment/v1.

Fix #507
