### PR TITLE
deploy(*) update Gateway/Enterprise repo and tags

### DIFF
--- a/deploy/manifests/enterprise-k8s/kustomization.yaml
+++ b/deploy/manifests/enterprise-k8s/kustomization.yaml
@@ -4,5 +4,5 @@ patchesStrategicMerge:
 - kong-enterprise-k8s.yaml
 images:
 - name: kong
-  newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  newTag: 2.2.0.0-alpine
+  newName: kong/kong-gateway
+  newTag: 2.3.3.2-alpine

--- a/deploy/manifests/enterprise/kustomization.yaml
+++ b/deploy/manifests/enterprise/kustomization.yaml
@@ -5,5 +5,5 @@ patchesStrategicMerge:
 - kong-enterprise.yaml
 images:
 - name: kong
-  newName: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  newTag: 2.2.0.0-alpine
+  newName: kong/kong-gateway
+  newTag: 2.3.3.2-alpine

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -650,7 +650,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
+        image: kong/kong-gateway:2.3.3.2-alpine
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -708,7 +708,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
+        image: kong/kong-gateway:2.3.3.2-alpine
         lifecycle:
           preStop:
             exec:
@@ -819,7 +819,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
+        image: kong/kong-gateway:2.3.3.2-alpine
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---
@@ -900,7 +900,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine
+        image: kong/kong-gateway:2.3.3.2-alpine
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker

--- a/test/integration/sut/kustomization.yaml
+++ b/test/integration/sut/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 patchesStrategicMerge:
 - patch-deployment.yaml
 images:
-  - name: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
+  - name: kong/kubernetes-ingress-controller
     newName: test-local-registry:5000/kic
     newTag: local
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the new Docker Hub repo for Kong Gateway (aka Kong Enterprise), which became available today. Bump to the latest version.

**Special notes for your reviewer**:
Some documentation and build files still reference Bintray stuff. Those are left untouched in this since #1156 also touches them. The manifests are more critical as those will fail entirely if Bintray is unavailable; the rest is easier to work around.