### PR TITLE
Handle Ingress v1 class

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -59,7 +59,8 @@ type cliConfig struct {
 
 	// Resource filtering
 	WatchNamespace                 string
-	ProcessClasslessIngressV1beta1 bool
+	ProcessClasslessIngressV1Beta1 bool
+	ProcessClasslessIngressV1      bool
 	ProcessClasslessKongConsumer   bool
 	IngressClass                   string
 	ElectionID                     string
@@ -342,7 +343,8 @@ func parseFlags() (cliConfig, error) {
 
 	// Resource filtering
 	config.WatchNamespace = viper.GetString("watch-namespace")
-	config.ProcessClasslessIngressV1beta1 = viper.GetBool("process-classless-ingress-v1beta1")
+	config.ProcessClasslessIngressV1Beta1 = viper.GetBool("process-classless-ingress-v1beta1")
+	config.ProcessClasslessIngressV1 = viper.GetBool("process-classless-ingress-v1")
 	config.ProcessClasslessKongConsumer = viper.GetBool("process-classless-kong-consumer")
 	config.IngressClass = viper.GetString("ingress-class")
 	config.ElectionID = viper.GetString("election-id")

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -444,8 +444,8 @@ func main() {
 		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
 	}
 
-	store := store.New(cacheStores, cliConfig.IngressClass, cliConfig.ProcessClasslessIngressV1beta1,
-		cliConfig.ProcessClasslessKongConsumer, log.WithField("component", "store"))
+	store := store.New(cacheStores, cliConfig.IngressClass, cliConfig.ProcessClasslessIngressV1Beta1,
+		cliConfig.ProcessClasslessIngressV1, cliConfig.ProcessClasslessKongConsumer, log.WithField("component", "store"))
 	kong, err := controller.NewKongController(ctx, &controllerConfig, updateChannel,
 		store)
 	if err != nil {

--- a/cli/ingress-controller/main_test.go
+++ b/cli/ingress-controller/main_test.go
@@ -80,8 +80,8 @@ func TestHandleSigterm(t *testing.T) {
 			KubeClient: kubeClient,
 		},
 		channels.NewRingChannel(1024),
-		store.New(store.CacheStores{}, conf.IngressClass, conf.ProcessClasslessIngressV1beta1,
-			conf.ProcessClasslessKongConsumer, logrus.New()),
+		store.New(store.CacheStores{}, conf.IngressClass, conf.ProcessClasslessIngressV1Beta1,
+			conf.ProcessClasslessIngressV1, conf.ProcessClasslessKongConsumer, logrus.New()),
 	)
 
 	exitCh := make(chan int, 1)

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -19,6 +19,8 @@ package annotations
 import (
 	"strings"
 
+	networkingv1 "k8s.io/api/networking/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,6 +95,15 @@ func IngressClassValidatorFuncFromObjectMeta(
 	return func(obj *metav1.ObjectMeta, handling ClassMatching) bool {
 		ingress := obj.GetAnnotations()[IngressClassKey]
 		return validIngress(ingress, ingressClass, handling)
+	}
+}
+
+func IngressClassValidatorFuncFromV1Ingress(
+	ingressClass string) func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
+
+	return func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
+		class := ingress.Spec.IngressClassName
+		return validIngress(*class, ingressClass, handling)
 	}
 }
 

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -103,7 +103,11 @@ func IngressClassValidatorFuncFromV1Ingress(
 
 	return func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
 		class := ingress.Spec.IngressClassName
-		return validIngress(*class, ingressClass, handling)
+		className := ""
+		if class != nil {
+			className = *class
+		}
+		return validIngress(className, ingressClass, handling)
 	}
 }
 

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -151,6 +151,7 @@ func NewFakeStore(
 		},
 		ingressClass:                annotations.DefaultIngressClass,
 		isValidIngressClass:         annotations.IngressClassValidatorFuncFromObjectMeta(annotations.DefaultIngressClass),
