### PR TITLE
Remove support for global KongPlugins

### DIFF
--- a/docs/guides/prometheus-grafana.md
+++ b/docs/guides/prometheus-grafana.md
@@ -113,14 +113,14 @@ each request that flows into the Kubernetes cluster gets tracked in Prometheus:
 
 ```bash
 $ echo 'apiVersion: configuration.konghq.com/v1
-kind: KongPlugin
+kind: KongClusterPlugin
 metadata:
   name: prometheus
   labels:
     global: "true"
 plugin: prometheus
 ' | kubectl apply -f -
-kongplugin.configuration.konghq.com/prometheus created
+kongclusterplugin.configuration.konghq.com/prometheus created
 ```
 
 ## Set Up Port Forwards

--- a/docs/guides/redis-rate-limiting.md
+++ b/docs/guides/redis-rate-limiting.md
@@ -98,7 +98,7 @@ We will start by creating a global rate-limiting policy:
 ```bash
 $ echo "
 apiVersion: configuration.konghq.com/v1
-kind: KongPlugin
+kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
   labels:
@@ -108,7 +108,7 @@ config:
   policy: local
 plugin: rate-limiting
 " | kubectl apply -f -
-kongplugin.configuration.konghq.com/global-rate-limit created
+kongclusterplugin.configuration.konghq.com/global-rate-limit created
 ```
 
 Here we are configuring Kong Ingress Controller to rate-limit traffic from
@@ -176,14 +176,14 @@ deployment.apps/redis created
 service/redis created
 ```
 
-Once this is deployed, let's update our KongPlugin configuration to use
+Once this is deployed, let's update our KongClusterPlugin configuration to use
 Redis as a datastore rather than each Kong node storing the counter information
 in-memory:
 
 ```bash
 $ echo "
 apiVersion: configuration.konghq.com/v1
-kind: KongPlugin
+kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
   labels:
@@ -194,7 +194,7 @@ config:
   redis_host: redis
 plugin: rate-limiting
 " | kubectl apply -f -
-kongplugin.configuration.konghq.com/global-rate-limit configured
+kongclusterplugin.configuration.konghq.com/global-rate-limit configured
 ```
 
 Notice, how the `policy` is now set to `redis` and we have configured Kong

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -324,12 +324,16 @@ Now, we will protect our Kubernetes cluster.
 For this, we will be configuring a rate-limiting plugin, which
 will throttle requests coming from the same client.
 
-Let's create the `KongPlugin` resource:
+This must be a cluster-level `KongClusterPlugin` resource, as `KongPlugin`
+resources cannot be applied globally, to preserve Kubernetes RBAC guarantees
+for cross-namepsace configuration.
+
+Let's create the `KongClusterPlugin` resource:
 
 ```bash
 $ echo "
 apiVersion: configuration.konghq.com/v1
-kind: KongPlugin
+kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
   labels:
@@ -340,7 +344,7 @@ config:
   policy: local
 plugin: rate-limiting
 " | kubectl apply -f -
-kongplugin.configuration.konghq.com/global-rate-limit created
+kongclusterplugin.configuration.konghq.com/global-rate-limit created
 ```
 
 With this plugin (please note the `global` label), every request through

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -326,7 +326,7 @@ will throttle requests coming from the same client.
 
 This must be a cluster-level `KongClusterPlugin` resource, as `KongPlugin`
 resources cannot be applied globally, to preserve Kubernetes RBAC guarantees
-for cross-namepsace configuration.
+for cross-namespace isolation.
 
 Let's create the `KongClusterPlugin` resource:
 

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -37,10 +37,6 @@ kind: KongPlugin
 metadata:
   name: <object name>
   namespace: <object namespace>
-  labels:
-    global: "true"   # optional, if set, then the plugin will be executed
-                     # for every request that Kong proxies
-                     # please note the quotes around true
 disabled: <boolean>  # optionally disable the plugin in Kong
 config:              # configuration for the plugin
     key: value
@@ -66,9 +62,6 @@ plugin: <name-of-plugin> # like key-auth, rate-limiting etc
   or `configFrom` may be used in a KongPlugin, not both at once.
 - `plugin` field determines the name of the plugin in Kong.
   This field was introduced in Kong Ingress Controller 0.2.0.
-- Setting a label `global` to `"true"` will result in the plugin being
-  applied globally in Kong, meaning it will be executed for every
-  request that is proxied via Kong.
 
 **Please note:** validation of the configuration fields is left to the user
 by default. It is advised to setup and use the admission validating controller
@@ -174,9 +167,9 @@ type: Opaque
 
 ## KongClusterPlugin
 
-A `KongClusterPlugin` is same as `KongPlugin` resource. The only difference
-being that it is a Kubernetes cluster-level resource instead of a
-namespaced resource.
+A `KongClusterPlugin` is same as `KongPlugin` resource. The only differences
+are that it is a Kubernetes cluster-level resource instead of a namespaced
+resource, and can be applied as a global plugin using labels.
 
 Please consult the [KongPlugin](#kongplugin) section for details.
 
@@ -189,6 +182,10 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: request-id
+  labels:
+    global: "true"   # optional, if set, then the plugin will be executed
+                     # for every request that Kong proxies
+                     # please note the quotes around true
 config:
   header_name: my-request-id
 configFrom:
@@ -200,6 +197,9 @@ plugin: correlation-id
 ```
 
 As with KongPlugin, only one of `config` or `configFrom` can be used.
