### PR TITLE
chore: clean up coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,8 @@ container:
 # Test
 # ------------------------------------------------------------------------------
 
-PKG_LIST = ./...
+PKG_LIST = ./pkg/...,./internal/...
 COVERAGE_PROFILE=coverage.out
-COVERAGE_INTEGRATION_PROFILE=coverage-integration.out
 KIND_CLUSTER_NAME ?= "integration-tests"
 
 .PHONY: test.all
@@ -177,14 +176,14 @@ test.integration.legacy: container
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
+	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./...
 
 # TODO: race checking has been temporarily turned off because of race conditions found with deck. This will be resolved in an upcoming Alpha release of KIC 2.0.
 #       See: https://github.com/Kong/kubernetes-ingress-controller/issues/1324
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) ./test/integration/
+	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./...
 
 # ------------------------------------------------------------------------------
 # Operations


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch reduces the packages we want coverage
for to pkg/ and internal/ (where all our code lives
now minus scripts and some build tools) and turns
on unit tests during the integration test runs to
capture more coverage data.