### PR TITLE
Fix Ingress v1beta1 API resource group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@
 - Added scripts to generate 2.x manifests.
   [#1563](https://github.com/Kong/kubernetes-ingress-controller/pull/1563)
 
+#### Fixed
+
+- Corrected the old Ingress v1beta1 API group.
+  [#1584](https://github.com/Kong/kubernetes-ingress-controller/pull/1584)
+
 #### Under the hood
 
 - New `v1` versions of `CustomResourceDefinitions` introduced for KIC 2.0 are now

--- a/deploy/single-v2/all-in-one-dbless.yaml
+++ b/deploy/single-v2/all-in-one-dbless.yaml
@@ -1105,22 +1105,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -1212,6 +1196,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch

--- a/deploy/single-v2/all-in-one-enterprise-dbless.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-dbless.yaml
@@ -1105,22 +1105,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -1212,6 +1196,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch

--- a/deploy/single-v2/all-in-one-enterprise-postgres.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-postgres.yaml
@@ -1105,22 +1105,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -1212,6 +1196,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch

--- a/deploy/single-v2/all-in-one-postgres.yaml
+++ b/deploy/single-v2/all-in-one-postgres.yaml
@@ -1105,22 +1105,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -1212,6 +1196,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch

--- a/railgun/config/rbac/role.yaml
+++ b/railgun/config/rbac/role.yaml
@@ -75,22 +75,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -182,6 +166,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch
@@ -296,22 +296,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins
@@ -403,6 +387,22 @@ rules:
   - configuration.konghq.com
   resources:
   - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
   verbs:
   - get
   - patch

--- a/railgun/hack/generators/controllers/networking/main.go
+++ b/railgun/hack/generators/controllers/networking/main.go
@@ -98,7 +98,7 @@ var inputControllersNeeded = &typesNeeded{
 		Package:                           extv1beta1,
 		Type:                              "Ingress",
 		Plural:                            "ingresses",
-		URL:                               "apiextensions.k8s.io",
+		URL:                               "extensions",
 		CacheType:                         "IngressV1beta1",
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,

--- a/railgun/internal/controllers/configuration/zz_generated_controllers.go
+++ b/railgun/internal/controllers/configuration/zz_generated_controllers.go
@@ -446,10 +446,10 @@ func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).For(&extv1beta1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=ingresses,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=ingresses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=extensions,resources=ingresses/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=extensions,namespace=CHANGEME,resources=ingresses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=extensions,namespace=CHANGEME,resources=ingresses/status,verbs=get;update;patch
 
 // Reconcile processes the watched objects
 func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the API group (URL) for the original v1beta1 Ingress from `apiextensions.k8s.io` to `extensions`.

**Which issue this PR fixes**:
AFAICT this was just wrong originally, and was never caught because integration tests only try against one Ingress version (V1). apiextensions contains the CRD definition, not Ingress. Caught while reviewing permissions differences between v1 and v2.

**Notes**
[First commit](4d24c8f5d06295b81908c91b93fdbacba193f320) is the actual change. Most of the diff is from running generators afer. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
