### PR TITLE
fix(ci) use the correct steps when license changes

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -49,24 +49,24 @@ jobs:
               repo: context.repo.repo,
               body: 'Licenses differ between commit ' + context.sha + ' and base:\n```' + process.env.DIFF_OUT + '```'
             })
-            github.issues.removeLabel({
+            github.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: ['ci/license/unchanged']
+              labels: ['ci/license/changed']
             })
-    - name: Update PR - go-license output differs
+    - name: Update PR - remove unchanged label
       continue-on-error: true
       uses: actions/github-script@v3
       if: ${{ env.DIFF_OUT != '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-            github.issues.addLabels({
+            github.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ci/license/changed']
+              name: ['ci/license/unchanged']
             })
     - name: Update PR - go-license output equal
       uses: actions/github-script@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
a435dc4 moved the wrong script block into the step that ignores errors.
This moves the "add changed label" call back into its original step
and the "remove unchanged label" into the step that ignores errors.
