### PR TITLE
Client go proxy unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/googleapis/gnostic v0.5.4 // indirect
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/kong/deck v1.6.0

--- a/pkg/sendconfig/common_workflows.go
+++ b/pkg/sendconfig/common_workflows.go
@@ -1,0 +1,58 @@
+package sendconfig
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kong/kubernetes-ingress-controller/pkg/deckgen"
+	"github.com/kong/kubernetes-ingress-controller/pkg/parser"
+	"github.com/kong/kubernetes-ingress-controller/pkg/store"
+)
+
+// UpdateKongAdminSimple is a helper function for the most common usage of PerformUpdate() with only minimal
+// upfront configuration required. This function is specialized and highly opinionated.
+//
+// If you're implementation needs to expand on the configuration and usage of the following inner components:
+//
+//   - store.Storer
+//   - kongstate.Kong
+//   - deckgen.ToDeckContent()
+//   - sendconfig.PerformUpdate()
+//
+// Or any other encapsulated components this function makes all of that opaque to the caller.
+// Treat this function as a very specific "workflow" to update the Kong Admin API,
+// and use it as a reference to implement the workflow you need.
+func UpdateKongAdminSimple(ctx context.Context,
+	lastConfigSHA []byte,
+	cache *store.CacheStores,
+	ingressClassName string,
+	deprecatedLogger logrus.FieldLogger,
+	kongConfig Kong,
+	enableReverseSync bool,
+) ([]byte, error) {
+	// build the kongstate object from the Kubernetes objects in the storer
+	storer := store.New(*cache, ingressClassName, false, false, false, deprecatedLogger)
+	kongstate, err := parser.Build(deprecatedLogger, storer)
+	if err != nil {
+		return nil, err
+	}
+
+	// generate the deck configuration to be applied to the admin API
+	targetConfig := deckgen.ToDeckContent(ctx, deprecatedLogger, kongstate, nil, nil)
+
+	// apply the configuration update in Kong
+	timedCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	configSHA, err := PerformUpdate(timedCtx,
+		deprecatedLogger, &kongConfig,
+		kongConfig.InMemory, enableReverseSync,
+		targetConfig, nil, nil, lastConfigSHA,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return configSHA, nil
+}

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -213,6 +213,9 @@ func (p *clientgoCachedProxyResolver) startCacheServer() {
 			p.lastConfigSHA = updateConfigSHA
 		case <-p.ctx.Done():
 			p.logger.Info("the proxy cache server's context is done, shutting down")
+			if err := p.ctx.Err(); err != nil {
+				p.logger.Error(err, "context completed with error")
+			}
 			return
 		}
 	}

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -216,6 +216,7 @@ func (p *clientgoCachedProxyResolver) startCacheServer() {
 			if err := p.ctx.Err(); err != nil {
 				p.logger.Error(err, "context completed with error")
 			}
+			p.syncTicker.Stop()
 			return
 		}
 	}

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -286,6 +286,8 @@ func (p *clientgoCachedProxyResolver) cacheDelete(cobj *cachedObject) error {
 	return cobj.err
 }
 
