### PR TITLE
 fix(consumer): duplicate ID2 breaking DB-mode

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -292,11 +292,13 @@ func (n *KongController) getIngressControllerTags() []string {
 	return res
 }
 
+const FormatVersion = "1.1"
+
 func (n *KongController) toDeckContent(
 	ctx context.Context,
 	k8sState *kongstate.KongState) *file.Content {
 	var content file.Content
-	content.FormatVersion = "1.1"
+	content.FormatVersion = FormatVersion
 	var err error
 
 	for _, s := range k8sState.Services {
@@ -412,7 +414,7 @@ func (n *KongController) toDeckContent(
 }
 
 func sortByString(slice interface{}, fieldFn func(i int) string) {
-	lessFn := func(i, j int) bool { return strings.Compare(fieldFn(i), fieldFn(j)) > 0 }
+	lessFn := func(i, j int) bool { return strings.Compare(fieldFn(i), fieldFn(j)) < 0 }
 	sort.SliceStable(slice, lessFn)
 }
 

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -395,12 +395,27 @@ func (n *KongController) toDeckContent(
 		for _, p := range c.Plugins {
 			consumer.Plugins = append(consumer.Plugins, &file.FPlugin{Plugin: p})
 		}
-		consumer.KeyAuths = c.KeyAuths
-		consumer.HMACAuths = c.HMACAuths
-		consumer.BasicAuths = c.BasicAuths
-		consumer.JWTAuths = c.JWTAuths
-		consumer.ACLGroups = c.ACLGroups
-		consumer.Oauth2Creds = c.Oauth2Creds
+
+		for k := range c.KeyAuths {
+			consumer.KeyAuths = append(consumer.KeyAuths, c.KeyAuths[k])
+		}
+		sort.SliceStable(consumer.KeyAuths, cmpField(func(i int) string { return *consumer.KeyAuths[i].Key }))
+		for k := range c.HMACAuths {
+			consumer.HMACAuths = append(consumer.HMACAuths, c.HMACAuths[k])
+		}
+		sort.SliceStable(consumer.HMACAuths, cmpField(func(i int) string { return *consumer.HMACAuths[i].Username }))
+		for k := range c.BasicAuths {
+			consumer.BasicAuths = append(consumer.BasicAuths, c.BasicAuths[k])
+		}
+		sort.SliceStable(consumer.BasicAuths, cmpField(func(i int) string { return *consumer.BasicAuths[i].Username }))
+		for k := range c.JWTAuths {
+			consumer.JWTAuths = append(consumer.JWTAuths, c.JWTAuths[k])
+		}
+		sort.SliceStable(consumer.JWTAuths, cmpField(func(i int) string { return *consumer.JWTAuths[i].Key }))
+		for k := range c.Oauth2Creds {
+			consumer.Oauth2Creds = append(consumer.Oauth2Creds, c.Oauth2Creds[k])
+		}
+		sort.SliceStable(consumer.Oauth2Creds, cmpField(func(i int) string { return *consumer.Oauth2Creds[i].ClientID }))
 		content.Consumers = append(content.Consumers, consumer)
 	}
 	sort.SliceStable(content.Consumers, func(i, j int) bool {
@@ -415,6 +430,11 @@ func (n *KongController) toDeckContent(
 
 	return &content
 }
+
+func cmpField(fieldFn func(int) string) func(i, j int) bool {
+	return func(i, j int) bool { return strings.Compare(fieldFn(i), fieldFn(j)) > 0 }
+}
+
 func getFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	var res file.FCertificate
 	if kongCert.ID != nil {

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -310,9 +310,7 @@ func (n *KongController) toDeckContent(
 				n.Logger.Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
 			}
 			service.Plugins = append(service.Plugins, &plugin)
-			sort.SliceStable(service.Plugins, func(i, j int) bool {
-				return strings.Compare(*service.Plugins[i].Name, *service.Plugins[j].Name) > 0
-			})
+			sortByString(service.Plugins, func(i int) string { return *service.Plugins[i].Name })
 		}
 
 		for _, r := range s.Routes {
@@ -328,20 +326,14 @@ func (n *KongController) toDeckContent(
 					n.Logger.Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
 				}
 				route.Plugins = append(route.Plugins, &plugin)
-				sort.SliceStable(route.Plugins, func(i, j int) bool {
-					return strings.Compare(*route.Plugins[i].Name, *route.Plugins[j].Name) > 0
-				})
+				sortByString(route.Plugins, func(i int) string { return *route.Plugins[i].Name })
 			}
 			service.Routes = append(service.Routes, &route)
 		}
-		sort.SliceStable(service.Routes, func(i, j int) bool {
-			return strings.Compare(*service.Routes[i].Name, *service.Routes[j].Name) > 0
-		})
+		sortByString(service.Routes, func(i int) string { return *service.Routes[i].Name })
 		content.Services = append(content.Services, service)
 	}
-	sort.SliceStable(content.Services, func(i, j int) bool {
-		return strings.Compare(*content.Services[i].Name, *content.Services[j].Name) > 0
-	})
+	sortByString(content.Services, func(i int) string { return *content.Services[i].Name })
 
 	for _, plugin := range k8sState.Plugins {
 		plugin := file.FPlugin{
@@ -353,10 +345,7 @@ func (n *KongController) toDeckContent(
 		}
 		content.Plugins = append(content.Plugins, plugin)
 	}
-	sort.SliceStable(content.Plugins, func(i, j int) bool {
-		return strings.Compare(pluginString(content.Plugins[i]),
-			pluginString(content.Plugins[j])) > 0
-	})
+	sortByString(content.Plugins, func(i int) string { return pluginString(content.Plugins[i]) })
 
 	for _, u := range k8sState.Upstreams {
 		n.fillUpstream(&u.Upstream)
@@ -365,30 +354,22 @@ func (n *KongController) toDeckContent(
 			target := file.FTarget{Target: t.Target}
 			upstream.Targets = append(upstream.Targets, &target)
 		}
-		sort.SliceStable(upstream.Targets, func(i, j int) bool {
-			return strings.Compare(*upstream.Targets[i].Target.Target, *upstream.Targets[j].Target.Target) > 0
-		})
+		sortByString(upstream.Targets, func(i int) string { return *upstream.Targets[i].Target.Target })
 		content.Upstreams = append(content.Upstreams, upstream)
 	}
-	sort.SliceStable(content.Upstreams, func(i, j int) bool {
-		return strings.Compare(*content.Upstreams[i].Name, *content.Upstreams[j].Name) > 0
-	})
+	sortByString(content.Upstreams, func(i int) string { return *content.Upstreams[i].Name })
 
 	for _, c := range k8sState.Certificates {
 		cert := getFCertificateFromKongCert(c.Certificate)
 		content.Certificates = append(content.Certificates, cert)
 	}
-	sort.SliceStable(content.Certificates, func(i, j int) bool {
-		return strings.Compare(*content.Certificates[i].Cert, *content.Certificates[j].Cert) > 0
-	})
+	sortByString(content.Certificates, func(i int) string { return *content.Certificates[i].Cert })
 
 	for _, c := range k8sState.CACertificates {
 		content.CACertificates = append(content.CACertificates,
 			file.FCACertificate{CACertificate: c})
 	}
-	sort.SliceStable(content.CACertificates, func(i, j int) bool {
-		return strings.Compare(*content.CACertificates[i].Cert, *content.CACertificates[j].Cert) > 0
-	})
+	sortByString(content.CACertificates, func(i int) string { return *content.CACertificates[i].Cert })
 
 	for _, c := range k8sState.Consumers {
 		consumer := file.FConsumer{Consumer: c.Consumer}
@@ -399,28 +380,27 @@ func (n *KongController) toDeckContent(
 		for k := range c.KeyAuths {
 			consumer.KeyAuths = append(consumer.KeyAuths, c.KeyAuths[k])
 		}
-		sort.SliceStable(consumer.KeyAuths, cmpField(func(i int) string { return *consumer.KeyAuths[i].Key }))
+		sortByString(consumer.KeyAuths, func(i int) string { return *consumer.KeyAuths[i].Key })
 		for k := range c.HMACAuths {
 			consumer.HMACAuths = append(consumer.HMACAuths, c.HMACAuths[k])
 		}
-		sort.SliceStable(consumer.HMACAuths, cmpField(func(i int) string { return *consumer.HMACAuths[i].Username }))
+		sortByString(consumer.HMACAuths, func(i int) string { return *consumer.HMACAuths[i].Username })
 		for k := range c.BasicAuths {
 			consumer.BasicAuths = append(consumer.BasicAuths, c.BasicAuths[k])
 		}
-		sort.SliceStable(consumer.BasicAuths, cmpField(func(i int) string { return *consumer.BasicAuths[i].Username }))
+		sortByString(consumer.BasicAuths, func(i int) string { return *consumer.BasicAuths[i].Username })
 		for k := range c.JWTAuths {
 			consumer.JWTAuths = append(consumer.JWTAuths, c.JWTAuths[k])
 		}
-		sort.SliceStable(consumer.JWTAuths, cmpField(func(i int) string { return *consumer.JWTAuths[i].Key }))
+		sortByString(consumer.JWTAuths, func(i int) string { return *consumer.JWTAuths[i].Key })
 		for k := range c.Oauth2Creds {
 			consumer.Oauth2Creds = append(consumer.Oauth2Creds, c.Oauth2Creds[k])
 		}
-		sort.SliceStable(consumer.Oauth2Creds, cmpField(func(i int) string { return *consumer.Oauth2Creds[i].ClientID }))
+		sortByString(consumer.Oauth2Creds, func(i int) string { return *consumer.Oauth2Creds[i].ClientID })
 		content.Consumers = append(content.Consumers, consumer)
 	}
-	sort.SliceStable(content.Consumers, func(i, j int) bool {
-		return strings.Compare(*content.Consumers[i].Username, *content.Consumers[j].Username) > 0
-	})
+	sortByString(content.Consumers, func(i int) string { return *content.Consumers[i].Username })
+
 	selectorTags := n.getIngressControllerTags()
 	if len(selectorTags) > 0 {
 		content.Info = &file.Info{
@@ -431,8 +411,9 @@ func (n *KongController) toDeckContent(
 	return &content
 }
 
-func cmpField(fieldFn func(int) string) func(i, j int) bool {
-	return func(i, j int) bool { return strings.Compare(fieldFn(i), fieldFn(j)) > 0 }
+func sortByString(slice interface{}, fieldFn func(i int) string) {
+	lessFn := func(i, j int) bool { return strings.Compare(fieldFn(i), fieldFn(j)) > 0 }
+	sort.SliceStable(slice, lessFn)
 }
 
 func getFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {

--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -292,6 +292,7 @@ func (n *KongController) getIngressControllerTags() []string {
 	return res
 }
 
+// FormatVersion denotes the format version of decK files that we generate.
 const FormatVersion = "1.1"
 
 func (n *KongController) toDeckContent(

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -1,12 +1,15 @@
 package controller
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/internal/ingress/controller/parser/kongstate"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_renderConfigWithCustomEntities(t *testing.T) {
@@ -115,6 +118,90 @@ func Test_renderConfigWithCustomEntities(t *testing.T) {
 				t.Errorf("renderConfigWithCustomEntities() = %v, want %v",
 					string(got), string(tt.want))
 			}
+		})
+	}
+}
+
+func Test_toDeckContent(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   kongstate.KongState
+		want file.Content
+	}{
+		{
+			name: "sorts credentials",
+			in: kongstate.KongState{
+				Consumers: []kongstate.Consumer{
+					{
+						KeyAuths: map[string]*kong.KeyAuth{
+							"a": {Key: kong.String("key-22")},
+							"b": {Key: kong.String("key-11")},
+							"c": {Key: kong.String("key-33")},
+						},
+						HMACAuths: map[string]*kong.HMACAuth{
+							"a": {Username: kong.String("hmac-22")},
+							"b": {Username: kong.String("hmac-11")},
+							"c": {Username: kong.String("hmac-33")},
+						},
+						JWTAuths: map[string]*kong.JWTAuth{
+							"a": {Key: kong.String("jwt-22")},
+							"b": {Key: kong.String("jwt-11")},
+							"c": {Key: kong.String("jwt-33")},
+						},
+						BasicAuths: map[string]*kong.BasicAuth{
+							"a": {Username: kong.String("basic-22")},
+							"b": {Username: kong.String("basic-11")},
+							"c": {Username: kong.String("basic-33")},
+						},
+						Oauth2Creds: map[string]*kong.Oauth2Credential{
+							"a": {ClientID: kong.String("oauth2-22")},
+							"b": {ClientID: kong.String("oauth2-11")},
+							"c": {ClientID: kong.String("oauth2-33")},
+						},
+					},
+				},
+			},
+			want: file.Content{
+				FormatVersion: FormatVersion,
+				Consumers: []file.FConsumer{
+					{
+						KeyAuths: []*kong.KeyAuth{
+							{Key: kong.String("key-11")},
+							{Key: kong.String("key-22")},
+							{Key: kong.String("key-33")},
+						},
+						HMACAuths: []*kong.HMACAuth{
+							{Username: kong.String("hmac-11")},
+							{Username: kong.String("hmac-22")},
+							{Username: kong.String("hmac-33")},
+						},
+						JWTAuths: []*kong.JWTAuth{
+							{Key: kong.String("jwt-11")},
+							{Key: kong.String("jwt-22")},
+							{Key: kong.String("jwt-33")},
+						},
+						BasicAuths: []*kong.BasicAuth{
+							{Username: kong.String("basic-11")},
+							{Username: kong.String("basic-22")},
+							{Username: kong.String("basic-33")},
+						},
+						Oauth2Creds: []*kong.Oauth2Credential{
+							{ClientID: kong.String("oauth2-11")},
+							{ClientID: kong.String("oauth2-22")},
+							{ClientID: kong.String("oauth2-33")},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			n := KongController{
+				cfg:    &Configuration{},
+				Logger: logrus.New(),
+			}
+			got := n.toDeckContent(context.Background(), &tt.in)
+			assert.Equal(t, tt.want, *got)
 		})
 	}
 }

--- a/internal/ingress/controller/kong_test.go
+++ b/internal/ingress/controller/kong_test.go
@@ -129,7 +129,7 @@ func Test_toDeckContent(t *testing.T) {
 		want file.Content
 	}{
 		{
-			name: "sorts credentials",
+			name: "sorts credentials consistently",
 			in: kongstate.KongState{
 				Consumers: []kongstate.Consumer{
 					{

--- a/internal/ingress/controller/parser/kongstate/consumer.go
+++ b/internal/ingress/controller/parser/kongstate/consumer.go
@@ -24,6 +24,7 @@ type Consumer struct {
 	K8sKongConsumer configurationv1.KongConsumer
 }
 
+// NewConsumer initializes an empty Consumer object.
 func NewConsumer() Consumer {
 	return Consumer{}.initEmpty()
 }

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -12,172 +12,173 @@ func TestConsumer_SetCredential(t *testing.T) {
 	username := "example"
 	type args struct {
 		credType   string
-		consumer   *Consumer
+		consumer   Consumer
 		credConfig interface{}
 	}
 	tests := []struct {
 		name    string
 		args    args
-		result  *Consumer
+		result  Consumer
 		wantErr bool
 	}{
 		{
 			name: "invalid cred type errors",
 			args: args{
 				credType:   "invalid-type",
-				consumer:   &Consumer{},
+				consumer:   Consumer{}.initEmpty(),
 				credConfig: nil,
 			},
-			result:  &Consumer{},
+			result:  Consumer{}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "key-auth",
 			args: args{
 				credType:   "key-auth",
-				consumer:   &Consumer{},
+				consumer:   Consumer{}.initEmpty(),
 				credConfig: map[string]string{"key": "foo"},
 			},
-			result: &Consumer{
-				KeyAuths: []*kong.KeyAuth{
-					{
+			result: Consumer{
+				KeyAuths: map[string]*kong.KeyAuth{
+					"foo": {
 						Key: kong.String("foo"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "key-auth without key",
 			args: args{
-				credType:   "key-auth",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				credType: "key-auth",
+				consumer: Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
+
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "keyauth_credential",
 			args: args{
 				credType:   "keyauth_credential",
-				consumer:   &Consumer{},
+				consumer:   Consumer{}.initEmpty(),
 				credConfig: map[string]string{"key": "foo"},
 			},
-			result: &Consumer{
-				KeyAuths: []*kong.KeyAuth{
-					{
+			result: Consumer{
+				KeyAuths: map[string]*kong.KeyAuth{
+					"foo": {
 						Key: kong.String("foo"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "basic-auth",
 			args: args{
 				credType: "basic-auth",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"username": "foo",
 					"password": "bar",
 				},
 			},
-			result: &Consumer{
-				BasicAuths: []*kong.BasicAuth{
-					{
+			result: Consumer{
+				BasicAuths: map[string]*kong.BasicAuth{
+					"foo": {
 						Username: kong.String("foo"),
 						Password: kong.String("bar"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "basic-auth without username",
 			args: args{
 				credType:   "basic-auth",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				consumer:   Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "basicauth_credential",
 			args: args{
 				credType: "basicauth_credential",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"username": "foo",
 					"password": "bar",
 				},
 			},
-			result: &Consumer{
-				BasicAuths: []*kong.BasicAuth{
-					{
+			result: Consumer{
+				BasicAuths: map[string]*kong.BasicAuth{
+					"foo": {
 						Username: kong.String("foo"),
 						Password: kong.String("bar"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "hmac-auth",
 			args: args{
 				credType: "hmac-auth",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"username": "foo",
 					"secret":   "bar",
 				},
 			},
-			result: &Consumer{
-				HMACAuths: []*kong.HMACAuth{
-					{
+			result: Consumer{
+				HMACAuths: map[string]*kong.HMACAuth{
+					"foo": {
 						Username: kong.String("foo"),
 						Secret:   kong.String("bar"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "hmac-auth without username",
 			args: args{
 				credType:   "hmac-auth",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				consumer:   Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "hmacauth_credential",
 			args: args{
 				credType: "hmacauth_credential",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"username": "foo",
 					"secret":   "bar",
 				},
 			},
-			result: &Consumer{
-				HMACAuths: []*kong.HMACAuth{
-					{
+			result: Consumer{
+				HMACAuths: map[string]*kong.HMACAuth{
+					"foo": {
 						Username: kong.String("foo"),
 						Secret:   kong.String("bar"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "oauth2",
 			args: args{
 				credType: "oauth2",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]interface{}{
 					"name":          "foo",
 					"client_id":     "bar",
@@ -185,42 +186,42 @@ func TestConsumer_SetCredential(t *testing.T) {
 					"redirect_uris": []string{"example.com"},
 				},
 			},
-			result: &Consumer{
-				Oauth2Creds: []*kong.Oauth2Credential{
-					{
+			result: Consumer{
+				Oauth2Creds: map[string]*kong.Oauth2Credential{
+					"bar": {
 						Name:         kong.String("foo"),
 						ClientID:     kong.String("bar"),
 						ClientSecret: kong.String("baz"),
 						RedirectURIs: kong.StringSlice("example.com"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "oauth2 without client_id",
 			args: args{
 				credType:   "oauth2",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				consumer:   Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "jwt",
 			args: args{
 				credType: "jwt",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"key":            "foo",
 					"rsa_public_key": "bar",
 					"secret":         "baz",
 				},
 			},
-			result: &Consumer{
-				JWTAuths: []*kong.JWTAuth{
-					{
+			result: Consumer{
+				JWTAuths: map[string]*kong.JWTAuth{
+					"foo": {
 						Key:          kong.String("foo"),
 						RSAPublicKey: kong.String("bar"),
 						Secret:       kong.String("baz"),
@@ -228,33 +229,33 @@ func TestConsumer_SetCredential(t *testing.T) {
 						Algorithm: kong.String("HS256"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "jwt without key",
 			args: args{
 				credType:   "jwt",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				consumer:   Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 		{
 			name: "jwt_secret",
 			args: args{
 				credType: "jwt_secret",
-				consumer: &Consumer{},
+				consumer: Consumer{}.initEmpty(),
 				credConfig: map[string]string{
 					"key":            "foo",
 					"rsa_public_key": "bar",
 					"secret":         "baz",
 				},
 			},
-			result: &Consumer{
-				JWTAuths: []*kong.JWTAuth{
-					{
+			result: Consumer{
+				JWTAuths: map[string]*kong.JWTAuth{
+					"foo": {
 						Key:          kong.String("foo"),
 						RSAPublicKey: kong.String("bar"),
 						Secret:       kong.String("baz"),
@@ -262,33 +263,33 @@ func TestConsumer_SetCredential(t *testing.T) {
 						Algorithm: kong.String("HS256"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "acl",
 			args: args{
 				credType:   "acl",
-				consumer:   &Consumer{},
+				consumer:   Consumer{}.initEmpty(),
 				credConfig: map[string]string{"group": "group-foo"},
 			},
-			result: &Consumer{
+			result: Consumer{
 				ACLGroups: []*kong.ACLGroup{
 					{
 						Group: kong.String("group-foo"),
 					},
 				},
-			},
+			}.initEmpty(),
 			wantErr: false,
 		},
 		{
 			name: "acl without group",
 			args: args{
 				credType:   "acl",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username}},
+				consumer:   Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 				credConfig: map[string]string{},
 			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username}},
+			result:  Consumer{Consumer: kong.Consumer{Username: &username}}.initEmpty(),
 			wantErr: true,
 		},
 	}

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -48,6 +48,30 @@ func TestConsumer_SetCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "key-auth duplicate",
+			args: args{
+				credType: "key-auth",
+				consumer: Consumer{
+					Consumer: kong.Consumer{Username: kong.String("x")},
+					KeyAuths: map[string]*kong.KeyAuth{
+						"foo": {
+							Key: kong.String("foo"),
+						},
+					},
+				}.initEmpty(),
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: Consumer{
+				Consumer: kong.Consumer{Username: kong.String("x")},
+				KeyAuths: map[string]*kong.KeyAuth{
+					"foo": {
+						Key: kong.String("foo"),
+					},
+				},
+			}.initEmpty(),
+			wantErr: true,
+		},
+		{
 			name: "key-auth without key",
 			args: args{
 				credType: "key-auth",
@@ -93,6 +117,30 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			}.initEmpty(),
 			wantErr: false,
+		},
+		{
+			name: "basic-auth duplicate",
+			args: args{
+				credType: "basic-auth",
+				consumer: Consumer{
+					Consumer: kong.Consumer{Username: kong.String("x")},
+					BasicAuths: map[string]*kong.BasicAuth{
+						"foo": {
+							Username: kong.String("foo"),
+						},
+					},
+				}.initEmpty(),
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: Consumer{
+				Consumer: kong.Consumer{Username: kong.String("x")},
+				BasicAuths: map[string]*kong.BasicAuth{
+					"foo": {
+						Username: kong.String("foo"),
+					},
+				},
+			}.initEmpty(),
+			wantErr: true,
 		},
 		{
 			name: "basic-auth without username",
@@ -143,6 +191,30 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			}.initEmpty(),
 			wantErr: false,
+		},
+		{
+			name: "hmac-auth duplicate",
+			args: args{
+				credType: "hmac-auth",
+				consumer: Consumer{
+					Consumer: kong.Consumer{Username: kong.String("x")},
+					HMACAuths: map[string]*kong.HMACAuth{
+						"foo": {
+							Username: kong.String("foo"),
+						},
+					},
+				}.initEmpty(),
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: Consumer{
+				Consumer: kong.Consumer{Username: kong.String("x")},
+				HMACAuths: map[string]*kong.HMACAuth{
+					"foo": {
+						Username: kong.String("foo"),
+					},
+				},
+			}.initEmpty(),
+			wantErr: true,
 		},
 		{
 			name: "hmac-auth without username",
@@ -199,6 +271,30 @@ func TestConsumer_SetCredential(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "oauth2 duplicate",
+			args: args{
+				credType: "oauth2",
+				consumer: Consumer{
+					Consumer: kong.Consumer{Username: kong.String("x")},
+					Oauth2Creds: map[string]*kong.Oauth2Credential{
+						"foo": {
+							ClientID: kong.String("foo"),
+						},
+					},
+				}.initEmpty(),
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: Consumer{
+				Consumer: kong.Consumer{Username: kong.String("x")},
+				Oauth2Creds: map[string]*kong.Oauth2Credential{
+					"foo": {
+						ClientID: kong.String("foo"),
+					},
+				},
+			}.initEmpty(),
+			wantErr: true,
+		},
+		{
 			name: "oauth2 without client_id",
 			args: args{
 				credType:   "oauth2",
@@ -231,6 +327,30 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			}.initEmpty(),
 			wantErr: false,
+		},
+		{
+			name: "jwt duplicate",
+			args: args{
+				credType: "jwt",
+				consumer: Consumer{
+					Consumer: kong.Consumer{Username: kong.String("x")},
+					JWTAuths: map[string]*kong.JWTAuth{
+						"foo": {
+							Key: kong.String("foo"),
+						},
+					},
+				}.initEmpty(),
+				credConfig: map[string]string{"key": "foo"},
+			},
+			result: Consumer{
+				Consumer: kong.Consumer{Username: kong.String("x")},
+				JWTAuths: map[string]*kong.JWTAuth{
+					"foo": {
+						Key: kong.String("foo"),
+					},
+				},
+			}.initEmpty(),
+			wantErr: true,
 		},
 		{
 			name: "jwt without key",

--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -28,7 +28,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 
 	// build consumer index
 	for _, kConsumer := range s.ListKongConsumers() {
-		var c Consumer
+		c := NewConsumer()
 		if kConsumer.Username == "" && kConsumer.CustomID == "" {
 			continue
 		}


### PR DESCRIPTION
fixes #729

Before this PR, KIC failed to apply config to DB-backed Kong, in
case the config contained a Consumer with two credentials having
equivalent ID2 fields (Key for key-auth, ClientID for OAuth2, etc.).

This commit de-duplicates credentials of each type, by replacing the
Consumer store for credentials with a map (ID2 -> credential object),
and updates relevant tests.

Also, this commit implements consistent credential ordering.

---

refactor(controller): implement sortByString

This REVERSES the sorting order from reverse to normal.

The history behind reverse order is purely accidental. There are no
known reasons in favor of one or the other. What matters is the order
being deterministic.

---

test(controller): toDeckContent sorts creds

---

test(kongstate): deduplicates credentials