### PR TITLE
docs: define the KIC-Kubernetes compat matrix

### DIFF
--- a/docs/references/version-compatibility.md
+++ b/docs/references/version-compatibility.md
@@ -50,3 +50,15 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kong Enterprise 1.3.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | Kong Enterprise 1.5.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Kong Enterprise 2.1.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
+
+## Kubernetes
+
+| Kong Ingress Controller  | 0.9.x              | 0.10.x             |
+|--------------------------|:------------------:|:------------------:|
+| Kubernetes 1.13          | :x:                | :x:                |
+| Kubernetes 1.14          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.15          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.16          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.17          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.18          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.19          | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
closes #820

k8s 1.13 is not supported in KIC 0.9 or KIC 0.10 because we define `admissionReviewVersions` in our `ValidatingWebhookConfiguration` which was added to k8s in 1.14, and fails to apply in 1.13.