### PR TITLE
chore(flags) remove deprecated flags

### DIFF
--- a/cli/ingress-controller/flag_test.go
+++ b/cli/ingress-controller/flag_test.go
@@ -155,15 +155,15 @@ func TestOverrideViaCLIFlags(t *testing.T) {
 		"--admission-webhook-cert-file", "/cert-file",
 		"--admission-webhook-key-file", "/key-file",
 
-		"--kong-url", "https://kong.example.com",
+		"--kong-admin-url", "https://kong.example.com",
 		"--kong-admin-concurrency", "1",
 		"--kong-workspace", "yolo",
 		"--kong-admin-filter-tag", "foo-tag",
-		"--admin-header", "foo:bar",
+		"--kong-admin-header", "foo:bar",
 		"--kong-admin-token", "my-token",
-		"--admin-tls-skip-verify",
-		"--admin-tls-server-name", "kong-admin.example.com",
-		"--admin-ca-cert-file", "/path/to/ca-cert",
+		"--kong-admin-tls-skip-verify",
+		"--kong-admin-tls-server-name", "kong-admin.example.com",
+		"--kong-admin-ca-cert-file", "/path/to/ca-cert",
 
 		"--kong-custom-entities-secret", "foons/foosecretname",
 
@@ -313,129 +313,6 @@ func TestOverrideViaEnvVars(t *testing.T) {
 
 		ShowVersion:      false,
 		AnonymousReports: false,
-	}
-	assert.Equal(expectedConf, conf)
-	assert.Nil(err, "unexpected error parsing default flags")
-}
-
-func TestDeprecatedFlags(t *testing.T) {
-	resetForTesting(func() { t.Fatal("bad parse") })
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
-
-	assert := assert.New(t)
-
-	os.Args = []string{
-		"cmd",
-		"--kong-url", "https://kong.example.com",
-		"--kong-workspace", "yolo",
-		"--admin-header", "foo:bar",
-		"--admin-tls-skip-verify",
-		"--admin-tls-server-name", "kong-admin.example.com",
-		"--admin-ca-cert-file", "/path/to/ca-cert",
-	}
-	conf, err := parseFlags()
-
-	expectedConf := cliConfig{
-		KongAdminURL:           "https://kong.example.com",
-		KongWorkspace:          "yolo",
-		KongAdminConcurrency:   10,
-		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
-		KongAdminHeaders:       []string{"foo:bar"},
-		KongAdminTLSSkipVerify: true,
-		KongAdminTLSServerName: "kong-admin.example.com",
-		KongAdminCACertPath:    "/path/to/ca-cert",
-
-		AdmissionWebhookListen:   "off",
-		AdmissionWebhookCertPath: "/admission-webhook/tls.crt",
-		AdmissionWebhookKeyPath:  "/admission-webhook/tls.key",
-
-		WatchNamespace: "",
-		IngressClass:   "kong",
-		ElectionID:     "ingress-controller-leader",
-
-		PublishService:         "",
-		PublishStatusAddress:   "",
-		UpdateStatus:           true,
-		UpdateStatusOnShutdown: true,
-
-		SyncPeriod:    600 * time.Second,
-		SyncRateLimit: 0.3,
-
-		APIServerHost:      "",
-		KubeConfigFilePath: "",
-
-		LogLevel:  "info",
-		LogFormat: "text",
-
-		EnableProfiling: true,
-
-		ShowVersion:      false,
-		AnonymousReports: true,
-	}
-	assert.Equal(expectedConf, conf)
-	assert.Nil(err, "unexpected error parsing default flags")
-}
-
-func TestDeprecatedFlagPrecedences(t *testing.T) {
-	resetForTesting(func() { t.Fatal("bad parse") })
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
-
-	assert := assert.New(t)
-
-	os.Args = []string{
-		"cmd",
-		"--kong-url", "https://kong.example.com",
-		"--kong-admin-url", "http://kong.yolo42.com",
-		"--kong-workspace", "yolo",
-		"--admin-header", "foo:bar",
-		"--kong-admin-header", "fuu:baz",
-		"--kong-admin-tls-skip-verify",
-		"--admin-tls-server-name", "kong-admin.example.com",
-		"--kong-admin-tls-server-name", "kong-admin-new.example.com",
-		"--admin-ca-cert-file", "/path/to/ca-cert",
-		"--kong-admin-ca-cert-file", "/path/to/new/ca-cert",
-		"--admission-webhook-listen", ":8080",
-	}
-	conf, err := parseFlags()
-
-	expectedConf := cliConfig{
-		KongAdminURL:           "http://kong.yolo42.com",
-		KongWorkspace:          "yolo",
-		KongAdminConcurrency:   10,
-		KongAdminFilterTags:    []string{"managed-by-ingress-controller"},
-		KongAdminHeaders:       []string{"fuu:baz"},
-		KongAdminTLSSkipVerify: true,
-		KongAdminTLSServerName: "kong-admin-new.example.com",
-		KongAdminCACertPath:    "/path/to/new/ca-cert",
-
-		AdmissionWebhookListen:   ":8080",
-		AdmissionWebhookCertPath: "/admission-webhook/tls.crt",
-		AdmissionWebhookKeyPath:  "/admission-webhook/tls.key",
-
-		WatchNamespace: "",
-		IngressClass:   "kong",
-		ElectionID:     "ingress-controller-leader",
-
-		PublishService:         "",
-		PublishStatusAddress:   "",
-		UpdateStatus:           true,
-		UpdateStatusOnShutdown: true,
-
-		SyncPeriod:    600 * time.Second,
-		SyncRateLimit: 0.3,
-
-		APIServerHost:      "",
-		KubeConfigFilePath: "",
-
-		LogLevel:  "info",
-		LogFormat: "text",
-
-		EnableProfiling: true,
-
-		ShowVersion:      false,
-		AnonymousReports: true,
 	}
 	assert.Equal(expectedConf, conf)
 	assert.Nil(err, "unexpected error parsing default flags")

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -116,12 +116,6 @@ TLS handshake`)
 		`PEM-encoded private key for TLS handshake`)
 
 	// Kong connection details
-	// deprecated
-	flags.String("kong-url", "",
-		`DEPRECATED, use --kong-admin-url
-The address of the Kong Admin URL to connect to in the
-format of protocol://address:port`)
-	// new
 	flags.String("kong-admin-url", defaultKongAdminURL,
 		`The address of the Kong Admin URL to connect to in the
 format of protocol://address:port`)
@@ -136,12 +130,6 @@ format of protocol://address:port`)
 		`The tag used to manage and filter entities in Kong
 This flag can be specified multiple times to specify multiple tags.`)
 
