### PR TITLE
deploy: change externalTrafficPolicy to the default of `Cluster`

### DIFF
--- a/deploy/manifests/base/service.yaml
+++ b/deploy/manifests/base/service.yaml
@@ -17,7 +17,6 @@ metadata:
     # Enable Proxy Protocol when Kong is listening for proxy-protocol
     #service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
 spec:
-  externalTrafficPolicy: Local
   type: LoadBalancer
   ports:
   - name: proxy

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -603,7 +603,6 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  externalTrafficPolicy: Local
   ports:
   - name: proxy
     port: 80

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -603,7 +603,6 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  externalTrafficPolicy: Local
   ports:
   - name: proxy
     port: 80

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -635,7 +635,6 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  externalTrafficPolicy: Local
   ports:
   - name: proxy
     port: 80

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -603,7 +603,6 @@ metadata:
   name: kong-proxy
   namespace: kong
 spec:
-  externalTrafficPolicy: Local
   ports:
   - name: proxy
     port: 80


### PR DESCRIPTION
Originally, the policy was set to `Local` in order to preserve client IP
address out of the box. It turns out that doing so has been more harmful
and frustrating for most users.

Managed k8s offerings other than GKE don't respect this setting.
Especially, traffic routing from an NLB/ELB breaks down terribly if the
policy is changed to `Local`. Google's implementation has/had a bug
where TCP connections are throttled if the policy is `Local`.

Due to these issues, the service will use the default value of
`Cluster`.
This patch only removes the property rather than changing it to avoid
affecting any existing installations.

No installation should use these manifests as is, but rather create a
copy. We don't know how users rely on this so we are going to err on the
safer side.