### PR TITLE
feat: implement environment variable substitution

### DIFF
--- a/railgun/cmd/rootcmd/env.go
+++ b/railgun/cmd/rootcmd/env.go
@@ -1,0 +1,28 @@
+package rootcmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const envKeyPrefix = "CONTROLLER_"
+
+// bindEnvVars, for each flag defined on `cmd` (local or parent persistent), looks up the corresponding environment
+// variable and (if the flag is unset) takes that environment variable value as the flag value.
+func bindEnvVars(cmd *cobra.Command, _ []string) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		envKey := fmt.Sprintf("%s%s", envKeyPrefix, strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_")))
+
+		if f.Changed {
+			return // flags take precedence over environment variables
+		}
+
+		if envValue, envSet := os.LookupEnv(envKey); envSet {
+			cmd.Flags().Set(f.Name, envValue)
+		}
+	})
+}

--- a/railgun/cmd/rootcmd/env_test.go
+++ b/railgun/cmd/rootcmd/env_test.go
@@ -31,8 +31,12 @@ func TestBindEnvVars(t *testing.T) {
 	cmd.Flags().String("flag-3", "default3", "Set by args only")
 	cmd.Flags().String("flag-4", "default4", "Set by both env and args")
 
-	os.Setenv("CONTROLLER_FLAG_2", "env2")
-	os.Setenv("CONTROLLER_FLAG_4", "env4")
+	_ = os.Setenv("CONTROLLER_FLAG_2", "env2")
+	_ = os.Setenv("CONTROLLER_FLAG_4", "env4")
+	defer func() {
+		_ = os.Unsetenv("CONTROLLER_FLAG_2")
+		_ = os.Unsetenv("CONTROLLER_FLAG_4")
+	}()
 
 	cmd.SetArgs([]string{
 		"--flag-3=args3",

--- a/railgun/cmd/rootcmd/env_test.go
+++ b/railgun/cmd/rootcmd/env_test.go
@@ -1,0 +1,45 @@
+package rootcmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindEnvVars(t *testing.T) {
+	commandHasRun := false
+	cmd := &cobra.Command{
+		PreRun: bindEnvVars,
+		Run: func(cmd *cobra.Command, args []string) {
+			got1, _ := cmd.Flags().GetString("flag-1")
+			got2, _ := cmd.Flags().GetString("flag-2")
+			got3, _ := cmd.Flags().GetString("flag-3")
+			got4, _ := cmd.Flags().GetString("flag-4")
+			require.Equal(t, "default1", got1) // env not set, arg not set
+			require.Equal(t, "env2", got2)     // env set, arg not set
+			require.Equal(t, "args3", got3)    // env not set, arg set
+			require.Equal(t, "args4", got4)    // env set, arg set
+			commandHasRun = true
+		},
+	}
+
+	cmd.Flags().String("flag-1", "default1", "Not set")
+	cmd.Flags().String("flag-2", "default2", "Set by env only")
+	cmd.Flags().String("flag-3", "default3", "Set by args only")
+	cmd.Flags().String("flag-4", "default4", "Set by both env and args")
+
+	os.Setenv("CONTROLLER_FLAG_2", "env2")
+	os.Setenv("CONTROLLER_FLAG_4", "env4")
+
+	cmd.SetArgs([]string{
+		"--flag-3=args3",
+		"--flag-4=args4",
+	})
+	err := cmd.Execute()
+
+	assert.True(t, commandHasRun)
+	assert.NoError(t, err)
+}

--- a/railgun/cmd/rootcmd/rootcmd.go
+++ b/railgun/cmd/rootcmd/rootcmd.go
@@ -16,6 +16,7 @@ func init() {
 }
 
 var rootCmd = &cobra.Command{
+	PersistentPreRun: bindEnvVars,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return Run(cmd.Context(), &cfg)
 	},


### PR DESCRIPTION
Resolves #1221.

This PR implements a `PersistentPreRun` function that walks through all the flags and, for each of these flags, sets it from the environment if not set by the command line.

KIC 1.x used Viper for that purpose, which feels cumbersome to use with Cobra, and comes with extra features unnecessary for our use case (support for a configuration file). This PR proposes that we drop Viper for a more straightforward and less "magical" solution.

This PR aims for flag-wise compatibility with KIC 1.x. If there's any difference in env var naming, that should be considered a bug.