### PR TITLE
Deterministically generate IDs from Ingress rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/eapache/channels v1.1.0
 	github.com/fatih/color v1.9.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-memdb v1.2.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/kong/deck v1.2.1

--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/annotations"
 	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller/parser/util"
@@ -28,6 +29,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 
 	// build consumer index
 	for _, kConsumer := range s.ListKongConsumers() {
+		computedConsumerID := uuid.NewSHA1(util.ControllerNamespace, []byte(kConsumer.Namespace+"/"+kConsumer.Name)).String()
 		var c Consumer
 		if kConsumer.Username == "" && kConsumer.CustomID == "" {
 			continue
@@ -39,6 +41,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 			c.CustomID = kong.String(kConsumer.CustomID)
 		}
 		c.K8sKongConsumer = *kConsumer
+		c.ID = kong.String(computedConsumerID)
 
 		log = log.WithFields(logrus.Fields{
 			"kongconsumer_name":      kConsumer.Name,

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1052,6 +1052,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
 		assert.Equal(kong.Service{
+			ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 			Name:           kong.String("default.foo-svc.80"),
 			Host:           kong.String("foo-svc.default.80.svc"),
 			Path:           kong.String("/"),
@@ -1130,6 +1131,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
 		assert.Equal(kong.Service{
+			ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 			Name:           kong.String("default.foo-svc.80"),
 			Host:           kong.String("foo-svc.default.80.svc"),
 			Path:           kong.String("/"),
@@ -1209,6 +1211,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -1289,6 +1292,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -1368,6 +1372,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -1447,6 +1452,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -1526,6 +1532,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -1605,6 +1612,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),
@@ -2048,6 +2056,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		svc := state.Services[0]
 
 		assert.Equal(kong.Service{
+			ID:             kong.String("311fc829-3976-5bb3-aa12-53029d1c09e7"),
 			Name:           kong.String("foo-ns.foo-svc.42"),
 			Host:           kong.String("foo-svc.foo-ns.42.svc"),
 			Path:           kong.String("/"),
@@ -2155,6 +2164,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
 		assert.Equal(kong.Service{
+			ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 			Name:           kong.String("default.foo-svc.80"),
 			Host:           kong.String("foo-svc.default.80.svc"),
 			Path:           kong.String("/baz"),
@@ -2236,6 +2246,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
 		assert.Equal(kong.Service{
+			ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 			Name:           kong.String("default.foo-svc.80"),
 			Host:           kong.String("foo-svc.default.80.svc"),
 			Path:           kong.String("/"),
@@ -2323,6 +2334,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services),
 				"expected one service to be rendered")
 			assert.Equal(kong.Service{
+				ID:             kong.String("0d31a75d-ddb3-5ded-b5da-98a23a7ef809"),
 				Name:           kong.String("default.foo-svc.80"),
 				Host:           kong.String("foo-svc.default.80.svc"),
 				Path:           kong.String("/"),

--- a/internal/ingress/controller/parser/parser_test.go
+++ b/internal/ingress/controller/parser/parser_test.go
@@ -1066,6 +1066,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
+			ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 			Name:          kong.String("default.bar.00"),
 			StripPath:     kong.Bool(true),
 			Hosts:         kong.StringSlice("example.com"),
@@ -1143,6 +1144,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
+			ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 			Name:          kong.String("default.bar.00"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
@@ -1221,6 +1223,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:                      kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:                    kong.String("default.bar.00"),
 				StripPath:               kong.Bool(false),
 				HTTPSRedirectStatusCode: kong.Int(301),
@@ -1300,6 +1303,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
@@ -1378,6 +1382,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
@@ -1456,6 +1461,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				Hosts:         kong.StringSlice("example.com"),
@@ -1534,6 +1540,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(10),
@@ -1612,6 +1619,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(0),
@@ -2064,6 +2072,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		assert.Equal(1, len(svc.Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
+			ID:            kong.String("41377089-4ddf-53ee-af01-eaaf5844e84d"),
 			Name:          kong.String("foo-ns.knative-ingress.00"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("my-func.example.com"),
@@ -2160,6 +2169,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
+			ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 			Name:          kong.String("default.bar.00"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
@@ -2247,6 +2257,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		assert.Equal(1, len(state.Services[0].Routes),
 			"expected one route to be rendered")
 		assert.Equal(kong.Route{
+			ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 			Name:          kong.String("default.bar.00"),
 			StripPath:     kong.Bool(false),
 			Hosts:         kong.StringSlice("example.com"),
@@ -2326,6 +2337,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			assert.Equal(1, len(state.Services[0].Routes),
 				"expected one route to be rendered")
 			assert.Equal(kong.Route{
+				ID:            kong.String("bbee3ffe-804e-5638-b947-401931c8c76a"),
 				Name:          kong.String("default.bar.00"),
 				StripPath:     kong.Bool(false),
 				RegexPriority: kong.Int(0),
@@ -2753,6 +2765,7 @@ func TestParserSNI(t *testing.T) {
 		assert.Nil(err)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
+			ID:            kong.String("2d079b4f-daf5-5aa5-8144-602c1544a685"),
 			Name:          kong.String("default.foo.00"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),
@@ -2762,6 +2775,7 @@ func TestParserSNI(t *testing.T) {
 			Protocols:     kong.StringSlice("http", "https"),
 		}, state.Services[0].Routes[0].Route)
 		assert.Equal(kong.Route{
+			ID:            kong.String("0be5a335-b654-5e32-be6e-e27f5cebb0d6"),
 			Name:          kong.String("default.foo.10"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),
@@ -2813,6 +2827,7 @@ func TestParserSNI(t *testing.T) {
 		assert.Nil(err)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
+			ID:            kong.String("2d079b4f-daf5-5aa5-8144-602c1544a685"),
 			Name:          kong.String("default.foo.00"),
 			StripPath:     kong.Bool(false),
 			RegexPriority: kong.Int(0),

--- a/internal/ingress/controller/parser/translate.go
+++ b/internal/ingress/controller/parser/translate.go
@@ -61,7 +61,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 				if path == "" {
 					path = "/"
 				}
-				computedID := uuid.NewSHA1(ingressNamespace, []byte(host+path)).String()
+				computedRouteID := uuid.NewSHA1(ingressNamespace, []byte(host+path)).String()
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),
 					Route: kong.Route{
@@ -73,7 +73,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 						// 2. Is it guaranteed that the order is stable?
 						// Meaning, the routes will always appear in the same
 						// order?
-						ID:            kong.String(computedID),
+						ID:            kong.String(computedRouteID),
 						Name:          kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
 						Paths:         kong.StringSlice(path),
 						StripPath:     kong.Bool(false),
@@ -92,8 +92,10 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 					rule.Backend.ServicePort.String()
 				service, ok := result.ServiceNameToServices[serviceName]
 				if !ok {
+					computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
 					service = kongstate.Service{
 						Service: kong.Service{
+							ID:   kong.String(computedServiceID),
 							Name: kong.String(serviceName),
 							Host: kong.String(rule.Backend.ServiceName +
 								"." + ingress.Namespace + "." +
@@ -132,8 +134,10 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 			defaultBackend.ServicePort.String()
 		service, ok := result.ServiceNameToServices[serviceName]
 		if !ok {
+			computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
 			service = kongstate.Service{
 				Service: kong.Service{
+					ID:   kong.String(computedServiceID),
 					Name: kong.String(serviceName),
 					Host: kong.String(defaultBackend.ServiceName + "." +
 						ingress.Namespace + "." +
@@ -219,7 +223,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 				for _, path := range paths {
 					pathsDeref = append(pathsDeref, *path)
 				}
-				computedID := uuid.NewSHA1(ingressNamespace, []byte(rule.Host+strings.Join(pathsDeref, ","))).String()
+				computedRouteID := uuid.NewSHA1(ingressNamespace, []byte(rule.Host+strings.Join(pathsDeref, ","))).String()
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),
 					Route: kong.Route{
@@ -231,7 +235,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 						// 2. Is it guaranteed that the order is stable?
 						// Meaning, the routes will always appear in the same
 						// order?
-						ID:            kong.String(computedID),
+						ID:            kong.String(computedRouteID),
 						Name:          kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
 						Paths:         paths,
 						StripPath:     kong.Bool(false),
@@ -249,8 +253,10 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 					rulePath.Backend.Service.Port.Number)
 				service, ok := result.ServiceNameToServices[serviceName]
 				if !ok {
+					computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
 					service = kongstate.Service{
 						Service: kong.Service{
+							ID:   kong.String(computedServiceID),
 							Name: kong.String(serviceName),
 							Host: kong.String(fmt.Sprintf("%s.%s.%s.svc", rulePath.Backend.Service.Name, ingress.Namespace,
 								port.CanonicalString())),
@@ -288,8 +294,10 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 			port.CanonicalString())
 		service, ok := result.ServiceNameToServices[serviceName]
 		if !ok {
+			computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
 			service = kongstate.Service{
 				Service: kong.Service{
+					ID:   kong.String(computedServiceID),
 					Name: kong.String(serviceName),
 					Host: kong.String(fmt.Sprintf("%s.%s.%d.svc", defaultBackend.Service.Name, ingress.Namespace,
 						defaultBackend.Service.Port.Number)),
@@ -351,7 +359,7 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 				log.Errorf("invalid TCPIngress: invalid port: %v", rule.Port)
 				continue
 			}
-			computedID := uuid.NewSHA1(ingressNamespace, []byte(rule.Host+strconv.Itoa(rule.Port))).String()
+			computedRouteID := uuid.NewSHA1(ingressNamespace, []byte(rule.Host+strconv.Itoa(rule.Port))).String()
 			r := kongstate.Route{
 				Ingress: util.FromK8sObject(ingress),
 				Route: kong.Route{
@@ -363,7 +371,7 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 					// 2. Is it guaranteed that the order is stable?
 					// Meaning, the routes will always appear in the same
 					// order?
-					ID:        kong.String(computedID),
+					ID:        kong.String(computedRouteID),
 					Name:      kong.String(ingress.Namespace + "." + ingress.Name + "." + strconv.Itoa(i)),
 					Protocols: kong.StringSlice("tcp", "tls"),
 					Destinations: []*kong.CIDRPort{
@@ -389,8 +397,10 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 			serviceName := fmt.Sprintf("%s.%s.%d", ingress.Namespace, rule.Backend.ServiceName, rule.Backend.ServicePort)
 			service, ok := result.ServiceNameToServices[serviceName]
 			if !ok {
+				computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
 				service = kongstate.Service{
 					Service: kong.Service{
+						ID:   kong.String(computedServiceID),
 						Name: kong.String(serviceName),
 						Host: kong.String(fmt.Sprintf("%s.%s.%d.svc", rule.Backend.ServiceName, ingress.Namespace,
 							rule.Backend.ServicePort)),
@@ -449,7 +459,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 				if path == "" {
 					path = "/"
 				}
-				computedID := uuid.NewSHA1(ingressNamespace, []byte(strings.Join(hosts, ",")+path)).String()
+				computedRouteID := uuid.NewSHA1(ingressNamespace, []byte(strings.Join(hosts, ",")+path)).String()
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),
 					Route: kong.Route{
@@ -461,7 +471,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 						// 2. Is it guaranteed that the order is stable?
 						// Meaning, the routes will always appear in the same
 						// order?
-						ID:            kong.String(computedID),
+						ID:            kong.String(computedRouteID),
 						Name:          kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
 						Paths:         kong.StringSlice(path),
 						StripPath:     kong.Bool(false),
@@ -479,6 +489,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 					knativeBackend.ServicePort.String())
 				service, ok := services[serviceName]
 				if !ok {
+					computedServiceID := uuid.NewSHA1(ingressNamespace, []byte(serviceName)).String()
 
 					var headers []string
 					for key, value := range knativeBackend.AppendHeaders {
@@ -490,6 +501,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 
 					service = kongstate.Service{
 						Service: kong.Service{
+							ID:             kong.String(computedServiceID),
 							Name:           kong.String(serviceName),
 							Host:           kong.String(serviceHost),
 							Port:           kong.Int(80),

--- a/internal/ingress/controller/parser/translate.go
+++ b/internal/ingress/controller/parser/translate.go
@@ -18,10 +18,6 @@ import (
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
 )
 
-var (
-	controllerNamespace, _ = uuid.Parse("a7640ba5-73a3-4816-a497-047ac54d7a24")
-)
-
 func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1.Ingress) ingressRules {
 	result := newIngressRules()
 
@@ -38,7 +34,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 			"ingress_name":      ingress.Name,
 		})
 
-		ingressNamespace := uuid.NewSHA1(controllerNamespace, []byte(ingress.Namespace+ingress.Name))
+		ingressNamespace := uuid.NewSHA1(util.ControllerNamespace, []byte(ingress.Namespace+ingress.Name))
 
 		if ingressSpec.Backend != nil {
 			allDefaultBackends = append(allDefaultBackends, *ingress)
@@ -92,7 +88,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 					rule.Backend.ServicePort.String()
 				service, ok := result.ServiceNameToServices[serviceName]
 				if !ok {
-					computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
+					computedServiceID := uuid.NewSHA1(util.ControllerNamespace, []byte(serviceName)).String()
 					service = kongstate.Service{
 						Service: kong.Service{
 							ID:   kong.String(computedServiceID),
@@ -134,7 +130,7 @@ func fromIngressV1beta1(log logrus.FieldLogger, ingressList []*networkingv1beta1
 			defaultBackend.ServicePort.String()
 		service, ok := result.ServiceNameToServices[serviceName]
 		if !ok {
-			computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
+			computedServiceID := uuid.NewSHA1(util.ControllerNamespace, []byte(serviceName)).String()
 			service = kongstate.Service{
 				Service: kong.Service{
 					ID:   kong.String(computedServiceID),
@@ -190,7 +186,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 			"ingress_name":      ingress.Name,
 		})
 
-		ingressNamespace := uuid.NewSHA1(controllerNamespace, []byte(ingress.Namespace+ingress.Name))
+		ingressNamespace := uuid.NewSHA1(util.ControllerNamespace, []byte(ingress.Namespace+ingress.Name))
 
 		if ingressSpec.DefaultBackend != nil {
 			allDefaultBackends = append(allDefaultBackends, *ingress)
@@ -253,7 +249,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 					rulePath.Backend.Service.Port.Number)
 				service, ok := result.ServiceNameToServices[serviceName]
 				if !ok {
-					computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
+					computedServiceID := uuid.NewSHA1(util.ControllerNamespace, []byte(serviceName)).String()
 					service = kongstate.Service{
 						Service: kong.Service{
 							ID:   kong.String(computedServiceID),
@@ -294,7 +290,7 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 			port.CanonicalString())
 		service, ok := result.ServiceNameToServices[serviceName]
 		if !ok {
-			computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
+			computedServiceID := uuid.NewSHA1(util.ControllerNamespace, []byte(serviceName)).String()
 			service = kongstate.Service{
 				Service: kong.Service{
 					ID:   kong.String(computedServiceID),
@@ -349,7 +345,7 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 			"tcpingress_name":      ingress.Name,
 		})
 
-		ingressNamespace := uuid.NewSHA1(controllerNamespace, []byte(ingress.Namespace+ingress.Name))
+		ingressNamespace := uuid.NewSHA1(util.ControllerNamespace, []byte(ingress.Namespace+ingress.Name))
 
 		result.SecretNameToSNIs.addFromIngressV1beta1TLS(tcpIngressToNetworkingTLS(ingressSpec.TLS), ingress.Namespace)
 
@@ -397,7 +393,7 @@ func fromTCPIngressV1beta1(log logrus.FieldLogger, tcpIngressList []*configurati
 			serviceName := fmt.Sprintf("%s.%s.%d", ingress.Namespace, rule.Backend.ServiceName, rule.Backend.ServicePort)
 			service, ok := result.ServiceNameToServices[serviceName]
 			if !ok {
-				computedServiceID := uuid.NewSHA1(controllerNamespace, []byte(serviceName)).String()
+				computedServiceID := uuid.NewSHA1(util.ControllerNamespace, []byte(serviceName)).String()
 				service = kongstate.Service{
 					Service: kong.Service{
 						ID:   kong.String(computedServiceID),
@@ -444,7 +440,7 @@ func fromKnativeIngress(log logrus.FieldLogger, ingressList []*knative.Ingress) 
 
 		ingressSpec := ingress.Spec
 
-		ingressNamespace := uuid.NewSHA1(controllerNamespace, []byte(ingress.Namespace+ingress.Name))
+		ingressNamespace := uuid.NewSHA1(util.ControllerNamespace, []byte(ingress.Namespace+ingress.Name))
 
 		secretToSNIs.addFromIngressV1beta1TLS(knativeIngressToNetworkingTLS(ingress.Spec.TLS), ingress.Namespace)
 

--- a/internal/ingress/controller/parser/translate_test.go
+++ b/internal/ingress/controller/parser/translate_test.go
@@ -755,6 +755,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		assert.Equal(1, len(svc.Routes))
 		route := svc.Routes[0]
 		assert.Equal(kong.Route{
+			ID:        kong.String("bc4b95ad-6a80-5a4e-bf45-49e53768033a"),
 			Name:      kong.String("default.foo.0"),
 			Protocols: kong.StringSlice("tcp", "tls"),
 			Destinations: []*kong.CIDRPort{
@@ -775,6 +776,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		assert.Equal(1, len(svc.Routes))
 		route := svc.Routes[0]
 		assert.Equal(kong.Route{
+			ID:        kong.String("6543a7d8-b590-5a0e-a709-6d65dfc09c01"),
 			Name:      kong.String("default.foo.0"),
 			Protocols: kong.StringSlice("tcp", "tls"),
 			SNIs:      kong.StringSlice("example.com"),
@@ -969,6 +971,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			Retries:        kong.Int(5),
 		}, svc.Service)
 		assert.Equal(kong.Route{
+			ID:            kong.String("58d08247-c7dc-5219-89b8-1fcbc4e9e088"),
 			Name:          kong.String("foo-namespace.foo.00"),
 			RegexPriority: kong.Int(0),
 			StripPath:     kong.Bool(false),
@@ -1012,6 +1015,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			Retries:        kong.Int(5),
 		}, svc.Service)
 		assert.Equal(kong.Route{
+			ID:            kong.String("58d08247-c7dc-5219-89b8-1fcbc4e9e088"),
 			Name:          kong.String("foo-namespace.foo.00"),
 			RegexPriority: kong.Int(0),
 			StripPath:     kong.Bool(false),

--- a/internal/ingress/controller/parser/translate_test.go
+++ b/internal/ingress/controller/parser/translate_test.go
@@ -960,6 +960,7 @@ func TestFromKnativeIngress(t *testing.T) {
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
 		svc := parsedInfo.ServiceNameToServices["foo-ns.foo-svc.42"]
 		assert.Equal(kong.Service{
+			ID:             kong.String("127ace6a-c96b-5a65-9977-5dbe44824f7c"),
 			Name:           kong.String("foo-ns.foo-svc.42"),
 			Port:           kong.Int(80),
 			Host:           kong.String("foo-svc.foo-ns.42.svc"),
@@ -1004,6 +1005,7 @@ func TestFromKnativeIngress(t *testing.T) {
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
 		svc := parsedInfo.ServiceNameToServices["foo-ns.foo-svc.42"]
 		assert.Equal(kong.Service{
+			ID:             kong.String("127ace6a-c96b-5a65-9977-5dbe44824f7c"),
 			Name:           kong.String("foo-ns.foo-svc.42"),
 			Port:           kong.Int(80),
 			Host:           kong.String("foo-svc.foo-ns.42.svc"),

--- a/internal/ingress/controller/parser/util/uuid_namespace.go
+++ b/internal/ingress/controller/parser/util/uuid_namespace.go
@@ -1,0 +1,9 @@
+package util
+
+import (
+	"github.com/google/uuid"
+)
+
+var (
+	ControllerNamespace, _ = uuid.Parse("a7640ba5-73a3-4816-a497-047ac54d7a24")
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Generates route IDs based on Ingress contents.

**Special notes for your reviewer**:
This is a PoC WIP and lacks tests. Tests will be similar to #1003's, i.e. mostly meaningless (but necessary) changes to expected objects for parser tests and a new translate test to confirm that rule order does not affect the ID->route configuration mapping. Route names will still change, but the hostname and path set for a given ID will not.

If this PoC looks good, we'll further add similar logic for Services and KongConsumers.

See https://github.com/Kong/kubernetes-ingress-controller/issues/834#issuecomment-759739025 for some additional overview of the landscape. Main important point is that this change does not affect existing routes for Postgres-backed databases; those will require a reset for the new IDs to appear.