### PR TITLE
Add storageversion tags to Railgun versions of CRD types

### DIFF
--- a/railgun/apis/configuration/v1/kongclusterplugin_types.go
+++ b/railgun/apis/configuration/v1/kongclusterplugin_types.go
@@ -24,6 +24,7 @@ import (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API
 type KongClusterPlugin struct {

--- a/railgun/apis/configuration/v1/kongconsumer_types.go
+++ b/railgun/apis/configuration/v1/kongconsumer_types.go
@@ -22,6 +22,7 @@ import (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // KongConsumer is the Schema for the kongconsumers API
 type KongConsumer struct {

--- a/railgun/apis/configuration/v1/kongingress_types.go
+++ b/railgun/apis/configuration/v1/kongingress_types.go
@@ -29,6 +29,7 @@ var _ = kicv1.KongIngress{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // KongIngress is the Schema for the kongingresses API
 type KongIngress struct {

--- a/railgun/apis/configuration/v1/kongplugin_types.go
+++ b/railgun/apis/configuration/v1/kongplugin_types.go
@@ -27,6 +27,7 @@ import (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // KongPlugin is the Schema for the kongplugins API
 type KongPlugin struct {

--- a/railgun/apis/configuration/v1alpha1/udpingress_types.go
+++ b/railgun/apis/configuration/v1alpha1/udpingress_types.go
@@ -24,6 +24,7 @@ import (
 //+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // UDPIngress is the Schema for the udpingresses API
 type UDPIngress struct {

--- a/railgun/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -100,7 +100,7 @@ spec:
             type: string
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1

--- a/railgun/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -48,42 +48,9 @@ spec:
             type: string
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: KongConsumer is a top-level type. A client is created for it.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          credentials:
-            description: Credentials are references to secrets containing a credential
-              to be provisioned in Kong.
-            items:
-              type: string
-            type: array
-          custom_id:
-            description: CustomID existing unique ID for the consumer - useful for
-              mapping Kong with users in your existing database
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          username:
-            description: Username unique username of the consumer.
-            type: string
-        type: object
-    served: true
-    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/railgun/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -392,6 +392,380 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is a top-level type. A client is created for it.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          proxy:
+            description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
+            properties:
+              ca_certificates:
+                items:
+                  type: string
+                type: array
+              client_certificate:
+                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
+                properties:
+                  cert:
+                    type: string
+                  created_at:
+                    format: int64
+                    type: integer
+                  id:
+                    type: string
+                  key:
+                    type: string
+                  snis:
+                    items:
+                      type: string
+                    type: array
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              connect_timeout:
+                type: integer
+              created_at:
+                type: integer
+              host:
+                type: string
+              id:
+                type: string
+              name:
+                type: string
+              path:
+                type: string
+              port:
+                type: integer
+              protocol:
+                type: string
+              read_timeout:
+                type: integer
+              retries:
+                type: integer
+              tags:
+                items:
+                  type: string
+                type: array
+              tls_verify:
+                type: boolean
+              tls_verify_depth:
+                type: integer
+              updated_at:
+                type: integer
+              url:
+                type: string
+              write_timeout:
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              created_at:
+                type: integer
+              destinations:
+                items:
+                  description: CIDRPort represents a set of CIDR and a port.
+                  properties:
+                    ip:
+                      type: string
+                    port:
+                      type: integer
+                  type: object
+                type: array
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              hosts:
+                items:
+                  type: string
+                type: array
+              https_redirect_status_code:
+                type: integer
+              id:
+                type: string
+              methods:
+                items:
+                  type: string
+                type: array
+              name:
+                type: string
+              path_handling:
+                type: string
+              paths:
+                items:
+                  type: string
+                type: array
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              service:
+                description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
+                properties:
+                  ca_certificates:
+                    items:
+                      type: string
+                    type: array
+                  client_certificate:
+                    description: Certificate represents a Certificate in Kong. Read
+                      https://getkong.org/docs/0.14.x/admin-api/#certificate-object
+                    properties:
+                      cert:
+                        type: string
+                      created_at:
+                        format: int64
+                        type: integer
+                      id:
+                        type: string
+                      key:
+                        type: string
+                      snis:
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  connect_timeout:
+                    type: integer
+                  created_at:
+                    type: integer
+                  host:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  path:
+                    type: string
+                  port:
+                    type: integer
+                  protocol:
+                    type: string
+                  read_timeout:
+                    type: integer
+                  retries:
+                    type: integer
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                  tls_verify:
+                    type: boolean
+                  tls_verify_depth:
+                    type: integer
+                  updated_at:
+                    type: integer
+                  url:
+                    type: string
+                  write_timeout:
+                    type: integer
+                type: object
+              snis:
+                items:
+                  type: string
+                type: array
+              sources:
+                items:
+                  description: CIDRPort represents a set of CIDR and a port.
+                  properties:
+                    ip:
+                      type: string
+                    port:
+                      type: integer
+                  type: object
+                type: array
+              strip_path:
+                type: boolean
+              tags:
+                items:
+                  type: string
+                type: array
+              updated_at:
+                type: integer
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                type: string
+              client_certificate:
+                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
+                properties:
+                  cert:
+                    type: string
+                  created_at:
+                    format: int64
+                    type: integer
+                  id:
+                    type: string
+                  key:
+                    type: string
+                  snis:
+                    items:
+                      type: string
+                    type: array
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              created_at:
+                format: int64
+                type: integer
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            type: integer
+                          successes:
+                            type: integer
+                        type: object
+                      http_path:
+                        type: string
+                      https_sni:
+                        type: string
+                      https_verify_certificate:
+                        type: boolean
+                      timeout:
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            type: integer
+                          tcp_failures:
+                            type: integer
+                          timeouts:
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            type: integer
+                          successes:
+                            type: integer
+                        type: object
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            type: integer
+                          tcp_failures:
+                            type: integer
+                          timeouts:
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: number
+                type: object
+              host_header:
+                type: string
+              id:
+                type: string
+              name:
+                type: string
+              slots:
+                type: integer
+              tags:
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the [storageversion kubebuilder tag](https://book.kubebuilder.io/multiversion-tutorial/api-changes.html#storage-versions) to the Railgun versions of our CRD types. Without this, manifest generation currently fails:

```
$ make test                                                                 
/home/traines/src/ingress-controller/railgun/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false,allowDangerousTypes=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1:-: CRD for KongPlugin.configuration.konghq.com has no storage version
github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1:-: CRD for KongConsumer.configuration.konghq.com has no storage version
Error: not all generators ran successfully
```

**Special notes for your reviewer**:

Not entirely clear if this _should_ happen, even though it does. It looks like kubebuilder picks up both the original instances of these types under `pkg/apis` and the instances under `railgun/apis`, but considers them separate versions even though the actual versions are the same. Looking [inside the controller-gen code](https://github.com/kubernetes-sigs/controller-tools/blob/v0.4.1/pkg/crd/spec.go#L151):

```
(dlv) p crd.Spec.Versions
[]k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceDefinitionVersion len: 2, cap: 2, [
	{
		Name: "v1",
		Served: true,
		Storage: false,
		Deprecated: false,
		DeprecationWarning: *string nil,
		Schema: *(*"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceValidation")(0xc001183aa8),
		Subresources: *(*"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceSubresources")(0xc001029600),
		AdditionalPrinterColumns: []k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceColumnDefinition len: 0, cap: 0, nil,},
	{
		Name: "v1",
		Served: true,
		Storage: false,
		Deprecated: false,
		DeprecationWarning: *string nil,
		Schema: *(*"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceValidation")(0xc001183ae0),
		Subresources: *k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceSubresources nil,
		AdditionalPrinterColumns: []k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceColumnDefinition len: 0, cap: 0, nil,},
]
(dlv) p crd.Name
"kongplugins.configuration.konghq.com"
```
This change allows generation to complete, but it's not clear why some of the generated manifests were previously marked `storage: false` automatically (and flipped to `storage: true`) or why the changes to the schema section happen at all.

Not sure if this matters beyond allowing controller-gen to work in the current state of affairs, since AFAIK we don't deploy these manifests outside Railgun tests (users of the 1.x controller still use the manifests under `deploy/`) and will presumably remove the original type definitions for a 2.x release, which should make this a non-issue. Given that this is odd (we don't actually have different versions), however, IMO hold this until we've had some chance to discuss it.