### PR TITLE
enhance #1138: run for all packages of source, make file reusable, comment also if output equal

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -16,22 +16,20 @@ jobs:
         go-version: '^1.16'
     - name: Install go-licenses
       run: go get github.com/google/go-licenses
-    - name: Create source location
-      run: mkdir -p src/github.com/Kong/
     - name: Checkout target
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.base.ref }}
-        path: src/github.com/Kong/kubernetes-ingress-controller
+        path: ./src
         fetch-depth: 0
     - name: Generate target license report
-      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/target_licenses.csv
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      run: go-licenses csv ./... | sort > ${{ github.workspace }}/target_licenses.csv
+      working-directory: ./src
     - name: Checkout PR
       run: git checkout ${{ github.head_ref }}
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      working-directory: ./src
     - name: Generate PR license report
-      run: go-licenses csv ./cli/ingress-controller/ | sort > ${{ github.workspace }}/pr_licenses.csv
+      run: go-licenses csv ./... | sort > ${{ github.workspace }}/pr_licenses.csv
       working-directory: src/github.com/Kong/kubernetes-ingress-controller
     - name: Compare license reports
       id: compare_reports

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -47,7 +47,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Licenses differ between PR and base:\n```' + process.env.DIFF_OUT + '```'
+              body: 'Licenses differ between commit ' + context.sha + ' and base:\n```' + process.env.DIFF_OUT + '```'
             })
             github.issues.addLabels({
               issue_number: context.issue.number,
@@ -66,6 +66,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Outputs of go-license for the PR and base were equal.'
+              body: 'Outputs of go-license for commit ' + context.sha + ' and base were equal.'
             })
 

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -37,7 +37,7 @@ jobs:
         echo 'DIFF_OUT<<EOF' >> $GITHUB_ENV
         diff -u target_licenses.csv pr_licenses.csv >> $GITHUB_ENV || true
         echo 'EOF' >> $GITHUB_ENV
-    - name: Update PR if licenses differ
+    - name: Update PR - go-license output differs
       uses: actions/github-script@v3
       if: ${{ env.DIFF_OUT != '' }}
       with:
@@ -54,5 +54,18 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['ci/license-status-change']
+            })
+
+    - name: Update PR - go-license output equal
+      uses: actions/github-script@v3
+      if: ${{ env.DIFF_OUT == '' }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Outputs of go-license for the PR and base were equal.'
             })
 

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -30,7 +30,7 @@ jobs:
       working-directory: ./src
     - name: Generate PR license report
       run: go-licenses csv ./... | sort > ${{ github.workspace }}/pr_licenses.csv
-      working-directory: src/github.com/Kong/kubernetes-ingress-controller
+      working-directory: ./src
     - name: Compare license reports
       id: compare_reports
       run: |


### PR DESCRIPTION
Enhances #1138:
- runs the license check not just for the `cli/ingress-controller` package and its dependencies, but for all packages in the source repository. This makes a difference if there is more than one `package main` (and railgun is a separate `package main`). Also I suspect that the current setting does not include testing dependencies.
- changes the checkout directory from `src/github.com/Kong/kubernetes-ingress-controller` to simply `./src` so that this job is reusable in other repos
- also puts a comment on the PR when the comparison resulted in empty diff; each comment includes a commit hash