### PR TITLE
Sendconfig update improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ released and the release notes may change significantly before then.
 
 #### Under the hood
 
+- the controller manager will no longer log multiple entries for `nil` updates
+  to the Kong Admin API. The result is that operators will no longer see multiple
+  "no configuration change, skipping sync to kong" entries for any single update,
+  instead it will only report this `nil` update scenario the first time it is
+  encountered for any particular SHA derived from the configuration contents.
 - the `--sync-rate-limit` is now deprecated in favor of `--sync-time-seconds`.
   This functionality no longer blocks goroutines until the provided number of
   seconds has passed to enforce rate limiting, now instead it configures a

--- a/pkg/sendconfig/common_workflows.go
+++ b/pkg/sendconfig/common_workflows.go
@@ -11,6 +11,10 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/pkg/store"
 )
 
+// -----------------------------------------------------------------------------
+// Sendconfig - Workflow Functions
+// -----------------------------------------------------------------------------
+
 // UpdateKongAdminSimple is a helper function for the most common usage of PerformUpdate() with only minimal
 // upfront configuration required. This function is specialized and highly opinionated.
 //

--- a/pkg/sendconfig/sendconfig.go
+++ b/pkg/sendconfig/sendconfig.go
@@ -198,12 +198,17 @@ var (
 	shaLock           sync.RWMutex
 )
 
-// hasUpdateAlreadyBeenReported is a helper function to allow sendconfig internals to be aware of the last logged/reported
-// update to the Kong Admin API. Given the most recent update SHA, it will return true/false whether or not that SHA has previously
-// been reported (logged, e.t.c.) so that the caller can make decisions such as staggering or stifling duplicate log lines.
+// hasUpdateAlreadyBeenReported is a helper function to allow
+// sendconfig internals to be aware of the last logged/reported
+// update to the Kong Admin API. Given the most recent update SHA,
+// it will return true/false whether or not that SHA has previously
+// been reported (logged, e.t.c.) so that the caller can make
+// decisions (such as staggering or stifling duplicate log lines).
 //
-// TODO: This is a bit of a hack for now to keep backwards compat, but in the future we might configure rolling this into
-//       some object/interface which has this functionality as an inherent behavior.
+// TODO: This is a bit of a hack for now to keep backwards compat,
+//       but in the future we might configure rolling this into
+//       some object/interface which has this functionality as an
+//       inherent behavior.
 func hasUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
 	shaLock.Lock()
 	defer shaLock.Unlock()

--- a/pkg/sendconfig/sendconfig.go
+++ b/pkg/sendconfig/sendconfig.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sync"
 
 	"github.com/kong/deck/diff"
 	"github.com/kong/deck/dump"
