### PR TITLE
Udate CONTRIBUTING Golang version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ patch](#submitting-a-patch) section.
 
 ## Environment
 
-- Golang version >= 1.15 installed
+- Golang version matching our [`Dockerfile`](./Dockerfile) installed
 - Access to a k8s cluster, you can use Minikube or GKE
 - make
 - Docker (for building)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ patch](#submitting-a-patch) section.
 
 ## Environment
 
-- Golang version >= 1.12 installed
+- Golang version >= 1.15 installed
 - Access to a k8s cluster, you can use Minikube or GKE
 - make
 - Docker (for building)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates CONTRIBUTING to instruct contributors to use Golang 1.15.

**Special notes for your reviewer**:
Updated following a review of community resources and realizing that this looked outdated re https://github.com/Kong/kubernetes-ingress-controller/pull/816