### PR TITLE
Add --publish-status-address to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Table of Contents
 
- - [2.0.0-alpha.2](#200-alpha2---tbd)
+ - [2.0.0-alpha.3](#200-alpha3---tbd)
+ - [2.0.0-alpha.2](#200-alpha2---20210707)
  - [2.0.0-alpha.1](#200-alpha1---20210527)
  - [1.3.1](#131---20210603)
  - [1.3.0](#130---20210527)
@@ -31,7 +32,17 @@
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
 
-## [2.0.0-alpha.2] - TBD
+## [2.0.0-alpha.3] - TBD
+
+#### Added
+
+- Implemented Ingress status updates in 2.x.
+  [#1451](https://github.com/Kong/kubernetes-ingress-controller/pull/1451)
+- Added `--publish-status-address` and `--publish-service` flags to 2.x.
+  [#1451](https://github.com/Kong/kubernetes-ingress-controller/pull/1451)
+  [#1509](https://github.com/Kong/kubernetes-ingress-controller/pull/1509)
+
+## [2.0.0-alpha.2] - 2021/07/07
 
 #### Fixed
 
@@ -1135,6 +1146,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.0.0-alpha.3]: https://github.com/kong/kubernetes-ingress-controller/compare/2.0.0-alpha.2...2.0.0-alpha.3
 [2.0.0-alpha.2]: https://github.com/kong/kubernetes-ingress-controller/compare/2.0.0-alpha.1...2.0.0-alpha.2
 [2.0.0-alpha.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...2.0.0-alpha.1
 [1.3.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.3.0...1.3.1

--- a/railgun/internal/ctrlutils/ingress-status.go
+++ b/railgun/internal/ctrlutils/ingress-status.go
@@ -31,8 +31,9 @@ const (
 )
 
 // PullConfigUpdate is a dedicated function that process ingress/customer resource status update after configuration is updated within kong.
-func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.Logger, kubeConfig *rest.Config, publishService, publishAddresses string) {
-	ips, hostname, err := RunningAddresses(ctx, kubeconfig, publishService, publishAddresses)
+func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.Logger, kubeConfig *rest.Config,
+	publishService string, publishAddresses []string) {
+	ips, hostname, err := RunningAddresses(ctx, kubeConfig, publishService, publishAddresses)
 	if err != nil {
 		log.Error(err, "failed to determine kong proxy external ips/hostnames.")
 		return
@@ -317,10 +318,11 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 }
 
 // RunningAddresses retrieve cluster loader balance IP or hostaddress using networking
-func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService, publishAddresses string) ([]string, string, error) {
+func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService string,
+	publishAddresses []string) ([]string, string, error) {
 	addrs := []string{}
-	if publishAddresses != "" {
-		addrs = append(addrs, strings.Split(",", publishAddresses)...)
+	if len(publishAddresses) > 0 {
+		addrs = append(addrs, publishAddresses...)
 		return addrs, "", nil
 	}
 	namespace, name, err := util.ParseNameNS(publishService)

--- a/railgun/internal/ctrlutils/ingress-status.go
+++ b/railgun/internal/ctrlutils/ingress-status.go
@@ -31,8 +31,8 @@ const (
 )
 
 // PullConfigUpdate is a dedicated function that process ingress/customer resource status update after configuration is updated within kong.
-func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.Logger, kubeConfig *rest.Config, publishService string) {
-	ips, hostname, err := RunningAddresses(ctx, kubeConfig, publishService)
+func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.Logger, kubeConfig *rest.Config, publishService, publishAddresses string) {
+	ips, hostname, err := RunningAddresses(ctx, kubeconfig, publishService, publishAddresses)
 	if err != nil {
 		log.Error(err, "failed to determine kong proxy external ips/hostnames.")
 		return
@@ -317,8 +317,12 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 }
 
 // RunningAddresses retrieve cluster loader balance IP or hostaddress using networking
-func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService string) ([]string, string, error) {
+func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService, publishAddresses string) ([]string, string, error) {
 	addrs := []string{}
+	if publishAddresses != "" {
+		addrs = append(addrs, strings.Split(",", publishAddresses)...)
+		return addrs, "", nil
+	}
 	namespace, name, err := util.ParseNameNS(publishService)
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to retrieve service for status: %w", err)
@@ -333,6 +337,7 @@ func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService 
 
 	clusterDomain := network.GetClusterDomainName()
 	hostname := fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain)
+
 	switch svc.Spec.Type {
 	case apiv1.ServiceTypeLoadBalancer:
 		for _, ip := range svc.Status.LoadBalancer.Ingress {
@@ -342,6 +347,7 @@ func RunningAddresses(ctx context.Context, kubeCfg *rest.Config, publishService 
 				addrs = append(addrs, ip.IP)
 			}
 		}
+
 		addrs = append(addrs, svc.Spec.ExternalIPs...)
 		return addrs, hostname, nil
 	default:

--- a/railgun/manager/run.go
+++ b/railgun/manager/run.go
@@ -120,6 +120,7 @@ func Run(ctx context.Context, c *config.Config) error {
 		filterTags = c.FilterTags
 	}
 
+	// configure the kong client
 	kongConfig := sendconfig.Kong{
 		URL:               c.KongAdminURL,
 		FilterTags:        filterTags,
@@ -166,7 +167,7 @@ func Run(ctx context.Context, c *config.Config) error {
 		return err
 	}
 
-	go ctrlutils.PullConfigUpdate(ctx, kongConfig, logger, kubeconfig, c.PublishService)
+	go ctrlutils.PullConfigUpdate(ctx, kongConfig, logger, kubeconfig, c.PublishService, c.PublishStatusAddress)
 
 	alwaysEnabled := util.EnablementStatusEnabled
 	controllers := []ControllerDef{

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -58,7 +58,7 @@ type Config struct {
 
 	// Ingress status
 	PublishService       string
-	PublishStatusAddress string
+	PublishStatusAddress []string
 
 	// Kubernetes API toggling
 	IngressExtV1beta1Enabled util.EnablementStatus
@@ -150,7 +150,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// Ingress status
 	flagSet.StringVar(&c.PublishService, "publish-service", "", `Service fronting Ingress resources in "namespace/name"
 			format. The controller will update Ingress status information with this Service's endpoints.`)
-	flagSet.StringVar(&c.PublishStatusAddress, "publish-status-address", "", `User-provided addresses in
+	flagSet.StringSliceVar(&c.PublishStatusAddress, "publish-status-address", []string{}, `User-provided addresses in
 			comma-separated string format, for use in lieu of "publish-service" when that Service lacks useful address
 			information (for example, in bare-metal environments).`)
 

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -57,7 +57,8 @@ type Config struct {
 	WatchNamespace       string
 
 	// Ingress status
-	PublishService string
+	PublishService       string
+	PublishStatusAddress string
 
 	// Kubernetes API toggling
 	IngressExtV1beta1Enabled util.EnablementStatus
@@ -117,7 +118,6 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.APIServerHost, "apiserver-host", "", `The Kubernetes API server URL. If not set, the controller will use cluster config discovery.`)
 	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", fmt.Sprintf(":%v", MetricsPort), "The address the metric endpoint binds to.")
 	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", fmt.Sprintf(":%v", HealthzPort), "The address the probe endpoint binds to.")
-	// the hardcod only for development debug purpose
 	flagSet.StringVar(&c.KongAdminURL, "kong-admin-url", "http://localhost:8001", `The Kong Admin URL to connect to in the format "protocol://address:port".`)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,
 		fmt.Sprintf(
@@ -150,6 +150,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// Ingress status
 	flagSet.StringVar(&c.PublishService, "publish-service", "", `Service fronting Ingress resources in "namespace/name"
 			format. The controller will update Ingress status information with this Service's endpoints.`)
+	flagSet.StringVar(&c.PublishStatusAddress, "publish-status-address", "", `User-provided addresses in
+			comma-separated string format, for use in lieu of "publish-service" when that Service lacks useful address
+			information (for example, in bare-metal environments).`)
 
 	// Kubernetes API toggling
 	flagSet.enablementStatusVar(&c.IngressNetV1Enabled, "controller-ingress-networkingv1", util.EnablementStatusEnabled, "Enable or disable the Ingress controller (using API version networking.k8s.io/v1)."+onOffUsage)


### PR DESCRIPTION
**What this PR does / why we need it**:
This was originally added to #1451, but later removed. I thought that removal had been reverted, but it wasn't, and I got confused in the PR history and missed that before it went in.

Per #1305 we do want to include this in 2.x for 1.x flag parity. The flag is useful when IP information is missing from the publish service (e.g. bare metal clusters) or does not reflect the true external address of the proxy (e.g. when you chain proxies and have something else in front of Kong).

Lastly, this updates `--publish-status-address` to use a StringSlice, following the same logic as #1496. Note that 1.x `--publish-status-address` originally supported only a single IP, but we may as well allow multiple, as it's compatible.

**Which issue this PR fixes**:
fixes #1305 in conjunction with #1451

**Special notes for your reviewer**:

The reverted commit also included an additional new feature for deriving the Kong admin API URL from its Service, instead of providing it directly in `--kong-admin-url`. Per my [comments in #1486](https://github.com/Kong/kubernetes-ingress-controller/pull/1487#issuecomment-874862259) (which also includes the same feature) this isn't ready for merge yet, as it breaks some existing functionality (namely HTTPS). The admin API doesn't factor into status information at all, and it should be raised in a separate PR if we wish to include it.

Edit: this actually was already reverted... somewhere in history. It's in the reverted commit, but not in the diff here, so the above can be ignored for the context here.

This updates the changelog to reflect the 2.0.0-alpha.2 release. We forgot to do that for the actual release.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
