### PR TITLE
fix: adjust docker image build paths

### DIFF
--- a/.github/workflows/2x-image-build-test.yaml
+++ b/.github/workflows/2x-image-build-test.yaml
@@ -16,10 +16,20 @@ jobs:
   verify-docker-build:
     runs-on: ubuntu-latest
     steps:
-    - name: Verify Railgun Docker Build
-      uses: docker/build-push-action@v2
-      with:
-        push: false
-        file: Dockerfile.railgun
-        tags: latest
-        cache-from: type=local,src=/tmp/.buildx-cache
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.6
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Verify Railgun Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          file: Dockerfile.railgun
+          tags: latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/2x-image-build-test.yaml
+++ b/.github/workflows/2x-image-build-test.yaml
@@ -1,0 +1,25 @@
+name: 2.x Image Build
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+      - 'next'
+    tags:
+      - '2.*'
+      - 'v2.*'
+
+jobs:
+  verify-docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify Railgun Docker Build
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        file: Dockerfile.railgun
+        tags: latest
+        cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/2x-integration-test.yaml
+++ b/.github/workflows/2x-integration-test.yaml
@@ -63,3 +63,4 @@ jobs:
         directory: ./railgun
         flags: integration-test
         fail_ci_if_error: true
+

--- a/.github/workflows/2x-integration-test.yaml
+++ b/.github/workflows/2x-integration-test.yaml
@@ -63,4 +63,3 @@ jobs:
         directory: ./railgun
         flags: integration-test
         fail_ci_if_error: true
-

--- a/Dockerfile.railgun
+++ b/Dockerfile.railgun
@@ -10,13 +10,10 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY pkg/ pkg/
-COPY railgun/apis/ railgun/apis/
-COPY railgun/cmd/ railgun/cmd/
-COPY railgun/controllers/ railgun/controllers/
-COPY railgun/manager/ railgun/manager/
 COPY railgun/pkg/ railgun/pkg/
-COPY railgun/main.go railgun/main.go
+COPY railgun/apis/ railgun/apis/
 COPY railgun/internal/ railgun/internal/
+COPY railgun/main.go railgun/main.go
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-s -w -X manager.Release=$TAG -X manager.Commit=$COMMIT -X manager.Repo=$REPO_INFO" ./railgun/main.go


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent PR made several packages private but the CI
that runs on each PR doesn't test the docker build.

This patch fixes the paths, but also adds a docker
build to the integration tests so that future PRs
will regression test against this kind of problem.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/runs/3077874445?check_suite_focus=true