### PR TITLE
fix(kongstate): missing logger fields

### DIFF
--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -207,7 +207,7 @@ func buildPlugins(log logrus.FieldLogger, s store.Storer, pluginRels map[string]
 			log.WithFields(logrus.Fields{
 				"kongplugin_name":      kongPluginName,
 				"kongplugin_namespace": namespace,
-			}).Logger.Errorf("failed to fetch KongPlugin: %v", err)
+			}).Errorf("failed to fetch KongPlugin: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`log.WithFields(...).Errorf()`  emits a log entry with all the recorded fields.
However, `log.WithFields(...).Logger.Errorf()` emits a log entry too, but without these fields.

This PR fixes the logger invocation by preventing it from dropping the recorded fields, by switching from calling the latter `Errorf` to the former.

**Which issue this PR fixes**
fixes #1002

**Special notes for your reviewer**:
This logger invocation (and tens of others) includes the `error` in the message. With structured logging, the preferred way is to put an error in a field of its own. Filed #1013 to take care of that.