### PR TITLE
Remove support for Cassandra-backed Kong

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -282,8 +282,8 @@ func main() {
 		controllerConfig.Kong.InMemory = true
 	}
 	if kongDB == "cassandra" {
-		log.Warn("running controller with kong cassandra as a datastore is deprecated; " +
-			"please consider using postgres or in-memory mode")
+		log.Fatalf("Cassandra-backed deployments of Kong managed by the ingress controller are no longer supported;" +
+			"you must migrate to a Postgres-backed or DB-less deployment")
 	}
 
 	req, _ := http.NewRequest("GET",


### PR DESCRIPTION
**What this PR does / why we need it**:
Cassandra-backed Kong instance support is going away in 1.1.0 after being deprecated in 0.9.0. This replaces the deprecation warning with a fatal error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #968
