### PR TITLE
Add host_header annotation for Services

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -180,7 +180,7 @@ func HasServiceUpstreamAnnotation(anns map[string]string) bool {
 	return anns["ingress.kubernetes.io/service-upstream"] == "true"
 }
 
-// ExtractRegexPriority extracts the regex-priority annotation value.
+// ExtractRegexPriority extracts the host-header annotation value.
 func ExtractRegexPriority(anns map[string]string) string {
 	return valueFromAnnotation(regexPriorityKey, anns)
 }

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -41,6 +41,7 @@ const (
 	httpsRedirectCodeKey = "/https-redirect-status-code"
 	preserveHostKey      = "/preserve-host"
 	regexPriorityKey     = "/regex-priority"
+	hostHeaderKey        = "/host-header"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -182,4 +183,9 @@ func HasServiceUpstreamAnnotation(anns map[string]string) bool {
 // ExtractRegexPriority extracts the regex-priority annotation value.
 func ExtractRegexPriority(anns map[string]string) string {
 	return valueFromAnnotation(regexPriorityKey, anns)
+}
+
+// ExtractHostHeader extracts the regex-priority annotation value.
+func ExtractHostHeader(anns map[string]string) string {
+	return valueFromAnnotation(hostHeaderKey, anns)
 }

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -621,3 +621,54 @@ func TestExtractRegexPriority(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractHostHeader(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty old group",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/host-header": "example.com",
+				},
+			},
+			want: "example.com",
+		},
+		{
+			name: "non-empty new group",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/host-header": "example.net",
+				},
+			},
+			want: "example.net",
+		},
+		{
+			name: "group preference",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/host-header": "example.com",
+					"konghq.com/host-header":               "example.net",
+				},
+			},
+			want: "example.net",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractHostHeader(tt.args.anns); got != tt.want {
+				t.Errorf("ExtractHostHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1149,7 +1149,9 @@ func overrideUpstreamByKongIngress(upstream *Upstream,
 		return
 	}
 
-	// name is the only field that is set
+	// The upstream within the KongIngress has no name.
+	// As this overwrites the entire upstream object, we must restore the
+	// original name after.
 	name := *upstream.Upstream.Name
 	upstream.Upstream = *kongIngress.Upstream.DeepCopy()
 	upstream.Name = &name

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1148,40 +1148,11 @@ func overrideUpstreamByKongIngress(upstream *Upstream,
 	if kongIngress == nil || kongIngress.Upstream == nil {
 		return
 	}
-	u := kongIngress.Upstream
-	if u.HostHeader != nil {
-		upstream.HostHeader = kong.String(*u.HostHeader)
-	}
-	if u.Algorithm != nil {
-		upstream.Algorithm = kong.String(*u.Algorithm)
-	}
-	if u.Slots != nil {
-		upstream.Slots = kong.Int(*u.Slots)
-	}
-	if u.Healthchecks != nil {
-		upstream.Healthchecks = u.Healthchecks
-	}
-	if u.HashOn != nil {
-		upstream.HashOn = kong.String(*u.HashOn)
-	}
-	if u.HashFallback != nil {
-		upstream.HashFallback = kong.String(*u.HashFallback)
-	}
-	if u.HashOnHeader != nil {
-		upstream.HashOnHeader = kong.String(*u.HashOnHeader)
-	}
-	if u.HashFallback != nil {
-		upstream.HashFallback = kong.String(*u.HashFallback)
-	}
-	if u.HashFallbackHeader != nil {
-		upstream.HashFallbackHeader = kong.String(*u.HashFallbackHeader)
-	}
-	if u.HashOnCookie != nil {
-		upstream.HashOnCookie = kong.String(*u.HashOnCookie)
-	}
-	if u.HashOnCookiePath != nil {
-		upstream.HashOnCookiePath = kong.String(*u.HashOnCookiePath)
-	}
+
+	// name is the only field that is set
+	name := *upstream.Upstream.Name
+	upstream.Upstream = *kongIngress.Upstream.DeepCopy()
+	upstream.Name = &name
 }
 
 // overrideUpstream sets Upstream fields by KongIngress first, then by annotation
@@ -1194,10 +1165,6 @@ func overrideUpstream(upstream *Upstream,
 
 	overrideUpstreamByKongIngress(upstream, kongIngress)
 	overrideUpstreamByAnnotation(&upstream.Upstream, anns)
-
-	// name is the only field that is set
-	name := *upstream.Upstream.Name
-	upstream.Name = &name
 }
 
 func (p *Parser) getUpstreams(serviceMap map[string]Service) ([]Upstream, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a `konghq.com/host-header` annotation for Services. The annotation sets the `host_header` parameter on the upstream associated with the Service, similar to the equivalent KongIngress setting added in bc506ef.

**Special notes for your reviewer**:
I forgot documentation for `regex-priority` and held off adding it for this one. Currently next does not have the fixes from 36474a5, and adding new docs would probably create conflicts. Do you have a standard process for rebasing next off master, or does it make more sense to just cherry-pick it?