### PR TITLE
Add ingress class docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
   - [Custom Resources](#custom-resources)
   - [Deployment methods](#deployment-methods)
   - [High-availability and scaling](#high-availability-and-scaling)
+  - [Resource classes](#resource-classes)
   - [Security](#security)
 - [Guides and Tutorials](#guides-and-tutorials)
 - [Configuration reference](#configuration-reference)
@@ -47,6 +48,12 @@ The Kong Ingress Controller is designed to scale with your traffic
 and infrastructure.
 Please refer to [this document](concepts/ha-and-scaling.md) to understand
 failures scenarios, recovery methods, as well as scaling considerations.
+
+### Resource classes
+
+[Resource classes](concepts/resource-classes.md) filter which resources the
+controller loads. They ensure that Kong Ingress Controller instances do not
+load configuration intended for other instances or other ingress controllers.
 
 ### Security
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,9 +49,9 @@ and infrastructure.
 Please refer to [this document](concepts/ha-and-scaling.md) to understand
 failures scenarios, recovery methods, as well as scaling considerations.
 
-### Resource classes
+### Ingress classes
 
-[Resource classes](concepts/resource-classes.md) filter which resources the
+[Ingress classes](concepts/ingress-classes.md) filter which resources the
 controller loads. They ensure that Kong Ingress Controller instances do not
 load configuration intended for other instances or other ingress controllers.
 

--- a/docs/concepts/custom-resources.md
+++ b/docs/concepts/custom-resources.md
@@ -73,9 +73,7 @@ The below diagram shows how the `KongPlugin` resource can be linked to an
 
 ## KongClusterPlugin
 
-_This resource requires the `kubernetes.io/ingress.class` annotation. Its value
-must match the value of the controller's `--ingress-class` argument, which is
-"kong" by default._
+_This resource requires the [`kubernetes.io/ingress.class` annotation](../README.md#resource-classes)._
 
 KongClusterPlugin resource is exactly same as KongPlugin, except that it is a
 Kubernetes cluster-level resources instead of being a namespaced resource.

--- a/docs/concepts/custom-resources.md
+++ b/docs/concepts/custom-resources.md
@@ -73,6 +73,10 @@ The below diagram shows how the `KongPlugin` resource can be linked to an
 
 ## KongClusterPlugin
 
+_This resource requires the `kubernetes.io/ingress.class` annotation. Its value
+must match the value of the controller's `--ingress-class` argument, which is
+"kong" by default._
+
 KongClusterPlugin resource is exactly same as KongPlugin, except that it is a
 Kubernetes cluster-level resources instead of being a namespaced resource.
 This can help when the configuration of the plugin needs to be centralized
@@ -87,11 +91,19 @@ KongClusterPlugin with the same name.
 
 ## KongConsumer
 
+_This resource requires the `kubernetes.io/ingress.class` annotation. Its value
+must match the value of the controller's `--ingress-class` argument, which is
+"kong" by default._
+
 This custom resource configures `Consumers` in Kong.
 Every `KongConsumer` resource in Kubernetes directly translates to a
 [Consumer][kong-consumer] object in Kong.
 
 ## TCPIngress
+
+_This resource requires the `kubernetes.io/ingress.class` annotation. Its value
+must match the value of the controller's `--ingress-class` argument, which is
+"kong" by default._
 
 This Custom Resource is used for exposing non-HTTP
 and non-GRPC services running inside Kubernetes to

--- a/docs/concepts/custom-resources.md
+++ b/docs/concepts/custom-resources.md
@@ -64,7 +64,7 @@ Once this resource is created, the resource needs to be associated with an
 `Ingress`, `Service`, or `KongConsumer` resource in Kubernetes.
 For more details, please read the reference documentation on `KongPlugin`.
 
-The below diagram shows how the `KongPlugin` resource can be linked to an
+The below diagram shows how you can link `KongPlugin` resource to an
 `Ingress`, `Service`, or `KongConsumer`:
 
 |  |  |

--- a/docs/concepts/ingress-classes.md
+++ b/docs/concepts/ingress-classes.md
@@ -35,7 +35,7 @@ categories:
   directly translated into Kong configuration.
 
 For example, an Ingress is translated directly into a Kong route, and a
-KongConsumer is translated directly into a Kong consumer. A Secret containing
+KongConsumer is translated directly into a [Kong consumer](https://docs.konghq.com/latest/admin-api/#consumer-object). A Secret containing
 an authentication plugin credential is _not_ translated directly: it is only
 translated into Kong configuration if a KongConsumer resource references it.
 
@@ -43,11 +43,11 @@ Because they create Kong configuration indenpendent of any other resources,
 directly-translated resources require an ingress class, and their class must
 match the class configured for the controller. Referenced resources do not
 require a class, but must be referenced by a directly-translated resource
-matches the controller.
+that matches the controller.
 
 ### Adding class information to resources
 
-Most resources use a [kubernetes.io/ingress-class annoration][class-annotation]
+Most resources use a [kubernetes.io/ingress-class annotation][class-annotation]
 to indicate their class. There are several exceptions:
 
 - v1 Ingress resources have a dedicated `class` field.
@@ -68,7 +68,7 @@ class annotation using flags:
   KongConsumer resources with no class annotation.
 
 These flags are primarily intended for compatibility with older configuration
-(older versions of the Kong Ingress Controller had less strict class
+(Kong Ingress Controller before 0.10 had less strict class
 requirements, and it was common to omit class annotations). If you are creating
 new configuration and do not have older configuration without class
 annotations, recommended best practice is to add class information to Ingress
@@ -112,7 +112,7 @@ custom classes:
 
 In versions 0.10.0+ you must instruct the controller to load classless
 resources, which is allowed (but not recommended) for either the default or
-custom classess. Resources referenced by another resource are always loaded and
+custom classes. Resources referenced by another resource are always loaded and
 updated correctly regardless of which class you set on the controller; you do
 not need to add class annotations to these resources when using a custom class.
 
@@ -124,7 +124,7 @@ the following configuration for authenticating a request, using a KongConsumer,
 credential Secret, Ingress, and KongPlugin (a Service is implied, but not
 shown):
 
-```
+```yaml
 kind: KongConsumer
 metadata:
   name: dyadya-styopa

--- a/docs/concepts/ingress-classes.md
+++ b/docs/concepts/ingress-classes.md
@@ -1,30 +1,30 @@
-# Kong Ingress Controller and resource class
+# Kong Ingress Controller and ingress class
 
 
 ## Table of Contents
 
 - [**Introduction**](#introduction)
-- [**Configuring the controller class**](#configuring-the-controller-class)
-- [**Kubernetes resource class**](#kubernetes-resource-class)
-- [**When to use custom classes**](#when-to-use-custom-classes)
+- [**Configuring the controller class**](#configuring-the-controller-ingress-class)
+- [**Loading resources by class**](#loading-resouces-by-class)
+- [**When to use a custom class**](#when-to-use-a-custom-class)
 - [**Legacy behavior**](#legacy-behavior)
 - [**Examples**](#examples)
 
 ## Introduction
 
-The Kong Ingress Controller uses resource classes to filter Kubernetes Ingress
+The Kong Ingress Controller uses ingress classes to filter Kubernetes Ingress
 objects and other resources before converting them into Kong configuration.
 This allows it to coexist with other ingress controllers and/or other
 deployments of the Kong Ingress Controller in the same cluster: a Kong Ingress
 Controller will only process configuration marked for its use.
 
-## Configuring the controller class
+## Configuring the controller ingress class
 
 The `--ingress-class` flag (or `CONTROLLER_INGRESS_CLASS` environment variable)
-specify the resource class expected by the Kong Ingress Controller. By default,
+specify the ingress class expected by the Kong Ingress Controller. By default,
 it expects the `kong` class.
 
-## Kubernetes resource class
+## Loading resources by class
 
 The Kong Ingress Controller translates a variety of Kubernetes resources into
 Kong configuration. Broadly speaking, we can separate these resources into two
@@ -40,10 +40,10 @@ an authentication plugin credential is _not_ translated directly: it is only
 translated into Kong configuration if a KongConsumer resource references it.
 
 Because they create Kong configuration indenpendent of any other resources,
-directly-translated resources require a class, and their class must match the
-class configured for the controller. Referenced resources do not require a
-class, but must be referenced by a directly-translated resource matches the
-controller.
+directly-translated resources require an ingress class, and their class must
+match the class configured for the controller. Referenced resources do not
+require a class, but must be referenced by a directly-translated resource
+matches the controller.
 
 ### Adding class information to resources
 
@@ -80,7 +80,7 @@ These flags do not _ignore_ `ingress.class` annotations: they allow resources
 with no such annotation, but will not allow resource that have a non-matching
 `ingress.class` annotation.
 
-## When to use custom classes
+## When to use a custom class
 
 Using the default `kong` class is fine for simpler deployments, where only one
 Kong Ingress Controller instance is running in a cluster. Changing the class is

--- a/docs/concepts/ingress-classes.md
+++ b/docs/concepts/ingress-classes.md
@@ -86,12 +86,14 @@ Using the default `kong` class is fine for simpler deployments, where only one
 Kong Ingress Controller instance is running in a cluster. Changing the class is
 typical when:
 
-- You install multiple Kong environments in one cluster to handle different
-  types of ingress traffic, e.g. when using separate Kong instances to handle
-  traffic on internal and external load balancers, or deploying different types
-  of non-production environments in a single test cluster.
-- You install multiple controller instances that create configuration in
-  different Kong workspaces (using the `--kong-workspace` flag).
+- You install multiple Kong environments in one Kubernetes cluster to handle
+  different types of ingress traffic, e.g. when using separate Kong instances
+  to handle traffic on internal and external load balancers, or deploying
+  different types of non-production environments in a single test cluster.
+- You install multiple controller instances alongside a single Kong cluster to
+  separate configuration into different Kong workspaces (using the
+  `--kong-workspace` flag) or to restrict which Kubernetes namespaces any one
+  controller instance has access to.
 
 ## Legacy behavior
 

--- a/docs/concepts/resource-classes.md
+++ b/docs/concepts/resource-classes.md
@@ -8,6 +8,7 @@
 - [**Kubernetes resource class**](#kubernetes-resource-class)
 - [**When to use custom classes**](#when-to-use-custom-classes)
 - [**Legacy behavior**](#legacy-behavior)
+- [**Examples**](#examples)
 
 ## Introduction
 
@@ -114,6 +115,66 @@ resources, which is allowed (but not recommended) for either the default or
 custom classess. Resources referenced by another resource are always loaded and
 updated correctly regardless of which class you set on the controller; you do
 not need to add class annotations to these resources when using a custom class.
+
+## Examples
+
+Typical configurations will include a mix of resources that have class
+information and resources that are referenced by them. For example, consider
+the following configuration for authenticating a request, using a KongConsumer,
+credential Secret, Ingress, and KongPlugin (a Service is implied, but not
+shown):
+
+```
+kind: KongConsumer
+metadata:
+  name: dyadya-styopa
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+username: styopa
+credentials:
+- styopa-key
+
+---
+
+kind: Secret
+apiVersion: v1
+stringData:
+  key: bylkogdatomoryakom
+  kongCredType: key-auth
+metadata:
+  name: styopa-key
+
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: ktonezhnaet
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+    konghq.com/plugins: "key-auth-example"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /vsemznakom
+        backend:
+          serviceName: httpbin
+          servicePort: 80
+
+---
+
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: key-auth-example
+plugin: key-auth
+```
+
+The KongConsumer and Ingress resources both have class annotations, as they are
+resources that the controller uses as a basis for building Kong configuration.
+The Secret and KongPlugin _do not_ have class annotations, as they are
+referenced by other resources that do.
 
 [class-annotation]: ../references/annotations.md#kubernetesioingressclass
 [knative-class]: ../guides/using-kong-with-knative.md#ingress-class

--- a/docs/concepts/resource-classes.md
+++ b/docs/concepts/resource-classes.md
@@ -56,7 +56,7 @@ to indicate their class. There are several exceptions:
   You can optionally [override this on a per-Service basis][knative-override]
   by adding a `networking.knative.dev/ingress.class` annotation to the Service.
 
-### Allowing resources without a class
+### Enabling support for classless resources
 
 Specifying a class is optional for some resources. Although specifying a class
 is recommended, you can instruct the controller to process resources without a

--- a/docs/concepts/resource-classes.md
+++ b/docs/concepts/resource-classes.md
@@ -1,0 +1,120 @@
+# Kong Ingress Controller and resource class
+
+
+## Table of Contents
+
+- [**Introduction**](#introduction)
+- [**Configuring the controller class**](#configuring-the-controller-class)
+- [**Kubernetes resource class**](#kubernetes-resource-class)
+- [**When to use custom classes**](#when-to-use-custom-classes)
+- [**Legacy behavior**](#legacy-behavior)
+
+## Introduction
+
+The Kong Ingress Controller uses resource classes to filter Kubernetes Ingress
+objects and other resources before converting them into Kong configuration.
+This allows it to coexist with other ingress controllers and/or other
+deployments of the Kong Ingress Controller in the same cluster: a Kong Ingress
+Controller will only process configuration marked for its use.
+
+## Configuring the controller class
+
+The `--ingress-class` flag (or `CONTROLLER_INGRESS_CLASS` environment variable)
+specify the resource class expected by the Kong Ingress Controller. By default,
+it expects the `kong` class.
+
+## Kubernetes resource class
+
+The Kong Ingress Controller translates a variety of Kubernetes resources into
+Kong configuration. Broadly speaking, we can separate these resources into two
+categories:
+
+- Resources that the controller translates directly into Kong configuration.
+- Resources referenced by some other resource, where the other resource is
+  directly translated into Kong configuration.
+
+For example, an Ingress is translated directly into a Kong route, and a
+KongConsumer is translated directly into a Kong consumer. A Secret containing
+an authentication plugin credential is _not_ translated directly: it is only
+translated into Kong configuration if a KongConsumer resource references it.
+
+Because they create Kong configuration indenpendent of any other resources,
+directly-translated resources require a class, and their class must match the
+class configured for the controller. Referenced resources do not require a
+class, but must be referenced by a directly-translated resource matches the
+controller.
+
+### Adding class information to resources
+
+Most resources use a [kubernetes.io/ingress-class annoration][class-annotation]
+to indicate their class. There are several exceptions:
+
+- v1 Ingress resources have a dedicated `class` field.
+- Knative Services [use the class specifed][knative-class] by the
+  `ingress.class` key of the Knative installation's `config-network` ConfigMap.
+  You can optionally [override this on a per-Service basis][knative-override]
+  by adding a `networking.knative.dev/ingress.class` annotation to the Service.
+
+### Allowing resources without a class
+
+Specifying a class is optional for some resources. Although specifying a class
+is recommended, you can instruct the controller to process resources without a
+class annotation using flags:
+
+- `--process-classless-ingress-v1beta1` instructs the controller to translate
+  v1beta1 Ingress resources with no class annotation.
+- `--process-classless-kong-consumer` instructs the controller to translate
+  KongConsumer resources with no class annotation.
+
+These flags are primarily intended for compatibility with older configuration
+(older versions of the Kong Ingress Controller had less strict class
+requirements, and it was common to omit class annotations). If you are creating
+new configuration and do not have older configuration without class
+annotations, recommended best practice is to add class information to Ingress
+and KongConsumer resources and not set the above flags. Doing so avoids
+accidentally creating duplicate configuration in other ingress controller
+instances.
+
+These flags do not _ignore_ `ingress.class` annotations: they allow resources
+with no such annotation, but will not allow resource that have a non-matching
+`ingress.class` annotation.
+
+## When to use custom classes
+
+Using the default `kong` class is fine for simpler deployments, where only one
+Kong Ingress Controller instance is running in a cluster. Changing the class is
+typical when:
+
+- You install multiple Kong environments in one cluster to handle different
+  types of ingress traffic, e.g. when using separate Kong instances to handle
+  traffic on internal and external load balancers, or deploying different types
+  of non-production environments in a single test cluster.
+- You install multiple controller instances that create configuration in
+  different Kong workspaces (using the `--kong-workspace` flag).
+
+## Legacy behavior
+
+This overview covers behavior in Kong Ingress Controller version 0.10.0 onward.
+Earlier versions had a special case for the default class and a bug affecting
+custom classes:
+
+- When using the default `kong` class, the controller would always process
+  classless resources in addition to `kong`-class resources. When using a
+  non-default controller class, the controller would only process resources
+  with that class, not classless resources. Although this was by design, it was
+  a source of user confusion.
+- When using a custom controller class, some resources that should not have
+  required a class (because they were referenced by other resources)
+  effectively did require a class: while these resources were loaded initially,
+  the controller would not track updates to them unless they had a class
+  annotation.
+
+In versions 0.10.0+ you must instruct the controller to load classless
+resources, which is allowed (but not recommended) for either the default or
+custom classess. Resources referenced by another resource are always loaded and
+updated correctly regardless of which class you set on the controller; you do
+not need to add class annotations to these resources when using a custom class.
+
+[class-annotation]: ../references/annotations.md#kubernetesioingressclass
+[knative-class]: ../guides/using-kong-with-knative.md#ingress-class
+[knative-override]: https://knative.tips/networking/ingress-override/

--- a/docs/deployment/admission-webhook.md
+++ b/docs/deployment/admission-webhook.md
@@ -142,6 +142,8 @@ $ echo "apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: harry
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: harry" | kubectl apply -f -
 kongconsumer.configuration.konghq.com/harry created
 ```
@@ -153,6 +155,8 @@ $ echo "apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: harry2
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: harry" | kubectl apply -f -
 Error from server: error when creating "STDIN": admission webhook "validations.kong.konghq.com" denied the request: consumer already exists
 ```

--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -124,6 +124,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: demo-yolo42-com
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: demo.yolo42.com
@@ -190,6 +192,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: kong
 spec:
   tls:
   - secretName: demo-yolo42-com

--- a/docs/guides/configure-acl-plugin.md
+++ b/docs/guides/configure-acl-plugin.md
@@ -54,6 +54,7 @@ metadata:
   name: demo-get
   annotations:
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -71,6 +72,7 @@ metadata:
   name: demo-post
   annotations:
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -161,6 +163,7 @@ metadata:
   annotations:
     plugins.konghq.com: app-jwt
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -179,6 +182,7 @@ metadata:
   annotations:
     plugins.konghq.com: app-jwt
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -567,6 +571,7 @@ metadata:
   annotations:
     plugins.konghq.com: app-jwt,plain-user-acl
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -585,6 +590,7 @@ metadata:
   annotations:
     plugins.konghq.com: app-jwt,admin-acl
     konghq.com/strip-path: "false"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/configure-acl-plugin.md
+++ b/docs/guides/configure-acl-plugin.md
@@ -238,6 +238,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: admin
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: admin
 " | kubectl apply -f -
 
@@ -246,6 +248,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: plain-user
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: plain-user
 " | kubectl apply -f -
 ```
@@ -303,6 +307,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: admin
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: admin
 credentials:
   - app-admin-jwt
@@ -313,6 +319,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: plain-user
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: plain-user
 credentials:
   - app-user-jwt
@@ -540,6 +548,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: admin
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: admin
 credentials:
   - app-admin-jwt
@@ -551,6 +561,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: plain-user
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: plain-user
 credentials:
   - app-user-jwt

--- a/docs/guides/configuring-fallback-service.md
+++ b/docs/guides/configuring-fallback-service.md
@@ -56,6 +56,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -104,6 +105,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: fallback
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   backend:
     serviceName: fallback-svc

--- a/docs/guides/configuring-health-checks.md
+++ b/docs/guides/configuring-health-checks.md
@@ -58,6 +58,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/configuring-https-redirect.md
+++ b/docs/guides/configuring-https-redirect.md
@@ -54,6 +54,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -53,6 +53,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: demo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -122,6 +124,7 @@ metadata:
   name: demo-example-com
   annotations:
     konghq.com/plugins: request-id
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: example.com

--- a/docs/guides/prometheus-grafana.md
+++ b/docs/guides/prometheus-grafana.md
@@ -116,6 +116,8 @@ $ echo 'apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: prometheus
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: "true"
 plugin: prometheus

--- a/docs/guides/prometheus-grafana.md
+++ b/docs/guides/prometheus-grafana.md
@@ -201,6 +201,7 @@ metadata:
   name: sample-ingresses
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/redis-rate-limiting.md
+++ b/docs/guides/redis-rate-limiting.md
@@ -102,6 +102,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: \"true\"
 config:
@@ -187,6 +189,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: \"true\"
 config:

--- a/docs/guides/redis-rate-limiting.md
+++ b/docs/guides/redis-rate-limiting.md
@@ -62,6 +62,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-consumer-credential-resource.md
+++ b/docs/guides/using-consumer-credential-resource.md
@@ -154,6 +154,8 @@ $ echo "apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: harry
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: harry" | kubectl apply -f -
 kongconsumer.configuration.konghq.com/harry created
 ```
@@ -187,6 +189,8 @@ $ echo "apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: harry
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: harry
 credentials:
 - harry-apikey" | kubectl apply -f -

--- a/docs/guides/using-consumer-credential-resource.md
+++ b/docs/guides/using-consumer-credential-resource.md
@@ -54,6 +54,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -113,6 +114,7 @@ metadata:
   annotations:
     konghq.com/strip-path: "true"
     konghq.com/plugins: httpbin-auth
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-external-service.md
+++ b/docs/guides/using-external-service.md
@@ -59,6 +59,7 @@ metadata:
   name: proxy-from-k8s-to-httpbin
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-ingress-with-grpc.md
+++ b/docs/guides/using-ingress-with-grpc.md
@@ -50,6 +50,8 @@ $ echo "apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: demo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-kongclusterplugin-resource.md
+++ b/docs/guides/using-kongclusterplugin-resource.md
@@ -148,6 +148,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: add-response-header
+  annotations:
+    kubernetes.io/ingress.class: kong
 config:
   add:
     headers:
@@ -230,6 +232,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: add-response-header
+  annotations:
+    kubernetes.io/ingress.class: kong
 config:
   add:
     headers:

--- a/docs/guides/using-kongclusterplugin-resource.md
+++ b/docs/guides/using-kongclusterplugin-resource.md
@@ -69,6 +69,7 @@ metadata:
   namespace: httpbin
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -86,6 +87,8 @@ kind: Ingress
 metadata:
   name: echo-app
   namespace: echo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-kongingress-resource.md
+++ b/docs/guides/using-kongingress-resource.md
@@ -53,6 +53,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: demo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -64,6 +64,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:
@@ -130,6 +131,7 @@ metadata:
   name: demo-2
   annotations:
     konghq.com/strip-path: "true"
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -415,6 +415,7 @@ kind: KongConsumer
 metadata:
   name: harry
   annotations:
+    kubernetes.io/ingress.class: kong
     konghq.com/plugins: harry-rate-limit
 username: harry
 credentials:

--- a/docs/guides/using-kongplugin-resource.md
+++ b/docs/guides/using-kongplugin-resource.md
@@ -338,6 +338,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: global-rate-limit
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: \"true\"
 config:

--- a/docs/guides/using-mtls-auth-plugin.md
+++ b/docs/guides/using-mtls-auth-plugin.md
@@ -57,6 +57,8 @@ $ echo "apiVersion: v1
 kind: Secret
 metadata:
   name: my-ca-cert
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     konghq.com/ca-cert: 'true'
 type: Opaque

--- a/docs/guides/using-mtls-auth-plugin.md
+++ b/docs/guides/using-mtls-auth-plugin.md
@@ -42,11 +42,14 @@ This is expected as Kong does not yet know how to proxy the request.
 CA certificates in Kong are provisioned by create a `Secret` resource in
 Kubernetes.
 
-The secret resource should have a few properties:
-- It should have the `konghq.com/ca-cert: "true"` label.
-- It should have a `cert` data property which contains a valid CA certificate
+The secret resource must have a few properties:
+- It must have the `konghq.com/ca-cert: "true"` label.
+- It must have a `cert` data property which contains a valid CA certificate
   in PEM format.
-- It should have an `id` data property which contains a random UUID.
+- It must have an `id` data property which contains a random UUID.
+- It must have a `kubernetes.io/ingress.class` annotation whose value matches
+  the value of the controller's `--ingress-class` argument. By default, that
+  value is "kong".
 
 Note that a self-signed CA certificate is being used for the purpose of this
 guide. You should use your own CA certificate that is backed by

--- a/docs/guides/using-mtls-auth-plugin.md
+++ b/docs/guides/using-mtls-auth-plugin.md
@@ -147,6 +147,7 @@ metadata:
   name: demo
   annotations:
     konghq.com/plugins: mtls-auth
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - http:

--- a/docs/guides/using-oidc-plugin.md
+++ b/docs/guides/using-oidc-plugin.md
@@ -54,6 +54,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: demo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: 192.0.2.8.xip.io

--- a/docs/guides/using-rewrites.md
+++ b/docs/guides/using-rewrites.md
@@ -84,6 +84,8 @@ kind: Ingress
 metadata:
   name: my-app
   namespace: echo
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: myapp.example.com

--- a/docs/guides/using-tcpingress.md
+++ b/docs/guides/using-tcpingress.md
@@ -141,6 +141,8 @@ $ echo "apiVersion: configuration.konghq.com/v1beta1
 kind: TCPIngress
 metadata:
   name: echo-plaintext
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - port: 9000
@@ -194,6 +196,8 @@ $ echo "apiVersion: configuration.konghq.com/v1beta1
 kind: TCPIngress
 metadata:
   name: echo-tls
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: example.com

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -27,7 +27,7 @@ the value of the `--ingress-class` controller argument ("kong" by default).
 Setting the `--process-classless-ingress-v1beta1` controller flag removes that requirement:
 when enabled, the controller will process Ingresses with no
 `kubernetes.io/ingress.class` annotation. Recommended best practice is to set
-the annotation and leave this flag disabled; the flag is primarily intended for
+the annotation and leave this flag disabled; the flag is intended for
 older configurations, as controller versions prior to 0.10 processed classless
 Ingress resources by default.
 

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -110,10 +110,16 @@ metadata:
 will target Kong Ingress controller, forcing the GCE controller
 to ignore it.
 
-Ingress, KongConsumer, TCPIngress, KongClusterPlugin, and Secret resources with
-the `ca-cert` label _require_ this annotation by default. You can optionally
-allow Ingress or KongConsumer resources with no class annotation (by setting
-the `--process-classless-ingress-v1beta1` or
+The following resources _require_ this annotation by default:
+
+- Ingress
+- KongConsumer
+- TCPIngress
+- KongClusterPlugin
+- Secret resources with the `ca-cert` label 
+
+You can optionally allow Ingress or KongConsumer resources with no class
+annotation (by setting the `--process-classless-ingress-v1beta1` or
 `--process-classless-kong-consumer` flags, respectively), though recommended
 best practice is to leave these flags disabled: the flags are primarily
 intended for compatibility with configuration created before this requirement

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -24,7 +24,7 @@ Following annotations are supported on Ingress resources:
 `kubernetes.io/ingress.class` is normally required, and its value should match
 the value of the `--ingress-class` controller argument ("kong" by default).
 
-Passing `--process-classless-ingress-v1beta1=true` removes that requirement:
+Setting the `--process-classless-ingress-v1beta1` controller flag removes that requirement:
 when enabled, the controller will process Ingresses with no
 `kubernetes.io/ingress.class` annotation. Recommended best practice is to set
 the annotation and leave this flag disabled; the flag is primarily intended for

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -62,7 +62,7 @@ Following annotaitons are supported on KongConsumer resources:
 `kubernetes.io/ingress.class` is normally required, and its value should match
 the value of the `--ingress-class` controller argument ("kong" by default).
 
-Passing `process-classless-kong-consumer` removes that requirement:
+Setting the `--process-classless-kong-consumer` controller flag removes that requirement:
 when enabled, the controller will process KongConsumers with no
 `kubernetes.io/ingress.class` annotation. Recommended best practice is to set
 the annotation and leave this flag disabled; the flag is primarily intended for

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -183,6 +183,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: request-id
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: "true"   # optional, if set, then the plugin will be executed
                      # for every request that Kong proxies

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -184,7 +184,7 @@ kind: KongClusterPlugin
 metadata:
   name: request-id
   annotations:
-    kubernetes.io/ingress.class: kong
+    kubernetes.io/ingress.class: <controller ingress class, "kong" by default>
   labels:
     global: "true"   # optional, if set, then the plugin will be executed
                      # for every request that Kong proxies
@@ -316,7 +316,7 @@ metadata:
   name: <object name>
   namespace: <object namespace>
   annotations:
-    kubernetes.io/ingress.class: kong
+    kubernetes.io/ingress.class: <controller ingress class, "kong" by default>
 spec:
   rules:
   - host: <SNI, optional>
@@ -347,7 +347,7 @@ metadata:
   name: <object name>
   namespace: <object namespace>
   annotations:
-    kubernetes.io/ingress.class: kong
+    kubernetes.io/ingress.class: <controller ingress class, "kong" by default>
 username: <user name>
 custom_id: <custom ID>
 ```

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -119,6 +119,7 @@ metadata:
   name: demo-example-com
   annotations:
     plugins.konghq.com: request-id
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: example.com

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -342,6 +342,8 @@ kind: KongConsumer
 metadata:
   name: <object name>
   namespace: <object namespace>
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: <user name>
 custom_id: <custom ID>
 ```
@@ -353,6 +355,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: consumer-team-x
+  annotations:
+    kubernetes.io/ingress.class: kong
 username: team-X
 ```
 

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -313,6 +313,8 @@ kind: TCPIngress
 metadata:
   name: <object name>
   namespace: <object namespace>
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
   rules:
   - host: <SNI, optional>


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation describing how the controller handles ingress.class annotations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #677

**Special notes for your reviewer**:
- Changes indicate when class annotations are required, but not when they are not required. I don't think it's as important to call out the latter, since worst case a user adds an annotation and it does more or less nothing (the only point of confusion may be that adding a class annotation to those resources, e.g. KongPlugin, does not prevent their use by other controllers). The new resource-classes.md concept guide should cover that: it goes over how classless resources are loaded via references in classful resources, and provides an overview of some of the confusing <0.10 behavior.
- Not all resources were covered equally to begin with. I've updated existing docs when they cover classful resources, but not added new sections where they previously weren't covered. For example, annotations.md has a section for KongConsumer (which now mentions its class requirements, but not TCPIngress). All resources are covered in at least one location, and I list all resources that require `ingress.class` under https://github.com/Kong/kubernetes-ingress-controller/blob/a72ba9c03f542aa8af6e16cb7d459a30c2c26bba/docs/references/annotations.md#kubernetesioingressclass
