### PR TITLE
[fix] enable all v1 crds for kustomize

### DIFF
--- a/railgun/config/crd/kustomization.yaml
+++ b/railgun/config/crd/kustomization.yaml
@@ -2,6 +2,10 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
+- bases/configuration.konghq.com_kongclusterplugins.yaml
+- bases/configuration.konghq.com_kongplugins.yaml
+- bases/configuration.konghq.com_kongconsumers.yaml
+- bases/configuration.konghq.com_kongingresses.yaml
 - bases/configuration.konghq.com_tcpingresses.yaml
 - bases/configuration.konghq.com_udpingresses.yaml
 #+kubebuilder:scaffold:crdkustomizeresource


### PR DESCRIPTION
**What this PR does / why we need it**:

The Kustomize configuration for CRDs was missing configuration for _all_ our CRDs, this fixes that.

**Which issue this PR fixes**

Doesn't complete, but is in support of https://github.com/Kong/charts/issues/391