+		isValidIngressV1Class:       annotations.IngressClassValidatorFuncFromV1Ingress(annotations.DefaultIngressClass),
 		ingressV1Beta1ClassMatching: annotations.ExactClassMatch,
 		ingressV1ClassMatching:      annotations.ExactClassMatch,
 		kongConsumerClassMatching:   annotations.ExactClassMatch,

--- a/internal/ingress/store/fake_store.go
+++ b/internal/ingress/store/fake_store.go
@@ -149,10 +149,11 @@ func NewFakeStore(
 
 			KnativeIngress: knativeIngressStore,
 		},
-		ingressClass:              annotations.DefaultIngressClass,
-		isValidIngressClass:       annotations.IngressClassValidatorFuncFromObjectMeta(annotations.DefaultIngressClass),
-		ingressClassMatching:      annotations.ExactClassMatch,
-		kongConsumerClassMatching: annotations.ExactClassMatch,
+		ingressClass:                annotations.DefaultIngressClass,
+		isValidIngressClass:         annotations.IngressClassValidatorFuncFromObjectMeta(annotations.DefaultIngressClass),
+		ingressV1Beta1ClassMatching: annotations.ExactClassMatch,
+		ingressV1ClassMatching:      annotations.ExactClassMatch,
+		kongConsumerClassMatching:   annotations.ExactClassMatch,
 	}
 	return s, nil
 }

--- a/internal/ingress/store/fake_store_test.go
+++ b/internal/ingress/store/fake_store_test.go
@@ -161,6 +161,7 @@ func TestFakeStoreIngressV1beta1(t *testing.T) {
 func TestFakeStoreIngressV1(t *testing.T) {
 	assert := assert.New(t)
 
+	defaultClass := annotations.DefaultIngressClass
 	ingresses := []*networkingv1.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -230,11 +231,34 @@ func TestFakeStoreIngressV1(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: "skip-me-im-not-default",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules:            []networkingv1.IngressRule{},
+				IngressClassName: &defaultClass,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules:            []networkingv1.IngressRule{},
+				IngressClassName: &defaultClass,
+			},
+		},
 	}
 	store, err := NewFakeStore(FakeObjects{IngressesV1: ingresses})
 	assert.Nil(err)
 	assert.NotNil(store)
-	assert.Len(store.ListIngressesV1(), 1)
+	assert.Len(store.ListIngressesV1(), 2)
 	assert.Len(store.ListIngressesV1beta1(), 0)
 }
 


### PR DESCRIPTION
**Цо ПР ділать бы, и пошімў**:
This handles Ingress v1 class, as we need to handle Ingress v1 class.

**Пробрэма, хторюю хорректировяло ПР**: fixes #790

**Нёты**:
This is in very rough draft state, so it's bad, untested, and full of misery, but it should be :smile: 

- AFAIK we do indeed intend to have separate flags for ignoring class on v1 Ingress and v1beta1 Ingress--I think I remember that from previous discussions, and it seems a bit weird (SO MANY FLAGS), but eh, whatever.
- "annotations" is in a weird spot: the minimally invasive version of this adds a new function generator there, but it's for something that's no longer an annotation. Other option was to export `validIngress` and stick the Ingress V1 validator function in store, but eh, that's no good either.
- That the validation functions are part of the store itself seems kinda weird, but maybe that does make sense.
- Checking between the original KEP, which [just called this ingress class](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingress-class-field), and the [actual 1.19 API](https://github.com/kubernetes/kubernetes/blob/release-1.19/staging/src/k8s.io/api/networking/v1/types.go#L244-L257) apparently calls it `IngressClassName`. Pretty sure those are equivalent, but wanted to double-check, and want to make sure I understand the relationship between that and the actual [IngressClass object](https://github.com/kubernetes/kubernetes/blob/release-1.19/staging/src/k8s.io/api/networking/v1/types.go#L468-L484) correctly.