### PR TITLE
Pull from remote PR repos

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -26,11 +26,15 @@ jobs:
       run: go-licenses csv ./... | grep -v "github.com/kong" | sort > ${{ github.workspace }}/target_licenses.csv
       working-directory: ./src
     - name: Checkout PR
-      run: git checkout ${{ github.head_ref }}
-      working-directory: ./src
+      uses: actions/checkout@v2
+      with:
+        path: ./pr
+        ref: ${{ github.head_ref }}
+        repository: ${{ github.repository }}
+        fetch-depth: 0
     - name: Generate PR license report
-      run: go-licenses csv ./... | grep -v "github.com/kong" || sort > ${{ github.workspace }}/pr_licenses.csv
-      working-directory: ./src
+      run: go-licenses csv ./... | sort > ${{ github.workspace }}/pr_licenses.csv
+      working-directory: ./pr
     - name: Compare license reports
       id: compare_reports
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses a separate checkout for the PR rather than trying to change the checked-out ref in the existing copy. I tried to economize on network requests originally, and it did not work.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1335 
