### PR TITLE
feat: new annotation for path stripping on Ingress resource

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -23,17 +23,19 @@ import (
 )
 
 const (
+	annotationPrefix = "configuration.konghq.com"
+
 	ingressClassKey = "kubernetes.io/ingress.class"
 
 	pluginsAnnotationKey = "plugins.konghq.com"
 
-	configurationAnnotationKey = "configuration.konghq.com"
+	configurationAnnotationKey = annotationPrefix
 
-	protocolAnnotationKey = "configuration.konghq.com/protocol"
+	protocolAnnotationKey = annotationPrefix + "/protocol"
 
-	protocolsAnnotationKey = "configuration.konghq.com/protocols"
+	protocolsAnnotationKey = annotationPrefix + "/protocols"
 
-	clientCertAnnotationKey = "configuration.konghq.com/client-cert"
+	clientCertAnnotationKey = annotationPrefix + "/client-cert"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -37,6 +37,8 @@ const (
 
 	clientCertAnnotationKey = annotationPrefix + "/client-cert"
 
+	stripPathAnnotationKey = annotationPrefix + "/strip-path"
+
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
 	DefaultIngressClass = "kong"
@@ -116,6 +118,12 @@ func ExtractProtocolNames(anns map[string]string) []string {
 // client-certificate to use.
 func ExtractClientCertificate(anns map[string]string) string {
 	return anns[clientCertAnnotationKey]
+}
+
+// ExtractStripPath extracts the strip-path annotations containing the
+// the boolean string "true" or "false".
+func ExtractStripPath(anns map[string]string) string {
+	return anns[stripPathAnnotationKey]
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -85,6 +85,17 @@ func TestExtractClientCert(t *testing.T) {
 	}
 }
 
+func TestExtractStripPath(t *testing.T) {
+	data := map[string]string{
+		"configuration.konghq.com/strip-path": "true",
+	}
+
+	secret := ExtractStripPath(data)
+	if secret != "true" {
+		t.Errorf("expected strip-path as true but got %v", secret)
+	}
+}
+
 func TestIngrssClassValidatorFunc(t *testing.T) {
 	tests := []struct {
 		ingress    string


### PR DESCRIPTION
Users can now use `configuration.konghq.com/strip-path` annotation on
Ingress resource  to  control the strip_path property of corresponding
routes in Kong.