### PR TITLE
deploy: drop security context from base manifest

### DIFF
--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -25,8 +25,6 @@ spec:
       containers:
       - name: proxy
         image: kong:2.1
-        securityContext:
-          runAsUser: 1000
         env:
           # servers
         - name: KONG_PROXY_LISTEN


### PR DESCRIPTION
This was mistakenly added during the merge of main branch into next.
