### PR TITLE
feat: add BYOK to integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  environment: "Configure ci"
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,6 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  environment: "Configure ci"
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -36,6 +35,7 @@ jobs:
       run: |
         make verify-manifests
   test:
+    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
     - name: Setup go


### PR DESCRIPTION
This adds a local debugging tool I had been keeping in my local stash, but realized it's potentially generally helpful. "bring your own kic" options for debugging the integration tests using a self-supplied controller.

A follow up item exists to later iterate further on how options for the integration tests are handled: https://github.com/Kong/kubernetes-ingress-controller/issues/1406