### PR TITLE
Use EKS-like status

### DIFF
--- a/docs/deployment/eks.md
+++ b/docs/deployment/eks.md
@@ -63,7 +63,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP                         
 kong-proxy   LoadBalancer   10.63.250.199   example.eu-west-1.elb.amazonaws.com   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Create an environment variable to hold the IP address:
+Create an environment variable to hold the ELB hostname:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" service -n kong kong-proxy)

--- a/docs/deployment/eks.md
+++ b/docs/deployment/eks.md
@@ -59,14 +59,14 @@ Execute the following command to get the IP address at which Kong is accessible:
 
 ```bash
 $ kubectl get services -n kong
-NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
-kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
+NAME         TYPE           CLUSTER-IP      EXTERNAL-IP                           PORT(S)                      AGE
+kong-proxy   LoadBalancer   10.63.250.199   example.eu-west-1.elb.amazonaws.com   80:31929/TCP,443:31408/TCP   57d
 ```
 
 Create an environment variable to hold the IP address:
 
 ```bash
-$ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
+$ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" service -n kong kong-proxy)
 ```
 
 > Note: It may take some time for Amazon to actually associate the


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates EKS deployment guide to make it more EKS-like

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #493 

**Special notes for your reviewer**:
The `PROXY_IP` name is now a misnomer, but shouldn't matter in practice as it'll resolve under the hood. Left as-is since we use that same variable name elsewhere and changing it would probably do more harm than good.

Github doesn't appear to want to let me add non-org member reviewers of my choice, but @harshal-shah does this look good to you? I don't have an EKS cluster ready to check myself, so this is a combination of the suggested change from the issue and a status that looks more or less like examples I can find in AWS docs.