### PR TITLE
enablement env vars bools

### DIFF
--- a/railgun/cmd/rootcmd/env.go
+++ b/railgun/cmd/rootcmd/env.go
@@ -22,6 +22,15 @@ func bindEnvVars(cmd *cobra.Command, _ []string) {
 		}
 
 		if envValue, envSet := os.LookupEnv(envKey); envSet {
+			// for convenience, any EnablementStatus type variable we need to translate "false" into "disabled"
+			if f.Value.Type() == "EnablementStatus" {
+				if envValue == "false" {
+					envValue = "disabled"
+				}
+				if envValue == "true" {
+					envValue = "enabled"
+				}
+			}
 			cmd.Flags().Set(f.Name, envValue)
 		}
 	})


### PR DESCRIPTION
- chore(deps): bump github.com/kong/kubernetes-testing-framework (#1388)
- follow process
- knative ingress support
- chore(deps): bump github.com/prometheus/common from 0.25.0 to 0.27.0 (#1395)
- fix typo
- fix typo
- isolate environment issue
- fix lint
- Sendconfig update improvements (#1397)
- add using kong with knative test case
- fix service access verification
- add kong legacy yaml
- fix knative webhook before ready after configuration window
- feat: add BYOK to integration tests (#1405)
- fix namespace
- chore(deps): bump github.com/prometheus/client_golang (#1404)
- debug
- chore(deps): bump sigs.k8s.io/controller-runtime from 0.8.3 to 0.9.0 (#1402)
- chore(deps): bump github.com/prometheus/common from 0.27.0 to 0.29.0 (#1412)
- feat(debug) add profiling server to 2.x (#1417)
- feat(config) make timeout configurable for the kong client (#1401)
- fix(*) handle KongClusterPlugins in 2.x (#1418)
- debug information
- enable controller
- fix knative controller up thing
- remove debug log
- debug cache.ListAll() fails to list Knative Ingress
- KIC 2.0 Alpha.1 KEP Updates (#1423)
- verify proxy sync knative configuration appropriately
- remove debug log
- fix integration test
- fix CI failure
- github test environment ingress sync takes more time.
- integration test comment
- feat: add redudancy reducing debug logr (#1431)
- some cleanup
- verify integration test
- revert comment within README.md
- rever unnessary changes
- clean up
- chore(deps): bump github.com/kong/kubernetes-testing-framework (#1434)
- address comments
- replace kubectl cmd with api creation
- add dependencies
- revert unnessary changes
- Use Plugins (GetSchema), Workspaces (Exists,Create), Tags (Exists) me… (#1321)
- fix log format
- fix make lint failure
- trigger pipeline
- adjust for test environment
- clean hardcode; re-use existing utilities
- add k8s utilitie
- remove knative crd dependencies
- clean up
- cleanup
- clean up
- clean up
- fix typo which results in integraiton test failure
- debug : update CR status
- clean up and fix legacy failure
- add note for legacy code
- chore(deps): bump sigs.k8s.io/controller-runtime from 0.9.0 to 0.9.1 (#1445)
- Enable cr status/condition update after kong configuration
- complete knative ingress update end2end
- revert unnessary changes
- revert uneeded deletion
- fix typo which resolves CI failure
- fix(mgr) handle Ingress certificates in 2.x (#1439)
- fix: work around a timing issue in the webhook tests
- chore: cleanup on TCPIngress tests
- fix: increase the default proxy sync seconds
- fix: cleanup object version updates in plugin tests
- fix: don't write val from failed kong update
- fix: race condition in testing logger
- chore: use const for tcp ing test ns
- chore: add more tests to debug logr
- fix: 20m timeout for integration tests
- fix: improve port validation in translate
- feat: add v1beta1.UDPIngress API
- chore: run the API generators
- chore: run the configuration generators
- fix: improve controller logging
- chore: run the controller generator
- chore: cleanup a misworded comment
- chore: regenerate clientsets for v1beta1.UDPIngress
- chore: enable UDPIngress ctrl by default
- fix: issue with making test cluster
- feat: add integration tests for UDPIngress
- docs: add changelog entry for v1beta1.UDPIngress
- fix: enable udpingress ns for int test suite
- clarity
- address content consuming from legacy part
- Fix legacy controller duplicated status update
- prevent goroutine leak
- fix typo; fix legacy code failure
- checking knative ingress readiness
- fix typo which resolves ci unit test error
- checking clientgo_proxy_test timing
- chore(deps): bump sigs.k8s.io/controller-runtime from 0.9.1 to 0.9.2 (#1459)
- feat(gen) rework RBAC generators (#1457)
- chore: update kind to v0.11.1
- feat(mgr) disable missing CRDs
- chore(doc) update changelog
- feat(mgr) negotiate Ingress versions
- [docs] Update CONTRIBUTING.md for recent KIC 2.0 tooling (#1463)
- chore: bump kind version for legacy int tests
- chore(deps): bump knative.dev/serving from 0.23.1 to 0.24.0 (#1471)
- chore(deps): bump github.com/tidwall/gjson from 1.8.0 to 1.8.1 (#1476)
- feat(kic 2.0) support selector tags (#1415)
- Add all ingress support
- add condition check for all ingresses
- clean up
- clean up
- cleanup
- Remove unused code - package configsecret (#1475)
- address comments
- Update railgun/internal/ctrlutils/ingress-status.go
- cleanup
- clean up
- cleanup
- chore(deps): bump github.com/spf13/cobra from 1.1.3 to 1.2.0 (#1483)
- cleanup
- cleanup
- clean up; clean confused
- revert different feature
- revert unrelated feature checkin
- cleanup
- use context done as a way stopping a goroutine
- use context replace stopCh
- adjustment for concurrency
- remove hardcoded namespace and proxy service name from code
- aa
- revert unneeded change
- remove hardcoded kong admin url; remove unused publishstatusAddress
- remove kong admin api hardcode and retrieve it from environment configuration or service namesapce/name configuration
- revert kic2.0 deployment associated change
- chore(deps): bump github.com/spf13/cobra from 1.2.0 to 1.2.1 (#1489)
- code optimization
- Update railgun/internal/ctrlutils/ingress-status.go
- optimization - re-use existing clientsetclient
- fix typo
- add status update retry
- fix kic ingress client type
- refine retry mechanism
- retry unit tests
- reset timetick back
- proxy test timer tune
- Make duplicate log suppressing a setting in config (#1494)
- Fix compilation error
- Update railgun/internal/ctrlutils/ingress-status.go
- Update railgun/internal/ctrlutils/ingress-status.go
- fix godoc - public function should document
- chore(deps): bump docker/metadata-action from 3.3.0 to 3.4.0 (#1499)
- fix: timing issue in proxy tests (#1502)
- fix: convert bool settings for enablementstatuses

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
