### PR TITLE
fix: plug ingressclass into ctrls

### DIFF
--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
@@ -181,7 +182,7 @@ type NetV1IngressReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -195,12 +196,12 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -289,7 +290,7 @@ type NetV1Beta1IngressReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -298,12 +299,12 @@ func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -382,7 +383,7 @@ type ExtV1Beta1IngressReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -391,12 +392,12 @@ func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -597,7 +598,7 @@ type KongV1KongClusterPluginReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -606,12 +607,12 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -690,7 +691,7 @@ type KongV1KongConsumerReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -699,12 +700,12 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -783,7 +784,7 @@ type KongV1Alpha1UDPIngressReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Alpha1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -792,12 +793,12 @@ func (r *KongV1Alpha1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) er
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -876,7 +877,7 @@ type KongV1Beta1TCPIngressReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -885,12 +886,12 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -32,10 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
@@ -185,45 +182,7 @@ type NetV1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if ing, ok := obj.(*netv1.Ingress); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if ing, ok := e.ObjectOld.(*netv1.Ingress); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-		if ing, ok := e.ObjectNew.(*netv1.Ingress); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, true, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&netv1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -297,30 +256,7 @@ type NetV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&netv1beta1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -394,30 +330,7 @@ type ExtV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&extv1beta1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -615,30 +528,7 @@ type KongV1KongClusterPluginReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&kongv1.KongClusterPlugin{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -712,30 +602,7 @@ type KongV1KongConsumerReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&kongv1.KongConsumer{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -809,30 +676,7 @@ type KongV1Alpha1UDPIngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Alpha1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&kongv1alpha1.UDPIngress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -906,30 +750,7 @@ type KongV1Beta1TCPIngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&kongv1beta1.TCPIngress{}, builder.WithPredicates(preds)).Complete(r)
 }
 

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -185,6 +185,8 @@ type NetV1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -295,6 +297,8 @@ type NetV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -390,6 +394,8 @@ type ExtV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -609,6 +615,8 @@ type KongV1KongClusterPluginReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -704,6 +712,8 @@ type KongV1KongConsumerReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -799,6 +809,8 @@ type KongV1Alpha1UDPIngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Alpha1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
@@ -894,6 +906,8 @@ type KongV1Beta1TCPIngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -51,6 +51,7 @@ import (
 // CoreV1Service reconciles a Ingress object
 type CoreV1ServiceReconciler struct {
 	client.Client
+
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
@@ -112,6 +113,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // CoreV1Endpoints reconciles a Ingress object
 type CoreV1EndpointsReconciler struct {
 	client.Client
+
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
@@ -173,9 +175,11 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // NetV1Ingress reconciles a Ingress object
 type NetV1IngressReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -281,9 +285,11 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // NetV1Beta1Ingress reconciles a Ingress object
 type NetV1Beta1IngressReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -374,9 +380,11 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // ExtV1Beta1Ingress reconciles a Ingress object
 type ExtV1Beta1IngressReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -467,6 +475,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // KongV1KongIngress reconciles a Ingress object
 type KongV1KongIngressReconciler struct {
 	client.Client
+
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
@@ -528,6 +537,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // KongV1KongPlugin reconciles a Ingress object
 type KongV1KongPluginReconciler struct {
 	client.Client
+
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
@@ -589,9 +599,11 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // KongV1KongClusterPlugin reconciles a Ingress object
 type KongV1KongClusterPluginReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -682,9 +694,11 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 // KongV1KongConsumer reconciles a Ingress object
 type KongV1KongConsumerReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -775,9 +789,11 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 // KongV1Alpha1UDPIngress reconciles a Ingress object
 type KongV1Alpha1UDPIngressReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 
@@ -868,9 +884,11 @@ func (r *KongV1Alpha1UDPIngressReconciler) Reconcile(ctx context.Context, req ct
 // KongV1Beta1TCPIngress reconciles a Ingress object
 type KongV1Beta1TCPIngressReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+
 	IngressClassName string
 }
 

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -249,6 +249,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
@@ -283,7 +284,7 @@ type {{.PackageAlias}}{{.Type}}Reconciler struct {
 func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 {{- if .AcceptsIngressClassNameAnnotation}}
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
@@ -299,12 +300,12 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager
 	})
 	preds.UpdateFunc = func(e event.UpdateEvent) bool {
 		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}
 		}
-		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {
 				return true
 			}

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -12,7 +12,18 @@ import (
 // Main
 // -----------------------------------------------------------------------------
 
-const outputFile = "controllers/configuration/zz_generated_controllers.go"
+const (
+	outputFile = "controllers/configuration/zz_generated_controllers.go"
+
+	corev1     = "k8s.io/api/core/v1"
+	netv1      = "k8s.io/api/networking/v1"
+	netv1beta1 = "k8s.io/api/networking/v1beta1"
+	extv1beta1 = "k8s.io/api/extensions/v1beta1"
+
+	kongv1       = "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
+	kongv1alpha1 = "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
+	kongv1beta1  = "github.com/kong/kubernetes-ingress-controller/railgun/api/configuration/v1beta1"
+)
 
 // inputControllersNeeded is a list of the supported Types for the
 // Kong Kubernetes Ingress Controller. If you need to add a new type
@@ -22,7 +33,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "corev1",
 		PackageAlias:                      "CoreV1",
-		Package:                           "k8s.io/api/core/v1",
+		Package:                           corev1,
 		Type:                              "Service",
 		Plural:                            "services",
 		URL:                               "v1",
@@ -33,7 +44,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "corev1",
 		PackageAlias:                      "CoreV1",
-		Package:                           "k8s.io/api/core/v1",
+		Package:                           corev1,
 		Type:                              "Endpoints",
 		Plural:                            "endpoints",
 		URL:                               "v1",
@@ -44,7 +55,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "netv1",
 		PackageAlias:                      "NetV1",
-		Package:                           "k8s.io/api/networking/v1",
+		Package:                           netv1,
 		Type:                              "Ingress",
 		Plural:                            "ingresses",
 		URL:                               "networking.k8s.io",
@@ -55,7 +66,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "netv1beta1",
 		PackageAlias:                      "NetV1Beta1",
-		Package:                           "k8s.io/api/networking/v1beta1",
+		Package:                           netv1beta1,
 		Type:                              "Ingress",
 		Plural:                            "ingresses",
 		URL:                               "networking.k8s.io",
@@ -66,7 +77,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "extv1beta1",
 		PackageAlias:                      "ExtV1Beta1",
-		Package:                           "k8s.io/api/extensions/v1beta1",
+		Package:                           extv1beta1,
 		Type:                              "Ingress",
 		Plural:                            "ingresses",
 		URL:                               "apiextensions.k8s.io",
@@ -77,7 +88,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1",
 		PackageAlias:                      "KongV1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Package:                           kongv1,
 		Type:                              "KongIngress",
 		Plural:                            "kongingresses",
 		URL:                               "configuration.konghq.com",
@@ -88,7 +99,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1",
 		PackageAlias:                      "KongV1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Package:                           kongv1,
 		Type:                              "KongPlugin",
 		Plural:                            "kongplugins",
 		URL:                               "configuration.konghq.com",
@@ -99,7 +110,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1",
 		PackageAlias:                      "KongV1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Package:                           kongv1,
 		Type:                              "KongClusterPlugin",
 		Plural:                            "kongclusterplugins",
 		URL:                               "configuration.konghq.com",
@@ -110,7 +121,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1",
 		PackageAlias:                      "KongV1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Package:                           kongv1,
 		Type:                              "KongConsumer",
 		Plural:                            "kongconsumers",
 		URL:                               "configuration.konghq.com",
@@ -121,7 +132,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1alpha1",
 		PackageAlias:                      "KongV1Alpha1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1",
+		Package:                           kongv1alpha1,
 		Type:                              "UDPIngress",
 		Plural:                            "udpingresses",
 		URL:                               "configuration.konghq.com",
@@ -132,7 +143,7 @@ var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
 		PackageImportAlias:                "kongv1beta1",
 		PackageAlias:                      "KongV1Beta1",
-		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/api/configuration/v1beta1",
+		Package:                           kongv1beta1,
 		Type:                              "TCPIngress",
 		Plural:                            "tcpingresses",
 		URL:                               "configuration.konghq.com",
@@ -246,10 +257,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
@@ -280,49 +288,7 @@ type {{.PackageAlias}}{{.Type}}Reconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 {{- if .AcceptsIngressClassNameAnnotation}}
-	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
-	//                  future release of Kubernetes.
-	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-{{- if .AcceptsIngressClassNameSpec }}
-		if ing, ok := obj.(*{{.PackageImportAlias}}.{{.Type}}); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-{{- end}}
-		return false
-	})
-	preds.UpdateFunc = func(e event.UpdateEvent) bool {
-		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
-		if v, ok := e.ObjectOld.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-		if v, ok := e.ObjectNew.GetAnnotations()[annotations.IngressClassKey]; ok {
-			if v == r.IngressClassName {
-				return true
-			}
-		}
-{{- if .AcceptsIngressClassNameSpec }}
-		if ing, ok := e.ObjectOld.(*{{.PackageImportAlias}}.{{.Type}}); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-		if ing, ok := e.ObjectNew.(*{{.PackageImportAlias}}.{{.Type}}); ok {
-			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
-				return true
-			}
-		}
-{{- end}}
-		return false
-	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, {{.AcceptsIngressClassNameSpec}}, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&{{.PackageImportAlias}}.{{.Type}}{}, builder.WithPredicates(preds)).Complete(r)
 {{- else}}
 	return ctrl.NewControllerManagedBy(mgr).For(&{{.PackageImportAlias}}.{{.Type}}{}).Complete(r)

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -20,103 +20,125 @@ const outputFile = "controllers/configuration/zz_generated_controllers.go"
 // when you run `make controllers`.
 var inputControllersNeeded = &typesNeeded{
 	typeNeeded{
-		PackageImportAlias: "corev1",
-		PackageAlias:       "CoreV1",
-		Package:            "k8s.io/api/core/v1",
-		Type:               "Service",
-		Plural:             "services",
-		URL:                "v1",
-		CacheType:          "Service",
+		PackageImportAlias:                "corev1",
+		PackageAlias:                      "CoreV1",
+		Package:                           "k8s.io/api/core/v1",
+		Type:                              "Service",
+		Plural:                            "services",
+		URL:                               "v1",
+		CacheType:                         "Service",
+		AcceptsIngressClassNameAnnotation: false,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "corev1",
-		PackageAlias:       "CoreV1",
-		Package:            "k8s.io/api/core/v1",
-		Type:               "Endpoints",
-		Plural:             "endpoints",
-		URL:                "v1",
-		CacheType:          "Endpoint",
+		PackageImportAlias:                "corev1",
+		PackageAlias:                      "CoreV1",
+		Package:                           "k8s.io/api/core/v1",
+		Type:                              "Endpoints",
+		Plural:                            "endpoints",
+		URL:                               "v1",
+		CacheType:                         "Endpoint",
+		AcceptsIngressClassNameAnnotation: false,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "netv1",
-		PackageAlias:       "NetV1",
-		Package:            "k8s.io/api/networking/v1",
-		Type:               "Ingress",
-		Plural:             "ingresses",
-		URL:                "networking.k8s.io",
-		CacheType:          "IngressV1",
+		PackageImportAlias:                "netv1",
+		PackageAlias:                      "NetV1",
+		Package:                           "k8s.io/api/networking/v1",
+		Type:                              "Ingress",
+		Plural:                            "ingresses",
+		URL:                               "networking.k8s.io",
+		CacheType:                         "IngressV1",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       true,
 	},
 	typeNeeded{
-		PackageImportAlias: "netv1beta1",
-		PackageAlias:       "NetV1Beta1",
-		Package:            "k8s.io/api/networking/v1beta1",
-		Type:               "Ingress",
-		Plural:             "ingresses",
-		URL:                "networking.k8s.io",
-		CacheType:          "IngressV1beta1",
+		PackageImportAlias:                "netv1beta1",
+		PackageAlias:                      "NetV1Beta1",
+		Package:                           "k8s.io/api/networking/v1beta1",
+		Type:                              "Ingress",
+		Plural:                            "ingresses",
+		URL:                               "networking.k8s.io",
+		CacheType:                         "IngressV1beta1",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "extv1beta1",
-		PackageAlias:       "ExtV1Beta1",
-		Package:            "k8s.io/api/extensions/v1beta1",
-		Type:               "Ingress",
-		Plural:             "ingresses",
-		URL:                "apiextensions.k8s.io",
-		CacheType:          "IngressV1beta1",
+		PackageImportAlias:                "extv1beta1",
+		PackageAlias:                      "ExtV1Beta1",
+		Package:                           "k8s.io/api/extensions/v1beta1",
+		Type:                              "Ingress",
+		Plural:                            "ingresses",
+		URL:                               "apiextensions.k8s.io",
+		CacheType:                         "IngressV1beta1",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1",
-		PackageAlias:       "KongV1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
-		Type:               "KongIngress",
-		Plural:             "kongingresses",
-		URL:                "configuration.konghq.com",
-		CacheType:          "KongIngress",
+		PackageImportAlias:                "kongv1",
+		PackageAlias:                      "KongV1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Type:                              "KongIngress",
+		Plural:                            "kongingresses",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "KongIngress",
+		AcceptsIngressClassNameAnnotation: false,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1",
-		PackageAlias:       "KongV1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
-		Type:               "KongPlugin",
-		Plural:             "kongplugins",
-		URL:                "configuration.konghq.com",
-		CacheType:          "Plugin",
+		PackageImportAlias:                "kongv1",
+		PackageAlias:                      "KongV1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Type:                              "KongPlugin",
+		Plural:                            "kongplugins",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "Plugin",
+		AcceptsIngressClassNameAnnotation: false,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1",
-		PackageAlias:       "KongV1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
-		Type:               "KongClusterPlugin",
-		Plural:             "kongclusterplugins",
-		URL:                "configuration.konghq.com",
-		CacheType:          "ClusterPlugin",
+		PackageImportAlias:                "kongv1",
+		PackageAlias:                      "KongV1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Type:                              "KongClusterPlugin",
+		Plural:                            "kongclusterplugins",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "ClusterPlugin",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1",
-		PackageAlias:       "KongV1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
-		Type:               "KongConsumer",
-		Plural:             "kongconsumers",
-		URL:                "configuration.konghq.com",
-		CacheType:          "Consumer",
+		PackageImportAlias:                "kongv1",
+		PackageAlias:                      "KongV1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1",
+		Type:                              "KongConsumer",
+		Plural:                            "kongconsumers",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "Consumer",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1alpha1",
-		PackageAlias:       "KongV1Alpha1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1",
-		Type:               "UDPIngress",
-		Plural:             "udpingresses",
-		URL:                "configuration.konghq.com",
-		CacheType:          "UDPIngress",
+		PackageImportAlias:                "kongv1alpha1",
+		PackageAlias:                      "KongV1Alpha1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1",
+		Type:                              "UDPIngress",
+		Plural:                            "udpingresses",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "UDPIngress",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 	typeNeeded{
-		PackageImportAlias: "kongv1beta1",
-		PackageAlias:       "KongV1Beta1",
-		Package:            "github.com/kong/kubernetes-ingress-controller/railgun/api/configuration/v1beta1",
-		Type:               "TCPIngress",
-		Plural:             "tcpingresses",
-		URL:                "configuration.konghq.com",
-		CacheType:          "TCPIngress",
+		PackageImportAlias:                "kongv1beta1",
+		PackageAlias:                      "KongV1Beta1",
+		Package:                           "github.com/kong/kubernetes-ingress-controller/railgun/api/configuration/v1beta1",
+		Type:                              "TCPIngress",
+		Plural:                            "tcpingresses",
+		URL:                               "configuration.konghq.com",
+		CacheType:                         "TCPIngress",
+		AcceptsIngressClassNameAnnotation: true,
+		AcceptsIngressClassNameSpec:       false,
 	},
 }
 
@@ -183,6 +205,14 @@ type typeNeeded struct {
 	Plural             string
 	URL                string
 	CacheType          string
+
+	// AcceptsIngressClassNameAnnotation indicates that the object accepts (and the controller will listen to)
+	// the "kubernetes.io/ingress.class" annotation to decide whether or not the object is supported.
+	AcceptsIngressClassNameAnnotation bool
+
+	// AcceptsIngressClassNameSpec indicates the the object indicates the ingress.class that should support it via
+	// an attribute in its specification named .IngressClassName
+	AcceptsIngressClassNameSpec bool
 }
 
 func (t *typeNeeded) generate(contents *bytes.Buffer) error {
@@ -214,7 +244,10 @@ import (
 	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
@@ -234,14 +267,66 @@ var controllerTemplate = `
 type {{.PackageAlias}}{{.Type}}Reconciler struct {
 	client.Client
 
+{{- if or .AcceptsIngressClassNameSpec .AcceptsIngressClassNameAnnotation}}
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	Proxy            proxy.Proxy
+	IngressClassName string
+{{- else}}
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
+{{- end}}
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+{{- if .AcceptsIngressClassNameAnnotation}}
+	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if v, ok := obj.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+			if v == r.IngressClassName {
+				return true
+			}
+		}
+{{- if .AcceptsIngressClassNameSpec }}
+		if ing, ok := obj.(*{{.PackageImportAlias}}.{{.Type}}); ok {
+			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
+				return true
+			}
+		}
+{{- end}}
+		return false
+	})
+	preds.UpdateFunc = func(e event.UpdateEvent) bool {
+		// at least one of the objects (old or new) needs to be configured with the relevant ingress.class to be supported.
+		if v, ok := e.ObjectOld.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+			if v == r.IngressClassName {
+				return true
+			}
+		}
+		if v, ok := e.ObjectNew.GetAnnotations()["kubernetes.io/ingress.class"]; ok {
+			if v == r.IngressClassName {
+				return true
+			}
+		}
+{{- if .AcceptsIngressClassNameSpec }}
+		if ing, ok := e.ObjectOld.(*{{.PackageImportAlias}}.{{.Type}}); ok {
+			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
+				return true
+			}
+		}
+		if ing, ok := e.ObjectNew.(*{{.PackageImportAlias}}.{{.Type}}); ok {
+			if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == r.IngressClassName {
+				return true
+			}
+		}
+{{- end}}
+		return false
+	}
+	return ctrl.NewControllerManagedBy(mgr).For(&{{.PackageImportAlias}}.{{.Type}}{}, builder.WithPredicates(preds)).Complete(r)
+{{- else}}
 	return ctrl.NewControllerManagedBy(mgr).For(&{{.PackageImportAlias}}.{{.Type}}{}).Complete(r)
+{{- end}}
 }
 
 //+kubebuilder:rbac:groups={{.URL}},resources={{.Plural}},verbs=get;list;watch;create;update;patch;delete
@@ -267,7 +352,16 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
-
+{{if .AcceptsIngressClassNameAnnotation}}
+	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
+	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
+		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		if err := r.Proxy.DeleteObject(obj); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+{{end}}
 	// before we store cache data for this object, ensure that it has our finalizer set
 	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
 		log.Info("finalizer is not set for ingress object, setting it", req.Namespace, req.Name)

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -268,15 +268,12 @@ var controllerTemplate = `
 type {{.PackageAlias}}{{.Type}}Reconciler struct {
 	client.Client
 
-{{- if or .AcceptsIngressClassNameSpec .AcceptsIngressClassNameAnnotation}}
-	Log              logr.Logger
-	Scheme           *runtime.Scheme
-	Proxy            proxy.Proxy
-	IngressClassName string
-{{- else}}
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Proxy  proxy.Proxy
+{{- if or .AcceptsIngressClassNameSpec .AcceptsIngressClassNameAnnotation}}
+
+	IngressClassName string
 {{- end}}
 }
 

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -280,6 +280,8 @@ type {{.PackageAlias}}{{.Type}}Reconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 {{- if .AcceptsIngressClassNameAnnotation}}
+	// NOTE(generated): keep in mind that the ingress.class annotation is deprecated and will be removed in a
+	//                  future release of Kubernetes.
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if v, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
 			if v == r.IngressClassName {

--- a/railgun/internal/ctrlutils/utils.go
+++ b/railgun/internal/ctrlutils/utils.go
@@ -11,7 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+// classSpec indicates the fieldName for objects which support indicating their Ingress Class by spec
+const classSpec = "IngressClassName"
 
 // CleanupFinalizer ensures that a deleted resource is no longer present in the object cache.
 func CleanupFinalizer(ctx context.Context, c client.Client, log logr.Logger, nsn types.NamespacedName, obj client.Object) (ctrl.Result, error) {
@@ -64,13 +69,9 @@ func IsAPIAvailable(mgr ctrl.Manager, obj client.Object) (bool, error) {
 
 // HasAnnotation is a helper function to determine whether an object has a given annotation, and whether it's
 // to the value provided.
-func HasAnnotation(obj client.Object, key, val string) bool {
-	if v, ok := obj.GetAnnotations()[key]; ok {
-		if v == val {
-			return true
-		}
-	}
-	return false
+func HasAnnotation(obj client.Object, key, expectedValue string) bool {
+	foundValue, ok := obj.GetAnnotations()[key]
+	return ok && foundValue == expectedValue
 }
 
 // MatchesIngressClassName indicates whether or not an object indicates that it's supported by the ingress class name provided.
@@ -81,4 +82,56 @@ func MatchesIngressClassName(obj client.Object, ingressClassName string) bool {
 		}
 	}
 	return HasAnnotation(obj, annotations.IngressClassKey, ingressClassName)
+}
+
+type objWithIngressClassNameSpec struct {
+	Spec struct{ IngressClassName *string }
+}
+
+// GeneratePredicateFuncsForIngressClassFilter builds a controller-runtime reconcilation predicate function which filters out objects
+// which do not have the "kubernetes.io/ingress.class" annotation configured and set to the provided value or in their .spec.
+func GeneratePredicateFuncsForIngressClassFilter(name string, specCheckEnabled, annotationCheckEnabled bool) predicate.Funcs {
+	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if annotationCheckEnabled && IsIngressClassAnnotationConfigured(obj, name) {
+			return true
+		}
+		if specCheckEnabled && IsIngressClassSpecConfigured(obj, name) {
+			return true
+		}
+		return false
+	})
+	preds.UpdateFunc = func(e event.UpdateEvent) bool {
+		if annotationCheckEnabled && IsIngressClassAnnotationConfigured(e.ObjectOld, name) || IsIngressClassAnnotationConfigured(e.ObjectNew, name) {
+			return true
+		}
+		if specCheckEnabled && IsIngressClassSpecConfigured(e.ObjectOld, name) || IsIngressClassSpecConfigured(e.ObjectNew, name) {
+			return true
+		}
+		return false
+	}
+	return preds
+}
+
+// IsIngressClassAnnotationConfigured determines whether an object has an ingress.class annotation configured that
+// matches the provide IngressClassName (and is therefore an object configured to be reconciled by that class).
+//
+// NOTE: keep in mind that the ingress.class annotation is deprecated and will be removed in a future release
+//       of Kubernetes in favor of the .spec based implementation.
+func IsIngressClassAnnotationConfigured(obj client.Object, expectedIngressClassName string) bool {
+	if foundIngressClassName, ok := obj.GetAnnotations()[annotations.IngressClassKey]; ok {
+		if foundIngressClassName == expectedIngressClassName {
+			return true
+		}
+	}
+	return false
+}
+
+// IsIngressClassAnnotationConfigured determines whether an object has IngressClassName field in its spec and whether the value
+// matches the provide IngressClassName (and is therefore an object configured to be reconciled by that class).
+func IsIngressClassSpecConfigured(obj client.Object, expectedIngressClassName string) bool {
+	switch obj := obj.(type) {
+	case *netv1.Ingress:
+		return obj.Spec.IngressClassName != nil && *obj.Spec.IngressClassName == expectedIngressClassName
+	}
+	return false
 }

--- a/railgun/internal/ctrlutils/utils.go
+++ b/railgun/internal/ctrlutils/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -79,5 +80,5 @@ func MatchesIngressClassName(obj client.Object, ingressClassName string) bool {
 			return true
 		}
 	}
-	return HasAnnotation(obj, "kubernetes.io/ingress.class", ingressClassName)
+	return HasAnnotation(obj, annotations.IngressClassKey, ingressClassName)
 }

--- a/railgun/internal/ctrlutils/utils.go
+++ b/railgun/internal/ctrlutils/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,4 +59,25 @@ func IsAPIAvailable(mgr ctrl.Manager, obj client.Object) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// HasAnnotation is a helper function to determine whether an object has a given annotation, and whether it's
+// to the value provided.
+func HasAnnotation(obj client.Object, key, val string) bool {
+	if v, ok := obj.GetAnnotations()[key]; ok {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesIngressClassName indicates whether or not an object indicates that it's supported by the ingress class name provided.
+func MatchesIngressClassName(obj client.Object, ingressClassName string) bool {
+	if ing, ok := obj.(*netv1.Ingress); ok {
+		if ing.Spec.IngressClassName != nil && *ing.Spec.IngressClassName == ingressClassName {
+			return true
+		}
+	}
+	return HasAnnotation(obj, "kubernetes.io/ingress.class", ingressClassName)
 }

--- a/railgun/manager/manager.go
+++ b/railgun/manager/manager.go
@@ -298,6 +298,10 @@ func Run(ctx context.Context, c *Config) error {
 	)
 
 	controllers := []ControllerDef{
+		// ---------------------------------------------------------------------------
+		// Core API Controllers
+		// ---------------------------------------------------------------------------
+
 		{
 			IsEnabled: &c.ServiceEnabled,
 			Controller: &configuration.CoreV1ServiceReconciler{
@@ -316,7 +320,6 @@ func Run(ctx context.Context, c *Config) error {
 				Proxy:  prx,
 			},
 		},
-
 		{
 			IsEnabled: &c.IngressNetV1Enabled,
 			Controller: &configuration.NetV1IngressReconciler{
@@ -344,22 +347,29 @@ func Run(ctx context.Context, c *Config) error {
 				Proxy:  prx,
 			},
 		},
+
+		// ---------------------------------------------------------------------------
+		// Kong API Controllers
+		// ---------------------------------------------------------------------------
+
 		{
 			IsEnabled: &c.UDPIngressEnabled,
 			Controller: &kongctrl.KongV1Alpha1UDPIngressReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("UDPIngress"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("UDPIngress"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 		{
 			IsEnabled: &c.TCPIngressEnabled,
 			Controller: &kongctrl.KongV1Beta1TCPIngressReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("TCPIngress"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("TCPIngress"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 		{
@@ -374,10 +384,11 @@ func Run(ctx context.Context, c *Config) error {
 		{
 			IsEnabled: &c.KongClusterPluginEnabled,
 			Controller: &kongctrl.KongV1KongClusterPluginReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("KongClusterPlugin"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("KongClusterPlugin"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 		{
@@ -392,10 +403,11 @@ func Run(ctx context.Context, c *Config) error {
 		{
 			IsEnabled: &c.KongConsumerEnabled,
 			Controller: &kongctrl.KongV1KongConsumerReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("KongConsumer"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("KongConsumer"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 	}

--- a/railgun/manager/manager.go
+++ b/railgun/manager/manager.go
@@ -323,28 +323,31 @@ func Run(ctx context.Context, c *Config) error {
 		{
 			IsEnabled: &c.IngressNetV1Enabled,
 			Controller: &configuration.NetV1IngressReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("Ingress").WithName("netv1"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("Ingress").WithName("netv1"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 		{
 			IsEnabled: &c.IngressNetV1beta1Enabled,
 			Controller: &configuration.NetV1Beta1IngressReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("Ingress").WithName("netv1beta1"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("Ingress").WithName("netv1beta1"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 		{
 			IsEnabled: &c.IngressExtV1beta1Enabled,
 			Controller: &configuration.ExtV1Beta1IngressReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("Ingress").WithName("extv1beta1"),
-				Scheme: mgr.GetScheme(),
-				Proxy:  prx,
+				Client:           mgr.GetClient(),
+				Log:              ctrl.Log.WithName("controllers").WithName("Ingress").WithName("extv1beta1"),
+				Scheme:           mgr.GetScheme(),
+				Proxy:            prx,
+				IngressClassName: c.IngressClassName,
 			},
 		},
 

--- a/railgun/test/integration/ingress_test.go
+++ b/railgun/test/integration/ingress_test.go
@@ -29,22 +29,22 @@ func TestMinimalIngress(t *testing.T) {
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := k8sgen.NewContainer("httpbin", httpBinImage, 80)
 	deployment := k8sgen.NewDeploymentForContainer(container)
-	deployment, err := cluster.Client().AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, cluster.Client().AppsV1().Deployments("default").Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = cluster.Client().CoreV1().Services("default").Create(ctx, service, metav1.CreateOptions{})
+	_, err = cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, cluster.Client().CoreV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s without ingress.class %s", service.Name, ingressClass)
@@ -52,12 +52,12 @@ func TestMinimalIngress(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Create(ctx, ingress, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
-		if err := cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+		if err := cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -84,10 +84,10 @@ func TestMinimalIngress(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("removing the ingress.class annotation %q from ingress %s", ingressClass, ingress.Name)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	t.Logf("verifying that removing the ingress.class annotation %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
@@ -116,10 +116,10 @@ func TestMinimalIngress(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the ingress.class annotation %q back on ingress %s", ingressClass, ingress.Name)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
@@ -141,7 +141,7 @@ func TestMinimalIngress(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
-	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
 		if err != nil {
@@ -174,22 +174,22 @@ func TestHTTPSRedirect(t *testing.T) {
 	t.Log("creating an HTTP container via deployment to test redirect functionality")
 	container := k8sgen.NewContainer("alsohttpbin", httpBinImage, 80)
 	deployment := k8sgen.NewDeploymentForContainer(container)
-	_, err := cluster.Client().AppsV1().Deployments("default").Create(ctx, deployment, opts)
+	_, err := cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, opts)
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up deployment %s", deployment.Name)
-		assert.NoError(t, cluster.Client().AppsV1().Deployments("default").Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via Service", deployment.Name)
 	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-	service, err = cluster.Client().CoreV1().Services("default").Create(ctx, service, opts)
+	service, err = cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, opts)
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up Service %s", service.Name)
-		assert.NoError(t, cluster.Client().CoreV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing Service %s via Ingress", service.Name)
@@ -198,12 +198,12 @@ func TestHTTPSRedirect(t *testing.T) {
 		"konghq.com/protocols":                  "https",
 		"konghq.com/https-redirect-status-code": "301",
 	}, service)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, opts)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Create(ctx, ingress, opts)
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up Ingress %s", ingress.Name)
-		assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("waiting for Ingress %s to be operational and properly redirect", ingress.Name)
@@ -230,33 +230,33 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
 	container := k8sgen.NewContainer("httpbin", httpBinImage, 80)
 	deployment := k8sgen.NewDeploymentForContainer(container)
-	deployment, err := cluster.Client().AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, cluster.Client().AppsV1().Deployments("default").Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = cluster.Client().CoreV1().Services("default").Create(ctx, service, metav1.CreateOptions{})
+	_, err = cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, cluster.Client().CoreV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s without ingress.class %s", service.Name, ingressClass)
 	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{"konghq.com/strip-path": "true"}, service)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Create(ctx, ingress, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
-		if err := cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+		if err := cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -283,10 +283,10 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("removing the IngressClassName %q from ingress %s", ingressClass, ingress.Name)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.Spec.IngressClassName = nil
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
@@ -315,10 +315,10 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the IngressClassName %q back on ingress %s", ingressClass, ingress.Name)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
-	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
@@ -340,7 +340,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
-	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
 		if err != nil {

--- a/railgun/test/integration/ingress_test.go
+++ b/railgun/test/integration/ingress_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -98,21 +97,7 @@ func TestMinimalIngress(t *testing.T) {
 			return false
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusNotFound {
-			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
-			// Expected: {"message":"no Route matched with those values"}
-			b := new(bytes.Buffer)
-			b.ReadFrom(resp.Body)
-			body := struct {
-				Message string `json:"message"`
-			}{}
-			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
-				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
-				return false
-			}
-			return body.Message == "no Route matched with those values"
-		}
-		return false
+		return expect404WithNoRoute(t, p.ProxyURL.String(), resp)
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the ingress.class annotation %q back on ingress %s", ingressClass, ingress.Name)
@@ -149,21 +134,7 @@ func TestMinimalIngress(t *testing.T) {
 			return false
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusNotFound {
-			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
-			// Expected: {"message":"no Route matched with those values"}
-			b := new(bytes.Buffer)
-			b.ReadFrom(resp.Body)
-			body := struct {
-				Message string `json:"message"`
-			}{}
-			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
-				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
-				return false
-			}
-			return body.Message == "no Route matched with those values"
-		}
-		return false
+		return expect404WithNoRoute(t, p.ProxyURL.String(), resp)
 	}, ingressWait, waitTick)
 }
 
@@ -297,21 +268,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 			return false
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusNotFound {
-			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
-			// Expected: {"message":"no Route matched with those values"}
-			b := new(bytes.Buffer)
-			b.ReadFrom(resp.Body)
-			body := struct {
-				Message string `json:"message"`
-			}{}
-			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
-				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
-				return false
-			}
-			return body.Message == "no Route matched with those values"
-		}
-		return false
+		return expect404WithNoRoute(t, p.ProxyURL.String(), resp)
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the IngressClassName %q back on ingress %s", ingressClass, ingress.Name)
@@ -348,21 +305,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 			return false
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusNotFound {
-			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
-			// Expected: {"message":"no Route matched with those values"}
-			b := new(bytes.Buffer)
-			b.ReadFrom(resp.Body)
-			body := struct {
-				Message string `json:"message"`
-			}{}
-			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
-				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
-				return false
-			}
-			return body.Message == "no Route matched with those values"
-		}
-		return false
+		return expect404WithNoRoute(t, p.ProxyURL.String(), resp)
 	}, ingressWait, waitTick)
 
 }

--- a/railgun/test/integration/ingress_test.go
+++ b/railgun/test/integration/ingress_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	k8sgen "github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
 )
 
@@ -48,8 +49,8 @@ func TestMinimalIngress(t *testing.T) {
 
 	t.Logf("creating an ingress for service %s without ingress.class %s", service.Name, ingressClass)
 	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{
-		"kubernetes.io/ingress.class": ingressClass,
-		"konghq.com/strip-path":       "true",
+		annotations.IngressClassKey: ingressClass,
+		"konghq.com/strip-path":     "true",
 	}, service)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -85,7 +86,7 @@ func TestMinimalIngress(t *testing.T) {
 	t.Logf("removing the ingress.class annotation \"%s\" from ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
-	delete(ingress.ObjectMeta.Annotations, "kubernetes.io/ingress.class")
+	delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
@@ -117,7 +118,7 @@ func TestMinimalIngress(t *testing.T) {
 	t.Logf("putting the ingress.class annotation \"%s\" back on ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
-	ingress.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = ingressClass
+	ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
@@ -193,7 +194,7 @@ func TestHTTPSRedirect(t *testing.T) {
 
 	t.Logf("exposing Service %s via Ingress", service.Name)
 	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{
-		"kubernetes.io/ingress.class":           ingressClass,
+		annotations.IngressClassKey:             ingressClass,
 		"konghq.com/protocols":                  "https",
 		"konghq.com/https-redirect-status-code": "301",
 	}, service)

--- a/railgun/test/integration/ingress_test.go
+++ b/railgun/test/integration/ingress_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/go-kong/kong"
 	k8sgen "github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
 )
 
@@ -45,7 +46,7 @@ func TestMinimalIngress(t *testing.T) {
 		assert.NoError(t, cluster.Client().CoreV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
-	t.Logf("routing to service %s via Ingress", service.Name)
+	t.Logf("creating an ingress for service %s without ingress.class %s", service.Name, ingressClass)
 	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{
 		"kubernetes.io/ingress.class": ingressClass,
 		"konghq.com/strip-path":       "true",
@@ -64,6 +65,63 @@ func TestMinimalIngress(t *testing.T) {
 
 	t.Logf("waiting for routes from Ingress %s to be operational", ingress.Name)
 	p := proxyReady()
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
+			// Expected: "<title>httpbin.org</title>"
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("removing the ingress.class annotation \"%s\" from ingress %s", ingressClass, ingress.Name)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	delete(ingress.ObjectMeta.Annotations, "kubernetes.io/ingress.class")
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	t.Logf("verifying that removing the ingress.class annotation \"%s\" from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusNotFound {
+			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
+			// Expected: {"message":"no Route matched with those values"}
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			body := struct {
+				Message string `json:"message"`
+			}{}
+			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
+				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
+				return false
+			}
+			return body.Message == "no Route matched with those values"
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("putting the ingress.class annotation \"%s\" back on ingress %s", ingressClass, ingress.Name)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	ingress.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = ingressClass
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
 		if err != nil {
@@ -163,4 +221,147 @@ func TestHTTPSRedirect(t *testing.T) {
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusMovedPermanently
 	}, ingressWait, waitTick)
+}
+
+func TestIngressClassNameSpec(t *testing.T) {
+	ctx := context.Background()
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
+	container := k8sgen.NewContainer("httpbin", httpBinImage, 80)
+	deployment := k8sgen.NewDeploymentForContainer(container)
+	deployment, err := cluster.Client().AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the deployment %s", deployment.Name)
+		assert.NoError(t, cluster.Client().AppsV1().Deployments("default").Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = cluster.Client().CoreV1().Services("default").Create(ctx, service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the service %s", service.Name)
+		assert.NoError(t, cluster.Client().CoreV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Logf("creating an ingress for service %s without ingress.class %s", service.Name, ingressClass)
+	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{"konghq.com/strip-path": "true"}, service)
+	ingress.Spec.IngressClassName = kong.String(ingressClass)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
+		if err := cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Logf("waiting for routes from Ingress %s to be operational", ingress.Name)
+	p := proxyReady()
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
+			// Expected: "<title>httpbin.org</title>"
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("removing the IngressClassName \"%s\" from ingress %s", ingressClass, ingress.Name)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	ingress.Spec.IngressClassName = nil
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	t.Logf("verifying that removing the IngressClassName \"%s\" from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusNotFound {
+			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
+			// Expected: {"message":"no Route matched with those values"}
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			body := struct {
+				Message string `json:"message"`
+			}{}
+			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
+				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
+				return false
+			}
+			return body.Message == "no Route matched with those values"
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("putting the IngressClassName \"%s\" back on ingress %s", ingressClass, ingress.Name)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	ingress.Spec.IngressClassName = kong.String(ingressClass)
+	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
+			// Expected: "<title>httpbin.org</title>"
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
+	assert.NoError(t, cluster.Client().NetworkingV1().Ingresses("default").Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", p.ProxyURL.String(), err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusNotFound {
+			// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
+			// Expected: {"message":"no Route matched with those values"}
+			b := new(bytes.Buffer)
+			b.ReadFrom(resp.Body)
+			body := struct {
+				Message string `json:"message"`
+			}{}
+			if err := json.Unmarshal(b.Bytes(), &body); err != nil {
+				t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", p.ProxyURL.String(), err)
+				return false
+			}
+			return body.Message == "no Route matched with those values"
+		}
+		return false
+	}, ingressWait, waitTick)
+
 }

--- a/railgun/test/integration/ingress_test.go
+++ b/railgun/test/integration/ingress_test.go
@@ -83,14 +83,14 @@ func TestMinimalIngress(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 
-	t.Logf("removing the ingress.class annotation \"%s\" from ingress %s", ingressClass, ingress.Name)
+	t.Logf("removing the ingress.class annotation %q from ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
-	t.Logf("verifying that removing the ingress.class annotation \"%s\" from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
+	t.Logf("verifying that removing the ingress.class annotation %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
 		if err != nil {
@@ -115,7 +115,7 @@ func TestMinimalIngress(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 
-	t.Logf("putting the ingress.class annotation \"%s\" back on ingress %s", ingressClass, ingress.Name)
+	t.Logf("putting the ingress.class annotation %q back on ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
@@ -282,14 +282,14 @@ func TestIngressClassNameSpec(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 
-	t.Logf("removing the IngressClassName \"%s\" from ingress %s", ingressClass, ingress.Name)
+	t.Logf("removing the IngressClassName %q from ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.Spec.IngressClassName = nil
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Update(ctx, ingress, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
-	t.Logf("verifying that removing the IngressClassName \"%s\" from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
+	t.Logf("verifying that removing the IngressClassName %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", p.ProxyURL.String()))
 		if err != nil {
@@ -314,7 +314,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 
-	t.Logf("putting the IngressClassName \"%s\" back on ingress %s", ingressClass, ingress.Name)
+	t.Logf("putting the IngressClassName %q back on ingress %s", ingressClass, ingress.Name)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, ingress.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)

--- a/railgun/test/integration/kongingress_test.go
+++ b/railgun/test/integration/kongingress_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/railgun/pkg/clientset"
 	k8sgen "github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
@@ -52,8 +53,8 @@ func TestMinimalKongIngress(t *testing.T) {
 
 	t.Logf("routing to service %s via Ingress", service.Name)
 	ingress := k8sgen.NewIngressForService("/httpbin", map[string]string{
-		"kubernetes.io/ingress.class": ingressClass,
-		"konghq.com/strip-path":       "true",
+		annotations.IngressClassKey: ingressClass,
+		"konghq.com/strip-path":     "true",
 	}, service)
 	ingress, err = cluster.Client().NetworkingV1().Ingresses("default").Create(ctx, ingress, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -69,7 +70,7 @@ func TestMinimalKongIngress(t *testing.T) {
 			Name:      testName,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": ingressClass,
+				annotations.IngressClassKey: ingressClass,
 			},
 		},
 		Proxy: &kong.Service{

--- a/railgun/test/integration/tcpingress_test.go
+++ b/railgun/test/integration/tcpingress_test.go
@@ -24,29 +24,28 @@ import (
 )
 
 func TestMinimalTCPIngress(t *testing.T) {
-	namespace := "default"
 	testName := "mintcp"
 	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
 	defer cancel()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	deployment := k8sgen.NewDeploymentForContainer(k8sgen.NewContainer(testName, httpBinImage, 80))
-	_, err := cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	_, err := cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, cluster.Client().AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := k8sgen.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	service, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	service, err = cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, cluster.Client().CoreV1().Services(namespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, cluster.Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("routing to service %s via TCPIngress", service.Name)
@@ -55,7 +54,7 @@ func TestMinimalTCPIngress(t *testing.T) {
 	tcp := &kongv1beta1.TCPIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
-			Namespace: namespace,
+			Namespace: corev1.NamespaceDefault,
 			Annotations: map[string]string{
 				annotations.IngressClassKey: ingressClass,
 			},
@@ -72,12 +71,12 @@ func TestMinimalTCPIngress(t *testing.T) {
 			},
 		},
 	}
-	tcp, err = c.ConfigurationV1beta1().TCPIngresses(namespace).Create(ctx, tcp, metav1.CreateOptions{})
+	tcp, err = c.ConfigurationV1beta1().TCPIngresses(corev1.NamespaceDefault).Create(ctx, tcp, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that TCPIngress %s is cleaned up", tcp.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(namespace).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.ConfigurationV1beta1().TCPIngresses(corev1.NamespaceDefault).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -105,7 +104,7 @@ func TestMinimalTCPIngress(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("tearing down TCPIngress %s and ensuring that the relevant backend routes are removed", tcp.Name)
-	assert.NoError(t, c.ConfigurationV1beta1().TCPIngresses(namespace).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, c.ConfigurationV1beta1().TCPIngresses(corev1.NamespaceDefault).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(tcpProxyURL.String())
 		if err != nil {

--- a/railgun/test/integration/tcpingress_test.go
+++ b/railgun/test/integration/tcpingress_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/railgun/pkg/clientset"
 	k8sgen "github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
@@ -56,7 +57,7 @@ func TestMinimalTCPIngress(t *testing.T) {
 			Name:      testName,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": ingressClass,
+				annotations.IngressClassKey: ingressClass,
 			},
 		},
 		Spec: kongv1beta1.TCPIngressSpec{

--- a/railgun/test/integration/udpingress_test.go
+++ b/railgun/test/integration/udpingress_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/railgun/pkg/clientset"
 )
@@ -49,7 +50,7 @@ func TestMinimalUDPIngress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testName,
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": ingressClass,
+				annotations.IngressClassKey: ingressClass,
 			},
 		},
 		Spec: kongv1alpha1.UDPIngressSpec{


### PR DESCRIPTION
This PR adds logic to our controllers which configures and handles the `ingress.class` during object reconcilation.

Highlights:
- `Ingress` style objects now require `kubernetes.io/ingress.class: ${CLASS}` in order to be resolved
- Removing the ingress class removes the object from cache/configuration
- Integration tests now prove the functionality above :point_up: 

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1220