### PR TITLE
Retrieve ports for rules that use ExternalName Services

### DIFF
--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -154,6 +154,16 @@ func tcpIngressToNetworkingTLS(tls []configurationv1beta1.IngressTLS) []networki
 func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServicePort, error) {
 	switch wantPort.Mode {
 	case kongstate.PortModeByNumber:
+		// ExternalName Services have no port declaration of their own
+		// We must assume that the user-requested port is valid and construct a ServicePort from it
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			servicePort := corev1.ServicePort{
+				Protocol:   "TCP",
+				Port:       wantPort.Number,
+				TargetPort: intstr.FromInt(int(wantPort.Number)),
+			}
+			return &servicePort, nil
+		}
 		for _, port := range svc.Spec.Ports {
 			if port.Port == wantPort.Number {
 				return &port, nil
@@ -161,6 +171,9 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 		}
 
 	case kongstate.PortModeByName:
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			return nil, fmt.Errorf("rules with an ExternalName service must specify numeric ports")
+		}
 		for _, port := range svc.Spec.Ports {
 			if port.Name == wantPort.Name {
 				return &port, nil
@@ -171,6 +184,9 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 		}
 
 	case kongstate.PortModeImplicit:
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			return nil, fmt.Errorf("rules with an ExternalName service must specify numeric ports")
+		}
 		if len(svc.Spec.Ports) != 1 {
 			return nil, fmt.Errorf("in implicit mode, service must have exactly 1 port, has %d", len(svc.Spec.Ports))
 		}

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -157,12 +157,11 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 		// ExternalName Services have no port declaration of their own
 		// We must assume that the user-requested port is valid and construct a ServicePort from it
 		if svc.Spec.Type == corev1.ServiceTypeExternalName {
-			servicePort := corev1.ServicePort{
+			return &corev1.ServicePort{
 				Protocol:   "TCP",
 				Port:       wantPort.Number,
 				TargetPort: intstr.FromInt(int(wantPort.Number)),
-			}
-			return &servicePort, nil
+			}, nil
 		}
 		for _, port := range svc.Spec.Ports {
 			if port.Port == wantPort.Number {

--- a/internal/ingress/controller/parser/parser.go
+++ b/internal/ingress/controller/parser/parser.go
@@ -158,7 +158,6 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 		// We must assume that the user-requested port is valid and construct a ServicePort from it
 		if svc.Spec.Type == corev1.ServiceTypeExternalName {
 			return &corev1.ServicePort{
-				Protocol:   "TCP",
 				Port:       wantPort.Number,
 				TargetPort: intstr.FromInt(int(wantPort.Number)),
 			}, nil

--- a/test/integration/cases/08-externalname/ingress.yaml
+++ b/test/integration/cases/08-externalname/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fake-external
+  annotations:
+    kubernetes.io/ingress.class: kong
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: fake-external
+            port:
+              number: 8080
+        path: /foo
+        pathType: Prefix
+---
+# Test that we can create configuration from ExternalName Services
+# Uses a K8S hostname as a pretend external hostname to avoid actual external test dependencies
+apiVersion: v1
+kind: Service
+metadata:
+  name: fake-external
+spec:
+  type: ExternalName
+  externalName: echo.default.svc

--- a/test/integration/cases/08-externalname/verify.sh
+++ b/test/integration/cases/08-externalname/verify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+[ "$(curl -sw '%{http_code}' -o /dev/null http://$SUT_HTTP_HOST/foo)" == 200 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
ExternalName Services have no ports of their own. They only receive ports when combined with an Ingress rule that specifies them.

`findPort()` currently returns an error if no port is available on the Service. ExternalName Services will thus [always return the no port error](https://github.com/Kong/kubernetes-ingress-controller/blob/1.1.0/internal/ingress/controller/parser/parser.go#L183).

This change adds the [0.8 logic for ExternalName Services](https://github.com/Kong/kubernetes-ingress-controller/blob/0.8.0/internal/ingress/controller/parser/parser.go#L1447-L1450) to `findPort()`, which just builds a ServicePort from the requested port. It returns errors from the non-numeric port cases indicating that they are not valid for ExternalNames.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #984 
