### PR TITLE
fix: correctly find other pods when exiting

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -271,8 +271,14 @@ func inSlice(e string, arr []string) bool {
 }
 
 func (s *statusSync) isRunningMultiplePods() bool {
+	selectLabels := map[string]string{}
+	for k, v := range s.pod.Labels {
+		if k != "pod-template-hash" {
+			selectLabels[k] = v
+		}
+	}
 	pods, err := s.CoreClient.CoreV1().Pods(s.pod.Namespace).List(metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(s.pod.Labels).String(),
+		LabelSelector: labels.SelectorFromSet(selectLabels).String(),
 	})
 	if err != nil {
 		return false


### PR DESCRIPTION
When the controller exits, it tries to search for other ingress
controller pods running in the cluster. It does so by looking up pods
which contain the same labels.

During an upgrade or any change to Deployment spec, the
pod-template-hash label value changes because ReplicaSet controller
needs to uniquely monitor the pods that are part of the previous version
and the new version. This leads to an incorrect logic where the
controller falsely assumes that there are no other pods running in the
cluster.

This commit fixes the logic for specific deployments but doesn't address
the problem for deployments of all types. This is discussed in more
detail in the connected issue.

Relates to #581