### PR TITLE
[fix] disable proxy backpressure mechanism

### DIFF
--- a/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -31,13 +31,13 @@ func NewCacheBasedProxy(ctx context.Context,
 	enableReverseSync bool,
 	kongUpdater KongUpdater,
 	diagnostic util.ConfigDumpDiagnostic,
-	timeout time.Duration,
+	proxyRequestTimeout time.Duration,
 ) (Proxy, error) {
 	stagger, err := time.ParseDuration(fmt.Sprintf("%gs", DefaultSyncSeconds))
 	if err != nil {
 		return nil, err
 	}
-	return NewCacheBasedProxyWithStagger(ctx, logger, k8s, kongConfig, ingressClassName, enableReverseSync, stagger, timeout, diagnostic, kongUpdater)
+	return NewCacheBasedProxyWithStagger(ctx, logger, k8s, kongConfig, ingressClassName, enableReverseSync, stagger, proxyRequestTimeout, diagnostic, kongUpdater)
 }
 
 // NewCacheBasedProxy will provide a new Proxy object. Note that this starts some background goroutines and the caller
@@ -50,7 +50,7 @@ func NewCacheBasedProxyWithStagger(ctx context.Context,
 	ingressClassName string,
 	enableReverseSync bool,
 	stagger time.Duration,
-	timeout time.Duration,
+	proxyRequestTimeout time.Duration,
 	diagnostic util.ConfigDumpDiagnostic,
 	kongUpdater KongUpdater,
 ) (Proxy, error) {
@@ -70,10 +70,10 @@ func NewCacheBasedProxyWithStagger(ctx context.Context,
 		ingressClassName: ingressClassName,
 		stopCh:           make(chan struct{}),
 
-		ctx:        ctx,
-		stagger:    stagger,
-		timeout:    timeout,
-		syncTicker: time.NewTicker(stagger),
+		ctx:                 ctx,
+		stagger:             stagger,
+		proxyRequestTimeout: proxyRequestTimeout,
+		syncTicker:          time.NewTicker(stagger),
 	}
 
 	// initialize the proxy which validates connectivity with the Admin API and
@@ -122,13 +122,13 @@ type clientgoCachedProxyResolver struct {
 	kongUpdater KongUpdater
 	diagnostic  util.ConfigDumpDiagnostic
 
-	// cache server configuration, flow control, channels and utility attributes
-	ingressClassName string
-	ctx              context.Context
-	stagger          time.Duration
-	timeout          time.Duration
-	syncTicker       *time.Ticker
-	stopCh           chan struct{}
+	// server configuration, flow control, channels and utility attributes
+	ingressClassName    string
+	ctx                 context.Context
+	stagger             time.Duration
+	proxyRequestTimeout time.Duration
+	syncTicker          *time.Ticker
+	stopCh              chan struct{}
 
 	// New code should log using "logger". "deprecatedLogger" is here for compatibility with legacy code that relies
 	// on the logrus API.
@@ -171,7 +171,7 @@ func (p *clientgoCachedProxyResolver) startProxyUpdateServer() {
 			return
 		case <-p.syncTicker.C:
 			updateConfigSHA, err := p.kongUpdater(p.ctx, p.lastConfigSHA, p.cache,
-				p.ingressClassName, p.deprecatedLogger, p.kongConfig, p.enableReverseSync, p.diagnostic)
+				p.ingressClassName, p.deprecatedLogger, p.kongConfig, p.enableReverseSync, p.diagnostic, p.proxyRequestTimeout)
 			if err != nil {
 				p.logger.Error(err, "could not update kong admin")
 				break
@@ -235,7 +235,7 @@ func (p *clientgoCachedProxyResolver) initialize() error {
 // kongRootWithTimeout provides the root configuration from Kong, but uses a configurable timeout to avoid long waits if the Admin API
 // is not yet ready to respond. If a timeout error occurs, the caller is responsible for providing a retry mechanism.
 func (p *clientgoCachedProxyResolver) kongRootWithTimeout() (map[string]interface{}, error) {
-	ctx, cancel := context.WithTimeout(p.ctx, p.timeout)
+	ctx, cancel := context.WithTimeout(p.ctx, p.proxyRequestTimeout)
 	defer cancel()
 	return p.kongConfig.Client.Root(ctx)
 }

--- a/internal/proxy/clientgo_cached_proxy_resolver_test.go
+++ b/internal/proxy/clientgo_cached_proxy_resolver_test.go
@@ -149,31 +149,6 @@ func TestCaching(t *testing.T) {
 		}
 	}
 	require.Equal(t, len(testObjects), matches)
-
-	t.Log("flushing the cache state to kong admin api")
-	proxy.syncTicker.Reset(time.Millisecond * 50)
-
-	t.Logf("ensuring that only a single update to the backend was performed, but that all cache objects are accounted for")
-	assert.Eventually(t, func() bool {
-		return fakeKongAdminUpdateCount() == 1 && len(proxy.cache.IngressV1.List()) == len(testObjects)
-	}, time.Second*5, time.Millisecond*50)
-
-	t.Log("freezing updates to the cache again")
-	fakeKongAdminUpdateCount(0) // reset the test counter
-	proxy.syncTicker.Reset(time.Minute * 3)
-
-	t.Log("deleting all the objects from the cache")
-	for _, testObj := range testObjects {
-		require.NoError(t, proxy.DeleteObject(testObj))
-	}
-
-	t.Log("flushing the cache state to kong admin api again")
-	proxy.syncTicker.Reset(time.Millisecond * 50)
-
-	t.Logf("ensuring that only a single update to the backend was performed when the cache is settled and not receiving further updates. verifying that all cache objects were removed")
-	assert.Eventually(t, func() bool {
-		return fakeKongAdminUpdateCount() == 1 && len(proxy.cache.IngressV1.List()) == 0
-	}, time.Second*5, time.Millisecond*50)
 }
 
 func TestProxyTimeout(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,4 +69,6 @@ type KongUpdater func(ctx context.Context,
 	deprecatedLogger logrus.FieldLogger,
 	kongConfig sendconfig.Kong,
 	enableReverseSync bool,
-	diagnostic util.ConfigDumpDiagnostic) ([]byte, error)
+	diagnostic util.ConfigDumpDiagnostic,
+	proxyRequestTimeout time.Duration,
+) ([]byte, error)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -32,22 +32,6 @@ const (
 	//
 	// See Also: https://github.com/Kong/kubernetes-ingress-controller/issues/1398
 	DefaultSyncSeconds float32 = 3.0
-
-	// DefaultObjectBufferSize is the number of client.Objects that the server will buffer
-	// before it starts rejecting new objects while it processes the originals.
-	// If you get to the point that objects are rejected, you'll find that the
-	// UpdateObject() and DeleteObject() methods will start throwing errors and you'll
-	// need to retry queing the object at a later time.
-	//
-	// NOTE: implementations of the Proxy interface should error, not block on full buffer.
-	//
-	// TODO: the current default of 50 is based on a loose approximation to allow ~5mb
-	//       of buffer space for client.Objects and assuming a throughput of ~50 API
-	//       updates per second, but in the future we may want to make this configurable,
-	//       provide metrics for it, and furthermore automate detecting good values for it.
-	//       depending on configuration and/or available system memory and the amount of
-	//       throughput (in Kubernetes object updates) that the API is meant to handle.
-	DefaultObjectBufferSize = 500
 )
 
 // -----------------------------------------------------------------------------

--- a/internal/proxy/suite_test.go
+++ b/internal/proxy/suite_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	kongt "github.com/kong/kubernetes-testing-framework/pkg/utils/kong"
 	"github.com/sirupsen/logrus"
@@ -81,7 +82,9 @@ var mockKongAdmin KongUpdater = func(ctx context.Context,
 	deprecatedLogger logrus.FieldLogger,
 	kongConfig sendconfig.Kong,
 	enableReverseSync bool,
-	diagnostic util.ConfigDumpDiagnostic) ([]byte, error) {
+	diagnostic util.ConfigDumpDiagnostic,
+	proxyRequestTimeout time.Duration,
+) ([]byte, error) {
 	fakeKongAdminUpdateCount(1)
 	return lastConfigSHA, nil
 }

--- a/internal/sendconfig/common_workflows.go
+++ b/internal/sendconfig/common_workflows.go
@@ -38,6 +38,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 	kongConfig Kong,
 	enableReverseSync bool,
 	diagnostic util.ConfigDumpDiagnostic,
+	proxyRequestTimeout time.Duration,
 ) ([]byte, error) {
 	// build the kongstate object from the Kubernetes objects in the storer
 	storer := store.New(*cache, ingressClassName, false, false, false, deprecatedLogger)
@@ -66,7 +67,7 @@ func UpdateKongAdminSimple(ctx context.Context,
 	}
 
 	// apply the configuration update in Kong
-	timedCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	timedCtx, cancel := context.WithTimeout(ctx, proxyRequestTimeout)
 	defer cancel()
 	configSHA, err := PerformUpdate(timedCtx,
 		deprecatedLogger, &kongConfig,


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on the investigation and report in https://github.com/Kong/kubernetes-ingress-controller/issues/1519 this patch disables the backpressure system that was introduced during the alpha stage which intended to try and help highlight kong proxy backend issues to operators. The findings were that the tradeoffs in performance didn't justify the value added and that for the moment we are going to make this work more like v1.x did for consistency and perhaps look at improvements in this area again in a later iteration.

**Which issue this PR fixes**

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1519