### PR TITLE
Clean up unused railgun variables

### DIFF
--- a/railgun/Makefile
+++ b/railgun/Makefile
@@ -74,7 +74,7 @@ build: generate fmt vet ## Build manager binary.
 		-X github.com/kong/kubernetes-ingress-controller/railgun/manager.Repo=$(REPO_INFO)" main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	KONG_EXTERNAL_CONTROLLER=true go run ./main.go
+	go run ./main.go
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}

--- a/railgun/internal/ctrlutils/utils.go
+++ b/railgun/internal/ctrlutils/utils.go
@@ -2,12 +2,10 @@ package ctrlutils
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	netv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,22 +47,6 @@ func HasFinalizer(obj client.Object, finalizer string) bool {
 		}
 	}
 	return hasFinalizer
-}
-
-// IsAPIAvailable is a hack to short circuit controllers for APIs which aren't available on the cluster,
-// enabling us to keep separate logic and logging for some legacy API versions.
-func IsAPIAvailable(mgr ctrl.Manager, obj client.Object) (bool, error) {
-	if err := mgr.GetAPIReader().Get(context.Background(), client.ObjectKey{Namespace: DefaultNamespace, Name: "non-existent"}, obj); err != nil {
-		if strings.Contains(err.Error(), "no matches for kind") {
-			return false, nil
-		}
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }
 
 // HasAnnotation is a helper function to determine whether an object has a given annotation, and whether it's

--- a/railgun/internal/ctrlutils/vars.go
+++ b/railgun/internal/ctrlutils/vars.go
@@ -1,21 +1,6 @@
 package ctrlutils
 
 // -----------------------------------------------------------------------------
-// Environment Variables
-// -----------------------------------------------------------------------------
-
-var (
-	// CtrlNamespaceEnv provides the name of the environment variable where controllers which
-	// manage the Kong configuration should use to find (or create) the configuration secret.
-	CtrlNamespaceEnv = "KONG_CONFIGURATION_NAMESPACE"
-
-	// ExternalCtrlEnv is an environment variable used to indicate whether the controller is running
-	// outside the cluster where the proxy instances are running. If unset it is assumed that the proxy
-	// instances can be reached via their Pod IP address. Only accepts "true" to enable.
-	ExternalCtrlEnv = "KONG_EXTERNAL_CONTROLLER"
-)
-
-// -----------------------------------------------------------------------------
 // General Controller Variables
 // -----------------------------------------------------------------------------
 

--- a/railgun/internal/ctrlutils/vars.go
+++ b/railgun/internal/ctrlutils/vars.go
@@ -5,10 +5,6 @@ package ctrlutils
 // -----------------------------------------------------------------------------
 
 var (
-	// DefaultNamespace indicates the namespace that will be used by default
-	// when no other is provided for the deployment or management of resources.
-	DefaultNamespace = "kong-system"
-
 	// KongIngressFinalizer is the finalizer used to ensure Kong configuration cleanup for deleted resources.
 	KongIngressFinalizer = "configuration.konghq.com/ingress"
 )

--- a/railgun/internal/ctrlutils/vars.go
+++ b/railgun/internal/ctrlutils/vars.go
@@ -9,14 +9,6 @@ var (
 	// when no other is provided for the deployment or management of resources.
 	DefaultNamespace = "kong-system"
 
-	// ConfigSecretName indicates the name of the Secret object where Ingress controllers will upload
-	// ingress objects for eventual parsing and configuration in the Kong Proxy APIs.
-	ConfigSecretName = "kong-config"
-
-	// ProxyInstanceLabel is a label used for controllers (such as the secret configuration
-	// controller) to identify which pods are running the Kong proxy which needs to be configured.
-	ProxyInstanceLabel = "konghq.com/proxy-instance"
-
 	// KongIngressFinalizer is the finalizer used to ensure Kong configuration cleanup for deleted resources.
 	KongIngressFinalizer = "configuration.konghq.com/ingress"
 )

--- a/railgun/internal/ctrlutils/vars.go
+++ b/railgun/internal/ctrlutils/vars.go
@@ -4,7 +4,5 @@ package ctrlutils
 // General Controller Variables
 // -----------------------------------------------------------------------------
 
-var (
-	// KongIngressFinalizer is the finalizer used to ensure Kong configuration cleanup for deleted resources.
-	KongIngressFinalizer = "configuration.konghq.com/ingress"
-)
+// KongIngressFinalizer is the finalizer used to ensure Kong configuration cleanup for deleted resources.
+const KongIngressFinalizer = "configuration.konghq.com/ingress"

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -4,7 +4,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/bombsimon/logrusr"
 	"github.com/go-logr/logr"
@@ -23,7 +22,6 @@ import (
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/railgun/controllers/configuration"
 	kongctrl "github.com/kong/kubernetes-ingress-controller/railgun/controllers/configuration"
-	"github.com/kong/kubernetes-ingress-controller/railgun/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/railgun/internal/mgrutils"
 	"github.com/kong/kubernetes-ingress-controller/railgun/internal/proxy"
 )
@@ -49,11 +47,6 @@ func Run(ctx context.Context, c *Config) error {
 	utilruntime.Must(konghqcomv1.AddToScheme(scheme))
 	utilruntime.Must(configurationv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(configurationv1beta1.AddToScheme(scheme))
-
-	// TODO: we might want to change how this works in the future, rather than just assuming the default ns
-	if v := os.Getenv(ctrlutils.CtrlNamespaceEnv); v == "" {
-		os.Setenv(ctrlutils.CtrlNamespaceEnv, ctrlutils.DefaultNamespace)
-	}
 
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(c.APIServerHost, c.KubeconfigPath)
 	if err != nil {

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/kind"
 	ktfkind "github.com/kong/kubernetes-testing-framework/pkg/kind"
 
-	"github.com/kong/kubernetes-ingress-controller/railgun/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/railgun/manager"
 )
 
@@ -51,6 +50,9 @@ const (
 
 	// ingressClass indicates the ingress class name which the tests will use for supported object reconcilation
 	ingressClass = "kongtests"
+
+	// controllerNamespace is the Kubernetes namespace where the controller is deployed
+	controllerNamespace = "kong-system"
 )
 
 // -----------------------------------------------------------------------------
@@ -103,7 +105,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// deploy the Kong Kubernetes Ingress Controller (KIC) to the cluster
-	if err := deployControllers(ctx, ready, cluster, os.Getenv("KONG_CONTROLLER_TEST_IMAGE"), ctrlutils.DefaultNamespace); err != nil {
+	if err := deployControllers(ctx, ready, cluster, os.Getenv("KONG_CONTROLLER_TEST_IMAGE"), controllerNamespace); err != nil {
 		cluster.Cleanup()
 		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(13)
@@ -273,7 +275,7 @@ func waitForExistingClusterReadiness(ctx context.Context, cluster ktfkind.Cluste
 			fmt.Fprintf(os.Stderr, "ERROR: timed out waiting for readiness from existing cluster %s", name)
 			os.Exit(11)
 		default:
-			svcs, err := cluster.Client().CoreV1().Services(ctrlutils.DefaultNamespace).List(ctx, metav1.ListOptions{})
+			svcs, err := cluster.Client().CoreV1().Services(controllerNamespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				ready <- ktfkind.ProxyReadinessEvent{Err: err}
 				break


### PR DESCRIPTION
- removes the ineffective `KONG_EXTERNAL_CONTROLLER` env variable (and its associated use in the makefile)
- removes the unused `CtrlNamespaceEnv` and its initialization in `manager.Run`
- since `DefaultNamespace` is no longer used by the configuration secret and the `IsAPIAvailable` function was unused:
    - removed the `IsAPIAvailable` function (if it gets reintroduced, it should use the `default` namespace instead because `kong-system` is not guaranteed to exist in a cluster)
    - moved the `DefaultNamespace` var to a const in the integration test
- removed the `ConfigSecretName` no longer relevant after we've deleted support for the config secret
- removed the unused `ProxyInstanceLabel`