### PR TITLE
[chore] finalizer removal & teardown logic cleanup

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -184,6 +184,46 @@ func NewCacheStoresFromObjs(objs ...runtime.Object) (CacheStores, error) {
 	return c, nil
 }
 
+// Get checks whether or not there's already some version of the provided object present in the cache.
+func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err error) {
+	switch obj := obj.(type) {
+	// ----------------------------------------------------------------------------
+	// Kubernetes Core API Support
+	// ----------------------------------------------------------------------------
+	case *extensions.Ingress:
+		return c.IngressV1beta1.Get(obj)
+	case *networkingv1.Ingress:
+		return c.IngressV1.Get(obj)
+	case *corev1.Service:
+		return c.Service.Get(obj)
+	case *corev1.Secret:
+		return c.Secret.Get(obj)
+	case *corev1.Endpoints:
+		return c.Endpoint.Get(obj)
+	// ----------------------------------------------------------------------------
+	// Kong API Support
+	// ----------------------------------------------------------------------------
+	case *kongv1.KongPlugin:
+		return c.Plugin.Get(obj)
+	case *kongv1.KongClusterPlugin:
+		return c.ClusterPlugin.Get(obj)
+	case *kongv1.KongConsumer:
+		return c.Consumer.Get(obj)
+	case *kongv1.KongIngress:
+		return c.KongIngress.Get(obj)
+	case *kongv1beta1.TCPIngress:
+		return c.TCPIngress.Get(obj)
+	case *kongv1beta1.UDPIngress:
+		return c.UDPIngress.Get(obj)
+	// ----------------------------------------------------------------------------
+	// 3rd Party API Support
+	// ----------------------------------------------------------------------------
+	case *knative.Ingress:
+		return c.KnativeIngress.Get(obj)
+	}
+	return nil, false, fmt.Errorf("%T is not a supported cache object type", obj)
+}
+
 // Add stores a provided runtime.Object into the CacheStore if it's of a supported type.
 // The CacheStore must be initialized (see NewCacheStores()) or this will panic.
 func (c CacheStores) Add(obj runtime.Object) error {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -2,11 +2,16 @@ package store
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	core "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,11 +36,11 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 		{
 			name: "returns nil if a non-ingress object is passed in",
 			args: args{
-				&core.Service{
-					Spec: core.ServiceSpec{
-						Type:      core.ServiceTypeClusterIP,
+				&corev1.Service{
+					Spec: corev1.ServiceSpec{
+						Type:      corev1.ServiceTypeClusterIP,
 						ClusterIP: "1.1.1.1",
-						Ports: []core.ServicePort{
+						Ports: []corev1.ServicePort{
 							{
 								Name:       "default",
 								TargetPort: intstr.FromString("port-1"),
@@ -75,8 +80,8 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 						},
 					},
 					Status: extensions.IngressStatus{
-						LoadBalancer: core.LoadBalancerStatus{
-							Ingress: []core.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
 						},
 					},
 				},
@@ -107,8 +112,8 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 					},
 				},
 				Status: networking.IngressStatus{
-					LoadBalancer: core.LoadBalancerStatus{
-						Ingress: []core.LoadBalancerIngress{{IP: "1.2.3.4"}},
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
 					},
 				},
 			},
@@ -124,4 +129,75 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCacheStoresGet(t *testing.T) {
+	t.Log("configuring some yaml objects to store in the cache")
+	svcYAML := []byte(`---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-deployment
+  namespace: default
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: httpbin
+  type: ClusterIP
+`)
+	ingYAML := []byte(`---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin-ingress
+  namespace: default
+  annotations:
+    httpbin.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "kong"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: httpbin-deployment
+            port:
+              number: 80
+`)
+
+	t.Log("creating a new cache store from object yaml files")
+	cs, err := NewCacheStoresFromObjYAML(svcYAML, ingYAML)
+	require.NoError(t, err)
+
+	t.Log("verifying that the cache store doesnt try to retrieve unsupported object types")
+	_, exists, err := cs.Get(new(appsv1.Deployment))
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Deployment is not a supported cache object type"))
+	assert.False(t, exists)
+
+	t.Log("verifying the integrity of the cache store")
+	assert.Len(t, cs.IngressV1.List(), 1)
+	assert.Len(t, cs.Service.List(), 1)
+	assert.Len(t, cs.IngressV1beta1.List(), 0)
+	assert.Len(t, cs.KongIngress.List(), 0)
+	_, exists, err = cs.Get(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "doesntexist", Name: "doesntexist"}})
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	t.Log("ensuring that we can Get() the objects back out of the cache store")
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "httpbin-deployment"}}
+	ing := &netv1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "httpbin-ingress"}}
+	_, exists, err = cs.Get(svc)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	_, exists, err = cs.Get(ing)
+	assert.NoError(t, err)
+	assert.True(t, exists)
 }

