### PR TITLE
[proposal] style: set GitHub tab rendering to width 2 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# Set GitHub rendering as per https://stackoverflow.com/a/33831598
+# Reference: https://editorconfig.org/
+
+[*.go]
+end_of_line = lf
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
**What this PR does / why we need it**:
GitHub displays tab characters in `*.go` files 8 characters wide. That makes viewing side-by-side diffs hungry for screen estate, and makes code reading exhausting (at least for me).

There's an editor-agnostic format for code styling, `.editorconfig`, which Github among others (e.g. JetBrains IDEs) respects.

This PR makes GitHub (and compatible editors) render tabs 2 letters wide. Affects code browsing and diffs/PRs/etc.

Proof that it works: [an example Go file](https://github.com/Kong/kubernetes-ingress-controller/blob/style/editorconfig/internal/admission/server_test.go). Compare with [this](https://github.com/Kong/kubernetes-ingress-controller/blob/edc272ad6316f82459a24efc4aabdc4df4fcd334/internal/admission/server_test.go).

Setting the width to 2 is my personal preference not consulted in any way. I'm happy with putting any number there, or dropping this change if we don't want it.