### PR TITLE
chore: temporarily disable auto ctrl loading

### DIFF
--- a/railgun/internal/manager/run.go
+++ b/railgun/internal/manager/run.go
@@ -4,28 +4,18 @@ package manager
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	k8scache "k8s.io/client-go/tools/cache"
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
-	knativeversioned "knative.dev/networking/pkg/client/clientset/versioned"
-	knativeinformerexternal "knative.dev/networking/pkg/client/informers/externalversions"
-	"knative.dev/pkg/signals"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/kong/kubernetes-ingress-controller/pkg/util"
 	konghqcomv1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1"
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/railgun/apis/configuration/v1beta1"
-	"github.com/kong/kubernetes-ingress-controller/railgun/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/railgun/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/railgun/internal/mgrutils"
-	"github.com/kong/kubernetes-ingress-controller/railgun/internal/proxy"
 )
 
 // -----------------------------------------------------------------------------
@@ -110,56 +100,6 @@ func Run(ctx context.Context, c *Config) error {
 		setupLog.Info("WARNING: status updates were disabled, resources like Ingress objects will not receive updates to their statuses.")
 	}
 
-	go func() {
-		if err := FlipKnativeController(mgr, proxy, &c.KnativeIngressEnabled, c, setupLog); err != nil {
-			panic(err)
-		}
-	}()
-
 	setupLog.Info("starting manager")
 	return mgr.Start(ctx)
-}
-
-// wait for knative cr before register and starting knative controller
-func FlipKnativeController(mgr manager.Manager, proxy proxy.Proxy, enablestatus *util.EnablementStatus, cfg *Config, log logr.Logger) error {
-	if *enablestatus == util.EnablementStatusEnabled {
-		log.Info("knative controller already enabled. skip flip process.\n")
-		return nil
-	}
-	kubeCfg, err := cfg.GetKubeconfig()
-	if err != nil || kubeCfg == nil {
-		return fmt.Errorf("failed to generate incluster configuration. err %v", err)
-	}
-	knativeCli, err := knativeversioned.NewForConfig(kubeCfg)
-	if err != nil {
-		return fmt.Errorf("failed to generate knative client. err %v", err)
-	}
-	knativeFactory := knativeinformerexternal.NewSharedInformerFactory(knativeCli, 0)
-	knativeInformer := knativeFactory.Networking().V1alpha1().Ingresses().Informer()
-	_, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	knativeInformer.AddEventHandler(&k8scache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			log.Info("knative networking customer resource added.")
-			if *enablestatus == util.EnablementStatusDisabled {
-				log.Info("knative controller does not exist. register one.")
-				knative := configuration.Knativev1alpha1IngressReconciler{
-					Client:           mgr.GetClient(),
-					Log:              ctrl.Log.WithName("controllers").WithName("Ingress").WithName("KnativeV1Alpha1"),
-					Scheme:           mgr.GetScheme(),
-					IngressClassName: cfg.IngressClassName,
-					Proxy:            proxy,
-				}
-				if err := knative.SetupWithManager(mgr); err != nil {
-					panic(err)
-				}
-				*enablestatus = util.EnablementStatusEnabled
-			} else {
-				log.Info("knative controller already on. Skip registration.")
-			}
-			cancel()
-		},
-	})
-	stopCh := signals.SetupSignalHandler()
-	knativeFactory.Start(stopCh)
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes some preliminary functionality we had put in
place to automatically load the Knative controller based
on the CRD showing up in the cluster during controller
manager runtime. This functionality is desired, but is
being temporarily pulled back so that we can consider it
as a feature again later for multiple CRDs.

See: https://github.com/Kong/kubernetes-ingress-controller/issues/1449