### PR TITLE
fix(parser) skip processing ingress rule with invalid '//' path

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -662,6 +662,12 @@ func (p *Parser) parseIngressRules(
 			for j, rule := range rule.HTTP.Paths {
 				path := rule.Path
 
+				if strings.Contains(path, "//") {
+					glog.Errorf("ingress rule skipped in Ingress'%v/%v', "+
+						"'%v' is an invalid path", ingress.Namespace,
+						ingress.Name, path)
+					continue
+				}
 				if path == "" {
 					path = "/"
 				}


### PR DESCRIPTION
A path with consecutive double slashes is considered invalid by Kong and
the reconcililation loop will break in Kong if such a route is added to
the configuration.

Fix #614
