### PR TITLE
Add proxy-cache to plugin matrix

### DIFF
--- a/docs/references/plugin-compatibility.md
+++ b/docs/references/plugin-compatibility.md
@@ -28,6 +28,8 @@ compatibility](https://docs.konghq.com/latest/db-less-and-declarative-config/#pl
 |  jwt                    |  :white_check_mark:  |  :white_check_mark:  |
 |  key-auth               |  :white_check_mark:  |  :white_check_mark:  |
 |  oauth2                 |  :white_check_mark:  |  :x:                 |
+|  post-function          |  :white_check_mark:  |  :white_check_mark:  |
+|  pre-function           |  :white_check_mark:  |  :white_check_mark:  |
 |  prometheus             |  :white_check_mark:  |  :white_check_mark:  |
 |  proxy-cache            |  :white_check_mark:  |  :white_check_mark:  |
 |  rate-limiting          |  :white_check_mark:  |  :white_check_mark:  |
@@ -63,6 +65,8 @@ There are [two distributions of Kong Enterprise](https://github.com/Kong/kuberne
 |  jwt                             |  :white_check_mark:                        |  :white_check_mark:              |
 |  key-auth                        |  :white_check_mark:                        |  :white_check_mark:              |
 |  oauth2                          |  :white_check_mark:                        |  :x:                             |
+|  post-function                   |  :white_check_mark:                        |  :white_check_mark:              |
+|  pre-function                    |  :white_check_mark:                        |  :white_check_mark:              |
 |  prometheus                      |  :white_check_mark:                        |  :white_check_mark:              |
 |  proxy-cache                     |  :white_check_mark:                        |  :white_check_mark:              |
 |  rate-limiting                   |  :white_check_mark:                        |  :white_check_mark:              |

--- a/docs/references/plugin-compatibility.md
+++ b/docs/references/plugin-compatibility.md
@@ -29,6 +29,7 @@ compatibility](https://docs.konghq.com/latest/db-less-and-declarative-config/#pl
 |  key-auth               |  :white_check_mark:  |  :white_check_mark:  |
 |  oauth2                 |  :white_check_mark:  |  :x:                 |
 |  prometheus             |  :white_check_mark:  |  :white_check_mark:  |
+|  proxy-cache            |  :white_check_mark:  |  :white_check_mark:  |
 |  rate-limiting          |  :white_check_mark:  |  :white_check_mark:  |
 |  request-termination    |  :white_check_mark:  |  :white_check_mark:  |
 |  request-transformer    |  :white_check_mark:  |  :white_check_mark:  |
@@ -63,6 +64,7 @@ There are [two distributions of Kong Enterprise](https://github.com/Kong/kuberne
 |  key-auth                        |  :white_check_mark:                        |  :white_check_mark:              |
 |  oauth2                          |  :white_check_mark:                        |  :x:                             |
 |  prometheus                      |  :white_check_mark:                        |  :white_check_mark:              |
+|  proxy-cache                     |  :white_check_mark:                        |  :white_check_mark:              |
 |  rate-limiting                   |  :white_check_mark:                        |  :white_check_mark:              |
 |  request-termination             |  :white_check_mark:                        |  :white_check_mark:              |
 |  request-transformer             |  :white_check_mark:                        |  :white_check_mark:              |


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds proxy-cache to the plugin matrix. I missed it before somehow.