### PR TITLE
Implement recursive SanitizedCopy() for KongState, refactor SetCredential

### DIFF
--- a/internal/ingress/controller/kong.go
+++ b/internal/ingress/controller/kong.go
@@ -395,12 +395,25 @@ func (n *KongController) toDeckContent(
 		for _, p := range c.Plugins {
 			consumer.Plugins = append(consumer.Plugins, &file.FPlugin{Plugin: p})
 		}
-		consumer.KeyAuths = c.KeyAuths
-		consumer.HMACAuths = c.HMACAuths
-		consumer.BasicAuths = c.BasicAuths
-		consumer.JWTAuths = c.JWTAuths
-		consumer.ACLGroups = c.ACLGroups
-		consumer.Oauth2Creds = c.Oauth2Creds
+
+		for _, v := range c.KeyAuths {
+			consumer.KeyAuths = append(consumer.KeyAuths, &v.KeyAuth)
+		}
+		for _, v := range c.HMACAuths {
+			consumer.HMACAuths = append(consumer.HMACAuths, &v.HMACAuth)
+		}
+		for _, v := range c.BasicAuths {
+			consumer.BasicAuths = append(consumer.BasicAuths, &v.BasicAuth)
+		}
+		for _, v := range c.JWTAuths {
+			consumer.JWTAuths = append(consumer.JWTAuths, &v.JWTAuth)
+		}
+		for _, v := range c.ACLGroups {
+			consumer.ACLGroups = append(consumer.ACLGroups, &v.ACLGroup)
+		}
+		for _, v := range c.Oauth2Creds {
+			consumer.Oauth2Creds = append(consumer.Oauth2Creds, &v.Oauth2Credential)
+		}
 		content.Consumers = append(content.Consumers, consumer)
 	}
 	sort.SliceStable(content.Consumers, func(i, j int) bool {
@@ -415,6 +428,7 @@ func (n *KongController) toDeckContent(
 
 	return &content
 }
+
 func getFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	var res file.FCertificate
 	if kongCert.ID != nil {

--- a/internal/ingress/controller/parser/kongstate/consumer.go
+++ b/internal/ingress/controller/parser/kongstate/consumer.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
-	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
 )
 
 // Consumer holds a Kong consumer and its plugins and credentials.
@@ -64,102 +62,46 @@ func (c *Consumer) SanitizedCopy() *Consumer {
 	}
 }
 
-func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credConfig interface{}) error {
+func (c *Consumer) SetCredential(credType string, credConfig interface{}) error {
 	switch credType {
 	case "key-auth", "keyauth_credential":
-		var cred KeyAuth
-		err := decodeCredential(credConfig, &cred.KeyAuth)
+		cred, err := NewKeyAuth(credConfig)
 		if err != nil {
-			return fmt.Errorf("failed to decode key-auth credential: %w", err)
-
+			return err
 		}
-		// TODO we perform these validity checks here because passing credentials without these fields will panic deck
-		// later on. Ideally this should not be handled in the controller, but we cannot currently handle it elsewhere
-		// (i.e. in deck or go-kong) without entering a sync failure loop that cannot actually report the problem
-		// piece of configuration. if we can address those limitations, we should remove these checks.
-		// See https://github.com/Kong/deck/pull/223 and https://github.com/Kong/kubernetes-ingress-controller/issues/532
-		// for more discussion.
-		if cred.Key == nil {
-			return fmt.Errorf("key-auth for consumer %s is invalid: no key", *c.Username)
-		}
-		c.KeyAuths = append(c.KeyAuths, &cred)
+		c.KeyAuths = append(c.KeyAuths, cred)
 	case "basic-auth", "basicauth_credential":
-		var cred BasicAuth
-		err := decodeCredential(credConfig, &cred.BasicAuth)
+		cred, err := NewBasicAuth(credConfig)
 		if err != nil {
-			return fmt.Errorf("failed to decode basic-auth credential: %w", err)
+			return err
 		}
-		if cred.Username == nil {
-			return fmt.Errorf("basic-auth for consumer %s is invalid: no username", *c.Username)
-		}
-		c.BasicAuths = append(c.BasicAuths, &cred)
+		c.BasicAuths = append(c.BasicAuths, cred)
 	case "hmac-auth", "hmacauth_credential":
-		var cred HMACAuth
-		err := decodeCredential(credConfig, &cred.HMACAuth)
+		cred, err := NewHMACAuth(credConfig)
 		if err != nil {
-			return fmt.Errorf("failed to decode hmac-auth credential: %w", err)
+			return err
 		}
-		if cred.Username == nil {
-			return fmt.Errorf("hmac-auth for consumer %s is invalid: no username", *c.Username)
-		}
-		c.HMACAuths = append(c.HMACAuths, &cred)
+		c.HMACAuths = append(c.HMACAuths, cred)
 	case "oauth2":
-		var cred Oauth2Credential
-		err := decodeCredential(credConfig, &cred.Oauth2Credential)
+		cred, err := NewOauth2Credential(credConfig)
 		if err != nil {
-			return fmt.Errorf("failed to decode oauth2 credential: %w", err)
+			return err
 		}
-		if cred.ClientID == nil {
-			return fmt.Errorf("oauth2 for consumer %s is invalid: no client_id", *c.Username)
-		}
-		c.Oauth2Creds = append(c.Oauth2Creds, &cred)
+		c.Oauth2Creds = append(c.Oauth2Creds, cred)
 	case "jwt", "jwt_secret":
-		var cred JWTAuth
-		err := decodeCredential(credConfig, &cred.JWTAuth)
+		cred, err := NewJWTAuth(credConfig)
 		if err != nil {
-			log.Errorf("failed to process JWT credential: %v", err)
+			return err
 		}
-		// This is treated specially because only this
-		// field might be omitted by user under the expectation
-		// that Kong will insert the default.
-		// If we don't set it, decK will detect a diff and PUT this
-		// credential everytime it performs a sync operation, which
-		// leads to unnecessary cache invalidations in Kong.
-		if cred.Algorithm == nil || *cred.Algorithm == "" {
-			cred.Algorithm = kong.String("HS256")
-		}
-		if cred.Key == nil {
-			return fmt.Errorf("jwt-auth for consumer %s is invalid: no key", *c.Username)
-		}
-		c.JWTAuths = append(c.JWTAuths, &cred)
+		c.JWTAuths = append(c.JWTAuths, cred)
 	case "acl":
-		var cred ACLGroup
-		err := decodeCredential(credConfig, &cred.ACLGroup)
+		cred, err := NewACLGroup(credConfig)
 		if err != nil {
-			log.Errorf("failed to process ACL group: %v", err)
+			return err
 		}
-		if cred.Group == nil {
-			return fmt.Errorf("acl for consumer %s is invalid: no group", *c.Username)
-		}
-		c.ACLGroups = append(c.ACLGroups, &cred)
+		c.ACLGroups = append(c.ACLGroups, cred)
 	default:
 		return fmt.Errorf("invalid credential type: '%v'", credType)
-	}
-	return nil
-}
-
-func decodeCredential(credConfig interface{},
-	credStructPointer interface{}) error {
-	decoder, err := mapstructure.NewDecoder(
-		&mapstructure.DecoderConfig{TagName: "json",
-			Result: credStructPointer,
-		})
-	if err != nil {
-		return fmt.Errorf("failed to create a decoder: %w", err)
-	}
-	err = decoder.Decode(credConfig)
-	if err != nil {
-		return fmt.Errorf("failed to decode credential: %w", err)
 	}
 	return nil
 }

--- a/internal/ingress/controller/parser/kongstate/consumer.go
+++ b/internal/ingress/controller/parser/kongstate/consumer.go
@@ -13,13 +13,13 @@ import (
 type Consumer struct {
 	kong.Consumer
 	Plugins    []kong.Plugin
-	KeyAuths   []*kong.KeyAuth
-	HMACAuths  []*kong.HMACAuth
-	JWTAuths   []*kong.JWTAuth
-	BasicAuths []*kong.BasicAuth
-	ACLGroups  []*kong.ACLGroup
+	KeyAuths   []*KeyAuth
+	HMACAuths  []*HMACAuth
+	JWTAuths   []*JWTAuth
+	BasicAuths []*BasicAuth
+	ACLGroups  []*ACLGroup
 
-	Oauth2Creds []*kong.Oauth2Credential
+	Oauth2Creds []*Oauth2Credential
 
 	K8sKongConsumer configurationv1.KongConsumer
 }
@@ -27,8 +27,8 @@ type Consumer struct {
 func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credConfig interface{}) error {
 	switch credType {
 	case "key-auth", "keyauth_credential":
-		var cred kong.KeyAuth
-		err := decodeCredential(credConfig, &cred)
+		var cred KeyAuth
+		err := decodeCredential(credConfig, &cred.KeyAuth)
 		if err != nil {
 			return fmt.Errorf("failed to decode key-auth credential: %w", err)
 
@@ -44,8 +44,8 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		}
 		c.KeyAuths = append(c.KeyAuths, &cred)
 	case "basic-auth", "basicauth_credential":
-		var cred kong.BasicAuth
-		err := decodeCredential(credConfig, &cred)
+		var cred BasicAuth
+		err := decodeCredential(credConfig, &cred.BasicAuth)
 		if err != nil {
 			return fmt.Errorf("failed to decode basic-auth credential: %w", err)
 		}
@@ -54,8 +54,8 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		}
 		c.BasicAuths = append(c.BasicAuths, &cred)
 	case "hmac-auth", "hmacauth_credential":
-		var cred kong.HMACAuth
-		err := decodeCredential(credConfig, &cred)
+		var cred HMACAuth
+		err := decodeCredential(credConfig, &cred.HMACAuth)
 		if err != nil {
 			return fmt.Errorf("failed to decode hmac-auth credential: %w", err)
 		}
@@ -64,8 +64,8 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		}
 		c.HMACAuths = append(c.HMACAuths, &cred)
 	case "oauth2":
-		var cred kong.Oauth2Credential
-		err := decodeCredential(credConfig, &cred)
+		var cred Oauth2Credential
+		err := decodeCredential(credConfig, &cred.Oauth2Credential)
 		if err != nil {
 			return fmt.Errorf("failed to decode oauth2 credential: %w", err)
 		}
@@ -74,8 +74,8 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		}
 		c.Oauth2Creds = append(c.Oauth2Creds, &cred)
 	case "jwt", "jwt_secret":
-		var cred kong.JWTAuth
-		err := decodeCredential(credConfig, &cred)
+		var cred JWTAuth
+		err := decodeCredential(credConfig, &cred.JWTAuth)
 		if err != nil {
 			log.Errorf("failed to process JWT credential: %v", err)
 		}
@@ -93,8 +93,8 @@ func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credCo
 		}
 		c.JWTAuths = append(c.JWTAuths, &cred)
 	case "acl":
