### PR TITLE
feat: implement support for custom entities in DB-less mode

### DIFF
--- a/cli/ingress-controller/flag_test.go
+++ b/cli/ingress-controller/flag_test.go
@@ -162,6 +162,8 @@ func TestOverrideViaCLIFlags(t *testing.T) {
 		"--admin-tls-server-name", "kong-admin.example.com",
 		"--admin-ca-cert-file", "/path/to/ca-cert",
 
+		"--kong-custom-entities-secret", "foons/foosecretname",
+
 		"--watch-namespace", "foons",
 		"--ingress-class", "kong-internal",
 		"--election-id", "new-election-id",
@@ -196,6 +198,8 @@ func TestOverrideViaCLIFlags(t *testing.T) {
 		KongAdminTLSSkipVerify: true,
 		KongAdminTLSServerName: "kong-admin.example.com",
 		KongAdminCACertPath:    "/path/to/ca-cert",
+
+		KongCustomEntitiesSecret: "foons/foosecretname",
 
 		WatchNamespace: "foons",
 		IngressClass:   "kong-internal",
@@ -235,6 +239,8 @@ func TestOverrideViaEnvVars(t *testing.T) {
 		"CONTROLLER_ANONYMOUS_REPORTS":           "false",
 		"CONTROLLER_KONG_ADMIN_CONCURRENCY":      "100",
 		"CONTROLLER_KONG_ADMIN_TOKEN":            "my-secret-token",
+
+		"CONTROLLER_KONG_CUSTOM_ENTITIES_SECRET": "foons/barsecretname",
 	}
 	for k, v := range envs {
 		os.Setenv(k, v)
@@ -256,6 +262,8 @@ func TestOverrideViaEnvVars(t *testing.T) {
 		KongAdminTLSSkipVerify: false,
 		KongAdminTLSServerName: "",
 		KongAdminCACertPath:    "",
+
+		KongCustomEntitiesSecret: "foons/barsecretname",
 
 		WatchNamespace: "",
 		IngressClass:   "kong",

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -47,15 +47,16 @@ type cliConfig struct {
 	AdmissionWebhookKey      string
 
 	// Kong connection details
-	KongAdminURL           string
-	KongWorkspace          string
-	KongAdminConcurrency   int
-	KongAdminFilterTags    []string
-	KongAdminHeaders       []string
-	KongAdminTLSSkipVerify bool
-	KongAdminTLSServerName string
-	KongAdminCACertPath    string
-	KongAdminCACert        string
+	KongAdminURL             string
+	KongWorkspace            string
+	KongAdminConcurrency     int
+	KongAdminFilterTags      []string
+	KongAdminHeaders         []string
+	KongAdminTLSSkipVerify   bool
+	KongAdminTLSServerName   string
+	KongAdminCACertPath      string
+	KongAdminCACert          string
+	KongCustomEntitiesSecret string
 
 	// Resource filtering
 	WatchNamespace string
@@ -167,7 +168,10 @@ Kong's Admin SSL certificate.`)
 	flags.String("kong-admin-ca-cert", "",
 		`PEM-encoded CA certificate to verify Kong's Admin SSL certificate.`)
 
-	// Resource filtering
+	flags.String("kong-custom-entities-secret", "",
+		`Secret containing custom entities that should be populated in DB-less
+mode of Kong. Takes the form of namespace/name.`)
+
 	// Resource filtering
 	flags.String("watch-namespace", apiv1.NamespaceAll,
 		`Namespace to watch for Ingress. Default is to watch all namespaces`)
@@ -191,7 +195,7 @@ should update the Ingress status IP/hostname.`)
 		`Indicates if the ingress controller should update the Ingress status 
 IP/hostname when the controller is being stopped.`)
 
-	// Rutnime behavior
+	// Runtime behavior
 	flags.Duration("sync-period", 600*time.Second,
 		`Relist and confirm cloud resources this often.`)
 	flags.Float32("sync-rate-limit", 0.3,
@@ -307,6 +311,9 @@ func parseFlags() (cliConfig, error) {
 	if kongAdminCACert != "" {
 		config.KongAdminCACert = kongAdminCACert
 	}
+
+	config.KongCustomEntitiesSecret = viper.GetString(
+		"kong-custom-entities-secret")
 
 	// Resource filtering
 	config.WatchNamespace = viper.GetString("watch-namespace")

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -68,6 +68,7 @@ func controllerConfigFromCLIConfig(cliConfig cliConfig) controller.Configuration
 			FilterTags:  cliConfig.KongAdminFilterTags,
 			Concurrency: cliConfig.KongAdminConcurrency,
 		},
+		KongCustomEntitiesSecret: cliConfig.KongCustomEntitiesSecret,
 
 		ResyncPeriod:      cliConfig.SyncPeriod,
 		SyncRateLimit:     cliConfig.SyncRateLimit,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -67,6 +67,7 @@ type Kong struct {
 // Configuration contains all the settings required by an Ingress controller
 type Configuration struct {
 	Kong
+	KongCustomEntitiesSecret string
 
 	KubeClient       clientset.Interface
 	KongConfigClient configClientSet.Interface

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hbagdi/deck/file"
+	"github.com/hbagdi/go-kong/kong"
+)
+
+func Test_renderConfigWithCustomEntities(t *testing.T) {
+	type args struct {
+		state                   *file.Content
+		customEntitiesJSONBytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "basic sanity test for fast-path",
+			args: args{
+				state: &file.Content{
+					FormatVersion: "1.1",
+					Services: []file.FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("foo"),
+								Host: kong.String("example.com"),
+							},
+						},
+					},
+				},
+				customEntitiesJSONBytes: nil,
+			},
+			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "does not break with random bytes in the custom entities",
+			args: args{
+				state: &file.Content{
+					FormatVersion: "1.1",
+					Services: []file.FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("foo"),
+								Host: kong.String("example.com"),
+							},
+						},
+					},
+				},
+				customEntitiesJSONBytes: []byte("random-bytes"),
+			},
+			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "custom entities cannot hijack core entities",
+			args: args{
+				state: &file.Content{
+					FormatVersion: "1.1",
+					Services: []file.FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("foo"),
+								Host: kong.String("example.com"),
+							},
+						},
+					},
+				},
+				customEntitiesJSONBytes: []byte(`{"services":[{"host":"rogue.example.com","name":"rogue"}]}`),
+			},
+			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "custom entities can be populated",
+			args: args{
+				state: &file.Content{
+					FormatVersion: "1.1",
+					Services: []file.FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("foo"),
+								Host: kong.String("example.com"),
+							},
+						},
+					},
+				},
+				customEntitiesJSONBytes: []byte(`{"my-custom-dao-name":` +
+					`[{"name":"custom1","key1":"value1"},` +
+					`{"name":"custom2","dumb":"test-value","boring-test-value-name":"really?"}]}`),
+			},
+			want: []byte(`{"_format_version":"1.1",` +
+				`"my-custom-dao-name":[{"key1":"value1","name":"custom1"},` +
+				`{"boring-test-value-name":"really?","dumb":"test-value","name":"custom2"}]` +
+				`,"services":[{"host":"example.com","name":"foo"}]}`),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderConfigWithCustomEntities(tt.args.state, tt.args.customEntitiesJSONBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("renderConfigWithCustomEntities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("renderConfigWithCustomEntities() = %v, want %v",
+					string(got), string(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Problem
-------

As of today, there is no support in the controller
for custom entities inside Kong. The core custom entities related to
auth plugins are supported out of the box to cover all features that
Kong supports out of the box.

For Kong deployments backed by a database, a custom entity can be
populated via the Admin API and the controller will leave those entities
as is. These custom entities can then be referenced in plugin
configuration. While not perfect, this works currently.

For Kong deployments running without a database, there currently is no
way to setup custom entities.

Solution
--------

This patch adds the ability to add in custom entities into DB-less
instances via a Secret. The secret should have a JSON encoded
representation of he custom entities inside a key with the name
'config'. The controller then ensures that the custom entities are
populated into Kong. The solution only works for DB-less modes.

Caveats
-------

The solution here addresses only a limited number of cases where the
custom entity is used by plugin configurations.
There could be a number of cases where the custom entities have a direct
relationship with core entities. Such cases are currently not supported
as the controller doesn't provide any stable UUIDs for core entities.

Future-work
-----------

- Supporting custom entities which refer core entities of Kong can be
added in future. As of today, I'm not aware of any use-cases that fall
into this category.

- Adding support for controller-managed entities for DB-mode is important
but not supported by decK (the underlying sync library).
decK's static nature makes it hard to extend it in any way currently.

- There is no validation performed by the controller. In future, the
controller can use `/schemas` endpoint on Kong's Admin API to perform
validation and be more resilient.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->