### PR TITLE
fix: increase the default for proxy requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 
 #### Fixed
 
+- Increased the default timeout strategy for backend proxy HTTP requests
+  from 3 seconds to 10 seconds.
+  [#1610](https://github.com/Kong/kubernetes-ingress-controller/pull/1610)
 - Corrected the old Ingress v1beta1 API group.
   [#1584](https://github.com/Kong/kubernetes-ingress-controller/pull/1584)
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -130,7 +130,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds)",
 			proxy.DefaultSyncSeconds,
 		))
-	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", proxy.DefaultSyncSeconds,
+	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", proxy.DefaultProxyTimeoutSeconds,
 		fmt.Sprintf(
 			"Define the rate (in seconds) in which the timeout configuration will be applied to the Kong client. (default: %g seconds)",
 			proxy.DefaultSyncSeconds,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -16,6 +16,13 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
+	// DefaultProxyTimeoutSeconds indicates the time.Duration allowed for responses to
+	// come back from the backend proxy API.
+	//
+	// NOTE: the current default is based on observed latency in a CI environment using
+	// the GKE cloud provider.
+	DefaultProxyTimeoutSeconds float32 = 10.0
+
 	// DefaultSyncSeconds indicates the time.Duration (minimum) that will occur between
 	// updates to the Kong Proxy Admin API when using the NewProxy() constructor.
 	// this 1s default was based on local testing wherein it appeared sub-second updates


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the default proxy timeout based on experiences in GKE (which was failing).

**Which issue this PR fixes**

Adds fixes that supports https://github.com/Kong/kubernetes-ingress-controller/issues/1095
Supports the analysis found in https://github.com/Kong/kubernetes-ingress-controller/issues/1519

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
