### PR TITLE
request response buffering options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ vendor
 # integration test residuals
 kind
 kubeconfig-test-cluster
+
+# ignore personal TODO lists
+TODO

--- a/deploy/manifests/base/custom-types.yaml
+++ b/deploy/manifests/base/custom-types.yaml
@@ -249,6 +249,10 @@ spec:
               type: array
               items:
                 type: string
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
         proxy:
           type: object
           properties:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -196,6 +196,10 @@ spec:
               type: array
             regex_priority:
               type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
             snis:
               items:
                 type: string

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -196,6 +196,10 @@ spec:
               type: array
             regex_priority:
               type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
             snis:
               items:
                 type: string

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -196,6 +196,10 @@ spec:
               type: array
             regex_priority:
               type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
             snis:
               items:
                 type: string

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -196,6 +196,10 @@ spec:
               type: array
             regex_priority:
               type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
             snis:
               items:
                 type: string

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-memdb v1.2.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/kong/deck v1.2.1
-	github.com/kong/go-kong v0.13.0
+	github.com/kong/go-kong v0.15.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/mapstructure v1.3.1
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,8 @@ github.com/kong/deck v1.2.1/go.mod h1:bQ3rKdw35e8oThRXhOMq6IgIFyDe39YQdiEgCp9qJW
 github.com/kong/go-kong v0.13.0 h1:r1eTq3lc6fjHAiWWv4Dv1b8e35hER+g6vlNLMFkfcRQ=
 github.com/kong/go-kong v0.13.0/go.mod h1:oF4kdI9l/a8ndDW2ayJA0yhDBpO8Qt2aLiJEv10hqnQ=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kong/go-kong v0.15.0 h1:9Y+7iqh7/0z8/BppAaLEV7ueSSyqK6lJOHFvqJnSSqM=
+github.com/kong/go-kong v0.15.0/go.mod h1:oF4kdI9l/a8ndDW2ayJA0yhDBpO8Qt2aLiJEv10hqnQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/hack/dev/common/custom-types.yaml
+++ b/hack/dev/common/custom-types.yaml
@@ -249,6 +249,10 @@ spec:
               type: array
               items:
                 type: string
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
         proxy:
           type: object
           properties:

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -50,6 +50,8 @@ const (
 	HostHeaderKey        = "/host-header"
 	MethodsKey           = "/methods"
 	SNIsKey              = "/snis"
+	RequestBuffering     = "/request-buffering"
+	ResponseBuffering    = "/response-buffering"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -214,4 +216,18 @@ func ExtractSNIs(anns map[string]string) ([]string, bool) {
 		return nil, exists
 	}
 	return strings.Split(val, ","), exists
+}
+
+// ExtractRequestBuffering extracts the boolean annotation indicating
+// whether or not a route should buffer requests.
+func ExtractRequestBuffering(anns map[string]string) (string, bool) {
+	s, ok := anns[AnnotationPrefix+RequestBuffering]
+	return s, ok
+}
+
+// ExtractResponseBuffering extracts the boolean annotation indicating
+// whether or not a route should buffer responses.
+func ExtractResponseBuffering(anns map[string]string) (string, bool) {
+	s, ok := anns[AnnotationPrefix+ResponseBuffering]
+	return s, ok
 }

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -564,6 +565,82 @@ func TestExtractSNIs(t *testing.T) {
 			var got []string
 			if got, _ = ExtractSNIs(tt.args.anns); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ExtractSNIs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRequestBuffering(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/request-buffering": "true",
+				},
+			},
+			want: "true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ExtractRequestBuffering(tt.args.anns)
+			if tt.want == "" {
+				assert.False(t, ok)
+			} else {
+				assert.True(t, ok)
+			}
+			if got != tt.want {
+				t.Errorf("ExtractRequestBuffering() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractResponseBuffering(t *testing.T) {
+	type args struct {
+		anns map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "non-empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/response-buffering": "true",
+				},
+			},
+			want: "true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ExtractResponseBuffering(tt.args.anns)
+			if tt.want == "" {
+				assert.False(t, ok)
+			} else {
+				assert.True(t, ok)
+			}
+			if got != tt.want {
+				t.Errorf("ExtractResponseBuffering() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/ingress/controller/parser/kongstate/route.go
+++ b/internal/ingress/controller/parser/kongstate/route.go
@@ -221,6 +221,8 @@ func (r *Route) overrideByAnnotation(log logrus.FieldLogger) {
 	r.overrideRegexPriority(r.Ingress.Annotations)
 	r.overrideMethods(log, r.Ingress.Annotations)
 	r.overrideSNIs(log, r.Ingress.Annotations)
+	r.overrideRequestBuffering(log, r.Ingress.Annotations)
+	r.overrideResponseBuffering(log, r.Ingress.Annotations)
 }
 
 // override sets Route fields by KongIngress first, then by annotation
@@ -303,4 +305,46 @@ func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *confi
 		}
 		r.SNIs = SNIs
 	}
+	if ir.RequestBuffering != nil {
+		r.RequestBuffering = kong.Bool(*ir.RequestBuffering)
+	}
+	if ir.ResponseBuffering != nil {
+		r.ResponseBuffering = kong.Bool(*ir.ResponseBuffering)
+	}
+}
+
+// overrideRequestBuffering ensures defaults for the request_buffering option
+func (r *Route) overrideRequestBuffering(log logrus.FieldLogger, anns map[string]string) {
+	annotationValue, ok := annotations.ExtractRequestBuffering(anns)
+	if !ok {
+		// the annotation is not set, quit
+		return
+	}
+
+	isEnabled, err := strconv.ParseBool(strings.ToLower(annotationValue))
+	if err != nil {
+		// the value provided is not a parseable boolean, quit
+		log.WithField("kongroute", r.Name).Errorf("invalid request_buffering value: %s", err)
+		return
+	}
+
+	r.RequestBuffering = kong.Bool(isEnabled)
+}
+
+// overrideResponseBuffering ensures defaults for the response_buffering option
+func (r *Route) overrideResponseBuffering(log logrus.FieldLogger, anns map[string]string) {
+	annotationValue, ok := annotations.ExtractResponseBuffering(anns)
+	if !ok {
+		// the annotation is not set, quit
+		return
+	}
+
+	isEnabled, err := strconv.ParseBool(strings.ToLower(annotationValue))
+	if err != nil {
+		// the value provided is not a parseable boolean, quit
+		log.WithField("kongroute", r.Name).Errorf("invalid response_buffering value: %s", err)
+		return
+	}
+
+	r.ResponseBuffering = kong.Bool(isEnabled)
 }

