### PR TITLE
test(integration): expose KUBE_VERSION

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -62,6 +62,8 @@ jobs:
   test-k8s:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      KUBE_VERSION: v1.20.2
     steps:
     - name: 'Arrange: Check out the repo'
       uses: actions/checkout@v2
@@ -75,6 +77,6 @@ jobs:
         docker load < image.tar
         docker tag local/kong-ingress-controller:ci localhost:32000/kong-ingress-controller:ci
 
-    - name: 'Test: Run integration tests'
+    - name: 'Test: Run integration tests (k8s ${{ env.KUBE_VERSION }})'
       run: |
         env KIC_IMAGE=local/kong-ingress-controller:ci ./test/integration/test.sh

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 # only for dev
 DB?=false
 RUN_VERSION?=20
+KUBE_VERSION?=v1.20.2
 
 ifndef COMMIT
   COMMIT := $(shell git rev-parse --short HEAD)
@@ -62,6 +63,7 @@ container:
 run:
 	./hack/dev/start.sh ${DB} ${RUN_VERSION}
 
+
 .PHONY: integration-test
 integration-test: container
-	KIC_IMAGE="${IMAGE}:${TAG}" ./test/integration/test.sh
+	KIC_IMAGE="${IMAGE}:${TAG}" KUBE_VERSION=${KUBE_VERSION} ./test/integration/test.sh

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -24,7 +24,7 @@ This command builds a KIC Docker image and runs the test against that image.
 It is possible to run the test against any prebuilt KIC image, skipping the build step:
 
 ```bash
-env KIC_IMAGE=some-kic-image:tag ./test/integration/test.sh
+env KIC_IMAGE=some-kic-image:tag KUBE_VERSION=v1.20.2 ./test/integration/test.sh
 ```
 
 ### Troubleshooting
@@ -37,7 +37,7 @@ By passing `SKIP_TEARDOWN=yes` to the test you can inspect the test environment 
 ```bash
 make SKIP_TEARDOWN=yes integration-test
 # or
-env KIC_IMAGE=some-kic-image:tag SKIP_TEARDOWN=yes ./test/integration/test.sh
+env KIC_IMAGE=some-kic-image:tag KUBE_VERSION=v1.20.2 SKIP_TEARDOWN=yes ./test/integration/test.sh
 ```
 
 #### Access the test cluster with `kubectl`

--- a/test/integration/util/create-cluster.sh
+++ b/test/integration/util/create-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 REGISTRY_PORT=5000
 docker run -d --restart=always -p "$REGISTRY_PORT:5000" --name "$REGISTRY_NAME" registry:2
@@ -9,6 +9,9 @@ KIND_CONFIG="
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: $CLUSTER_NAME
+nodes:
+- role: control-plane
+  image: 'kindest/node:$KUBE_VERSION'
 containerdConfigPatches:
 - |-
   [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"$REGISTRY_NAME:$REGISTRY_PORT\"]


### PR DESCRIPTION
Makes it possible to specify the version of Kubernetes running KIC's integration test.

The choice is limited to available tags of the `docker/io/kindest/node` docker registry (which doesn't cover all releases at this moment). Asked `kind` maintainers (https://github.com/kubernetes-sigs/kind/issues/197#issuecomment-769034378) to increase coverage (specifically: start providing images for pre-release k8s builds as well)