### PR TITLE
fix: add a kb shim to work around Dockerfile validation

### DIFF
--- a/railgun/Dockerfile
+++ b/railgun/Dockerfile
@@ -1,0 +1,6 @@
+# NOTE: at the time of writing Kubebuilder does not tolerate moving or removing the `Dockerfile`
+#       and if present will validate that the line "COPY api/ api/" exists. If you're looking
+#       for the actual image build, look at ../Dockerfile.railgun.
+#       Otherwise this file simply exists as a shim to work around the upstream functionality.
+#       See https://github.com/kubernetes-sigs/kubebuilder/issues/2165 for follow-up.
+COPY api/ api/

--- a/railgun/Dockerfile
+++ b/railgun/Dockerfile
@@ -3,4 +3,4 @@
 #       for the actual image build, look at ../Dockerfile.railgun.
 #       Otherwise this file simply exists as a shim to work around the upstream functionality.
 #       See https://github.com/kubernetes-sigs/kubebuilder/issues/2165 for follow-up.
-COPY api/ api/
+COPY apis/ apis/


### PR DESCRIPTION
This adds a workaround for `kubebuilder` validation of Dockerfiles, as we've moved our container build up one directory and this is not tolerated in kubebuilder `v3.0.0`. This will fix running `kubebuilder` commands in the `railgun/` project.

Relates to https://github.com/kubernetes-sigs/kubebuilder/issues/2165