### PR TITLE
Add methods annotation

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -42,6 +42,7 @@ const (
 	preserveHostKey      = "/preserve-host"
 	regexPriorityKey     = "/regex-priority"
 	hostHeaderKey        = "/host-header"
+	methodsKey           = "/methods"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -188,4 +189,13 @@ func ExtractRegexPriority(anns map[string]string) string {
 // ExtractHostHeader extracts the regex-priority annotation value.
 func ExtractHostHeader(anns map[string]string) string {
 	return valueFromAnnotation(hostHeaderKey, anns)
+}
+
+// ExtractMethods extracts the methods annotation value.
+func ExtractMethods(anns map[string]string) []string {
+	val := valueFromAnnotation(methodsKey, anns)
+	if val == "" {
+		return []string{}
+	}
+	return strings.Split(val, ",")
 }

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -672,3 +672,54 @@ func TestExtractHostHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractMethods(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty",
+			want: []string{},
+		},
+		{
+			name: "legacy annotation",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/methods": "POST,GET",
+				},
+			},
+			want: []string{"POST", "GET"},
+		},
+		{
+			name: "new annotation",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/methods": "POST,GET",
+				},
+			},
+			want: []string{"POST", "GET"},
+		},
+		{
+			name: "annotation priority",
+			args: args{
+				anns: map[string]string{
+					"configuration.konghq.com/methods": "GET,POST",
+					"konghq.com/methods":               "POST,PUT",
+				},
+			},
+			want: []string{"POST", "PUT"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractMethods(tt.args.anns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractMethods() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -943,7 +943,18 @@ func overrideRouteByKongIngress(route *Route,
 
 	r := kongIngress.Route
 	if len(r.Methods) != 0 {
-		route.Methods = cloneStringPointerSlice(r.Methods...)
+		invalid := false
+		for _, method := range r.Methods {
+			if !validMethods.MatchString(*method) {
+				// if any method is invalid (not an uppercase alpha string),
+				// discard everything
+				glog.Errorf("invalid method found while processing '%v': %v", route.Name, *method)
+				invalid = true
+			}
+		}
+		if !invalid {
+			route.Methods = cloneStringPointerSlice(r.Methods...)
+		}
 	}
 	if len(r.Headers) != 0 {
 		route.Headers = r.Headers
@@ -1090,6 +1101,7 @@ func overrideRouteMethods(route *kong.Route, anns map[string]string) {
 		} else {
 			// if any method is invalid (not an uppercase alpha string),
 			// discard everything
+			glog.Errorf("invalid method found while processing '%v': %v", route.Name, method)
 			return
 		}
 	}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -948,7 +948,8 @@ func overrideRouteByKongIngress(route *Route,
 			if !validMethods.MatchString(*method) {
 				// if any method is invalid (not an uppercase alpha string),
 				// discard everything
-				glog.Errorf("invalid method found while processing '%v': %v", route.Name, *method)
+				glog.Errorf("invalid method found while processing ingress '%v/%v': %v",
+					route.Ingress.Namespace, route.Ingress.Name, *method)
 				invalid = true
 			}
 		}

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -2877,6 +2877,23 @@ func TestOverrideRoute(t *testing.T) {
 			},
 			configurationv1.KongIngress{
 				Route: &kong.Route{
+					Methods: kong.StringSlice("GET", "true"),
+				},
+			},
+			Route{
+				Route: kong.Route{
+					Hosts: kong.StringSlice("foo.com", "bar.com"),
+				},
+			},
+		},
+		{
+			Route{
+				Route: kong.Route{
+					Hosts: kong.StringSlice("foo.com", "bar.com"),
+				},
+			},
+			configurationv1.KongIngress{
+				Route: &kong.Route{
 					HTTPSRedirectStatusCode: kong.Int(302),
 				},
 			},

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -2877,7 +2877,25 @@ func TestOverrideRoute(t *testing.T) {
 			},
 			configurationv1.KongIngress{
 				Route: &kong.Route{
-					Methods: kong.StringSlice("GET", "true"),
+					Methods: kong.StringSlice("GET   ", "post"),
+				},
+			},
+			Route{
+				Route: kong.Route{
+					Hosts:   kong.StringSlice("foo.com", "bar.com"),
+					Methods: kong.StringSlice("GET", "POST"),
+				},
+			},
+		},
+		{
+			Route{
+				Route: kong.Route{
+					Hosts: kong.StringSlice("foo.com", "bar.com"),
+				},
+			},
+			configurationv1.KongIngress{
+				Route: &kong.Route{
+					Methods: kong.StringSlice("GET", "-1"),
 				},
 			},
 			Route{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `konghq.com/methods` annotation for Ingress resources.

**Special notes for your reviewer**:
This validates the methods array based on the [upstream schema validation](https://github.com/Kong/kong/blob/2.0.3/kong/db/schema/typedefs.lua#L204-L207). It follows the pattern used for protocol validation: if any element is invalid, all elements are discarded and the controller logs an error.