### PR TITLE
Feat/ingress resource annotations

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -31,13 +31,14 @@ const (
 	deprecatedPluginsKey       = "plugins.konghq.com"
 	deprecatedConfigurationKey = deprecatedAnnotationPrefix
 
-	configurationKey = "/override"
-	pluginsKey       = "/plugins"
-	protocolKey      = "/protocol"
-	protocolsKey     = "/protocols"
-	clientCertKey    = "/client-cert"
-	stripPathKey     = "/strip-path"
-	pathKey          = "/path"
+	configurationKey     = "/override"
+	pluginsKey           = "/plugins"
+	protocolKey          = "/protocol"
+	protocolsKey         = "/protocols"
+	clientCertKey        = "/client-cert"
+	stripPathKey         = "/strip-path"
+	pathKey              = "/path"
+	httpsRedirectCodeKey = "/https-redirect-status-code"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -157,6 +158,12 @@ func ExtractStripPath(anns map[string]string) string {
 // HTTP path.
 func ExtractPath(anns map[string]string) string {
 	return valueFromAnnotation(pathKey, anns)
+}
+
+// ExtractHTTPSRedirectStatusCode extracts the https redirect status
+// code annotation value.
+func ExtractHTTPSRedirectStatusCode(anns map[string]string) string {
+	return valueFromAnnotation(httpsRedirectCodeKey, anns)
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -39,6 +39,7 @@ const (
 	stripPathKey         = "/strip-path"
 	pathKey              = "/path"
 	httpsRedirectCodeKey = "/https-redirect-status-code"
+	preserveHostKey      = "/preserve-host"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -164,6 +165,11 @@ func ExtractPath(anns map[string]string) string {
 // code annotation value.
 func ExtractHTTPSRedirectStatusCode(anns map[string]string) string {
 	return valueFromAnnotation(httpsRedirectCodeKey, anns)
+}
+
+// ExtractPreserveHost extracts the preserve-host annotation value.
+func ExtractPreserveHost(anns map[string]string) string {
+	return valueFromAnnotation(preserveHostKey, anns)
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -538,3 +538,35 @@ func TestExtractHTTPSRedirectStatusCode(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractPreserveHost(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/preserve-host": "true",
+				},
+			},
+			want: "true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractPreserveHost(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractPreserveHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -487,3 +487,54 @@ func TestExtractStripPath(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractHTTPSRedirectStatusCode(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/https-redirect-status-code": "301",
+				},
+			},
+			want: "301",
+		},
+		{
+			name: "non-empty new group",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/https-redirect-status-code": "302",
+				},
+			},
+			want: "302",
+		},
+		{
+			name: "group preference",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/https-redirect-status-code": "301",
+					"konghq.com/https-redirect-status-code":               "302",
+				},
+			},
+			want: "302",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractHTTPSRedirectStatusCode(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractHTTPSRedirectStatusCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -893,6 +893,26 @@ func overrideRouteProtocols(route *kong.Route, anns map[string]string) {
 	route.Protocols = prots
 }
 
+func overrideRouteHTTPSRedirectCode(route *kong.Route, anns map[string]string) {
+	code := annotations.ExtractHTTPSRedirectStatusCode(anns)
+	if code == "" {
+		return
+	}
+	statusCode, err := strconv.Atoi(code)
+	if err != nil {
+		return
+	}
+	if statusCode != 426 &&
+		statusCode != 301 &&
+		statusCode != 302 &&
+		statusCode != 307 &&
+		statusCode != 308 {
+		return
+	}
+
+	route.HTTPSRedirectStatusCode = kong.Int(statusCode)
+}
+
 // overrideRouteByAnnotation sets Route protocols via annotation
 func overrideRouteByAnnotation(route *Route) {
 	anns := route.Ingress.Annotations
@@ -901,6 +921,7 @@ func overrideRouteByAnnotation(route *Route) {
 	}
 	overrideRouteProtocols(&route.Route, anns)
 	overrideRouteStripPath(&route.Route, anns)
+	overrideRouteHTTPSRedirectCode(&route.Route, anns)
 }
 
 // overrideRoute sets Route fields by KongIngress first, then by annotation

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -913,6 +913,22 @@ func overrideRouteHTTPSRedirectCode(route *kong.Route, anns map[string]string) {
 	route.HTTPSRedirectStatusCode = kong.Int(statusCode)
 }
 
+func overrideRoutePreserveHost(route *kong.Route, anns map[string]string) {
+	preserveHostValue := annotations.ExtractPreserveHost(anns)
+	if preserveHostValue == "" {
+		return
+	}
+	preserveHostValue = strings.ToLower(preserveHostValue)
+	switch preserveHostValue {
+	case "true":
+		route.PreserveHost = kong.Bool(true)
+	case "false":
+		route.PreserveHost = kong.Bool(false)
+	default:
+		return
+	}
+}
+
 // overrideRouteByAnnotation sets Route protocols via annotation
 func overrideRouteByAnnotation(route *Route) {
 	anns := route.Ingress.Annotations
@@ -922,6 +938,7 @@ func overrideRouteByAnnotation(route *Route) {
 	overrideRouteProtocols(&route.Route, anns)
 	overrideRouteStripPath(&route.Route, anns)
 	overrideRouteHTTPSRedirectCode(&route.Route, anns)
+	overrideRoutePreserveHost(&route.Route, anns)
 }
 
 // overrideRoute sets Route fields by KongIngress first, then by annotation

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -514,6 +514,162 @@ func TestKongRouteAnnotations(t *testing.T) {
 				RegexPriority: kong.Int(0),
 			}, state.Services[0].Routes[0].Route)
 		})
