### PR TITLE
Prune extra subresource block in TCPIngress CRD

### DIFF
--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -379,8 +379,6 @@ spec:
     type: date
     description: Age
     JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/hack/dev/common/custom-types.yaml
+++ b/hack/dev/common/custom-types.yaml
@@ -379,8 +379,6 @@ spec:
     type: date
     description: Age
     JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
TCPIngress already had a subresource block with status when it was originally added. I added an extra one when updating the other resources.

No functional change at the moment since manifest generation de-duplicates and sorts fields already, but would become an issue if we added additional subresources later and they got out of sync.

**Special notes for your reviewer**:
Thanks to @slacksach for pointing out the issue.