### PR TITLE
ci(license) ignore unsuccessful label removal

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -55,6 +55,13 @@ jobs:
               repo: context.repo.repo,
               name: ['ci/license/unchanged']
             })
+    - name: Update PR - go-license output differs
+      continue-on-error: true
+      uses: actions/github-script@v3
+      if: ${{ env.DIFF_OUT != '' }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
             github.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
**What this PR does / why we need it**:
Handles the issue seen in https://github.com/Kong/kubernetes-ingress-controller/pull/1192/checks?check_run_id=2382616820

**Special notes for your reviewer**:
github-script is supposedly just JS, so [wrapping this in a try block](https://github.com/rainest/kubernetes-ingress-controller/actions/runs/764307898/workflow#L58-L68) _should_ handle this, but [doesn't](https://github.com/rainest/kubernetes-ingress-controller/runs/2382916706?check_suite_focus=true), hence the additional step.