### PR TITLE
Use number for verify depth

### DIFF
--- a/docs/guides/upstream-mtls.md
+++ b/docs/guides/upstream-mtls.md
@@ -33,7 +33,7 @@ environment variables on Kong's container in your deployment:
 
 ```
 KONG_NGINX_PROXY_PROXY_SSL_VERIFY="on"
-KONG_NGINX_PROXY_PROXY_SSL_VERIFY_DEPTH="on"
+KONG_NGINX_PROXY_PROXY_SSL_VERIFY_DEPTH="3"
 KONG_NGINX_PROXY_PROXY_SSL_TRUSTED_CERTIFICATE="/path/to/ca_certs.pem"
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Doc is incorrect and will prevent Kong from starting because it tries to use a bool for an int setting. This fixes it with a reasonable value for most environments.