### PR TITLE
chore: update kind to v0.11.1

### DIFF
--- a/railgun/scripts/setup-integration-tests.sh
+++ b/railgun/scripts/setup-integration-tests.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-KIND_VERSION="v0.10.0"
+KIND_VERSION="v0.11.1"
 
 # ensure docker command is accessible
 if ! command -v docker &> /dev/null


### PR DESCRIPTION
Updates to the latest release of [Kind](https://github.com/kubernetes-sigs/kind) for CI.