### PR TITLE
test: test upstream ingress route cleanup

### DIFF
--- a/railgun/test/integration/ingress_controllers_test.go
+++ b/railgun/test/integration/ingress_controllers_test.go
@@ -3,7 +3,9 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -56,6 +58,31 @@ func TestMinimalIngress(t *testing.T) {
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
 	}, ingressTimeout, ingressTimeoutTick)
+
+	// ensure that a deleted ingress results in the route being torn down
+	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	assert.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("%s/nginx", u.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", u.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+
+		return resp.StatusCode == http.StatusNotFound
+	}, ingressTimeout, ingressTimeoutTick)
+
+	// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
+	// Expected: {"message":"no Route matched with those values"}
+	resp, err := http.Get(fmt.Sprintf("%s/nginx", u.String()))
+	assert.NoError(t, err)
+	b := new(bytes.Buffer)
+	b.ReadFrom(resp.Body)
+	body := struct {
+		Message string `json:"message"`
+	}{}
+	assert.NoError(t, json.Unmarshal(b.Bytes(), &body))
+	assert.Equal(t, "no Route matched with those values", body.Message)
 }
 
 func TestHTTPSRedirect(t *testing.T) {


### PR DESCRIPTION
This PR adds a small integration test to validate upstream Ingress cleanup.