-	// deprecated
-	flags.StringSlice("admin-header", nil,
-		`DEPRECATED, use --kong-admin-header
-add a header (key:value) to every Admin API call,
-this flag can be used multiple times to specify multiple headers`)
-	// new
 	flags.StringSlice("kong-admin-header", nil,
 		`add a header (key:value) to every Admin API call,
 this flag can be used multiple times to specify multiple headers`)
@@ -150,28 +138,12 @@ this flag can be used multiple times to specify multiple headers`)
 		`Sets the value of the 'kong-admin-token' header; useful for
 authentication/authorization for Kong Enterprise environments`)
 
-	// deprecated
-	flags.Bool("admin-tls-skip-verify", false,
-		`DEPRECATED, use --kong-admin-tls-skip-verify
-Disable verification of TLS certificate of Kong's Admin endpoint.`)
-	// new
 	flags.Bool("kong-admin-tls-skip-verify", false,
 		"Disable verification of TLS certificate of Kong's Admin endpoint.")
 
-	// deprecated
-	flags.String("admin-tls-server-name", "",
-		`DEPRECATED, use --kong-admin-tls-server-name
-SNI name to use to verify the certificate presented by Kong in TLS.`)
-	// new
 	flags.String("kong-admin-tls-server-name", "",
 		"SNI name to use to verify the certificate presented by Kong in TLS.")
 