--- a/pkg/util/debug_logging_test.go
+++ b/pkg/util/debug_logging_test.go
@@ -133,8 +133,9 @@ func TestDebugLoggerThreadSafety(t *testing.T) {
 
 	// spam the logger concurrently across several goroutines to ensure no dataraces
 	wg := &sync.WaitGroup{}
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
+	total := 100
+	wg.Add(total)
+	for i := 0; i < total; i++ {
 		go func() {
 			defer wg.Done()
 			log.Debug("unique")
@@ -142,9 +143,10 @@ func TestDebugLoggerThreadSafety(t *testing.T) {
 	}
 	wg.Wait()
 	assert.Contains(t, buf.String(), "unique")
-	lines := strings.Split(buf.String(), "\n")
+
 	// Ensure that _some_ lines have been stifled. The actual number is not deterministic.
-	assert.True(t, len(lines) < 100)
+	lines := strings.Split(buf.String(), "\n")
+	assert.True(t, len(lines) < total)
 }
 
 // -----------------------------------------------------------------------------

--- a/railgun/Makefile
+++ b/railgun/Makefile
@@ -166,7 +166,7 @@ test.integration: test.integration.dbless test.integration.postgres
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@./scripts/setup-integration-tests.sh
-	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 20m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
+	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
 
 # Our integration tests using the postgres backend, with verbose output
 # TODO: race checking has been temporarily turned off because of race conditions found with deck. This will be resolved in an upcoming Alpha release of KIC 2.0.
@@ -174,10 +174,10 @@ test.integration.dbless:
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@./scripts/setup-integration-tests.sh
-	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 20m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
+	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
 
 # Our integration tests using the legacy v1 controller manager
 .PHONY: test.integration.legacy
 test.integration.legacy:
 	@./scripts/setup-integration-tests.sh
-	@KONG_LEGACY_CONTROLLER=1 GOFLAGS="-tags=integration_tests" go test -timeout 20m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
+	@KONG_LEGACY_CONTROLLER=1 GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/

--- a/railgun/config/rbac/role.yaml
+++ b/railgun/config/rbac/role.yaml
@@ -16,12 +16,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints/status
   verbs:
   - get
@@ -59,12 +53,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
   - secrets/status
   verbs:
   - get
@@ -78,12 +66,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/finalizers
-  verbs:
-  - update
 - apiGroups:
   - ""
   resources:
@@ -103,12 +85,6 @@ rules:
 - apiGroups:
   - apiextensions.k8s.io
   resources:
-  - ingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
   - ingresses/status
   verbs:
   - get
@@ -122,12 +98,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongclusterplugins/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -147,12 +117,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - kongconsumers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - kongconsumers/status
   verbs:
   - get
@@ -166,12 +130,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -191,12 +149,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - kongplugins/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - kongplugins/status
   verbs:
   - get
@@ -210,12 +162,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -235,12 +181,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - udpingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - udpingresses/status
   verbs:
   - get
@@ -257,12 +197,6 @@ rules:
 - apiGroups:
   - networking.internal.knative.dev
   resources:
-  - ingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - networking.internal.knative.dev
-  resources:
   - ingresses/status
   verbs:
   - get
@@ -276,12 +210,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -309,12 +237,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints/status
   verbs:
   - get
@@ -352,12 +274,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
   - secrets/status
   verbs:
   - get
@@ -371,12 +287,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/finalizers
-  verbs:
-  - update
 - apiGroups:
   - ""
   resources:
@@ -396,12 +306,6 @@ rules:
 - apiGroups:
   - apiextensions.k8s.io
   resources:
-  - ingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
   - ingresses/status
   verbs:
   - get
@@ -415,12 +319,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongclusterplugins/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -440,12 +338,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - kongconsumers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - kongconsumers/status
   verbs:
   - get
@@ -459,12 +351,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -484,12 +370,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - kongplugins/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - kongplugins/status
   verbs:
   - get
@@ -503,12 +383,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -528,12 +402,6 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - udpingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
   - udpingresses/status
   verbs:
   - get
@@ -550,12 +418,6 @@ rules:
 - apiGroups:
   - networking.internal.knative.dev
   resources:
-  - ingresses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - networking.internal.knative.dev
-  resources:
   - ingresses/status
   verbs:
   - get
@@ -569,12 +431,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -45,7 +45,7 @@ import (
 // CoreV1 Service
 // -----------------------------------------------------------------------------
 
-// CoreV1Service reconciles a Ingress object
+// CoreV1Service reconciles Service resources
 type CoreV1ServiceReconciler struct {
 	client.Client
 
@@ -71,13 +71,14 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// get the relevant object
 	obj := new(corev1.Service)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Service object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -116,7 +117,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // CoreV1 Endpoints
 // -----------------------------------------------------------------------------
 
-// CoreV1Endpoints reconciles a Ingress object
+// CoreV1Endpoints reconciles Endpoints resources
 type CoreV1EndpointsReconciler struct {
 	client.Client
 
@@ -142,13 +143,14 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// get the relevant object
 	obj := new(corev1.Endpoints)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Endpoints object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -187,7 +189,7 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // CoreV1 Secret
 // -----------------------------------------------------------------------------
 
-// CoreV1Secret reconciles a Ingress object
+// CoreV1Secret reconciles Secret resources
 type CoreV1SecretReconciler struct {
 	client.Client
 
@@ -213,13 +215,14 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// get the relevant object
 	obj := new(corev1.Secret)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Secret object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -258,7 +261,7 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // NetV1 Ingress
 // -----------------------------------------------------------------------------
 
-// NetV1Ingress reconciles a Ingress object
+// NetV1Ingress reconciles Ingress resources
 type NetV1IngressReconciler struct {
 	client.Client
 
@@ -287,13 +290,14 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// get the relevant object
 	obj := new(netv1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -341,7 +345,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // NetV1Beta1 Ingress
 // -----------------------------------------------------------------------------
 
-// NetV1Beta1Ingress reconciles a Ingress object
+// NetV1Beta1Ingress reconciles Ingress resources
 type NetV1Beta1IngressReconciler struct {
 	client.Client
 
@@ -370,13 +374,14 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// get the relevant object
 	obj := new(netv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -424,7 +429,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // ExtV1Beta1 Ingress
 // -----------------------------------------------------------------------------
 
-// ExtV1Beta1Ingress reconciles a Ingress object
+// ExtV1Beta1Ingress reconciles Ingress resources
 type ExtV1Beta1IngressReconciler struct {
 	client.Client
 
@@ -453,13 +458,14 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// get the relevant object
 	obj := new(extv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -507,7 +513,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // KongV1 KongIngress
 // -----------------------------------------------------------------------------
 
-// KongV1KongIngress reconciles a Ingress object
+// KongV1KongIngress reconciles KongIngress resources
 type KongV1KongIngressReconciler struct {
 	client.Client
 
@@ -533,13 +539,14 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// get the relevant object
 	obj := new(kongv1.KongIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted KongIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -578,7 +585,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // KongV1 KongPlugin
 // -----------------------------------------------------------------------------
 
-// KongV1KongPlugin reconciles a Ingress object
+// KongV1KongPlugin reconciles KongPlugin resources
 type KongV1KongPluginReconciler struct {
 	client.Client
 
@@ -604,13 +611,14 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// get the relevant object
 	obj := new(kongv1.KongPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted KongPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -649,7 +657,7 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // KongV1 KongClusterPlugin
 // -----------------------------------------------------------------------------
 
-// KongV1KongClusterPlugin reconciles a Ingress object
+// KongV1KongClusterPlugin reconciles KongClusterPlugin resources
 type KongV1KongClusterPluginReconciler struct {
 	client.Client
 
@@ -678,13 +686,14 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// get the relevant object
 	obj := new(kongv1.KongClusterPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted KongClusterPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -732,7 +741,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 // KongV1 KongConsumer
 // -----------------------------------------------------------------------------
 
-// KongV1KongConsumer reconciles a Ingress object
+// KongV1KongConsumer reconciles KongConsumer resources
 type KongV1KongConsumerReconciler struct {
 	client.Client
 
@@ -761,13 +770,14 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// get the relevant object
 	obj := new(kongv1.KongConsumer)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted KongConsumer object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -815,7 +825,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 // KongV1Beta1 TCPIngress
 // -----------------------------------------------------------------------------
 
-// KongV1Beta1TCPIngress reconciles a Ingress object
+// KongV1Beta1TCPIngress reconciles TCPIngress resources
 type KongV1Beta1TCPIngressReconciler struct {
 	client.Client
 
@@ -844,13 +854,14 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// get the relevant object
 	obj := new(kongv1beta1.TCPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted TCPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -898,7 +909,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 // KongV1Beta1 UDPIngress
 // -----------------------------------------------------------------------------
 
-// KongV1Beta1UDPIngress reconciles a Ingress object
+// KongV1Beta1UDPIngress reconciles UDPIngress resources
 type KongV1Beta1UDPIngressReconciler struct {
 	client.Client
 
@@ -927,13 +938,14 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// get the relevant object
 	obj := new(kongv1beta1.UDPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted UDPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -981,7 +993,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 // Knativev1alpha1 Ingress
 // -----------------------------------------------------------------------------
 
-// Knativev1alpha1Ingress reconciles a Ingress object
+// Knativev1alpha1Ingress reconciles Ingress resources
 type Knativev1alpha1IngressReconciler struct {
 	client.Client
 
@@ -1010,13 +1022,14 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	// get the relevant object
 	obj := new(knativev1alpha1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -74,7 +74,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	obj := new(corev1.Service)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -92,7 +92,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -147,7 +147,7 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	obj := new(corev1.Endpoints)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -165,7 +165,7 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Endpoints", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -220,7 +220,7 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	obj := new(corev1.Secret)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -238,7 +238,7 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Secret", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -296,7 +296,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	obj := new(netv1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -314,7 +314,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -392,7 +392,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(netv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -410,7 +410,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -488,7 +488,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(extv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -506,7 +506,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -581,7 +581,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(kongv1.KongIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -599,7 +599,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongIngress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -654,7 +654,7 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	obj := new(kongv1.KongPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -672,7 +672,7 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongPlugin", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -730,7 +730,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	obj := new(kongv1.KongClusterPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -748,7 +748,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongClusterPlugin", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -826,7 +826,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	obj := new(kongv1.KongConsumer)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -844,7 +844,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongConsumer", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -922,7 +922,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	obj := new(kongv1beta1.TCPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -940,7 +940,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "TCPIngress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1018,7 +1018,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	obj := new(kongv1beta1.UDPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1036,7 +1036,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1114,7 +1114,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	obj := new(knativev1alpha1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1132,7 +1132,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -61,10 +61,8 @@ func (r *CoreV1ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=services/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=services/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=services/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -134,10 +132,8 @@ func (r *CoreV1EndpointsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=list;watch
 //+kubebuilder:rbac:groups="",resources=endpoints/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=endpoints/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=endpoints,verbs=list;watch
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=endpoints/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=endpoints/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -207,10 +203,8 @@ func (r *CoreV1SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
 //+kubebuilder:rbac:groups="",resources=secrets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=secrets/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=secrets,verbs=list;watch
 //+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=secrets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",namespace=CHANGEME,resources=secrets/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -283,10 +277,8 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -324,7 +316,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -334,17 +326,6 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -379,10 +360,8 @@ func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.k8s.io,namespace=CHANGEME,resources=ingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -420,7 +399,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -430,17 +409,6 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -475,10 +443,8 @@ func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=ingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,namespace=CHANGEME,resources=ingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -516,7 +482,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -526,17 +492,6 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -568,10 +523,8 @@ func (r *KongV1KongIngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -641,10 +594,8 @@ func (r *KongV1KongPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongplugins,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongplugins/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongplugins/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongplugins,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongplugins/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongplugins/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -717,10 +668,8 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongclusterplugins,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongclusterplugins/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongclusterplugins/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongclusterplugins,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongclusterplugins/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongclusterplugins/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -758,7 +707,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -768,17 +717,6 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -813,10 +751,8 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=kongconsumers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongconsumers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongconsumers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=kongconsumers/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -854,7 +790,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -864,17 +800,6 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -909,10 +834,8 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=tcpingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=tcpingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=tcpingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=tcpingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=tcpingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=tcpingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -950,7 +873,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -960,17 +883,6 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -1005,10 +917,8 @@ func (r *KongV1Beta1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=udpingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,resources=udpingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=udpingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=udpingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=udpingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=configuration.konghq.com,namespace=CHANGEME,resources=udpingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -1046,7 +956,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -1056,17 +966,6 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -1101,10 +1000,8 @@ func (r *Knativev1alpha1IngressReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 //+kubebuilder:rbac:groups=networking.internal.knative.dev,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.internal.knative.dev,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.internal.knative.dev,resources=ingresses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=networking.internal.knative.dev,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.internal.knative.dev,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.internal.knative.dev,namespace=CHANGEME,resources=ingresses/finalizers,verbs=update
 
 // Reconcile processes the watched objects
 func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -1142,7 +1039,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 			}
 			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
+		return ctrl.Result{}, nil
 	}
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
@@ -1152,17 +1049,6 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// update the kong Admin API with the changes

--- a/railgun/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/controllers/configuration/zz_generated_controllers.go
@@ -74,6 +74,17 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	obj := new(corev1.Service)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -81,21 +92,17 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -140,6 +147,17 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	obj := new(corev1.Endpoints)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -147,21 +165,17 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Endpoints", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -206,6 +220,17 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	obj := new(corev1.Secret)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -213,21 +238,17 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Secret", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -275,6 +296,17 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	obj := new(netv1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -282,8 +314,15 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -353,6 +392,17 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(netv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -360,8 +410,15 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -431,6 +488,17 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(extv1beta1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -438,8 +506,15 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -506,6 +581,17 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	obj := new(kongv1.KongIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -513,21 +599,17 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongIngress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -572,6 +654,17 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	obj := new(kongv1.KongPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -579,21 +672,17 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongPlugin", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
-	}
-
-	// before we store cache data for this object, ensure that it has our finalizer set
-	if !ctrlutils.HasFinalizer(obj, ctrlutils.KongIngressFinalizer) {
-		log.Info("finalizer is not set for resource, setting it", req.Namespace, req.Name)
-		finalizers := obj.GetFinalizers()
-		obj.SetFinalizers(append(finalizers, ctrlutils.KongIngressFinalizer))
-		if err := r.Client.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// update the kong Admin API with the changes
@@ -641,6 +730,17 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	obj := new(kongv1.KongClusterPlugin)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -648,8 +748,15 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongClusterPlugin", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -719,6 +826,17 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	obj := new(kongv1.KongConsumer)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -726,8 +844,15 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "KongConsumer", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -797,6 +922,17 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	obj := new(kongv1beta1.TCPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -804,8 +940,15 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "TCPIngress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -875,6 +1018,17 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	obj := new(kongv1beta1.UDPIngress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -882,8 +1036,15 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}
@@ -953,6 +1114,17 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	obj := new(knativev1alpha1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
@@ -960,8 +1132,15 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		if err := r.Proxy.DeleteObject(obj); err != nil {
+		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
 		}
 		return ctrlutils.CleanupFinalizer(ctx, r.Client, log, req.NamespacedName, obj)
 	}

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -413,7 +413,7 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 	obj := new({{.PackageImportAlias}}.{{.Type}})
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -431,7 +431,7 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.Info("resource is being deleted, its configuration will be removed", "type", "{{.Type}}", "namespace", req.Namespace, "name", req.Name)
-		objectExistsInCache, err := p.Proxy.ObjectExists(obj)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -372,7 +372,7 @@ var controllerTemplate = `
 // {{.PackageAlias}} {{.Type}}
 // -----------------------------------------------------------------------------
 
-// {{.PackageAlias}}{{.Type}} reconciles a Ingress object
+// {{.PackageAlias}}{{.Type}} reconciles {{.Type}} resources
 type {{.PackageAlias}}{{.Type}}Reconciler struct {
 	client.Client
 
@@ -407,13 +407,14 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 	// get the relevant object
 	obj := new({{.PackageImportAlias}}.{{.Type}})
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "object was queued for reconcilation but could not be retrieved", "namespace", req.Namespace, "name", req.Name)
+		obj.Namespace = req.Namespace
+		obj.Name = req.Name
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Error(err, "object which wasn't found in the Kubernetes API still exists in the cache, deleting", "namespace", req.Namespace, "name", req.Name)
+			log.Info("deleted {{.Type}} object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}

--- a/railgun/internal/ctrlutils/utils.go
+++ b/railgun/internal/ctrlutils/utils.go
@@ -1,16 +1,11 @@
 package ctrlutils
 
 import (
-	"context"
-
-	"github.com/go-logr/logr"
 	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -18,39 +13,6 @@ import (
 
 // classSpec indicates the fieldName for objects which support indicating their Ingress Class by spec
 const classSpec = "IngressClassName"
-
-// CleanupFinalizer removes an object finalizer from an object which is currently being deleted.
-func CleanupFinalizer(ctx context.Context, c client.Client, log logr.Logger, nsn types.NamespacedName, obj client.Object) (ctrl.Result, error) {
-	if HasFinalizer(obj, KongIngressFinalizer) {
-		log.Info("kong ingress finalizer needs to be removed from a resource which is deleting", "ingress", obj.GetName(), "finalizer", KongIngressFinalizer)
-		finalizers := []string{}
-		for _, finalizer := range obj.GetFinalizers() {
-			if finalizer != KongIngressFinalizer {
-				finalizers = append(finalizers, finalizer)
-			}
-		}
-		obj.SetFinalizers(finalizers)
-		if err := c.Update(ctx, obj); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("the kong ingress finalizer was removed from an a resource which is deleting", "ingress", obj.GetName(), "finalizer", KongIngressFinalizer)
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	return ctrl.Result{}, nil
-}
-
-// HasFinalizer is a helper function to check whether a client.Object
-// already has a specific finalizer set.
-func HasFinalizer(obj client.Object, finalizer string) bool {
-	hasFinalizer := false
-	for _, foundFinalizer := range obj.GetFinalizers() {
-		if foundFinalizer == finalizer {
-			hasFinalizer = true
-		}
-	}
-	return hasFinalizer
-}
 
 // HasAnnotation is a helper function to determine whether an object has a given annotation, and whether it's
 // to the value provided.

--- a/railgun/internal/ctrlutils/vars.go
+++ b/railgun/internal/ctrlutils/vars.go
@@ -1,8 +1,0 @@
-package ctrlutils
-
-// -----------------------------------------------------------------------------
-// General Controller Variables
-// -----------------------------------------------------------------------------
-
-// KongIngressFinalizer is the finalizer used to ensure Kong configuration cleanup for deleted resources.
-const KongIngressFinalizer = "configuration.konghq.com/ingress"

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -63,7 +63,7 @@ type Proxy interface {
 	// A status will later be added to the object whether the configuration update succeeds or fails.
 	DeleteObject(obj client.Object) error
 
-	// ObjectExists indicates whether or not any version of the provided object is already present in the cache.
+	// ObjectExists indicates whether or not any version of the provided object is already present in the proxy.
 	ObjectExists(obj client.Object) (bool, error)
 }
 

--- a/railgun/internal/proxy/proxy.go
+++ b/railgun/internal/proxy/proxy.go
@@ -62,6 +62,9 @@ type Proxy interface {
 	// The delete action will asynchronously be converted to Kong DSL and applied to the Kong Admin API.
 	// A status will later be added to the object whether the configuration update succeeds or fails.
 	DeleteObject(obj client.Object) error
+
+	// ObjectExists indicates whether or not any version of the provided object is already present in the cache.
+	ObjectExists(obj client.Object) (bool, error)
 }
 
 // KongUpdater is a type of function that describes how to provide updates to the Kong Admin API

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -33,9 +33,6 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	// clusterDeployWait is the timeout duration for deploying the kind cluster for testing
-	clusterDeployWait = time.Minute * 5
-
 	// waitTick is the default timeout tick interval for checking on ingress resources.
 	waitTick = time.Second * 1
 
@@ -103,7 +100,7 @@ var (
 
 func TestMain(m *testing.M) {
 	var err error
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(clusterDeployWait))
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	fmt.Println("INFO: configuring testing environment")

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -75,6 +75,7 @@ var (
 		testIngressNamespace,
 		testTCPIngressNamespace,
 		testUDPIngressNamespace,
+		testPluginsNamespace,
 	}, ",")
 
 	// dbmode indicates the database backend of the test cluster ("off" and "postgres" are supported)

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -75,6 +75,7 @@ var (
 	watchNamespaces = strings.Join([]string{
 		elsewhere,
 		corev1.NamespaceDefault,
+		testIngressNamespace,
 		testTCPIngressNamespace,
 		testUDPIngressNamespace,
 	}, ",")


### PR DESCRIPTION
**What this PR does / why we need it**:

- corrects issues with finalizers that's been holding over since early railgun prototypes
- improves consistency on object deletions
- adds tests to prove new finalizer logic works appropriately

**Which issue this PR fixes**

fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1515