### PR TITLE
Merge next into main

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
         go-version: '^1.16'
 
     - name: Cache Go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.6
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Docker meta (alpine)
         id: meta_alpine
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3.3.0
         with:
           images: kong/kubernetes-ingress-controller
           flavor: |
@@ -71,7 +71,7 @@ jobs:
           tags: ${{ env.ALPINE_STANDARD }}${{ env.ALPINE_SUPPLEMENTAL }}
       - name: Docker meta (redhat)
         id: meta_redhat
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3.3.0
         with:
           images: kong/kubernetes-ingress-controller
           flavor: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         go-version: '^1.16'
     - name: cache go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
@@ -40,7 +40,7 @@ jobs:
       with:
         go-version: '^1.16'
     - name: cache go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
@@ -59,7 +59,7 @@ jobs:
       with:
         go-version: '^1.16'
     - name: cache go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -42,7 +42,7 @@ jobs:
         diff -u target_licenses.csv pr_licenses.csv >> $GITHUB_ENV || true
         echo 'EOF' >> $GITHUB_ENV
     - name: Update PR - go-license output differs
-      uses: actions/github-script@v3
+      uses: actions/github-script@v4.0.2
       if: ${{ env.DIFF_OUT != '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
             })
     - name: Update PR - remove unchanged label
       continue-on-error: true
-      uses: actions/github-script@v3
+      uses: actions/github-script@v4.0.2
       if: ${{ env.DIFF_OUT != '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
               name: ['ci/license/unchanged']
             })
     - name: Update PR - go-license output equal
-      uses: actions/github-script@v3
+      uses: actions/github-script@v4.0.2
       if: ${{ env.DIFF_OUT == '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       with:
         go-version: '^1.16'
     - name: Cache Go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
@@ -42,7 +42,7 @@ jobs:
       with:
         go-version: '^1.16'
     - name: Cache Go modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-build-test-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Dependabot has bad timing. Merge next into main again since the updates today were all for Github actions, which we want in both next and main.