### PR TITLE
feat: implement --enable-reverse-sync flag

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -63,9 +63,10 @@ type cliConfig struct {
 	UpdateStatus           bool
 	UpdateStatusOnShutdown bool
 
-	// Rutnime behavior
-	SyncPeriod    time.Duration
-	SyncRateLimit float32
+	// Runtime behavior
+	SyncPeriod        time.Duration
+	SyncRateLimit     float32
+	EnableReverseSync bool
 
 	// k8s connection details
 	APIServerHost      string
@@ -182,6 +183,7 @@ IP/hostname when the controller is being stopped.`)
 		`Relist and confirm cloud resources this often.`)
 	flags.Float32("sync-rate-limit", 0.3,
 		`Define the sync frequency upper limit`)
+	flag.Bool("enable-reverse-sync", false, `Enable reverse checks from Kong to Kubernetes`)
 
 	// k8s connection details
 	flags.String("apiserver-host", "",
@@ -293,6 +295,7 @@ func parseFlags() (cliConfig, error) {
 	// Rutnime behavior
 	config.SyncPeriod = viper.GetDuration("sync-period")
 	config.SyncRateLimit = (float32)(viper.GetFloat64("sync-rate-limit"))
+	config.EnableReverseSync = viper.GetBool("enable-reverse-sync")
 
 	// k8s connection details
 	config.APIServerHost = viper.GetString("apiserver-host")

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -69,8 +69,9 @@ func controllerConfigFromCLIConfig(cliConfig cliConfig) controller.Configuration
 			Concurrency: cliConfig.KongAdminConcurrency,
 		},
 
-		ResyncPeriod:  cliConfig.SyncPeriod,
-		SyncRateLimit: cliConfig.SyncRateLimit,
+		ResyncPeriod:      cliConfig.SyncPeriod,
+		SyncRateLimit:     cliConfig.SyncRateLimit,
+		EnableReverseSync: cliConfig.EnableReverseSync,
 
 		Namespace: cliConfig.WatchNamespace,
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -72,8 +72,9 @@ type Configuration struct {
 	KongConfigClient configurationClientSet.Interface
 	KnativeClient    knativeClientSet.Interface
 
-	ResyncPeriod  time.Duration
-	SyncRateLimit float32
+	ResyncPeriod      time.Duration
+	SyncRateLimit     float32
+	EnableReverseSync bool
 
 	Namespace string
 
@@ -219,7 +220,7 @@ type KongController struct {
 	// backgroundGroup tracks running background goroutines, on which we'll wait to stop in Stop.
 	backgroundGroup errgroup.Group
 
-	runningConfigHash [32]byte
+	runningConfigHash []byte
 
 	isShuttingDown uint32
 


### PR DESCRIPTION
Disable the optimization of reducing the number of syncs when this flag
is enabled.
This should be used only if there is any human who has write access to
Kong's Admin API or Kong Manager in case of Kong Enterprise.

Fix #559