### PR TITLE
fix(ci) correct license label

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -78,6 +78,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ci/license-status-unchanged']
+              labels: ['ci/license/unchanged']
             })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
An earlier change from ci/license-status-unchanged to
ci/license/unchanged updated one instance of this label in the workflow
but not the other. This updates the remaining instance.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
See failure in https://github.com/Kong/kubernetes-ingress-controller/runs/2392503019