### PR TITLE
Add flags to provide certificate PEM string

### DIFF
--- a/cli/ingress-controller/flag_test.go
+++ b/cli/ingress-controller/flag_test.go
@@ -25,6 +25,63 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type TLSPair struct {
+	Key, Cert string
+}
+
+var (
+	tlsPairs = []TLSPair{
+		{
+			Cert: `-----BEGIN CERTIFICATE-----
+MIIC2DCCAcACCQC32eFOsWpKojANBgkqhkiG9w0BAQsFADAuMRcwFQYDVQQDDA5z
+ZWN1cmUtZm9vLWJhcjETMBEGA1UECgwKa29uZ2hxLm9yZzAeFw0xODEyMTgyMTI4
+MDBaFw0xOTEyMTgyMTI4MDBaMC4xFzAVBgNVBAMMDnNlY3VyZS1mb28tYmFyMRMw
+EQYDVQQKDAprb25naHEub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAqhl/HSwV6PbMv+cMFU9X+HuM7QbNNPh39GKa4pkxzFgiAnuuJ4jw9V/bzsEy
+S+ZIyjzo+QKB1LzmgdcX4vkdI22BjxUd9HPHdZxtv3XilbNmSk9UOl2Hh1fORJoS
+7YH+VbvVwiz5lo7qKRepbg/jcKkbs6AUE0YWFygtDLTvhP2qkphQkxZ0m8qroW91
+CWgI73Ar6U2W/YQBRI3+LwtsKo0p2ASDijvqxElQBgBIiyGIr0RZc5pkCJ1eQdDB
+2F6XaMfpeEyBj0MxypNL4S9HHfchOt55J1KOzYnUPkQnSoxp6oEjef4Q/ZCj5BRL
+EGZnTb3tbwzHZCxGtgl9KqO9pQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAKQ5BX
+kkBL+alERL31hsOgWgRiUMw+sPDtRS96ozUlPtVvAg9XFdpY4ldtWkxFcmBnhKzp
+UewjrHkf9rR16NISwUTjlGIwaJu/ACQrY15v+r301Crq2DV+GjiUJFVuT495dp/l
+0LZbt2Sh/uD+r3UNTcJpJ7jb1V0UP7FWXFj8oafsoFSgmxAPjpKQySTC54JK4AYb
+QSnWu1nQLyohnrB9qLZhe2+jOQZnkKuCcWJQ5njvU6SxT3SOKE5XaOZCezEQ6IVL
+U47YCCXsq+7wKWXBhKl4H2Ztk6x3HOC56l0noXWezsMfrou/kjwGuuViGnrjqelS
+WQ7uVeNCUBY+l+qY
+-----END CERTIFICATE-----`,
+			Key: `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCqGX8dLBXo9sy/
+5wwVT1f4e4ztBs00+Hf0YprimTHMWCICe64niPD1X9vOwTJL5kjKPOj5AoHUvOaB
+1xfi+R0jbYGPFR30c8d1nG2/deKVs2ZKT1Q6XYeHV85EmhLtgf5Vu9XCLPmWjuop
+F6luD+NwqRuzoBQTRhYXKC0MtO+E/aqSmFCTFnSbyquhb3UJaAjvcCvpTZb9hAFE
+jf4vC2wqjSnYBIOKO+rESVAGAEiLIYivRFlzmmQInV5B0MHYXpdox+l4TIGPQzHK
+k0vhL0cd9yE63nknUo7NidQ+RCdKjGnqgSN5/hD9kKPkFEsQZmdNve1vDMdkLEa2
+CX0qo72lAgMBAAECggEADxMTYNJ3Xp4Ap0EioQDXGv5YDul7ZiZe+xmCAHLzJtjo
+qq+rT3WjZRuJr1kPzAosiT+8pdTDDMdw5jDZvRO2sV0TDksgzHk2RAYI897OpdWw
+SwWcwU9oo2X0sb+1zbang5GR8BNsSxt/RQUDzu05itJx0gltvgeIDaVR2L5wO6ja
+USa8OVuj/92XtIIve9OtyK9jAzgR6LQOTFrCCEv89/vmy5Bykv4Uz8s8swZmTs3v
+XJmAmruHGuSLMfXk8lBRp/gVyNTi3uMsdph5AJbVKnra5TZLguEozZKbLdNUYk0p
++aAc7rxDcH2sPqa/7DwRvei9dvd5oB3VJlxGVgC8AQKBgQDfznRSSKAD15hoSDzt
+cKNyhLgWAL+MD0jhHKUy3x+Z9OCvf0DVnmru5HfQKq5UfT0t8VTRPGKmOtAMD4cf
+LYjIurvMvpVzQGSJfhtHQuULZTh3dfsM7xivMqSV+9txklMAakM7vGQlOQxhrScM
+21Mp5LWDU6+e2pFCrQPop0IPkQKBgQDCkVE+dou2yFuJx3uytCH1yKPSy9tkdhQH
+dGF12B5dq8MZZozAz5P9YN/COa9WjsNKDqWbEgLEksEQUq4t8SBjHnSV/D3x7rEF
+qgwii0GETYxax6gms8nueIqWZQf+0NbX7Gc5mTqeVb7v3TrhsKr0VNMFRXXQwP2E
+M/pxJq8q1QKBgQC3rH7oXLP+Ez0AMHDYSL3LKULOw/RvpMeh/9lQA6+ysTaIsP3r
+kuSdhCEUVULXEiVYhBug0FcBp3jAvSmem8cLPb0Mjkim2mzoLfeDJ1JEZODPoaLU
+fZEbj4tlj9oLvhOiXpMo/jaOGeCgdPN8aK86zXlt+wtBao0WVFnF4SalEQKBgQC1
+uLfi2SGgs/0a8B/ORoO5ZY3s4c2lRMtsMvyb7iBeaIAuByPLKZUVABe89deXxnsL
+fiaacPX41wBO2IoqCp2vNdC6DP9mKQNZQPtYgCvPAAbo+rVIgH9HpXn7AZ24FyGy
+RfAbUcv3+in9KelGxZTF4zu8HqXtNXMSuOFeMT1FiQKBgF0R+IFDGHhD4nudAQvo
+hncXsgyzK6QUzak6HmFji/CMZ6EU9q6A67JkiEWrYoKqIAKZ2Og8+Eucr/rDdGWc
+kqlmLPBJAJeUsP/9KidBjTE5mIbn/2n089VPMBvnlt2xIcuB6+zrf2NjvlcZEyKS
+Gn+T2uCyOP4a1DTUoPyoNJXo
+-----END PRIVATE KEY-----`,
+		},
+	}
+)
+
 // resetForTesting clears all flag state and sets the usage function as directed.
 // After calling resetForTesting, parse errors in flag handling will not
 // exit the program.
