### PR TITLE
use only github.com/google/uuid for uuid generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
   flag has been deprecated and will no longer have any effect, it will be removed
   in a later release.
   [#1304](https://github.com/Kong/kubernetes-ingress-controller/issues/1304)
+- The uuid generation is now done by the same library in the whole project
+[#1604](https://github.com/Kong/kubernetes-ingress-controller/issues/1604)
 
 ## [2.0.0-alpha.2] - 2021/07/07
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.20.0

--- a/internal/mgrutils/reports.go
+++ b/internal/mgrutils/reports.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/go-uuid"
+	"github.com/google/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -28,10 +28,7 @@ func RunReport(ctx context.Context, kubeCfg *rest.Config, kongCfg sendconfig.Kon
 	}
 
 	// create a universal unique identifier for this system
-	uuid, err := uuid.GenerateUUID()
-	if err != nil {
-		return fmt.Errorf("failed to generate a random uuid: %w", err)
-	}
+	uuid := uuid.NewString()
 
 	// record the current Kubernetes server version
 	kc, err := kubernetes.NewForConfig(kubeCfg)

--- a/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -119,7 +119,7 @@ func TestCaching(t *testing.T) {
 	t.Log("generating 10 new objects to the proxy cache server")
 	testObjects := make([]client.Object, 10)
 	for i := 0; i < 10; i++ {
-		name := uuid.New().String()
+		name := uuid.NewString()
 		deployment := generators.NewDeploymentForContainer(generators.NewContainer(name, name, 8080))
 		service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
 		ingress := generators.NewIngressForService("/testing", nil, service)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This use only one library as direct dependency for uuid generation as it was done on go-kong and deck before

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
