### PR TITLE
logr backend: replace zap with logrus

### DIFF
--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -113,12 +113,9 @@ func main() {
 		logrus.Fatalf("failed to parse configuration: %v", err)
 	}
 
-	log := logrus.New()
-	if log.Level, err = util.GetLogrusLevel(cliConfig.LogLevel); err != nil {
-		logrus.WithError(err).Fatalf("setting log level failed")
-	}
-	if log.Formatter, err = util.GetLogrusFormatter(cliConfig.LogFormat); err != nil {
-		logrus.WithError(err).Fatalf("setting log formatter failed")
+	log, err := util.MakeLogger(cliConfig.LogLevel, cliConfig.LogFormat)
+	if err != nil {
+		log.WithError(err).Fatal("failed to make logger")
 	}
 
 	for key, value := range viper.AllSettings() {

--- a/cli/ingress-controller/main.go
+++ b/cli/ingress-controller/main.go
@@ -65,22 +65,6 @@ import (
 	knativeinformer "knative.dev/networking/pkg/client/informers/externalversions"
 )
 
-var (
-	logrusLevel = map[string]logrus.Level{
-		"panic": logrus.PanicLevel,
-		"fatal": logrus.FatalLevel,
-		"error": logrus.ErrorLevel,
-		"warn":  logrus.WarnLevel,
-		"info":  logrus.InfoLevel,
-		"debug": logrus.DebugLevel,
-		"trace": logrus.TraceLevel,
-	}
-	logrusFormat = map[string]logrus.Formatter{
-		"text": &logrus.TextFormatter{},
-		"json": &logrus.JSONFormatter{},
-	}
-)
-
 func controllerConfigFromCLIConfig(cliConfig cliConfig) controller.Configuration {
 	return controller.Configuration{
 		Kong: sendconfig.Kong{
@@ -128,18 +112,14 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("failed to parse configuration: %v", err)
 	}
-	log := logrus.New()
-	level, ok := logrusLevel[cliConfig.LogLevel]
-	if !ok {
-		logrus.Fatalf("invalid log-level: %v", cliConfig.LogLevel)
-	}
-	log.Level = level
 
-	format, ok := logrusFormat[cliConfig.LogFormat]
-	if !ok {
-		logrus.Fatalf("invalid log-format: %v", cliConfig.LogFormat)
+	log := logrus.New()
+	if log.Level, err = util.GetLogrusLevel(cliConfig.LogLevel); err != nil {
+		logrus.WithError(err).Fatalf("setting log level failed")
 	}
-	log.Formatter = format
+	if log.Formatter, err = util.GetLogrusFormatter(cliConfig.LogFormat); err != nil {
+		logrus.WithError(err).Fatalf("setting log formatter failed")
+	}
 
 	for key, value := range viper.AllSettings() {
 		log.WithField(key, fmt.Sprintf("%v", value)).Debug("input flag")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/bombsimon/logrusr v1.0.0
 	github.com/docker/docker v20.10.5+incompatible // indirect
 	github.com/eapache/channels v1.1.0
 	github.com/fatih/color v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
+github.com/bombsimon/logrusr v1.0.0 h1:CTCkURYAt5nhCCnKH9eLShYayj2/8Kn/4Qg3QfiU+Ro=
+github.com/bombsimon/logrusr v1.0.0/go.mod h1:Jq0nHtvxabKE5EMwAAdgTaz7dfWE8C4i11NOltxGQpc=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -462,6 +464,7 @@ github.com/kong/go-kong v0.18.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmd
 github.com/kong/kubernetes-testing-framework v0.0.8 h1:/lNNrCa24L9njypFthJawdJu3sjYFjuGSmWHahKw950=
 github.com/kong/kubernetes-testing-framework v0.0.8/go.mod h1:foCWC7ga4p2O+kuz/NoCQAqFOCupoZrZrENM3cOcFcA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -934,6 +937,7 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -16,10 +16,6 @@ var (
 		"debug": logrus.DebugLevel,
 		"trace": logrus.TraceLevel,
 	}
-	logrusFormats = map[string]logrus.Formatter{
-		"text": &logrus.TextFormatter{},
-		"json": &logrus.JSONFormatter{},
-	}
 )
 
 func MakeLogger(level string, formatter string) (logrus.FieldLogger, error) {

--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -22,7 +22,20 @@ var (
 	}
 )
 
-func GetLogrusLevel(level string) (logrus.Level, error) {
+func MakeLogger(level string, formatter string) (logrus.FieldLogger, error) {
+	log := logrus.New()
+	var err error
+	if log.Level, err = getLogrusLevel(level); err != nil {
+		return nil, fmt.Errorf("setting log level failed: %w", err)
+	}
+	if log.Formatter, err = getLogrusFormatter(formatter); err != nil {
+		return nil, fmt.Errorf("setting log formatter failed: %w", err)
+	}
+
+	return log, nil
+}
+
+func getLogrusLevel(level string) (logrus.Level, error) {
 	res, ok := logrusLevels[level]
 	if !ok {
 		return 0, fmt.Errorf("%q is not a valid log level", level)
@@ -30,7 +43,7 @@ func GetLogrusLevel(level string) (logrus.Level, error) {
 	return res, nil
 }
 
-func GetLogrusFormatter(typ string) (logrus.Formatter, error) {
+func getLogrusFormatter(typ string) (logrus.Formatter, error) {
 	switch typ {
 	case "text":
 		return &logrus.TextFormatter{}, nil

--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	logrusLevels = map[string]logrus.Level{
+		"panic": logrus.PanicLevel,
+		"fatal": logrus.FatalLevel,
+		"error": logrus.ErrorLevel,
+		"warn":  logrus.WarnLevel,
+		"info":  logrus.InfoLevel,
+		"debug": logrus.DebugLevel,
+		"trace": logrus.TraceLevel,
+	}
+	logrusFormats = map[string]logrus.Formatter{
+		"text": &logrus.TextFormatter{},
+		"json": &logrus.JSONFormatter{},
+	}
+)
+
+func GetLogrusLevel(level string) (logrus.Level, error) {
+	res, ok := logrusLevels[level]
+	if !ok {
+		return 0, fmt.Errorf("%q is not a valid log level", level)
+	}
+	return res, nil
+}
+
+func GetLogrusFormatter(typ string) (logrus.Formatter, error) {
+	switch typ {
+	case "text":
+		return &logrus.TextFormatter{}, nil
+	case "json":
+		return &logrus.JSONFormatter{}, nil
+	}
+	return nil, fmt.Errorf("%q is not a valid log formatter", typ)
+}

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -212,6 +212,8 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 				"--controller-kongconsumer=disabled",
 				"--election-id=integrationtests.konghq.com",
 				fmt.Sprintf("--ingress-class=%s", ingressClass),
+				"--log-level=trace",
+				"--log-format=text",
 			})
 			fmt.Printf("config: %+v\n", config)
 


### PR DESCRIPTION
Fixes #1224 

KIC 1.x uses logrus.
KIC 2.x:
- uses controller-runtime which uses logr.
- uses parts of KIC 1.x that use logrus.
- uses zap as the backend for logr.

This PR:
- makes all of the logging plumbed throughout the controller manager use logrus: the legacy parts use logrus directly, the controller-runtime parts use logrus through a shim that implements a logr frontend over logrus
- plumbs the structured loggers through (instead of using locally created loggers)
- ports the KIC 1.x log control flags over to KIC 2.x
- sets the log level and format for tests

Caveats:
- internals of client-go use klog that is not injected from anywhere, and it seems that we don't have control over it. So, this PR reduces the ecosystem of loggers in KIC 2.x from [zap, logrus, klog] to [logrus, klog]