### PR TITLE
chore: upgrade gh action uses

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Docker meta (alpine)
         id: meta_alpine
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3.3.0
         with:
           images: kong/kubernetes-ingress-controller
           flavor: |
@@ -71,7 +71,7 @@ jobs:
           tags: ${{ env.ALPINE_STANDARD }}${{ env.ALPINE_SUPPLEMENTAL }}
       - name: Docker meta (redhat)
         id: meta_redhat
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3.3.0
         with:
           images: kong/kubernetes-ingress-controller
           flavor: |


### PR DESCRIPTION
This upgrades metadata-action to the latest v3.3.0, but
also switches to the new upstream: https://github.com/docker/metadata-action