### PR TITLE
Add status subresources to Kong CRDs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup kustomize
       uses: imranismail/setup-kustomize@v1
       with:
-        kustomize-version: "3.1.0"
+        kustomize-version: "3.8.1"
     - name: Verify manifest consistency
       run: |
         make verify-manifests

--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -72,6 +72,8 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -150,6 +152,8 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -185,6 +189,8 @@ spec:
           type: array
           items:
             type: string
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -221,6 +227,8 @@ spec:
           type: string
         type:
           type: string
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -382,6 +390,8 @@ spec:
                   properties:
                     healthy: *healthy
                     unhealthy: *unhealthy
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -448,6 +458,8 @@ spec:
                         type: integer
         status:
           type: object
+  subresources:
+    status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -34,6 +34,8 @@ spec:
     shortNames:
     - kcp
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -101,6 +103,8 @@ spec:
     shortNames:
     - kc
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -137,6 +141,8 @@ spec:
     kind: KongCredential
     plural: kongcredentials
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -161,6 +167,8 @@ spec:
     shortNames:
     - ki
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -370,6 +378,8 @@ spec:
     shortNames:
     - kp
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -646,11 +656,6 @@ spec:
     spec:
       containers:
       - env:
-        - name: KONG_LICENSE_DATA
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: kong-enterprise-license
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
         - name: KONG_PORT_MAPS
@@ -669,6 +674,11 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_LICENSE_DATA
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: kong-enterprise-license
         image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.4.1-alpine
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -34,6 +34,8 @@ spec:
     shortNames:
     - kcp
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -101,6 +103,8 @@ spec:
     shortNames:
     - kc
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -137,6 +141,8 @@ spec:
     kind: KongCredential
     plural: kongcredentials
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -161,6 +167,8 @@ spec:
     shortNames:
     - ki
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -370,6 +378,8 @@ spec:
     shortNames:
     - kp
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -34,6 +34,8 @@ spec:
     shortNames:
     - kcp
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -101,6 +103,8 @@ spec:
     shortNames:
     - kc
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -137,6 +141,8 @@ spec:
     kind: KongCredential
     plural: kongcredentials
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -161,6 +167,8 @@ spec:
     shortNames:
     - ki
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -370,6 +378,8 @@ spec:
     shortNames:
     - kp
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -692,6 +702,28 @@ spec:
     spec:
       containers:
       - env:
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: postgres
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "1"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
         - name: KONG_LICENSE_DATA
           valueFrom:
             secretKeyRef:
@@ -705,28 +737,6 @@ spec:
           value: "on"
         - name: KONG_ADMIN_GUI_SESSION_CONF
           value: '{"cookie_secure":false,"storage":"kong","cookie_name":"admin_session","cookie_lifetime":31557600,"cookie_samesite":"off","secret":"please-change-me"}'
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
-        - name: KONG_PORT_MAPS
-          value: 80:8000, 443:8443
-        - name: KONG_ADMIN_LISTEN
-          value: 0.0.0.0:8001, 0.0.0.0:8444 ssl
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: postgres
-        - name: KONG_PG_HOST
-          value: postgres
-        - name: KONG_PG_PASSWORD
-          value: kong
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "1"
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
-        - name: KONG_PROXY_ERROR_LOG
-          value: /dev/stderr
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         lifecycle:
           preStop:
@@ -747,12 +757,6 @@ spec:
           timeoutSeconds: 1
         name: proxy
         ports:
-        - containerPort: 8001
-          name: admin
-          protocol: TCP
-        - containerPort: 8002
-          name: manager
-          protocol: TCP
         - containerPort: 8000
           name: proxy
           protocol: TCP
@@ -761,6 +765,12 @@ spec:
           protocol: TCP
         - containerPort: 8100
           name: metrics
+          protocol: TCP
+        - containerPort: 8001
+          name: admin
+          protocol: TCP
+        - containerPort: 8002
+          name: manager
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
@@ -773,11 +783,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       - env:
-        - name: CONTROLLER_KONG_ADMIN_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: kong-enterprise-superuser-password
         - name: CONTROLLER_KONG_ADMIN_URL
           value: https://127.0.0.1:8444
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
@@ -794,6 +799,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: CONTROLLER_KONG_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: kong-enterprise-superuser-password
         image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -827,18 +837,17 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
-          sleep 2;  done;
+        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;
         env:
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
         - name: KONG_LICENSE_DATA
           valueFrom:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
