### PR TITLE
chore(stale): limit stale[bot] to issues labeled as "pending author feedback"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,9 @@ daysUntilStale: 14
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 7
 
+onlyLabels:
+  - "pending author feedback"
+
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - pinned


### PR DESCRIPTION
Our current stale[bot] config is way too restrictive. It has closed a lot of issues that shouldn't have been closed, which required manual intervention.

This PR follows a discussion among contributors. After this PR, stale[bot] will only act on issues labeled with `pending author feedback`