### PR TITLE
Update remaining resource ingress.class behaviors

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -31,12 +31,12 @@ const (
 )
 
 const (
-	ingressClassKey = "kubernetes.io/ingress.class"
+	IngressClassKey = "kubernetes.io/ingress.class"
 
 	deprecatedAnnotationPrefix = "configuration.konghq.com"
 	annotationPrefix           = "konghq.com"
 
-	deprecatedPluginsKey       = "plugins.konghq.com"
+	DeprecatedPluginsKey       = "plugins.konghq.com"
 	deprecatedConfigurationKey = deprecatedAnnotationPrefix
 
 	configurationKey     = "/override"
@@ -80,7 +80,7 @@ func IngressClassValidatorFunc(
 	ingressClass string) func(obj metav1.Object, handling ClassMatching) bool {
 
 	return func(obj metav1.Object, handling ClassMatching) bool {
-		ingress := obj.GetAnnotations()[ingressClassKey]
+		ingress := obj.GetAnnotations()[IngressClassKey]
 		return validIngress(ingress, ingressClass, handling)
 	}
 }
@@ -91,7 +91,7 @@ func IngressClassValidatorFuncFromObjectMeta(
 	ingressClass string) func(obj *metav1.ObjectMeta, handling ClassMatching) bool {
 
 	return func(obj *metav1.ObjectMeta, handling ClassMatching) bool {
-		ingress := obj.GetAnnotations()[ingressClassKey]
+		ingress := obj.GetAnnotations()[IngressClassKey]
 		return validIngress(ingress, ingressClass, handling)
 	}
 }
@@ -114,7 +114,7 @@ func pluginsFromAnnotations(anns map[string]string) (string, bool) {
 	if exists {
 		return value, exists
 	}
-	value, exists = anns[deprecatedPluginsKey]
+	value, exists = anns[DeprecatedPluginsKey]
 	return value, exists
 }
 

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -60,7 +60,7 @@ func TestIngressClassValidatorFunc(t *testing.T) {
 	data := map[string]string{}
 	ing.SetAnnotations(data)
 	for _, test := range tests {
-		ing.Annotations[ingressClassKey] = test.ingress
+		ing.Annotations[IngressClassKey] = test.ingress
 		f := IngressClassValidatorFunc(test.controller)
 
 		result := f(&ing.ObjectMeta, test.classMatching)
@@ -190,7 +190,7 @@ func TestExtractKongPluginsFromAnnotations(t *testing.T) {
 			name: "legacy annotation",
 			args: args{
 				anns: map[string]string{
-					"plugins.konghq.com": "kp-rl, kp-cors",
+					DeprecatedPluginsKey: "kp-rl, kp-cors",
 				},
 			},
 			want: []string{"kp-rl", "kp-cors"},
@@ -208,7 +208,7 @@ func TestExtractKongPluginsFromAnnotations(t *testing.T) {
 			name: "annotation prioriy",
 			args: args{
 				anns: map[string]string{
-					"plugins.konghq.com": "a,b",
+					DeprecatedPluginsKey: "a,b",
 					"konghq.com/plugins": "kp-rl, kp-cors",
 				},
 			},

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/store"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/utils"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
@@ -149,7 +150,7 @@ func TestGlobalPlugin(t *testing.T) {
 							"global": "true",
 						},
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Protocols:  []string{"http"},
@@ -198,7 +199,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -228,7 +229,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "bar-plugin",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -279,7 +280,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							"global": "true",
 						},
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Protocols:  []string{"http"},
@@ -713,7 +714,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -748,7 +749,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -764,7 +765,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -795,7 +796,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -811,7 +812,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -827,7 +828,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -863,7 +864,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -945,7 +946,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1331,7 +1332,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Namespace: "default",
 						Annotations: map[string]string{
 							"konghq.com/preserve-host":    "faLsE",
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1409,7 +1410,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 							"konghq.com/preserve-host":    "wiggle wiggle wiggle",
 						},
 					},
@@ -1489,7 +1490,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Namespace: "default",
 						Annotations: map[string]string{
 							"konghq.com/regex-priority":   "10",
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1568,7 +1569,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Namespace: "default",
 						Annotations: map[string]string{
 							"konghq.com/regex-priority":   "IAmAString",
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1649,7 +1650,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1885,7 +1886,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1966,7 +1967,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2056,7 +2057,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 						Namespace: "default",
 						Annotations: map[string]string{
 							"konghq.com/methods":          "POST,GET",
-							"kubernetes.io/ingress.class": "kong",
+							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -2138,7 +2139,7 @@ func TestDefaultBackend(t *testing.T) {
 					Name:      "ing-with-default-backend",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2184,7 +2185,7 @@ func TestDefaultBackend(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2253,7 +2254,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2312,7 +2313,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2329,7 +2330,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "ns1",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2407,7 +2408,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2490,7 +2491,7 @@ func TestPluginAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2580,7 +2581,7 @@ func TestPluginAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2665,7 +2666,7 @@ func TestPluginAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2727,7 +2728,7 @@ func TestPluginAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"plugins.konghq.com":          "does-not-exist",
-						"kubernetes.io/ingress.class": "kong",
+						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2778,7 +2779,7 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "foo",
 				Namespace: "foo-namespace",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 			Spec: networking.IngressSpec{

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -712,6 +712,9 @@ func TestCACertificate(t *testing.T) {
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
 					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
+					},
 				},
 				Data: map[string][]byte{
 					"id":   []byte("8214a145-a328-4c56-ab72-2973a56d4eae"),
@@ -744,6 +747,9 @@ func TestCACertificate(t *testing.T) {
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
 					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
+					},
 				},
 				Data: map[string][]byte{
 					"id":   []byte("8214a145-a328-4c56-ab72-2973a56d4eae"),
@@ -756,6 +762,9 @@ func TestCACertificate(t *testing.T) {
 					Namespace: "non-default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
+					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
 					},
 				},
 				Data: map[string][]byte{
@@ -785,6 +794,9 @@ func TestCACertificate(t *testing.T) {
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
 					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
+					},
 				},
 				Data: map[string][]byte{
 					"id":   []byte("8214a145-a328-4c56-ab72-2973a56d4eae"),
@@ -798,6 +810,9 @@ func TestCACertificate(t *testing.T) {
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
 					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
+					},
 				},
 				Data: map[string][]byte{
 					"id": []byte("570c28aa-e784-43c1-8ec7-ae7f4ce40189"),
@@ -810,6 +825,9 @@ func TestCACertificate(t *testing.T) {
 					Namespace: "non-default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
+					},
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "kong",
 					},
 				},
 				Data: map[string][]byte{

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -150,7 +150,7 @@ func TestGlobalPlugin(t *testing.T) {
 							"global": "true",
 						},
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Protocols:  []string{"http"},
@@ -198,8 +198,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "foo-plugin",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -228,8 +228,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "bar-plugin",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "bar-plugin",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -280,7 +280,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							"global": "true",
 						},
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Protocols:  []string{"http"},
@@ -714,7 +714,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -749,7 +749,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -765,7 +765,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -796,7 +796,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -812,7 +812,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -828,7 +828,7 @@ func TestCACertificate(t *testing.T) {
 						"konghq.com/ca-cert": "true",
 					},
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Data: map[string][]byte{
@@ -864,7 +864,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -946,7 +946,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1016,7 +1016,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"configuration.konghq.com/strip-path": "trUe",
-						"kubernetes.io/ingress.class":         "kong",
+						annotations.IngressClassKey:           "kong",
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1093,7 +1093,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class":         "kong",
+						annotations.IngressClassKey:           "kong",
 						"configuration.konghq.com/strip-path": "false",
 					},
 				},
@@ -1172,7 +1172,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "kong",
+							annotations.IngressClassKey:             "kong",
 							"konghq.com/https-redirect-status-code": "301",
 						},
 					},
@@ -1252,7 +1252,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "kong",
+							annotations.IngressClassKey:             "kong",
 							"konghq.com/https-redirect-status-code": "whoops",
 						},
 					},
@@ -1331,8 +1331,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"konghq.com/preserve-host":    "faLsE",
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							"konghq.com/preserve-host":  "faLsE",
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1410,8 +1410,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
-							"konghq.com/preserve-host":    "wiggle wiggle wiggle",
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
+							"konghq.com/preserve-host":  "wiggle wiggle wiggle",
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1489,8 +1489,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"konghq.com/regex-priority":   "10",
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							"konghq.com/regex-priority": "10",
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1568,8 +1568,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"konghq.com/regex-priority":   "IAmAString",
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							"konghq.com/regex-priority": "IAmAString",
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -1650,7 +1650,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1797,7 +1797,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"plugins.konghq.com":                   "knative-key-auth",
+						annotations.DeprecatedPluginsKey:       "knative-key-auth",
 						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
@@ -1890,7 +1890,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -1971,7 +1971,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2060,8 +2060,8 @@ func TestKongServiceAnnotations(t *testing.T) {
 						Name:      "bar",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"konghq.com/methods":          "POST,GET",
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+							"konghq.com/methods":        "POST,GET",
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
 					Spec: networking.IngressSpec{
@@ -2143,7 +2143,7 @@ func TestDefaultBackend(t *testing.T) {
 					Name:      "ing-with-default-backend",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2189,7 +2189,7 @@ func TestDefaultBackend(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2258,7 +2258,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2317,7 +2317,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2334,7 +2334,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "ns1",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2412,7 +2412,7 @@ func TestParserSecret(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2494,8 +2494,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "foo-plugin",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2584,8 +2584,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "foo-plugin",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2669,8 +2669,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "foo-plugin",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "foo-plugin",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2731,8 +2731,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"plugins.konghq.com":          "does-not-exist",
-						"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+						annotations.DeprecatedPluginsKey: "does-not-exist",
+						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networking.IngressSpec{
@@ -2783,7 +2783,7 @@ func TestParseIngressRules(t *testing.T) {
 				Name:      "foo",
 				Namespace: "foo-namespace",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 			Spec: networking.IngressSpec{
@@ -4947,7 +4947,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foo,bar",
+										annotations.DeprecatedPluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -4973,7 +4973,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foo,bar",
+										annotations.DeprecatedPluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -5005,7 +5005,7 @@ func Test_getPluginRelations(t *testing.T) {
 											Name:      "some-ingress",
 											Namespace: "ns2",
 											Annotations: map[string]string{
-												"plugins.konghq.com": "foo,bar",
+												annotations.DeprecatedPluginsKey: "foo,bar",
 											},
 										},
 									},
@@ -5039,7 +5039,7 @@ func Test_getPluginRelations(t *testing.T) {
 											Name:      "some-ingress",
 											Namespace: "ns2",
 											Annotations: map[string]string{
-												"plugins.konghq.com": "foo,bar",
+												annotations.DeprecatedPluginsKey: "foo,bar",
 											},
 										},
 									},
@@ -5053,7 +5053,7 @@ func Test_getPluginRelations(t *testing.T) {
 											Name:      "some-ingress",
 											Namespace: "ns2",
 											Annotations: map[string]string{
-												"plugins.konghq.com": "bar,baz",
+												annotations.DeprecatedPluginsKey: "bar,baz",
 											},
 										},
 									},
@@ -5082,7 +5082,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foo,bar",
+										annotations.DeprecatedPluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -5095,7 +5095,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns2",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foo,bar",
+										annotations.DeprecatedPluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -5108,7 +5108,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foobar",
+										annotations.DeprecatedPluginsKey: "foobar",
 									},
 								},
 							},
@@ -5123,7 +5123,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										"plugins.konghq.com": "foo,bar",
+										annotations.DeprecatedPluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -5137,7 +5137,7 @@ func Test_getPluginRelations(t *testing.T) {
 											Name:      "some-ingress",
 											Namespace: "ns2",
 											Annotations: map[string]string{
-												"plugins.konghq.com": "foo,bar",
+												annotations.DeprecatedPluginsKey: "foo,bar",
 											},
 										},
 									},
@@ -5151,7 +5151,7 @@ func Test_getPluginRelations(t *testing.T) {
 											Name:      "some-ingress",
 											Namespace: "ns2",
 											Annotations: map[string]string{
-												"plugins.konghq.com": "bar,baz",
+												annotations.DeprecatedPluginsKey: "bar,baz",
 											},
 										},
 									},

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1758,6 +1758,9 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "knative-ingress",
 					Namespace: "foo-ns",
+					Annotations: map[string]string{
+						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+					},
 				},
 				Spec: knative.IngressSpec{
 					Rules: []knative.IngressRule{
@@ -1794,7 +1797,8 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"plugins.konghq.com": "knative-key-auth",
+						"plugins.konghq.com":                   "knative-key-auth",
+						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
 					},
 				},
 			},

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -139,6 +139,7 @@ func NewFakeStore(
 
 			KnativeIngress: knativeIngressStore,
 		},
