### PR TITLE
fix: add kong update sha checks

### DIFF
--- a/pkg/sendconfig/sendconfig.go
+++ b/pkg/sendconfig/sendconfig.go
@@ -40,6 +40,7 @@ func PerformUpdate(ctx context.Context,
 	}
 	// disable optimization if reverse sync is enabled
 	if !reverseSync {
+		// use the previous SHA to determine whether or not to perform an update
 		if equalSHA(oldSHA, newSHA) {
 			log.Info("no configuration change, skipping sync to kong")
 			return oldSHA, nil


### PR DESCRIPTION
This PR adds back the SHA update checks for updating the Kong proxy.

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1280