### PR TITLE
docs: create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+See our [Version Compatibility Documentation](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/#kubernetes).
+
+## Reporting a Vulnerability
+
+See our [Reporting A Vulnerability Documentation](https://docs.konghq.com/enterprise/latest/kong-security-update-process/#reporting-a-vulnerability).


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't have a standing security policy at this time so this patch
adds once, and specifically points out that we are no longer
supporting versions less than v1.