### PR TITLE
Add configuration dumps for 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   [#1509](https://github.com/Kong/kubernetes-ingress-controller/pull/1509)
 - Added scripts to generate 2.x manifests.
   [#1563](https://github.com/Kong/kubernetes-ingress-controller/pull/1563)
+- Added support for --dump-config to 2.x.
+  [#1589](https://github.com/Kong/kubernetes-ingress-controller/pull/1589)
 
 #### Fixed
 

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -13,7 +13,7 @@ func Run(ctx context.Context, c *manager.Config) error {
 	}
 	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c)
 	if err != nil {
-		return fmt.Errorf("StartDiagnosticsServer: %w", err)
+		return fmt.Errorf("failed to start diagnostics server: %w", err)
 	}
 	return manager.Run(ctx, c, diag.ConfigDumps)
 }

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -11,8 +11,9 @@ func Run(ctx context.Context, c *manager.Config) error {
 	if err := StartAdmissionServer(ctx, c); err != nil {
 		return fmt.Errorf("StartAdmissionServer: %w", err)
 	}
-	if err := StartProfilingServer(ctx, c); err != nil {
-		return fmt.Errorf("StartProfilingServer: %w", err)
+	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c)
+	if err != nil {
+		return fmt.Errorf("StartDiagnosticsServer: %w", err)
 	}
-	return manager.Run(ctx, c)
+	return manager.Run(ctx, c, diag.ConfigDumps)
 }

--- a/internal/cmd/rootcmd/servers.go
+++ b/internal/cmd/rootcmd/servers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/bombsimon/logrusr"
-	"github.com/kong/deck/file"
 
 	"github.com/kong/kubernetes-ingress-controller/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/internal/diagnostics"
@@ -66,8 +65,7 @@ func StartDiagnosticsServer(ctx context.Context, port int, c *manager.Config) (d
 	if c.EnableConfigDumps {
 		s.ConfigDumps = util.ConfigDumpDiagnostic{
 			DumpsIncludeSensitive: c.DumpSensitiveConfig,
-			SuccessfulConfigs:     make(chan file.Content, 3),
-			FailedConfigs:         make(chan file.Content, 3),
+			Configs:               make(chan util.ConfigDump, 3),
 		}
 	}
 	go func() {

--- a/internal/cmd/rootcmd/servers.go
+++ b/internal/cmd/rootcmd/servers.go
@@ -66,8 +66,8 @@ func StartDiagnosticsServer(ctx context.Context, port int, c *manager.Config) (d
 	if c.EnableConfigDumps {
 		s.ConfigDumps = util.ConfigDumpDiagnostic{
 			DumpsIncludeSensitive: c.DumpSensitiveConfig,
-			SuccessfulConfigs:     make(chan file.Content),
-			FailedConfigs:         make(chan file.Content),
+			SuccessfulConfigs:     make(chan file.Content, 3),
+			FailedConfigs:         make(chan file.Content, 3),
 		}
 	}
 	go func() {

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -69,7 +69,7 @@ func (s *Server) receiveConfig(ctx context.Context) {
 	for {
 		select {
 		case dump := <-s.ConfigDumps.Configs:
-			if dump.Failed {
+			if !dump.Failed {
 				successfulConfigDump = dump.Config
 			} else {
 				failedConfigDump = dump.Config

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -68,10 +68,12 @@ func (s *Server) Listen(ctx context.Context, port int) error {
 func (s *Server) receiveConfig(ctx context.Context) {
 	for {
 		select {
-		case dump := <-s.ConfigDumps.SuccessfulConfigs:
-			successfulConfigDump = dump
-		case dump := <-s.ConfigDumps.FailedConfigs:
-			failedConfigDump = dump
+		case dump := <-s.ConfigDumps.Configs:
+			if dump.Failed {
+				successfulConfigDump = dump.Config
+			} else {
+				failedConfigDump = dump.Config
+			}
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
 				s.Logger.Error(err, "error received while stopping diagnostic config collection")

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -27,6 +27,7 @@ var failedConfigDump file.Content
 
 // Listen starts up the HTTP server and blocks until ctx expires.
 func (s *Server) Listen(ctx context.Context, port int) error {
+	s.lock1 = sync.RWMutex{}
 	mux := http.NewServeMux()
 	if s.ConfigDumps != (util.ConfigDumpDiagnostic{}) {
 		s.installDumpHandlers(mux)

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -73,6 +73,10 @@ func (s *Server) receiveConfig(ctx context.Context) {
 		case dump := <-s.ConfigDumps.FailedConfigs:
 			failedConfigDump = dump
 		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				s.Logger.Error(err, "error received while stopping diagnostic config collection")
+			}
+			s.Logger.V(3).Info("shutting down diagnostic config collection")
 			return
 		}
 	}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -79,8 +79,10 @@ type Config struct {
 	// Admission Webhook server config
 	AdmissionServer admission.ServerConfig
 
-	// Performance monitoring
-	EnableProfiling bool
+	// Diagnostics and performance
+	EnableProfiling     bool
+	EnableConfigDumps   bool
+	DumpSensitiveConfig bool
 }
 
 // -----------------------------------------------------------------------------
@@ -183,8 +185,10 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.AdmissionServer.Key, "admission-webhook-key", "",
 		`admission server PEM private key value`)
 
-	// Misc
-	flagSet.BoolVar(&c.EnableProfiling, "profiling", false, "Enable profiling via web interface host:10256/debug/pprof/")
+	// Diagnostics
+	flagSet.BoolVar(&c.EnableProfiling, "profiling", false, fmt.Sprintf("Enable profiling via web interface host:%v/debug/pprof/", DiagnosticsPort))
+	flagSet.BoolVar(&c.EnableConfigDumps, "dump-config", false, fmt.Sprintf("Enable config dumps via web interface host:%v/debug/config", DiagnosticsPort))
+	flagSet.BoolVar(&c.DumpSensitiveConfig, "dump-sensitive-config", false, "Include credentials and TLS secrets in configs exposed with --dump-config")
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/internal/mgrutils"
+	"github.com/kong/kubernetes-ingress-controller/internal/util"
 	konghqcomv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1beta1"
 )
@@ -23,7 +24,7 @@ import (
 // -----------------------------------------------------------------------------
 
 // Run starts the controller manager and blocks until it exits.
-func Run(ctx context.Context, c *Config) error {
+func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) error {
 	deprecatedLogger, logger, err := setupLoggers(c)
 	if err != nil {
 		return err
@@ -59,7 +60,7 @@ func Run(ctx context.Context, c *Config) error {
 	}
 
 	setupLog.Info("configuring and building the proxy cache server")
-	proxy, err := setupProxyServer(ctx, setupLog, deprecatedLogger, mgr, kongConfig, c)
+	proxy, err := setupProxyServer(ctx, setupLog, deprecatedLogger, mgr, kongConfig, diagnostic, c)
 	if err != nil {
 		return fmt.Errorf("unable to start proxy cache server: %w", err)
 	}

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -99,7 +99,8 @@ func setupKongConfig(ctx context.Context, logger logr.Logger, c *Config) (sendco
 
 func setupProxyServer(ctx context.Context,
 	logger logr.Logger, fieldLogger logrus.FieldLogger,
-	mgr manager.Manager, kongConfig sendconfig.Kong, c *Config,
+	mgr manager.Manager, kongConfig sendconfig.Kong,
+	diagnostic util.ConfigDumpDiagnostic, c *Config,
 ) (proxy.Proxy, error) {
 	if c.ProxySyncSeconds < proxy.DefaultSyncSeconds {
 		logger.Info(fmt.Sprintf("WARNING: --proxy-sync-seconds is configured for %fs, in DBLESS mode this may result in"+
@@ -128,5 +129,6 @@ func setupProxyServer(ctx context.Context,
 		c.EnableReverseSync,
 		syncTickDuration,
 		timeoutDuration,
+		diagnostic,
 		sendconfig.UpdateKongAdminSimple)
 }

--- a/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -7,15 +7,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kong/kubernetes-ingress-controller/internal/store"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/internal/util"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
 func Test_FetchCustomEntities(t *testing.T) {
@@ -101,7 +103,8 @@ func TestCaching(t *testing.T) {
 	defer cancel()
 
 	t.Log("configuring and starting a new proxy server")
-	proxyInterface, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false, mockKongAdmin, time.Millisecond*300)
+	proxyInterface, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig,
+		"kongtests", false, mockKongAdmin, util.ConfigDumpDiagnostic{}, time.Millisecond*300)
 	assert.NoError(t, err)
 
 	t.Log("ensuring the integrity of the proxy server")
@@ -189,6 +192,6 @@ func TestProxyTimeout(t *testing.T) {
 	// to see the the context deadline for the http response triggered.
 	timeout := time.Millisecond * 10
 
-	_, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false, mockKongAdmin, timeout)
+	_, err := NewCacheBasedProxy(ctx, logger, fakeK8sClient, fakeKongConfig, "kongtests", false, mockKongAdmin, util.ConfigDumpDiagnostic{}, timeout)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/internal/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/internal/util"
 )
 
 // -----------------------------------------------------------------------------
@@ -75,4 +76,5 @@ type KongUpdater func(ctx context.Context,
 	ingressClassName string,
 	deprecatedLogger logrus.FieldLogger,
 	kongConfig sendconfig.Kong,
-	enableReverseSync bool) ([]byte, error)
+	enableReverseSync bool,
+	diagnostic util.ConfigDumpDiagnostic) ([]byte, error)

--- a/internal/proxy/suite_test.go
+++ b/internal/proxy/suite_test.go
@@ -80,7 +80,8 @@ var mockKongAdmin KongUpdater = func(ctx context.Context,
 	ingressClassName string,
 	deprecatedLogger logrus.FieldLogger,
 	kongConfig sendconfig.Kong,
-	enableReverseSync bool) ([]byte, error) {
+	enableReverseSync bool,
+	diagnostic util.ConfigDumpDiagnostic) ([]byte, error) {
 	fakeKongAdminUpdateCount(1)
 	return lastConfigSHA, nil
 }

--- a/internal/sendconfig/common_workflows.go
+++ b/internal/sendconfig/common_workflows.go
@@ -79,7 +79,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 			case diagnostic.Configs <- util.ConfigDump{Failed: true, Config: *diagnosticConfig}:
 				deprecatedLogger.Debug("shipping config to diagnostic server")
 			default:
-				deprecatedLogger.Debug("config diagnostic buffer full, dropping diagnostic config")
+				deprecatedLogger.Error("config diagnostic buffer full, dropping diagnostic config")
 			}
 		}
 		return nil, err
@@ -89,7 +89,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 		case diagnostic.Configs <- util.ConfigDump{Failed: false, Config: *diagnosticConfig}:
 			deprecatedLogger.Debug("shipping config to diagnostic server")
 		default:
-			deprecatedLogger.Debug("config diagnostic buffer full, dropping diagnostic config")
+			deprecatedLogger.Error("config diagnostic buffer full, dropping diagnostic config")
 		}
 	}
 

--- a/internal/sendconfig/common_workflows.go
+++ b/internal/sendconfig/common_workflows.go
@@ -54,7 +54,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 	if diagnostic != (util.ConfigDumpDiagnostic{}) {
 		if !diagnostic.DumpsIncludeSensitive {
 			redactedConfig := deckgen.ToDeckContent(ctx,
-				deprecatedLogger, kongstate,
+				deprecatedLogger, kongstate.SanitizedCopy(),
 				kongConfig.PluginSchemaStore, kongConfig.FilterTags)
 			diagConfig = redactedConfig
 		} else {

--- a/internal/sendconfig/common_workflows.go
+++ b/internal/sendconfig/common_workflows.go
@@ -73,7 +73,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 	if err != nil {
 		if diagnostic != (util.ConfigDumpDiagnostic{}) {
 			select {
-			case diagnostic.FailedConfigs <- *diagConfig:
+			case diagnostic.Configs <- util.ConfigDump{Failed: true, Config: *diagConfig}:
 				deprecatedLogger.Debug("shipping config to diagnostic server")
 			default:
 				deprecatedLogger.Debug("config diagnostic buffer full, dropping diagnostic config")
@@ -83,7 +83,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 	}
 	if diagnostic != (util.ConfigDumpDiagnostic{}) {
 		select {
-		case diagnostic.SuccessfulConfigs <- *diagConfig:
+		case diagnostic.Configs <- util.ConfigDump{Failed: false, Config: *diagConfig}:
 			deprecatedLogger.Debug("shipping config to diagnostic server")
 		default:
 			deprecatedLogger.Debug("config diagnostic buffer full, dropping diagnostic config")

--- a/internal/util/configdiag.go
+++ b/internal/util/configdiag.go
@@ -2,9 +2,14 @@ package util
 
 import "github.com/kong/deck/file"
 
+// ConfigDump contains a config dump and a flag indicating that the config was not successfully applid
+type ConfigDump struct {
+	Config file.Content
+	Failed bool
+}
+
 // ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps
 type ConfigDumpDiagnostic struct {
 	DumpsIncludeSensitive bool
-	SuccessfulConfigs     chan file.Content
-	FailedConfigs         chan file.Content
+	Configs               chan ConfigDump
 }

--- a/internal/util/configdiag.go
+++ b/internal/util/configdiag.go
@@ -1,0 +1,10 @@
+package util
+
+import "github.com/kong/deck/file"
+
+// ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps
+type ConfigDumpDiagnostic struct {
+	DumpsIncludeSensitive bool
+	SuccessfulConfigs     chan file.Content
+	FailedConfigs         chan file.Content
+}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -81,17 +81,17 @@ func TestConfigEndpoint(t *testing.T) {
 		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)
 		successResp, err := httpc.Get(successURL)
+		defer successResp.Body.Close()
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", successURL, err)
 			return false
 		}
-		defer successResp.Body.Close()
 		failResp, err := httpc.Get(failURL)
+		defer failResp.Body.Close()
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", failURL, err)
 			return false
 		}
-		defer failResp.Body.Close()
 		return successResp.StatusCode == http.StatusOK && failResp.StatusCode == http.StatusOK
 	}, ingressWait, waitTick)
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -82,13 +82,13 @@ func TestConfigEndpoint(t *testing.T) {
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)
 		successResp, err := httpc.Get(successURL)
 		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", profilingURL, err)
+			t.Logf("WARNING: error while waiting for %s: %v", successURL, err)
 			return false
 		}
 		defer successResp.Body.Close()
 		failResp, err := httpc.Get(failURL)
 		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", profilingURL, err)
+			t.Logf("WARNING: error while waiting for %s: %v", failURL, err)
 			return false
 		}
 		defer failResp.Body.Close()

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -92,6 +92,6 @@ func TestConfigEndpoint(t *testing.T) {
 			return false
 		}
 		defer failResp.Body.Close()
-		return successResp == failResp.StatusCode == http.StatusOK
+		return successResp.StatusCode == http.StatusOK && failResp.StatusCode == http.StatusOK
 	}, ingressWait, waitTick)
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -72,3 +72,26 @@ func TestProfilingEndpoint(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, ingressWait, waitTick)
 }
+
+func TestConfigEndpoint(t *testing.T) {
+	if useLegacyKIC() {
+		t.Skip("config endpoint not available in legacy KIC")
+	}
+	assert.Eventually(t, func() bool {
+		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
+		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)
+		successResp, err := httpc.Get(successURL)
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", profilingURL, err)
+			return false
+		}
+		defer successResp.Body.Close()
+		failResp, err := httpc.Get(failURL)
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", profilingURL, err)
+			return false
+		}
+		defer failResp.Body.Close()
+		return successResp == failResp.StatusCode == http.StatusOK
+	}, ingressWait, waitTick)
+}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -312,6 +312,7 @@ func deployControllers(ctx context.Context, namespace string) error {
 				"--controller-kongclusterplugin=enabled",
 				"--controller-kongplugin=enabled",
 				"--controller-kongconsumer=disabled",
+				"--dump-config",
 				"--election-id=integrationtests.konghq.com",
 				"--publish-service=kong-system/ingress-controller-kong-proxy",
 				fmt.Sprintf("--watch-namespace=%s", watchNamespaces),


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `--dump-config` to 2.x. Expose successful and failed configurations via a new endpoint on the diagnostics server.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1308 

**Special notes for your reviewer**:
This intentionally introduces breaking changes from 1.x:
- Dumped configs are no longer saved to the filesystem. The diagnostic server is less cumbersome to use.
- Flag now accepts a boolean with an additional `--dump-sensitive-config` flag for redaction, rather than a single flag that accepts various string modes.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
