### PR TITLE
Use modern plugins annotation in documentation

### DIFF
--- a/docs/guides/configure-acl-plugin.md
+++ b/docs/guides/configure-acl-plugin.md
@@ -161,7 +161,7 @@ kind: Ingress
 metadata:
   name: demo-get
   annotations:
-    plugins.konghq.com: app-jwt
+    konghq.com/plugins: app-jwt
     konghq.com/strip-path: "false"
     kubernetes.io/ingress.class: kong
 spec:
@@ -180,7 +180,7 @@ kind: Ingress
 metadata:
   name: demo-post
   annotations:
-    plugins.konghq.com: app-jwt
+    konghq.com/plugins: app-jwt
     konghq.com/strip-path: "false"
     kubernetes.io/ingress.class: kong
 spec:
@@ -581,7 +581,7 @@ kind: Ingress
 metadata:
   name: demo-get
   annotations:
-    plugins.konghq.com: app-jwt,plain-user-acl
+    konghq.com/plugins: app-jwt,plain-user-acl
     konghq.com/strip-path: "false"
     kubernetes.io/ingress.class: kong
 spec:
@@ -600,7 +600,7 @@ kind: Ingress
 metadata:
   name: demo-post
   annotations:
-    plugins.konghq.com: app-jwt,admin-acl
+    konghq.com/plugins: app-jwt,admin-acl
     konghq.com/strip-path: "false"
     kubernetes.io/ingress.class: kong
 spec:

--- a/docs/guides/using-kongclusterplugin-resource.md
+++ b/docs/guides/using-kongclusterplugin-resource.md
@@ -178,10 +178,10 @@ We will associate the `KongClusterPlugin` resource with the two Ingress resource
 that we previously created:
 
 ```bash
-$ kubectl patch ingress -n httpbin httpbin-app -p '{"metadata":{"annotations":{"plugins.konghq.com":"add-response-header"}}}'
+$ kubectl patch ingress -n httpbin httpbin-app -p '{"metadata":{"annotations":{"konghq.com/plugins":"add-response-header"}}}'
 ingress.extensions/httpbin-app patched
 
-$ kubectl patch ingress -n echo echo-app -p '{"metadata":{"annotations":{"plugins.konghq.com":"add-response-header"}}}'
+$ kubectl patch ingress -n echo echo-app -p '{"metadata":{"annotations":{"konghq.com/plugins":"add-response-header"}}}'
 ingress.extensions/echo-app patched
 ```
 

--- a/docs/references/custom-resources.md
+++ b/docs/references/custom-resources.md
@@ -68,7 +68,7 @@ by default. It is advised to setup and use the admission validating controller
 to catch user errors.
 
 The plugins can be associated with Ingress
-or Service object in Kubernetes using `plugins.konghq.com` annotation.
+or Service object in Kubernetes using `konghq.com/plugins` annotation.
 
 ### Examples
 
@@ -97,7 +97,7 @@ metadata:
   labels:
      app: myapp-service
   annotations:
-     plugins.konghq.com: request-id
+     konghq.com/plugins: request-id
 spec:
   ports:
   - port: 80
@@ -118,7 +118,7 @@ kind: Ingress
 metadata:
   name: demo-example-com
   annotations:
-    plugins.konghq.com: request-id
+    konghq.com/plugins: request-id
     kubernetes.io/ingress.class: kong
 spec:
   rules:
@@ -132,7 +132,7 @@ spec:
 ```
 
 A plugin can also be applied to a specific KongConsumer by adding
-`plugins.konghq.com` annotation to the KongConsumer resource.
+`konghq.com/plugins` annotation to the KongConsumer resource.
 
 Please follow the
 [Using the KongPlugin resource](../guides/using-kongplugin-resource.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
Several pieces of documentation still used the old `plugins.konghq.com` annotation. This change updates those to use the modern `konghq.com/plugins` resource.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #920 

**Special notes for your reviewer**:
Fixed several instances after the initial report of the one. Hurray for sed!

Performed a cursory check through the docs.konghq.com repo to see if we have any of the old annotation there; we do not.