### PR TITLE
Enable Dependabot for KIC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,6 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /
+  target-branch: next
   schedule:
     interval: daily


### PR DESCRIPTION
Enables [Dependabot](https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates) for the KIC repository, so that we get PRs to `next` with Go module updates.