@@ -33,7 +34,6 @@ func PerformUpdate(ctx context.Context,
 	customEntities []byte,
 	oldSHA []byte,
 ) ([]byte, error) {
-
 	newSHA, err := deckgen.GenerateSHA(targetContent, customEntities)
 	if err != nil {
 		return oldSHA, err
@@ -42,7 +42,9 @@ func PerformUpdate(ctx context.Context,
 	if !reverseSync {
 		// use the previous SHA to determine whether or not to perform an update
 		if equalSHA(oldSHA, newSHA) {
-			log.Info("no configuration change, skipping sync to kong")
+			if !hasUpdateAlreadyBeenReported(newSHA) {
+				log.Info("no configuration change, skipping sync to kong")
+			}
 			return oldSHA, nil
 		}
 	}
@@ -185,4 +187,29 @@ func onUpdateDBMode(ctx context.Context,
 		return deckutils.ErrArray{Errors: errs}
 	}
 	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Sendconfig - Logging & Reporting Helper Functions
+// -----------------------------------------------------------------------------
+
+var (
+	latestReportedSHA []byte
+	shaLock           sync.RWMutex
+)
+
+// hasUpdateAlreadyBeenReported is a helper function to allow sendconfig internals to be aware of the last logged/reported
+// update to the Kong Admin API. Given the most recent update SHA, it will return true/false whether or not that SHA has previously
+// been reported (logged, e.t.c.) so that the caller can make decisions such as staggering or stifling duplicate log lines.
+//
+// TODO: This is a bit of a hack for now to keep backwards compat, but in the future we might configure rolling this into
+//       some object/interface which has this functionality as an inherent behavior.
+func hasUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
+	shaLock.Lock()
+	defer shaLock.Unlock()
+	if equalSHA(latestReportedSHA, latestUpdateSHA) {
+		return true
+	}
+	latestReportedSHA = latestUpdateSHA
+	return false
 }

--- a/pkg/sendconfig/sendconfig.go
+++ b/pkg/sendconfig/sendconfig.go
@@ -42,7 +42,7 @@ func PerformUpdate(ctx context.Context,
 	if !reverseSync {
 		// use the previous SHA to determine whether or not to perform an update
 		if equalSHA(oldSHA, newSHA) {
-			if !hasUpdateAlreadyBeenReported(newSHA) {
+			if !hasSHAUpdateAlreadyBeenReported(newSHA) {
 				log.Info("no configuration change, skipping sync to kong")
 			}
 			return oldSHA, nil
@@ -198,7 +198,7 @@ var (
 	shaLock           sync.RWMutex
 )
 
-// hasUpdateAlreadyBeenReported is a helper function to allow
+// hasSHAUpdateAlreadyBeenReported is a helper function to allow
 // sendconfig internals to be aware of the last logged/reported
 // update to the Kong Admin API. Given the most recent update SHA,
 // it will return true/false whether or not that SHA has previously
@@ -209,7 +209,7 @@ var (
 //       but in the future we might configure rolling this into
 //       some object/interface which has this functionality as an
 //       inherent behavior.
-func hasUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
+func hasSHAUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
 	shaLock.Lock()
 	defer shaLock.Unlock()
 	if equalSHA(latestReportedSHA, latestUpdateSHA) {

--- a/pkg/sendconfig/sendconfig_test.go
+++ b/pkg/sendconfig/sendconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_renderConfigWithCustomEntities(t *testing.T) {
@@ -115,4 +116,15 @@ func Test_renderConfigWithCustomEntities(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_updateReportingUtilities(t *testing.T) {
+	assert.False(t, hasUpdateAlreadyBeenReported([]byte("fake-sha")))
+	assert.True(t, hasUpdateAlreadyBeenReported([]byte("fake-sha")))
+	assert.False(t, hasUpdateAlreadyBeenReported([]byte("another-fake-sha")))
+	assert.True(t, hasUpdateAlreadyBeenReported([]byte("another-fake-sha")))
+	assert.False(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
 }

--- a/pkg/sendconfig/sendconfig_test.go
+++ b/pkg/sendconfig/sendconfig_test.go
@@ -119,12 +119,12 @@ func Test_renderConfigWithCustomEntities(t *testing.T) {
 }
 
 func Test_updateReportingUtilities(t *testing.T) {
-	assert.False(t, hasUpdateAlreadyBeenReported([]byte("fake-sha")))
-	assert.True(t, hasUpdateAlreadyBeenReported([]byte("fake-sha")))
-	assert.False(t, hasUpdateAlreadyBeenReported([]byte("another-fake-sha")))
-	assert.True(t, hasUpdateAlreadyBeenReported([]byte("another-fake-sha")))
-	assert.False(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
-	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
-	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
-	assert.True(t, hasUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.False(t, hasSHAUpdateAlreadyBeenReported([]byte("fake-sha")))
+	assert.True(t, hasSHAUpdateAlreadyBeenReported([]byte("fake-sha")))
+	assert.False(t, hasSHAUpdateAlreadyBeenReported([]byte("another-fake-sha")))
+	assert.True(t, hasSHAUpdateAlreadyBeenReported([]byte("another-fake-sha")))
+	assert.False(t, hasSHAUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasSHAUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasSHAUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
+	assert.True(t, hasSHAUpdateAlreadyBeenReported([]byte("yet-another-fake-sha")))
 }

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -17,9 +17,7 @@ import (
 const (
 	// DefaultSyncSeconds indicates the time.Duration (minimum) that will occur between
 	// updates to the Kong Proxy Admin API when using the NewProxy() constructor.
-	//
-	// NOTE: this default was originally inherited from KIC v1.x.
-	DefaultSyncSeconds float32 = 0.3
+	DefaultSyncSeconds float32 = 1.0
 
 	// DefaultObjectBufferSize is the number of client.Objects that the server will buffer
 	// before it starts rejecting new objects while it processes the originals.

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -17,6 +17,12 @@ import (
 const (
 	// DefaultSyncSeconds indicates the time.Duration (minimum) that will occur between
 	// updates to the Kong Proxy Admin API when using the NewProxy() constructor.
+	// this 1s default was based on local testing wherein it appeared sub-second updates
+	// to the Admin API could be problematic (or at least operate differently) based on
+	// which storage backend was in use (i.e. "dbless", "postgres"). This is a workaround
+	// for improvements we still need to investigate upstream.
+	//
+	// See Also: https://github.com/Kong/kubernetes-ingress-controller/issues/1398
 	DefaultSyncSeconds float32 = 1.0
 
 	// DefaultObjectBufferSize is the number of client.Objects that the server will buffer

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -40,7 +40,7 @@ const (
 	waitTick = time.Second * 1
 
 	// ingressWait is the default amount of time to wait for any particular ingress resource to be provisioned.
-	ingressWait = time.Minute * 5
+	ingressWait = time.Minute * 3
 
 	// httpcTimeout is the default client timeout for HTTP clients used in tests.
 	httpcTimeout = time.Second * 3


### PR DESCRIPTION
In CI there have been several problems that appear to be due to the high rate at which KIC 2.0 has been sending updates to the Kong Admin API at a regular interval. This PR includes some improvements that seemed to function better with minimal/no end-user impact, while making the defaults less noisy in testing/CI. This also adds an update to `sendconfig.SendUpdate()` which will stifle repetitive `nil` update warnings (you'll get one once for each update that would make no change now, rather than them repeating every few seconds).

This helps to resolve https://github.com/Kong/kubernetes-ingress-controller/issues/1390