### PR TITLE
feat(config) make timeout configurable for the kong client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ released and the release notes may change significantly before then.
   `--watch-namespace "namespaceA,namespaceB"`).
 - support for the `konghq.com/host-aliases` annotation.
   [#1016](https://github.com/Kong/kubernetes-ingress-controller/pull/1016/)
+- Added `--proxy-timeout-seconds` flag to configure the kong client api timeout.
+  [#1401](https://github.com/Kong/kubernetes-ingress-controller/pull/1401)
 
 [kong-udp]:https://konghq.com/blog/kong-gateway-2-2-released/#UDP-Support
 

--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -31,12 +31,9 @@ func NewCacheBasedProxy(ctx context.Context,
 	ingressClassName string,
 	enableReverseSync bool,
 	kongUpdater KongUpdater,
+	timeout time.Duration,
 ) (Proxy, error) {
 	stagger, err := time.ParseDuration(fmt.Sprintf("%gs", DefaultSyncSeconds))
-	if err != nil {
-		return nil, err
-	}
-	timeout, err := time.ParseDuration(fmt.Sprintf("%gs", DefaultSyncSeconds))
 	if err != nil {
 		return nil, err
 	}

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -107,6 +107,13 @@ func Run(ctx context.Context, c *config.Config) error {
 		return err
 	}
 
+	// determine the proxy timeout
+	timeoutDuration, err := time.ParseDuration(fmt.Sprintf("%gs", c.ProxyTimeoutSeconds))
+	if err != nil {
+		setupLog.Error(err, "%s is not a valid number of seconds to the timeout config for the kong client")
+		return err
+	}
+
 	// start the proxy cache server
 	prx, err := proxy.NewCacheBasedProxyWithStagger(ctx,
 		// NOTE: logr-based loggers use the "logger" field instead of "subsystem". When replacing logrus with logr, replace
@@ -117,6 +124,7 @@ func Run(ctx context.Context, c *config.Config) error {
 		c.IngressClassName,
 		c.EnableReverseSync,
 		syncTickDuration,
+		timeoutDuration,
 		sendconfig.UpdateKongAdminSimple,
 	)
 	if err != nil {

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -118,7 +118,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds)",
 			proxy.DefaultSyncSeconds,
 		))
-	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "timeout-seconds", proxy.DefaultSyncSeconds,
+	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", proxy.DefaultSyncSeconds,
 		fmt.Sprintf(
 			"Define the rate (in seconds) in which the timeout configuration will be applied to the Kong client. (default: %g seconds)",
 			proxy.DefaultSyncSeconds,

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ProbeAddr                string
 	KongAdminURL             string
 	ProxySyncSeconds         float32
+	ProxyTimeoutSeconds      float32
 	KongCustomEntitiesSecret string
 
 	// Kubernetes configurations
@@ -115,6 +116,11 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxySyncSeconds, "proxy-sync-seconds", proxy.DefaultSyncSeconds,
 		fmt.Sprintf(
 			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds)",
+			proxy.DefaultSyncSeconds,
+		))
+	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "timeout-seconds", proxy.DefaultSyncSeconds,
+		fmt.Sprintf(
+			"Define the rate (in seconds) in which the timeout configuration will be applied to the Kong client. (default: %g seconds)",
 			proxy.DefaultSyncSeconds,
 		))
 	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `A Secret containing custom entities for DB-less mode, in "namespace/name" format`)


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**: make the timeout seconds configurable in `cached_proxy_resolver`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1291

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
