### PR TITLE
feat: adding Kuma annotation on ingress Deployment object

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -502,6 +502,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -502,6 +502,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -548,6 +548,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -516,6 +516,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/hack/dev-env/dev-config.yaml
+++ b/hack/dev-env/dev-config.yaml
@@ -493,6 +493,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:

--- a/hack/dev-env/kong-ingress-dbless.yaml
+++ b/hack/dev-env/kong-ingress-dbless.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/port: "9542"
         prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
+        kuma.io/gateway: enabled
       labels:
         app: ingress-kong
     spec:


### PR DESCRIPTION
Adding the `kuma.io/gateway: enabled` annotation on the Kong ingress `Deployment` object in order to support a Kuma Service Mesh.