### PR TITLE
Warn about unique consumer fields in docs

### DIFF
--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -309,6 +309,12 @@ username: team-X
 When this resource is created, a corresponding consumer entity will be
 created in Kong.
 
+Consumers' `username` and `custom_id` values must be unique across the Kong
+cluster. While KongConsumers exist in a specific Kubernetes namespace,
+KongConsumers from all namespaces are combined into a single Kong
+configuration, and no KongConsumers with the same `kubernetes.io/ingress.class`
+may share the same `username` or `custom_id` value.
+
 ## KongCredential (Deprecated)
 
 This custom resource can be used to configure a consumer specific


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation to KongConsumer reference indicating that `username` and `custom_id` need to be unique across namespaces.

**Special notes for your reviewer**:
This intentionally does not go into workspaces since we don't have much other documentation on that and because workspaces complicate consumer usage a lot. I've added a card to track this and other docs that need additions to account for workspaced workflows: https://trello.com/c/j8eiEszz/433-kic-with-workspaces