+// kongRootWithTimeout provides the root configuration from Kong, but uses a default timeout to avoid long waits if the Admin API
+// is not yet ready to respond. If a timeout error occurs, the caller is responsible for providing a retry mechanism.
 func (p *clientgoCachedProxyResolver) kongRootWithTimeout() (map[string]interface{}, error) {
 	ctx, cancel := context.WithTimeout(p.ctx, 3*time.Second)
 	defer cancel()

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -17,7 +17,7 @@ func TestCaching(t *testing.T) {
 	defer cancel()
 
 	t.Log("configuring and starting a new proxy server")
-	proxyInterface, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false)
+	proxyInterface, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false, mockKongAdmin)
 	assert.NoError(t, err)
 
 	t.Log("ensuring the integrity of the proxy server")

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCaching(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("configuring and starting a new proxy server")
+	proxyInterface, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false)
+	assert.NoError(t, err)
+
+	t.Log("ensuring the integrity of the proxy server")
+	proxy, ok := proxyInterface.(*clientgoCachedProxyResolver)
+	assert.True(t, ok)
+	assert.NotNil(t, proxy.cache)
+
+	t.Log("intentionally freezing async updates to inspect cache state during tests")
+	proxy.syncTicker.Reset(time.Minute * 1)
+
+	t.Log("generating 10 new objects to the proxy cache server")
+	testObjects := make([]client.Object, 10)
+	for i := 0; i < 10; i++ {
+		name := uuid.New().String()
+		deployment := k8s.NewDeploymentForContainer(k8s.NewContainer(name, name, 8080))
+		service := k8s.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+		ingress := k8s.NewIngressForService("/testing", nil, service)
+		testObjects[i] = ingress
+	}
+
+	t.Logf("adding %d new objects to the proxy cache server", len(testObjects))
+	assert.Len(t, proxy.cache.IngressV1.List(), 0)
+	for _, testObject := range testObjects {
+		proxy.UpdateObject(testObject)
+	}
+
+	t.Log("ensuring the consistency of the underlying object cache (that objects were added properly)")
+	assert.Eventually(t, func() bool {
+		return len(proxy.cache.IngressV1.List()) == len(testObjects)
+	}, time.Second*10, time.Millisecond*200)
+
+	t.Log("flushing the cache state to kong admin api")
+	previousUpdateCount := fakeKongAdminUpdateCount()
+	proxy.syncTicker.Reset(time.Millisecond * 200)
+	assert.Eventually(t, func() bool { return fakeKongAdminUpdateCount() == previousUpdateCount+1 }, time.Second*10, time.Millisecond*200)
+}

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -1,7 +1,13 @@
 package proxy
 
 import (
+	"context"
+
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/pkg/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/pkg/store"
 )
 
 // -----------------------------------------------------------------------------
@@ -53,3 +59,13 @@ type Proxy interface {
 	// A status will later be added to the object whether the configuration update succeeds or fails.
 	DeleteObject(obj client.Object) error
 }
+
+// KongUpdater is a type of function that describes how to provide updates to the Kong Admin API
+// and implementations will report the configuration SHA that results from any update performed.
+type KongUpdater func(ctx context.Context,
+	lastConfigSHA []byte,
+	cache *store.CacheStores,
+	ingressClassName string,
+	deprecatedLogger logrus.FieldLogger,
+	kongConfig sendconfig.Kong,
+	enableReverseSync bool) ([]byte, error)

--- a/railgun/internal/proxy/suite_test.go
+++ b/railgun/internal/proxy/suite_test.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	kongt "github.com/kong/kubernetes-testing-framework/pkg/kong"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/kubernetes-ingress-controller/pkg/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/pkg/store"
+	"github.com/kong/kubernetes-ingress-controller/pkg/util"
+)
+
+// -----------------------------------------------------------------------------
+// Test Vars
+// -----------------------------------------------------------------------------
+
+var (
+	logger logrus.FieldLogger
+
+	fakeKongConfig   sendconfig.Kong
+	fakeKongAdminAPI *kongt.FakeAdminAPIServer
+
+	fakeK8sClient client.Client
+)
+
+// -----------------------------------------------------------------------------
+// Test Main
+// -----------------------------------------------------------------------------
+
+func TestMain(m *testing.M) {
+	setupVars()
+	setupMocks()
+	code := m.Run()
+	os.Exit(code)
+}
+
+// -----------------------------------------------------------------------------
+// Test Main - Helper Functions
+// -----------------------------------------------------------------------------
+
+func setupVars() {
+	var err error
+
+	// setup logging and other general configurations
+	logger, err = util.MakeLogger("debug", "json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not create test logger: %v\n", err)
+		os.Exit(10)
+	}
+
+	// setup kubernetes related configurations
+	fakeK8sClient = fake.NewClientBuilder().Build()
+
+	// setup kong proxy related configurations
+	fakeKongAdminAPI, err = kongt.NewFakeAdminAPIServer()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not setup Kong Proxy testing environment: %v\n", err)
+		os.Exit(10)
+	}
+	fakeKongConfig.Client = fakeKongAdminAPI.KongClient
+}
+
+func setupMocks() {
+	// this mock will stop us from needing a functioning Kong proxy and simply
+	// assumes that all updates to the Kong Admin API succeed. Test which want
+	// to test failure conditions will need to add their own mock, and then put
+	// this one back when they're done.
+	//
+	// NOTE: as these tests grow, we can use the kongt.FakeAdminAPIServer implementation to properly
+	//       mock out the requests (this is used above to ensure that tests can properly initialize a Proxy instance)
+	//       instead of the always-succeed functionality we use currently.
+	updateKongAdmin = func(ctx context.Context,
+		lastConfigSHA []byte,
+		cache *store.CacheStores,
+		ingressClassName string,
+		deprecatedLogger logrus.FieldLogger,
+		kongConfig sendconfig.Kong,
+		enableReverseSync bool) ([]byte, error) {
+		fakeKongAdminUpdateCount(1)
+		return lastConfigSHA, nil
+	}
+}
+
+// these globs are for threadsafety and tracking of the fakeKongAdminUpdateCount() function,
+// use that function directly, don't use these vars.
+var (
+	countLock   = &sync.RWMutex{}
+	updateCount int
+)
+
+// fakeKongAdminUpdateCount keeps track of the number of times the Kong Admin API has
+// received updates from the proxy cache server during the runtime of the tests. This
+// can be useful for simple checks to ensure updates ran, or to validate counts of the
+// number of updates run over time when cache server resolution configuration options
+// are tweaked to change throughput and test performance.
+//
+// If newcounts are provided the function appends the count with those provided counts first.
+func fakeKongAdminUpdateCount(newcounts ...int) int {
+	if len(newcounts) < 1 {
+		countLock.RLock()
+		defer countLock.RUnlock()
+		return updateCount
+	}
+	countLock.Lock()
+	defer countLock.Unlock()
+	for _, count := range newcounts {
+		updateCount = updateCount + count
+	}
+	return updateCount
+}

