### PR TITLE
Fix CRD definition

### DIFF
--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -46,14 +46,14 @@ spec:
           type: object
           properties:
             secretKeyRef:
+              required:
+              - name
+              - key
               type: object
-              required: true
               properties:
                 name:
-                  required: true
                   type: string
                 key:
-                  required: true
                   type: string
         run_on:
           type: string
@@ -121,18 +121,18 @@ spec:
           type: object
           properties:
             secretKeyRef:
+              required:
+              - name
+              - namespace
+              - key
               type: object
-              required: true
               properties:
                 namespace:
                   type: string
-                  required: true
                 name:
                   type: string
-                  required: true
                 key:
                   type: string
-                  required: true
         run_on:
           type: string
           enum:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -44,15 +44,15 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
                 namespace:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - namespace
+              - key
               type: object
           type: object
         disabled:
@@ -380,12 +380,12 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - key
               type: object
           type: object
         disabled:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -44,15 +44,15 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
                 namespace:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - namespace
+              - key
               type: object
           type: object
         disabled:
@@ -380,12 +380,12 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - key
               type: object
           type: object
         disabled:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -44,15 +44,15 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
                 namespace:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - namespace
+              - key
               type: object
           type: object
         disabled:
@@ -380,12 +380,12 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - key
               type: object
           type: object
         disabled:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -44,15 +44,15 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
                 namespace:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - namespace
+              - key
               type: object
           type: object
         disabled:
@@ -380,12 +380,12 @@ spec:
             secretKeyRef:
               properties:
                 key:
-                  required: true
                   type: string
                 name:
-                  required: true
                   type: string
-              required: true
+              required:
+              - name
+              - key
               type: object
           type: object
         disabled:

--- a/hack/dev/common/custom-types.yaml
+++ b/hack/dev/common/custom-types.yaml
@@ -46,14 +46,14 @@ spec:
           type: object
           properties:
             secretKeyRef:
+              required:
+              - name
+              - key
               type: object
-              required: true
               properties:
                 name:
-                  required: true
                   type: string
                 key:
-                  required: true
                   type: string
         run_on:
           type: string
@@ -121,18 +121,18 @@ spec:
           type: object
           properties:
             secretKeyRef:
+              required:
+              - name
+              - namespace
+              - key
               type: object
-              required: true
               properties:
                 namespace:
                   type: string
-                  required: true
                 name:
                   type: string
-                  required: true
                 key:
                   type: string
-                  required: true
         run_on:
           type: string
           enum:


### PR DESCRIPTION
**What this PR does / why we need it**:
Despite https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#jsonschemaprops-v1beta1-apiextensions-k8s-io indicating that `properties` is a generic object (that presumably uses OpenAPI syntax), it is apparently instead a nested JSONSchemaProps and uses the same top-level array of required elements rather than the OpenAPI inline required booleans :shrug:
