### PR TITLE
Log print memory address instead service.Name

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -193,7 +193,7 @@ func getUpstreams(
 		if err == nil {
 			targets = getServiceEndpoints(log, s, service.K8sService, port)
 		} else {
-			log.WithField("service_name", service.Name).Warnf("skipping service - getServiceEndpoints failed: %v", err)
+			log.WithField("service_name", *service.Name).Warnf("skipping service - getServiceEndpoints failed: %v", err)
 		}
 
 		upstream := kongstate.Upstream{


### PR DESCRIPTION
service.Name for this point is kong.String('') and it's pointer to string. As a result in logs I can see only RAM address:

`time="2020-10-20T12:39:52Z" level=warning msg="skipping service - getServiceEndpoints failed: no suitable port found" component=store service_name=0xc000bacaf0
time="2020-10-20T12:39:52Z" level=warning msg="skipping service - getServiceEndpoints failed: no suitable port found" component=store service_name=0xc000bac9a0`

And after fix:
`time="2020-10-20T14:35:02Z" level=warning msg="skipping service - getServiceEndpoints failed: no suitable port found" component=store service_name=default.kong-ingress-add-gcp-stg-zendesk-sso-gcp-stg-root.80
time="2020-10-20T14:35:02Z" level=warning msg="skipping service - getServiceEndpoints failed: no suitable port found" component=store service_name=default.kong-ingress-add-gcp-stg-fms-gcp-stg.80`