### PR TITLE
Release 1.0.0-rc.1 to next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [1.0.0-rc.1](#0100rc1---20201002)
  - [0.10.0](#0100---20200915)
  - [0.9.1](#091---20200608)
  - [0.9.0](#090---20200526)
@@ -22,6 +23,49 @@
  - [0.1.0](#010---20180817)
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
+
+## [1.0.0-rc.1] - 2020/10/02
+
+#### Breaking changes
+
+- The controller no longer supports versions of Kong prior to 2.0.0.
+  [#875](https://github.com/Kong/kubernetes-ingress-controller/pull/875)
+- Deprecated 0.x.x flags are no longer supported. Please see [the documentation
+  changes](https://github.com/Kong/kubernetes-ingress-controller/pull/866/files#diff-9a686fb3bf9c18ab81952a0933fb5c00)
+  for a complete list of removed flags and their replacements. Note that this
+  change applies to both flags and their equivalent environment variables, e.g.
+  for `--admin-header`, if you set `CONTROLLER_ADMIN_HEADER`, you should now
+  use `CONTROLLER_KONG_ADMIN_HEADER`.
+  [#866](https://github.com/Kong/kubernetes-ingress-controller/pull/866)
+- KongCredential custom resources are no longer supported. You should convert
+  any KongCredential resources to [credential Secrets](https://github.com/Kong/kubernetes-ingress-controller/blob/next/docs/guides/using-consumer-credential-resource.md#provision-a-consumer)
+  before upgrading to 1.0.0.
+  [#862](https://github.com/Kong/kubernetes-ingress-controller/pull/862)
+- Deprecated 0.x.x annotations are no longer supported. Please see [the
+  documentation changes](https://github.com/Kong/kubernetes-ingress-controller/pull/873/files#diff-777e08783d63482620961c4f93a1e1f6)
+  for a complete list of removed annotations and their replacements.
+  [#873](https://github.com/Kong/kubernetes-ingress-controller/pull/873)
+
+#### Added
+
+- The controller Docker registry now has minor version tags. These always point
+  to the latest patch release for a given minor version, e.g. if `1.0.3` is the
+  latest patch release for the `1.0.x` series, the `1.0` Docker tag will point
+  to `1.0.3`.
+  [#747](https://github.com/Kong/kubernetes-ingress-controller/pull/747)
+- Custom resources now all have a status field. For 1.0.0, this field is a
+  placeholder, and does not contain any actual status information. Future
+  versions will add status information that reflects whether the controller has
+  created Kong configuration for that custom resource.
+  [#824](https://github.com/Kong/kubernetes-ingress-controller/pull/824)
+- Version compatibility documentation now includes [information about supported
+  Kubernetes versions for a given controller version](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/version-compatibility.md#kubernetes).
+  [#820](https://github.com/Kong/kubernetes-ingress-controller/pull/820)
+
+#### Fixed
+
+- EKS documentation now uses hostnames rather than IP addresses.
+  [#877](https://github.com/Kong/kubernetes-ingress-controller/pull/877)
 
 ## [0.10.0] - 2020/09/15
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hbagdi @rainest
+* @hbagdi @rainest @mflendrich

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,6 @@
 
 ## Current maintainers
 
-- Harry Bagdi ([@hbagdi](https://github.com/hbagdi)
+- Harry Bagdi ([@hbagdi](https://github.com/hbagdi))
 - Travis Raines ([@rainest](https://github.com/hbagdi))
-
+- Michał Flendrich ([@mflendrich](https://github.com/mflendrich))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY?=kong-docker-kubernetes-ingress-controller.bintray.io
-TAG?=0.10.0
+TAG?=1.0.0-rc.1
 REPO_INFO=$(shell git config --get remote.origin.url)
 IMGNAME?=kong-ingress-controller
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -102,7 +102,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0.0-rc.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: webhook

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -698,7 +698,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0.0-rc.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -693,7 +693,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0.0-rc.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -767,7 +767,7 @@ spec:
             secretKeyRef:
               key: password
               name: kong-enterprise-superuser-password
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0.0-rc.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -711,7 +711,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.10.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0.0-rc.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/docs/deployment/eks.md
+++ b/docs/deployment/eks.md
@@ -59,14 +59,14 @@ Execute the following command to get the IP address at which Kong is accessible:
 
 ```bash
 $ kubectl get services -n kong
-NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
-kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
+NAME         TYPE           CLUSTER-IP      EXTERNAL-IP                           PORT(S)                      AGE
+kong-proxy   LoadBalancer   10.63.250.199   example.eu-west-1.elb.amazonaws.com   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Create an environment variable to hold the IP address:
+Create an environment variable to hold the ELB hostname:
 
 ```bash
-$ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
+$ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" service -n kong kong-proxy)
 ```
 
 > Note: It may take some time for Amazon to actually associate the

--- a/docs/references/cli-arguments.md
+++ b/docs/references/cli-arguments.md
@@ -30,7 +30,6 @@ Following table describes all the flags that are available:
 | --admission-webhook-cert             |`string`   | none                            | PEM-encoded certificate string for TLS handshake.|
 | --admission-webhook-key              |`string`   | none                            | PEM-encoded private key string for TLS handshake.|
 | --admission-webhook-listen           |`string`   | `off`                           | The address to start admission controller on (ip:port). Setting it to 'off' disables the admission controller.|
-| --alsologtostderr                    |`boolean`  | `false`                         | Logs are written to standard error as well as to files.|
 | --anonymous-reports                  |`string`   | `true`                          | Send anonymized usage data to help improve Kong.|
 | --apiserver-host                     |`string`   | none                            | The address of the Kubernetes Apiserver to connect to in the format of protocol://address:port, e.g., "http://localhost:8080. If not specified, the assumption is that the binary runs inside a Kubernetes cluster and local discovery is attempted.|
 | --disable-ingress-extensionsv1beta1  |`boolean`  | `false`                         | Disable processing Ingress resources with apiVersion `extensions/v1beta1`.|
@@ -49,11 +48,10 @@ Following table describes all the flags that are available:
 | --kong-admin-url                     |`string`   | `http://localhost:8001`         | The address of the Kong Admin URL to connect to in the format of `protocol://address:port`.|
 | --kong-workspace                     |`string`   | `default`                       | Workspace in Kong Enterprise to be configured.|
 | --kong-custom-entities-secret        |`string`   | none                            | Secret containing custom entities to be populated in DB-less mode, takes the form `namespace/name`.|
+| --log-format                         |`string`   | `text`                          | Format of logs of the controller. Allowed values are `text` and `json`. |
+| --log-level                          |`string`   | `info`                          | Level of logging for the controller. Allowed values are `trace`, `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
 | --enable-reverse-sync                |`bool`     | `false`                         | Enable reverse checks from Kong to Kubernetes. Use this option only if a human has edit access to Kong's Admin API. |
 | --kubeconfig                         |`string`   | none                            | Path to kubeconfig file with authorization and master location information.|
-| --log_backtrace_at                   |`string`   | none                            | When set to a file and line number holding a logging statement, such as -log_backtrace_at=gopherflakes.go:234 a stack trace will be written to the Info log whenever execution hits that statement. (Unlike with -vmodule, the ".go" must be present.)|
-| --log_dir                            |`string`   | none                            | If non-empty, write log files in this directory.|
-| --logtostderr                        |`boolean`  | `true`                          | Logs to standard error instead of files.|
 | --profiling                          |`boolean`  | `true`                          | Enable profiling via web interface `host:port/debug/pprof/`. |
 | --publish-service                    |`string`   | none                            | The namespaces and name of the Kubernetes Service fronting Kong Ingress Controller in the form of namespace/name. The controller will set the status of the Ingress resouces to match the endpoints of this service. In reference deployments, this is kong/kong-proxy.|
 | --publish-status-address             |`string`   | none                            | User customized address to be set in the status of ingress resources. The controller will set the endpoint records on the ingress using this address.|
@@ -65,9 +63,7 @@ Following table describes all the flags that are available:
 | --sync-rate-limit                    |`float32`  | `0.3`                           | Define the sync frequency upper limit. |
 | --update-status                      |`boolean`  | `true`                          | Indicates if the ingress controller should update the Ingress status IP/hostname.|
 | --update-status-on-shutdown          |`boolean`  | `true`                          | Indicates if the ingress controller should update the Ingress status IP/hostname when the controller is being stopped.|
-|  -v, --v Level                        `int`      | `0`                             | | Enable V-leveled logging at the specified level.|
 | --version                            |`boolean`  | `false`                         | Shows release information about the Kong Ingress controller.|
-| --vmodule moduleSpec                 |`string`   | none                            | The syntax of the argument is a comma-separated list of pattern=N, where pattern is a literal file name (minus the ".go" suffix) or "glob" pattern and N is a V level. For instance, -vmodule=gopher*=3 sets the V level to 3 in all Go files whose names begin "gopher".|
 | --watch-namespace                    |`string`   | none                            | Namespace to watch for Ingress and custom resources. The default value of an empty string results in the controller watching for resources in all namespaces and configuring Kong accordingly.|
 | --help                               |`boolean`  | `false`                         | Shows this documentation on the CLI and exit.|
 

--- a/docs/references/version-compatibility.md
+++ b/docs/references/version-compatibility.md
@@ -50,3 +50,15 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kong Enterprise 1.3.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | Kong Enterprise 1.5.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Kong Enterprise 2.1.x    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
+
+## Kubernetes
+
+| Kong Ingress Controller  | 0.9.x              | 0.10.x             |
+|--------------------------|:------------------:|:------------------:|
+| Kubernetes 1.13          | :x:                | :x:                |
+| Kubernetes 1.14          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.15          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.16          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.17          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.18          | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.19          | :white_check_mark: | :white_check_mark: |

--- a/docs/references/version-compatibility.md
+++ b/docs/references/version-compatibility.md
@@ -53,12 +53,12 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 
 ## Kubernetes
 
-| Kong Ingress Controller  | 0.9.x              | 0.10.x             |
-|--------------------------|:------------------:|:------------------:|
-| Kubernetes 1.13          | :x:                | :x:                |
-| Kubernetes 1.14          | :white_check_mark: | :white_check_mark: |
-| Kubernetes 1.15          | :white_check_mark: | :white_check_mark: |
-| Kubernetes 1.16          | :white_check_mark: | :white_check_mark: |
-| Kubernetes 1.17          | :white_check_mark: | :white_check_mark: |
-| Kubernetes 1.18          | :white_check_mark: | :white_check_mark: |
-| Kubernetes 1.19          | :white_check_mark: | :white_check_mark: |
+| Kong Ingress Controller  | 0.9.x              | 0.10.x             | 1.0.x              |
+|--------------------------|:------------------:|:------------------:|:------------------:|
+| Kubernetes 1.13          | :x:                | :x:                | :x:                |
+| Kubernetes 1.14          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.15          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.16          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.17          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.18          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kubernetes 1.19          | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/hack/dev/common/custom-types.yaml
+++ b/hack/dev/common/custom-types.yaml
@@ -196,44 +196,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kongcredentials.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  version: v1
-  scope: Namespaced
-  names:
-    kind: KongCredential
-    plural: kongcredentials
-  additionalPrinterColumns:
-  - name: Credential-type
-    type: string
-    description: Type of credential
-    JSONPath: .type
-  - name: Age
-    type: date
-    description: Age
-    JSONPath: .metadata.creationTimestamp
-  - name: Consumer-Ref
-    type: string
-    description: Owner of the credential
-    JSONPath: .consumerRef
-  validation:
-    openAPIV3Schema:
-      required:
-      - consumerRef
-      - type
-      properties:
-        consumerRef:
-          type: string
-        type:
-          type: string
-  subresources:
-    status: {}
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -125,9 +125,7 @@ func (n *KongController) syncIngress(interface{}) error {
 	return nil
 }
 
-// NewKongController creates a new NGINX Ingress controller.
-// If the environment variable NGINX_BINARY exists it will be used
-// as source for nginx commands
+// NewKongController creates a new Ingress controller.
 func NewKongController(ctx context.Context,
 	config *Configuration,
 	updateCh *channels.RingChannel,
@@ -235,7 +233,7 @@ type KongController struct {
 	Logger logrus.FieldLogger
 }
 
-// Start starts a new NGINX master process running in foreground, blocking until the next call to
+// Start starts a new master process running in foreground, blocking until the next call to
 // Stop.
 func (n *KongController) Start() {
 	n.Logger.Debugf("startin up controller")
@@ -286,7 +284,7 @@ func (n *KongController) Start() {
 	}
 }
 
-// Stop stops the NGINX master process gracefully.
+// Stop stops the master process gracefully.
 func (n *KongController) Stop() error {
 	atomic.StoreUint32(&n.isShuttingDown, 1)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Merge main into next and release 1.0.0-rc.1

**Special notes for your reviewer**:
We have not previously released a release candidate version. Absent previous controller RC releases to mimic, I've attempted to follow the style conventions used by the `kong` repo, namely:

- The RC version format is x.y.z-rc.RCCOUNTER
- CHANGELOG.md stages expected 1.0.0 changes under a "1.0.0-rc.1" header. We will need to change this to "1.0.0" and update the anchor date before final release, and move any subsequent RC changelogs under the consolidated 1.0.0 changelog section. Slight deviation from `kong` here: at least for the 2.0.0-rc.1 release, it used [a "2.1.0rc1" header](https://github.com/Kong/kong/blob/2.1.0-rc.1/CHANGELOG.md#210rc1). I kept the `.` between `rc` and `1` in ours to keep the version formatting consistent throughout.

I have future-dated this to tomorrow, as Harry is out today and Michal probably is out for the evening, and I expect this will get reviewed EMEA tomorrow when Michal's workday starts. In the process doc, the next step following approval and merger into next is 'Tag 0.10.0 and push it (e.g. “git tag 0.10.0 origin/next; git push --tags”)'.

Mundane retro stuff:
- The steps we wrote for 0.10.0 omit a few steps (creating a release branch and merge it). I've added those in suggestion mode. Please review them and approve if they make sense.
- The changelog merger step assumes that we've written a changelog in advance of release and have an open draft PR. That's probably good practice for future releases, as they can take a while to write depending on how clean history is and how complex the changeset is. 1.0.0's is fortunately pretty simple, since it's mostly just deprecations and everything was indeed included in the milestone, which wasn't the case for 0.10.0. We should definitely continue adding things to milestones in the future, as that saves a lot of error-prone PR/commit history review by release date.
- Google Docs is misery, at least for me, as finding stuff in it can be a crapshoot, and as-is we could easily miss steps because they're just a bullet list--no way to mark a step as done. I propose migrating the release steps to Confluence with a templated checklist similar to what Fast Track uses for Enterprise releases. Confluence is its own set of misery on account of Atlassian's incredibly slow JS+slow managed services grinding the editor to a halt after any appreciable amount of time (maybe it works better in Chrome, but lol web devs doing performance testing under any JS engine other than V8), but I figure that's outweighed by the organizational benefits here--ticking boxes on a checklist while reading through them is pretty simple, so it doesn't suffer as much from the slowness (not much in the way of "okay, wait for the text displayed on the page to catch up with my typing speed" pauses when ticking boxes on an existing checklist).