### PR TITLE
feat(ci) codecoverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,5 +52,7 @@ jobs:
       run: go get -u golang.org/x/lint/golint
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Run tests
-      run: make test
+    - name: Run tests with Coverage
+      run: make coverage
+    - name: Upload Code Coverage
+      run: "bash <(curl -s https://codecov.io/bash)"

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,10 @@ _testmain.go
 .coverprofile
 /gover.coverprofile
 e2e-tests
-
+coverage.out
+coverage.out.tmp
 coverage.txt
+
 # for this repo only
 kong-ingress-controller
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ test-all: lint test
 test:
 	go test -race ./...
 
+.PHONY: coverage
+coverage:
+	go test -race -v -count=1 -coverprofile=coverage.out.tmp ./...
+	# ignoring generated code for coverage
+	grep -E -v 'pkg/apis/|pkg/client/|generated.go|generated.deepcopy.go' coverage.out.tmp > coverage.out
+	rm -f coverage.out.tmp
+
 .PHONY: lint
 lint: verify-tidy
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![][kong-logo]][kong-url]
 [![Build Status](https://github.com/kong/kubernetes-ingress-controller/workflows/Test/badge.svg)](https://github.com/kong/kubernetes-ingress-controller/actions?query=branch%3Amaster+event%3Apush)
+[![codecov](https://codecov.io/gh/Kong/kubernetes-ingress-controller/branch/main/graph/badge.svg?token=S1aqcXiGEo)](https://codecov.io/gh/Kong/kubernetes-ingress-controller)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds [codecov](https://codecov.io) coverage to our CI for pushes and PRs.

**Which issue this PR fixes**
Fixes #835

**Special notes for your reviewer**:
Configuration available for maintainers at: https://app.codecov.io/gh/Kong/kubernetes-ingress-controller