### PR TITLE
Restart Ingress status leader election cycle after premature exit

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -28,6 +29,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -349,12 +351,15 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	go handleSigterm(kong, stopCh, func(code int) {
-		os.Exit(code)
-	})
-
+	exitCh := make(chan int, 1)
+	var wg sync.WaitGroup
 	mux := http.NewServeMux()
-	go registerHandlers(cliConfig.EnableProfiling, 10254, kong, mux)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		serveHTTP(cliConfig.EnableProfiling, 10254, mux, stopCh)
+	}()
+	go handleSigterm(kong, stopCh, exitCh)
 
 	if cliConfig.AnonymousReports {
 		hostname, err := os.Hostname()
@@ -397,12 +402,13 @@ func main() {
 		}()
 	}
 	kong.Start()
+	wg.Wait()
+	os.Exit(<-exitCh)
 }
 
 type exiter func(code int)
 
-func handleSigterm(kong *controller.KongController, stopCh chan struct{},
-	exit exiter) {
+func handleSigterm(kong *controller.KongController, stopCh chan<- struct{}, exitCh chan<- int) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 	<-signalChan
@@ -411,15 +417,10 @@ func handleSigterm(kong *controller.KongController, stopCh chan struct{},
 	exitCode := 0
 	close(stopCh)
 	if err := kong.Stop(); err != nil {
-		glog.Infof("Error during shutdown %v", err)
+		glog.Warningf("Stopping Kong controller failed: %v", err)
 		exitCode = 1
 	}
-
-	glog.Infof("Handled quit, awaiting pod deletion")
-	time.Sleep(10 * time.Second)
-
-	glog.Infof("Exiting with %v", exitCode)
-	exit(exitCode)
+	exitCh <- exitCode
 }
 
 // createApiserverClient creates new Kubernetes Apiserver client. When kubeconfig or apiserverHost param is empty
@@ -512,8 +513,7 @@ func handleFatalInitError(err error) {
 		"https://github.com/kubernetes/ingress-nginx/blob/master/docs/troubleshooting.md", err)
 }
 
