### PR TITLE
Update 2.0.0-alpha.1 and 1.3 changelogs for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Table of Contents
 
  - [2.0.0-alpha.1](#200-alpha1---20210527)
+ - [1.3.0](#130---20210527)
  - [1.2.0](#120---20210324)
  - [1.1.1](#111---20210107)
  - [1.1.0](#110---20201209)
@@ -92,6 +93,23 @@ released and the release notes may change significantly before then.
 [controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
 [go]:https://golang.org
 [ktf]:https://github.com/kong/kubernetes-testing-framework
+
+## [1.3.0] - 2021/05/27
+
+#### Added
+
+- support for the `konghq.com/host-aliases` annotation.
+  [#1016](https://github.com/Kong/kubernetes-ingress-controller/pull/1016/)
+
+#### Fixed
+
+- Sort SNIs and certificates consistently to avoid an issue with unnecessary
+  configuration re-syncs.
+  [#1268](https://github.com/Kong/kubernetes-ingress-controller/pull/1016/)
+
+#### Under the hood
+
+- Upgraded various dependencies.
 
 ## [1.2.0] - 2021/03/24
 
@@ -1070,6 +1088,7 @@ Please read the changelog and test in your environment.
    a working ingress controller.
 
 [2.0.0-alpha.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...2.0.0-alpha.1
+[1.3.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.0.0...1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,29 +30,61 @@
 
 ## [2.0.0-alpha.1] - 2021/05/27
 
-**NOTE**: This is a draft of release notes for the next major version to be released and the release notes may change significantly before then.
+**NOTE**: This is a draft of release notes for the next major version to be
+released and the release notes may change significantly before then.
 
 #### Added
 
 - support for [UDP][kong-udp] via the new `UDPIngress` API.
-- `--watch-namespace` now supports multiple distinct namespaces versus simply supporting all namespaces (the default) or a single namespace. To watch multiple namespaces, use a comma-separated list (for example, `--watch-namespace "namespaceA,namespaceB"`).
+- `--watch-namespace` now supports multiple distinct namespaces versus simply
+  supporting all namespaces (the default) or a single namespace. To watch
+  multiple namespaces, use a comma-separated list (for example,
+  `--watch-namespace "namespaceA,namespaceB"`).
 - support for the `konghq.com/host-aliases` annotation.
+  [#1016](https://github.com/Kong/kubernetes-ingress-controller/pull/1016/)
 
 [kong-udp]:https://konghq.com/blog/kong-gateway-2-2-released/#UDP-Support
 
 #### Breaking changes
 
-- support for "classless" ingress types has been removed: the controller flags `--process-classless-ingress-v1beta1`, `--process-classless-ingress-v1` and `--process-classless-kong-consumer` flags are no longer valid
-- autonegotiation of the Ingress API version (extensions v1beta1, networking v1beta1, networking v1) has been disabled. Instead, the user is expected to set **exactly** one of `--controller-ingress-networkingv1`, `--controller-ingress-networkingv1beta1`, `--controller-ingress-extensionsv1beta1` flags to `enabled`. There will be an `auto` mode implemented soon that will add the autonegotiation capability back.
+- support for "classless" ingress types has been removed: the controller flags
+  `--process-classless-ingress-v1beta1`, `--process-classless-ingress-v1` and
+  `--process-classless-kong-consumer` flags are no longer valid
+- autonegotiation of the Ingress API version (extensions v1beta1, networking
+  v1beta1, networking v1) has been disabled. Instead, the user is expected to
+  set **exactly** one of `--controller-ingress-networkingv1`,
+  `--controller-ingress-networkingv1beta1`,
+  `--controller-ingress-extensionsv1beta1` flags to `enabled`. There will be an
+  `auto` mode implemented soon that will add the autonegotiation capability
+  back.
 
 #### Under the hood
 
-- the `--sync-rate-limit` is now deprecated in favor of `--sync-time-seconds`. This functionality no longer blocks goroutines until the provided number of seconds has passed to enforce rate limiting, now instead it configures a non-blocking [time.Ticker][go-tick] that runs at the provided seconds interval. Input remains a float that indicates seconds.
-- project layout for contributions has been changed: this project now uses the [Kubebuilder SDK][kubebuilder] and there are layout changes and configurations specific to the new build environment.
-- controller architecture has been changed: each API type now has an independent controller implementation and all controllers now utilize [controller-runtime][controller-runtime].
-- full integration testing in [Golang][go] has been added for testing APIs and controllers on a fully featured Kubernetes cluster, this is now supported by the new [Kong Kubernetes Testing Framework (KTF)][ktf] project and now runs as part of CI.
-- the mechanism for caching and resolving Kong Admin `/config` configurations when running in `DBLESS` mode has been reimplemented to enable fine-tuned configuration options in later iterations.
-- contains the refactored admission webhook server. The server key and certificate flags have improved semantics: the default flag value is no longer the default path, but an empty string. When both key/cert value flags and key/cert file flags remain unset, KIC will read cert/key files from the default paths, as said in the flag descriptions. This change should not affect any existing configuration - in all configuration cases, behavior is expected to remain unchanged.
+- the `--sync-rate-limit` is now deprecated in favor of `--sync-time-seconds`.
+  This functionality no longer blocks goroutines until the provided number of
+  seconds has passed to enforce rate limiting, now instead it configures a
+  non-blocking [time.Ticker][go-tick] that runs at the provided seconds
+  interval. Input remains a float that indicates seconds.
+- project layout for contributions has been changed: this project now uses the
+  [Kubebuilder SDK][kubebuilder] and there are layout changes and
+  configurations specific to the new build environment.
+- controller architecture has been changed: each API type now has an
+  independent controller implementation and all controllers now utilize
+  [controller-runtime][controller-runtime].
+- full integration testing in [Golang][go] has been added for testing APIs and
+  controllers on a fully featured Kubernetes cluster, this is now supported by
+  the new [Kong Kubernetes Testing Framework (KTF)][ktf] project and now runs
+  as part of CI.
+- the mechanism for caching and resolving Kong Admin `/config` configurations
+  when running in `DBLESS` mode has been reimplemented to enable fine-tuned
+  configuration options in later iterations.
+- contains the refactored admission webhook server. The server key and
+  certificate flags have improved semantics: the default flag value is no
+  longer the default path, but an empty string. When both key/cert value flags
+  and key/cert file flags remain unset, KIC will read cert/key files from the
+  default paths, as said in the flag descriptions. This change should not
+  affect any existing configuration - in all configuration cases, behavior is
+  expected to remain unchanged.
 - taking configuration values from environment variables no longer uses Viper.
 
 [go-tick]:https://golang.org/pkg/time/#Ticker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Table of Contents
 
- - [2.0.0-alpha.1](#200-alpha1---TBD)
+ - [2.0.0-alpha.1](#200-alpha1---20210527)
  - [1.2.0](#120---20210324)
  - [1.1.1](#111---20210107)
  - [1.1.0](#110---20201209)
@@ -28,7 +28,7 @@
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
 
-## [2.0.0-alpha.1] - TBD
+## [2.0.0-alpha.1] - 2021/05/27
 
 **NOTE**: This is a draft of release notes for the next major version to be released and the release notes may change significantly before then.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor updates to the existing 2.0.0-alpha.1 changelog for formatting and date info, 1.3.0 changelog.
