### PR TITLE
cherry-pick #1528 (bump kind node version) to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 # only for dev
 DB?=false
 RUN_VERSION?=20
-KUBE_VERSION?=v1.20.2
+KUBE_VERSION?=v1.20.7
 
 PKG_LIST := ./...
 

--- a/railgun/scripts/setup-integration-tests.sh
+++ b/railgun/scripts/setup-integration-tests.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-KIND_VERSION="v0.10.0"
+KIND_VERSION="v0.11.1"
 
 # ensure docker command is accessible
 if ! command -v docker &> /dev/null

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -6,7 +6,7 @@ export CLUSTER_NAME="test-cluster"
 export REGISTRY_NAME="test-local-registry"
 
 export KIND_BINARY=./kind
-export KIND_URL=https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-linux-amd64
+export KIND_URL=https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
 
 wget "$KIND_URL" -O "$KIND_BINARY" || exit 1
 chmod +x "$KIND_BINARY" || exit 1


### PR DESCRIPTION
This PR takes #1528 (which is a fix for our integration tests) that went to `next` and cherry-picks it over to `main` in order to resolve CI failures blocking other PRs from being merged.