### PR TITLE
fix: convert bool settings for enablementstatuses

### DIFF
--- a/railgun/cmd/rootcmd/env.go
+++ b/railgun/cmd/rootcmd/env.go
@@ -9,20 +9,30 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const envKeyPrefix = "CONTROLLER_"
+const (
+	// ExitCodeBadFlagValue is the program exit code that will be produced when an environment
+	// variable has a value that failed validation when an attempt was made to use it to Set()
+	// the relevant flagset variable.
+	ExitCodeBadFlagValue = 25
+
+	envKeyPrefix = "CONTROLLER_"
+)
 
 // bindEnvVars, for each flag defined on `cmd` (local or parent persistent), looks up the corresponding environment
 // variable and (if the flag is unset) takes that environment variable value as the flag value.
 func bindEnvVars(cmd *cobra.Command, _ []string) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
 		envKey := fmt.Sprintf("%s%s", envKeyPrefix, strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_")))
 
 		if f.Changed {
-			return // flags take precedence over environment variables
+			//return // flags take precedence over environment variables
 		}
 
 		if envValue, envSet := os.LookupEnv(envKey); envSet {
-			cmd.Flags().Set(f.Name, envValue)
+			if err := f.Value.Set(envValue); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: could not set %s value from environment to %s: %s\n", envKey, envValue, err)
+				os.Exit(ExitCodeBadFlagValue)
+			}
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch will automatically convert boolean values into
util.EnablementStatus values for any corresponding ENV var.
This makes it convenient to set "true" or "false" for enabling
controllers if the caller wishes to do so.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1498