### PR TITLE
bugfix: implement extensions->networking v1beta1 conversion

### DIFF
--- a/internal/ingress/store/store_test.go
+++ b/internal/ingress/store/store_test.go
@@ -8,6 +8,7 @@ import (
 	core "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -49,6 +50,10 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 			name: "correctly transformers from extensions to networking group",
 			args: args{
 				obj: &extensions.Ingress{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "extensions/v1beta1",
+						Kind:       "Ingress",
+					},
 					Spec: extensions.IngressSpec{
 						Rules: []extensions.IngressRule{
 							{
@@ -72,6 +77,10 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 				},
 			},
 			want: &networking.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1beta1",
+					Kind:       "Ingress",
+				},
 				Spec: networking.IngressSpec{
 					Rules: []networking.IngressRule{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR, the conversion mechanism (from `extensions/v1beta1` Ingress to `networking.k8s.io/v1beta1` Ingress) relied on the API scheme performing a fallback (recursive field-wise) conversion. This mode of conversion stops working in k8s 1.19. Per 1.19 release notes:

> K8s.io/apimachinery - scheme.Convert() now uses only explicitly registered conversions - default reflection based conversion is no longer available. +k8s:conversion-gen tags can be used with the k8s.io/code-generator component to generate conversions.

These types (`extensions/v1beta1` and `networking.k8s.io/v1beta1` Ingress) are field-wise compatible. This PR introduces an explicit field-wise conversion using JSON as an intermediary, [as advised on k8s sig-api-machinery slack](https://kubernetes.slack.com/archives/C0EG7JC6T/p1598018172011800).

**Which issue this PR fixes** unblocks #788 which requires k8s API update to v1.19

**Special notes for your reviewer**:

This PR also renames the `networking` package import as `networkingv1beta1` because we're about to introduce `networkingv1`. The import naming format follows the usual way for k8s API packages.