--- a/internal/ingress/controller/parser/kongstate/route_test.go
+++ b/internal/ingress/controller/parser/kongstate/route_test.go
@@ -190,6 +190,26 @@ func TestOverrideRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			Route{
+				Route: kong.Route{
+					Hosts: kong.StringSlice("foo.com", "bar.com"),
+				},
+			},
+			configurationv1.KongIngress{
+				Route: &kong.Route{
+					RequestBuffering:  kong.Bool(true),
+					ResponseBuffering: kong.Bool(true),
+				},
+			},
+			Route{
+				Route: kong.Route{
+					Hosts:             kong.StringSlice("foo.com", "bar.com"),
+					RequestBuffering:  kong.Bool(true),
+					ResponseBuffering: kong.Bool(true),
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testTable {
@@ -818,6 +838,150 @@ func Test_overrideRouteSNIs(t *testing.T) {
 			tt.args.route.overrideSNIs(logrus.New(), tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route, tt.want) {
 				t.Errorf("overrideRouteSNIs() got = %v, want %v", tt.args.route, tt.want)
+			}
+		})
+	}
+}
+
+func Test_overrideRequestBuffering(t *testing.T) {
+	type args struct {
+		route Route
+		anns  map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want kong.Route
+	}{
+		{},
+		{
+			name: "basic empty route",
+			args: args{
+				route: Route{Route: kong.Route{}},
+			},
+			want: kong.Route{},
+		},
+		{
+			name: "set to false",
+			args: args{
+				route: Route{
+					Route: kong.Route{}},
+				anns: map[string]string{
+					"konghq.com/request-buffering": "false",
+				},
+			},
+			want: kong.Route{
+				RequestBuffering: kong.Bool(false),
+			},
+		},
+		{
+			name: "set to true and case insensitive",
+			args: args{
+				route: Route{
+					Route: kong.Route{},
+				},
+				anns: map[string]string{
+					"konghq.com/request-buffering": "tRuE",
+				},
+			},
+			want: kong.Route{
+				RequestBuffering: kong.Bool(true),
+			},
+		},
+		{
+			name: "overrides any other value",
+			args: args{
+				route: Route{
+					Route: kong.Route{
+						RequestBuffering: kong.Bool(false),
+					},
+				},
+				anns: map[string]string{
+					"konghq.com/request-buffering": "tRuE",
+				},
+			},
+			want: kong.Route{
+				RequestBuffering: kong.Bool(true),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.route.overrideRequestBuffering(logrus.New(), tt.args.anns)
+			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
+				t.Errorf("overrideRequestBuffering() got = %v, want %v", &tt.args.route.Route, tt.want)
+			}
+		})
+	}
+}
+
+func Test_overrideResponseBuffering(t *testing.T) {
+	type args struct {
+		route Route
+		anns  map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want kong.Route
+	}{
+		{},
+		{
+			name: "basic empty route",
+			args: args{
+				route: Route{Route: kong.Route{}},
+			},
+			want: kong.Route{},
+		},
+		{
+			name: "set to false",
+			args: args{
+				route: Route{
+					Route: kong.Route{}},
+				anns: map[string]string{
+					"konghq.com/response-buffering": "false",
+				},
+			},
+			want: kong.Route{
+				ResponseBuffering: kong.Bool(false),
+			},
+		},
+		{
+			name: "set to true and case insensitive",
+			args: args{
+				route: Route{
+					Route: kong.Route{},
+				},
+				anns: map[string]string{
+					"konghq.com/response-buffering": "tRuE",
+				},
+			},
+			want: kong.Route{
+				ResponseBuffering: kong.Bool(true),
+			},
+		},
+		{
+			name: "overrides any other value",
+			args: args{
+				route: Route{
+					Route: kong.Route{
+						ResponseBuffering: kong.Bool(false),
+					},
+				},
+				anns: map[string]string{
+					"konghq.com/response-buffering": "tRuE",
+				},
+			},
+			want: kong.Route{
+				ResponseBuffering: kong.Bool(true),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.route.overrideResponseBuffering(logrus.New(), tt.args.anns)
+			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
+				t.Errorf("overrideResponseBuffering() got = %v, want %v", &tt.args.route.Route, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add options to `KongIngress` and ingress annotations for `request_buffering` and `response_buffering` options.

**Which issue this PR fixes**
fixes #924
