### PR TITLE
Update Enterprise manifest examples and docs

### DIFF
--- a/deploy/manifests/enterprise-k8s/kustomization.yaml
+++ b/deploy/manifests/enterprise-k8s/kustomization.yaml
@@ -4,5 +4,5 @@ patchesStrategicMerge:
 - kong-enterprise-k8s.yaml
 images:
 - name: kong
-  newName: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  newTag: 2.0.4.1-alpine
+  newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  newTag: 2.1.4.0-alpine

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -642,7 +642,7 @@ spec:
             secretKeyRef:
               key: license
               name: kong-enterprise-license
-        image: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s:2.0.4.1-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.1.4.0-alpine
         lifecycle:
           preStop:
             exec:

--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -60,11 +60,11 @@ to log in to Bintray and password
 is an API-key that can be provisioned via Bintray.
 
 ```bash
-$ kubectl create secret -n kong docker-registry kong-enterprise-k8s-docker \
-    --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
+$ kubectl create secret docker-registry kong-enterprise-edition-docker \
+    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username@kong> \
     --docker-password=<your-bintray-api-key>
-secret/kong-enterprise-k8s-docker created
+secret/kong-enterprise-edition-docker created
 ```
 
 Again, please take a note of the namespace `kong`.

--- a/docs/deployment/k4k8s-enterprise.md
+++ b/docs/deployment/k4k8s-enterprise.md
@@ -60,7 +60,7 @@ to log in to Bintray and password
 is an API-key that can be provisioned via Bintray.
 
 ```bash
-$ kubectl create secret docker-registry kong-enterprise-edition-docker \
+$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username@kong> \
     --docker-password=<your-bintray-api-key>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates Enterprise manifests to use kong-enterprise-edition at the current latest patch version.
- Updates registry secret instructions to use kong-enterprise-edition.

I missed the KIC repo version/registry in the course of updating various pieces of documentation to reflect the switch from kong-enterprise-k8s to kong-enterprise-edition, which broke instructions elsewhere that _were_ updated when attempting to deploy using the example Enterprise manifests here.

That may have been intentional when 2.1 Enterprise was still in beta. It no longer is, so everything should now reflect the current 2.1 kong-enterprise-edition guidance for new installs. I think this was the last of the holdouts :crossed_fingers: 

**Special notes for your reviewer**:
@lena-larionova not actually adding this to the changelog here since there's no good release to put it in. Doc fixes in this repo are a bit odd, since changelog items are tied to code releases, and doc fixes usually go on top of the current tip of main regardless of whether they accompany a release. 1.0.1 or 1.1.0 (depending on whether or not we do a patch release) notes should include it.
