### PR TITLE
release/1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG?=1.3.0
+TAG?=1.3.1
 RG_TAG?=2.0.0-alpha.1
 REGISTRY?=kong
 REPO_INFO=$(shell git config --get remote.origin.url)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,22 +1,45 @@
-# KIC Release process
+# Release Process
 
-## Git workflow and image builds
+## Prerequisites
 
-- [ ] Merge main into next (ignore if patch release). Use a merge commit.
-- [ ] Check out a new branch from next (major/minor release) or main (patch release), e.g. `release/1.2.0`.
-- [ ] Update manifest versions under `deploy/base` with the new version and run `hack/build-single-manifests.sh` (ignore for pre-releases).
-- [ ] Bump the Makefile version (see [example](https://github.com/Kong/kubernetes-ingress-controller/pull/851/commits/b874b36bfdb0d7c6a13cc35ed06f666d135b04a4)
+- [Docker](https://docs.docker.com/get-docker/) `v20.10.x`
+- [GNU Make](https://www.gnu.org/software/make/) `v4.x`
+- [Kustomize](https://github.com/kubernetes-sigs/kustomize) `v1.3.x`
+
+## Release Branch
+
+**For all releases**
+
+For this step we're going to start with the `next` branch and merge in `main` to create our release branch (e.g. `release/X.Y.Z`) which will later be submitted as a pull request back to `main`.
+
+- [ ] ensure that you have up to date copy of `main` and `next`: `git fetch --all`
+- [ ] merge main into next: `git checkout next && git merge main`
+- [ ] create the release branch for the version (e.g. `release/1.3.1`): `git branch -m release/x.y.z`
 - [ ] Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
-- [ ] Open a PR from your branch to next (major/minor) or main (patch).
-- [ ] Once the PR is merged, tag your release (e.g. `git fetch; git tag origin/next 1.2.0; git push origin --tags`.
-- [ ] Wait for CI to build images and push them to Docker Hub.
-- [ ] Open a PR from next to main (ignore if patch release).
-- [ ] [Draft a new release](https://github.com/Kong/kubernetes-ingress-controller/releases), using a title and body similar to previous releases. Use your existing tag.
-- [ ] Create a new minor version branch and push it, e.g. `git checkout 1.2.0; git checkout -b 1.2.x; git push 1.2.x` (ignore if patch or pre-release).
+- [ ] update manifest files: `./hack/build-single-manifests.sh`
+- [ ] update the `TAG` variable in the `Makefile` to the new version release and commit the change
+- [ ] push the branch up to the remote: `git push --set-upstream origin release/x.y.z`
+
+## Release Pull Request
+
+**For all releases**
+
+- [ ] Open a PR from your branch to `next` (major/minor) or `main` (patch)
+- [ ] Once the PR is merged, tag your release: `git fetch --all && git tag origin/next 1.3.1 && git push origin --tags`
+- [ ] Wait for CI to build images and push them to Docker Hub
+- [ ] Open a PR from next to main (ignore if patch release)
+
+## Github Release
+
+**For all releases**
+
+- [ ] draft a new [release](https://github.com/Kong/kubernetes-ingress-controller/releases), using a title and body similar to previous releases. Use your existing tag.
+- [ ] for new `major` version releases create a new branch (e.g. `1.3.x`) from the release tag and push it
+- [ ] for `minor` and `patch` version releases rebase the release tag onto the release branch: `git checkout 1.3.x && git rebase 1.3.1 && git push`
 
 ## Documentation
 
-For major/minor releases only.
+**For major/minor releases only**
 
 - [ ] Create a new branch in the [documentation site repo](https://github.com/Kong/docs.konghq.com).
 - [ ] Copy `app/kubernetes-ingress-controller/OLD_VERSION` to `app/kubernetes-ingress-controller/NEW_VERSION`.
@@ -26,9 +49,11 @@ For major/minor releases only.
 - [ ] Add a section to `app/_data/kong_versions.yml` for your version.
 - [ ] Open a PR from your branch.
 
+# Release Troubleshooting
+
 ## Manual Docker image build
 
-If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually.
+If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually:
 
 - [ ] Check out your release tag.
 - [ ] Run `make container` (legacy) or `make railgun-container` (Railgun/2.x). Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.

--- a/hack/get-github-actions-logs.sh
+++ b/hack/get-github-actions-logs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# For the last (NPAGES * PERPAGE) workflow runs in REPO, obtain logs for all jobs matching JOBFILTER.
+# Requires `hub` and `jq`.
+
+set -e
+
+REPO=Kong/kubernetes-ingress-controller
+NPAGES=5
+PERPAGE=100
+WORKFLOWNAME="Integration Tests"
+JOBFILTER="select(.name == \"integration-test-postgres\" or .name == \"integration-test-dbless\")"
+
+for page in $(seq 1 $NPAGES); do
+	echo "Getting runs (page $page out of $NPAGES)..."
+	hub api "/repos/$REPO/actions/runs?per_page=$PERPAGE&page=$page" | jq ".workflow_runs" > "01_repo_runs_$page.json"
+done
+
+echo "Concatenating the list of workflow runs..."
+jq -s 'add' $(for page in $(seq 1 $NPAGES); do echo "01_repo_runs_$page.json"; done) > "02_repo_runs.json"
+
+echo "Filtering for workflow name $WORKFLOWNAME..."
+jq ".[] | select(.name == \"$WORKFLOWNAME\")" "02_repo_runs.json" > "03_repo_runs_for_workflow.json"
+
+echo "Extracting workflow run IDs..."
+jq -r ".id" "03_repo_runs_for_workflow.json" > "04_workflow_run_ids.txt"
+
+nruns="$(wc -l 04_workflow_run_ids.txt | cut -d' ' -f1)"
+echo "Retrieving workflow run metadata ($nruns runs...)"
+for id in $(cat 04_workflow_run_ids.txt); do
+	echo "Retrieving metadata for workflow run $id"
+	hub api "https://api.github.com/repos/Kong/kubernetes-ingress-controller/actions/runs/$id/jobs" > "05_workflow_run_$id.json"
+done
+
+echo "Joining jobs into one big file..."
+jq -s 'map(.jobs[])' 05_workflow_run_*.json > "06_all_jobs.json"
+
+echo "Filtering jobs..."
+jq ".[] | $JOBFILTER" "06_all_jobs.json" > "07_jobs_filtered.json"
+
+echo "Getting logs for each job..."
+for jobid in $(jq -r '.id' "07_jobs_filtered.json"); do
+	echo "Getting logs for job $jobid..."
+	hub api "https://api.github.com/repos/$REPO/actions/jobs/$jobid/logs" > "08_job_$jobid.log"
+done


### PR DESCRIPTION
Resolves #1384 & https://github.com/Kong/kubernetes-ingress-controller/issues/1363

# Release Checklist

## Release Branch

**For all releases**

For this step we're going to start with the `next` branch and merge in `main` to create our release branch (e.g. `release/X.Y.Z`) which will later be submitted as a pull request back to `main`.

- [x] ensure that you have up to date copy of `main` and `next`: `git fetch --all`
- [x] merge main into next: `git checkout next && git merge main`
- [x] create the release branch for the version (e.g. `release/1.3.1`): `git branch -m release/x.y.z`
- [x] Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
- [x] update manifest files: `./hack/build-single-manifests.sh`
- [x] update the `TAG` variable in the `Makefile` to the new version release and commit the change
- [x] push the branch up to the remote: `git push --set-upstream origin release/x.y.z`

## Release Pull Request

**For all releases**

- [ ] Open a PR from your branch to `next` (major/minor) or `main` (patch)
- [ ] Once the PR is merged, tag your release: `git fetch --all && git tag origin/next 1.3.1 && git push origin --tags`
- [ ] Wait for CI to build images and push them to Docker Hub
- [ ] Open a PR from next to main (ignore if patch release)

## Github Release

**For all releases**

- [ ] draft a new [release](https://github.com/Kong/kubernetes-ingress-controller/releases), using a title and body similar to previous releases. Use your existing tag.
- [ ] for new `major` version releases create a new branch (e.g. `1.3.x`) from the release tag and push it
- [ ] for `minor` and `patch` version releases rebase the release tag onto the release branch: `git checkout 1.3.x && git rebase 1.3.1 && git push`