### PR TITLE
feat: new annotations group konghq.com

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -23,23 +23,22 @@ import (
 )
 
 const (
-	annotationPrefix = "configuration.konghq.com"
-
 	ingressClassKey = "kubernetes.io/ingress.class"
 
-	pluginsAnnotationKey = "plugins.konghq.com"
+	deprecatedAnnotationPrefix = "configuration.konghq.com"
+	annotationPrefix           = "konghq.com"
 
-	configurationAnnotationKey = annotationPrefix
+	deprecatedPluginsKey       = "plugins.konghq.com"
+	deprecatedConfigurationKey = deprecatedAnnotationPrefix
 
-	protocolAnnotationKey = annotationPrefix + "/protocol"
+	configurationKey = "/override"
+	pluginsKey       = "/plugins"
+	protocolKey      = "/protocol"
+	protocolsKey     = "/protocols"
+	clientCertKey    = "/client-cert"
+	stripPathKey     = "/strip-path"
+	pathKey          = "/path"
 
-	protocolsAnnotationKey = annotationPrefix + "/protocols"
-
-	clientCertAnnotationKey = annotationPrefix + "/client-cert"
-
-	stripPathAnnotationKey = annotationPrefix + "/strip-path"
-
-	pathAnnotationKey = annotationPrefix + "/path"
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
 	DefaultIngressClass = "kong"
@@ -81,12 +80,34 @@ func IngressClassValidatorFuncFromObjectMeta(
 	}
 }
 
+// valueFromAnnotation returns the value of an annotation with key.
+// key is without the annotation prefix of configuration.konghq.com or
+// konghq.com.
+// It first looks up key under the konghq.com group and if one doesn't
+// exist then it looks up the configuration.konghq.com  annotation group.
+func valueFromAnnotation(key string, anns map[string]string) string {
+	value, exists := anns[annotationPrefix+key]
+	if exists {
+		return value
+	}
+	return anns[deprecatedAnnotationPrefix+key]
+}
+
+func pluginsFromAnnotations(anns map[string]string) (string, bool) {
+	value, exists := anns[annotationPrefix+pluginsKey]
+	if exists {
+		return value, exists
+	}
+	value, exists = anns[deprecatedPluginsKey]
+	return value, exists
+}
+
 // ExtractKongPluginsFromAnnotations extracts information about Kong
 // Plugins configured using plugins.konghq.com annotation.
 // This returns a list of KongPlugin resource names that should be applied.
 func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 	var kongPluginCRs []string
-	v, ok := anns[pluginsAnnotationKey]
+	v, ok := pluginsFromAnnotations(anns)
 	if !ok {
 		return kongPluginCRs
 	}
