### PR TITLE
Allow "klog" library to use "glog" library's command-line flags

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 )
@@ -203,7 +204,6 @@ Kubernetes cluster and local discovery is attempted.`)
 }
 
 func parseFlags() (cliConfig, error) {
-
 	flagSet := flagSet()
 
 	// glog
@@ -211,6 +211,17 @@ func parseFlags() (cliConfig, error) {
 
 	flagSet.AddGoFlagSet(flag.CommandLine)
 	flagSet.Parse(os.Args)
+
+	// klog
+	// Adapted from the following example:
+	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
+			f2.Value.Set(f1.Value.String())
+		}
+	})
 
 	// Workaround for this issue:
 	// https://github.com/kubernetes/kubernetes/issues/17162


### PR DESCRIPTION
**What this PR does / why we need it**:

With both the "glog" and "klog" libraries in use in the same program, the command-line flags that normally control "glog" wind up controlling "klog" instead, and only "klog." To allow both libraries
to consume their pertinent command-line flags, apply all flag values for flags defined by "klog" in a separate pass.

**Special notes for your reviewer**:

Without this patch, I find that the `--v` command-line flag controls only "klog," and is ignored by "glog." See kubernetes/klog#27 for precedent.