### PR TITLE
fix: correctly set knative status

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -537,16 +537,16 @@ func (p *Parser) parseKnativeIngressRules(ingressList []*knative.Ingress) (
 							Name: knativeBackend.ServiceName,
 							Port: knativeBackend.ServicePort,
 						},
-						Plugins: []kong.Plugin{
-							{
-								Name: kong.String("request-transformer"),
-								Config: kong.Configuration{
-									"add": map[string]interface{}{
-										"headers": headers,
-									},
+					}
+					if len(headers) > 0 {
+						service.Plugins = append(service.Plugins, kong.Plugin{
+							Name: kong.String("request-transformer"),
+							Config: kong.Configuration{
+								"add": map[string]interface{}{
+									"headers": headers,
 								},
 							},
-						},
+						})
 					}
 				}
 				service.Routes = append(service.Routes, r)


### PR DESCRIPTION
Knative requires DomainInternal in the status to be populated as it is
used for in-cluster communication.

Also fixed a corner case which occurs in knative conformance test only
where no headers are added. Kong 500s if all fields in
config of request-transformer are empty. This is a bug in Kong but we
are working around it with this change.