@@ -424,4 +481,42 @@ func TestKongAdminFilterTagEnvVar(t *testing.T) {
 		conf.KongAdminFilterTags)
 
 	assert.Nil(err, "unexpected error parsing default flags")
+}
+
+// test the certificate environment variables
+// these are mutually exclusive with their _FILE partners
+// and aren't tested in the regular override test as such
+func TestEnvironmentCertificates(t *testing.T) {
+	resetForTesting(func() { t.Fatal("bad parse") })
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	assert := assert.New(t)
+
+	envs := map[string]string{
+		"CONTROLLER_ADMISSION_WEBHOOK_LISTEN": ":9001",
+		"CONTROLLER_ADMISSION_WEBHOOK_CERT":   tlsPairs[0].Cert,
+		"CONTROLLER_ADMISSION_WEBHOOK_KEY":    tlsPairs[0].Key,
+		"CONTROLLER_KONG_ADMIN_CA_CERT":       tlsPairs[0].Cert,
+	}
+	for k, v := range envs {
+		os.Setenv(k, v)
+		defer os.Unsetenv(k)
+	}
+
+	conf, err := parseFlags()
+
+	expected := cliConfig{
+		AdmissionWebhookListen:   ":9001",
+		AdmissionWebhookCertPath: "/admission-webhook/tls.crt",
+		AdmissionWebhookKeyPath:  "/admission-webhook/tls.key",
+		AdmissionWebhookCert:     tlsPairs[0].Cert,
+		AdmissionWebhookKey:      tlsPairs[0].Key,
+
+		KongAdminCACert: tlsPairs[0].Cert,
+	}
+	assert.Nil(err, "unexpected error supplying certificates via environment")
+	assert.Equal(expected.AdmissionWebhookCert, conf.AdmissionWebhookCert)
+	assert.Equal(expected.AdmissionWebhookKey, conf.AdmissionWebhookKey)
+	assert.Equal(expected.KongAdminCACert, conf.KongAdminCACert)
 }

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -32,8 +32,10 @@ import (
 )
 
 const (
-	defaultKongAdminURL  = "http://localhost:8001"
-	defaultKongFilterTag = "managed-by-ingress-controller"
+	defaultKongAdminURL             = "http://localhost:8001"
+	defaultKongFilterTag            = "managed-by-ingress-controller"
+	defaultAdmissionWebhookCertPath = "/admission-webhook/tls.crt"
+	defaultAdmissionWebhookKeyPath  = "/admission-webhook/tls.key"
 )
 
 type cliConfig struct {
@@ -90,10 +92,10 @@ func flagSet() *pflag.FlagSet {
 	flags.String("admission-webhook-listen", "off",
 		`The address to start admission controller on (ip:port).
 Setting it to 'off' disables the admission controller.`)
-	flags.String("admission-webhook-cert-file", "/admission-webhook/tls.crt",
+	flags.String("admission-webhook-cert-file", defaultAdmissionWebhookCertPath,
 		`Path to the PEM-encoded certificate file for
 TLS handshake`)
-	flags.String("admission-webhook-key-file", "/admission-webhook/tls.key",
+	flags.String("admission-webhook-key-file", defaultAdmissionWebhookKeyPath,
 		`Path to the PEM-encoded private key file for
 TLS handshake`)
 	flags.String("admission-webhook-cert", "",

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -41,6 +41,8 @@ type cliConfig struct {
 	AdmissionWebhookListen   string
 	AdmissionWebhookCertPath string
 	AdmissionWebhookKeyPath  string
+	AdmissionWebhookCert     string
+	AdmissionWebhookKey      string
 
 	// Kong connection details
 	KongAdminURL           string
@@ -51,6 +53,7 @@ type cliConfig struct {
 	KongAdminTLSSkipVerify bool
 	KongAdminTLSServerName string
 	KongAdminCACertPath    string
+	KongAdminCACert        string
 
 	// Resource filtering
 	WatchNamespace string
@@ -93,6 +96,10 @@ TLS handshake`)
 	flags.String("admission-webhook-key-file", "/admission-webhook/tls.key",
 		`Path to the PEM-encoded private key file for
 TLS handshake`)
+	flags.String("admission-webhook-cert", "",
+		`PEM-encoded certificate for TLS handshake`)
+	flags.String("admission-webhook-key", "",
+		`PEM-encoded private key for TLS handshake`)
 
 	// Kong connection details
 	// deprecated
@@ -155,6 +162,10 @@ Kong's Admin SSL certificate.`)
 		`Path to PEM-encoded CA certificate file to verify
 Kong's Admin SSL certificate.`)
 
+	flags.String("kong-admin-ca-cert", "",
+		`PEM-encoded CA certificate to verify Kong's Admin SSL certificate.`)
+
+	// Resource filtering
 	// Resource filtering
 	flags.String("watch-namespace", apiv1.NamespaceAll,
 		`Namespace to watch for Ingress. Default is to watch all namespaces`)
@@ -234,6 +245,10 @@ func parseFlags() (cliConfig, error) {
 		viper.GetString("admission-webhook-cert-file")
 	config.AdmissionWebhookKeyPath =
 		viper.GetString("admission-webhook-key-file")
+	config.AdmissionWebhookCert =
+		viper.GetString("admission-webhook-cert")
+	config.AdmissionWebhookKey =
+		viper.GetString("admission-webhook-key")
 
 	// Kong connection details
 	kongAdminURL := defaultKongAdminURL
@@ -279,6 +294,11 @@ func parseFlags() (cliConfig, error) {
 	kongAdminCACertPath := viper.GetString("kong-admin-ca-cert-file")
 	if kongAdminCACertPath != "" {
 		config.KongAdminCACertPath = kongAdminCACertPath
+	}
+
+	kongAdminCACert := viper.GetString("kong-admin-ca-cert")
+	if kongAdminCACert != "" {
+		config.KongAdminCACert = kongAdminCACert
 	}
 
 	// Resource filtering

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -420,7 +420,7 @@ func main() {
 				glog.Fatalf("failed to load admission webhook cert: %s", err)
 			}
 		}
-		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert == "" {
+		if cliConfig.AdmissionWebhookCertPath != "" {
 			var err error
 			cert, err = tls.LoadX509KeyPair(cliConfig.AdmissionWebhookCertPath, cliConfig.AdmissionWebhookKeyPath)
 			if err != nil {

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -405,11 +405,11 @@ func main() {
 			},
 		}
 		var cert tls.Certificate
-		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert != defaultAdmissionWebhookCertPath {
+		if cliConfig.AdmissionWebhookCertPath != defaultAdmissionWebhookCertPath && cliConfig.AdmissionWebhookCert != "" {
 			glog.Fatalf("both --admission-webhook-cert-file and --admission-webhook-cert" +
 				"are set. Please remove one or the other")
 		}
-		if cliConfig.AdmissionWebhookKeyPath != "" && cliConfig.AdmissionWebhookKey != defaultAdmissionWebhookKeyPath {
+		if cliConfig.AdmissionWebhookKeyPath != defaultAdmissionWebhookKeyPath && cliConfig.AdmissionWebhookKey != "" {
 			glog.Fatalf("both --admission-webhook-cert-key and --admission-webhook-key" +
 				"are set. Please remove one or the other")
 		}

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -420,7 +420,7 @@ func main() {
 				glog.Fatalf("failed to load admission webhook cert: %s", err)
 			}
 		}
-		if cliConfig.AdmissionWebhookCertPath != "" {
+		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert == "" {
 			var err error
 			cert, err = tls.LoadX509KeyPair(cliConfig.AdmissionWebhookCertPath, cliConfig.AdmissionWebhookKeyPath)
 			if err != nil {

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -420,6 +420,9 @@ func main() {
 				glog.Fatalf("failed to load admission webhook cert: %s", err)
 			}
 		}
+		// although this is partially checked earlier, that check does not fail if it sees the default path
+		// we don't want to overwrite any certs set by admission-webhook-cert, but also don't want to run this
+		// first, as it can potentially result in a fatal error
 		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert == "" {
 			var err error
 			cert, err = tls.LoadX509KeyPair(cliConfig.AdmissionWebhookCertPath, cliConfig.AdmissionWebhookKeyPath)

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -405,17 +405,13 @@ func main() {
 			},
 		}
 		var cert tls.Certificate
-		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert != "" {
-			if cliConfig.AdmissionWebhookCertPath != "/admission-webhook/tls.crt" {
-				glog.Fatalf("both --admission-webhook-cert-file and --admission-webhook-cert" +
-					"are set. Please remove one or the other")
-			}
+		if cliConfig.AdmissionWebhookCertPath != "" && cliConfig.AdmissionWebhookCert != defaultAdmissionWebhookCertPath {
+			glog.Fatalf("both --admission-webhook-cert-file and --admission-webhook-cert" +
+				"are set. Please remove one or the other")
 		}
-		if cliConfig.AdmissionWebhookKeyPath != "" && cliConfig.AdmissionWebhookKey != "" {
-			if cliConfig.AdmissionWebhookKeyPath != "/admission-webhook/tls.key" {
-				glog.Fatalf("both --admission-webhook-cert-key and --admission-webhook-key" +
-					"are set. Please remove one or the other")
-			}
+		if cliConfig.AdmissionWebhookKeyPath != "" && cliConfig.AdmissionWebhookKey != defaultAdmissionWebhookKeyPath {
+			glog.Fatalf("both --admission-webhook-cert-key and --admission-webhook-key" +
+				"are set. Please remove one or the other")
 		}
 		if cliConfig.AdmissionWebhookCert != "" {
 			var err error


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds flags to provide the admin CA certificate and admission webhook cert/key pair as strings, as opposed to their existing file path flags.

**Special notes for your reviewer**:
Tests are for the flags only. I didn't see tests for the details of what main.go loads, or tests elsewhere that appear to set these flags and confirm the content of internal structures.

Manual debugger verification looked fine (insofar as the variables populated and didn't fatally abort), and the webhook listen returned the correct certificate. Didn't have a proper Kong setup for the CA cert part to confirm successful verification.

Ditto negative tests: the other failure cases for args don't appear to have tests in main.go, so none added for these. Manual checks look fine.

