### PR TITLE
add step to handle ipv6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.idea
 
 # coverage artifacts
 .coverprofile

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -394,12 +394,19 @@ func getEndpoints(
 			}
 
 			for _, epAddress := range ss.Addresses {
-				ep := fmt.Sprintf("%v:%v", epAddress.IP, targetPort)
+				var epAddressIP string
+				if s.Spec.IPFamily != nil && *s.Spec.IPFamily == corev1.IPv6Protocol {
+					epAddressIP = fmt.Sprintf("[%v]", epAddress.IP)
+				} else {
+					epAddressIP = epAddress.IP
+				}
+
+				ep := fmt.Sprintf("%v:%v", epAddressIP, targetPort)
 				if _, exists := adus[ep]; exists {
 					continue
 				}
 				ups := utils.Endpoint{
-					Address: epAddress.IP,
+					Address: epAddressIP,
 					Port:    fmt.Sprintf("%v", targetPort),
 				}
 				upsServers = append(upsServers, ups)

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -60,6 +60,19 @@ env SUT_HTTP_HOST=127.0.0.1:27080 SUT_HTTPS_HOST=127.0.0.1:27443 ./test/integrat
 kubectl --kubeconfig=./kubeconfig-test-cluster delete -f ./test/integration/cases/01-https
 ```
 
+Run service-dual-stack test case use different command manually:
+```bash
+# get ingress-kong pod name
+INGRESS_KONG_POD_ID=`kubectl --kubeconfig=./kubeconfig-test-cluster -n kong get pods -l app=ingress-kong \
+  -o jsonpath='{.items[*].metadata.name}' | head -n 1`
+  
+kubectl --kubeconfig=./kubeconfig-test-cluster port-forward -n kong pod/"$INGRESS_KONG_POD_ID" "28444:8444"
+# in a separate terminal window:
+kubectl --kubeconfig=./kubeconfig-test-cluster apply -f ./test/integration/cases/07-service-dual-stack
+env SUT_ADMIN_API_HOST=127.0.0.1:28444 ./test/integration/cases/07-service-dual-stack/verify.sh
+kubectl --kubeconfig=./kubeconfig-test-cluster delete -f ./test/integration/cases/07-service-dual-stack
+```
+
 #### Manually tear down the test cluster
 
 At the end of the debugging session, you can tear down the environment like this:

--- a/test/integration/cases/08-service-dual-stack/endpoint-ipv4.yaml
+++ b/test/integration/cases/08-service-dual-stack/endpoint-ipv4.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test-ipv4
+subsets:
+  - addresses:
+      - ip: "1.1.1.1"
+    ports:
+      - name: test-ipv4
+        port: 8080
+        protocol: TCP

--- a/test/integration/cases/08-service-dual-stack/endpoint-ipv6.yaml
+++ b/test/integration/cases/08-service-dual-stack/endpoint-ipv6.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test-ipv6
+subsets:
+  - addresses:
+      - ip: "1::1"
+    ports:
+      - name: test-ipv6
+        port: 8080
+        protocol: TCP

--- a/test/integration/cases/08-service-dual-stack/ingress.yaml
+++ b/test/integration/cases/08-service-dual-stack/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-dual-stack
+  annotations:
+    kubernetes.io/ingress.class: kong
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: test-ipv4
+            port:
+              number: 8080
+        path: /foo
+        pathType: Prefix
+      - backend:
+          service:
+            name: test-ipv6
+            port:
+              number: 8080
+        path: /bar
+        pathType: Prefix

--- a/test/integration/cases/08-service-dual-stack/service-ipv4.yaml
+++ b/test/integration/cases/08-service-dual-stack/service-ipv4.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-ipv4
+spec:
+  ports:
+  - name: test-ipv4
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  type: ClusterIP

--- a/test/integration/cases/08-service-dual-stack/service-ipv6.yaml
+++ b/test/integration/cases/08-service-dual-stack/service-ipv6.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-ipv6
+spec:
+  ipFamily: IPv6
+  ports:
+  - name: test-ipv6
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  type: ClusterIP

--- a/test/integration/cases/08-service-dual-stack/verify.sh
+++ b/test/integration/cases/08-service-dual-stack/verify.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+# For ipv4 service
+TARGET_IPV4_ENDPOINT="target: 1.1.1.1:8080"
+[ "$(curl -s -k https://$SUT_ADMIN_API_HOST/config | grep -o "$TARGET_IPV4_ENDPOINT")" == "$TARGET_IPV4_ENDPOINT" ]
+
+# For ipv6 service
+TARGET_IPV6_ENDPOINT="target: '[1::1]:8080'"
+[ "$(curl -s -k https://$SUT_ADMIN_API_HOST/config/| grep -o -F "$TARGET_IPV6_ENDPOINT")" == "$TARGET_IPV6_ENDPOINT" ]

--- a/test/integration/util/create-cluster.sh
+++ b/test/integration/util/create-cluster.sh
@@ -13,6 +13,36 @@ containerdConfigPatches:
 - |-
   [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"$REGISTRY_NAME:$REGISTRY_PORT\"]
     endpoint = [\"http://${REGISTRY_NAME}:${REGISTRY_PORT}\"]
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "feature-gates": "IPv6DualStack=true"
+      "service-cluster-ip-range": "10.96.0.0/16,fd00::/108"
+  controllerManager:
+    extraArgs:
+      "feature-gates": "IPv6DualStack=true"
+      "service-cluster-ip-range": "10.96.0.0/16,fd00::/108"
+      "cluster-cidr": "10.244.0.0/16,fc00::/48"
+      "node-cidr-mask-size": \"0\"
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: InitConfiguration
+  metadata:
+    name: config
+  nodeRegistration:
+    kubeletExtraArgs:
+      "feature-gates": "IPv6DualStack=true"
+- |
+  apiVersion: kubeproxy.config.k8s.io/v1alpha1
+  kind: KubeProxyConfiguration
+  featureGates:
+    IPv6DualStack: true
+  clusterCIDR: "10.244.0.0/16,fc00::/48"
 "
 
 "$KIND_BINARY" create cluster --config=<(echo "$KIND_CONFIG")

--- a/test/integration/util/run-all-tests.sh
+++ b/test/integration/util/run-all-tests.sh
@@ -16,6 +16,14 @@ export SUT_HTTP_HOST="127.0.0.1:$HTTP_PORT"
 export SUT_HTTPS_HOST="127.0.0.1:$HTTPS_PORT"
 echo ">>> Kong proxy host is '$SUT_HTTP_HOST' for HTTP and '$SUT_HTTPS_HOST' for HTTPS."
 
+echo ">>> Obtaining Kong admin IP..."
+ADMIN_API_PORT=28444
+INGRESS_KONG_POD_ID=`kubectl -n kong get pods -l app=ingress-kong \
+  -o jsonpath='{.items[*].metadata.name}' | head -n 1`
+kubectl port-forward -n kong pod/"$INGRESS_KONG_POD_ID" "$ADMIN_API_PORT:8444" &
+export SUT_ADMIN_API_HOST="127.0.0.1:$ADMIN_API_PORT"
+echo ">>> Kong admin api host is '$SUT_ADMIN_API_HOST'."
+
 echo ">>> Setting up example services..."
 setup_example_services() (
 	set -ex


### PR DESCRIPTION
if service IPFamily is IPv6, the kong target address:port
must be ipv6 format, like [1:1]:80.

fixes #972 