### PR TITLE
fix: add back the --sync-period flag

### DIFF
--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -86,6 +86,7 @@ func Run(ctx context.Context, c *config.Config) error {
 		HealthProbeBindAddress: c.ProbeAddr,
 		LeaderElection:         c.EnableLeaderElection,
 		LeaderElectionID:       c.LeaderElectionID,
+		SyncPeriod:             &c.SyncPeriod,
 	}
 
 	// determine how to configure namespace watchers

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-ingress-controller/pkg/adminapi"
@@ -37,6 +38,7 @@ type Config struct {
 	KongWorkspace      string
 	AnonymousReports   bool
 	EnableReverseSync  bool
+	SyncPeriod         time.Duration
 
 	// Kong Proxy configurations
 	APIServerHost            string
@@ -113,6 +115,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
+	flagSet.DurationVar(&c.SyncPeriod, "sync-period", time.Hour*48, `Relist and confirm cloud resources this often`) // 48 hours derived from controller-runtime defaults
 
 	// Kong Proxy and Proxy Cache configurations
 	flagSet.StringVar(&c.APIServerHost, "apiserver-host", "", `The Kubernetes API server URL. If not set, the controller will use cluster config discovery.`)


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch adds the `--sync-period` flag back and delivers
the provided time duration to controller runtime, which
now in v2 handles the relevant client-go configuration on
our behalf (whereas in v1 we used it directly).

This intentionally uses the same settings that V1 established
(instead of the defaults provided by `controller-runtime`) to avoid
change where we don't otherwise have any data influencing us
to pick a new setting.

More context can be seen in [this relevant comment](https://github.com/Kong/kubernetes-ingress-controller/issues/1309#issuecomment-875828600).

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1309