### PR TITLE
[feat] legacy CRD compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
 #### Under the hood
 
 - New `v1` versions of `CustomResourceDefinitions` introduced for KIC 2.0 are now
-  backwards compatible with the previous `v1beta1` CRD definitions. In practice
+  backwards compatible with the previous `v1beta1` CRD definitions (i.e. `v1beta1 -> v1`
+  upgrades of KIC's CustomResourceDefinitions now work fully automatically). In practice
   the upgrade process should be seamless for end-users (e.g. `kubectl apply -f <NEW CRDS>`).
   If you're interested in better understanding the differences and what's going on
   under the hood, please see the relevant PR which includes the user facing changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@
 
 #### Under the hood
 
+- New `v1` versions of `CustomResourceDefinitions` introduced for KIC 2.0 are now
+  backwards compatible with the previous `v1beta1` CRD definitions. In practice
+  the upgrade process should be seamless for end-users (e.g. `kubectl apply -f`).
+  If you're interested in better understanding the differences and what's going on
+  under the hood, please see the relevant PR which includes the user facing changes.
+  [Kubernetes#79604](https://github.com/kubernetes/kubernetes/pull/79604)
+  [#1133](https://github.com/Kong/kubernetes-ingress-controller/issues/1133)
 - The historical `--stderrthreshold` flag is now deprecated: it no longer has
   any effect when used and will be removed in a later release.
   [#1297](https://github.com/Kong/kubernetes-ingress-controller/issues/1297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 - New `v1` versions of `CustomResourceDefinitions` introduced for KIC 2.0 are now
   backwards compatible with the previous `v1beta1` CRD definitions. In practice
-  the upgrade process should be seamless for end-users (e.g. `kubectl apply -f`).
+  the upgrade process should be seamless for end-users (e.g. `kubectl apply -f <NEW CRDS>`).
   If you're interested in better understanding the differences and what's going on
   under the hood, please see the relevant PR which includes the user facing changes.
   [Kubernetes#79604](https://github.com/kubernetes/kubernetes/pull/79604)

--- a/railgun/Makefile
+++ b/railgun/Makefile
@@ -59,6 +59,7 @@ help: ## Display this help.
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	go run hack/generators/manifests/main.go --directory config/crd/bases/
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/railgun/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: KongClusterPluginList
     plural: kongclusterplugins
     singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/railgun/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: KongConsumerList
     plural: kongconsumers
     singular: kongconsumer
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/railgun/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: KongIngressList
     plural: kongingresses
     singular: kongingress
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/railgun/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: KongPluginList
     plural: kongplugins
     singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/railgun/config/crd/bases/configuration.konghq.com_tcpingresses.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_tcpingresses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: TCPIngressList
     plural: tcpingresses
     singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/railgun/config/crd/bases/configuration.konghq.com_udpingresses.yaml
+++ b/railgun/config/crd/bases/configuration.konghq.com_udpingresses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: UDPIngressList
     plural: udpingresses
     singular: udpingress
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/railgun/config/crd/patches/upgrade_compat.yaml
+++ b/railgun/config/crd/patches/upgrade_compat.yaml
@@ -1,0 +1,5 @@
+# The following patch makes upgrading from our v1beta1 CRDs to v1 CRDs clean
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  preserveUnknownFields: false

--- a/railgun/hack/generators/manifests/main.go
+++ b/railgun/hack/generators/manifests/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// -----------------------------------------------------------------------------
+// Vars
+// -----------------------------------------------------------------------------
+
+var (
+	// directory that will be used for walking the filesystem to find CRDs.
+	directory string
+
+	// patchfile is the patch that will be used for each CRD file
+	patchfile = "config/crd/patches/upgrade_compat.yaml"
+)
+
+// -----------------------------------------------------------------------------
+// Main
+//
+// This script exists as a workaround for some problems that arouse between the
+// apiextensions.k8s.io/v1beta1 and apiextensions.k8s.io/v1 versions of the
+// CustomResourceDefinition API.
+//
+// In the v1beta1 version of the API a field called "preserveUnknownFields" was
+// used to trigger pruning for API fields that are sent in the request payload
+// but not a valid part of the API. In v1 this field is effectively deprecated
+// and MUST be set to false:
+//
+//  https://github.com/kubernetes/kubernetes/pull/93078
+//
+// Problematically: even though validation enforces the "false" setting of this
+// deprecated attribute for v1 CRDs, the previous default was "true" in v1beta1
+// and if you try to apply a v1 CRD that does NOT have this field set where a
+// v1beta1 version of the CRD already exists on the cluster this can result in
+// and error and fail to upgrade the CRD.
+//
+// This program accounts for this by applying "preserveUnknownFields: false" to
+// any v1 CustomResourceDefinition to work around the upstream backwards
+// incompatibility issue automatically.
+//
+// NOTE: When this was first written using controller-gen configuration options
+//       and kubebuilder flags on the API types was attempted but none of these
+//       things could produce the right result.
+//
+//       The controller-gen CLI can't really do it (easily) because the default
+//       behavior of the marshaller in sigs.k8s.io/yaml is to not emit optional
+//       boolean fields to YAML if they're set to false. 😑
+//
+//       It's quite possible there's a better way to do this and if you find one
+//       we encourage you to put in a PR and replace this.
+//
+// -----------------------------------------------------------------------------
+
+func main() {
+	// handle arguments
+	flag.StringVar(&directory, "directory", ".", "which directory to find CRDs in")
+	flag.Parse()
+
+	// find all the YAML CRDs in the provided directory and patch them
+	if err := filepath.Walk(directory, processFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Error processing files in %s: %s\n", directory, err)
+		os.Exit(1)
+	}
+}
+
+func processFile(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		return nil
+	}
+
+	// filter out any files that don't identify themselves as YAML files via file extensions
+	if !strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml") {
+		return nil
+	}
+
+	// read in the file contents
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// filter out any YAML files that don't contain a v1.CustomResourceDefinition
+	if !bytes.Contains(b, []byte(`kind: CustomResourceDefinition`)) || !bytes.Contains(b, []byte(`apiVersion: apiextensions.k8s.io/v1`)) {
+		return nil
+	}
+
+	// don't allow files that contain multiple objects (controller-gen wont be configured to emit these anyway)
+	yamlCRDs := bytes.Split(b, []byte(`\n---\n`))
+	if len(yamlCRDs) > 1 {
+		return fmt.Errorf("file %s contained multiple objects (%d) which this script doesn't yet support", path, len(yamlCRDs))
+	}
+
+	// generate a patch command to ensure "preserveUnknownFields" is set to false
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	patchCMD := exec.Command("kubectl", "patch", "--type", "merge", "--local", "-o", "yaml", "-f", path, "--patch-file", patchfile)
+	patchCMD.Stdout = stdout
+	patchCMD.Stderr = stderr
+
+	// run the patcher and make sure there are no errors
+	if err := patchCMD.Run(); err != nil {
+		return fmt.Errorf("failed to patch crd in %s: %w; STDOUT=(%s) STDERR=(%s)",
+			path, err, strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()),
+		)
+	}
+
+	// controller-gen will add a YAML delimiter in the header, so we match that for consistency
+	patchedCRD := append([]byte("\n---\n"), stdout.Bytes()...)
+
+	// write the patched CRD back to the original file
+	return ioutil.WriteFile(path, patchedCRD, info.Mode().Perm())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a workaround for an upstream problem in upgrading `apiextensions.k8s.io/v1beta1` versioned `CustomerResourceDefinitions` to `apiextensions.k8s.io/v1` versioned `CustomResourceDefinitions` in support of making it seamless to upgrade CRDs from KIC v1.x to the new CRDs in KIC v2.x.

For the full details, see the contributed `main.go` which includes documentation to justify its existence.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1133
Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1209

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR