### PR TITLE
Make duplicate log suppressing a setting in config

### DIFF
--- a/.github/workflows/2x-integration-test.yaml
+++ b/.github/workflows/2x-integration-test.yaml
@@ -15,8 +15,6 @@ on:
 jobs:
   integration-test-dbless:
     runs-on: ubuntu-latest
-    env:
-      KONG_TEST_ENVIRONMENT: true
     steps:
     - name: setup golang
       uses: actions/setup-go@v2
@@ -36,8 +34,6 @@ jobs:
       working-directory: ./railgun
   integration-test-postgres:
     runs-on: ubuntu-latest
-    env:
-      KONG_TEST_ENVIRONMENT: true
     steps:
     - name: setup golang
       uses: actions/setup-go@v2

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -48,10 +48,9 @@ func Run(ctx context.Context, c *config.Config) error {
 	var deprecatedLogger logrus.FieldLogger
 	var err error
 
-	if v := os.Getenv("KONG_TEST_ENVIRONMENT"); v != "" {
+	if c.LogReduceRedundancy {
 		deprecatedLogger = util.MakeDebugLoggerWithReducedRedudancy(os.Stdout, &logrus.TextFormatter{}, 3, time.Second*30)
-		deprecatedLogger.Info("detected that the controller is running in an automated testing environment: " +
-			"log stifling has been enabled")
+		deprecatedLogger.Info("log stifling has been enabled")
 	} else {
 		deprecatedLogger, err = util.MakeLogger(c.LogLevel, c.LogFormat)
 		if err != nil {

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -95,8 +95,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// Logging configurations
 	flagSet.StringVar(&c.LogLevel, "log-level", "info", `Level of logging for the controller. Allowed values are trace, debug, info, warn, error, fatal and panic.`)
 	flagSet.StringVar(&c.LogFormat, "log-format", "text", `Format of logs of the controller. Allowed values are text and json.`)
-	flagSet.BoolVar(&c.LogReduceRedundancy, "log-reduce-redundancy", false, `If enabled, repetitive log entries are suppressed. Built for testing environments - production use not recommended.`)
-	flagSet.MarkHidden("log-reduce-redundancy")
+	flagSet.BoolVar(&c.LogReduceRedundancy, "debug-log-reduce-redundancy", false, `If enabled, repetitive log entries are suppressed. Built for testing environments - production use not recommended.`)
+	flagSet.MarkHidden("debug-log-reduce-redundancy")
 
 	// Kong high-level controller manager configurations
 	flagSet.BoolVar(&c.KongAdminAPIConfig.TLSSkipVerify, "kong-admin-tls-skip-verify", false, "Disable verification of TLS certificate of Kong's Admin endpoint.")

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -26,8 +26,9 @@ type Config struct {
 	// See flag definitions in RegisterFlags(...) for documentation of the fields defined here.
 
 	// Logging configurations
-	LogLevel  string
-	LogFormat string
+	LogLevel            string
+	LogFormat           string
+	LogReduceRedundancy bool
 
 	// Kong high-level controller manager configurations
 	KongAdminAPIConfig adminapi.HTTPClientOpts
@@ -94,6 +95,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// Logging configurations
 	flagSet.StringVar(&c.LogLevel, "log-level", "info", `Level of logging for the controller. Allowed values are trace, debug, info, warn, error, fatal and panic.`)
 	flagSet.StringVar(&c.LogFormat, "log-format", "text", `Format of logs of the controller. Allowed values are text and json.`)
+	flagSet.BoolVar(&c.LogReduceRedundancy, "log-reduce-redundancy", false, `If enabled, repetitive log entries are suppressed. Built for testing environments - production use not recommended.`)
+	flagSet.MarkHidden("log-reduce-redundancy")
 
 	// Kong high-level controller manager configurations
 	flagSet.BoolVar(&c.KongAdminAPIConfig.TLSSkipVerify, "kong-admin-tls-skip-verify", false, "Disable verification of TLS certificate of Kong's Admin endpoint.")

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -249,6 +249,7 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 				fmt.Sprintf("--ingress-class=%s", ingressClass),
 				"--log-level=trace",
 				"--log-format=text",
+				"--log-reduce-redundancy",
 				"--admission-webhook-listen=172.17.0.1:49023",
 				fmt.Sprintf("--admission-webhook-cert=%s", admissionWebhookCert),
 				fmt.Sprintf("--admission-webhook-key=%s", admissionWebhookKey),

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -249,7 +249,7 @@ func deployControllers(ctx context.Context, ready chan ktfkind.ProxyReadinessEve
 				fmt.Sprintf("--ingress-class=%s", ingressClass),
 				"--log-level=trace",
 				"--log-format=text",
-				"--log-reduce-redundancy",
+				"--debug-log-reduce-redundancy",
 				"--admission-webhook-listen=172.17.0.1:49023",
 				fmt.Sprintf("--admission-webhook-cert=%s", admissionWebhookCert),
 				fmt.Sprintf("--admission-webhook-key=%s", admissionWebhookKey),


### PR DESCRIPTION
Follow-up to #1431 

This replaces the `KONG_TEST_ENVIRONMENT` environment variable (used by KIC as of #1431) with a setting in `config.Config` called `log-reduce-redundancy` (which maps to the `--log-reduce-redundancy` **hidden** flag, and the `CONTROLLER_LOG_REDUCE_REDUNDANCY` environment variable.

Also, moves the setting from the CI job to the place where all the configuration for the controller manager under test is initialized.

Why?
- for consistency with all the other settings: https://github.com/Kong/kubernetes-ingress-controller/issues/1182
- because the `KONG_` prefix is reserved for Gateway; KIC uses `CONTROLLER_`

Also note that there is a bug:
the integration test configures the logger the following way
https://github.com/Kong/kubernetes-ingress-controller/blob/07ae1516d0ac17efc6afdf9ab5d95c42c31b12a8/railgun/test/integration/suite_test.go#L250-L252

but the logger initialization code in `manager/run.go` disregards `--log-level` and `--log-format` if `--log-reduce-redundancy` is in use. This has been the case before this PR and this PR preserves preexisting behavior.