### PR TITLE
KIC 2.0: introduce Admin API mtls and headers. Refactor and reuse KIC 1.x logic.

### DIFF
--- a/pkg/adminapi/client.go
+++ b/pkg/adminapi/client.go
@@ -20,6 +20,7 @@ type HTTPClientOpts struct {
 // MakeHTTPClient returns an HTTP client with the specified mTLS/headers configuration.
 // BUG: This function overwrites the default transport and client in package http!
 // This problem is being left as-is during refactoring to avoid regression of untested code.
+// https://github.com/Kong/kubernetes-ingress-controller/issues/1233
 func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 

--- a/pkg/adminapi/client.go
+++ b/pkg/adminapi/client.go
@@ -1,0 +1,72 @@
+package adminapi
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// HTTPClientOpts defines parameters that configure an HTTP client.
+type HTTPClientOpts struct {
+	TLSSkipVerify bool
+	TLSServerName string
+	CACertPath    string
+	CACert        string
+	Headers       []string
+}
+
+// MakeHTTPClient returns an HTTP client with the specified mTLS/headers configuration.
+// BUG: This function overwrites the default transport and client in package http!
+// This problem is being left as-is during refactoring to avoid regression of untested code.
+func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+
+	var tlsConfig tls.Config
+
+	if opts.TLSSkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if opts.TLSServerName != "" {
+		tlsConfig.ServerName = opts.TLSServerName
+	}
+
+	if opts.CACertPath != "" && opts.CACert != "" {
+		return nil, fmt.Errorf("both --kong-admin-ca-cert-path and --kong-admin-ca-cert" +
+			"are set; please remove one or the other")
+	}
+	if opts.CACert != "" {
+		certPool := x509.NewCertPool()
+		ok := certPool.AppendCertsFromPEM([]byte(opts.CACert))
+		if !ok {
+			// TODO give user an error to make this actionable
+			return nil, fmt.Errorf("failed to load kong-admin-ca-cert")
+		}
+		tlsConfig.RootCAs = certPool
+	}
+	if opts.CACertPath != "" {
+		certPath := opts.CACertPath
+		certPool := x509.NewCertPool()
+		cert, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read kong-admin-ca-cert from path '%s': %w", certPath, err)
+		}
+		ok := certPool.AppendCertsFromPEM(cert)
+		if !ok {
+			// TODO give user an error to make this actionable
+			return nil, fmt.Errorf("failed to load kong-admin-ca-cert from path '%s'", certPath)
+		}
+		tlsConfig.RootCAs = certPool
+	}
+	defaultTransport.TLSClientConfig = &tlsConfig
+	c := http.DefaultClient
+	// BUG: this overwrites the DefaultClient instance!
+	c.Transport = &HeaderRoundTripper{
+		headers: opts.Headers,
+		rt:      defaultTransport,
+	}
+
+	return c, nil
+}

--- a/pkg/adminapi/header_roundtripper.go
+++ b/pkg/adminapi/header_roundtripper.go
@@ -1,4 +1,4 @@
-package main
+package adminapi
 
 import (
 	"net/http"

--- a/pkg/util/enablementstatus.go
+++ b/pkg/util/enablementstatus.go
@@ -42,3 +42,7 @@ func (e *EnablementStatus) Set(s string) error {
 
 	return fmt.Errorf("%q is not a valid EnablementStatus", s)
 }
+
+func (e *EnablementStatus) Type() string {
+	return "EnablementStatus"
+}

--- a/railgun/cmd/rootcmd/rootcmd.go
+++ b/railgun/cmd/rootcmd/rootcmd.go
@@ -11,7 +11,7 @@ import (
 var config manager.Config
 
 func init() {
-	rootCmd.Flags().AddGoFlagSet(manager.MakeFlagSetFor(&config))
+	rootCmd.Flags().AddFlagSet(manager.MakeFlagSetFor(&config))
 }
 
 var rootCmd = &cobra.Command{

--- a/railgun/manager/flagset.go
+++ b/railgun/manager/flagset.go
@@ -1,14 +1,13 @@
 package manager
 
 import (
-	"flag"
-
 	"github.com/kong/kubernetes-ingress-controller/pkg/util"
+	"github.com/spf13/pflag"
 )
 
 // flagSet extends flag.FlagSet with additional variable types.
 type flagSet struct {
-	flag.FlagSet
+	pflag.FlagSet
 }
 
 // EnablementStatusVar defines a flag of type EnablementStatus.

--- a/railgun/manager/manager.go
+++ b/railgun/manager/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/railgun/controllers"
 	"github.com/kong/kubernetes-ingress-controller/railgun/controllers/configuration"
 	kongctrl "github.com/kong/kubernetes-ingress-controller/railgun/controllers/configuration"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -58,8 +59,8 @@ type Config struct {
 }
 
 // MakeFlagSetFor binds the provided Config to commandline flags.
-func MakeFlagSetFor(c *Config) *flag.FlagSet {
-	flagSet := flagSet{*flag.NewFlagSet("", flag.ExitOnError)}
+func MakeFlagSetFor(c *Config) *pflag.FlagSet {
+	flagSet := flagSet{*pflag.NewFlagSet("", pflag.ExitOnError)}
 
 	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -95,7 +96,9 @@ func MakeFlagSetFor(c *Config) *flag.FlagSet {
 	flagSet.EnablementStatusVar(&c.KongConsumerEnabled, "controller-kongconsumer", util.EnablementStatusDisabled,
 		"Enable or disable the KongConsumer controller. "+onOffUsage)
 
-	c.ZapOptions.BindFlags(&flagSet.FlagSet)
+	zapFlagSet := flag.NewFlagSet("", flag.ExitOnError)
+	c.ZapOptions.BindFlags(zapFlagSet)
+	flagSet.AddGoFlagSet(zapFlagSet)
 
 	return &flagSet.FlagSet
 }


### PR DESCRIPTION
Fixes #1203 
Contributes towards #1097 

This PR does the following, in commit order:
- Extracts `cli/ingress-controller`'s Admin API `http.Client` creation logic to a function `makeHTTPClient`
    - This preserves a bug: reported https://github.com/Kong/kubernetes-ingress-controller/issues/1233 and marked with a `// BUG` comment in the code. I decided not to touch the logic here, because avoiding regressions in KIC 1.x is the priority here.
- Changes the error handling mechanism inside `makeHTTPClient` from `log.Fatalf` to `return err`, for reusability in Railgun
- Decouples `makeHTTPClient` from `cliConfig` by introduction of `struct HTTPClientOpts`, for reusability in Railgun
 - Moves `makeHTTPClient` to `pkg/adminapi` (I'm not particularly attached nor sure about this name - I'm open to better alternatives)
 - Switches Railgun's `manager.RegisterFlags()` from Go `flag` to `pflag` because one of the flags being ported from KIC 1.x depends on `pflag` (because it's a `StringSlice` flag)
 - Adds the kong client creation logic extracted from KIC 1.x into Railgun, including appropriate CLI flags copied 1-1.

Expected impact on KIC 1.x: none, other than the error messages changing when admin api client creation fails

I recommend reviewing commit by commit.

Not included in this change: automated tests. Created a separate issue: https://github.com/Kong/kubernetes-ingress-controller/issues/1234