### PR TITLE
Release 1.1.0 to next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [1.1.0](#110---20201209)
  - [1.0.0](#100---20201005)
  - [0.10.0](#0100---20200915)
  - [0.9.1](#091---20200608)
@@ -23,6 +24,43 @@
  - [0.1.0](#010---20180817)
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
+
+## [1.1.0] - 2020/12/09
+
+#### Breaking changes
+
+- The controller no longer supports Cassandra-backed Kong clusters, following
+  deprecation in 0.9.0. You must migrate to a Postgres-backed or DB-less
+  cluster before upgrading to 1.1.0. The controller will restore configuration
+  from Kubernetes resources (Ingresses, Services, KongPlugins, etc.) into the
+  new datastore automatically. Kong Enterprise users with
+  non-controller-managed configuration (Portal configuration, RBAC
+  configuration, etc.) will need to migrate that configuration manually.
+  [#974](https://github.com/Kong/kubernetes-ingress-controller/pull/974)
+
+#### Added
+
+- The default Kong version is now 2.2.x and the default Kong Enterprise version
+  is now 2.2.0.0.
+  [#932](https://github.com/Kong/kubernetes-ingress-controller/pull/932)
+  [#965](https://github.com/Kong/kubernetes-ingress-controller/pull/965)
+- The default worker count is now 2 instead of 1. This avoids request latency
+  during blocking configuration changes.
+  [#957](https://github.com/Kong/kubernetes-ingress-controller/pull/957)
+- Knative Services now support `konghq.com/override` (for attaching
+  KongIngress resources).
+  [#908](https://github.com/Kong/kubernetes-ingress-controller/pull/908)
+- Added the `konghq.com/snis` Ingress annotation. This populates SNI
+  configuration on the routes derived from the annotated Ingress.
+  [#863](https://github.com/Kong/kubernetes-ingress-controller/pull/863)
+
+#### Fixed
+
+- The controller now correctly prints the affected Service name when logging
+  warnings about Services without any endpoints.
+  [#915](https://github.com/Kong/kubernetes-ingress-controller/pull/915)
+- Credentials that lack critical fields no longer result in a panic.
+  [#944](https://github.com/Kong/kubernetes-ingress-controller/pull/944)
 
 ## [1.0.0] - 2020/10/05
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY?=kong-docker-kubernetes-ingress-controller.bintray.io
-TAG?=1.0.0
+TAG?=1.1.0
 REPO_INFO=$(shell git config --get remote.origin.url)
 IMGNAME?=kong-ingress-controller
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -102,7 +102,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: webhook

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -698,7 +698,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -693,7 +693,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -767,7 +767,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -711,7 +711,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0
+        image: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Releases 1.1.0 to next. Bumps manifest controller version and Makefile version; updates changelog.

**Special notes for your reviewer**:
This is predicated on both #975 and #863.

This includes both release changes and a merge from main to next, to incorporate the doc migration changes and Enterprise default tag update that occurred after the last merge. #863 will further need a rebase after that and another round of manifest regeneration, so drafting this for now.