### PR TITLE
chore(ci): obtain ref without git cloning

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -51,7 +51,7 @@ jobs:
         set -e
 
         REPO="kong-docker-kubernetes-ingress-controller.bintray.io"
-        REF="$(git rev-parse --short HEAD)"
+        REF="${GITHUB_REF//^refs\/+([a-z])\//}" # remove "^refs/(heads|tags|remotes)"
 
         DOCKER_TAG="$REPO/master:$REF"
         docker load < image.tar


### PR DESCRIPTION
Fixes the build failure https://github.com/Kong/kubernetes-ingress-controller/actions/runs/342391558 .

The reason for the failure is that `git rev-parse` works only if the git repository has been cloned. This is not necessary there - GITHUB_REF gives us the information we need.