### PR TITLE
chore: deprecate klog stderrthreshold flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
   [#1451](https://github.com/Kong/kubernetes-ingress-controller/pull/1451)
   [#1509](https://github.com/Kong/kubernetes-ingress-controller/pull/1509)
 
+#### Under the hood
+
+- The historical `--stderrthreshold` flag is now deprecated: it no longer has
+  any effect when used and will be removed in a later release.
+  [#1297](https://github.com/Kong/kubernetes-ingress-controller/issues/1297)
+
 ## [2.0.0-alpha.2] - 2021/07/07
 
 #### Fixed

--- a/railgun/pkg/config/config.go
+++ b/railgun/pkg/config/config.go
@@ -119,11 +119,6 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.MetricsAddr, "metrics-bind-address", fmt.Sprintf(":%v", MetricsPort), "The address the metric endpoint binds to.")
 	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", fmt.Sprintf(":%v", HealthzPort), "The address the probe endpoint binds to.")
 	flagSet.StringVar(&c.KongAdminURL, "kong-admin-url", "http://localhost:8001", `The Kong Admin URL to connect to in the format "protocol://address:port".`)
-	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,
-		fmt.Sprintf(
-			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds) (DEPRECATED, use --proxy-sync-seconds instead)",
-			proxy.DefaultSyncSeconds,
-		))
 	flagSet.Float32Var(&c.ProxySyncSeconds, "proxy-sync-seconds", proxy.DefaultSyncSeconds,
 		fmt.Sprintf(
 			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds)",
@@ -184,6 +179,14 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 
 	// Misc
 	flagSet.BoolVar(&c.EnableProfiling, "profiling", false, "Enable profiling via web interface host:10256/debug/pprof/")
+
+	// Deprecated (to be removed in future releases)
+	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,
+		fmt.Sprintf(
+			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds) (DEPRECATED, use --proxy-sync-seconds instead)",
+			proxy.DefaultSyncSeconds,
+		))
+	flagSet.Int("stderrthreshold", 0, "DEPRECATED: has no effect and will be removed in future releases (see github issue #1297)")
 
 	return &flagSet.FlagSet
 }


### PR DESCRIPTION
**Which issue this PR fixes**

fixes #1297 