### PR TITLE
fix: update kubernetes version for legacy tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 # only for dev
 DB?=false
 RUN_VERSION?=20
-KUBE_VERSION?=v1.20.2
+KUBE_VERSION?=v1.20.7
 
 PKG_LIST := ./...
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that Github Actions CI was failing over the last
day or so, and it seemed to be due to the components in the
Kind image never coming online properly. This isn't the first
time recently we found that the older images or KIND components
were breaking. This patch simply updates to the latest Kubernetes
v1.20.x patch release to try and fix CI.