### PR TITLE
ci(coverage): switch to codecov GH action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,4 +58,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
-        verbose: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,5 +54,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Run tests with Coverage
       run: make coverage
-    - name: Upload Code Coverage
-      run: "bash <(curl -s https://codecov.io/bash)"
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        verbose: true


### PR DESCRIPTION
Replaces the existing `curl | bash` code coverage upload mechanism with an official GH Action.

Why?
- a GH action is more GitHub-native
- `curl | bash` is controversial
- the action is easier to parameterize