### PR TITLE
deploy: change CLI flags to environment variables

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -80,12 +80,13 @@ spec:
         - name: kong-server-blocks
           mountPath: /kong
       - name: ingress-controller
-        args:
-        - /kong-ingress-controller
-        - --kong-admin-url=https://localhost:8444
-        - --admin-tls-skip-verify
-        - --publish-service=kong/kong-proxy
         env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: "https://127.0.0.1:8444"
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: "kong/kong-proxy"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -718,12 +718,13 @@ spec:
         volumeMounts:
         - mountPath: /kong
           name: kong-server-blocks
-      - args:
-        - /kong-ingress-controller
-        - --kong-admin-url=https://localhost:8444
-        - --admin-tls-skip-verify
-        - --publish-service=kong/kong-proxy
-        env:
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -713,12 +713,13 @@ spec:
         volumeMounts:
         - mountPath: /kong
           name: kong-server-blocks
-      - args:
-        - /kong-ingress-controller
-        - --kong-admin-url=https://localhost:8444
-        - --admin-tls-skip-verify
-        - --publish-service=kong/kong-proxy
-        env:
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -782,17 +782,18 @@ spec:
         volumeMounts:
         - mountPath: /kong
           name: kong-server-blocks
-      - args:
-        - /kong-ingress-controller
-        - --kong-admin-url=https://localhost:8444
-        - --admin-tls-skip-verify
-        - --publish-service=kong/kong-proxy
-        env:
+      - env:
         - name: CONTROLLER_KONG_ADMIN_TOKEN
           valueFrom:
             secretKeyRef:
               key: password
               name: kong-enterprise-superuser-password
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -731,12 +731,13 @@ spec:
         volumeMounts:
         - mountPath: /kong
           name: kong-server-blocks
-      - args:
-        - /kong-ingress-controller
-        - --kong-admin-url=https://localhost:8444
-        - --admin-tls-skip-verify
-        - --publish-service=kong/kong-proxy
-        env:
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Environment variables are easier to manage and override in the k8s ecosystem.

This change also changes the the Kong URL from `localhost` to
`127.0.0.1` because some support tickets indicated that the DNS was
resolving the IPv6 loopback interface for some (unknown) reason.