-		var cred kong.ACLGroup
-		err := decodeCredential(credConfig, &cred)
+		var cred ACLGroup
+		err := decodeCredential(credConfig, &cred.ACLGroup)
 		if err != nil {
 			log.Errorf("failed to process ACL group: %v", err)
 		}

--- a/internal/ingress/controller/parser/kongstate/consumer.go
+++ b/internal/ingress/controller/parser/kongstate/consumer.go
@@ -24,6 +24,46 @@ type Consumer struct {
 	K8sKongConsumer configurationv1.KongConsumer
 }
 
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *Consumer) SanitizedCopy() *Consumer {
+	return &Consumer{
+		Consumer: c.Consumer,
+		Plugins:  c.Plugins,
+		KeyAuths: func() (res []*KeyAuth) {
+			for _, v := range c.KeyAuths {
+				res = append(res, v.SanitizedCopy())
+			}
+			return
+		}(),
+		HMACAuths: func() (res []*HMACAuth) {
+			for _, v := range c.HMACAuths {
+				res = append(res, v.SanitizedCopy())
+			}
+			return
+		}(),
+		JWTAuths: func() (res []*JWTAuth) {
+			for _, v := range c.JWTAuths {
+				res = append(res, v.SanitizedCopy())
+			}
+			return
+		}(),
+		BasicAuths: func() (res []*BasicAuth) {
+			for _, v := range c.BasicAuths {
+				res = append(res, v.SanitizedCopy())
+			}
+			return
+		}(),
+		Oauth2Creds: func() (res []*Oauth2Credential) {
+			for _, v := range c.Oauth2Creds {
+				res = append(res, v.SanitizedCopy())
+			}
+			return
+		}(),
+		ACLGroups:       c.ACLGroups,
+		K8sKongConsumer: c.K8sKongConsumer,
+	}
+}
+
 func (c *Consumer) SetCredential(log logrus.FieldLogger, credType string, credConfig interface{}) error {
 	switch credType {
 	case "key-auth", "keyauth_credential":

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -39,10 +39,10 @@ func TestConsumer_SetCredential(t *testing.T) {
 				credConfig: map[string]string{"key": "foo"},
 			},
 			result: &Consumer{
-				KeyAuths: []*kong.KeyAuth{
-					{
+				KeyAuths: []*KeyAuth{
+					{kong.KeyAuth{
 						Key: kong.String("foo"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -65,10 +65,10 @@ func TestConsumer_SetCredential(t *testing.T) {
 				credConfig: map[string]string{"key": "foo"},
 			},
 			result: &Consumer{
-				KeyAuths: []*kong.KeyAuth{
-					{
+				KeyAuths: []*KeyAuth{
+					{kong.KeyAuth{
 						Key: kong.String("foo"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -84,11 +84,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				BasicAuths: []*kong.BasicAuth{
-					{
+				BasicAuths: []*BasicAuth{
+					{kong.BasicAuth{
 						Username: kong.String("foo"),
 						Password: kong.String("bar"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -114,11 +114,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				BasicAuths: []*kong.BasicAuth{
-					{
+				BasicAuths: []*BasicAuth{
+					{kong.BasicAuth{
 						Username: kong.String("foo"),
 						Password: kong.String("bar"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -134,11 +134,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				HMACAuths: []*kong.HMACAuth{
-					{
+				HMACAuths: []*HMACAuth{
+					{kong.HMACAuth{
 						Username: kong.String("foo"),
 						Secret:   kong.String("bar"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -164,11 +164,11 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				HMACAuths: []*kong.HMACAuth{
-					{
+				HMACAuths: []*HMACAuth{
+					{kong.HMACAuth{
 						Username: kong.String("foo"),
 						Secret:   kong.String("bar"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -186,13 +186,13 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				Oauth2Creds: []*kong.Oauth2Credential{
-					{
+				Oauth2Creds: []*Oauth2Credential{
+					{kong.Oauth2Credential{
 						Name:         kong.String("foo"),
 						ClientID:     kong.String("bar"),
 						ClientSecret: kong.String("baz"),
 						RedirectURIs: kong.StringSlice("example.com"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -219,14 +219,14 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				JWTAuths: []*kong.JWTAuth{
-					{
+				JWTAuths: []*JWTAuth{
+					{kong.JWTAuth{
 						Key:          kong.String("foo"),
 						RSAPublicKey: kong.String("bar"),
 						Secret:       kong.String("baz"),
 						// set by default
 						Algorithm: kong.String("HS256"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -253,14 +253,14 @@ func TestConsumer_SetCredential(t *testing.T) {
 				},
 			},
 			result: &Consumer{
-				JWTAuths: []*kong.JWTAuth{
-					{
+				JWTAuths: []*JWTAuth{
+					{kong.JWTAuth{
 						Key:          kong.String("foo"),
 						RSAPublicKey: kong.String("bar"),
 						Secret:       kong.String("baz"),
 						// set by default
 						Algorithm: kong.String("HS256"),
-					},
+					}},
 				},
 			},
 			wantErr: false,
@@ -273,10 +273,10 @@ func TestConsumer_SetCredential(t *testing.T) {
 				credConfig: map[string]string{"group": "group-foo"},
 			},
 			result: &Consumer{
-				ACLGroups: []*kong.ACLGroup{
-					{
+				ACLGroups: []*ACLGroup{
+					{kong.ACLGroup{
 						Group: kong.String("group-foo"),
-					},
+					}},
 				},
 			},
 			wantErr: false,

--- a/internal/ingress/controller/parser/kongstate/consumer_test.go
+++ b/internal/ingress/controller/parser/kongstate/consumer_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -354,7 +353,7 @@ func TestConsumer_SetCredential(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.args.consumer.SetCredential(logrus.New(), tt.args.credType,
+			if err := tt.args.consumer.SetCredential(tt.args.credType,
 				tt.args.credConfig); (err != nil) != tt.wantErr {
 				t.Errorf("processCredential() error = %v, wantErr %v",
 					err, tt.wantErr)

--- a/internal/ingress/controller/parser/kongstate/credentials.go
+++ b/internal/ingress/controller/parser/kongstate/credentials.go
@@ -1,6 +1,11 @@
 package kongstate
 
-import "github.com/kong/go-kong/kong"
+import (
+	"fmt"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/mitchellh/mapstructure"
+)
 
 var redactedString = kong.String("REDACTED")
 
@@ -33,6 +38,94 @@ type ACLGroup struct {
 // Oauth2Credential represents an OAuth2 client configuration including credentials.
 type Oauth2Credential struct {
 	kong.Oauth2Credential
+}
+
+func NewKeyAuth(config interface{}) (*KeyAuth, error) {
+	var res KeyAuth
+	err := decodeCredential(config, &res.KeyAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode key-auth credential: %w", err)
+	}
+
+	// TODO we perform these validity checks here because passing credentials without these fields will panic deck
+	// later on. Ideally this should not be handled in the controller, but we cannot currently handle it elsewhere
+	// (i.e. in deck or go-kong) without entering a sync failure loop that cannot actually report the problem
+	// piece of configuration. if we can address those limitations, we should remove these checks.
+	// See https://github.com/Kong/deck/pull/223 and https://github.com/Kong/kubernetes-ingress-controller/issues/532
+	// for more discussion.
+	if res.Key == nil {
+		return nil, fmt.Errorf("key-auth is invalid: no key")
+	}
+	return &res, nil
+}
+
+func NewHMACAuth(config interface{}) (*HMACAuth, error) {
+	var res HMACAuth
+	err := decodeCredential(config, &res.HMACAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hmac-auth credential: %w", err)
+	}
+	if res.Username == nil {
+		return nil, fmt.Errorf("hmac-auth is invalid: no username")
+	}
+	return &res, nil
+}
+
+func NewJWTAuth(config interface{}) (*JWTAuth, error) {
+	var res JWTAuth
+	err := decodeCredential(config, &res.JWTAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process JWT credential: %v", err)
+	}
+	// This is treated specially because only this
+	// field might be omitted by user under the expectation
+	// that Kong will insert the default.
+	// If we don't set it, decK will detect a diff and PUT this
+	// credential everytime it performs a sync operation, which
+	// leads to unnecessary cache invalidations in Kong.
+	if res.Algorithm == nil || *res.Algorithm == "" {
+		res.Algorithm = kong.String("HS256")
+	}
+	if res.Key == nil {
+		return nil, fmt.Errorf("jwt-auth for is invalid: no key")
+	}
+	return &res, nil
+}
+
+func NewBasicAuth(config interface{}) (*BasicAuth, error) {
+	var res BasicAuth
+	err := decodeCredential(config, &res.BasicAuth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode basic-auth credential: %w", err)
+	}
+	if res.Username == nil {
+		return nil, fmt.Errorf("basic-auth is invalid: no username")
+	}
+	return &res, nil
+}
+
+func NewACLGroup(config interface{}) (*ACLGroup, error) {
+	var res ACLGroup
+	err := decodeCredential(config, &res.ACLGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process ACL group: %v", err)
+	}
+	if res.Group == nil {
+		return nil, fmt.Errorf("acl is invalid: no group")
+	}
+	return &res, nil
+}
+
+func NewOauth2Credential(config interface{}) (*Oauth2Credential, error) {
+	var res Oauth2Credential
+	err := decodeCredential(config, &res.Oauth2Credential)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode oauth2 credential: %w", err)
+	}
+	if res.ClientID == nil {
+		return nil, fmt.Errorf("oauth2 is invalid: no client_id")
+	}
+	return &res, nil
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
@@ -106,4 +199,20 @@ func (c *Oauth2Credential) SanitizedCopy() *Oauth2Credential {
 			Tags:         c.Tags,
 		},
 	}
+}
+
+func decodeCredential(credConfig interface{},
+	credStructPointer interface{}) error {
+	decoder, err := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{TagName: "json",
+			Result: credStructPointer,
+		})
+	if err != nil {
+		return fmt.Errorf("failed to create a decoder: %w", err)
+	}
+	err = decoder.Decode(credConfig)
+	if err != nil {
+		return fmt.Errorf("failed to decode credential: %w", err)
+	}
+	return nil
 }

--- a/internal/ingress/controller/parser/kongstate/credentials.go
+++ b/internal/ingress/controller/parser/kongstate/credentials.go
@@ -34,3 +34,76 @@ type ACLGroup struct {
 type Oauth2Credential struct {
 	kong.Oauth2Credential
 }
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *KeyAuth) SanitizedCopy() *KeyAuth {
+	return &KeyAuth{
+		kong.KeyAuth{
+			// Consumer field omitted
+			CreatedAt: c.CreatedAt,
+			ID:        c.ID,
+			Key:       redactedString,
+			Tags:      c.Tags,
+		},
+	}
+}
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *HMACAuth) SanitizedCopy() *HMACAuth {
+	return &HMACAuth{
+		kong.HMACAuth{
+			// Consumer field omitted
+			CreatedAt: c.CreatedAt,
+			ID:        c.ID,
+			Username:  c.Username,
+			Secret:    redactedString,
+			Tags:      c.Tags,
+		},
+	}
+}
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *JWTAuth) SanitizedCopy() *JWTAuth {
+	return &JWTAuth{
+		kong.JWTAuth{
+			// Consumer field omitted
+			CreatedAt:    c.CreatedAt,
+			ID:           c.ID,
+			Algorithm:    c.Algorithm,
+			Key:          c.Key, // despite field name, "key" is an identifier
+			RSAPublicKey: c.RSAPublicKey,
+			Secret:       redactedString,
+			Tags:         c.Tags,
+		},
+	}
+}
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *BasicAuth) SanitizedCopy() *BasicAuth {
+	return &BasicAuth{
+		kong.BasicAuth{
+			// Consumer field omitted
+			CreatedAt: c.CreatedAt,
+			ID:        c.ID,
+			Username:  c.Username,
+			Password:  redactedString,
+			Tags:      c.Tags,
+		},
+	}
+}
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *Oauth2Credential) SanitizedCopy() *Oauth2Credential {
+	return &Oauth2Credential{
+		kong.Oauth2Credential{
+			// Consumer field omitted
+			CreatedAt:    c.CreatedAt,
+			ID:           c.ID,
+			Name:         c.Name,
+			ClientID:     c.ClientID,
+			ClientSecret: redactedString,
+			RedirectURIs: c.RedirectURIs,
+			Tags:         c.Tags,
+		},
+	}
+}

--- a/internal/ingress/controller/parser/kongstate/credentials.go
+++ b/internal/ingress/controller/parser/kongstate/credentials.go
@@ -1,0 +1,36 @@
+package kongstate
+
+import "github.com/kong/go-kong/kong"
+
+var redactedString = kong.String("REDACTED")
+
+// KeyAuth represents a key-auth credential.
+type KeyAuth struct {
+	kong.KeyAuth
+}
+
+// HMACAuth represents a HMAC credential.
+type HMACAuth struct {
+	kong.HMACAuth
+}
+
+// JWTAuth represents a JWT credential.
+type JWTAuth struct {
+	kong.JWTAuth
+}
+
+// BasicAuth represents a basic authentication credential.
+type BasicAuth struct {
+	kong.BasicAuth
+}
+
+// ACLGroup represents an ACL associated with a consumer. Due to ACL implementation in Kong being similar to
+// credentials, ACLs are treated as credentials, too.
+type ACLGroup struct {
+	kong.ACLGroup
+}
+
+// Oauth2Credential represents an OAuth2 client configuration including credentials.
+type Oauth2Credential struct {
+	kong.Oauth2Credential
+}

--- a/internal/ingress/controller/parser/kongstate/credentials_test.go
+++ b/internal/ingress/controller/parser/kongstate/credentials_test.go
@@ -1,0 +1,174 @@
+package kongstate
+
+import (
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyAuth_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   KeyAuth
+		want KeyAuth
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes key",
+			in: KeyAuth{kong.KeyAuth{
+				Consumer:  &kong.Consumer{Username: kong.String("foo")},
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Key:       kong.String("3"),
+				Tags:      []*string{kong.String("4.1"), kong.String("4.2")},
+			}},
+			want: KeyAuth{kong.KeyAuth{
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Key:       redactedString,
+				Tags:      []*string{kong.String("4.1"), kong.String("4.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHMACAuth_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   HMACAuth
+		want HMACAuth
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes secret",
+			in: HMACAuth{kong.HMACAuth{
+				Consumer:  &kong.Consumer{Username: kong.String("foo")},
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Username:  kong.String("3"),
+				Secret:    kong.String("4"),
+				Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
+			}},
+			want: HMACAuth{kong.HMACAuth{
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Username:  kong.String("3"),
+				Secret:    redactedString,
+				Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestJWTAuth_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   JWTAuth
+		want JWTAuth
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes secret",
+			in: JWTAuth{kong.JWTAuth{
+				Consumer:     &kong.Consumer{Username: kong.String("foo")},
+				CreatedAt:    kong.Int(1),
+				ID:           kong.String("2"),
+				Algorithm:    kong.String("3"),
+				Key:          kong.String("4"),
+				RSAPublicKey: kong.String("5"),
+				Secret:       kong.String("6"),
+				Tags:         []*string{kong.String("7.1"), kong.String("7.2")},
+			}},
+			want: JWTAuth{kong.JWTAuth{
+				CreatedAt:    kong.Int(1),
+				ID:           kong.String("2"),
+				Algorithm:    kong.String("3"),
+				Key:          kong.String("4"),
+				RSAPublicKey: kong.String("5"),
+				Secret:       redactedString,
+				Tags:         []*string{kong.String("7.1"), kong.String("7.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBasicAuth_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   BasicAuth
+		want BasicAuth
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes password",
+			in: BasicAuth{kong.BasicAuth{
+				Consumer:  &kong.Consumer{Username: kong.String("foo")},
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Username:  kong.String("3"),
+				Password:  kong.String("4"),
+				Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
+			}},
+			want: BasicAuth{kong.BasicAuth{
+				CreatedAt: kong.Int(1),
+				ID:        kong.String("2"),
+				Username:  kong.String("3"),
+				Password:  redactedString,
+				Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOauth2Credential_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   Oauth2Credential
+		want Oauth2Credential
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes client secret",
+			in: Oauth2Credential{kong.Oauth2Credential{
+				Consumer:     &kong.Consumer{Username: kong.String("foo")},
+				CreatedAt:    kong.Int(1),
+				ID:           kong.String("2"),
+				Name:         kong.String("3"),
+				ClientID:     kong.String("4"),
+				ClientSecret: kong.String("5"),
+				RedirectURIs: []*string{kong.String("6.1"), kong.String("6.2")},
+				Tags:         []*string{kong.String("7.1"), kong.String("7.2")},
+			}},
+			want: Oauth2Credential{kong.Oauth2Credential{
+				CreatedAt:    kong.Int(1),
+				ID:           kong.String("2"),
+				Name:         kong.String("3"),
+				ClientID:     kong.String("4"),
+				ClientSecret: redactedString,
+				RedirectURIs: []*string{kong.String("6.1"), kong.String("6.2")},
+				Tags:         []*string{kong.String("7.1"), kong.String("7.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -23,6 +23,23 @@ type KongState struct {
 	Consumers      []Consumer
 }
 
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (ks *KongState) SanitizedCopy() *KongState {
+	return &KongState{
+		Services:       ks.Services,
+		Upstreams:      ks.Upstreams,
+		Certificates:   ks.Certificates, // TODO
+		CACertificates: ks.CACertificates,
+		Plugins:        ks.Plugins,
+		Consumers: func() (res []Consumer) {
+			for _, v := range ks.Consumers {
+				res = append(res, *v.SanitizedCopy())
+			}
+			return
+		}(),
+	}
+}
+
 func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store.Storer) {
 	consumerIndex := make(map[string]Consumer)
 

--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -26,9 +26,14 @@ type KongState struct {
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
 func (ks *KongState) SanitizedCopy() *KongState {
 	return &KongState{
-		Services:       ks.Services,
-		Upstreams:      ks.Upstreams,
-		Certificates:   ks.Certificates, // TODO
+		Services:  ks.Services,
+		Upstreams: ks.Upstreams,
+		Certificates: func() (res []Certificate) {
+			for _, v := range ks.Certificates {
+				res = append(res, *v.SanitizedCopy())
+			}
+			return
+		}(),
 		CACertificates: ks.CACertificates,
 		Plugins:        ks.Plugins,
 		Consumers: func() (res []Consumer) {

--- a/internal/ingress/controller/parser/kongstate/kongstate.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate.go
@@ -93,7 +93,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 				log.Errorf("failed to provision credential: empty secret")
 				continue
 			}
-			err = c.SetCredential(log, credType, credConfig)
+			err = c.SetCredential(credType, credConfig)
 			if err != nil {
 				log.Errorf("failed to provision credential: %v", err)
 				continue

--- a/internal/ingress/controller/parser/kongstate/kongstate_test.go
+++ b/internal/ingress/controller/parser/kongstate/kongstate_test.go
@@ -20,11 +20,11 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 		want KongState
 	}{
 		{
-			name: "sanitizes all consumers and copies all other fields",
+			name: "sanitizes all consumers and certificates and copies all other fields",
 			in: KongState{
 				Services:       []Service{{Service: kong.Service{ID: kong.String("1")}}},
 				Upstreams:      []Upstream{{Upstream: kong.Upstream{ID: kong.String("1")}}},
-				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1")}}},
+				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1"), Key: kong.String("secret")}}},
 				CACertificates: []kong.CACertificate{{ID: kong.String("1")}},
 				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1")}}},
 				Consumers: []Consumer{{
@@ -34,7 +34,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 			want: KongState{
 				Services:       []Service{{Service: kong.Service{ID: kong.String("1")}}},
 				Upstreams:      []Upstream{{Upstream: kong.Upstream{ID: kong.String("1")}}},
-				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1")}}},
+				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1"), Key: redactedString}}},
 				CACertificates: []kong.CACertificate{{ID: kong.String("1")}},
 				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1")}}},
 				Consumers: []Consumer{{

--- a/internal/ingress/controller/parser/kongstate/types.go
+++ b/internal/ingress/controller/parser/kongstate/types.go
@@ -54,6 +54,20 @@ type Certificate struct {
 	kong.Certificate
 }
 
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *Certificate) SanitizedCopy() *Certificate {
+	return &Certificate{
+		kong.Certificate{
+			ID:        c.ID,
+			Cert:      c.Cert,
+			Key:       redactedString,
+			CreatedAt: c.CreatedAt,
+			SNIs:      c.SNIs,
+			Tags:      c.Tags,
+		},
+	}
+}
+
 // Plugin represetns a plugin Object in Kong.
 type Plugin struct {
 	kong.Plugin

--- a/internal/ingress/controller/parser/kongstate/types_test.go
+++ b/internal/ingress/controller/parser/kongstate/types_test.go
@@ -1,0 +1,41 @@
+package kongstate
+
+import (
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCertificate_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   Certificate
+		want Certificate
+	}{
+		{
+			name: "fills all fields but Consumer and sanitizes key",
+			in: Certificate{kong.Certificate{
+				ID:        kong.String("1"),
+				Cert:      kong.String("2"),
+				Key:       kong.String("3"),
+				CreatedAt: int64Ptr(4),
+				SNIs:      []*string{kong.String("5.1"), kong.String("5.2")},
+				Tags:      []*string{kong.String("6.1"), kong.String("6.2")},
+			}},
+			want: Certificate{kong.Certificate{
+				ID:        kong.String("1"),
+				Cert:      kong.String("2"),
+				Key:       redactedString,
+				CreatedAt: int64Ptr(4),
+				SNIs:      []*string{kong.String("5.1"), kong.String("5.2")},
+				Tags:      []*string{kong.String("6.1"), kong.String("6.2")},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Please review commit by commit and merge without squashing.
Inspired by #991.

This PR:
- defines Go types for credential types in KIC (as wrappers for `go-kong` types allowing for implementation of KIC business logic in those wrappers) consistently with wrappers for other `go-kong` types (`Consumer`, `Service`, `Route`, etc.)
- implements a recursive `Kongstate.SanitizedCopy()` produces a copy of `KongState` containing only a subset of `KongState` fields,
- refactors `SetCredential` by breaking its type-specific logic out to individual type creator functions `NewXXX()`