-        - name: KONG_PG_HOST
-          value: postgres
-        - name: KONG_PG_PASSWORD
-          value: kong
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
@@ -904,6 +913,12 @@ spec:
         - -c
         - kong migrations bootstrap
         env:
+        - name: KONG_PG_PASSWORD
+          value: kong
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PORT
+          value: "5432"
         - name: KONG_LICENSE_DATA
           valueFrom:
             secretKeyRef:
@@ -914,12 +929,6 @@ spec:
             secretKeyRef:
               key: password
               name: kong-enterprise-superuser-password
-        - name: KONG_PG_PASSWORD
-          value: kong
-        - name: KONG_PG_HOST
-          value: postgres
-        - name: KONG_PG_PORT
-          value: "5432"
         image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
         name: kong-migrations
       imagePullSecrets:
@@ -928,8 +937,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
-          sleep 1; done
+        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -34,6 +34,8 @@ spec:
     shortNames:
     - kcp
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -101,6 +103,8 @@ spec:
     shortNames:
     - kc
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -137,6 +141,8 @@ spec:
     kind: KongCredential
     plural: kongcredentials
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -161,6 +167,8 @@ spec:
     shortNames:
     - ki
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -370,6 +378,8 @@ spec:
     shortNames:
     - kp
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -670,10 +680,6 @@ spec:
           value: 0.0.0.0:8100
         - name: KONG_DATABASE
           value: postgres
-        - name: KONG_PG_HOST
-          value: postgres
-        - name: KONG_PG_PASSWORD
-          value: kong
         - name: KONG_NGINX_WORKER_PROCESSES
           value: "1"
         - name: KONG_ADMIN_ACCESS_LOG
@@ -682,6 +688,10 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_PG_HOST
+          value: postgres
+        - name: KONG_PG_PASSWORD
+          value: kong
         image: kong:2.1
         lifecycle:
           preStop:
@@ -769,8 +779,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
-          sleep 2;  done;
+        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;
         env:
         - name: KONG_PG_HOST
           value: postgres
@@ -853,8 +862,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
-          sleep 1; done
+        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/hack/dev/common/custom-types.yaml
+++ b/hack/dev/common/custom-types.yaml
@@ -72,6 +72,8 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -150,6 +152,8 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -185,6 +189,8 @@ spec:
           type: array
           items:
             type: string
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -221,6 +227,8 @@ spec:
           type: string
         type:
           type: string
+  subresources:
+    status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -382,6 +390,8 @@ spec:
                   properties:
                     healthy: *healthy
                     unhealthy: *unhealthy
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -448,6 +458,8 @@ spec:
                         type: integer
         status:
           type: object
+  subresources:
+    status: {}
 status:
   acceptedNames:
     kind: ""

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -26,5 +26,7 @@ then
   echo "${DIFFROOT} up to date."
 else
   echo "${DIFFROOT} is out of date. Please run hack/build-single-manifests.sh"
+  echo "Diff output:"
+  git --no-pager diff "${DIFFROOT}"
   exit 1
 fi

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -10,7 +10,6 @@ import (
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KongIngress is a top-level type. A client is created for it.
@@ -38,7 +37,6 @@ type KongIngressList struct {
 
 // +genclient
 // +genclient:nonNamespaced
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KongClusterPlugin is a top-level type. A client is created for it.
@@ -83,7 +81,6 @@ type KongClusterPluginList struct {
 }
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KongPlugin is a top-level type. A client is created for it.
@@ -194,7 +191,6 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 }
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KongConsumer is a top-level type. A client is created for it.
@@ -228,7 +224,6 @@ type KongConsumerList struct {
 }
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KongCredential is a top-level type. A client is created for it.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add status subresources to Kong CRDs, following the example at https://github.com/kubernetes/sample-controller/commit/ad67096f17e0ef1c48f761370cb2a2261fe84c42

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #824

**Notes/questions for reviewers**:
Searching for prior art on this brought me to https://book-v1.book.kubebuilder.io/basics/status_subresource.html also. Kubebuilder does some additional stuff on top where it adds `Status` to the struct as well, whereas this just strips the `+genclient:noStatus`  out of `types.go` and adds object statuses to `custom-types.yaml`.

It looks like that's where intend to go in the future (vaguely recalling some previous discussion of migrating CRDs to kubebuilder), and that where we'll eventually add more detailed status info/logic, but for now we're just adding the stub statuses a la the sample-controller example, correct?