### PR TITLE
feat: add kongingress integration tests

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -122,6 +122,7 @@ type CacheStores struct {
 	ClusterPlugin cache.Store
 	Consumer      cache.Store
 	Configuration cache.Store
+	KongIngress   cache.Store
 
 	KnativeIngress cache.Store
 }
@@ -140,6 +141,7 @@ func NewCacheStores() (c CacheStores) {
 	c.Service = cache.NewStore(keyFunc)
 	c.TCPIngress = cache.NewStore(keyFunc)
 	c.UDPIngress = cache.NewStore(keyFunc)
+	c.KongIngress = cache.NewStore(keyFunc)
 	return
 }
 
@@ -211,6 +213,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.ClusterPlugin.Add(obj)
 	case *kongv1.KongConsumer:
 		return c.Consumer.Add(obj)
+	case *kongv1.KongIngress:
+		return c.KongIngress.Add(obj)
 	case *kongv1beta1.TCPIngress:
 		return c.TCPIngress.Add(obj)
 	case *kongv1alpha1.UDPIngress:
@@ -228,6 +232,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.Plugin.Add(obj)
 	case *legacyv1.KongClusterPlugin:
 		return c.ClusterPlugin.Add(obj)
+	case *legacyv1.KongIngress:
+		return c.KongIngress.Add(obj)
 	case *legacyv1.KongConsumer:
 		return c.Consumer.Add(obj)
 	case *legacyv1.ConfigSource:
@@ -619,6 +625,8 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 		return &networkingv1.Ingress{}, nil
 	case legacyv1beta1.SchemeGroupVersion.WithKind("TCPIngress"):
 		return &legacyv1beta1.TCPIngress{}, nil
+	case legacyv1.SchemeGroupVersion.WithKind("KongIngress"):
+		return &legacyv1.KongIngress{}, nil
 	case kongv1alpha1.SchemeGroupVersion.WithKind("UDPIngress"):
 		return &kongv1alpha1.UDPIngress{}, nil
 	case corev1.SchemeGroupVersion.WithKind("Service"):

--- a/railgun/manager/manager.go
+++ b/railgun/manager/manager.go
@@ -86,7 +86,7 @@ func MakeFlagSetFor(c *Config) *flag.FlagSet {
 		"Enable or disable the UDPIngress controller. "+onOffUsage)
 	flagSet.EnablementStatusVar(&c.TCPIngressEnabled, "controller-tcpingress", util.EnablementStatusDisabled,
 		"Enable or disable the TCPIngress controller. "+onOffUsage)
-	flagSet.EnablementStatusVar(&c.KongIngressEnabled, "controller-kongingress", util.EnablementStatusDisabled,
+	flagSet.EnablementStatusVar(&c.KongIngressEnabled, "controller-kongingress", util.EnablementStatusEnabled,
 		"Enable or disable the KongIngress controller. "+onOffUsage)
 	flagSet.EnablementStatusVar(&c.KongClusterPluginEnabled, "controller-kongclusterplugin", util.EnablementStatusDisabled,
 		"Enable or disable the KongClusterPlugin controller. "+onOffUsage)

--- a/railgun/test/integration/kongingress_test.go
+++ b/railgun/test/integration/kongingress_test.go
@@ -1,0 +1,101 @@
+//+build integration_tests
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/go-kong/kong"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/railgun/pkg/clientset"
+	k8sgen "github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
+)
+
+func TestMinimalKongIngress(t *testing.T) {
+	// test setup
+	namespace := "default"
+	testName := "minking"
+	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
+	defer cancel()
+
+	// push a minimal deployment to test KongIngress routes to
+	deployment := k8sgen.NewDeploymentForContainer(k8sgen.NewContainer(testName, "kennethreitz/httpbin", 80))
+	_, err := cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// make sure we clean up after ourselves
+	defer func() {
+		assert.NoError(t, cluster.Client().AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+	}()
+
+	// initialize a clientset for the KongIngress API
+	c, err := clientset.NewForConfig(cluster.Config())
+	assert.NoError(t, err)
+
+	// expose the deployment via service
+	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Annotations = map[string]string{"konghq.com/override": testName}
+	service, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// make sure we clean up after ourselves
+	defer func() {
+		assert.NoError(t, cluster.Client().CoreV1().Services(namespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+	}()
+
+	// route to the service via Ingress
+	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{
+		"kubernetes.io/ingress.class": "kong",
+		"konghq.com/strip-path":       "true",
+	}, service)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// ensure cleanup of the ingress
+	defer func() {
+		assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	}()
+
+	// TODO: this is a workaround for https://github.com/Kong/kubernetes-ingress-controller/issues/1146
+	time.Sleep(time.Second * 30)
+
+	// deploy the KongIngress object to apply overrides
+	king := &kongv1.KongIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "kong",
+			},
+		},
+		Proxy: &kong.Service{
+			ReadTimeout: kong.Int(1),
+		},
+	}
+	king, err = c.ConfigurationV1().KongIngresses(namespace).Create(ctx, king, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// make sure we clean up after ourselves
+	defer func() {
+		assert.NoError(t, c.ConfigurationV1().KongIngresses(namespace).Delete(ctx, king.Name, metav1.DeleteOptions{}))
+	}()
+
+	// test that the read delay works properly
+	assert.Eventually(t, func() bool {
+		p := proxyReady()
+		resp, err := http.Get(fmt.Sprintf("%s/httpbin/delay/5", p.ProxyURL.String()))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusGatewayTimeout
+	}, ingressWait, waitTick)
+}

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -172,7 +172,7 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 				"--controller-ingress-extensionsv1beta1=disabled",
 				"--controller-udpingress=enabled",
 				"--controller-tcpingress=enabled",
-				"--controller-kongingress=disabled",
+				"--controller-kongingress=enabled",
 				"--controller-kongclusterplugin=disabled",
 				"--controller-kongplugin=disabled",
 				"--controller-kongconsumer=disabled",


### PR DESCRIPTION
This PR adds integration tests for the `KongIngress` API in support of https://github.com/Kong/kubernetes-ingress-controller/issues/1189