### PR TITLE
fix(deploy): bump up wait-for-migrations to 2.0

### DIFF
--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -774,7 +774,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:1.3
+        image: kong:2.0
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
KIC deploy manifests reference Kong `2.0` but `wait-for-migrations` uses `1.3` which causes bug #755.

**Which issue this PR fixes**
fixes #755

**Special notes for your reviewer**:
none