--- a/railgun/internal/proxy/suite_test.go
+++ b/railgun/internal/proxy/suite_test.go
@@ -36,7 +36,6 @@ var (
 
 func TestMain(m *testing.M) {
 	setupVars()
-	setupMocks()
 	code := m.Run()
 	os.Exit(code)
 }
@@ -67,25 +66,23 @@ func setupVars() {
 	fakeKongConfig.Client = fakeKongAdminAPI.KongClient
 }
 
-func setupMocks() {
-	// this mock will stop us from needing a functioning Kong proxy and simply
-	// assumes that all updates to the Kong Admin API succeed. Test which want
-	// to test failure conditions will need to add their own mock, and then put
-	// this one back when they're done.
-	//
-	// NOTE: as these tests grow, we can use the kongt.FakeAdminAPIServer implementation to properly
-	//       mock out the requests (this is used above to ensure that tests can properly initialize a Proxy instance)
-	//       instead of the always-succeed functionality we use currently.
-	updateKongAdmin = func(ctx context.Context,
-		lastConfigSHA []byte,
-		cache *store.CacheStores,
-		ingressClassName string,
-		deprecatedLogger logrus.FieldLogger,
-		kongConfig sendconfig.Kong,
-		enableReverseSync bool) ([]byte, error) {
-		fakeKongAdminUpdateCount(1)
-		return lastConfigSHA, nil
-	}
+// this mock will stop us from needing a functioning Kong proxy and simply
+// assumes that all updates to the Kong Admin API succeed. Test which want
+// to test failure conditions will need to add their own mock, and then put
+// this one back when they're done.
+//
+// NOTE: as these tests grow, we can use the kongt.FakeAdminAPIServer implementation to properly
+//       mock out the requests (this is used above to ensure that tests can properly initialize a Proxy instance)
+//       instead of the always-succeed functionality we use currently.
+var mockKongAdmin KongUpdater = func(ctx context.Context,
+	lastConfigSHA []byte,
+	cache *store.CacheStores,
+	ingressClassName string,
+	deprecatedLogger logrus.FieldLogger,
+	kongConfig sendconfig.Kong,
+	enableReverseSync bool) ([]byte, error) {
+	fakeKongAdminUpdateCount(1)
+	return lastConfigSHA, nil
 }
 
 // these globs are for threadsafety and tracking of the fakeKongAdminUpdateCount() function,

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -125,6 +125,7 @@ func Run(ctx context.Context, c *Config) error {
 		c.IngressClassName,
 		c.EnableReverseSync,
 		syncTickDuration,
+		sendconfig.UpdateKongAdminSimple,
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to start proxy cache server")


### PR DESCRIPTION
This adds unit tests to the client-go cached based proxy server implementation used to resolve cache to the Kong Admin API.

This was previous integration tested, but this PR adds some new KTF functionality that makes it simple to unit test so we can further validate the operations, tunables, and memory consumption of this implementation.