### PR TITLE
ci: automatically move master to follow main

### DIFF
--- a/.github/workflows/master-mirrors-main.yaml
+++ b/.github/workflows/master-mirrors-main.yaml
@@ -1,0 +1,19 @@
+name: 'master mirrors this branch'
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  reattach-master:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Push HEAD to master
+      # Deliberately not force-pushing: designed to fail if this would mean rewriting history
+      run: |
+        git push origin HEAD:master

--- a/.github/workflows/master-mirrors-main.yaml
+++ b/.github/workflows/master-mirrors-main.yaml
@@ -1,4 +1,4 @@
-name: 'master mirrors this branch'
+name: 'sync master with main'
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  reattach-master:
+  push-master:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a CI job triggered for pushes to `main` which pushes CI HEAD to `master`.

Does not rewrite `master` history for added defensiveness (`git push` without `-f`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

fixes #792

**Special notes for your reviewer**:

Tested manually with a different pair of branches.
