### PR TITLE
Add missing docs for previous PRs

### DIFF
--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -355,6 +355,11 @@ address of an individual target (the Pod IP for controller-managed
 configuration). This annotation overrides the default behavior and sends
 the annotation value as the `Host` header value.
 
+If `konghq.com/preserve-host: true` is present on an Ingress (or
+`route.preserve_host: true` is present in a linked KongIngress), it will take
+precedence over this annotation, and requests to the application will use the
+hostname in the Ingress rule.
+
 Sample usage:
 
 ```yaml

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -14,6 +14,8 @@ Following annotations are supported on Ingress resources:
 | [`konghq.com/preserve-host`](#konghqcompreserve-host) | Pass the `host` header as is to the upstream service. |
 | [`konghq.com/strip-path`](#konghqcomstrip-path) | Strip the path defined in Ingress resource and then forward the request to the upstream service. |
 | [`konghq.com/https-redirect-status-code`](#konghqcomhttps-redirect-status-code) | Set the HTTPS redirect status code to use when an HTTP request is recieved. |
+| [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority. |
+| [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress. |
 | [`konghq.com/override`](#konghqcomoverride) | Control other routing attributes via `KongIngress` resource. |
 | DEPRECATED [`plugins.konghq.com`](#pluginskonghqcom) | Please use [`konghq.com/plugins`](#konghqcomplugins) |
 | DEPRECATED [`configuration.konghq.com`](#configurationkonghqcom) | Please use [`konghq.com/override`](#konghqcomoverride) |
@@ -29,6 +31,7 @@ Following annotations are supported on Service resources:
 | [`konghq.com/protocol`](#konghqcomprotocol) | Set protocol Kong should use to talk to a Kubernetes service |
 | [`konghq.com/path`](#konghqcompath) | HTTP Path that is always prepended to each request that is forwarded to a Kubernetes service |
 | [`konghq.com/client-cert`](#konghqcomclient-cert) | Client certificate and key pair Kong should use to authenticate itself to a specific Kubernetes service |
+| [`konghq.com/host-header`](#konghqcomhost-header) | Set the value sent in the `Host` header when proxying requests upstream |
 | [`konghq.com/override`](#konghqcomoverride) | Fine grained routing and load-balancing |
 | [`ingress.kubernetes.io/service-upstream`](#ingresskubernetesioservice-upstream) | Offload load-balancing to kube-proxy or sidecar |
 | DEPRECATED [`plugins.konghq.com`](#pluginskonghqcom) | Please use [`konghq.com/plugins`](#konghqcomplugins) |
@@ -246,6 +249,39 @@ konghq.com/https-redirect-status-code: "301"
 
 Please note the quotes (`"`) around the integer value.
 
+### `konghq.com/https-regex-priority`
+
+> Available since controller 0.9
+
+Sets the `regex_priority` setting to this value on the Kong route associated
+with the Ingress resource. This controls the [matching evaluation
+order](https://docs.konghq.com/latest/proxy/#evaluation-order) for regex-based
+routes. It accepts any integer value. Routes are evaluated in order of highest
+priority to lowest.
+
+Sample usage:
+
+```yaml
+konghq.com/regex-priority: "10"
+```
+
+Please note the quotes (`"`) around the integer value.
+
+### `konghq.com/methods`
+
+> Available since controller 0.9
+
+Sets the `methods` setting on the Kong route associated with the Ingress
+resource. This controls which request methods will match the route. Any
+uppercase alpha ASCII string is accepted, though most users will use only
+[standard methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
+
+Sample usage:
+
+```yaml
+konghq.com/regex-priority: "GET,POST"
+```
+
 ### `konghq.com/override`
 
 > Available since controller 0.8
@@ -308,6 +344,22 @@ Under the hood, the controller creates a Certificate in Kong and then
 sets the
 [`service.client_certificate`](https://docs.konghq.com/latest/admin-api/#service-object)
 for the service.
+
+### `konghq.com/host-header`
+
+> Available since controller 0.9
+
+Sets the `host_header` setting on the Kong upstream created to represent a
+Kubernetes Service. By default, Kong upstreams set `Host` to the hostname or IP
+address of an individual target (the Pod IP for controller-managed
+configuration). This annotation overrides the default behavior and sends
+the annotation value as the `Host` header value.
+
+Sample usage:
+
+```yaml
+konghq.com/host-header: "test.example.com"
+```
 
 ### `ingress.kubernetes.io/service-upstream`
 

--- a/docs/references/cli-arguments.md
+++ b/docs/references/cli-arguments.md
@@ -31,6 +31,8 @@ Following table describes all the flags that are available:
 | --admin-tls-skip-verify              |`boolean`  | none                            | DEPRECATED, use `--kong-admin-tls-skip-verify`|
 | --admission-webhook-cert-file        |`string`   | `/admission-webhook/tls.crt`    | Path to the PEM-encoded certificate file for TLS handshake.|
 | --admission-webhook-key-file         |`string`   | `/admission-webhook/tls.key`    | Path to the PEM-encoded private key file for TLS handshake.|
+| --admission-webhook-cert             |`string`   | none                            | PEM-encoded certificate string for TLS handshake.|
+| --admission-webhook-key              |`string`   | none                            | PEM-encoded private key string for TLS handshake.|
 | --admission-webhook-listen           |`string`   | `off`                           | The address to start admission controller on (ip:port). Setting it to 'off' disables the admission controller.|
 | --alsologtostderr                    |`boolean`  | `false`                         | Logs are written to standard error as well as to files.|
 | --anonymous-reports                  |`string`   | `true`                          | Send anonymized usage data to help improve Kong.|
@@ -38,6 +40,7 @@ Following table describes all the flags that are available:
 | --election-id                        |`string`   | `ingress-controller-leader`     | The name of ConfigMap (in the same namespace) to use to facilitate leader-election between multiple instances of the controller.|
 | --ingress-class                      |`string`   | `kong`                          | Ingress class name to use to filter Ingress and custom resources when multiple Ingress Controllers are running in the same Kubernetes cluster.|
 | --kong-admin-ca-cert-file            |`string`   | none                            | Path to PEM-encoded CA certificate file to verify Kong's Admin SSL certificate.|
+| --kong-admin-ca-cert                 |`string`   | none                            | PEM-encoded CA certificate string to verify Kong's Admin SSL certificate.|
 | --kong-admin-concurrency             |`int`      | `10`                            | Max number of concurrent requests sent to Kong's Admin API.|
 | --kong-admin-filter-tag              |`string`   | `managed-by-ingress-controller` | The tag used to manage entities in Kong.|
 | --kong-admin-header                  |`string`   | none                            | Add a header (key:value) to every Admin API call, this flag can be used multiple times to specify multiple headers.|


### PR DESCRIPTION
**What this PR does / why we need it**:
Docs for #628, #591, #597, and #609 were previously missing because most of them needed something from master. Master has since been merged into next, and these can now be added.