### PR TITLE
Set the GH Actions environment on docker push workflows

### DIFF
--- a/.github/workflows/1x-docker-build-push.yaml
+++ b/.github/workflows/1x-docker-build-push.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   docker:
+    environment: 'Docker Push'
     runs-on: ubuntu-latest
     steps:
       - name: Parse semver string
@@ -59,7 +60,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/2x-docker-build-push.yaml
+++ b/.github/workflows/2x-docker-build-push.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   docker:
+    environment: 'Docker Push'
     runs-on: ubuntu-latest
     steps:
       - name: Parse semver string
@@ -43,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
Ensures that the right environment is set on GH Actions workflows that need to access docker push credentials.

Also makes a whitespace fix (automatically performed by my editor)