### PR TITLE
feat: deprecate cassandra compatibility

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -203,6 +203,11 @@ func main() {
 	if kongDB == "off" {
 		controllerConfig.Kong.InMemory = true
 	}
+	if kongDB == "cassandra" {
+		glog.Error("running controller with kong backed by cassandra is " +
+			"deprecated; please consider using postgres or in-memory mode")
+	}
+
 	req, _ := http.NewRequest("GET",
 		cliConfig.KongAdminURL+"/tags", nil)
 	res, err := kongClient.Do(nil, req, nil)


### PR DESCRIPTION
Running the controller with cassandra has caused all sorts of pains for
users.

We already don't provide any tooling and documentation around
running ingress controller with kong and cassandra.
Helm chart removed easy cassandra mode a while ago, this change emits a
warning. In a future version, the controller will not startup if kong is
running with cassandra as it's data-store.

Based on the current statistics, there is a very small group of
users that will be affected by this change.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
