### PR TITLE
hotfix: correctly set Knative Ingress status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,6 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
-	knative.dev/pkg v0.0.0-20200205160431-4ec5e09f716b // indirect
+	knative.dev/pkg v0.0.0-20200205160431-4ec5e09f716b
 	knative.dev/serving v0.12.1
 )


### PR DESCRIPTION
Knative controllers expect a few status conditions to be set in order to
detect that the Ingress has been correctly satisfied.
