### PR TITLE
[feat] CI testing kubernetes version matrix

### DIFF
--- a/.github/workflows/2x-kubernetes-version-matrix-test.yaml
+++ b/.github/workflows/2x-kubernetes-version-matrix-test.yaml
@@ -1,0 +1,42 @@
+name: 2.x Kubernetes Version Matrix Tests
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'next'
+
+jobs:
+  test-dbless:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kubernetes-version:
+          - 'v1.19.11'
+          - 'v1.20.7'
+          - 'v1.21.2'
+        dbmode:
+          - 'dbless'
+          - 'postgres'
+    steps:
+      - name: setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+
+      - name: cache go modules
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
+
+      - name: checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Kubernetes ${{ matrix.kubernetes_version }} ${{ matrix.dbmode }} Integration Tests
+        run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes_version }} make test.integration.${{ matrix.dbmode }}
+        working-directory: ./railgun

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,7 @@ For this step we're going to start with the `next` branch and merge in `main` to
 
 **For all releases**
 
+- [ ] verify that CI is passing for `main` first: if there are CI errors on main they must be investigated and fixed
 - [ ] draft a new [release](https://github.com/Kong/kubernetes-ingress-controller/releases), using a title and body similar to previous releases. Use your existing tag.
 - [ ] for new `major` version releases create a new branch (e.g. `1.3.x`) from the release tag and push it
 - [ ] for `minor` and `patch` version releases rebase the release tag onto the release branch: `git checkout 1.3.x && git rebase 1.3.1 && git push`

--- a/pkg/sendconfig/sendconfig.go
+++ b/pkg/sendconfig/sendconfig.go
@@ -44,7 +44,7 @@ func PerformUpdate(ctx context.Context,
 		// use the previous SHA to determine whether or not to perform an update
 		if equalSHA(oldSHA, newSHA) {
 			if !hasSHAUpdateAlreadyBeenReported(newSHA) {
-				log.Info("sha %s has been reported", hex.EncodeToString(newSHA))
+				log.Infof("sha %s has been reported", hex.EncodeToString(newSHA))
 			}
 			log.Info("no configuration change, skipping sync to kong")
 			return oldSHA, nil

--- a/railgun/test/integration/suite_test.go
+++ b/railgun/test/integration/suite_test.go
@@ -80,18 +80,6 @@ var (
 		testPluginsNamespace,
 	}, ",")
 
-	// dbmode indicates the database backend of the test cluster ("off" and "postgres" are supported)
-	dbmode = os.Getenv("TEST_DATABASE_MODE")
-
-	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
-	maxBatchSize = determineMaxBatchSize()
-
-	// ClusterVersionEnvVar indicates the environment variable used to configure the Kubernetes cluster version.
-	ClusterVersionEnvVar = "KONG_CLUSTER_VERSION"
-
-	// clusterVersion indicates the version of Kubernetes to use for the tests (if the cluster was not provided by the caller)
-	clusterVersionStr = os.Getenv(ClusterVersionEnvVar)
-
 	// env is the primary testing environment object which includes access to the Kubernetes cluster
 	// and all the addons deployed in support of the tests.
 	env environments.Environment
@@ -104,6 +92,25 @@ var (
 
 	// proxyUDPURL provides access to the UDP API endpoint for the Kong Addon which is deployed to the test environment's cluster.
 	proxyUDPURL *url.URL
+)
+
+// -----------------------------------------------------------------------------
+// Testing Variables - Environment Overrides
+// -----------------------------------------------------------------------------
+
+var (
+	// dbmode indicates the database backend of the test cluster ("off" and "postgres" are supported)
+	dbmode = os.Getenv("TEST_DATABASE_MODE")
+
+	// clusterVersion indicates the version of Kubernetes to use for the tests (if the cluster was not provided by the caller)
+	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
+
+	// existingClusterName indicates whether or not the caller is providing their own kind cluster for running the tests,
+	// and if so what the name of that cluster is.
+	existingClusterName = os.Getenv("KIND_CLUSTER")
+
+	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
+	maxBatchSize = determineMaxBatchSize()
 )
 
 // -----------------------------------------------------------------------------
@@ -124,16 +131,16 @@ func TestMain(m *testing.M) {
 	builder := environments.NewBuilder().WithAddons(metallb.New(), kongAddon)
 
 	fmt.Println("INFO: checking for reusable environment components")
-	if existingClusterName := os.Getenv("KIND_CLUSTER"); existingClusterName != "" {
+	if existingClusterName != "" {
 		if clusterVersionStr != "" {
-			fmt.Fprintf(os.Stderr, "Error: cant use both %s and KONG_CLUSTER at the same time", ClusterVersionEnvVar)
-			os.Exit(33)
+			fmt.Fprintf(os.Stderr, "Error: can't flag cluster version and provide an existing cluster at the same time")
+			os.Exit(ExitCodeIncompatibleOptions)
 		}
 		fmt.Printf("INFO: using existing cluster %s\n", existingClusterName)
 		cluster, err := kind.NewFromExisting(existingClusterName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: could not use existing cluster for test env: %s", err.Error())
-			os.Exit(24)
+			fmt.Fprintf(os.Stderr, "Error: could not use existing cluster for test env: %s", err)
+			os.Exit(ExitCodeCantUseExistingCluster)
 		}
 		builder = builder.WithExistingCluster(cluster)
 	}
@@ -142,13 +149,13 @@ func TestMain(m *testing.M) {
 	if clusterVersionStr != "" {
 		clusterVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: invalid %s provided (%s): %s", ClusterVersionEnvVar, clusterVersionStr, err.Error())
-			os.Exit(31)
+			fmt.Fprintf(os.Stderr, "Error: invalid cluster version provided (%s): %s", clusterVersionStr, err)
+			os.Exit(ExitCodeInvalidOptions)
 		}
 		cluster, err := kind.NewBuilder().WithClusterVersion(clusterVersion).Build(ctx)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to build kind cluster with version %s: %s", clusterVersion, err.Error())
-			os.Exit(32)
+			fmt.Fprintf(os.Stderr, "Error: failed to build kind cluster with version %s: %s", clusterVersion, err)
+			os.Exit(ExitCodeCantCreateCluster)
 		}
 		builder.WithExistingCluster(cluster)
 	}
@@ -156,8 +163,8 @@ func TestMain(m *testing.M) {
 	fmt.Println("INFO: building test environment (note: can take some time)")
 	env, err = builder.Build(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: could not create testing environment: %s", err.Error())
-		os.Exit(25)
+		fmt.Fprintf(os.Stderr, "Error: could not create testing environment: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 	fmt.Printf(
 		"INFO: environment built CLUSTER_NAME=(%s) CLUSTER_TYPE=(%s) ADDONS=(metallb, kong)\n",
@@ -165,32 +172,32 @@ func TestMain(m *testing.M) {
 	)
 	defer func() {
 		if err := env.Cleanup(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: could not cleanup testing environment: %s", err.Error())
-			os.Exit(30)
+			fmt.Fprintf(os.Stderr, "Error: could not cleanup testing environment: %s", err)
+			os.Exit(ExitCodeCleanupFailed)
 		}
 	}()
 
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
 	if err := <-env.WaitForReady(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: testing environment never became ready: %s", err.Error())
-		os.Exit(26)
+		fmt.Fprintf(os.Stderr, "Error: testing environment never became ready: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 
 	fmt.Printf("INFO: collecting Kong Proxy URLs from cluster %s for tests to make HTTP calls\n", env.Cluster().Name())
 	proxyURL, err = kongAddon.ProxyURL(ctx, env.Cluster())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err.Error())
-		os.Exit(27)
+		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 	proxyAdminURL, err = kongAddon.ProxyAdminURL(ctx, env.Cluster())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err.Error())
-		os.Exit(28)
+		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 	proxyUDPURL, err = kongAddon.ProxyUDPURL(ctx, env.Cluster())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err.Error())
-		os.Exit(29)
+		fmt.Fprintf(os.Stderr, "Error: could not get proxy URL from Kong Addon: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 
 	if v := os.Getenv("KONG_BRING_MY_OWN_KIC"); v == "true" {
@@ -198,19 +205,19 @@ func TestMain(m *testing.M) {
 	} else {
 		fmt.Println("INFO: deploying controller manager")
 		if err := deployControllers(ctx, controllerNamespace); err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(13)
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(ExitCodeCantCreateCluster)
 		}
 	}
 
 	fmt.Printf("INFO: running final testing environment checks")
 	serverVersion, err := env.Cluster().Client().ServerVersion()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: could not retrieve server version for cluster: %s", err.Error())
-		os.Exit(34)
+		fmt.Fprintf(os.Stderr, "Error: could not retrieve server version for cluster: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
 	}
 
-	fmt.Printf("INFO: testing environment is ready KUBERNETES_VERSION=(%s): running tests\n", serverVersion.String())
+	fmt.Printf("INFO: testing environment is ready KUBERNETES_VERSION=(%v): running tests\n", serverVersion)
 	code := m.Run()
 	os.Exit(code)
 }
@@ -330,7 +337,7 @@ func deployControllers(ctx context.Context, namespace string) error {
 }
 
 func buildLegacyCommand(ctx context.Context, kubeconfigPath string) *exec.Cmd {
-	fmt.Fprintln(os.Stdout, "WARNING: deploying legacy Kong Kubernetes Ingress Controller (KIC)")
+	fmt.Fprintln(os.Stderr, "WARNING: deploying legacy Kong Kubernetes Ingress Controller (KIC)")
 
 	// get the proxy pod
 	podList, err := env.Cluster().Client().CoreV1().Pods("kong-system").List(ctx, metav1.ListOptions{

--- a/railgun/test/integration/utils_test.go
+++ b/railgun/test/integration/utils_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// -----------------------------------------------------------------------------
+// Testing Utility Functions
+// -----------------------------------------------------------------------------
+
 // expect404WithNoRoute is used to check whether a given http response is (specifically) a Kong 404.
 func expect404WithNoRoute(t *testing.T, proxyURL string, resp *http.Response) bool {
 	if resp.StatusCode == http.StatusNotFound {
@@ -45,3 +49,29 @@ func determineMaxBatchSize() int {
 	}
 	return 50
 }
+
+// -----------------------------------------------------------------------------
+// Test Suite Exit Codes
+// -----------------------------------------------------------------------------
+
+const (
+	// ExitCodeIncompatibleOptions is a POSIX compliant exit code for the test suite to
+	// indicate that some combination of provided configurations were not compatible.
+	ExitCodeIncompatibleOptions = 100
+
+	// ExitCodeInvalidOptions is a POSIX compliant exit code for the test suite to indicate
+	// that some of the provided runtime options were not valid and the tests could not run.
+	ExitCodeInvalidOptions = 101
+
+	// ExitCodeCantUseExistingCluster is a POSIX compliant exit code for the test suite to
+	// indicate that an existing cluster provided for the tests was not usable.
+	ExitCodeCantUseExistingCluster = 101
+
+	// ExitCodeCantCreateCluster is a POSIX compliant exit code for the test suite to indicate
+	// that a failure occurred when trying to create a Kubernetes cluster to run the tests.
+	ExitCodeCantCreateCluster = 102
+
+	// ExitCodeCleanupFailed is a POSIX compliant exit code for the test suite to indicate
+	// that a failure occurred during cluster cleanup.
+	ExitCodeCleanupFailed = 103
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables tests for `main` and `next` pushes to run tests for the KIC against a history of Kubernetes versions.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1542