### PR TITLE
remove Get started about Helm 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ $ kubectl apply -f https://bit.ly/k4k8s
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
-
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove about Helm v2 in README.md due to Helm v2 Deprecation.
After November 13, 2020,No further Helm v2 releases.

[ref. helm-v2-deprecation-timeline](https://helm.sh/blog/helm-v2-deprecation-timeline/)
