### PR TITLE
refactor: replace pkg/errors with %w

### DIFF
--- a/cli/ingress-controller/util.go
+++ b/cli/ingress-controller/util.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hbagdi/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 func getSemVerVer(v string) (semver.Version, error) {
@@ -40,11 +39,11 @@ func ensureWorkspace(client *kong.Client, workspace string) error {
 	if err != nil {
 		if kong.IsNotFoundErr(err) {
 			if err := createWorkspace(client, workspace); err != nil {
-				return errors.Wrapf(err, "creating workspace '%v'", workspace)
+				return fmt.Errorf("creating workspace '%v': %w", workspace, err)
 			}
 			return nil
 		}
-		return errors.Wrapf(err, "looking up workspace '%v'", workspace)
+		return fmt.Errorf("looking up workspace '%v': %w", workspace, err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/openzipkin/zipkin-go v0.2.2 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -2,11 +2,11 @@ package admission
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	configuration "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	admission "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -127,8 +127,7 @@ func (a Server) handleValidation(request admission.AdmissionRequest) (
 				ok = true
 			}
 		default:
-			return nil, errors.New("unknown operation '" +
-				string(request.Operation) + "'")
+			return nil, fmt.Errorf("unknown operation '%v'", string(request.Operation))
 		}
 
 	case pluginGVResource:
@@ -163,7 +162,7 @@ func (a Server) handleValidation(request admission.AdmissionRequest) (
 			return nil, err
 		}
 	default:
-		return nil, errors.Errorf("unknown resource type to validate: %s/%s %s",
+		return nil, fmt.Errorf("unknown resource type to validate: %s/%s %s",
 			request.Resource.Group, request.Resource.Version,
 			request.Resource.Resource)
 	}

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,6 @@ import (
 
 	configuration "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	admission "k8s.io/api/admission/v1"

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -2,11 +2,11 @@ package admission
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hbagdi/go-kong/kong"
 	configuration "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -41,7 +41,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 			return true, "", nil
 		}
 		validator.Logger.Errorf("failed to fetch consumer from kong: %v", err)
-		return false, "", errors.Wrap(err, "fetching consumer from Kong")
+		return false, "", fmt.Errorf("fetching consumer from Kong: %w", err)
 	}
 	if c != nil {
 		return false, "consumer already exists", nil

--- a/internal/ingress/controller/plugin_schema_helper.go
+++ b/internal/ingress/controller/plugin_schema_helper.go
@@ -3,9 +3,9 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/hbagdi/go-kong/kong"
-	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 )
 
@@ -31,7 +31,7 @@ func NewPluginSchemaStore(client *kong.Client) *PluginSchemaStore {
 // the cache.
 func (p *PluginSchemaStore) Schema(pluginName string) (map[string]interface{}, error) {
 	if pluginName == "" {
-		return nil, errors.New("pluginName can not be empty")
+		return nil, fmt.Errorf("pluginName can not be empty")
 	}
 
 	// lookup in cache

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/task"
@@ -364,7 +363,7 @@ func (s *statusSync) runUpdate(ing *networking.Ingress, status []apiv1.LoadBalan
 
 			currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch Ingress %v/%v", ing.Namespace, ing.Name))
+				return nil, fmt.Errorf("failed to fetch Ingress %v/%v: %w", ing.Namespace, ing.Name, err)
 			}
 
 			logger.WithField("ingress_status", status).Debugf("attempting to update ingress status")
@@ -382,7 +381,7 @@ func (s *statusSync) runUpdate(ing *networking.Ingress, status []apiv1.LoadBalan
 
 			currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch Ingress %v/%v", ing.Namespace, ing.Name))
+				return nil, fmt.Errorf("failed to fetch Ingress %v/%v: %w", ing.Namespace, ing.Name, err)
 			}
 
 			logger.WithField("ingress_status", status).Debugf("attempting to update ingress status")
@@ -446,7 +445,7 @@ func (s *statusSync) runUpdateKnativeIngress(ing *knative.Ingress,
 
 		currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch Knative Ingress %v/%v", ing.Namespace, ing.Name))
+			return nil, fmt.Errorf("failed to fetch Knative Ingress %v/%v: %w", ing.Namespace, ing.Name, err)
 		}
 
 		if ingressSliceEqual(status, curIPs) &&
@@ -511,7 +510,7 @@ func (s *statusSync) runUpdateTCPIngress(ing *configurationv1beta1.TCPIngress,
 
 		currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch TCPIngress %v/%v", ing.Namespace, ing.Name))
+			return nil, fmt.Errorf("failed to fetch TCPIngress %v/%v: %w", ing.Namespace, ing.Name, err)
 		}
 
 		logger.WithField("ingress_status", status).Debugf("attempting to update TCPIngress status")

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -1,17 +1,17 @@
 package store
 
 import (
+	"errors"
+	"testing"
+
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1beta1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/serving/pkg/apis/networking/v1alpha1"
-
-	"testing"
 )
 
 func Test_keyFunc(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the use of github.com/pkg/errors package and instead uses error checking additions shipped in Go 1.13.

**Special notes for your reviewer**:

This is based on top of #748. Review the HEAD of the PR. I'll rebase once 748 is merged in.