@@ -102,35 +123,40 @@ func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 // ExtractConfigurationName extracts the name of the KongIngress object that holds
 // information about the configuration to use in Routes, Services and Upstreams
 func ExtractConfigurationName(anns map[string]string) string {
-	return anns[configurationAnnotationKey]
+	value, exists := anns[annotationPrefix+configurationKey]
+	if exists {
+		return value
+	}
+	return anns[deprecatedConfigurationKey]
 }
 
 // ExtractProtocolName extracts the protocol supplied in the annotation
 func ExtractProtocolName(anns map[string]string) string {
-	return anns[protocolAnnotationKey]
+	return valueFromAnnotation(protocolKey, anns)
 }
 
 // ExtractProtocolNames extracts the protocols supplied in the annotation
 func ExtractProtocolNames(anns map[string]string) []string {
-	return strings.Split(anns[protocolsAnnotationKey], ",")
+	val := valueFromAnnotation(protocolsKey, anns)
+	return strings.Split(val, ",")
 }
 
 // ExtractClientCertificate extracts the secret name containing the
 // client-certificate to use.
 func ExtractClientCertificate(anns map[string]string) string {
-	return anns[clientCertAnnotationKey]
+	return valueFromAnnotation(clientCertKey, anns)
 }
 
 // ExtractStripPath extracts the strip-path annotations containing the
 // the boolean string "true" or "false".
 func ExtractStripPath(anns map[string]string) string {
-	return anns[stripPathAnnotationKey]
+	return valueFromAnnotation(stripPathKey, anns)
 }
 
 // ExtractPath extracts the path annotations containing the
 // HTTP path.
 func ExtractPath(anns map[string]string) string {
-	return anns[pathAnnotationKey]
+	return valueFromAnnotation(pathKey, anns)
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -25,78 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestExtractKongPluginsFromAnnotations(t *testing.T) {
-	data := map[string]string{
-		"plugins.konghq.com": "kp-rl, kp-cors",
-	}
-
-	ka := ExtractKongPluginsFromAnnotations(data)
-	if len(ka) != 2 {
-		t.Errorf("expected two keys but %v returned", len(ka))
-	}
-	if ka[0] != "kp-rl" {
-		t.Errorf("expected first element to be 'kp-rl'")
-	}
-}
-
-func TestExtractConfigurationName(t *testing.T) {
-	data := map[string]string{
-		"configuration.konghq.com": "demo",
-	}
-
-	cn := ExtractConfigurationName(data)
-	if cn != "demo" {
-		t.Errorf("expected demo as configuration name but got %v", cn)
-	}
-}
-
-func TestExtractProtocolName(t *testing.T) {
-	data := map[string]string{
-		"configuration.konghq.com/protocol": "grpc",
-	}
-
-	pn := ExtractProtocolName(data)
-	if pn != "grpc" {
-		t.Errorf("expected grpc as configuration name but got %v", pn)
-	}
-}
-
-func TestExtractProtocolNames(t *testing.T) {
-	data := map[string]string{
-		"configuration.konghq.com/protocols": "grpc,grpcs",
-	}
-
-	s := []string{"grpc", "grpcs"}
-
-	pns := ExtractProtocolNames(data)
-	if !reflect.DeepEqual(pns, s) {
-		t.Errorf("expected grpc,grpcs as configuration name but got %v", pns)
-	}
-}
-
-func TestExtractClientCert(t *testing.T) {
-	data := map[string]string{
-		"configuration.konghq.com/client-cert": "secret1",
-	}
-
-	secret := ExtractClientCertificate(data)
-	if secret != "secret1" {
-		t.Errorf("expected secret as secret1 but got %v", secret)
-	}
-}
-
-func TestExtractStripPath(t *testing.T) {
-	data := map[string]string{
-		"configuration.konghq.com/strip-path": "true",
-	}
-
-	secret := ExtractStripPath(data)
-	if secret != "true" {
-		t.Errorf("expected strip-path as true but got %v", secret)
-	}
-}
-
-func TestIngrssClassValidatorFunc(t *testing.T) {
+func TestIngressClassValidatorFunc(t *testing.T) {
 	tests := []struct {
 		ingress    string
 		controller string
@@ -151,11 +80,409 @@ func TestExtractPath(t *testing.T) {
 			},
 			want: "/foo",
 		},
+		{
+			name: "non-empty new group",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/path": "/foo",
+				},
+			},
+			want: "/foo",
+		},
+		{
+			name: "group preference",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/path": "/foo",
+					"konghq.com/path":               "/bar",
+				},
+			},
+			want: "/bar",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ExtractPath(tt.args.anns); got != tt.want {
 				t.Errorf("ExtractPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_valueFromAnnotation(t *testing.T) {
+	type args struct {
+		key  string
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			args: args{},
+			want: "",
+		},
+		{
+			name: "legacy group lookup",
+			args: args{
+				key: "/protocol",
+				anns: map[string]string{
+					"configuration.konghq.com/protocol": "https",
+				},
+			},
+			want: "https",
+		},
+		{
+			name: "new group lookup",
+			args: args{
+				key: "/protocol",
+				anns: map[string]string{
+					"konghq.com/protocol": "https",
+				},
+			},
+			want: "https",
+		},
+		{
+			name: "new annotation takes precedence over deprecated one",
+			args: args{
+				key: "/protocol",
+				anns: map[string]string{
+					"konghq.com/protocol":               "https",
+					"configuration.konghq.com/protocol": "grpc",
+				},
+			},
+			want: "https",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := valueFromAnnotation(tt.args.key, tt.args.anns); got != tt.want {
+				t.Errorf("valueFromAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractKongPluginsFromAnnotations(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"plugins.konghq.com": "kp-rl, kp-cors",
+				},
+			},
+			want: []string{"kp-rl", "kp-cors"},
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/plugins": "kp-rl, kp-cors",
+				},
+			},
+			want: []string{"kp-rl", "kp-cors"},
+		},
+		{
+			name: "annotation prioriy",
+			args: args{
+				anns: map[string]string{
+					"plugins.konghq.com": "a,b",
+					"konghq.com/plugins": "kp-rl, kp-cors",
+				},
+			},
+			want: []string{"kp-rl", "kp-cors"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractKongPluginsFromAnnotations(tt.args.anns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractKongPluginsFromAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractConfigurationName(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/override": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "annotation prioriy",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com": "bar",
+					"konghq.com/override":      "foo",
+				},
+			},
+			want: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractConfigurationName(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractConfigurationName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProtocolName(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/protocol": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/protocol": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "annotation prioriy",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/protocol": "bar",
+					"konghq.com/protocol":               "foo",
+				},
+			},
+			want: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractProtocolName(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractProtocolName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProtocolNames(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/protocols": "foo,bar",
+				},
+			},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/protocols": "foo,bar",
+				},
+			},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "annotation prioriy",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/protocols": "bar,foo",
+					"konghq.com/protocols":               "foo,baz",
+				},
+			},
+			want: []string{"foo", "baz"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractProtocolNames(tt.args.anns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractProtocolNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractClientCertificate(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/client-cert": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/client-cert": "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			name: "annotation prioriy",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/client-cert": "bar",
+					"konghq.com/client-cert":               "foo",
+				},
+			},
+			want: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractClientCertificate(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractClientCertificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasServiceUpstreamAnnotation(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "basic sanity",
+			args: args{
+				anns: map[string]string{
+					"ingress.kubernetes.io/service-upstream": "true",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "garbage value",
+			args: args{
+				anns: map[string]string{
+					"ingress.kubernetes.io/service-upstream": "42",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasServiceUpstreamAnnotation(tt.args.anns); got != tt.want {
+				t.Errorf("HasServiceUpstreamAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractStripPath(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/strip-path": "false",
+				},
+			},
+			want: "false",
+		},
+		{
+			name: "non-empty new group",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/strip-path": "true",
+				},
+			},
+			want: "true",
+		},
+		{
+			name: "group preference",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/strip-path": "false",
+					"konghq.com/strip-path":               "true",
+				},
+			},
+			want: "true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractStripPath(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractStripPath() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This commit moves annotations from `configuration.konghq.com` to
`konghq.com`. Thre previous annotations are now deprecated and will be
removed in a future release.

The annotations are mostly the same with the exception of:
- `configuration.konghq.com` is changed to `konghq.com/override`
- `plugins.konghq.com` is changed to `konghq.com/plugins`
