### PR TITLE
Set CODEOWNERS to team-k8s

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hbagdi @rainest @mflendrich
+* @kong/team-k8s


### PR DESCRIPTION
Replaces individuals' names with the GH team.
