### PR TITLE
Fix: typo need to be corrected

### DIFF
--- a/cli/ingress-controller/flags.go
+++ b/cli/ingress-controller/flags.go
@@ -312,7 +312,7 @@ func parseFlags() (cliConfig, error) {
 	config.UpdateStatus = viper.GetBool("update-status")
 	config.UpdateStatusOnShutdown = viper.GetBool("update-status-on-shutdown")
 
-	// Rutnime behavior
+	// Runtime behavior
 	config.SyncPeriod = viper.GetDuration("sync-period")
 	config.SyncRateLimit = (float32)(viper.GetFloat64("sync-rate-limit"))
 	config.EnableReverseSync = viper.GetBool("enable-reverse-sync")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is for correcting the typo on  cli/ingress-controller/flags.go line: 315: "// Rutnime behavior" ,Rutnime should be corrected to "Runtime".


**Which issue this PR fixes** : fixes #1302 

**Special notes for your reviewer**:
