### PR TITLE
Repo/test manifest divergence

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,13 @@ jobs:
       run: |
         export GOPATH=$(go env GOPATH)
         make verify-codegen
+    - name: Setup kustomize
+      uses: imranismail/setup-kustomize@v1
+      with:
+        kustomize-version: "3.1.0"
+    - name: Verify manifest consistency
+      run: |
+        make verify-manifests
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ lint:
 build:
 	CGO_ENABLED=0 go build -o kong-ingress-controller ./cli/ingress-controller
 
+.PHONY: verify-manifests
+verify-manifests:
+	./hack/verify-manifests.sh
+
 .PHONY: verify-codegen
 verify-codegen:
 	./hack/verify-codegen.sh

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -651,24 +651,24 @@ spec:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         - name: KONG_DATABASE
           value: "off"
         - name: KONG_NGINX_WORKER_PROCESSES
           value: "1"
-        - name: KONG_PORT_MAPS
-          value: "80:8000, 443:8443"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
         image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.4.1-alpine
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -646,24 +646,24 @@ spec:
     spec:
       containers:
       - env:
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         - name: KONG_DATABASE
           value: "off"
         - name: KONG_NGINX_WORKER_PROCESSES
           value: "1"
-        - name: KONG_PORT_MAPS
-          value: "80:8000, 443:8443"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
         image: kong:2.0
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -697,36 +697,36 @@ spec:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
         - name: KONG_ADMIN_API_URI
           value: set-me
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
         - name: KONG_ADMIN_GUI_AUTH
           value: basic-auth
-        - name: KONG_ADMIN_GUI_SESSION_CONF
-          value: '{"cookie_secure":false,"storage":"kong","cookie_name":"admin_session","cookie_lifetime":31557600,"cookie_samesite":"off","secret":"please-change-me"}'
-        - name: KONG_ADMIN_LISTEN
-          value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
-        - name: KONG_DATABASE
-          value: postgres
         - name: KONG_ENFORCE_RBAC
           value: "on"
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
+        - name: KONG_ADMIN_GUI_SESSION_CONF
+          value: '{"cookie_secure":false,"storage":"kong","cookie_name":"admin_session","cookie_lifetime":31557600,"cookie_samesite":"off","secret":"please-change-me"}'
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: postgres
         - name: KONG_PG_HOST
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        - name: KONG_PORT_MAPS
-          value: "80:8000, 443:8443"
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -660,28 +660,28 @@ spec:
     spec:
       containers:
       - env:
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
           value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
         - name: KONG_DATABASE
           value: postgres
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
         - name: KONG_PG_HOST
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        - name: KONG_PORT_MAPS
-          value: "80:8000, 443:8443"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
         image: kong:2.0
         lifecycle:
           preStop:

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT="$(dirname "${BASH_SOURCE}")/.."
 
 DIFFROOT="${SCRIPT_ROOT}/deploy/single/"
 
@@ -13,17 +13,18 @@ cleanup() {
 }
 trap "cleanup" EXIT SIGINT
 
-cleanup
+if ! git status --porcelain --untracked-files=no "$DIFFROOT" ; then
+    echo "error: please run this script on a clean working copy"
+    exit 1
+fi
+
 
 "${SCRIPT_ROOT}/hack/build-single-manifests.sh"
 echo "diffing ${DIFFROOT} against freshly generated single manifests"
-ret=0
-git diff --quiet "${DIFFROOT}" || ret=$?
-if [[ $ret -eq 0 ]]
+if git diff --quiet "${DIFFROOT}"
 then
   echo "${DIFFROOT} up to date."
 else
   echo "${DIFFROOT} is out of date. Please run hack/build-single-manifests.sh"
-  git checkout "${DIFFROOT}"
   exit 1
 fi

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+DIFFROOT="${SCRIPT_ROOT}/deploy/single/"
+
+cleanup() {
+  git checkout "${DIFFROOT}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+"${SCRIPT_ROOT}/hack/build-single-manifests.sh"
+echo "diffing ${DIFFROOT} against freshly generated single manifests"
+ret=0
+git diff --quiet "${DIFFROOT}" || ret=$?
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run hack/build-single-manifests.sh"
+  git checkout "${DIFFROOT}"
+  exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds CI task to run the manifest generation script, check if it resulted in changes, and fail if it did. This ensures that single and base manifests do not diverge.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #668

**Special notes for your reviewer**:
https://github.com/Kong/kubernetes-ingress-controller/runs/960118920?check_suite_focus=true failed because it should. The manifests _aren't_ in sync currently. In a local test directory where I have updated them:

```
15:20:02-0700 yagody $ git status
On branch repo/test-manifest-divergence
nothing to commit, working tree clean
15:20:04-0700 yagody $ ./hack/build-single-manifests.sh 
15:20:21-0700 yagody $ git status                      
On branch repo/test-manifest-divergence
nothing to commit, working tree clean
15:20:22-0700 yagody $ make verify-manifests
./hack/verify-manifests.sh
diffing ./hack/../deploy/single/ against freshly generated single manifests
./hack/../deploy/single/ up to date.
```

How do we want to handle that? Just update them and roll the changes into this PR, or separate PR to update them and then rebase this onto next (or main) after it's merged?