### PR TITLE
deploy: Define port_maps for Kong (OSS + Enterprise)

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -29,6 +29,8 @@ spec:
           # servers
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
         - name: KONG_STATUS_LISTEN

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -651,22 +651,24 @@ spec:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: "off"
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
         - name: KONG_ADMIN_ACCESS_LOG
           value: /dev/stdout
         - name: KONG_ADMIN_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.4.1-alpine
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -646,22 +646,24 @@ spec:
     spec:
       containers:
       - env:
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: "off"
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
         - name: KONG_ADMIN_ACCESS_LOG
           value: /dev/stdout
         - name: KONG_ADMIN_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         image: kong:2.0
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -697,34 +697,36 @@ spec:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
         - name: KONG_ADMIN_API_URI
           value: set-me
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
         - name: KONG_ADMIN_GUI_AUTH
           value: basic-auth
-        - name: KONG_ENFORCE_RBAC
-          value: "on"
         - name: KONG_ADMIN_GUI_SESSION_CONF
           value: '{"cookie_secure":false,"storage":"kong","cookie_name":"admin_session","cookie_lifetime":31557600,"cookie_samesite":"off","secret":"please-change-me"}'
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
         - name: KONG_ADMIN_LISTEN
           value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
         - name: KONG_DATABASE
           value: postgres
+        - name: KONG_ENFORCE_RBAC
+          value: "on"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
         - name: KONG_PG_HOST
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -660,26 +660,28 @@ spec:
     spec:
       containers:
       - env:
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: postgres
-        - name: KONG_PG_HOST
-          value: postgres
-        - name: KONG_PG_PASSWORD
-          value: kong
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
         - name: KONG_ADMIN_ACCESS_LOG
           value: /dev/stdout
         - name: KONG_ADMIN_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_DATABASE
+          value: postgres
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         image: kong:2.0
         lifecycle:
           preStop:


### PR DESCRIPTION
**What this PR does / why we need it**:
`kong-ingress` is a service exposing low ports `tcp/80` and `tcp/443`. The implementation detail of `deploy/` is that these get NAT'ed by kube-proxy to high container ports `tcp/8000` and `tcp/8443` of the proxy container. Without knowledge of the externally exposed low ports, Kong puts those high ports in `X-Forwarded-Port` request headers which end-users can consider surprising, incorrect and unnecessarily exposing the implementation details of the Kong deployment.

This PR sets `KONG_PORT_MAPS` to enable Kong's feature to perform a reverse address translation for the purpose of identifying the actual port a request was received on by the service.

~This feature is present in Kong as of `2.1.0-beta.1`, hence also an upgrade of Kong.~ _edits per https://github.com/Kong/kubernetes-ingress-controller/pull/753#issuecomment-653137202_

**Which issue this PR fixes** 
closes #691

**Special notes for your reviewer**:
- ~Does not touch Kong Enterprise~
- ~Updates `kong` from `2.0` to `2.1.0-beta.1` with an exception of `wait-for-migrations` where it updates from `1.3`~
- Does not touch Helm charts (to be updated in a separate PR)
- ~We probably want to shelve this PR until `2.1.0` gets released, and then update this PR to use `2.1.0` before merging.~