-func registerHandlers(enableProfiling bool, port int, ic *controller.KongController, mux *http.ServeMux) {
-
+func serveHTTP(enableProfiling bool, port int, mux *http.ServeMux, stop <-chan struct{}) {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -554,5 +554,19 @@ func registerHandlers(enableProfiling bool, port int, ic *controller.KongControl
 		WriteTimeout:      300 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	glog.Fatal(server.ListenAndServe())
+	var wg sync.WaitGroup
+	go func() {
+		<-stop
+		wg.Add(1)
+		defer wg.Done()
+		// Allow the server to drain for as long as it takes.
+		if err := server.Shutdown(context.Background()); err != nil {
+			// We know the error wasn't due to a timeout.
+			glog.Warningf("Shutting down HTTP server failed: %v", err)
+		}
+	}()
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		glog.Fatalf("HTTP server failed: %v", err)
+	}
+	wg.Wait()
 }

--- a/cli/ingress-controller/main_test.go
+++ b/cli/ingress-controller/main_test.go
@@ -72,26 +72,32 @@ func TestHandleSigterm(t *testing.T) {
 		t.Errorf("unexpected error creating Kong controller: %v", err)
 	}
 
-	kong, err := controller.NewKongController(&controller.Configuration{
-		KubeClient: kubeClient,
-	},
+	kong, err := controller.NewKongController(
+		&controller.Configuration{
+			KubeClient: kubeClient,
+		},
 		channels.NewRingChannel(1024),
 		store.New(store.CacheStores{}, conf.IngressClass),
 	)
 
-	go handleSigterm(kong, make(chan struct{}), func(code int) {
-		if code != 1 {
-			t.Errorf("expected exit code 1 but %v received", code)
-		}
-
-		return
-	})
-
-	time.Sleep(1 * time.Second)
+	exitCh := make(chan int)
+	go handleSigterm(kong, make(chan struct{}), exitCh)
 
 	t.Logf("sending SIGTERM to process PID %v", syscall.Getpid())
 	err = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	if err != nil {
 		t.Errorf("unexpected error sending SIGTERM signal")
 	}
+
+	time.Sleep(1 * time.Second)
+
+	select {
+	case code := <-exitCh:
+		if code != 1 {
+			t.Errorf("expected exit code 1 but %v received", code)
+		}
+	default:
+		t.Errorf("expected exit code to be available")
+	}
+
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/tidwall/gjson v1.2.1
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/pool.v3 v3.1.1

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -297,8 +297,8 @@ func (n *KongController) Stop() error {
 	return nil
 }
 
-// handleBasicAuthUpdates updates basic-auth password field
-// in Kong whenever it is changed.
+// handleBasicAuthUpdates updates basic-auth password field in Kong whenever it is changed.
+//
 // Kong hashes basic-auth passwords in DB and API responses once created.
 // Due to this reason, one can't perform a 'diff' with them.
 // This function filters for basic-auth password changes and applies them

--- a/internal/ingress/election/election.go
+++ b/internal/ingress/election/election.go
@@ -15,11 +15,12 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 // Elector elects a leader in a cluster.
 type Elector interface {
-	Run()
+	Run(context.Context)
 	IsLeader() bool
 }
 
@@ -35,9 +36,30 @@ type elector struct {
 	elector *leaderelection.LeaderElector
 }
 
-func (e elector) Run() {
-	// TODO pass the correct context in here
-	e.elector.Run(context.Background())
+func (e elector) Run(ctx context.Context) {
+	backoff := flowcontrol.NewBackOff(1*time.Second, 15*time.Second)
+	const backoffID = "kong-leader-election"
+	retryCount := 0 // Count of previous attempts, biased by one for "session" labels.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if retryCount > 0 {
+				backoff.Next(backoffID, backoff.Clock.Now())
+				delay := backoff.Get(backoffID)
+				glog.Warningf("leader election session %d terminated unexpectedly; waiting %s before proceeding", retryCount+1, delay)
+				select {
+				case <-time.After(delay):
+				case <-ctx.Done():
+					return
+				}
+			}
+			glog.Infof("starting leader election session %d", retryCount+1)
+			e.elector.Run(ctx)
+			retryCount++
+		}
+	}
 }
 
 func (e elector) IsLeader() bool {
@@ -76,11 +98,12 @@ func NewElector(config Config) Elector {
 	ttl := 30 * time.Second
 	le, err := leaderelection.NewLeaderElector(
 		leaderelection.LeaderElectionConfig{
-			Lock:          &lock,
-			LeaseDuration: ttl,
-			RenewDeadline: ttl / 2,
-			RetryPeriod:   ttl / 4,
-			Callbacks:     config.Callbacks,
+			Lock:            &lock,
+			LeaseDuration:   ttl,
+			RenewDeadline:   ttl / 2,
+			RetryPeriod:     ttl / 4,
+			Callbacks:       config.Callbacks,
+			ReleaseOnCancel: true,
 		})
 
 	if err != nil {

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -101,7 +101,7 @@ type statusSync struct {
 	callbacks leaderelection.LeaderCallbacks
 }
 
-// Run starts the loop to keep the status in sync
+// Run starts the loop to keep the status in sync.
 func (s statusSync) Run() {
 }
 
@@ -109,8 +109,10 @@ func (s statusSync) Callbacks() leaderelection.LeaderCallbacks {
 	return s.callbacks
 }
 
-// Shutdown stop the sync. In case the instance is the leader it will remove the current IP
-// if there is no other instances running.
+// Shutdown stop the sync.
+//
+// When this instance is the leader it will remove its current IP address if no other instances are
+// running.
 func (s statusSync) Shutdown(isLeader bool) {
 	go s.syncQueue.Shutdown()
 	if !isLeader {
@@ -127,22 +129,22 @@ func (s statusSync) Shutdown(isLeader bool) {
 
 	addrs, err := s.runningAddresses()
 	if err != nil {
-		glog.Errorf("error obtaining running IPs: %v", addrs)
+		glog.Errorf("error obtaining IP addresses of running ingress controllers: %v", err)
 		return
 	}
 
 	if len(addrs) > 1 {
-		// leave the job to the next leader
-		glog.Infof("leaving status update for next leader (%v)", len(addrs))
+		// Leave the job to the next leader.
+		glog.Infof("leaving status update for next leader (%d other candidates)", len(addrs)-1)
 		return
 	}
 
 	if s.isRunningMultiplePods() {
-		glog.V(2).Infof("skipping Ingress status update (multiple pods running - another one will be elected as master)")
+		glog.V(2).Infof("skipping Ingress status update (multiple pods running; another one will be elected as leader)")
 		return
 	}
 
-	glog.Infof("removing address from ingress status (%v)", addrs)
+	glog.Infof("removing address from Ingress status (%v)", addrs)
 	s.updateStatus([]apiv1.LoadBalancerIngress{})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The leader election procedure that ensures no more than one Kong ingress controller will update _Ingress_ "status" subresources should run for the life of the process. However, if the leader renewal attempts take longer than the configured ["renewal deadline"](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection?tab=doc#LeaderElectionConfig) (15 seconds) to succeed, the election procedure terminates.

Since the ingress controller continues running even after such repeated election failure, ensure that the procedure starts again. Delay each restart via exponential backoff.

**Which issue this PR fixes**:
Fixes #561.

**Special notes for your reviewer**
I found that _staticcheck_ is displeased with a lot of this code base. I resolved several of its complaints in this patch (unused fields, nil passed as an argument to a `context.Context` parameter).

Also, as part of testing this patch, I noticed that Kong is susceptible to the following issues:
- kubernetes/kubernetes#84729
- kubernetes/kubernetes#87800

Please see these related patches and the discussion that's still underway:
- kubernetes/kubernetes#84737
- kubernetes/kubernetes#84801
- kubernetes/kubernetes#85216
- kubernetes/kubernetes#87821