+	t.Run("preserve-host annotation is correctly processed",
+		func(t *testing.T) {
+			ingresses := []*networking.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"konghq.com/preserve-host": "faLsE",
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: networking.IngressBackend{
+													ServiceName: "foo-svc",
+													ServicePort: intstr.FromInt(80),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			services := []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-svc",
+						Namespace: "default",
+					},
+				},
+			}
+			store, err := store.NewFakeStore(store.FakeObjects{
+				Ingresses: ingresses,
+				Services:  services,
+			})
+			assert.Nil(err)
+			parser := New(store)
+			state, err := parser.Build()
+			assert.Nil(err)
+			assert.NotNil(state)
+
+			assert.Equal(1, len(state.Services),
+				"expected one service to be rendered")
+			assert.Equal(kong.Service{
+				Name:           kong.String("default.foo-svc.80"),
+				Host:           kong.String("foo-svc.default.80.svc"),
+				Path:           kong.String("/"),
+				Port:           kong.Int(80),
+				ConnectTimeout: kong.Int(60000),
+				ReadTimeout:    kong.Int(60000),
+				WriteTimeout:   kong.Int(60000),
+				Retries:        kong.Int(5),
+				Protocol:       kong.String("http"),
+			}, state.Services[0].Service)
+
+			assert.Equal(1, len(state.Services[0].Routes),
+				"expected one route to be rendered")
+			assert.Equal(kong.Route{
+				Name:          kong.String("default.bar.00"),
+				StripPath:     kong.Bool(true),
+				Hosts:         kong.StringSlice("example.com"),
+				PreserveHost:  kong.Bool(false),
+				Paths:         kong.StringSlice("/"),
+				Protocols:     kong.StringSlice("http", "https"),
+				RegexPriority: kong.Int(0),
+			}, state.Services[0].Routes[0].Route)
+		})
+	t.Run("preserve-host annotation with random string is correctly processed",
+		func(t *testing.T) {
+			ingresses := []*networking.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"konghq.com/preserve-host": "wiggle wiggle wiggle",
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: networking.IngressBackend{
+													ServiceName: "foo-svc",
+													ServicePort: intstr.FromInt(80),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			services := []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-svc",
+						Namespace: "default",
+					},
+				},
+			}
+			store, err := store.NewFakeStore(store.FakeObjects{
+				Ingresses: ingresses,
+				Services:  services,
+			})
+			assert.Nil(err)
+			parser := New(store)
+			state, err := parser.Build()
+			assert.Nil(err)
+			assert.NotNil(state)
+
+			assert.Equal(1, len(state.Services),
+				"expected one service to be rendered")
+			assert.Equal(kong.Service{
+				Name:           kong.String("default.foo-svc.80"),
+				Host:           kong.String("foo-svc.default.80.svc"),
+				Path:           kong.String("/"),
+				Port:           kong.Int(80),
+				ConnectTimeout: kong.Int(60000),
+				ReadTimeout:    kong.Int(60000),
+				WriteTimeout:   kong.Int(60000),
+				Retries:        kong.Int(5),
+				Protocol:       kong.String("http"),
+			}, state.Services[0].Service)
+
+			assert.Equal(1, len(state.Services[0].Routes),
+				"expected one route to be rendered")
+			assert.Equal(kong.Route{
+				Name:          kong.String("default.bar.00"),
+				StripPath:     kong.Bool(true),
+				Hosts:         kong.StringSlice("example.com"),
+				PreserveHost:  kong.Bool(true),
+				Paths:         kong.StringSlice("/"),
+				Protocols:     kong.StringSlice("http", "https"),
+				RegexPriority: kong.Int(0),
+			}, state.Services[0].Routes[0].Route)
+		})
 }
 
 func TestKongServiceAnnotations(t *testing.T) {
@@ -3662,6 +3818,79 @@ func Test_overrideRouteHTTPSRedirectCode(t *testing.T) {
 			overrideRouteHTTPSRedirectCode(tt.args.route, tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route, tt.want) {
 				t.Errorf("overrideRouteHTTPSRedirectCode() got = %v, want %v", tt.args.route, tt.want)
+			}
+		})
+	}
+}
+
+func Test_overrideRoutePreserveHost(t *testing.T) {
+	type args struct {
+		route *kong.Route
+		anns  map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *kong.Route
+	}{
+		{},
+		{
+			name: "basic empty route",
+			args: args{
+				route: &kong.Route{},
+			},
+			want: &kong.Route{},
+		},
+		{
+			name: "basic sanity",
+			args: args{
+				route: &kong.Route{},
+				anns: map[string]string{
+					"konghq.com/preserve-host": "true",
+				},
+			},
+			want: &kong.Route{
+				PreserveHost: kong.Bool(true),
+			},
+		},
+		{
+			name: "case insensitive",
+			args: args{
+				route: &kong.Route{},
+				anns: map[string]string{
+					"konghq.com/preserve-host": "faLSe",
+				},
+			},
+			want: &kong.Route{
+				PreserveHost: kong.Bool(false),
+			},
+		},
+		{
+			name: "random integer value",
+			args: args{
+				route: &kong.Route{},
+				anns: map[string]string{
+					"konghq.com/https-redirect-status-code": "42",
+				},
+			},
+			want: &kong.Route{},
+		},
+		{
+			name: "random string",
+			args: args{
+				route: &kong.Route{},
+				anns: map[string]string{
+					"konghq.com/https-redirect-status-code": "foo",
+				},
+			},
+			want: &kong.Route{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overrideRoutePreserveHost(tt.args.route, tt.args.anns)
+			if !reflect.DeepEqual(tt.args.route, tt.want) {
+				t.Errorf("overrideRoutePreserveHost() got = %v, want %v", tt.args.route, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Implement two new annotations:
- `konghq.com/https-redirect-status-code`
- `konghq.com/preserve-host`