### PR TITLE
Use rule order-invariant names for routes

### DIFF
--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1066,7 +1066,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.bar.00"),
+			Name:          kong.String("default.bar.3419939762"),
 			StripPath:     kong.Bool(true),
 			Hosts:         kong.StringSlice("example.com"),
 			PreserveHost:  kong.Bool(true),
@@ -1143,7 +1143,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.bar.00"),
+			Name:          kong.String("default.bar.3419939762"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
 			PreserveHost:  kong.Bool(true),
@@ -1221,7 +1221,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:                    kong.String("default.bar.00"),
+				Name:                    kong.String("default.bar.3419939762"),
 				StripPath:               kong.Bool(false),
 				HTTPSRedirectStatusCode: kong.Int(301),
 				Hosts:                   kong.StringSlice("example.com"),
@@ -1300,7 +1300,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
 				PreserveHost:  kong.Bool(true),
@@ -1378,7 +1378,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
 				PreserveHost:  kong.Bool(false),
@@ -1456,7 +1456,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
 				PreserveHost:  kong.Bool(true),
@@ -1534,7 +1534,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(10),
 				Hosts:         kong.StringSlice("example.com"),
@@ -1612,7 +1612,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(0),
 				Hosts:         kong.StringSlice("example.com"),
@@ -2064,7 +2064,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		assert.Equal(1, len(svc.Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
-			Name:          kong.String("foo-ns.knative-ingress.00"),
+			Name:          kong.String("foo-ns.knative-ingress.1231748600"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("my-func.example.com"),
 			PreserveHost:  kong.Bool(true),
@@ -2160,7 +2160,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.bar.00"),
+			Name:          kong.String("default.bar.3419939762"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
 			PreserveHost:  kong.Bool(true),
@@ -2247,7 +2247,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.bar.00"),
+			Name:          kong.String("default.bar.3419939762"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
 			PreserveHost:  kong.Bool(true),
@@ -2326,7 +2326,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
-				Name:          kong.String("default.bar.00"),
+				Name:          kong.String("default.bar.3419939762"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(0),
 				Hosts:         kong.StringSlice("example.com"),
@@ -2753,7 +2753,7 @@ func TestParserSNI(t *testing.T) {
 		assert.Nil(err)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.foo.00"),
+			Name:          kong.String("default.foo.3419939762"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),
 			Hosts:         kong.StringSlice("example.com"),
@@ -2762,7 +2762,7 @@ func TestParserSNI(t *testing.T) {
 			Protocols:     kong.StringSlice("http", "https"),
 		}, state.Services[0].Routes[0].Route)
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.foo.10"),
+			Name:          kong.String("default.foo.930969884"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),
 			Hosts:         kong.StringSlice("*.example.com"),
@@ -2813,7 +2813,7 @@ func TestParserSNI(t *testing.T) {
 		assert.Nil(err)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
-			Name:          kong.String("default.foo.00"),
+			Name:          kong.String("default.foo.3419939762"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),
 			Hosts:         kong.StringSlice("example.com"),

--- a/internal/ingress/controller/parser/translate_test.go
+++ b/internal/ingress/controller/parser/translate_test.go
@@ -242,6 +242,87 @@ func TestFromIngressV1beta1(t *testing.T) {
 				},
 			},
 		},
+		// 8
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Spec: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1beta1.IngressRuleValue{
+							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+								Paths: []networkingv1beta1.HTTPIngressPath{
+									{
+										Path: "/first",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+									{
+										Path: "/second",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// 9
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Spec: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1beta1.IngressRuleValue{
+							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+								Paths: []networkingv1beta1.HTTPIngressPath{
+									{
+										Path: "/first",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+									{
+										Path: "/inserted",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+									{
+										Path: "/second",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "foo-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	t.Run("no ingress returns empty info", func(t *testing.T) {
@@ -326,6 +407,17 @@ func TestFromIngressV1beta1(t *testing.T) {
 			ingressList[7],
 		})
 		assert.Empty(parsedInfo.ServiceNameToServices)
+	})
+	t.Run("rule order has no effect on route name", func(t *testing.T) {
+		parsedInfoA := fromIngressV1beta1(logrus.New(), []*networkingv1beta1.Ingress{
+			ingressList[8],
+		})
+		parsedInfoB := fromIngressV1beta1(logrus.New(), []*networkingv1beta1.Ingress{
+			ingressList[9],
+		})
+		assert.Equal(
+			parsedInfoA.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[1].Name,
+			parsedInfoB.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[2].Name)
 	})
 }
 
@@ -570,6 +662,97 @@ func TestFromIngressV1(t *testing.T) {
 				},
 			},
 		},
+		// 8
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path: "/first",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+									{
+										Path: "/second",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// 9
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path: "/first",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+									{
+										Path: "/inserted",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+									{
+										Path: "/second",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	t.Run("no ingress returns empty info", func(t *testing.T) {
@@ -655,6 +838,17 @@ func TestFromIngressV1(t *testing.T) {
 		})
 		assert.Empty(parsedInfo.ServiceNameToServices)
 	})
+	t.Run("rule order has no effect on route name", func(t *testing.T) {
+		parsedInfoA := fromIngressV1(logrus.New(), []*networkingv1.Ingress{
+			ingressList[8],
+		})
+		parsedInfoB := fromIngressV1(logrus.New(), []*networkingv1.Ingress{
+			ingressList[9],
+		})
+		assert.Equal(
+			parsedInfoA.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[1].Name,
+			parsedInfoB.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[2].Name)
+	})
 }
 
 func TestFromTCPIngressV1beta1(t *testing.T) {
@@ -729,6 +923,68 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 				},
 			},
 		},
+		// 4
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+			Spec: configurationv1beta1.IngressSpec{
+				Rules: []configurationv1beta1.IngressRule{
+					{
+						Host: "example.com",
+						Port: 9000,
+						Backend: configurationv1beta1.IngressBackend{
+							ServiceName: "foo-svc",
+							ServicePort: 80,
+						},
+					},
+					{
+						Host: "example.com",
+						Port: 9002,
+						Backend: configurationv1beta1.IngressBackend{
+							ServiceName: "foo-svc",
+							ServicePort: 80,
+						},
+					},
+				},
+			},
+		},
+		// 5
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+			Spec: configurationv1beta1.IngressSpec{
+				Rules: []configurationv1beta1.IngressRule{
+					{
+						Host: "example.com",
+						Port: 9000,
+						Backend: configurationv1beta1.IngressBackend{
+							ServiceName: "foo-svc",
+							ServicePort: 80,
+						},
+					},
+					{
+						Host: "example.com",
+						Port: 9001,
+						Backend: configurationv1beta1.IngressBackend{
+							ServiceName: "foo-svc",
+							ServicePort: 80,
+						},
+					},
+					{
+						Host: "example.com",
+						Port: 9002,
+						Backend: configurationv1beta1.IngressBackend{
+							ServiceName: "foo-svc",
+							ServicePort: 80,
+						},
+					},
+				},
+			},
+		},
 	}
 	t.Run("no TCPIngress returns empty info", func(t *testing.T) {
 		parsedInfo := fromTCPIngressV1beta1(logrus.New(), []*configurationv1beta1.TCPIngress{})
@@ -755,7 +1011,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		assert.Equal(1, len(svc.Routes))
 		route := svc.Routes[0]
 		assert.Equal(kong.Route{
-			Name:      kong.String("default.foo.0"),
+			Name:      kong.String("default.foo.1905495032"),
 			Protocols: kong.StringSlice("tcp", "tls"),
 			Destinations: []*kong.CIDRPort{
 				{
@@ -775,7 +1031,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		assert.Equal(1, len(svc.Routes))
 		route := svc.Routes[0]
 		assert.Equal(kong.Route{
-			Name:      kong.String("default.foo.0"),
+			Name:      kong.String("default.foo.2814129580"),
 			Protocols: kong.StringSlice("tcp", "tls"),
 			SNIs:      kong.StringSlice("example.com"),
 			Destinations: []*kong.CIDRPort{
@@ -790,6 +1046,13 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["default/sooper-secret"]))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["default/sooper-secret2"]))
+	})
+	t.Run("rule order has no effect on route name", func(t *testing.T) {
+		parsedInfoA := fromTCPIngressV1beta1(logrus.New(), []*configurationv1beta1.TCPIngress{tcpIngressList[4]})
+		parsedInfoB := fromTCPIngressV1beta1(logrus.New(), []*configurationv1beta1.TCPIngress{tcpIngressList[5]})
+		assert.Equal(
+			parsedInfoA.ServiceNameToServices["default.foo-svc.80"].Routes[1].Name,
+			parsedInfoB.ServiceNameToServices["default.foo-svc.80"].Routes[2].Name)
 	})
 }
 
@@ -942,6 +1205,122 @@ func TestFromKnativeIngress(t *testing.T) {
 				},
 			},
 		},
+		// 4
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+			},
+			Spec: knative.IngressSpec{
+				Rules: []knative.IngressRule{
+					{
+						Hosts: []string{"my-func.example.com"},
+						HTTP: &knative.HTTPIngressRuleValue{
+							Paths: []knative.HTTPIngressPath{
+								{
+									Path: "/first",
+									AppendHeaders: map[string]string{
+										"foo": "bar",
+									},
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceNamespace: "foo-ns",
+												ServiceName:      "foo-svc",
+												ServicePort:      intstr.FromInt(42),
+											},
+											Percent: 100,
+										},
+									},
+								},
+								{
+									Path: "/second",
+									AppendHeaders: map[string]string{
+										"foo": "bar",
+									},
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceNamespace: "foo-ns",
+												ServiceName:      "foo-svc",
+												ServicePort:      intstr.FromInt(42),
+											},
+											Percent: 100,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// 5
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo-namespace",
+			},
+			Spec: knative.IngressSpec{
+				Rules: []knative.IngressRule{
+					{
+						Hosts: []string{"my-func.example.com"},
+						HTTP: &knative.HTTPIngressRuleValue{
+							Paths: []knative.HTTPIngressPath{
+								{
+									Path: "/first",
+									AppendHeaders: map[string]string{
+										"foo": "bar",
+									},
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceNamespace: "foo-ns",
+												ServiceName:      "foo-svc",
+												ServicePort:      intstr.FromInt(42),
+											},
+											Percent: 100,
+										},
+									},
+								},
+								{
+									Path: "/inserted",
+									AppendHeaders: map[string]string{
+										"foo": "bar",
+									},
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceNamespace: "foo-ns",
+												ServiceName:      "foo-svc",
+												ServicePort:      intstr.FromInt(42),
+											},
+											Percent: 100,
+										},
+									},
+								},
+								{
+									Path: "/second",
+									AppendHeaders: map[string]string{
+										"foo": "bar",
+									},
+									Splits: []knative.IngressBackendSplit{
+										{
+											IngressBackend: knative.IngressBackend{
+												ServiceNamespace: "foo-ns",
+												ServiceName:      "foo-svc",
+												ServicePort:      intstr.FromInt(42),
+											},
+											Percent: 100,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	t.Run("no ingress returns empty info", func(t *testing.T) {
 		parsedInfo := fromKnativeIngress(logrus.New(), []*knative.Ingress{})
@@ -969,7 +1348,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			Retries:        kong.Int(5),
 		}, svc.Service)
 		assert.Equal(kong.Route{
-			Name:          kong.String("foo-namespace.foo.00"),
+			Name:          kong.String("foo-namespace.foo.1231748600"),
 			RegexPriority: kong.Int(0),
 			StripPath:     kong.Bool(false),
 			Paths:         kong.StringSlice("/"),
@@ -1012,7 +1391,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			Retries:        kong.Int(5),
 		}, svc.Service)
 		assert.Equal(kong.Route{
-			Name:          kong.String("foo-namespace.foo.00"),
+			Name:          kong.String("foo-namespace.foo.1231748600"),
 			RegexPriority: kong.Int(0),
 			StripPath:     kong.Bool(false),
 			Paths:         kong.StringSlice("/"),
@@ -1030,6 +1409,13 @@ func TestFromKnativeIngress(t *testing.T) {
 		}, svc.Plugins[0])
 
 		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+	})
+	t.Run("rule order has no effect on route name", func(t *testing.T) {
+		parsedInfoA := fromKnativeIngress(logrus.New(), []*knative.Ingress{ingressList[4]})
+		parsedInfoB := fromKnativeIngress(logrus.New(), []*knative.Ingress{ingressList[5]})
+		assert.Equal(
+			parsedInfoA.ServiceNameToServices["foo-ns.foo-svc.42"].Routes[1].Name,
+			parsedInfoB.ServiceNameToServices["foo-ns.foo-svc.42"].Routes[2].Name)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces order-based name suffix for an Ingress' routes with a checksum suffix based on the rule host and paths. This guarantees a consistent route name regardless of changes to the rule order in an Ingress. Similar changes for Knative Ingresses and TCPIngresses.

**Which issue this PR fixes**:
fixes #834

**Special notes for your reviewer**:
This annoyingly makes tests that include rule names (parser tests that compare complete objects) more difficult to write, as the names are no longer easily predictable. We do at least reuse the same host+paths set often for those tests, so copy-pasta usually works. If not, you're basically stuck with entering garbage first, checking the failure, and correcting the name to match it (or computing the CRC32 elsewhere).

That said, I don't think there's an obvious implementation choice that will produce easily predictable, order invariant, and short suffixes.

Per comments in the issue, these suffixes are also not useful for mapping routes to individual rules in the Ingress definition, and are more for ensuring consistent naming in reporting tools. However, there shouldn't be any issue inferring the rule in question by reviewing the route's host and path configuration.