### PR TITLE
fix: make admission controller script compatible with macOS

### DIFF
--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+BASE64_OPTIONS=""
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  BASE64_OPTIONS="-w 0"
+fi
+
 # create a self-signed certificate
 openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365  \
   -nodes -subj "/CN=kong-validation-webhook.kong.svc"
@@ -43,5 +48,5 @@ webhooks:
     service:
       namespace: kong
       name: kong-validation-webhook
-    caBundle: $(cat tls.crt  | base64 -w 0) " | kubectl apply -f -
+    caBundle: $(cat tls.crt  | base64 ${BASE64_OPTIONS}) " | kubectl apply -f -
 


### PR DESCRIPTION
BSD version of `base64` doesn't have `-w` flag and doesn't need any
options either because it doesn't wrap lines.
