### PR TITLE
Revert fix: remove statement that always errored"

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -226,6 +226,9 @@ func parseFlags() (cliConfig, error) {
 	flagSet := flagSet()
 
 	// glog
+	// The error is being ignored here for unit testing,
+	// this always errors out in unit tests but succeeds in e2e runs.
+	_ = flag.Set("logtostderr", "true")
 
 	flagSet.AddGoFlagSet(flag.CommandLine)
 	if err := flagSet.Parse(os.Args); err != nil {


### PR DESCRIPTION
This reverts commit db0576642738d111bad71663a4ef517d8966a22b.

This actually doesn't error and works well. Removing this results in no
logs from glog.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
