### PR TITLE
deploy: bump up enterprise image to the latest

### DIFF
--- a/deploy/manifests/enterprise-k8s/kustomization.yaml
+++ b/deploy/manifests/enterprise-k8s/kustomization.yaml
@@ -5,4 +5,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  newTag: 2.0.2.0-alpine
+  newTag: 2.0.4.1-alpine

--- a/deploy/manifests/enterprise/kustomization.yaml
+++ b/deploy/manifests/enterprise/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  newTag: 1.3.0.1-alpine
+  newTag: 1.5.0.2-alpine

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -673,7 +673,7 @@ spec:
           value: 127.0.0.1:8444 ssl
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.2.0-alpine
+        image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.4.1-alpine
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -731,7 +731,7 @@ spec:
           value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.3.0.1-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         lifecycle:
           preStop:
             exec:
@@ -848,7 +848,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.3.0.1-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -933,7 +933,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.3.0.1-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker


### PR DESCRIPTION
- Bump kong-enterprise-k8s to 2.0.4.1
  Changelog: https://docs.konghq.com/enterprise/k8s-changelog/
- Bump kong-enterprise to 1.5.0.2
  Changelog: https://docs.konghq.com/enterprise/changelog/