### PR TITLE
fix: dont run ci twice for branch

### DIFF
--- a/.github/workflows/1x-integration-test.yaml
+++ b/.github/workflows/1x-integration-test.yaml
@@ -3,8 +3,7 @@ name: 1.x Integration Tests
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'next'
+      - '*'
   push:
     branches:
       - 'main'

--- a/.github/workflows/1x-integration-test.yaml
+++ b/.github/workflows/1x-integration-test.yaml
@@ -7,7 +7,8 @@ on:
       - 'next'
   push:
     branches:
-      - '*'
+      - 'main'
+      - 'next'
     tags:
       - '1.*'
       - 'v1.*'

--- a/.github/workflows/2x-integration-test.yaml
+++ b/.github/workflows/2x-integration-test.yaml
@@ -3,8 +3,7 @@ name: 2.x Integration Tests
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'next'
+      - '*'
   push:
     branches:
       - 'main'

--- a/.github/workflows/2x-integration-test.yaml
+++ b/.github/workflows/2x-integration-test.yaml
@@ -7,7 +7,8 @@ on:
       - 'next'
   push:
     branches:
-      - '*'
+      - 'main'
+      - 'next'
     tags:
       - '2.*'
       - 'v2.*'


### PR DESCRIPTION
**What this PR does / why we need it**:

Up until recently we never really had a problem with
the fact that we were incidentally duplicating CI runs
for every PR that was pushed. As our test suite is growing
and we're nearing a 2.0 release now is as good a time as
any to fix this and ensure we're only running one copy
of the integration tests per PR.