### PR TITLE
Ingress V1: port matching without port number

### DIFF
--- a/internal/ingress/controller/parser/kongstate/types.go
+++ b/internal/ingress/controller/parser/kongstate/types.go
@@ -1,13 +1,53 @@
 package kongstate
 
 import (
+	"fmt"
+
 	"github.com/kong/go-kong/kong"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+type PortMode int
+
+const (
+	// PortModeImplicit means that the Ingress does not specify the Kubernetes Service port, and that KIC should expect
+	// the Service to have only one port defined.
+	PortModeImplicit PortMode = iota
+	// PortModeNumber means that the Ingress specifies the Service port by raw port number.
+	PortModeByNumber PortMode = iota
+	// PortModeNumber means that the Ingress specifies the Service port by its name field.
+	PortModeByName PortMode = iota
+)
+
+type PortDef struct {
+	Mode PortMode
+
+	// Name is the port name as stated in the Kubernetes service. Must be set iff Mode == PortModeName.
+	Name string
+	// Number is the port number. Must be set iff PortMode == PortModeNumber.
+	Number int32
+}
+
+func PortDefFromIntStr(is intstr.IntOrString) PortDef {
+	if is.Type == intstr.String {
+		return PortDef{Mode: PortModeByName, Name: is.StrVal}
+	}
+	return PortDef{Mode: PortModeByNumber, Number: is.IntVal}
+}
+
+func (p *PortDef) CanonicalString() string {
+	switch p.Mode {
+	case PortModeByNumber:
+		return fmt.Sprintf("%d", p.Number)
+	case PortModeByName:
+		return p.Name
+	}
+	return "implicitPort"
+}
+
 type ServiceBackend struct {
 	Name string
-	Port intstr.IntOrString
+	Port PortDef
 }
 
 // Target is a wrapper around Target object in Kong.

--- a/internal/ingress/controller/parser/kongstate/types.go
+++ b/internal/ingress/controller/parser/kongstate/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kong/go-kong/kong"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type PortMode int
@@ -28,12 +27,7 @@ type PortDef struct {
 	Number int32
 }
 
-func PortDefFromIntStr(is intstr.IntOrString) PortDef {
-	if is.Type == intstr.String {
-		return PortDef{Mode: PortModeByName, Name: is.StrVal}
-	}
-	return PortDef{Mode: PortModeByNumber, Number: is.IntVal}
-}
+const ImplicitPort = "implicitPort"
 
 func (p *PortDef) CanonicalString() string {
 	switch p.Mode {
@@ -42,7 +36,7 @@ func (p *PortDef) CanonicalString() string {
 	case PortModeByName:
 		return p.Name
 	}
-	return "implicitPort"
+	return ImplicitPort
 }
 
 type ServiceBackend struct {

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -287,13 +287,15 @@ func getCerts(log logrus.FieldLogger, s store.Storer, secretsToSNIs map[string][
 	return res
 }
 
-func getServiceEndpoints(log logrus.FieldLogger, s store.Storer, svc corev1.Service, servicePort *corev1.ServicePort) []kongstate.Target {
+func getServiceEndpoints(log logrus.FieldLogger, s store.Storer, svc corev1.Service,
+	servicePort *corev1.ServicePort) []kongstate.Target {
 	var targets []kongstate.Target
 	var endpoints []utils.Endpoint
 
 	log = log.WithFields(logrus.Fields{
 		"service_name":      svc.Name,
 		"service_namespace": svc.Namespace,
+		"service_port":      servicePort,
 	})
 
 	endpoints = getEndpoints(log, &svc, servicePort, corev1.ProtocolTCP, s.GetEndpointsForService)

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -192,6 +192,8 @@ func getUpstreams(
 		port, err := findPort(&service.K8sService, service.Backend.Port)
 		if err == nil {
 			targets = getServiceEndpoints(log, s, service.K8sService, port)
+		} else {
+			log.WithField("service_name", service.Name).Warnf("skipping service - getServiceEndpoints failed: %v", err)
 		}
 
 		upstream := kongstate.Upstream{

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -155,16 +155,14 @@ func getUpstreams(
 	log logrus.FieldLogger, s store.Storer, serviceMap map[string]kongstate.Service) []kongstate.Upstream {
 	var upstreams []kongstate.Upstream
 	for _, service := range serviceMap {
-		upstreamName := service.Backend.Name + "." + service.Namespace + "." + service.Backend.Port.String() + ".svc"
 		upstream := kongstate.Upstream{
 			Upstream: kong.Upstream{
-				Name: kong.String(upstreamName),
+				Name: kong.String(
+					fmt.Sprintf("%s.%s.%s.svc", service.Backend.Name, service.Namespace, service.Backend.Port.String())),
 			},
 			Service: service,
+			Targets: getServiceEndpoints(log, s, service.K8sService, service.Backend.Port.String()),
 		}
-		targets := getServiceEndpoints(log, s, service.K8sService,
-			service.Backend.Port.String())
-		upstream.Targets = targets
 		upstreams = append(upstreams, upstream)
 	}
 	return upstreams

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -17,7 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -191,7 +192,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 				},
 			},
 		},
-		IngressesV1beta1: []*networking.Ingress{
+		IngressesV1beta1: []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -201,16 +202,16 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -231,16 +232,16 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.net",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -849,7 +850,7 @@ func TestCACertificate(t *testing.T) {
 func TestServiceClientCertificate(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("valid client-cert annotation", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -858,16 +859,16 @@ func TestServiceClientCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -877,7 +878,7 @@ func TestServiceClientCertificate(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networking.IngressTLS{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -930,7 +931,7 @@ func TestServiceClientCertificate(t *testing.T) {
 			*state.Services[0].ClientCertificate.ID)
 	})
 	t.Run("client-cert secret doesn't exist", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -939,16 +940,16 @@ func TestServiceClientCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -958,7 +959,7 @@ func TestServiceClientCertificate(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networking.IngressTLS{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -998,7 +999,7 @@ func TestServiceClientCertificate(t *testing.T) {
 func TestKongRouteAnnotations(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("strip-path annotation is correctly processed (true)", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1008,16 +1009,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						annotations.IngressClassKey:           "kong",
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1075,7 +1076,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("strip-path annotation is correctly processed (false)", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1085,16 +1086,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						"configuration.konghq.com/strip-path": "false",
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1153,7 +1154,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 	})
 	t.Run("https-redirect-status-code annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1163,16 +1164,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/https-redirect-status-code": "301",
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1232,7 +1233,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("bad https-redirect-status-code annotation is ignored",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1242,16 +1243,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/https-redirect-status-code": "whoops",
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1310,7 +1311,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("preserve-host annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1320,16 +1321,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1388,7 +1389,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("preserve-host annotation with random string is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1398,16 +1399,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/preserve-host":  "wiggle wiggle wiggle",
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1466,7 +1467,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("regex-priority annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1476,16 +1477,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1544,7 +1545,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("non-integer regex-priority annotation is ignored",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1554,16 +1555,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1625,7 +1626,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 func TestKongProcessClasslessIngress(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("Kong classless ingress evaluated (true)", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1634,16 +1635,16 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1678,22 +1679,22 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			"expected one service to be rendered")
 	})
 	t.Run("Kong classless ingress evaluated (false)", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "default",
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1862,7 +1863,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 func TestKongServiceAnnotations(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("path annotation is correctly processed", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1871,16 +1872,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1942,7 +1943,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 	})
 
 	t.Run("host-header annotation is correctly processed", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1951,16 +1952,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2030,7 +2031,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 
 	t.Run("methods annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networking.Ingress{
+			ingresses := []*networkingv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -2040,16 +2041,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networking.IngressSpec{
-						Rules: []networking.IngressRule{
+					Spec: networkingv1beta1.IngressSpec{
+						Rules: []networkingv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networking.IngressRuleValue{
-									HTTP: &networking.HTTPIngressRuleValue{
-										Paths: []networking.HTTPIngressPath{
+								IngressRuleValue: networkingv1beta1.IngressRuleValue{
+									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+										Paths: []networkingv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networking.IngressBackend{
+												Backend: networkingv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -2112,7 +2113,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 func TestDefaultBackend(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("default backend is processed correctly", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ing-with-default-backend",
@@ -2121,8 +2122,8 @@ func TestDefaultBackend(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Backend: &networking.IngressBackend{
+				Spec: networkingv1beta1.IngressSpec{
+					Backend: &networkingv1beta1.IngressBackend{
 						ServiceName: "default-svc",
 						ServicePort: intstr.FromInt(80),
 					},
@@ -2157,7 +2158,7 @@ func TestDefaultBackend(t *testing.T) {
 	})
 
 	t.Run("client-cert secret doesn't exist", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2166,16 +2167,16 @@ func TestDefaultBackend(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2185,7 +2186,7 @@ func TestDefaultBackend(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networking.IngressTLS{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2225,7 +2226,7 @@ func TestDefaultBackend(t *testing.T) {
 func TestParserSecret(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("invalid TLS secret", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2234,8 +2235,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2248,8 +2249,8 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"bar.com"},
@@ -2283,7 +2284,7 @@ func TestParserSecret(t *testing.T) {
 			"expected no certificates to be rendered with empty secret")
 	})
 	t.Run("duplicate certificates", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2292,8 +2293,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2309,8 +2310,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret2",
 							Hosts:      []string{"bar.com"},
@@ -2377,7 +2378,7 @@ func TestParserSecret(t *testing.T) {
 		}, state.Certificates[0])
 	})
 	t.Run("duplicate SNIs", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2386,8 +2387,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2400,8 +2401,8 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "ns1",
 				},
-				Spec: networking.IngressSpec{
-					TLS: []networking.IngressTLS{
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
 						{
 							SecretName: "secret2",
 							Hosts:      []string{"foo.com"},
@@ -2458,7 +2459,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2468,16 +2469,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2547,7 +2548,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2557,16 +2558,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2631,7 +2632,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2641,16 +2642,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2692,7 +2693,7 @@ func TestPluginAnnotations(t *testing.T) {
 		assert.Equal("grpc", *state.Plugins[0].Protocols[0])
 	})
 	t.Run("missing plugin", func(t *testing.T) {
-		ingresses := []*networking.Ingress{
+		ingresses := []*networkingv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2702,16 +2703,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:      annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3250,6 +3251,203 @@ func Test_knativeSelectSplit(t *testing.T) {
 			if got := knativeSelectSplit(tt.args.splits); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("knativeSelectSplit() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestPickPort(t *testing.T) {
+	assert := assert.New(t)
+	svc0 := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-0",
+			Namespace: "foo-namespace",
+			Annotations: map[string]string{
+				annotations.IngressClassKey: annotations.DefaultIngressClass,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "port1", Port: 111, TargetPort: intstr.FromInt(1111)},
+				{Name: "port2", Port: 222, TargetPort: intstr.FromString("port1")},
+				{Name: "port3", Port: 333, TargetPort: intstr.FromString("potato")},
+				{Port: 444},
+			},
+		},
+	}
+
+	svc1 := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-1",
+			Namespace: "foo-namespace",
+			Annotations: map[string]string{
+				annotations.IngressClassKey: annotations.DefaultIngressClass,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "port1", Port: 9999},
+			},
+		},
+	}
+
+	endpointList := []*corev1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "service-0", Namespace: "foo-namespace"},
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.1.1.1"}},
+				Ports: []corev1.EndpointPort{
+					{Name: "port1", Port: 111, Protocol: "TCP"},
+					{Name: "port2", Port: 222, Protocol: "TCP"},
+					{Name: "port3", Port: 333, Protocol: "TCP"},
+				},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "service-1", Namespace: "foo-namespace"},
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "2.2.2.2"}},
+				Ports: []corev1.EndpointPort{
+					{Name: "port1", Port: 9999, Protocol: "TCP"},
+				},
+			}},
+		},
+	}
+
+	for _, tt := range []struct {
+		name string
+		objs store.FakeObjects
+		port networkingv1.ServiceBackendPort
+
+		wantTarget string
+	}{
+		{
+			name: "port by number",
+			objs: store.FakeObjects{
+				Services:  []*corev1.Service{&svc0},
+				Endpoints: endpointList,
+
+				IngressesV1: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "foo",
+							Namespace:   "foo-namespace",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path: "/",
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-0",
+															Port: networkingv1.ServiceBackendPort{Number: 111},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTarget: "1.1.1.1:111",
+		},
+		{
+			name: "port by name",
+			objs: store.FakeObjects{
+				Services:  []*corev1.Service{&svc0},
+				Endpoints: endpointList,
+
+				IngressesV1: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "foo",
+							Namespace:   "foo-namespace",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path: "/",
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-0",
+															Port: networkingv1.ServiceBackendPort{Name: "port3"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTarget: "1.1.1.1:333",
+		},
+		{
+			name: "port implicit",
+			objs: store.FakeObjects{
+				Services:  []*corev1.Service{&svc1},
+				Endpoints: endpointList,
+
+				IngressesV1: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "foo",
+							Namespace:   "foo-namespace",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path: "/",
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTarget: "2.2.2.2:9999",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := store.NewFakeStore(tt.objs)
+			assert.NoError(err)
+
+			state, err := Build(logrus.New(), store)
+			assert.NoError(err)
+
+			assert.Equal(tt.wantTarget, *state.Upstreams[0].Targets[0].Target.Target)
 		})
 	}
 }

--- a/internal/ingress/controller/parser/translate.go
+++ b/internal/ingress/controller/parser/translate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
 )
 
@@ -99,7 +98,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 						Namespace: ingress.Namespace,
 						Backend: kongstate.ServiceBackend{
 							Name: rule.Backend.ServiceName,
-							Port: rule.Backend.ServicePort,
+							Port: kongstate.PortDefFromIntStr(rule.Backend.ServicePort),
 						},
 					}
 				}
@@ -138,7 +137,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 				Namespace: ingress.Namespace,
 				Backend: kongstate.ServiceBackend{
 					Name: defaultBackend.ServiceName,
-					Port: defaultBackend.ServicePort,
+					Port: kongstate.PortDefFromIntStr(defaultBackend.ServicePort),
 				},
 			}
 		}
@@ -246,7 +245,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 						Namespace: ingress.Namespace,
 						Backend: kongstate.ServiceBackend{
 							Name: rulePath.Backend.Service.Name,
-							Port: intstr.FromInt(int(rulePath.Backend.Service.Port.Number)),
+							Port: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: rulePath.Backend.Service.Port.Number},
 						},
 					}
 				}
@@ -283,7 +282,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 				Namespace: ingress.Namespace,
 				Backend: kongstate.ServiceBackend{
 					Name: defaultBackend.Service.Name,
-					Port: intstr.FromInt(int(defaultBackend.Service.Port.Number)),
+					Port: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: defaultBackend.Service.Port.Number},
 				},
 			}
 		}
@@ -380,7 +379,7 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 					Namespace: ingress.Namespace,
 					Backend: kongstate.ServiceBackend{
 						Name: rule.Backend.ServiceName,
-						Port: intstr.FromInt(rule.Backend.ServicePort),
+						Port: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
 					},
 				}
 			}
@@ -474,7 +473,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 						Namespace: ingress.Namespace,
 						Backend: kongstate.ServiceBackend{
 							Name: knativeBackend.ServiceName,
-							Port: knativeBackend.ServicePort,
+							Port: kongstate.PortDefFromIntStr(knativeBackend.ServicePort),
 						},
 					}
 					if len(headers) > 0 {


### PR DESCRIPTION
Fixes #836

This PR:
- refactors KongState to use `PortDef` instead of `intstr.IntOrString` for the following benefits:
    - Explicit semantics of port matching (by name, by number, or the only port of the service)
    - Further decoupling of `package kongstate` from k8s APIs
- implements all port definition flavors from ingressv1 KEP (#836) in parser
- implements a test verifying that parser puts the right endpoints for all of the flavors mentioned above

Consider merging without squashing.