### PR TITLE
Mitigate Admin API Integration Test Flakes

### DIFF
--- a/hack/get-github-actions-logs.sh
+++ b/hack/get-github-actions-logs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# For the last (NPAGES * PERPAGE) workflow runs in REPO, obtain logs for all jobs matching JOBFILTER.
+# Requires `hub` and `jq`.
+
+set -e
+
+REPO=Kong/kubernetes-ingress-controller
+NPAGES=5
+PERPAGE=100
+WORKFLOWNAME="Integration Tests"
+JOBFILTER="select(.name == \"integration-test-postgres\" or .name == \"integration-test-dbless\")"
+
+for page in $(seq 1 $NPAGES); do
+	echo "Getting runs (page $page out of $NPAGES)..."
+	hub api "/repos/$REPO/actions/runs?per_page=$PERPAGE&page=$page" | jq ".workflow_runs" > "01_repo_runs_$page.json"
+done
+
+echo "Concatenating the list of workflow runs..."
+jq -s 'add' $(for page in $(seq 1 $NPAGES); do echo "01_repo_runs_$page.json"; done) > "02_repo_runs.json"
+
+echo "Filtering for workflow name $WORKFLOWNAME..."
+jq ".[] | select(.name == \"$WORKFLOWNAME\")" "02_repo_runs.json" > "03_repo_runs_for_workflow.json"
+
+echo "Extracting workflow run IDs..."
+jq -r ".id" "03_repo_runs_for_workflow.json" > "04_workflow_run_ids.txt"
+
+nruns="$(wc -l 04_workflow_run_ids.txt | cut -d' ' -f1)"
+echo "Retrieving workflow run metadata ($nruns runs...)"
+for id in $(cat 04_workflow_run_ids.txt); do
+	echo "Retrieving metadata for workflow run $id"
+	hub api "https://api.github.com/repos/Kong/kubernetes-ingress-controller/actions/runs/$id/jobs" > "05_workflow_run_$id.json"
+done
+
+echo "Joining jobs into one big file..."
+jq -s 'map(.jobs[])' 05_workflow_run_*.json > "06_all_jobs.json"
+
+echo "Filtering jobs..."
+jq ".[] | $JOBFILTER" "06_all_jobs.json" > "07_jobs_filtered.json"
+
+echo "Getting logs for each job..."
+for jobid in $(jq -r '.id' "07_jobs_filtered.json"); do
+	echo "Getting logs for job $jobid..."
+	hub api "https://api.github.com/repos/$REPO/actions/jobs/$jobid/logs" > "08_job_$jobid.log"
+done

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -215,7 +215,6 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 			flags.Parse([]string{
 				fmt.Sprintf("--kong-admin-url=http://%s:8001", adminHost),
 				fmt.Sprintf("--kubeconfig=%s", kubeconfig.Name()),
-				"--proxy-sync-seconds=0.05", // run the test updates at 50ms for high speed
 				"--controller-kongstate=enabled",
 				"--controller-ingress-networkingv1=enabled",
 				"--controller-ingress-networkingv1beta1=disabled",


### PR DESCRIPTION
In CI recently we've observed a 15% failure rate on the `TCPIngress` integration tests wherein the tests fail to tear down their resources properly, but this only happens in `DBLESS` and `Postgres` mode works properly.

A related timing issue was found previously with DB mode wherein the Admin API was not tolerant of repeated updates every `50ms` or even `200ms` and we eventually dropped back that update interval which resulted in stability, the purpose of this PR is to test (and then if successful, merge) a similar fix for DBLESS mode.