### PR TITLE
Remove deprecated annotations

### DIFF
--- a/docs/guides/upstream-mtls.md
+++ b/docs/guides/upstream-mtls.md
@@ -85,7 +85,7 @@ server that it talks to.
 
 To configure a different client certificate for each service or only for a
 subset of services, you can do so using the
-[`configuration.konghq.com/client-cert`](../references/annotations.md#configurationkonghqcom/client-cert)
+[`konghq.com/client-cert`](../references/annotations.md#configurationkonghqcom/client-cert)
 annotation.
 
 To use the annotation, you first need to create a TLS secret with the 
@@ -96,7 +96,7 @@ Service to which Kong should authenticate itself.
 Once the secret is in place, add the follow annotation on the service:
 
 ```
-configuration.konghq.com/client-cert: <name-of-secret>
+konghq.com/client-cert: <name-of-secret>
 ```
 
 Kong will then use the TLS key-pair to authenticate itself against that service.

--- a/docs/guides/upstream-mtls.md
+++ b/docs/guides/upstream-mtls.md
@@ -85,7 +85,7 @@ server that it talks to.
 
 To configure a different client certificate for each service or only for a
 subset of services, you can do so using the
-[`konghq.com/client-cert`](../references/annotations.md#configurationkonghqcom/client-cert)
+[`konghq.com/client-cert`](../references/annotations.md#konghqcom/client-cert)
 annotation.
 
 To use the annotation, you first need to create a TLS secret with the 

--- a/docs/references/annotations.md
+++ b/docs/references/annotations.md
@@ -17,9 +17,6 @@ Following annotations are supported on Ingress resources:
 | [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority. |
 | [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress. |
 | [`konghq.com/override`](#konghqcomoverride) | Control other routing attributes via `KongIngress` resource. |
-| DEPRECATED [`plugins.konghq.com`](#pluginskonghqcom) | Please use [`konghq.com/plugins`](#konghqcomplugins) |
-| DEPRECATED [`configuration.konghq.com`](#configurationkonghqcom) | Please use [`konghq.com/override`](#konghqcomoverride) |
-| DEPRECATED [`configuration.konghq.com/protocols`](#configurationkonghqcomprotocols) | Please use [`konghq.com/protocols`](#konghqcomprotocols) |
 
 `kubernetes.io/ingress.class` is normally required, and its value should match
 the value of the `--ingress-class` controller argument ("kong" by default).
@@ -44,10 +41,6 @@ Following annotations are supported on Service resources:
 | [`konghq.com/host-header`](#konghqcomhost-header) | Set the value sent in the `Host` header when proxying requests upstream |
 | [`konghq.com/override`](#konghqcomoverride) | Fine grained routing and load-balancing |
 | [`ingress.kubernetes.io/service-upstream`](#ingresskubernetesioservice-upstream) | Offload load-balancing to kube-proxy or sidecar |
-| DEPRECATED [`plugins.konghq.com`](#pluginskonghqcom) | Please use [`konghq.com/plugins`](#konghqcomplugins) |
-| DEPRECATED [`configuration.konghq.com`](#configurationkonghqcom) | Please use [`konghq.com/override`](#konghqcomoverride) |
-| DEPRECATED [`configuration.konghq.com/protocol`](#configurationkonghqcomprotocol) | Please use [`konghq.com/protocol`](#konghqcomprotocol) |
-| DEPRECATED [`configuration.konghq.com/client-cert`](#configurationkonghqcomclient-cert) | Please use [`konghq.com/client-cert`](#konghqcomclient-cert) |
 
 ## KongConsumer resource
 
@@ -57,7 +50,6 @@ Following annotaitons are supported on KongConsumer resources:
 |-----------------|-------------|
 | REQUIRED [`kubernetes.io/ingress.class`](#kubernetesioingressclass) | Restrict the KongConsumers that a controller should satisfy |
 | [`konghq.com/plugins`](#konghqcomplugins) | Run plugins for a specific consumer |
-| DEPRECATED [`plugins.konghq.com`](#pluginskonghqcom) | Please use [`konghq.com/plugins`](#konghqcomplugins) |
 
 `kubernetes.io/ingress.class` is normally required, and its value should match
 the value of the `--ingress-class` controller argument ("kong" by default).
@@ -430,33 +422,3 @@ annotations:
 ```
 
 You need Kong Ingress Controller >= 0.6 for this annotation.
-
-### `plugins.konghq.com`
-
-> DEPRECATED in Controller 0.8
-
-Please instead use [`konghq.com/plugins`](#konghqcomplugins).
-
-### `configuration.konghq.com`
-
-> DEPRECATED in Controller 0.8
-
-Please instead use [`konghq.com/override`](#konghqcomoverride).
-
-### `configuration.konghq.com/protocol`
-
-> DEPRECATED in Controller 0.8
-
-Please instead use [`konghq.com/protocol`](#konghqcomprotocol).
-
-### `configuration.konghq.com/protocols`
-
-> DEPRECATED in Controller 0.8
-
-Please instead use [`konghq.com/protocols`](#konghqcomprotocols).
-
-### `configuration.konghq.com/client-cert`
-
-> DEPRECATED in Controller 0.8
-
-Please instead use [`konghq.com/client-cert`](#konghqcomclient-cert).

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -35,24 +35,20 @@ const (
 const (
 	IngressClassKey = "kubernetes.io/ingress.class"
 
-	deprecatedAnnotationPrefix = "configuration.konghq.com"
-	annotationPrefix           = "konghq.com"
+	AnnotationPrefix = "konghq.com"
 
-	DeprecatedPluginsKey       = "plugins.konghq.com"
-	deprecatedConfigurationKey = deprecatedAnnotationPrefix
-
-	configurationKey     = "/override"
-	pluginsKey           = "/plugins"
-	protocolKey          = "/protocol"
-	protocolsKey         = "/protocols"
-	clientCertKey        = "/client-cert"
-	stripPathKey         = "/strip-path"
-	pathKey              = "/path"
-	httpsRedirectCodeKey = "/https-redirect-status-code"
-	preserveHostKey      = "/preserve-host"
-	regexPriorityKey     = "/regex-priority"
-	hostHeaderKey        = "/host-header"
-	methodsKey           = "/methods"
+	ConfigurationKey     = "/override"
+	PluginsKey           = "/plugins"
+	ProtocolKey          = "/protocol"
+	ProtocolsKey         = "/protocols"
+	ClientCertKey        = "/client-cert"
+	StripPathKey         = "/strip-path"
+	PathKey              = "/path"
+	HTTPSRedirectCodeKey = "/https-redirect-status-code"
+	PreserveHostKey      = "/preserve-host"
+	RegexPriorityKey     = "/regex-priority"
+	HostHeaderKey        = "/host-header"
+	MethodsKey           = "/methods"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -111,35 +107,22 @@ func IngressClassValidatorFuncFromV1Ingress(
 	}
 }
 
-// valueFromAnnotation returns the value of an annotation with key.
-// key is without the annotation prefix of configuration.konghq.com or
-// konghq.com.
-// It first looks up key under the konghq.com group and if one doesn't
-// exist then it looks up the configuration.konghq.com  annotation group.
+// valueFromAnnotation returns the value of an annotation with key konghq.com.
 func valueFromAnnotation(key string, anns map[string]string) string {
-	value, exists := anns[annotationPrefix+key]
-	if exists {
-		return value
-	}
-	return anns[deprecatedAnnotationPrefix+key]
+	return anns[AnnotationPrefix+key]
 }
 
-func pluginsFromAnnotations(anns map[string]string) (string, bool) {
-	value, exists := anns[annotationPrefix+pluginsKey]
-	if exists {
-		return value, exists
-	}
-	value, exists = anns[DeprecatedPluginsKey]
-	return value, exists
+func pluginsFromAnnotations(anns map[string]string) string {
+	return valueFromAnnotation(PluginsKey, anns)
 }
 
 // ExtractKongPluginsFromAnnotations extracts information about Kong
-// Plugins configured using plugins.konghq.com annotation.
+// Plugins configured using konghq.com/plugins annotation.
 // This returns a list of KongPlugin resource names that should be applied.
 func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 	var kongPluginCRs []string
-	v, ok := pluginsFromAnnotations(anns)
-	if !ok {
+	v := pluginsFromAnnotations(anns)
+	if v == "" {
 		return kongPluginCRs
 	}
 	for _, kongPlugin := range strings.Split(v, ",") {
@@ -154,46 +137,42 @@ func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 // ExtractConfigurationName extracts the name of the KongIngress object that holds
 // information about the configuration to use in Routes, Services and Upstreams
 func ExtractConfigurationName(anns map[string]string) string {
-	value, exists := anns[annotationPrefix+configurationKey]
-	if exists {
-		return value
-	}
-	return anns[deprecatedConfigurationKey]
+	return valueFromAnnotation(ConfigurationKey, anns)
 }
 
 // ExtractProtocolName extracts the protocol supplied in the annotation
 func ExtractProtocolName(anns map[string]string) string {
-	return valueFromAnnotation(protocolKey, anns)
+	return valueFromAnnotation(ProtocolKey, anns)
 }
 
 // ExtractProtocolNames extracts the protocols supplied in the annotation
 func ExtractProtocolNames(anns map[string]string) []string {
-	val := valueFromAnnotation(protocolsKey, anns)
+	val := valueFromAnnotation(ProtocolsKey, anns)
 	return strings.Split(val, ",")
 }
 
 // ExtractClientCertificate extracts the secret name containing the
 // client-certificate to use.
 func ExtractClientCertificate(anns map[string]string) string {
-	return valueFromAnnotation(clientCertKey, anns)
+	return valueFromAnnotation(ClientCertKey, anns)
 }
 
 // ExtractStripPath extracts the strip-path annotations containing the
 // the boolean string "true" or "false".
 func ExtractStripPath(anns map[string]string) string {
-	return valueFromAnnotation(stripPathKey, anns)
+	return valueFromAnnotation(StripPathKey, anns)
 }
 
 // ExtractPath extracts the path annotations containing the
 // HTTP path.
 func ExtractPath(anns map[string]string) string {
-	return valueFromAnnotation(pathKey, anns)
+	return valueFromAnnotation(PathKey, anns)
 }
 
 // ExtractHTTPSRedirectStatusCode extracts the https redirect status
 // code annotation value.
 func ExtractHTTPSRedirectStatusCode(anns map[string]string) string {
-	return valueFromAnnotation(httpsRedirectCodeKey, anns)
+	return valueFromAnnotation(HTTPSRedirectCodeKey, anns)
 }
 
 // HasForceSSLRedirectAnnotation returns true if the annotation
@@ -204,7 +183,7 @@ func HasForceSSLRedirectAnnotation(anns map[string]string) bool {
 
 // ExtractPreserveHost extracts the preserve-host annotation value.
 func ExtractPreserveHost(anns map[string]string) string {
-	return valueFromAnnotation(preserveHostKey, anns)
+	return valueFromAnnotation(PreserveHostKey, anns)
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation
@@ -215,17 +194,17 @@ func HasServiceUpstreamAnnotation(anns map[string]string) bool {
 
 // ExtractRegexPriority extracts the host-header annotation value.
 func ExtractRegexPriority(anns map[string]string) string {
-	return valueFromAnnotation(regexPriorityKey, anns)
+	return valueFromAnnotation(RegexPriorityKey, anns)
 }
 
 // ExtractHostHeader extracts the regex-priority annotation value.
 func ExtractHostHeader(anns map[string]string) string {
-	return valueFromAnnotation(hostHeaderKey, anns)
+	return valueFromAnnotation(HostHeaderKey, anns)
 }
 
 // ExtractMethods extracts the methods annotation value.
 func ExtractMethods(anns map[string]string) []string {
-	val := valueFromAnnotation(methodsKey, anns)
+	val := valueFromAnnotation(MethodsKey, anns)
 	if val == "" {
 		return []string{}
 	}

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -107,13 +107,8 @@ func IngressClassValidatorFuncFromV1Ingress(
 	}
 }
 
-// valueFromAnnotation returns the value of an annotation with key konghq.com.
-func valueFromAnnotation(key string, anns map[string]string) string {
-	return anns[AnnotationPrefix+key]
-}
-
 func pluginsFromAnnotations(anns map[string]string) string {
-	return valueFromAnnotation(PluginsKey, anns)
+	return anns[AnnotationPrefix+PluginsKey]
 }
 
 // ExtractKongPluginsFromAnnotations extracts information about Kong
@@ -137,42 +132,42 @@ func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 // ExtractConfigurationName extracts the name of the KongIngress object that holds
 // information about the configuration to use in Routes, Services and Upstreams
 func ExtractConfigurationName(anns map[string]string) string {
-	return valueFromAnnotation(ConfigurationKey, anns)
+	return anns[AnnotationPrefix+ConfigurationKey]
 }
 
 // ExtractProtocolName extracts the protocol supplied in the annotation
 func ExtractProtocolName(anns map[string]string) string {
-	return valueFromAnnotation(ProtocolKey, anns)
+	return anns[AnnotationPrefix+ProtocolKey]
 }
 
 // ExtractProtocolNames extracts the protocols supplied in the annotation
 func ExtractProtocolNames(anns map[string]string) []string {
-	val := valueFromAnnotation(ProtocolsKey, anns)
+	val := anns[AnnotationPrefix+ProtocolsKey]
 	return strings.Split(val, ",")
 }
 
 // ExtractClientCertificate extracts the secret name containing the
 // client-certificate to use.
 func ExtractClientCertificate(anns map[string]string) string {
-	return valueFromAnnotation(ClientCertKey, anns)
+	return anns[AnnotationPrefix+ClientCertKey]
 }
 
 // ExtractStripPath extracts the strip-path annotations containing the
 // the boolean string "true" or "false".
 func ExtractStripPath(anns map[string]string) string {
-	return valueFromAnnotation(StripPathKey, anns)
+	return anns[AnnotationPrefix+StripPathKey]
 }
 
 // ExtractPath extracts the path annotations containing the
 // HTTP path.
 func ExtractPath(anns map[string]string) string {
-	return valueFromAnnotation(PathKey, anns)
+	return anns[AnnotationPrefix+PathKey]
 }
 
 // ExtractHTTPSRedirectStatusCode extracts the https redirect status
 // code annotation value.
 func ExtractHTTPSRedirectStatusCode(anns map[string]string) string {
-	return valueFromAnnotation(HTTPSRedirectCodeKey, anns)
+	return anns[AnnotationPrefix+HTTPSRedirectCodeKey]
 }
 
 // HasForceSSLRedirectAnnotation returns true if the annotation
@@ -183,7 +178,7 @@ func HasForceSSLRedirectAnnotation(anns map[string]string) bool {
 
 // ExtractPreserveHost extracts the preserve-host annotation value.
 func ExtractPreserveHost(anns map[string]string) string {
-	return valueFromAnnotation(PreserveHostKey, anns)
+	return anns[AnnotationPrefix+PreserveHostKey]
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation
@@ -194,17 +189,17 @@ func HasServiceUpstreamAnnotation(anns map[string]string) bool {
 
 // ExtractRegexPriority extracts the host-header annotation value.
 func ExtractRegexPriority(anns map[string]string) string {
-	return valueFromAnnotation(RegexPriorityKey, anns)
+	return anns[AnnotationPrefix+RegexPriorityKey]
 }
 
 // ExtractHostHeader extracts the regex-priority annotation value.
 func ExtractHostHeader(anns map[string]string) string {
-	return valueFromAnnotation(HostHeaderKey, anns)
+	return anns[AnnotationPrefix+HostHeaderKey]
 }
 
 // ExtractMethods extracts the methods annotation value.
 func ExtractMethods(anns map[string]string) []string {
-	val := valueFromAnnotation(MethodsKey, anns)
+	val := anns[AnnotationPrefix+MethodsKey]
 	if val == "" {
 		return []string{}
 	}

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -130,41 +130,6 @@ func TestExtractPath(t *testing.T) {
 	}
 }
 
-func Test_valueFromAnnotation(t *testing.T) {
-	type args struct {
-		key  string
-		anns map[string]string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "empty",
-			args: args{},
-			want: "",
-		},
-		{
-			name: "non-empty",
-			args: args{
-				key: "/protocol",
-				anns: map[string]string{
-					"konghq.com/protocol": "https",
-				},
-			},
-			want: "https",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := valueFromAnnotation(tt.args.key, tt.args.anns); got != tt.want {
-				t.Errorf("valueFromAnnotation() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestExtractKongPluginsFromAnnotations(t *testing.T) {
 	type args struct {
 		anns map[string]string

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -115,29 +115,10 @@ func TestExtractPath(t *testing.T) {
 			name: "non-empty",
 			args: args{
 				anns: map[string]string{
-					"configuration.konghq.com/path": "/foo",
-				},
-			},
-			want: "/foo",
-		},
-		{
-			name: "non-empty new group",
-			args: args{
-				anns: map[string]string{
 					"konghq.com/path": "/foo",
 				},
 			},
 			want: "/foo",
-		},
-		{
-			name: "group preference",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/path": "/foo",
-					"konghq.com/path":               "/bar",
-				},
-			},
-			want: "/bar",
 		},
 	}
 	for _, tt := range tests {
@@ -165,32 +146,11 @@ func Test_valueFromAnnotation(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "legacy group lookup",
-			args: args{
-				key: "/protocol",
-				anns: map[string]string{
-					"configuration.konghq.com/protocol": "https",
-				},
-			},
-			want: "https",
-		},
-		{
-			name: "new group lookup",
+			name: "non-empty",
 			args: args{
 				key: "/protocol",
 				anns: map[string]string{
 					"konghq.com/protocol": "https",
-				},
-			},
-			want: "https",
-		},
-		{
-			name: "new annotation takes precedence over deprecated one",
-			args: args{
-				key: "/protocol",
-				anns: map[string]string{
-					"konghq.com/protocol":               "https",
-					"configuration.konghq.com/protocol": "grpc",
 				},
 			},
 			want: "https",
@@ -215,28 +175,9 @@ func TestExtractKongPluginsFromAnnotations(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "legacy annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
-					DeprecatedPluginsKey: "kp-rl, kp-cors",
-				},
-			},
-			want: []string{"kp-rl", "kp-cors"},
-		},
-		{
-			name: "new annotation",
-			args: args{
-				anns: map[string]string{
-					"konghq.com/plugins": "kp-rl, kp-cors",
-				},
-			},
-			want: []string{"kp-rl", "kp-cors"},
-		},
-		{
-			name: "annotation prioriy",
-			args: args{
-				anns: map[string]string{
-					DeprecatedPluginsKey: "a,b",
 					"konghq.com/plugins": "kp-rl, kp-cors",
 				},
 			},
@@ -262,29 +203,10 @@ func TestExtractConfigurationName(t *testing.T) {
 		want string
 	}{
 		{
-			name: "legacy annotation",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "new annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/override": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "annotation prioriy",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com": "bar",
-					"konghq.com/override":      "foo",
 				},
 			},
 			want: "foo",
@@ -309,29 +231,10 @@ func TestExtractProtocolName(t *testing.T) {
 		want string
 	}{
 		{
-			name: "legacy annotation",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/protocol": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "new annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/protocol": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "annotation prioriy",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/protocol": "bar",
-					"konghq.com/protocol":               "foo",
 				},
 			},
 			want: "foo",
@@ -356,32 +259,13 @@ func TestExtractProtocolNames(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "legacy annotation",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/protocols": "foo,bar",
-				},
-			},
-			want: []string{"foo", "bar"},
-		},
-		{
-			name: "new annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/protocols": "foo,bar",
 				},
 			},
 			want: []string{"foo", "bar"},
-		},
-		{
-			name: "annotation prioriy",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/protocols": "bar,foo",
-					"konghq.com/protocols":               "foo,baz",
-				},
-			},
-			want: []string{"foo", "baz"},
 		},
 	}
 	for _, tt := range tests {
@@ -403,29 +287,10 @@ func TestExtractClientCertificate(t *testing.T) {
 		want string
 	}{
 		{
-			name: "legacy annotation",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/client-cert": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "new annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/client-cert": "foo",
-				},
-			},
-			want: "foo",
-		},
-		{
-			name: "annotation prioriy",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/client-cert": "bar",
-					"konghq.com/client-cert":               "foo",
 				},
 			},
 			want: "foo",
@@ -494,26 +359,7 @@ func TestExtractStripPath(t *testing.T) {
 			name: "non-empty",
 			args: args{
 				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "false",
-				},
-			},
-			want: "false",
-		},
-		{
-			name: "non-empty new group",
-			args: args{
-				anns: map[string]string{
 					"konghq.com/strip-path": "true",
-				},
-			},
-			want: "true",
-		},
-		{
-			name: "group preference",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "false",
-					"konghq.com/strip-path":               "true",
 				},
 			},
 			want: "true",
@@ -545,26 +391,7 @@ func TestExtractHTTPSRedirectStatusCode(t *testing.T) {
 			name: "non-empty",
 			args: args{
 				anns: map[string]string{
-					"configuration.konghq.com/https-redirect-status-code": "301",
-				},
-			},
-			want: "301",
-		},
-		{
-			name: "non-empty new group",
-			args: args{
-				anns: map[string]string{
 					"konghq.com/https-redirect-status-code": "302",
-				},
-			},
-			want: "302",
-		},
-		{
-			name: "group preference",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/https-redirect-status-code": "301",
-					"konghq.com/https-redirect-status-code":               "302",
 				},
 			},
 			want: "302",
@@ -662,29 +489,10 @@ func TestExtractRegexPriority(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "non-empty old group",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/regex-priority": "5",
-				},
-			},
-			want: "5",
-		},
-		{
-			name: "non-empty new group",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/regex-priority": "10",
-				},
-			},
-			want: "10",
-		},
-		{
-			name: "group preference",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/regex-priority": "5",
-					"konghq.com/regex-priority":               "10",
 				},
 			},
 			want: "10",
@@ -713,29 +521,10 @@ func TestExtractHostHeader(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "non-empty old group",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/host-header": "example.com",
-				},
-			},
-			want: "example.com",
-		},
-		{
-			name: "non-empty new group",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/host-header": "example.net",
-				},
-			},
-			want: "example.net",
-		},
-		{
-			name: "group preference",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/host-header": "example.com",
-					"konghq.com/host-header":               "example.net",
 				},
 			},
 			want: "example.net",
@@ -764,32 +553,13 @@ func TestExtractMethods(t *testing.T) {
 			want: []string{},
 		},
 		{
-			name: "legacy annotation",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/methods": "POST,GET",
-				},
-			},
-			want: []string{"POST", "GET"},
-		},
-		{
-			name: "new annotation",
+			name: "non-empty",
 			args: args{
 				anns: map[string]string{
 					"konghq.com/methods": "POST,GET",
 				},
 			},
 			want: []string{"POST", "GET"},
-		},
-		{
-			name: "annotation priority",
-			args: args{
-				anns: map[string]string{
-					"configuration.konghq.com/methods": "GET,POST",
-					"konghq.com/methods":               "POST,PUT",
-				},
-			},
-			want: []string{"POST", "PUT"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/ingress/controller/parser/kongstate/kongstate_test.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate_test.go
@@ -38,7 +38,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foo,bar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -64,7 +64,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foo,bar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -95,7 +95,7 @@ func Test_getPluginRelations(t *testing.T) {
 										Name:      "some-ingress",
 										Namespace: "ns2",
 										Annotations: map[string]string{
-											annotations.DeprecatedPluginsKey: "foo,bar",
+											annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 										},
 									},
 								},
@@ -127,7 +127,7 @@ func Test_getPluginRelations(t *testing.T) {
 										Name:      "some-ingress",
 										Namespace: "ns2",
 										Annotations: map[string]string{
-											annotations.DeprecatedPluginsKey: "foo,bar",
+											annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 										},
 									},
 								},
@@ -139,7 +139,7 @@ func Test_getPluginRelations(t *testing.T) {
 										Name:      "some-ingress",
 										Namespace: "ns2",
 										Annotations: map[string]string{
-											annotations.DeprecatedPluginsKey: "bar,baz",
+											annotations.AnnotationPrefix + annotations.PluginsKey: "bar,baz",
 										},
 									},
 								},
@@ -167,7 +167,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foo,bar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -180,7 +180,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns2",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foo,bar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -193,7 +193,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foobar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foobar",
 									},
 								},
 							},
@@ -208,7 +208,7 @@ func Test_getPluginRelations(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
-										annotations.DeprecatedPluginsKey: "foo,bar",
+										annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 									},
 								},
 							},
@@ -221,7 +221,7 @@ func Test_getPluginRelations(t *testing.T) {
 										Name:      "some-ingress",
 										Namespace: "ns2",
 										Annotations: map[string]string{
-											annotations.DeprecatedPluginsKey: "foo,bar",
+											annotations.AnnotationPrefix + annotations.PluginsKey: "foo,bar",
 										},
 									},
 								},
@@ -233,7 +233,7 @@ func Test_getPluginRelations(t *testing.T) {
 										Name:      "some-ingress",
 										Namespace: "ns2",
 										Annotations: map[string]string{
-											annotations.DeprecatedPluginsKey: "bar,baz",
+											annotations.AnnotationPrefix + annotations.PluginsKey: "bar,baz",
 										},
 									},
 								},

--- a/internal/ingress/controller/parser/kongstate/route_test.go
+++ b/internal/ingress/controller/parser/kongstate/route_test.go
@@ -219,7 +219,7 @@ func TestOverrideRoutePriority(t *testing.T) {
 
 	ingMeta := util.K8sObjectInfo{
 		Annotations: map[string]string{
-			"configuration.konghq.com/protocols": "grpc,grpcs",
+			"konghq.com/protocols": "grpc,grpcs",
 		},
 	}
 
@@ -265,7 +265,7 @@ func TestOverrideRouteByAnnotation(t *testing.T) {
 
 	ingMeta := util.K8sObjectInfo{
 		Annotations: map[string]string{
-			"configuration.konghq.com/protocols": "grpc,grpcs",
+			"konghq.com/protocols": "grpc,grpcs",
 		},
 	}
 
@@ -429,7 +429,7 @@ func Test_overrideRouteStripPath(t *testing.T) {
 				route: Route{
 					Route: kong.Route{}},
 				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "false",
+					"konghq.com/strip-path": "false",
 				},
 			},
 			want: kong.Route{
@@ -443,7 +443,7 @@ func Test_overrideRouteStripPath(t *testing.T) {
 					Route: kong.Route{},
 				},
 				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "truE",
+					"konghq.com/strip-path": "truE",
 				},
 			},
 			want: kong.Route{
@@ -459,7 +459,7 @@ func Test_overrideRouteStripPath(t *testing.T) {
 					},
 				},
 				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "truE",
+					"konghq.com/strip-path": "truE",
 				},
 			},
 			want: kong.Route{
@@ -475,7 +475,7 @@ func Test_overrideRouteStripPath(t *testing.T) {
 					},
 				},
 				anns: map[string]string{
-					"configuration.konghq.com/strip-path": "42",
+					"konghq.com/strip-path": "42",
 				},
 			},
 			want: kong.Route{

--- a/internal/ingress/controller/parser/kongstate/service_test.go
+++ b/internal/ingress/controller/parser/kongstate/service_test.go
@@ -255,7 +255,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     nil,
 				},
 			},
-			map[string]string{"configuration.konghq.com/protocol": "grpcs"},
+			map[string]string{"konghq.com/protocol": "grpcs"},
 		},
 		{
 			Service{
@@ -281,7 +281,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     nil,
 				},
 			},
-			map[string]string{"configuration.konghq.com/protocol": "grpc"},
+			map[string]string{"konghq.com/protocol": "grpc"},
 		},
 		{
 			Service{
@@ -305,7 +305,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     nil,
 				},
 			},
-			map[string]string{"configuration.konghq.com/protocol": "grpcs"},
+			map[string]string{"konghq.com/protocol": "grpcs"},
 		},
 		{
 			Service{
@@ -331,7 +331,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			map[string]string{"configuration.konghq.com/protocol": "https"},
+			map[string]string{"konghq.com/protocol": "https"},
 		},
 		{
 			Service{
@@ -355,7 +355,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			map[string]string{"configuration.konghq.com/protocol": "https"},
+			map[string]string{"konghq.com/protocol": "https"},
 		},
 	}
 
@@ -386,7 +386,7 @@ func Test_overrideServicePath(t *testing.T) {
 			name: "set to valid value",
 			args: args{
 				anns: map[string]string{
-					"configuration.konghq.com/path": "/foo",
+					"konghq.com/path": "/foo",
 				},
 			},
 			want: Service{
@@ -399,7 +399,7 @@ func Test_overrideServicePath(t *testing.T) {
 			name: "does not set path if doesn't start with /",
 			args: args{
 				anns: map[string]string{
-					"configuration.konghq.com/path": "foo",
+					"konghq.com/path": "foo",
 				},
 			},
 			want: Service{},
@@ -413,7 +413,7 @@ func Test_overrideServicePath(t *testing.T) {
 					},
 				},
 				anns: map[string]string{
-					"configuration.konghq.com/path": "/bar",
+					"konghq.com/path": "/bar",
 				},
 			},
 			want: Service{

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -198,8 +198,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "foo-plugin",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "foo-plugin",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -228,8 +228,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "bar-plugin",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "bar-plugin",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -907,7 +907,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/client-cert": "secret1",
+						"konghq.com/client-cert": "secret1",
 					},
 				},
 			},
@@ -975,7 +975,7 @@ func TestServiceClientCertificate(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/client-cert": "secret1",
+						"konghq.com/client-cert": "secret1",
 					},
 				},
 			},
@@ -1005,8 +1005,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/strip-path": "trUe",
-						annotations.IngressClassKey:           "kong",
+						"konghq.com/strip-path":     "trUe",
+						annotations.IngressClassKey: "kong",
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -1082,8 +1082,8 @@ func TestKongRouteAnnotations(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.IngressClassKey:           "kong",
-						"configuration.konghq.com/strip-path": "false",
+						annotations.IngressClassKey: "kong",
+						"konghq.com/strip-path":     "false",
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -1777,8 +1777,8 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey:       "knative-key-auth",
-						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "knative-key-auth",
+						"networking.knative.dev/ingress.class":                annotations.DefaultIngressClass,
 					},
 				},
 			},
@@ -1901,7 +1901,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/path": "/baz",
+						"konghq.com/path": "/baz",
 					},
 				},
 			},
@@ -1981,7 +1981,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/host-header": "example.com",
+						"konghq.com/host-header": "example.com",
 					},
 				},
 			},
@@ -2202,7 +2202,7 @@ func TestDefaultBackend(t *testing.T) {
 					Name:      "foo-svc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"configuration.konghq.com/client-cert": "secret1",
+						"konghq.com/client-cert": "secret1",
 					},
 				},
 			},
@@ -2465,8 +2465,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "foo-plugin",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "foo-plugin",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -2554,8 +2554,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "foo-plugin",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "foo-plugin",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -2638,8 +2638,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "foo-plugin",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "foo-plugin",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{
@@ -2699,8 +2699,8 @@ func TestPluginAnnotations(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotations.DeprecatedPluginsKey: "does-not-exist",
-						annotations.IngressClassKey:      annotations.DefaultIngressClass,
+						annotations.AnnotationPrefix + annotations.PluginsKey: "does-not-exist",
+						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
 				Spec: networkingv1beta1.IngressSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes deprecated annotations.

**Special notes for your reviewer**:
Tests still use literal `"konghq.com/regex-priority": 3` style test values instead of `AnnotationPrefix + RegexPriorityKey: 3` package constants. We're kinda moving towards the latter in general, though you could make the argument that we want the literal strings so tests complain in the event that we change something: while that works in code using the constants, users won't have changed their annotations in advance if we release such a change, so those literals could serve as a useful canary to make sure that we call out breaking changes if we do change these in the future.

Several tests outside the annotations package referenced `annotations.DeprecatedPluginsKey` and now instead reference `annotations.AnnotationPrefix + annotations.PluginsKey`. For consistency, and lack of an obvious reason not to, the annotations package now exports both the modern prefix and all keys, even though not all keys are currently used in non-annotation tests.