### PR TITLE
chore(ci) update kustomize flag

### DIFF
--- a/test/integration/util/install-sut.sh
+++ b/test/integration/util/install-sut.sh
@@ -8,6 +8,6 @@ docker tag "$KIC_IMAGE" "$REMOTE_IMAGE"
 docker push "$REMOTE_IMAGE"
 
 SUT_ROOT="$(dirname "$BASH_SOURCE")/../sut"
-kustomize build --load_restrictor none "$SUT_ROOT" | kubectl apply -f -
+kustomize build --load-restrictor LoadRestrictionsNone "$SUT_ROOT" | kubectl apply -f -
 
 kubectl wait --for=condition=Available --namespace=kong deploy/ingress-kong --timeout=300s


### PR DESCRIPTION
Addresses the CI issue @shaneutt noticed this morning. Latest kustomize changed the old `--load_restrictor` flag.

I'm not exactly sure what determines our kustomize version in test-k8s. I don't see anywhere we install it independently, so I'm guessing we get it from KIND? The KIND version didn't change, which suggests that it's pulling the latest kustomize down automatically. https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.0.1 is quite recent (12 days ago).