### PR TITLE
feat(consumer) validate credential secret fields

### DIFF
--- a/internal/ingress/controller/parser/kongstate/consumer.go
+++ b/internal/ingress/controller/parser/kongstate/consumer.go
@@ -33,12 +33,24 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 			return fmt.Errorf("failed to decode key-auth credential: %w", err)
 
 		}
+		// TODO we perform these validity checks here because passing credentials without these fields will panic deck
+		// later on. Ideally this should not be handled in the controller, but we cannot currently handle it elsewhere
+		// (i.e. in deck or go-kong) without entering a sync failure loop that cannot actually report the problem
+		// piece of configuration. if we can address those limitations, we should remove these checks.
+		// See https://github.com/Kong/deck/pull/223 and https://github.com/Kong/kubernetes-ingress-controller/issues/532
+		// for more discussion.
+		if cred.Key == nil {
+			return fmt.Errorf("key-auth for consumer %s is invalid: no key", *c.Username)
+		}
 		c.KeyAuths = append(c.KeyAuths, &cred)
 	case "basic-auth", "basicauth_credential":
 		var cred kong.BasicAuth
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
 			return fmt.Errorf("failed to decode basic-auth credential: %w", err)
+		}
+		if cred.Username == nil {
+			return fmt.Errorf("basic-auth for consumer %s is invalid: no username", *c.Username)
 		}
 		c.BasicAuths = append(c.BasicAuths, &cred)
 	case "hmac-auth", "hmacauth_credential":
@@ -47,12 +59,18 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		if err != nil {
 			return fmt.Errorf("failed to decode hmac-auth credential: %w", err)
 		}
+		if cred.Username == nil {
+			return fmt.Errorf("hmac-auth for consumer %s is invalid: no username", *c.Username)
+		}
 		c.HMACAuths = append(c.HMACAuths, &cred)
 	case "oauth2":
 		var cred kong.Oauth2Credential
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
 			return fmt.Errorf("failed to decode oauth2 credential: %w", err)
+		}
+		if cred.ClientID == nil {
+			return fmt.Errorf("oauth2 for consumer %s is invalid: no client_id", *c.Username)
 		}
 		c.Oauth2Creds = append(c.Oauth2Creds, &cred)
 	case "jwt", "jwt_secret":
@@ -70,12 +88,18 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		if cred.Algorithm == nil || *cred.Algorithm == "" {
 			cred.Algorithm = kong.String("HS256")
 		}
+		if cred.Key == nil {
+			return fmt.Errorf("jwt-auth for consumer %s is invalid: no key", *c.Username)
+		}
 		c.JWTAuths = append(c.JWTAuths, &cred)
 	case "acl":
 		var cred kong.ACLGroup
 		err := decodeCredential(credConfig, &cred)
 		if err != nil {
 			log.Errorf("failed to process ACL group: %v", err)
+		}
+		if cred.Group == nil {
+			return fmt.Errorf("acl for consumer %s is invalid: no group", *c.Username)
 		}
 		c.ACLGroups = append(c.ACLGroups, &cred)
 	default:

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -50,19 +50,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "key-auth without key",
 			args: args{
-				credType: "key-auth",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "key-auth",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 		{
@@ -104,19 +96,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "basic-auth without username",
 			args: args{
-				credType: "basic-auth",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "basic-auth",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 		{
@@ -162,19 +146,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "hmac-auth without username",
 			args: args{
-				credType: "hmac-auth",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "hmac-auth",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 		{
@@ -224,19 +200,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "oauth2 without client_id",
 			args: args{
-				credType: "oauth2",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "oauth2",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 		{
@@ -266,19 +234,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "jwt without key",
 			args: args{
-				credType: "jwt",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "jwt",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 		{
@@ -324,19 +284,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 		{
 			name: "acl without group",
 			args: args{
-				credType: "acl",
-				consumer: &Consumer{
-					Consumer: kong.Consumer{
-						Username: &username,
-					},
-				},
+				credType:   "acl",
+				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
 				credConfig: map[string]string{},
 			},
-			result: &Consumer{
-				Consumer: kong.Consumer{
-					Username: &username,
-				},
-			},
+			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
 			wantErr: true,
 		},
 	}

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestConsumer_SetCredential(t *testing.T) {
+	username := "example"
 	type args struct {
 		credType   string
 		consumer   *Consumer
@@ -47,6 +48,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "key-auth without key",
+			args: args{
+				credType: "key-auth",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "keyauth_credential",
 			args: args{
 				credType:   "keyauth_credential",
@@ -81,6 +100,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "basic-auth without username",
+			args: args{
+				credType: "basic-auth",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "basicauth_credential",
@@ -121,6 +158,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "hmac-auth without username",
+			args: args{
+				credType: "hmac-auth",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "hmacauth_credential",
@@ -167,6 +222,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "oauth2 without client_id",
+			args: args{
+				credType: "oauth2",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "jwt",
 			args: args{
 				credType: "jwt",
@@ -189,6 +262,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "jwt without key",
+			args: args{
+				credType: "jwt",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "jwt_secret",
@@ -229,6 +320,24 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "acl without group",
+			args: args{
+				credType: "acl",
+				consumer: &Consumer{
+					Consumer: kong.Consumer{
+						Username: &username,
+					},
+				},
+				credConfig: map[string]string{},
+			},
+			result: &Consumer{
+				Consumer: kong.Consumer{
+					Username: &username,
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the band-aid solution discussed in https://github.com/Kong/deck/pull/223#issuecomment-719042303

It's effectively the same set of checks on the go-kong structs, but in the controller instead of deck. This allows us to log richer information than we would if we delegated this check to either deck or go-kong.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: Fix #532

**Special notes for your reviewer**:
Per comments in deck#223, this is an imperfect stopgap solution to a complicated problem

No new tests, as there's not a whole lot to test here. We could add one with one or more broken credentials, but given the band-aid nature of the solution (checks specific to each credential type, in a codebase that ideally shouldn't have them), it seems like they'd be of limited use. Regressions shouldn't occur unless we remove this code, and we shouldn't be doing that unless we're replacing it with some better system, which would have its own, more effective checks.
