### PR TITLE
Let admission webhook check KongPlugins with secret configuration

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -506,6 +506,7 @@ func main() {
 			Validator: admission.KongHTTPValidator{
 				Client: kongClient,
 				Logger: logger,
+				Store:  store,
 			},
 			Logger: logger,
 		}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/kong/go-kong/kong"
-	configuration "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
+	configurationv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/pkg/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/pkg/store"
 	"github.com/sirupsen/logrus"
@@ -15,8 +15,8 @@ import (
 
 // KongValidator validates Kong entities.
 type KongValidator interface {
-	ValidateConsumer(ctx context.Context, consumer configuration.KongConsumer) (bool, string, error)
-	ValidatePlugin(consumer configuration.KongPlugin) (bool, string, error)
+	ValidateConsumer(ctx context.Context, consumer configurationv1.KongConsumer) (bool, string, error)
+	ValidatePlugin(consumer configurationv1.KongPlugin) (bool, string, error)
 	ValidateCredential(secret corev1.Secret) (bool, string, error)
 }
 
@@ -34,7 +34,7 @@ type KongHTTPValidator struct {
 // The first boolean communicates if the consumer is valid or not and string
 // holds a message if the entity is not valid.
 func (validator KongHTTPValidator) ValidateConsumer(ctx context.Context,
-	consumer configuration.KongConsumer) (bool, string, error) {
+	consumer configurationv1.KongConsumer) (bool, string, error) {
 	if consumer.Username == "" {
 		return false, "username cannot be empty", nil
 	}
@@ -58,7 +58,7 @@ func (validator KongHTTPValidator) ValidateConsumer(ctx context.Context,
 // The first boolean communicates if k8sPluign is valid or not and string
 // holds a message if the entity is not valid.
 func (validator KongHTTPValidator) ValidatePlugin(
-	k8sPlugin configuration.KongPlugin) (bool, string, error) {
+	k8sPlugin configurationv1.KongPlugin) (bool, string, error) {
 	if k8sPlugin.PluginName == "" {
 		return false, "plugin name cannot be empty", nil
 	}
@@ -67,7 +67,7 @@ func (validator KongHTTPValidator) ValidatePlugin(
 	if k8sPlugin.Config != nil {
 		plugin.Config = kong.Configuration(k8sPlugin.Config)
 	}
-	if k8sPlugin.ConfigFrom.SecretValue != (configuration.SecretValueFromSource{}) {
+	if k8sPlugin.ConfigFrom.SecretValue != (configurationv1.SecretValueFromSource{}) {
 		if k8sPlugin.Config != nil {
 			return false, "plugin cannot use both Config and ConfigFrom", nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't currently support pulling configuration a KongPlugin's ConfigFrom configuration in the admission webhook. Some plugins have fields that must be populated and have no default, e.g. `issuer` for the OpenID Connect plugin. The only current remedy is to disable validation entirely, which isn't ideal.

This PR:
- Provides access to the store in the admission webhook, so that it can retrieve content from resources (in this case, a Secret) referenced by proposed resource.
- Validates that Secrets referenced by ConfigFrom exist, and uses the configuration in them when validating the plugin schema.
- Checks that a KongPlugin doesn't provide both Config and ConfigFrom.
- Uses the `configurationv1` import convention we use elsewhere for `github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1` in the admission webhook.

**Which issue this PR fixes**:
fixes #1023

**Special notes for your reviewer**:
Reviewed validation unit tests. We currently lack units for most of the webhook checks because most of them require a Kong instance's `/schemas/<whatever>/validate` endpoint or other admin API access (e.g. `GET /consumers/<username>` to check whether a consumer would be a duplicate). We'd need integration tests to validate these, but our current framework doesn't allow us to easily test just whether we can upload configuration, since it's based around testing proxy behavior after. We should consider how to work such validation webhook tests into the new Go integration test system.
