### PR TITLE
Add CI check for untidy go modules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,9 @@ jobs:
     - name: Verify manifest consistency
       run: |
         make verify-manifests
+    - name: Verify modules are tidy
+      run: |
+        make verify-tidy
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,9 +34,6 @@ jobs:
     - name: Verify manifest consistency
       run: |
         make verify-manifests
-    - name: Verify modules are tidy
-      run: |
-        make verify-tidy
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ verify-codegen:
 update-codegen:
 	./hack/update-codegen.sh
 
+.PHONY: verify-tidy
+verify-tidy:
+	./hack/verify-tidy.sh
+
 .PHONY: container
 container:
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 	go test -race ./...
 
 .PHONY: lint
-lint:
+lint: verify-tidy
 	golangci-lint run ./...
 
 .PHONY: build

--- a/hack/verify-tidy.sh
+++ b/hack/verify-tidy.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+
+#    Copyright 2015 Grafana Labs
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   Kong Inc. has modified the original Grafana source of this script.
+#   The modifications add additional instructions to its output text.
+
 set -eo pipefail
 
 # Verify that Go is properly installed and available

--- a/hack/verify-tidy.sh
+++ b/hack/verify-tidy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eo pipefail
+
+# Verify that Go is properly installed and available
+command -v go >/dev/null 2>&1 || { echo 'please install Go or use an image that has it'; exit 1; }
+
+backup_go_mod_files()
+{
+    mod=$(mktemp)
+    cp go.mod "$mod"
+
+    sum=$(mktemp)
+    cp go.sum "$sum"
+}
+
+restore_go_mod_files()
+{
+    cp "$mod" go.mod
+    rm "$mod"
+
+    cp "$sum" go.sum
+    rm "$sum"
+}
+
+# Backup current go.mod and go.sum files
+backup_go_mod_files
+
+# Defer the go.mod and go.sum files backup recovery
+trap restore_go_mod_files EXIT
+
+# Tidy go.mod and go.sum files
+go mod tidy
+
+diff "$mod" go.mod || { echo "your go.mod is inconsistent. please run \"go mod tidy\""; exit 1; }
+diff "$sum" go.sum || { echo "your go.sum is inconsistent. please run \"go mod tidy\""; exit 1; }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a CI check to confirm whether go modules are tidy. If they are not tidy, complain!

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #917 

**Special notes for your reviewer**:
Demo failure on https://github.com/Kong/kubernetes-ingress-controller/pull/948/checks?check_run_id=1366090329

Shamelessly copy-pastaed script from https://github.com/grafana/grafana/pull/27204 with minor modifications to add problem-correction instructions.