### PR TITLE
Remove legacy tests from next

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ KIND_CLUSTER_NAME ?= "integration-tests"
 test.all: test test.integration
 
 .PHONY: test.integration
-test.integration: test.integration.legacy test.integration.dbless test.integration.postgres
+test.integration: test.integration.dbless test.integration.postgres
 
 .PHONY: test
 test:

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -28,9 +28,6 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestMetricsEndpoint(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("metrics endpoint test does not apply to legacy KIC")
-	}
 	assert.Eventually(t, func() bool {
 		metricsURL := fmt.Sprintf("http://localhost:%v/metrics", manager.MetricsPort)
 		resp, err := httpc.Get(metricsURL)
@@ -58,9 +55,6 @@ func TestMetricsEndpoint(t *testing.T) {
 }
 
 func TestProfilingEndpoint(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("profiling endpoint behaves differently in legacy KIC")
-	}
 	assert.Eventually(t, func() bool {
 		profilingURL := fmt.Sprintf("http://localhost:%v/debug/pprof/", manager.DiagnosticsPort)
 		resp, err := httpc.Get(profilingURL)
@@ -74,9 +68,6 @@ func TestProfilingEndpoint(t *testing.T) {
 }
 
 func TestConfigEndpoint(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("config endpoint not available in legacy KIC")
-	}
 	assert.Eventually(t, func() bool {
 		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -308,9 +308,6 @@ func TestIngressClassNameSpec(t *testing.T) {
 }
 
 func TestIngressNamespaces(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("support for distinct namespace watches is not supported in legacy KIC")
-	}
 	ctx := context.Background()
 
 	// ensure the alternative namespace is created

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -33,10 +33,6 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("knative is supported in KIC 1.3.x and skip in legacy KIC")
-	}
-
 	cluster := env.Cluster()
 	proxy := proxyURL.Hostname()
 	assert.NotEmpty(t, proxy)

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -26,11 +26,6 @@ import (
 const testUDPIngressNamespace = "udpingress"
 
 func TestUDPIngressEssentials(t *testing.T) {
-	// TODO: once KIC 2.0 lands and pre v2 is gone, we can remove this check
-	if useLegacyKIC() {
-		t.Skip("legacy KIC does not support UDPIngress, skipping")
-	}
-
 	testName := "minudp"
 	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
 	defer cancel()

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -20,9 +20,6 @@ import (
 const defaultNs = "default"
 
 func TestValidationWebhook(t *testing.T) {
-	if useLegacyKIC() {
-		t.Skip("not testing validation webhook for KIC 1.x")
-	}
 	ctx := context.Background()
 
 	const webhookSvcName = "validations"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove the legacy integration tests from the main integration test Makefile target. They weren't there previously and aren't normally run, and slow local tests considerably.
- Remove the legacy KIC handling from the modern integration tests. After #1595 they are no longer usable on this branch.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