-	// deprecated
-	flags.String("admin-ca-cert-file", "",
-		`DEPRECATED, use --kong-admin-ca-cert-file
-Path to PEM-encoded CA certificate file to verify
-Kong's Admin SSL certificate.`)
-	// new
 	flags.String("kong-admin-ca-cert-file", "",
 		`Path to PEM-encoded CA certificate file to verify
 Kong's Admin SSL certificate.`)
@@ -289,13 +261,9 @@ func parseFlags() (cliConfig, error) {
 
 	// Kong connection details
 	kongAdminURL := defaultKongAdminURL
-	oldURL := viper.GetString("kong-url")
-	newURL := viper.GetString("kong-admin-url")
-	if oldURL != "" {
-		kongAdminURL = oldURL
-	}
-	if newURL != defaultKongAdminURL {
-		kongAdminURL = newURL
+	flagURL := viper.GetString("kong-admin-url")
+	if flagURL != defaultKongAdminURL {
+		kongAdminURL = flagURL
 	}
 	config.KongAdminURL = kongAdminURL
 
@@ -303,11 +271,7 @@ func parseFlags() (cliConfig, error) {
 	config.KongAdminConcurrency = viper.GetInt("kong-admin-concurrency")
 	config.KongAdminFilterTags = viper.GetStringSlice("kong-admin-filter-tag")
 
-	config.KongAdminHeaders = viper.GetStringSlice("admin-header")
-	kongAdminHeaders := viper.GetStringSlice("kong-admin-header")
-	if len(kongAdminHeaders) > 0 {
-		config.KongAdminHeaders = kongAdminHeaders
-	}
+	config.KongAdminHeaders = viper.GetStringSlice("kong-admin-header")
 
 	kongAdminToken := viper.GetString("kong-admin-token")
 	if kongAdminToken != "" {
@@ -315,23 +279,11 @@ func parseFlags() (cliConfig, error) {
 			"kong-admin-token:"+kongAdminToken)
 	}
 
-	config.KongAdminTLSSkipVerify = viper.GetBool("admin-tls-skip-verify")
-	kongAdminTLSSkipVerify := viper.GetBool("kong-admin-tls-skip-verify")
-	if kongAdminTLSSkipVerify {
-		config.KongAdminTLSSkipVerify = kongAdminTLSSkipVerify
-	}
+	config.KongAdminTLSSkipVerify = viper.GetBool("kong-admin-tls-skip-verify")
 
-	config.KongAdminTLSServerName = viper.GetString("admin-tls-server-name")
-	kongAdminTLSServerName := viper.GetString("kong-admin-tls-server-name")
-	if kongAdminTLSServerName != "" {
-		config.KongAdminTLSServerName = kongAdminTLSServerName
-	}
+	config.KongAdminTLSServerName = viper.GetString("kong-admin-tls-server-name")
 
-	config.KongAdminCACertPath = viper.GetString("admin-ca-cert-file")
-	kongAdminCACertPath := viper.GetString("kong-admin-ca-cert-file")
-	if kongAdminCACertPath != "" {
-		config.KongAdminCACertPath = kongAdminCACertPath
-	}
+	config.KongAdminCACertPath = viper.GetString("kong-admin-ca-cert-file")
 
 	kongAdminCACert := viper.GetString("kong-admin-ca-cert")
 	if kongAdminCACert != "" {

--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -260,13 +260,7 @@ func parseFlags() (cliConfig, error) {
 		viper.GetString("admission-webhook-key")
 
 	// Kong connection details
-	kongAdminURL := defaultKongAdminURL
-	flagURL := viper.GetString("kong-admin-url")
-	if flagURL != defaultKongAdminURL {
-		kongAdminURL = flagURL
-	}
-	config.KongAdminURL = kongAdminURL
-
+	config.KongAdminURL = viper.GetString("kong-admin-url")
 	config.KongWorkspace = viper.GetString("kong-workspace")
 	config.KongAdminConcurrency = viper.GetInt("kong-admin-concurrency")
 	config.KongAdminFilterTags = viper.GetStringSlice("kong-admin-filter-tag")
@@ -285,10 +279,7 @@ func parseFlags() (cliConfig, error) {
 
 	config.KongAdminCACertPath = viper.GetString("kong-admin-ca-cert-file")
 
-	kongAdminCACert := viper.GetString("kong-admin-ca-cert")
-	if kongAdminCACert != "" {
-		config.KongAdminCACert = kongAdminCACert
-	}
+	config.KongAdminCACert = viper.GetString("kong-admin-ca-cert")
 
 	config.KongCustomEntitiesSecret = viper.GetString(
 		"kong-custom-entities-secret")

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -49,7 +49,7 @@ security.
 The Controller comes with support for injecting arbitrary HTTP headers
 in the requests it makes to Kong's Admin API, which can be used to inject
 authentication credentials.
-The headers can be specified using the CLI flag `--admin-header` in the Ingress
+The headers can be specified using the CLI flag `--kong-admin-header` in the Ingress
 Controller.
 
 The Ingress Controller will support mutual-TLS-based authentication on Kong's Admin
@@ -61,5 +61,5 @@ Kong Enterprise comes with support for authentication and authorization on
 Kong's Admin API.
 
 Once an RBAC token is provisioned, Kong Ingress Controller can use the RBAC
-token to authenticate against Kong Enterprise. Use the `--admin-header` CLI
+token to authenticate against Kong Enterprise. Use the `--kong-admin-header` CLI
 flag to pass the RBAC token the Ingress Controller.

--- a/docs/references/cli-arguments.md
+++ b/docs/references/cli-arguments.md
@@ -25,10 +25,6 @@ Following table describes all the flags that are available:
 
 |  Flag | Type | Default | Description |
 |-------|------|---------|-------------|
-| --admin-ca-cert-file                 |`string`   | none                            | DEPRECATED, use `--kong-admin-ca-cert-file`|
-| --admin-header                       |`string`   | none                            | DEPRECATED, use `--kong-admin-header`|
-| --admin-tls-server-name              |`string`   | none                            | DEPRECATED, use `--kong-admin-tls-server-name`|
-| --admin-tls-skip-verify              |`boolean`  | none                            | DEPRECATED, use `--kong-admin-tls-skip-verify`|
 | --admission-webhook-cert-file        |`string`   | `/admission-webhook/tls.crt`    | Path to the PEM-encoded certificate file for TLS handshake.|
 | --admission-webhook-key-file         |`string`   | `/admission-webhook/tls.key`    | Path to the PEM-encoded private key file for TLS handshake.|
 | --admission-webhook-cert             |`string`   | none                            | PEM-encoded certificate string for TLS handshake.|
@@ -48,7 +44,6 @@ Following table describes all the flags that are available:
 | --kong-admin-tls-server-name         |`string`   | none                            | SNI name to use to verify the certificate presented by Kong in TLS.|
 | --kong-admin-tls-skip-verify         |`boolean`  | `false`                         | Disable verification of TLS certificate of Kong's Admin endpoint.|
 | --kong-admin-url                     |`string`   | `http://localhost:8001`         | The address of the Kong Admin URL to connect to in the format of `protocol://address:port`.|
-| --kong-url                           |`string`   | none                            | DEPRECATED, use `--kong-admin-url` |
 | --kong-workspace                     |`string`   | `default`                       | Workspace in Kong Enterprise to be configured.|
 | --kong-custom-entities-secret        |`string`   | none                            | Secret containing custom entities to be populated in DB-less mode, takes the form `namespace/name`.|
 | --enable-reverse-sync                |`bool`     | `false`                         | Enable reverse checks from Kong to Kubernetes. Use this option only if a human has edit access to Kong's Admin API. |


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated 0.x.x flags. Remove logic for giving deprecated flags
precedece. Update docs to mention modern flags only.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #840 

**Special notes for your reviewer**:
Related tests removed entirely, as we no longer have any deprecated flags. Will we have any in the future? Probably. Figured it made more sense to cut out the existing tests entirely for now rather than leaving no-op stubs. We can always retrieve the old diff assuming we need to re-add similar tests later for future deprecations.