### PR TITLE
feat(*) disable KongClusterPlugins if unavailable

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/store"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/utils"
+	configuration "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	configclientv1 "github.com/kong/kubernetes-ingress-controller/pkg/client/configuration/clientset/versioned"
 	configinformer "github.com/kong/kubernetes-ingress-controller/pkg/client/configuration/informers/externalversions"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -413,10 +414,22 @@ func main() {
 	cacheStores.Plugin = kongPluginInformer.GetStore()
 	informers = append(informers, kongPluginInformer)
 
-	kongClusterPluginInformer := kongInformerFactory.Configuration().V1().KongClusterPlugins().Informer()
-	kongClusterPluginInformer.AddEventHandler(reh)
-	cacheStores.ClusterPlugin = kongClusterPluginInformer.GetStore()
-	informers = append(informers, kongClusterPluginInformer)
+	supportedKongResources, _ := kubeClient.Discovery().ServerResourcesForGroupVersion(
+		configuration.SchemeGroupVersion.String())
+	hasKongClusterPlugin := false
+	for _, resource := range supportedKongResources.APIResources {
+		if resource.Kind == "KongClusterPlugin" {
+			hasKongClusterPlugin = true
+			break
+		}
+	}
+
+	if hasKongClusterPlugin {
+		kongClusterPluginInformer := kongInformerFactory.Configuration().V1().KongClusterPlugins().Informer()
+		kongClusterPluginInformer.AddEventHandler(reh)
+		cacheStores.ClusterPlugin = kongClusterPluginInformer.GetStore()
+		informers = append(informers, kongClusterPluginInformer)
+	}
 
 	kongConsumerInformer := kongInformerFactory.Configuration().V1().KongConsumers().Informer()
 	kongConsumerInformer.AddEventHandler(reh)

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -414,7 +414,7 @@ func main() {
 	cacheStores.Plugin = kongPluginInformer.GetStore()
 	informers = append(informers, kongPluginInformer)
 
-	hasKongClusterPlugin, _ := utils.ServerHasGVK(kubeClient.Discovery(),
+	hasKongClusterPlugin, err := utils.ServerHasGVK(kubeClient.Discovery(),
 		configuration.SchemeGroupVersion.String(), "KongClusterPlugin")
 
 	if hasKongClusterPlugin {
@@ -423,6 +423,9 @@ func main() {
 		cacheStores.ClusterPlugin = kongClusterPluginInformer.GetStore()
 		informers = append(informers, kongClusterPluginInformer)
 	} else {
+		if err != nil {
+			log.Fatalf("failed to retrieve KongClusterPlugin availability: %s", err)
+		}
 		log.Warn("KongClusterPlugin CRD not detected. Disabling KongClusterPlugin functionality.")
 		cacheStores.ClusterPlugin = newEmptyStore()
 	}

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -286,12 +286,15 @@ func (s Store) GetKongPlugin(namespace, name string) (*configurationv1.KongPlugi
 
 // GetKongClusterPlugin returns the 'name' KongClusterPlugin resource.
 func (s Store) GetKongClusterPlugin(name string) (*configurationv1.KongClusterPlugin, error) {
+	if s.stores.ClusterPlugin == nil {
+		return nil, ErrNotFound{fmt.Sprintf("KongClusterPlugins are not enabled")}
+	}
 	p, exists, err := s.stores.ClusterPlugin.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongClusterPluign %v not found", name)}
+		return nil, ErrNotFound{fmt.Sprintf("KongClusterPlugin %v not found", name)}
 	}
 	return p.(*configurationv1.KongClusterPlugin), nil
 }
@@ -367,8 +370,12 @@ func (s Store) ListGlobalKongPlugins() ([]*configurationv1.KongPlugin, error) {
 // filtered by the ingress.class annotation and with the
 // label global:"true".
 func (s Store) ListGlobalKongClusterPlugins() ([]*configurationv1.KongClusterPlugin, error) {
-
 	var plugins []*configurationv1.KongClusterPlugin
+	if s.stores.ClusterPlugin == nil {
+		// if there is no store, this feature is disabled, and the result is always empty
+		return plugins, nil
+	}
+
 	req, err := labels.NewRequirement("global", selection.Equals, []string{"true"})
 	if err != nil {
 		return nil, err

--- a/internal/ingress/store/store.go
+++ b/internal/ingress/store/store.go
@@ -286,9 +286,6 @@ func (s Store) GetKongPlugin(namespace, name string) (*configurationv1.KongPlugi
 
 // GetKongClusterPlugin returns the 'name' KongClusterPlugin resource.
 func (s Store) GetKongClusterPlugin(name string) (*configurationv1.KongClusterPlugin, error) {
-	if s.stores.ClusterPlugin == nil {
-		return nil, ErrNotFound{fmt.Sprintf("KongClusterPlugins are not enabled")}
-	}
 	p, exists, err := s.stores.ClusterPlugin.GetByKey(name)
 	if err != nil {
 		return nil, err
@@ -371,10 +368,6 @@ func (s Store) ListGlobalKongPlugins() ([]*configurationv1.KongPlugin, error) {
 // label global:"true".
 func (s Store) ListGlobalKongClusterPlugins() ([]*configurationv1.KongClusterPlugin, error) {
 	var plugins []*configurationv1.KongClusterPlugin
-	if s.stores.ClusterPlugin == nil {
-		// if there is no store, this feature is disabled, and the result is always empty
-		return plugins, nil
-	}
 
 	req, err := labels.NewRequirement("global", selection.Equals, []string{"true"})
 	if err != nil {

--- a/internal/ingress/utils/ingressapi.go
+++ b/internal/ingress/utils/ingressapi.go
@@ -30,8 +30,8 @@ func (ia IngressAPI) String() string {
 	return "unknown API"
 }
 
-// serverHasGVK returns true iff the Kubernetes API server supports the given resource kind at the given group-version.
-func serverHasGVK(client discovery.ServerResourcesInterface, groupVersion, kind string) (bool, error) {
+// ServerHasGVK returns true iff the Kubernetes API server supports the given resource kind at the given group-version.
+func ServerHasGVK(client discovery.ServerResourcesInterface, groupVersion, kind string) (bool, error) {
 	list, err := client.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
 		return false, err
@@ -48,7 +48,7 @@ func serverHasGVK(client discovery.ServerResourcesInterface, groupVersion, kind 
 func NegotiateResourceAPI(client discovery.ServerResourcesInterface, kind string, allowedVersions []IngressAPI,
 ) (IngressAPI, error) {
 	for _, candidate := range allowedVersions {
-		if ok, err := serverHasGVK(client, candidate.String(), kind); err != nil {
+		if ok, err := ServerHasGVK(client, candidate.String(), kind); err != nil {
 			return OtherAPI, err
 		} else if ok {
 			return candidate, nil

--- a/internal/ingress/utils/ingressapi_test.go
+++ b/internal/ingress/utils/ingressapi_test.go
@@ -88,13 +88,13 @@ func TestServerHasGVK(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotResult, gotErr := serverHasGVK(tt.client, tt.groupVersion, tt.kind)
+			gotResult, gotErr := ServerHasGVK(tt.client, tt.groupVersion, tt.kind)
 
 			if gotResult != tt.wantResult {
-				t.Errorf("serverHasGVK result: got %t, want %t", gotResult, tt.wantResult)
+				t.Errorf("ServerHasGVK result: got %t, want %t", gotResult, tt.wantResult)
 			}
 			if (gotErr != nil) != tt.wantErr {
-				t.Errorf("serverHasGVK: got error: %v, wanted error? %t", gotErr, tt.wantErr)
+				t.Errorf("ServerHasGVK: got error: %v, wanted error? %t", gotErr, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Check if KongClusterPlugins are available from the API Server. If not, do not create their informer or store, and handle the store's absence elsewhere:
- When getting a specific plugin, return a not found error. This is equivalent to existing behavior when no KongClusterPlugin with that name is found; we just now assume that no such KongClusterPlugin exists because we know no KongClusterPlugins exist.
- When listing global plugins, silently return an empty list.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #717

**Special notes for your reviewer**:
We only want the above no-ops if the resource isn't available, though it doesn't appear that there's a great way to determine this. client-go doesn't appear to offer any means to check if an individual resource is supported. Listing everything in `configuration.konghq.com/v1` and searching it exhaustively works, though it feels a bit ham-fisted, even if we don't expect the list to be large and only need to search once.

Alternatives would be to make this an explicit flag or rely on something else. We can kinda assume that specifying `--watch-namespace` means you won't be using KongClusterPlugins, though that's not immediately obvious to users.