### PR TITLE
Split registry secrets

### DIFF
--- a/deploy/manifests/enterprise-k8s/kong-enterprise-k8s.yaml
+++ b/deploy/manifests/enterprise-k8s/kong-enterprise-k8s.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-k8s-docker
       containers:
       - name: proxy
         env:

--- a/deploy/manifests/enterprise/kong-enterprise.yaml
+++ b/deploy/manifests/enterprise/kong-enterprise.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-edition-docker
       initContainers:
       - name: wait-for-migrations
         env:
@@ -58,7 +58,7 @@ spec:
   template:
     spec:
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-edition-docker
       containers:
       - name: kong-migrations
         env:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -614,7 +614,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-k8s-docker
       serviceAccountName: kong-serviceaccount
       volumes:
       - configMap:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -683,7 +683,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-edition-docker
       initContainers:
       - command:
         - /bin/sh
@@ -788,7 +788,7 @@ spec:
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.3.0.1-alpine
         name: kong-migrations
       imagePullSecrets:
-      - name: kong-enterprise-docker
+      - name: kong-enterprise-edition-docker
       initContainers:
       - command:
         - /bin/sh

--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -63,11 +63,11 @@ to log in to Bintray and password
 is an API-key that can be provisioned via Bintray.
 
 ```bash
-$ kubectl create secret -n kong docker-registry kong-enterprise-docker \
+$ kubectl create secret -n kong docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-username> \
-    --docker-password=<your-password>
-secret/kong-enterprise-docker created
+    --docker-username=<your-bintray-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-k8s-docker created
 ```
 
 Again, please take a note of the namespace `kong`.

--- a/docs/deployment/kong-enterprise.md
+++ b/docs/deployment/kong-enterprise.md
@@ -59,11 +59,11 @@ to log in to Bintray and password
 is an API-key that can be provisioned via Bintray.
 
 ```bash
-$ kubectl create secret -n kong docker-registry kong-enterprise-docker \
+$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-    --docker-username=<your-username> \
-    --docker-password=<your-password>
-secret/kong-enterprise-docker created
+    --docker-username=<your-bintray-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-edition-docker created
 ```
 
 ### Kong Enterprise bootstrap password


### PR DESCRIPTION
**What this PR does / why we need it**:
Use separate names for the kong-enterprise-edition and kong-enterprise-k8s registry secrets in documentation and manifests.

**Special notes for your reviewer**:
Related to https://github.com/Kong/charts/pull/65 and https://github.com/Kong/docs.konghq.com/pull/1825