### PR TITLE
KIC 2.0 - Add 2.0 CHANGELOG & Remove ClassLess Ingress Support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
 2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
+3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
 -->
 
 **What this PR does / why we need it**:
@@ -9,3 +9,9 @@
 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
 
 **Special notes for your reviewer**:
+
+**PR Readiness Checklist**:
+
+Complete these before marking the PR as `ready to review`:
+
+- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [2.0.0-alpha.1](#200-alpha1---TBD)
  - [1.2.0](#120---20210324)
  - [1.1.1](#111---20210107)
  - [1.1.0](#110---20201209)
@@ -26,6 +27,33 @@
  - [0.1.0](#010---20180817)
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.0.0-alpha.1] - TBD
+
+**NOTE**: This is a draft of release notes for the next major version to be released and the release notes may change significantly before then.
+
+#### Added
+
+- support for [UDP][kong-udp] via the new `UDPIngress` API.
+- `--watch-namespace` now supports multiple distinct namespaces versus simply supporting all namespaces (the default) or a single namespace. To watch multiple namespaces, use a comma-separated list (for example, `--watch-namespace "namespaceA,namespaceB"`).
+
+[kong-udp]:https://konghq.com/blog/kong-gateway-2-2-released/#UDP-Support
+
+#### Breaking changes
+
+- support for "classless" ingress types has been removed: the controller flags `--process-classless-ingress-v1beta1`, `--process-classless-ingress-v1` and `--process-classless-kong-consumer` flags are no longer valid
+
+#### Under the hood
+
+- project layout for contributions has been changed: this project now uses the [Kubebuilder SDK][kubebuilder] and there are layout changes and configurations specific to the new build environment.
+- controller architecture has been changed: each API type now has an independent controller implementation and all controllers now utilize [controller-runtime][controller-runtime].
+- full integration testing in [Golang][go] has been added for testing APIs and controllers on a fully featured Kubernetes cluster, this is now supported by the new [Kong Kubernetes Testing Framework (KTF)][ktf] project and now runs as part of CI.
+- the mechanism for caching and resolving Kong Admin `/config` configurations when running in `DBLESS` mode has been reimplemented to enable fine-tuned configuration options in later iterations.
+
+[kubebuilder]:https://github.com/kubernetes-sigs/kubebuilder
+[controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
+[go]:https://golang.org
+[ktf]:https://github.com/kong/kubernetes-testing-framework
 
 ## [1.2.0] - 2021/03/24
 
@@ -1003,6 +1031,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.0.0-alpha.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...2.0.0-alpha.1
 [1.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.0.0...1.1.0

--- a/railgun/manager/config.go
+++ b/railgun/manager/config.go
@@ -57,11 +57,6 @@ type Config struct {
 	KongPluginEnabled        util.EnablementStatus
 	KongConsumerEnabled      util.EnablementStatus
 	ServiceEnabled           util.EnablementStatus
-
-	// "Classless" API support
-	ProcessClasslessIngressV1      bool
-	ProcessClasslessIngressV1Beta1 bool
-	ProcessClasslessKongConsumer   bool
 }
 
 // -----------------------------------------------------------------------------
@@ -124,11 +119,6 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.enablementStatusVar(&c.KongPluginEnabled, "controller-kongplugin", util.EnablementStatusDisabled, "Enable or disable the KongPlugin controller. "+onOffUsage)
 	flagSet.enablementStatusVar(&c.KongConsumerEnabled, "controller-kongconsumer", util.EnablementStatusDisabled, "Enable or disable the KongConsumer controller. "+onOffUsage)
 	flagSet.enablementStatusVar(&c.ServiceEnabled, "controller-service", util.EnablementStatusEnabled, "Enable or disable the Service controller. "+onOffUsage)
-
-	// "Classless" API support
-	flagSet.BoolVar(&c.ProcessClasslessIngressV1Beta1, "process-classless-ingress-v1beta1", false, `Process v1beta1 Ingress resources with no class annotation.`)
-	flagSet.BoolVar(&c.ProcessClasslessIngressV1, "process-classless-ingress-v1", false, `Process v1 Ingress resources with no class annotation.`)
-	flagSet.BoolVar(&c.ProcessClasslessKongConsumer, "process-classless-kong-consumer", false, `Process KongConsumer resources with no class annotation.`)
 
 	return &flagSet.FlagSet
 }

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -115,9 +115,6 @@ func Run(ctx context.Context, c *Config) error {
 		mgr.GetClient(),
 		kongConfig,
 		c.IngressClassName,
-		c.ProcessClasslessIngressV1Beta1,
-		c.ProcessClasslessIngressV1,
-		c.ProcessClasslessKongConsumer,
 		c.EnableReverseSync,
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the `KIC 2.0.0` CHANGELOG release notes and removes support for "class-less" ingress options.

**Which issue this PR fixes**
fixes https://github.com/Kong/team-k8s/issues/78
fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1293

**PR Readiness Checklist**:

- [x] unit and integration tests have been added which cover any changes or added functionality, and code coverage CI has _not decreased_
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
