### PR TITLE
Fix invalid tag generation in CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -51,7 +51,7 @@ jobs:
         set -e
 
         REPO="kong-docker-kubernetes-ingress-controller.bintray.io"
-        REF="${GITHUB_REF//^refs\/+([a-z])\//}" # remove "^refs/(heads|tags|remotes)"
+        REF=`sed -re "s/^refs\/[a-z]+\///" <<< $GITHUB_REF` # remove "^refs/(heads|tags|remotes)"
 
         DOCKER_TAG="$REPO/master:$REF"
         docker load < image.tar


### PR DESCRIPTION
**What this PR does / why we need it**:
CI is sad; this makes it not sad.

**Special notes for your reviewer**:

push-public has
```
if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
```
so this doesn't actually execute until the commit lands in main. This should suffice to confirm it gets what we want:

```
$ export GITHUB_REF="refs/heads/main"   
$ REF=`sed -re "s/^refs\/[a-z]+\///" <<< $GITHUB_REF`; echo $REF 
main
```
IDK much about bash's built-in pattern matching language, but brief research suggests it doesn't support the `+` operator or the PCRE-style classes we're using. sed definitely does, so may as well use that.