### PR TITLE
feat: add --proxy-sync-seconds mgr cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,13 @@
 
 #### Under the hood
 
+- the `--sync-rate-limit` is now deprecated in favor of `--sync-time-seconds`. This functionality no longer blocks goroutines until the provided number of seconds has passed to enforce rate limiting, now instead it configures a non-blocking [time.Ticker][go-tick] that runs at the provided seconds interval. Input remains a float that indicates seconds.
 - project layout for contributions has been changed: this project now uses the [Kubebuilder SDK][kubebuilder] and there are layout changes and configurations specific to the new build environment.
 - controller architecture has been changed: each API type now has an independent controller implementation and all controllers now utilize [controller-runtime][controller-runtime].
 - full integration testing in [Golang][go] has been added for testing APIs and controllers on a fully featured Kubernetes cluster, this is now supported by the new [Kong Kubernetes Testing Framework (KTF)][ktf] project and now runs as part of CI.
 - the mechanism for caching and resolving Kong Admin `/config` configurations when running in `DBLESS` mode has been reimplemented to enable fine-tuned configuration options in later iterations.
 
+[go-tick]:https://golang.org/pkg/time/#Ticker
 [kubebuilder]:https://github.com/kubernetes-sigs/kubebuilder
 [controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
 [go]:https://golang.org

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"time"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -11,10 +9,11 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	// DefaultStagger indicates the time.Duration (minimum) that will occur between
+	// DefaultSyncSeconds indicates the time.Duration (minimum) that will occur between
 	// updates to the Kong Proxy Admin API when using the NewProxy() constructor.
-	// Use the NewProxyWithStagger() constructor to provide your own duration.
-	DefaultStagger time.Duration = time.Second * 3
+	//
+	// NOTE: this default was originally inherited from KIC v1.x.
+	DefaultSyncSeconds float32 = 0.3
 
 	// DefaultObjectBufferSize is the number of client.Objects that the server will buffer
 	// before it starts rejecting new objects while it processes the originals.

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bombsimon/logrusr"
 	"github.com/go-logr/logr"
@@ -107,8 +108,15 @@ func Run(ctx context.Context, c *Config) error {
 		Client:      kongClient,
 	}
 
+	// determine the proxy synchronization strategy
+	syncTickDuration, err := time.ParseDuration(fmt.Sprintf("%gs", c.ProxySyncSeconds))
+	if err != nil {
+		setupLog.Error(err, "%s is not a valid number of seconds to stagger the proxy server synchronization")
+		return err
+	}
+
 	// start the proxy cache server
-	prx, err := proxy.NewCacheBasedProxy(ctx,
+	prx, err := proxy.NewCacheBasedProxyWithStagger(ctx,
 		// NOTE: logr-based loggers use the "logger" field instead of "subsystem". When replacing logrus with logr, replace
 		// WithField("subsystem", ...) with WithName(...).
 		deprecatedLogger.WithField("subsystem", "proxy-cache-resolver"),
@@ -116,6 +124,7 @@ func Run(ctx context.Context, c *Config) error {
 		kongConfig,
 		c.IngressClassName,
 		c.EnableReverseSync,
+		syncTickDuration,
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to start proxy cache server")

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -214,6 +214,7 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 			flags.Parse([]string{
 				fmt.Sprintf("--kong-admin-url=http://%s:8001", adminHost),
 				fmt.Sprintf("--kubeconfig=%s", kubeconfig.Name()),
+				"--proxy-sync-seconds=0.05", // run the test updates at 50ms for high speed
 				"--controller-kongstate=enabled",
 				"--controller-ingress-networkingv1=enabled",
 				"--controller-ingress-networkingv1beta1=disabled",


### PR DESCRIPTION
Add `--proxy-sync-seconds` and deprecates and changes the inner workings of `--sync-rate-limit` in a backwards-compatible manner.

Resolves #1300