+
+Setting the label `global` to `"true"` will apply the plugin globally in Kong,
+meaning it will be executed for every request that is proxied via Kong.
 
 ## KongIngress
 

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1499,6 +1499,17 @@ func (p *Parser) fillPlugins(state KongState) []Plugin {
 }
 
 func (p *Parser) globalPlugins() ([]Plugin, error) {
+	// removed as of 0.10.0
+	// only retrieved now to warn users
+	globalPlugins, err := p.store.ListGlobalKongPlugins()
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing global KongPlugins:")
+	}
+	if len(globalPlugins) > 0 {
+		glog.Warning("global KongPlugins found. These are no longer applied as of and",
+			" must be replaced with KongClusterPlugins.",
+			" Please run \"kubectl get kongplugin -l global=true --all-namespaces\" to list existing plugins")
+	}
 	res := make(map[string]Plugin)
 	var duplicates []string // keep track of duplicate
 	// TODO respect the oldest CRD

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1506,7 +1506,7 @@ func (p *Parser) globalPlugins() ([]Plugin, error) {
 		return nil, errors.Wrap(err, "error listing global KongPlugins:")
 	}
 	if len(globalPlugins) > 0 {
-		glog.Warning("global KongPlugins found. These are no longer applied as of 0.10.0 and",
+		glog.Warning("global KongPlugins found. These are no longer applied and",
 			" must be replaced with KongClusterPlugins.",
 			" Please run \"kubectl get kongplugin -l global=true --all-namespaces\" to list existing plugins")
 	}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1506,7 +1506,7 @@ func (p *Parser) globalPlugins() ([]Plugin, error) {
 		return nil, errors.Wrap(err, "error listing global KongPlugins:")
 	}
 	if len(globalPlugins) > 0 {
-		glog.Warning("global KongPlugins found. These are no longer applied as of and",
+		glog.Warning("global KongPlugins found. These are no longer applied as of 0.10.0 and",
 			" must be replaced with KongClusterPlugins.",
 			" Please run \"kubectl get kongplugin -l global=true --all-namespaces\" to list existing plugins")
 	}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -1499,10 +1499,6 @@ func (p *Parser) fillPlugins(state KongState) []Plugin {
 }
 
 func (p *Parser) globalPlugins() ([]Plugin, error) {
-	globalPlugins, err := p.store.ListGlobalKongPlugins()
-	if err != nil {
-		return nil, errors.Wrap(err, "error listing global KongPlugins:")
-	}
 	res := make(map[string]Plugin)
 	var duplicates []string // keep track of duplicate
 	// TODO respect the oldest CRD
@@ -1510,32 +1506,6 @@ func (p *Parser) globalPlugins() ([]Plugin, error) {
 	// of duplicate plugin definitions, we should respect the oldest one
 	// This is important since if a user comes in to k8s and creates a new
 	// CRD, the user now deleted an older plugin
-
-	for i := 0; i < len(globalPlugins); i++ {
-		k8sPlugin := *globalPlugins[i]
-		pluginName := k8sPlugin.PluginName
-		// empty pluginName skip it
-		if pluginName == "" {
-			glog.Errorf("KongPlugin '%v' does not specify a plugin name",
-				k8sPlugin.Name)
-			continue
-		}
-		if _, ok := res[pluginName]; ok {
-			glog.Error("Multiple KongPlugin definitions found with"+
-				" 'global' annotation for '", pluginName,
-				"', the plugin will not be applied")
-			duplicates = append(duplicates, pluginName)
-			continue
-		}
-		if plugin, err := p.kongPluginFromK8SPlugin(k8sPlugin); err == nil {
-			res[pluginName] = Plugin{
-				Plugin: plugin,
-			}
-		} else {
-			glog.Errorf("Failed to generate configuration for KongPlugin "+
-				"%v/%v: %v", k8sPlugin.Namespace, pluginName, err)
-		}
-	}
 
 	globalClusterPlugins, err := p.store.ListGlobalKongClusterPlugins()
 	if err != nil {

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -330,28 +330,8 @@ func TestFakeStorePlugins(t *testing.T) {
 	store, err := NewFakeStore(FakeObjects{KongPlugins: plugins})
 	assert.Nil(err)
 	assert.NotNil(store)
-	plugins, err = store.ListGlobalKongPlugins()
-	assert.Len(plugins, 0)
 
 	plugins = []*configurationv1.KongPlugin{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "default",
-				Labels: map[string]string{
-					"global": "true",
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "default",
-				Labels: map[string]string{
-					"global": "true",
-				},
-			},
-		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "baz",
@@ -362,14 +342,8 @@ func TestFakeStorePlugins(t *testing.T) {
 	store, err = NewFakeStore(FakeObjects{KongPlugins: plugins})
 	assert.Nil(err)
 	assert.NotNil(store)
-	plugins, err = store.ListGlobalKongPlugins()
-	assert.Len(plugins, 2)
 
-	plugin, err := store.GetKongPlugin("default", "bar")
-	assert.NotNil(plugin)
-	assert.Nil(err)
-
-	plugin, err = store.GetKongPlugin("default", "does-not-exist")
+	plugin, err := store.GetKongPlugin("default", "does-not-exist")
 	assert.NotNil(err)
 	assert.True(errors.As(err, &ErrNotFound{}))
 	assert.Nil(plugin)

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -342,6 +342,8 @@ func TestFakeStorePlugins(t *testing.T) {
 	store, err = NewFakeStore(FakeObjects{KongPlugins: plugins})
 	assert.Nil(err)
 	assert.NotNil(store)
+	plugins, err = store.ListGlobalKongPlugins()
+	assert.Len(plugins, 0)
 
 	plugin, err := store.GetKongPlugin("default", "does-not-exist")
 	assert.NotNil(err)

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -66,7 +66,6 @@ type Storer interface {
 	ListIngresses() []*networking.Ingress
 	ListTCPIngresses() ([]*configurationv1beta1.TCPIngress, error)
 	ListKnativeIngresses() ([]*knative.Ingress, error)
-	ListGlobalKongPlugins() ([]*configurationv1.KongPlugin, error)
 	ListGlobalKongClusterPlugins() ([]*configurationv1.KongClusterPlugin, error)
 	ListKongConsumers() []*configurationv1.KongConsumer
 	ListKongCredentials() []*configurationv1.KongCredential
@@ -290,31 +289,6 @@ func (s Store) ListKongCredentials() []*configurationv1.KongCredential {
 	}
 
 	return credentials
-}
-
-// ListGlobalKongPlugins returns all KongPlugin resources
-// filtered by the ingress.class annotation and with the
-// label global:"true".
-func (s Store) ListGlobalKongPlugins() ([]*configurationv1.KongPlugin, error) {
-
-	var plugins []*configurationv1.KongPlugin
-	// var globalPlugins []*configurationv1.KongPlugin
-	req, err := labels.NewRequirement("global", selection.Equals, []string{"true"})
-	if err != nil {
-		return nil, err
-	}
-	err = cache.ListAll(s.stores.Plugin,
-		labels.NewSelector().Add(*req),
-		func(ob interface{}) {
-			p, ok := ob.(*configurationv1.KongPlugin)
-			if ok && s.isValidIngresClass(&p.ObjectMeta) {
-				plugins = append(plugins, p)
-			}
-		})
-	if err != nil {
-		return nil, err
-	}
-	return plugins, nil
 }
 
 // ListGlobalKongClusterPlugins returns all KongClusterPlugin resources


### PR DESCRIPTION
**What this PR does / why we need it**:
* Removes support for global KongPlugins, in favor of allowing this on KongClusterPlugin only.
* Updates documentation using global KongPlugins to use KongClusterPlugins.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

Fixes #681

**Special notes for your reviewer**:
This change only removes support. It does not do anything to warn about existing KongPlugins with the global label. Users will need to review (future) changelog documentation to know that they need to migrate configuration, and their existing global plugins will break (the controller will not look for them and they will no longer be applied to Kong/will be removed from Kong during sync).

I have a sneaking suspicion that we may want to be a bit more graceful about this, probably by leaving the store retrieval in and complaining, while not doing anything with the retrieved plugins after, e.g.

```
 func (p *Parser) globalPlugins() ([]Plugin, error) {
       globalPlugins, err := p.store.ListGlobalKongPlugins()
       if err != nil {
               return nil, errors.Wrap(err, "error listing global KongPlugins:")
       } if if len(globalPlugins) > 0 {
             glog.Warningf("YOU STILL HAVE GLOBAL KONGPLUGINS. YOU WILL REGRET THIS!!!")
       }
```

For future changelog/upgrading entries, we should mention `kubectl get kongplugin -l global=true --all-namespaces` to find anything that needs migrating.

Probably with a loop over `globalPlugins` to warn on all by `namespace/name` individually.