### PR TITLE
ci(*) report if a PR results in a license change

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -16,22 +16,20 @@ jobs:
         go-version: '^1.16'
     - name: Install go-licenses
       run: go get github.com/google/go-licenses
-    - name: Create source location
-      run: mkdir -p src/github.com/Kong/
     - name: Checkout target
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.base.ref }}
-        path: src/github.com/Kong/kubernetes-ingress-controller
+        path: ./src
         fetch-depth: 0
     - name: Generate target license report
-      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/target_licenses.csv
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      run: go-licenses csv ./... | sort > ${{ github.workspace }}/target_licenses.csv
+      working-directory: ./src
     - name: Checkout PR
       run: git checkout ${{ github.head_ref }}
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      working-directory: ./src
     - name: Generate PR license report
-      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/pr_licenses.csv
+      run: go-licenses csv ./... | sort > ${{ github.workspace }}/pr_licenses.csv
       working-directory: src/github.com/Kong/kubernetes-ingress-controller
     - name: Compare license reports
       id: compare_reports

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -1,0 +1,60 @@
+name: 'Check for license changes'
+
+on: [pull_request]
+
+jobs:
+  licenses:
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license-status-change')"
+    env:
+      GOPATH: ${{ github.workspace }}
+      GOBIN: ${{ github.workspace }}/bin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16'
+    - name: Install go-licenses
+      run: go get github.com/google/go-licenses
+    - name: Create source location
+      run: mkdir -p src/github.com/Kong/
+    - name: Checkout target
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
+        path: src/github.com/Kong/kubernetes-ingress-controller
+        fetch-depth: 0
+    - name: Generate target license report
+      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/target_licenses.csv
+      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+    - name: Checkout PR
+      run: git checkout ${{ github.head_ref }}
+      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+    - name: Generate PR license report
+      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/pr_licenses.csv
+      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+    - name: Compare license reports
+      id: compare_reports
+      run: |
+        echo 'DIFF_OUT<<EOF' >> $GITHUB_ENV
+        diff -u target_licenses.csv pr_licenses.csv >> $GITHUB_ENV || true
+        echo 'EOF' >> $GITHUB_ENV
+    - name: Update PR if licenses differ
+      uses: actions/github-script@v3
+      if: ${{ env.DIFF_OUT != '' }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Licenses differ between PR and base:\n```' + process.env.DIFF_OUT + '```'
+            })
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ci/license-status-change']
+            })
+

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   licenses:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license-status-changed')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license/changed')"
     env:
       GOPATH: ${{ github.workspace }}
       GOBIN: ${{ github.workspace }}/bin
@@ -53,13 +53,13 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: ['ci/license-status-unchanged']
+              name: ['ci/license/unchanged']
             })
             github.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ci/license-status-changed']
+              labels: ['ci/license/changed']
             })
     - name: Update PR - go-license output equal
       uses: actions/github-script@v3

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   licenses:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license-status-change')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license-status-changed')"
     env:
       GOPATH: ${{ github.workspace }}
       GOBIN: ${{ github.workspace }}/bin
@@ -37,7 +37,7 @@ jobs:
         echo 'DIFF_OUT<<EOF' >> $GITHUB_ENV
         diff -u target_licenses.csv pr_licenses.csv >> $GITHUB_ENV || true
         echo 'EOF' >> $GITHUB_ENV
-    - name: Update PR if licenses differ
+    - name: Update PR - go-license output differs
       uses: actions/github-script@v3
       if: ${{ env.DIFF_OUT != '' }}
       with:
@@ -47,12 +47,30 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Licenses differ between PR and base:\n```' + process.env.DIFF_OUT + '```'
+              body: 'Licenses differ between commit ' + context.sha + ' and base:\n```' + process.env.DIFF_OUT + '```'
+            })
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['ci/license-status-unchanged']
             })
             github.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ci/license-status-change']
+              labels: ['ci/license-status-changed']
+            })
+    - name: Update PR - go-license output equal
+      uses: actions/github-script@v3
+      if: ${{ env.DIFF_OUT == '' }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ci/license-status-unchanged']
             })
 

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -30,7 +30,7 @@ jobs:
       working-directory: ./src
     - name: Generate PR license report
       run: go-licenses csv ./... | sort > ${{ github.workspace }}/pr_licenses.csv
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      working-directory: ./src
     - name: Compare license reports
       id: compare_reports
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a license change report workflow for PRs based on the spike in https://github.com/Kong/team-k8s/issues/40

**Special notes for your reviewer**:
The license checker tool is imperfect and cannot find licenses for everything, but it does still include lines for those packages:
```
github.com/xeipuuv/gojsonreference,Unknown,Unknown
```
We'd be alerted the first time those are added, but not if they change.

The workflow checks the PR for a license change after each commit until it finds one. Once it does find a change, it adds a `ci/license-status-change` label, and will not check again unless that label is manually removed. It adds a comment every time it runs and finds a diff, so without that label, it'd spam comments on commits since the start of the PR, even if the individual commit didn't introduce anything new. Not sure if there's a better condition we should use and/or if there's some way this could update a single copy of the report, rather than adding a new comment.

If the workflow detects a license change, the result looks like:
![example_report](https://user-images.githubusercontent.com/571832/112703309-b7ae1100-8e53-11eb-95a3-42b3e1076385.png)