+		ingressClass:              "kong",
 		isValidIngressClass:       annotations.IngressClassValidatorFuncFromObjectMeta("kong"),
 		ingressClassMatching:      annotations.ExactClassMatch,
 		kongConsumerClassMatching: annotations.ExactClassMatch,

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -139,8 +139,8 @@ func NewFakeStore(
 
 			KnativeIngress: knativeIngressStore,
 		},
-		ingressClass:              "kong",
-		isValidIngressClass:       annotations.IngressClassValidatorFuncFromObjectMeta("kong"),
+		ingressClass:              annotations.DefaultIngressClass,
+		isValidIngressClass:       annotations.IngressClassValidatorFuncFromObjectMeta(annotations.DefaultIngressClass),
 		ingressClassMatching:      annotations.ExactClassMatch,
 		kongConsumerClassMatching: annotations.ExactClassMatch,
 	}

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -264,7 +264,7 @@ func TestFakeStoreListKnativeIngress(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "idontgetprocessedbecauseihavenoclassannotation",
+				Name:      "i-dont-get-processed-because-i-have-no-class-annotation",
 				Namespace: "default",
 			},
 			Spec: knative.IngressSpec{

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -95,7 +96,7 @@ func TestFakeStoreIngress(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 			Spec: networking.IngressSpec{
@@ -164,7 +165,7 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 			Spec: configurationv1beta1.IngressSpec{
@@ -324,7 +325,7 @@ func TestFakeStoreConsumer(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -402,7 +403,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 					"global": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -536,7 +537,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 					"konghq.com/ca-cert": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -548,7 +549,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 					"konghq.com/ca-cert": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "kong",
+					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
 				},
 			},
 		},

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -235,6 +235,37 @@ func TestFakeStoreListKnativeIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "default",
+				Annotations: map[string]string{
+					"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+				},
+			},
+			Spec: knative.IngressSpec{
+				Rules: []knative.IngressRule{
+					{
+						Hosts: []string{"example.com"},
+						HTTP: &knative.HTTPIngressRuleValue{
+							Paths: []knative.HTTPIngressPath{
+								{
+									Path: "/",
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceName: "foo-svc",
+												ServicePort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "idontgetprocessedbecauseihavenoclassannotation",
+				Namespace: "default",
 			},
 			Spec: knative.IngressSpec{
 				Rules: []knative.IngressRule{

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -535,6 +535,9 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 				Labels: map[string]string{
 					"konghq.com/ca-cert": "true",
 				},
+				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "kong",
+				},
 			},
 		},
 		{
@@ -543,6 +546,9 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 				Namespace: "default",
 				Labels: map[string]string{
 					"konghq.com/ca-cert": "true",
+				},
+				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "kong",
 				},
 			},
 		},

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -96,7 +96,7 @@ func TestFakeStoreIngress(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 			Spec: networking.IngressSpec{
@@ -125,7 +125,7 @@ func TestFakeStoreIngress(t *testing.T) {
 				Name:      "bar",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "not-kong",
+					annotations.IngressClassKey: "not-kong",
 				},
 			},
 			Spec: networking.IngressSpec{
@@ -165,7 +165,7 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 			Spec: configurationv1beta1.IngressSpec{
@@ -203,7 +203,7 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 				Name:      "bar",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "not-kong",
+					annotations.IngressClassKey: "not-kong",
 				},
 			},
 			Spec: configurationv1beta1.IngressSpec{
@@ -356,7 +356,7 @@ func TestFakeStoreConsumer(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -434,7 +434,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 					"global": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -568,7 +568,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 					"konghq.com/ca-cert": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 		},
@@ -580,7 +580,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 					"konghq.com/ca-cert": "true",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
 		},

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -194,10 +194,6 @@ func (s Store) ListTCPIngresses() ([]*configurationv1beta1.TCPIngress, error) {
 
 func (s Store) validKnativeIngressClass(objectMeta *metav1.ObjectMeta) bool {
 	ingressAnnotationValue := objectMeta.GetAnnotations()[knativeIngressClassKey]
-	if ingressAnnotationValue == "" &&
-		s.ingressClass == annotations.DefaultIngressClass {
-		return true
-	}
 	return ingressAnnotationValue == s.ingressClass
 }
 
@@ -211,6 +207,9 @@ func (s Store) ListKnativeIngresses() ([]*knative.Ingress, error) {
 	err := cache.ListAll(s.stores.KnativeIngress, labels.NewSelector(),
 		func(ob interface{}) {
 			ing, ok := ob.(*knative.Ingress)
+			// this is implemented directly in store as s.isValidIngressClass only checks the value of the
+			// kubernetes.io/ingress.class annotation (annotations.ingressClassKey), not
+			// networking.knative.dev/ingress.class (knativeIngressClassKey)
 			if ok && s.validKnativeIngressClass(&ing.ObjectMeta) {
 				ingresses = append(ingresses, ing)
 			}

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -330,7 +330,7 @@ func (s Store) ListGlobalKongPlugins() ([]*configurationv1.KongPlugin, error) {
 		labels.NewSelector().Add(*req),
 		func(ob interface{}) {
 			p, ok := ob.(*configurationv1.KongPlugin)
-			if ok && s.isValidIngressClass(&p.ObjectMeta, s.ingressClassMatching) {
+			if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.ExactOrEmptyClassMatch) {
 				plugins = append(plugins, p)
 			}
 		})

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -377,7 +377,7 @@ func (s Store) ListCACerts() ([]*apiv1.Secret, error) {
 		labels.NewSelector().Add(*req),
 		func(ob interface{}) {
 			p, ok := ob.(*apiv1.Secret)
-			if ok {
+			if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.ExactClassMatch) {
 				secrets = append(secrets, p)
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
* Updates the last permissive legacy class matching logic (for Knative and CA certificate secrets) to their modern, exact match logic.
* Updates CA certificate tests to include class annotations.
* Use a reference to the default class exported by annotations rather than the literal `"kong"` string in tests.
* Explicitly sets global KongPlugin matching to ExactOrEmptyMatching.

**Which issue this PR fixes**
fixes #739 
fixes #731 

**Special notes for your reviewer**:
Changes for #731 are a composite of this and the implementation for #732, which was merged in #767. See comments in #731 for additional details.

We had originally discussed also rolling removal of the `ListGlobalKongPlugins()` store function into this, but on further review, we should leave that in. We list them only to report that they're there and instruct users to convert them to KongClusterPlugins: https://github.com/Kong/kubernetes-ingress-controller/blob/de29e98edd351e264a901847af7b6f1128e15e5f/internal/ingress/controller/parser/parser.go#L1593-L1601

`ListGlobalKongPlugins()` is still a bit odd as it sorta still used the legacy matching behavior: it tracked the Ingress matching behavior, but _that_ has since changed. Tracking it now would omit warnings for global KongPlugins with no class annotation (which were previously processed if you used the default "kong" class). As such, this PR preserves the function, but always uses ExactOrEmptyMatching to try and match the old behavior as best possible.