### PR TITLE
docs: specify key in --from-file parameter

### DIFF
--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -40,14 +40,11 @@ Save the license file temporarily to disk with filename `license`
 and execute the following:
 
 ```bash
-$ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+$ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
 secret/kong-enterprise-license created
 ```
 
-Please note:
-
-- There is no `.json` extension in the `--from-file` parameter.
-- `-n kong` specifies the namespace in which you are deploying
+Please note that `-n kong` specifies the namespace in which you are deploying
   Kong Ingress Controller. If you are deploying in a different namespace,
   please change this value.
 

--- a/docs/deployment/kong-enterprise.md
+++ b/docs/deployment/kong-enterprise.md
@@ -37,14 +37,11 @@ As part of sign up for Kong Enterprise, you should have received a license file.
 Save the license file temporarily to disk and execute the following:
 
 ```bash
-$ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+$ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
 secret/kong-enterprise-license created
 ```
 
-Please note:
-
-- There is no `.json` extension in the `--from-file` parameter.
-- `-n kong` specifies the namespace in which you are deploying
+Please note that `-n kong` specifies the namespace in which you are deploying
   Kong Ingress Controller. If you are deploying in a different namespace,
   please change this value.
 


### PR DESCRIPTION
Enterprise users frequently run into problems with the current way the
secret is created. The files have extensions which cause problem later
on in the deployment and this has taken up a lot of time in debugging
several support tickets.

The new format makes it clear and avoids problems when the file has an
extension or is present in a different directory.