### PR TITLE
feat: add some bulk ingress testing

### DIFF
--- a/railgun/test/integration/ingress_bulk_test.go
+++ b/railgun/test/integration/ingress_bulk_test.go
@@ -20,10 +20,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
-const (
-	maxBatchSize             = 50
-	testBulkIngressNamespace = "ingress-bulk-testing"
-)
+const testBulkIngressNamespace = "ingress-bulk-testing"
 
 // TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {

--- a/railgun/test/integration/ingress_bulk_test.go
+++ b/railgun/test/integration/ingress_bulk_test.go
@@ -22,6 +22,7 @@ import (
 
 const testBulkIngressNamespace = "ingress-bulk-testing"
 
+// TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
 	ctx := context.Background()
 

--- a/railgun/test/integration/ingress_bulk_test.go
+++ b/railgun/test/integration/ingress_bulk_test.go
@@ -20,7 +20,10 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
-const testBulkIngressNamespace = "ingress-bulk-testing"
+const (
+	maxBatchSize             = 50
+	testBulkIngressNamespace = "ingress-bulk-testing"
+)
 
 // TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
@@ -51,8 +54,8 @@ func TestIngressBulk(t *testing.T) {
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(testBulkIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	t.Logf("exposing deployment %s via ingress 50 times", deployment.Name)
-	for i := 0; i < 50; i++ {
+	t.Logf("exposing deployment %s via ingress %d times", deployment.Name, maxBatchSize)
+	for i := 0; i < maxBatchSize; i++ {
 		name := fmt.Sprintf("bulk-httpbin-%d", i)
 		path := fmt.Sprintf("/%s", name)
 
@@ -70,24 +73,8 @@ func TestIngressBulk(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	/*
-		t.Log("verifying that all 50 ingresses receive status updates properly")
-		for i := 0; i < 50; i++ {
-			name := fmt.Sprintf("bulk-httpbin-%d", i)
-			path := fmt.Sprintf("/%s", name)
-
-			require.Eventually(t, func() bool {
-				ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-				return len(ingress.Status.LoadBalancer.Ingress) > 0
-			}, ingressWait, waitTick)
-		}
-	*/
-
-	t.Log("verifying that all 50 ingresses route properly")
-	for i := 0; i < 50; i++ {
+	t.Logf("verifying that all %d ingresses route properly", maxBatchSize)
+	for i := 0; i < maxBatchSize; i++ {
 		name := fmt.Sprintf("bulk-httpbin-%d", i)
 		path := fmt.Sprintf("/%s", name)
 

--- a/railgun/test/integration/ingress_bulk_test.go
+++ b/railgun/test/integration/ingress_bulk_test.go
@@ -93,8 +93,9 @@ func TestIngressBulk(t *testing.T) {
 		}, ingressWait, waitTick)
 	}
 
-	t.Log("staggering deployment: 10 new ingress resources every second for the next 10 seconds (total 100)")
-	for i := 0; i < 100; i++ {
+	t.Log("staggering ingress deployments over several seconds")
+	maxStaggeredBatchSize := maxBatchSize * 2
+	for i := 0; i < maxStaggeredBatchSize; i++ {
 		name := fmt.Sprintf("bulk-staggered-httpbin-%d", i)
 		path := fmt.Sprintf("/%s", name)
 
@@ -117,8 +118,8 @@ func TestIngressBulk(t *testing.T) {
 		}
 	}
 
-	t.Log("verifying that all 100 staggered ingresses route properly")
-	for i := 0; i < 100; i++ {
+	t.Logf("verifying that all %d staggered ingresses route properly", maxStaggeredBatchSize)
+	for i := 0; i < maxStaggeredBatchSize; i++ {
 		name := fmt.Sprintf("bulk-staggered-httpbin-%d", i)
 		path := fmt.Sprintf("/%s", name)
 

--- a/railgun/test/integration/ingress_bulk_test.go
+++ b/railgun/test/integration/ingress_bulk_test.go
@@ -1,0 +1,109 @@
+//+build integration_tests
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/pkg/annotations"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+)
+
+const testBulkIngressNamespace = "ingress-bulk-testing"
+
+func TestIngressBulk(t *testing.T) {
+	ctx := context.Background()
+
+	t.Logf("creating namespace %s for testing", testBulkIngressNamespace)
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testBulkIngressNamespace}}
+	namespace, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up namespace %s", testBulkIngressNamespace)
+		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{}))
+		require.Eventually(t, func() bool {
+			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return true
+				}
+			}
+			return false
+		}, ingressWait, waitTick)
+	}()
+
+	t.Log("deploying a minimal HTTP container to be exoposed via ingress")
+	container := generators.NewContainer("httpbin", httpBinImage, 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(testBulkIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing deployment %s via ingress 50 times", deployment.Name)
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("bulk-httpbin-%d", i)
+		path := fmt.Sprintf("/%s", name)
+
+		service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+		service.Name = name
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		_, err = env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		ingress := generators.NewIngressForService(path, map[string]string{
+			annotations.IngressClassKey: ingressClass,
+			"konghq.com/strip-path":     "true",
+		}, service)
+		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testBulkIngressNamespace).Create(ctx, ingress, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	/*
+		t.Log("verifying that all 50 ingresses receive status updates properly")
+		for i := 0; i < 50; i++ {
+			name := fmt.Sprintf("bulk-httpbin-%d", i)
+			path := fmt.Sprintf("/%s", name)
+
+			require.Eventually(t, func() bool {
+				ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return len(ingress.Status.LoadBalancer.Ingress) > 0
+			}, ingressWait, waitTick)
+		}
+	*/
+
+	t.Log("verifying that all 50 ingresses route properly")
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("bulk-httpbin-%d", i)
+		path := fmt.Sprintf("/%s", name)
+
+		require.Eventually(t, func() bool {
+			resp, err := httpc.Get(fmt.Sprintf("%s/%s", proxyURL, path))
+			if err != nil {
+				t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+				return false
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				b := new(bytes.Buffer)
+				n, err := b.ReadFrom(resp.Body)
+				require.NoError(t, err)
+				require.True(t, n > 0)
+				return strings.Contains(b.String(), "<title>httpbin.org</title>")
+			}
+			return false
+		}, ingressWait, waitTick)
+	}
+}

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -73,6 +73,7 @@ var (
 		elsewhere,
 		corev1.NamespaceDefault,
 		testIngressNamespace,
+		testBulkIngressNamespace,
 		testTCPIngressNamespace,
 		testUDPIngressNamespace,
 		testPluginsNamespace,

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -82,6 +82,9 @@ var (
 	// dbmode indicates the database backend of the test cluster ("off" and "postgres" are supported)
 	dbmode = os.Getenv("TEST_DATABASE_MODE")
 
+	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
+	maxBatchSize = determineMaxBatchSize()
+
 	// env is the primary testing environment object which includes access to the Kubernetes cluster
 	// and all the addons deployed in support of the tests.
 	env environments.Environment

--- a/railgun/test/integration/utils_test.go
+++ b/railgun/test/integration/utils_test.go
@@ -5,7 +5,10 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,4 +32,16 @@ func expect404WithNoRoute(t *testing.T, proxyURL string, resp *http.Response) bo
 		return body.Message == "no Route matched with those values"
 	}
 	return false
+}
+
+// determineMaxBatchSize provides a size limit for the number of resources to POST in a single second during tests, and can be overridden with an ENV var if desired.
+func determineMaxBatchSize() int {
+	if v := os.Getenv("KONG_BULK_TESTING_BATCH_SIZE"); v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			panic(fmt.Sprintf("Error: invalid batch size %s: %s", v, err))
+		}
+		return i
+	}
+	return 50
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds some tests to protect us against performance
regressions when deploying large numbers of ingress
resources all within a single second or two.