### PR TITLE
docs: Further adjust guides to new strip_path default

### DIFF
--- a/docs/guides/prometheus-grafana.md
+++ b/docs/guides/prometheus-grafana.md
@@ -37,7 +37,7 @@ you can skip these steps.
 
 First, we will install Prometheus with a
 scrape interval of 10 seconds to have fine-grained data points for all metrics.
-We’ll install both Prometheus and Grafana in a dedicated ‘monitoring’ namespace.
+We’ll install both Prometheus and Grafana in a dedicated `monitoring` namespace.
 
 To install Prometheus, execute the following:
 
@@ -194,10 +194,13 @@ This will configure Kong to proxy traffic destined for these services correctly.
 Execute the following:
 
 ```bash
-echo "apiVersion: extensions/v1beta1
+echo '
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: sample-ingresses
+  annotations:
+    konghq.com/strip-path: "true"
 spec:
   rules:
   - http:
@@ -213,7 +216,8 @@ spec:
      - path: /invoice
        backend:
          serviceName: invoice
-         servicePort: 80" | kubectl apply -f -
+         servicePort: 80
+' | kubectl apply -f -
 ```
 
 ## Let’s Create Some Traffic

--- a/docs/guides/using-kongingress-resource.md
+++ b/docs/guides/using-kongingress-resource.md
@@ -105,12 +105,11 @@ Request Information:
 
 ## Use KongIngress with Ingress resource
 
-Kong will strip the path defined in the Ingress rule before proxying
-the request to the service.
+By default, Kong will proxy the entire path to the service.
 This can be seen in the real path value in the above response.
 
-We can configure Kong to not strip out this path and to only respond to GET requests
-for this particular Ingress rule.
+We can configure Kong to strip out the part of the path defined in the
+Ingress rule and to only respond to GET requests for this particular rule.
 
 To modify these behaviours, let's first create a KongIngress resource
 defining the new behaviour:
@@ -135,7 +134,7 @@ $ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/overrid
 ingress.extensions/demo patched
 ```
 
-Now, Kong will proxy only GET requests on `/foo/bar` path and
+Now, Kong will proxy only GET requests on `/foo` path and
 strip away `/foo`:
 
 ```bash


### PR DESCRIPTION
Two places that need adjustment after the default for `strip_path` changed to `false` in 0.8:

1. `prometheus-grafana.md`: Without setting it to `true`, the later traffic generation step will generate a lot of errors rather than be silent as intended.
2. `using-kongingress-resource.md`: The configurations are already adjusted, but the text needed to change as well.