### PR TITLE
Use same health listen in Railgun as 1.x

### DIFF
--- a/railgun/config/default/manager_auth_proxy_patch.yaml
+++ b/railgun/config/default/manager_auth_proxy_patch.yaml
@@ -21,6 +21,6 @@ spec:
           name: https
       - name: manager
         args:
-        - "--health-probe-bind-address=:8081"
+        - "--health-probe-bind-address=:10254"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"

--- a/railgun/config/manager/controller_manager_config.yaml
+++ b/railgun/config/manager/controller_manager_config.yaml
@@ -1,7 +1,7 @@
 apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
 kind: ControllerManagerConfig
 health:
-  healthProbeBindAddress: :8081
+  healthProbeBindAddress: :10254
 metrics:
   bindAddress: 127.0.0.1:8080
 webhook:

--- a/railgun/config/manager/manager.yaml
+++ b/railgun/config/manager/manager.yaml
@@ -36,13 +36,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 10254
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 10254
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/railgun/manager/manager.go
+++ b/railgun/manager/manager.go
@@ -92,7 +92,7 @@ func MakeFlagSetFor(c *Config) *pflag.FlagSet {
 	flagSet := flagSet{*pflag.NewFlagSet("", pflag.ExitOnError)}
 
 	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":10254", "The address the probe endpoint binds to.")
 	flagSet.BoolVar(&c.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the health service default address to use the same port as 1.x did.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: part of #1223 
