### PR TITLE
ingress V1: implement status sync

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -328,7 +328,7 @@ func (s *statusSync) updateStatus(ctx context.Context, newIngressPoint []apiv1.L
 	batch := p.Batch()
 
 	for _, ing := range ings {
-		batch.Queue(s.runUpdate(ctx, ing, newIngressPoint, s.CoreClient))
+		batch.Queue(s.runUpdateIngressV1beta1(ctx, ing, newIngressPoint, s.CoreClient))
 	}
 	for _, ing := range tcpIngresses {
 		batch.Queue(s.runUpdateTCPIngress(ctx, ing, newIngressPoint, s.KongConfigClient))
@@ -341,7 +341,7 @@ func (s *statusSync) updateStatus(ctx context.Context, newIngressPoint []apiv1.L
 	batch.WaitAll()
 }
 
-func (s *statusSync) runUpdate(ctx context.Context, ing *networkingv1beta1.Ingress, status []apiv1.LoadBalancerIngress,
+func (s *statusSync) runUpdateIngressV1beta1(ctx context.Context, ing *networkingv1beta1.Ingress, status []apiv1.LoadBalancerIngress,
 	client clientset.Interface) pool.WorkFunc {
 	return func(wu pool.WorkUnit) (interface{}, error) {
 		if wu.IsCancelled() {

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -183,7 +183,7 @@ func fakeSynFn(interface{}) error {
 	return nil
 }
 
-func buildExtensionsIngresses() []networkingv1beta1.Ingress {
+func buildIngressesV1beta1() []networkingv1beta1.Ingress {
 	return []networkingv1beta1.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -234,18 +234,66 @@ func buildExtensionsIngresses() []networkingv1beta1.Ingress {
 	}
 }
 
-type testIngressLister struct {
+func buildIngressesV1() []networkingv1.Ingress {
+	return []networkingv1.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo_ingress_1",
+				Namespace: apiv1.NamespaceDefault,
+			},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: apiv1.LoadBalancerStatus{
+					Ingress: []apiv1.LoadBalancerIngress{
+						{
+							IP:       "10.0.0.1",
+							Hostname: "foo1",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo_ingress_different_class",
+				Namespace: metav1.NamespaceDefault,
+				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "no-nginx",
+				},
+			},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: apiv1.LoadBalancerStatus{
+					Ingress: []apiv1.LoadBalancerIngress{
+						{
+							IP:       "0.0.0.0",
+							Hostname: "foo.bar.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo_ingress_2",
+				Namespace: apiv1.NamespaceDefault,
+			},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: apiv1.LoadBalancerStatus{
+					Ingress: []apiv1.LoadBalancerIngress{},
+				},
+			},
+		},
+	}
 }
 
-func (til *testIngressLister) ListIngressesV1beta1() []*networkingv1beta1.Ingress {
-	var ingresses []*networkingv1beta1.Ingress
-	ingresses = append(ingresses, &networkingv1beta1.Ingress{
+var sampleIngressesV1beta1 = []*networkingv1beta1.Ingress{
+	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo_ingress_non_01",
 			Namespace: apiv1.NamespaceDefault,
-		}})
+		},
+	},
 
-	ingresses = append(ingresses, &networkingv1beta1.Ingress{
+	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo_ingress_1",
 			Namespace: apiv1.NamespaceDefault,
@@ -255,13 +303,41 @@ func (til *testIngressLister) ListIngressesV1beta1() []*networkingv1beta1.Ingres
 				Ingress: buildLoadBalancerIngressByIP(),
 			},
 		},
-	})
+	},
+}
 
-	return ingresses
+var sampleIngressesV1 = []*networkingv1.Ingress{
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo_ingress_non_01",
+			Namespace: apiv1.NamespaceDefault,
+		},
+	},
+
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo_ingress_1",
+			Namespace: apiv1.NamespaceDefault,
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: apiv1.LoadBalancerStatus{
+				Ingress: buildLoadBalancerIngressByIP(),
+			},
+		},
+	},
+}
+
+type testIngressLister struct {
+	ingressesV1beta1 []*networkingv1beta1.Ingress
+	ingressesV1      []*networkingv1.Ingress
+}
+
+func (til *testIngressLister) ListIngressesV1beta1() []*networkingv1beta1.Ingress {
+	return til.ingressesV1beta1
 }
 
 func (til *testIngressLister) ListIngressesV1() []*networkingv1.Ingress {
-	return nil
+	return til.ingressesV1
 }
 
 func (til *testIngressLister) ListTCPIngresses() ([]*configurationv1beta1.TCPIngress, error) {
@@ -270,10 +346,6 @@ func (til *testIngressLister) ListTCPIngresses() ([]*configurationv1beta1.TCPIng
 
 func (til *testIngressLister) ListKnativeIngresses() ([]*knative.Ingress, error) {
 	return nil, nil
-}
-
-func buildIngressLister() ingressLister {
-	return &testIngressLister{}
 }
 
 func buildStatusSync() statusSync {
@@ -287,9 +359,9 @@ func buildStatusSync() statusSync {
 		},
 		syncQueue: task.NewTaskQueue(fakeSynFn, logrus.New()),
 		Config: Config{
-			CoreClient:     buildSimpleClientSet(&networkingv1beta1.IngressList{Items: buildExtensionsIngresses()}),
+			CoreClient:     buildSimpleClientSet(&networkingv1beta1.IngressList{Items: buildIngressesV1beta1()}),
 			PublishService: apiv1.NamespaceDefault + "/" + "foo",
-			IngressLister:  buildIngressLister(),
+			IngressLister:  &testIngressLister{ingressesV1beta1: sampleIngressesV1beta1},
 			IngressAPI:     utils.ExtensionsV1beta1,
 		},
 	}
@@ -301,9 +373,9 @@ func TestStatusActionsV1beta1(t *testing.T) {
 	os.Setenv("POD_NAME", "foo1")
 	os.Setenv("POD_NAMESPACE", apiv1.NamespaceDefault)
 	c := Config{
-		CoreClient:             buildSimpleClientSet(&networkingv1beta1.IngressList{Items: buildExtensionsIngresses()}),
+		CoreClient:             buildSimpleClientSet(&networkingv1beta1.IngressList{Items: buildIngressesV1beta1()}),
 		PublishService:         apiv1.NamespaceDefault + "/" + "foo",
-		IngressLister:          buildIngressLister(),
+		IngressLister:          &testIngressLister{ingressesV1beta1: sampleIngressesV1beta1},
 		UpdateStatusOnShutdown: true,
 		IngressAPI:             utils.NetworkingV1beta1,
 		Logger:                 logrus.New(),
@@ -356,6 +428,76 @@ func TestStatusActionsV1beta1(t *testing.T) {
 	}
 
 	oic, err := fk.CoreClient.NetworkingV1beta1().Ingresses(
+		metav1.NamespaceDefault).Get(ctx, "foo_ingress_different_class", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+	if oic.Status.LoadBalancer.Ingress[0].IP != "0.0.0.0" && oic.Status.LoadBalancer.Ingress[0].Hostname != "foo.bar.com" {
+		t.Fatalf("invalid ingress status for rule with different class")
+	}
+}
+
+func TestStatusActionsV1(t *testing.T) {
+	ctx := context.Background()
+	// make sure election can be created
+	os.Setenv("POD_NAME", "foo1")
+	os.Setenv("POD_NAMESPACE", apiv1.NamespaceDefault)
+	c := Config{
+		CoreClient:             buildSimpleClientSet(&networkingv1.IngressList{Items: buildIngressesV1()}),
+		PublishService:         apiv1.NamespaceDefault + "/" + "foo",
+		IngressLister:          &testIngressLister{ingressesV1: sampleIngressesV1},
+		UpdateStatusOnShutdown: true,
+		IngressAPI:             utils.NetworkingV1,
+		Logger:                 logrus.New(),
+	}
+	// create object
+	fkSync, err := NewStatusSyncer(ctx, c)
+	if fkSync == nil {
+		t.Fatalf("expected a valid Sync")
+	}
+
+	fk := fkSync.(statusSync)
+
+	// start it and wait for the election and syn actions
+	go fk.Run()
+	//  wait for the election
+	time.Sleep(100 * time.Millisecond)
+	// execute sync
+	err = fk.sync("just-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	newIPs := []apiv1.LoadBalancerIngress{{
+		IP: "11.0.0.2",
+	}}
+	fooIngress1, err1 := fk.CoreClient.NetworkingV1().Ingresses(
+		apiv1.NamespaceDefault).Get(ctx, "foo_ingress_1", metav1.GetOptions{})
+	if err1 != nil {
+		t.Fatalf("unexpected error")
+	}
+	fooIngress1CurIPs := fooIngress1.Status.LoadBalancer.Ingress
+	if !ingressSliceEqual(fooIngress1CurIPs, newIPs) {
+		t.Fatalf("returned %v but expected %v", fooIngress1CurIPs, newIPs)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// execute shutdown
+	fk.Shutdown(true)
+	// ingress should be empty
+	newIPs2 := []apiv1.LoadBalancerIngress{}
+	fooIngress2, err2 := fk.CoreClient.NetworkingV1().Ingresses(
+		apiv1.NamespaceDefault).Get(ctx, "foo_ingress_1", metav1.GetOptions{})
+	if err2 != nil {
+		t.Fatalf("unexpected error")
+	}
+	fooIngress2CurIPs := fooIngress2.Status.LoadBalancer.Ingress
+	if !ingressSliceEqual(fooIngress2CurIPs, newIPs2) {
+		t.Fatalf("returned %v but expected %v", fooIngress2CurIPs, newIPs2)
+	}
+
+	oic, err := fk.CoreClient.NetworkingV1().Ingresses(
 		metav1.NamespaceDefault).Get(ctx, "foo_ingress_different_class", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error")


### PR DESCRIPTION
This PR makes `statusSync` update the `status` of Ingress v1 resources in Store just like it does for Ingress v1beta1.
Includes a test (equivalent to the v1beta1 test).

Notes to reviewers:
- This implementation (and test) is an almost direct copy of the preexisting v1beta1 code, including todos and bugs (most notably #829). For review comments regarding v1 functionality, please think whether the same problem applies to v1beta1. For such (preexisting) problems, use your best judgment to tell if a fix should belong in scope of this PR (which I define as "introduce v1 syncing") or not (and be therefore reported as an issue affecting both v1beta1 and v1 to be fixed later)
- Consider not squashing when merging