### PR TITLE
fix: timing issue in proxy tests

### DIFF
--- a/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/railgun/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/generators/k8s"
 	"github.com/kong/kubernetes-testing-framework/pkg/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -108,7 +110,7 @@ func TestCaching(t *testing.T) {
 	assert.NotNil(t, proxy.cache)
 
 	t.Log("intentionally freezing async updates to inspect cache state during tests")
-	proxy.syncTicker.Reset(time.Minute * 1)
+	proxy.syncTicker.Reset(time.Minute * 3)
 
 	t.Log("generating 10 new objects to the proxy cache server")
 	testObjects := make([]client.Object, 10)
@@ -131,10 +133,24 @@ func TestCaching(t *testing.T) {
 		return len(proxy.cache.IngressV1.List()) == len(testObjects)
 	}, time.Second*10, time.Millisecond*200)
 
+	t.Log("verifying the integrity of the object cache items")
+	matches := 0
+	for _, testObj := range testObjects {
+		for _, obj := range proxy.cache.IngressV1.List() {
+			ing, ok := obj.(*netv1.Ingress)
+			require.True(t, ok)
+			if ing.Namespace == testObj.GetNamespace() && ing.Name == testObj.GetName() {
+				matches++
+			}
+		}
+	}
+	require.Equal(t, len(testObjects), matches)
+
 	t.Log("flushing the cache state to kong admin api")
-	previousUpdateCount := fakeKongAdminUpdateCount()
-	proxy.syncTicker.Reset(time.Millisecond * 200)
-	assert.Eventually(t, func() bool { return fakeKongAdminUpdateCount() == previousUpdateCount+1 }, time.Second*10, time.Millisecond*200)
+	proxy.syncTicker.Reset(time.Millisecond * 50)
+
+	t.Logf("waiting for kong admin api updates to synchronize")
+	assert.Eventually(t, func() bool { return fakeKongAdminUpdateCount() == len(testObjects) }, time.Second*5, time.Millisecond*50)
 }
 
 func TestProxyTimeout(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch fixes a race condition in the tests, which was specific
to the mocking implementation and not a problem with the implementation
itself. Some additional validation and hardening of these tests were
added as well.

**Which issue this PR fixes**

fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1469