### PR TITLE
Updated Kong Enterprise to 2.2.0.0 in deployments

### DIFF
--- a/deploy/manifests/enterprise-k8s/kustomization.yaml
+++ b/deploy/manifests/enterprise-k8s/kustomization.yaml
@@ -5,4 +5,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  newTag: 2.1.4.0-alpine
+  newTag: 2.2.0.0-alpine

--- a/deploy/manifests/enterprise/kustomization.yaml
+++ b/deploy/manifests/enterprise/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  newTag: 1.5.0.2-alpine
+  newTag: 2.2.0.0-alpine

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -642,7 +642,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.1.4.0-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -700,7 +700,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
         lifecycle:
           preStop:
             exec:
@@ -811,7 +811,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---
@@ -892,7 +892,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:1.5.0.2-alpine
+        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker


### PR DESCRIPTION
**What this PR does / why we need it**:

The prepared deployment YAML files for Kong Enterprise still used to be on 2.1.4 and 1.5. Updated to latest version 2.2.0.0

As the bit.ly in the documentation pointed to those files prospects and customers got old (and very old - see 1.5) version installed instead of the latest one available.

