### PR TITLE
Add ValidatePlugin tests and mock client

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -516,9 +516,10 @@ func main() {
 		logger := log.WithField("component", "admission-server")
 		admissionServer := admission.Server{
 			Validator: admission.KongHTTPValidator{
-				Client: kongClient,
-				Logger: logger,
-				Store:  store,
+				ConsumerSvc: kongClient.Consumers,
+				PluginSvc:   kongClient.Plugins,
+				Logger:      logger,
+				Store:       store,
 			},
 			Logger: logger,
 		}

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -140,7 +140,7 @@ func (a Server) handleValidation(ctx context.Context, request admission.Admissio
 			return nil, err
 		}
 
-		ok, message, err = a.Validator.ValidatePlugin(plugin)
+		ok, message, err = a.Validator.ValidatePlugin(ctx, plugin)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -31,7 +31,7 @@ func (v KongFakeValidator) ValidateConsumer(_ context.Context,
 	return v.Result, v.Message, v.Error
 }
 
-func (v KongFakeValidator) ValidatePlugin(
+func (v KongFakeValidator) ValidatePlugin(_ context.Context,
 	k8sPlugin configuration.KongPlugin) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -62,8 +62,6 @@ func (validator KongHTTPValidator) ValidateConsumer(ctx context.Context,
 // If an error occurs during validation, it is returned as the last argument.
 // The first boolean communicates if k8sPluign is valid or not and string
 // holds a message if the entity is not valid.
-//
-// XXX: this function never returns non-nil error
 func (validator KongHTTPValidator) ValidatePlugin(ctx context.Context,
 	k8sPlugin configurationv1.KongPlugin) (bool, string, error) {
 	if k8sPlugin.PluginName == "" {
@@ -81,7 +79,7 @@ func (validator KongHTTPValidator) ValidatePlugin(ctx context.Context,
 		config, err := kongstate.SecretToConfiguration(validator.Store,
 			k8sPlugin.ConfigFrom.SecretValue, k8sPlugin.Namespace)
 		if err != nil {
-			return false, fmt.Sprintf("could not load secret plugin configuration: %v", err), nil
+			return false, "could not load secret plugin configuration", err
 		}
 		plugin.Config = kong.Configuration(config)
 
@@ -93,7 +91,7 @@ func (validator KongHTTPValidator) ValidatePlugin(ctx context.Context,
 		plugin.Protocols = kong.StringSlice(k8sPlugin.Protocols...)
 	}
 	if isValid, err := validator.PluginSvc.Validate(ctx, &plugin); err != nil {
-		return false, err.Error(), nil
+		return false, "plugin failed schema validation", err
 	} else {
 		return isValid, "", nil
 	}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -23,8 +23,8 @@ type KongValidator interface {
 // KongHTTPValidator implements KongValidator interface to validate Kong
 // entities using the Admin API of Kong.
 type KongHTTPValidator struct {
-	consumerSvc kong.AbstractConsumerService
-	pluginSvc   kong.AbstractPluginService
+	ConsumerSvc kong.AbstractConsumerService
+	PluginSvc   kong.AbstractPluginService
 	//	Client *kong.Client
 	Logger logrus.FieldLogger
 	Store  store.Storer
@@ -43,7 +43,7 @@ func (validator KongHTTPValidator) ValidateConsumer(ctx context.Context,
 	if consumer.Username == "" {
 		return false, ErrTextUsernameEmpty, nil
 	}
-	c, err := validator.consumerSvc.Get(ctx, &consumer.Username)
+	c, err := validator.ConsumerSvc.Get(ctx, &consumer.Username)
 	if err != nil {
 		if kong.IsNotFoundErr(err) {
 			return true, "", nil
@@ -92,7 +92,7 @@ func (validator KongHTTPValidator) ValidatePlugin(ctx context.Context,
 	if len(k8sPlugin.Protocols) > 0 {
 		plugin.Protocols = kong.StringSlice(k8sPlugin.Protocols...)
 	}
-	if isValid, err := validator.pluginSvc.Validate(ctx, &plugin); err != nil {
+	if isValid, err := validator.PluginSvc.Validate(ctx, &plugin); err != nil {
 		return false, err.Error(), nil
 	} else {
 		return isValid, "", nil

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -16,7 +16,7 @@ import (
 // KongValidator validates Kong entities.
 type KongValidator interface {
 	ValidateConsumer(ctx context.Context, consumer configurationv1.KongConsumer) (bool, string, error)
-	ValidatePlugin(consumer configurationv1.KongPlugin) (bool, string, error)
+	ValidatePlugin(ctx context.Context, plugin configurationv1.KongPlugin) (bool, string, error)
 	ValidateCredential(secret corev1.Secret) (bool, string, error)
 }
 
@@ -64,7 +64,7 @@ func (validator KongHTTPValidator) ValidateConsumer(ctx context.Context,
 // holds a message if the entity is not valid.
 //
 // XXX: this function never returns non-nil error
-func (validator KongHTTPValidator) ValidatePlugin(
+func (validator KongHTTPValidator) ValidatePlugin(ctx context.Context,
 	k8sPlugin configurationv1.KongPlugin) (bool, string, error) {
 	if k8sPlugin.PluginName == "" {
 		return false, "plugin name cannot be empty", nil
@@ -92,7 +92,7 @@ func (validator KongHTTPValidator) ValidatePlugin(
 	if len(k8sPlugin.Protocols) > 0 {
 		plugin.Protocols = kong.StringSlice(k8sPlugin.Protocols...)
 	}
-	if isValid, err := validator.pluginSvc.Validate(context.TODO(), &plugin); err != nil {
+	if isValid, err := validator.pluginSvc.Validate(ctx, &plugin); err != nil {
 		return false, err.Error(), nil
 	} else {
 		return isValid, "", nil

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -183,7 +183,7 @@ func (f *fakeConsumerSvc) Get(ctx context.Context, usernameOrID *string) (*kong.
 func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
-		consumerSvc kong.AbstractConsumerService
+		ConsumerSvc kong.AbstractConsumerService
 
 		in configurationv1.KongConsumer
 
@@ -199,34 +199,34 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 		},
 		{
 			name:        "kong says consumer not found",
-			consumerSvc: &fakeConsumerSvc{err: kong.NewAPIError(404, "")},
+			ConsumerSvc: &fakeConsumerSvc{err: kong.NewAPIError(404, "")},
 			in:          configurationv1.KongConsumer{Username: "something"},
 			wantSuccess: true,
 		},
 		{
 			name:        "kong says HTTP 500",
-			consumerSvc: &fakeConsumerSvc{err: kong.NewAPIError(500, "")},
+			ConsumerSvc: &fakeConsumerSvc{err: kong.NewAPIError(500, "")},
 			in:          configurationv1.KongConsumer{Username: "something"},
 			wantSuccess: false,
 			wantErr:     true,
 		},
 		{
 			name:          "consumer already exists",
-			consumerSvc:   &fakeConsumerSvc{consumer: &kong.Consumer{}},
+			ConsumerSvc:   &fakeConsumerSvc{consumer: &kong.Consumer{}},
 			in:            configurationv1.KongConsumer{Username: "something"},
 			wantSuccess:   false,
 			wantErrorText: ErrTextConsumerExists,
 		},
 		{
 			name:        "validation successful",
-			consumerSvc: &fakeConsumerSvc{},
+			ConsumerSvc: &fakeConsumerSvc{},
 			in:          configurationv1.KongConsumer{Username: "something"},
 			wantSuccess: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			v := KongHTTPValidator{
-				consumerSvc: tt.consumerSvc,
+				ConsumerSvc: tt.ConsumerSvc,
 				Logger:      logrus.New(),
 			}
 			gotSuccess, gotErrorText, gotErr := v.ValidateConsumer(context.Background(), tt.in)


### PR DESCRIPTION
**What this PR does / why we need it**:
Continuation of the pair programming session from today:

- Exposes the Validator clients (aka services) from earlier and sets them from the Kong client when main instantiates the real Validator.
- Passes context into ValidatePlugin from the admission server.
- Adds a mock plugin client for testing.
- Fixes several cases within ValidatePlugin that combined their failure description with additional context information.
- Adds tests for ValidatePlugin.

**Special notes for your reviewer**:
Targeted into the refactor branch from today. This cannot go into next until we've released the associated go-kong changes and updated its version.

The tests that do not require a mock client were previously written for https://github.com/Kong/kubernetes-ingress-controller/pull/1034 and were mostly copy-pasted into this branch. They needed some adjustment because refactor/validator-mocking is based off current next and still uses the KIC Configuration type, not apiextensionsv1.JSON.

The ValidatePlugin changes and new ValidatePlugin tests in this and #1034 will conflict with one another/require a bit of reworking depending on which we merge first. I'm inclined to merge #1034 first given that:

- It doesn't require any changes to go-kong/we can complete it within this repo alone.
- It unblocks Railgun work (we can't generate Kong(Cluster)Plugin manifests otherwise).
- The existing tests proposed there are still valid and don't really change with this. This provides a means to add new tests that weren't possible without a mock client; the other tests all exited ValidatePlugin before that client was called.
- The ValidatePlugin tests are still ancillary to the main purpose of #1034 (the type change). They were requested because those changes touched code that previously had no tests.

Tagging this do not merge pending some decision on that