### PR TITLE
chore: remove ingress-nginx's comments

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -127,9 +127,7 @@ func (n *KongController) syncIngress(interface{}) error {
 	return nil
 }
 
-// NewKongController creates a new NGINX Ingress controller.
-// If the environment variable NGINX_BINARY exists it will be used
-// as source for nginx commands
+// NewKongController creates a new Ingress controller.
 func NewKongController(ctx context.Context,
 	config *Configuration,
 	updateCh *channels.RingChannel,
@@ -237,7 +235,7 @@ type KongController struct {
 	Logger logrus.FieldLogger
 }
 
-// Start starts a new NGINX master process running in foreground, blocking until the next call to
+// Start starts a new master process running in foreground, blocking until the next call to
 // Stop.
 func (n *KongController) Start() {
 	n.Logger.Debugf("startin up controller")
@@ -296,7 +294,7 @@ func (n *KongController) Start() {
 	}
 }
 
-// Stop stops the NGINX master process gracefully.
+// Stop stops the master process gracefully.
 func (n *KongController) Stop() error {
 	atomic.StoreUint32(&n.isShuttingDown, 1)
 


### PR DESCRIPTION
There a few comments seem to be part of ingress-nginx's code.
It's unnecessary and confusing.