### PR TITLE
Correct broken Helm 3 command

### DIFF
--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -148,7 +148,7 @@ $ helm install kong/kong \
 
 # Helm 3
 $ helm install kong/kong --generate-name
-    --name demo --namespace kong \
+    demo --namespace kong \
     --values https://l.yolo42.com/k4k8s-enterprise-helm-values \
      --set ingressController.installCRDs=false
 ```

--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -148,7 +148,7 @@ $ helm install kong/kong \
 
 # Helm 3
 $ helm install kong/kong --generate-name
-    demo --namespace kong \
+    --namespace kong \
     --values https://l.yolo42.com/k4k8s-enterprise-helm-values \
      --set ingressController.installCRDs=false
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm 3 command to install currently uses the `--name` flag, which was removed/is only available in Helm 2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Fix #758 