### PR TITLE
Do not require any jwt-auth fields

### DIFF
--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -92,7 +92,9 @@ var (
 	keyAuthFields   = []string{"key"}
 	basicAuthFields = []string{"username", "password"}
 	hmacAuthFields  = []string{"username", "secret"}
-	jwtAuthFields   = []string{"algorithm", "rsa_public_key", "key", "secret"}
+	// placeholder. jwt-auth required fields vary depending on other fields,
+	// which is more complex than than the VAWH can handle on its own
+	jwtAuthFields = []string{}
 
 	// TODO dynamically fetch these from Kong
 	credTypeToFields = map[string][]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Per https://docs.konghq.com/hub/kong-inc/jwt/#create-a-jwt-credential
there are /no/ required fields for jwt-auth other that the associated
consumer. This is kinda true but not really: fields may be required
depending on the value of other fields, or may be required but generate
random values if none is presented.

In any case, the validation logic is complex enough that it makes more
sense to remove this from the webhook and let Kong handle it.

**Which issue this PR fixes**
Fix #750

**Special notes for your reviewer**:
