### PR TITLE
[feat] Dynamic Controller Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@
 
 #### Added
 
+- added a new controller to the controller manager which will watch for new CRDs
+  being added to the cluster, and will dynamically load controllers for them at
+  runtime if applicable. This was specifically added in support of knative.Ingress
+  (which is the only implementation at this time) so that if the 3rd party CRD becomes
+  available in the cluster later on, the manager does not need to be restarted in order
+  to load the controller.
+  Consequentially a new flag was added which allows end-users to disable this
+  functionality if they wish: `--controller-dynamic-loader`
+  [#1479](https://github.com/Kong/kubernetes-ingress-controller/pull/1479)
 - fix kongClusterPlugin handling for kic 2.0.
   [#1418](https://github.com/Kong/kubernetes-ingress-controller/pull/1418)
 - profiling using `pprof` is now a standalone HTTP server listening on port 10256.

--- a/railgun/config/rbac/role.yaml
+++ b/railgun/config/rbac/role.yaml
@@ -9,6 +9,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   verbs:
   - list

--- a/railgun/controllers/configuration/controller_loader.go
+++ b/railgun/controllers/configuration/controller_loader.go
@@ -1,0 +1,103 @@
+package configuration
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/kong/kubernetes-ingress-controller/railgun/internal/proxy"
+)
+
+// -----------------------------------------------------------------------------
+// APIExtensions CustomResourceDefinition
+// -----------------------------------------------------------------------------
+
+// CustomResourceDefinition reconciles a Ingress object
+type CustomResourceDefinitionReconciler struct {
+	client.Client
+	Mgr              manager.Manager
+	IngressClassName string
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *CustomResourceDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&apiextv1beta1.CustomResourceDefinition{}).Complete(r)
+}
+
+//+kubebuilder:rbac:groups="",resources=customresourcedefinitions,verbs=get;list;watch
+
+// Reconcile processes the watched objects
+func (r *CustomResourceDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("CustomResourceDefinition", req.NamespacedName)
+
+	// get the relevant object
+	obj := new(apiextv1beta1.CustomResourceDefinition)
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// don't act on any CRDs until they have been established (i.e. they are usable)
+	established := false
+	for _, condition := range obj.Status.Conditions {
+		established = condition.Type == apiextv1beta1.Established && condition.Status == apiextv1beta1.ConditionTrue
+	}
+	if !established {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// for some 3rd party CRDs we support (e.g. knative.Ingress) we will dynamically load a controller
+	// for those types once the CRD becomes present in the API.
+	loaded, err := r.dynamicallyLoadControllerForCRD(obj)
+	if err != nil {
+		log.Error(err, "supported CRD found but could not load the controller", "name", obj.Name)
+		return ctrl.Result{}, err
+	}
+
+	if loaded {
+		log.Info("found supported CRD, controller for this supported API has now beed started")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// -----------------------------------------------------------------------------
+// Dynamically Loaded Controllers
+// -----------------------------------------------------------------------------
+
+const (
+	supportedKnativeCRD            = "ingresses.networking.internal.knative.dev"
+	supportedKnativeIngressVersion = "v1alpha1"
+)
+
+// dynamicallyLoadControllerForCRD accepts a provided CRD and controller manager and if
+// that CRD is a supported 3rd party type which we provide a controller for, it will ensure
+// that controller is loaded into the manager now that the API has become available in Kubernetes.
+// if this returns false, nil then it was a no-op and the CRD is not supported.
+func (r *CustomResourceDefinitionReconciler) dynamicallyLoadControllerForCRD(crd *apiextv1beta1.CustomResourceDefinition) (loaded bool, err error) {
+	if crd.Name == supportedKnativeCRD {
+		for _, version := range crd.Spec.Versions {
+			if version.Name == supportedKnativeIngressVersion {
+				knative := Knativev1alpha1IngressReconciler{
+					Client:           r.Mgr.GetClient(),
+					Log:              ctrl.Log.WithName("controllers").WithName("Ingress").WithName("KnativeV1Alpha1"),
+					Scheme:           r.Mgr.GetScheme(),
+					IngressClassName: r.IngressClassName,
+					Proxy:            r.Proxy,
+				}
+				err = knative.SetupWithManager(r.Mgr)
+				loaded = true
+			}
+		}
+	}
+	return
+}

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -344,13 +344,17 @@ func Run(ctx context.Context, c *config.Config) error {
 			knativeWasLoaded = true
 		}
 
-		// if knative is not explicitly disabled but was not previously loaded we will run a controller that will
-		// watch the cluster CRDs to determine if/when that API is loaded and when it becomes available we will
-		// dynamically load the knative.Ingress controller into the controller manager at runtime.
-		//
-		// In the future if we have other 3rd party APIs we would like to load controllers for dynamically
-		// we can expand this controller to include them.
-		if !knativeWasLoaded {
+		if c.DynamicControllerLoaderEnabled == util.EnablementStatusDisabled {
+			// if the end-user explicitly disabled dynamic controller loading, then let them be but warn them that
+			// a restart will be required in order for the relevant controller to be started.
+			setupLog.Info(`WARNING: the dynamic controller loader was explicitly disabled: knative support can not be
+				 dynamically added to the cluster and if the knative.Ingress CRD later becomes available, the manager
+				 will need to be restarted in order to pick it up and start the relevant controller(s).`)
+
+		} else if !knativeWasLoaded {
+			// if knative is not explicitly disabled but was not previously loaded we will run a controller that will
+			// watch the cluster CRDs to determine if/when that API is loaded and when it becomes available we will
+			// dynamically load the knative.Ingress controller into the controller manager at runtime.
 			setupLog.Info(fmt.Sprintf("knative support set to %s, but the API is not yet available (CRD not found)",
 				c.KnativeIngressEnabled.String()))
 

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -56,17 +56,18 @@ type Config struct {
 	WatchNamespace       string
 
 	// Kubernetes API toggling
-	IngressExtV1beta1Enabled util.EnablementStatus
-	IngressNetV1beta1Enabled util.EnablementStatus
-	IngressNetV1Enabled      util.EnablementStatus
-	UDPIngressEnabled        util.EnablementStatus
-	TCPIngressEnabled        util.EnablementStatus
-	KongIngressEnabled       util.EnablementStatus
-	KnativeIngressEnabled    util.EnablementStatus
-	KongClusterPluginEnabled util.EnablementStatus
-	KongPluginEnabled        util.EnablementStatus
-	KongConsumerEnabled      util.EnablementStatus
-	ServiceEnabled           util.EnablementStatus
+	DynamicControllerLoaderEnabled util.EnablementStatus
+	IngressExtV1beta1Enabled       util.EnablementStatus
+	IngressNetV1beta1Enabled       util.EnablementStatus
+	IngressNetV1Enabled            util.EnablementStatus
+	UDPIngressEnabled              util.EnablementStatus
+	TCPIngressEnabled              util.EnablementStatus
+	KongIngressEnabled             util.EnablementStatus
+	KnativeIngressEnabled          util.EnablementStatus
+	KongClusterPluginEnabled       util.EnablementStatus
+	KongPluginEnabled              util.EnablementStatus
+	KongConsumerEnabled            util.EnablementStatus
+	ServiceEnabled                 util.EnablementStatus
 
 	// Admission Webhook server config
 	AdmissionServer admission.ServerConfig
@@ -141,6 +142,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		a comma-separated list of namespaces.`)
 
 	// Kubernetes API toggling
+	flagSet.enablementStatusVar(&c.DynamicControllerLoaderEnabled, "controller-dynamic-loader", util.EnablementStatusEnabled, `Enable or disable the controller which will dynamically load other
+		 controllers as the relevant supported APIs become available in the cluster.`+onOffUsage)
 	flagSet.enablementStatusVar(&c.IngressNetV1Enabled, "controller-ingress-networkingv1", util.EnablementStatusEnabled, "Enable or disable the Ingress controller (using API version networking.k8s.io/v1)."+onOffUsage)
 	// TODO the other Ingress versions remain disabled for now. 2.x does not yet support version negotiation
 	flagSet.enablementStatusVar(&c.IngressNetV1beta1Enabled, "controller-ingress-networkingv1beta1", util.EnablementStatusDisabled, "Enable or disable the Ingress controller (using API version networking.k8s.io/v1beta1)."+onOffUsage)


### PR DESCRIPTION
**What this PR does / why we need it**:

- adds a controller which can automatically load new controllers when supported APIs become available (e.g. knative)
- fixes the errors as reported in https://github.com/Kong/kubernetes-ingress-controller/issues/1466

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1466

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
