### PR TITLE
[feat] add gke release testing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# TODO: right now the release is not fully automated, but the tests below must pass before a release is made manually. See RELEASE.md for more information.
 name: release
 
 on:
@@ -7,7 +8,7 @@ on:
       - 'next'
 
 jobs:
-  latest-tests:
+  test-current-kubernetes:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,13 +39,14 @@ jobs:
       - name: Kubernetes ${{ matrix.kubernetes_version }} ${{ matrix.dbmode }} Integration Tests
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes_version }} make test.integration.${{ matrix.dbmode }}
 
-  legacy-tests:
+  test-previous-kubernetes:
+    environment: gcloud
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes-version:
-          - 'v1.19.11'
-          - 'v1.20.7'
+        minor:
+          - '19'
+          - '20'
         dbmode:
           - 'dbless'
           - 'postgres'
@@ -67,7 +69,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Kubernetes ${{ matrix.kubernetes_version }} ${{ matrix.dbmode }} Integration Tests
-        run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes_version }} make test.integration.${{ matrix.dbmode }}
+      - name: test ${{ matrix.dbmode }} on GKE v1.${{ matrix.minor }}
+        run: ./hack/e2e/run.sh
+        env:
+          KUBERNETES_MAJOR_VERSION: 1
+          KUBERNETES_MINOR_VERSION: ${{ matrix.minor }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
-  # TODO: right now the release is not fully automated, but the above tests must pass before a release is made manually. See RELEASE.md for more information.
+# TODO: need kubernetes latest job (test against v1.20.7 and v1.21.2): https://github.com/Kong/kubernetes-ingress-controller/issues/1616

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.20.0
-	github.com/kong/kubernetes-testing-framework v0.2.2
+	github.com/kong/kubernetes-testing-framework v0.3.3
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,10 @@ cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmW
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
-cloud.google.com/go v0.83.0 h1:bAMqZidYkmIsUqe6PtkEPT7Q+vfizScn+jfNA6jwK9c=
 cloud.google.com/go v0.83.0/go.mod h1:Z7MJUsANfY0pYPdw0lbnivPx4/vhy/e2FEkSkF7vAVY=
+cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
+cloud.google.com/go v0.88.0 h1:MZ2cf9Elnv1wqccq8ooKO2MqHQLc+ChCp/+QWObCpxg=
+cloud.google.com/go v0.88.0/go.mod h1:dnKwfYbP9hQhefiUvpbcAyoGSHUrOxR20JVElLiUvEY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -466,6 +468,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -539,6 +542,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -669,8 +673,8 @@ github.com/kong/deck v1.7.0/go.mod h1:o2letQaSpXVnDNoXehEibOF6q7v46qtbsKOCC+1owA
 github.com/kong/go-kong v0.19.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmdy5aog=
 github.com/kong/go-kong v0.20.0 h1:KiPsJORNs9UbjU8m1Tr3MZkIiKkzcVHIz0EYeT7SD3c=
 github.com/kong/go-kong v0.20.0/go.mod h1:eQP22bzJVeiEH77hYdWD019WjecJFVFHm77kPXquC28=
-github.com/kong/kubernetes-testing-framework v0.2.2 h1:gRfM85kOf8kXcpio5AA+X164DAbjVFzx2FMk/F05Yu0=
-github.com/kong/kubernetes-testing-framework v0.2.2/go.mod h1:Cn5+MjhyRwN2J0Iyk7/Rdwt+1UlF+aN3oJ+ygrxeKZc=
+github.com/kong/kubernetes-testing-framework v0.3.3 h1:UgWjsApvxD/86DnwLQnr6OIk/sgDi+C2lcgFEFw7Buk=
+github.com/kong/kubernetes-testing-framework v0.3.3/go.mod h1:O9ARzRPAnEBURREH4fiGmCBhEUxj3HRIyUEjR9eYIVU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1206,8 +1210,9 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c h1:pkQiBZBvdos9qq4wBAHqlzuZHEXo07pqV06ef90u1WI=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1314,6 +1319,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1407,6 +1413,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1449,8 +1457,11 @@ google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjR
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
 google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1AvkYD8=
-google.golang.org/api v0.47.0 h1:sQLWZQvP6jPGIP4JGPkJu4zHswrv81iobiyszr3b/0I=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
+google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
+google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
+google.golang.org/api v0.52.0 h1:m5FLEd6dp5CU1F0tMWyqDi2XjchviIz8ntzOSz7w8As=
+google.golang.org/api v0.52.0/go.mod h1:Him/adpjt0sxtkWViy0b6xyKW/SD71CwdJ7HqJo7SrU=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1511,6 +1522,11 @@ google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaE
 google.golang.org/genproto v0.0.0-20210416161957-9910b6c460de/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
+google.golang.org/genproto v0.0.0-20210721163202-f1cecdd8b78a/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
+google.golang.org/genproto v0.0.0-20210722135532-667f2b7c528f/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0 h1:VpRFBmFg/ol+rqJnkKLPjVebPNFbSxuj17B7bH1xMc8=
 google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/hack/e2e/main.go
+++ b/hack/e2e/main.go
@@ -1,0 +1,94 @@
+package main
+
+// TODO: this is temporary: it was created for speed but will be replaced
+//       by upstream functionality in KTF.
+//       See: https://github.com/Kong/kubernetes-testing-framework/issues/61
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
+)
+
+const (
+	k8sNameVar  = "KUBERNETES_CLUSTER_NAME"
+	k8sMajorVar = "KUBERNETES_MAJOR_VERSION"
+	k8sMinorVar = "KUBERNETES_MINOR_VERSION"
+)
+
+var (
+	ctx     = context.Background()
+	cluster clusters.Cluster
+
+	gkeCreds    = os.Getenv(gke.GKECredsVar)
+	gkeProject  = os.Getenv(gke.GKEProjectVar)
+	gkeLocation = os.Getenv(gke.GKELocationVar)
+	k8sName     = os.Getenv(k8sNameVar)
+	k8sMajor    = os.Getenv(k8sMajorVar)
+	k8sMinor    = os.Getenv(k8sMinorVar)
+)
+
+func main() {
+	fmt.Println("INFO: configuring GKE cloud environment for tests")
+	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
+	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
+	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)
+	mustNotBeEmpty(k8sNameVar, k8sName)
+	mustNotBeEmpty(k8sMajorVar, k8sMajor)
+	mustNotBeEmpty(k8sMinorVar, k8sMinor)
+
+	fmt.Println("INFO: validating cluster version requirements")
+	major, err := strconv.Atoi(k8sMajor)
+	mustNotError(err)
+	minor, err := strconv.Atoi(k8sMinor)
+	mustNotError(err)
+
+	if len(os.Args) > 1 && os.Args[1] == "cleanup" {
+		fmt.Printf("INFO: cleanup called, deleting GKE cluster %s\n", k8sName)
+		cluster, err := gke.NewFromExistingWithEnv(ctx, k8sName)
+		mustNotError(err)
+		mustNotError(cluster.Cleanup(ctx))
+		fmt.Printf("INFO: GKE cluster %s successfully cleaned up\n", k8sName)
+		os.Exit(0)
+	}
+
+	fmt.Printf("INFO: configuring the GKE cluster NAME=(%s) VERSION=(v%d.%d) PROJECT=(%s) LOCATION=(%s)\n", k8sName, major, minor, gkeProject, gkeLocation)
+	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation).WithName(k8sName)
+	builder.WithClusterMinorVersion(uint64(major), uint64(minor))
+
+	fmt.Printf("INFO: building cluster %s (this can take some time)\n", builder.Name)
+	cluster, err = builder.Build(ctx)
+	mustNotError(err)
+
+	fmt.Println("INFO: verifying that the cluster can be communicated with")
+	version, err := cluster.Client().ServerVersion()
+	mustNotError(err)
+
+	fmt.Printf("INFO: server version found: %s\n", version)
+}
+
+func mustNotBeEmpty(name, value string) {
+	if value == "" {
+		if cluster != nil {
+			if err := cluster.Cleanup(ctx); err != nil {
+				panic(fmt.Sprintf("%s was empty, and then cleanup failed: %s", name, err))
+			}
+		}
+		panic(fmt.Sprintf("%s was empty", name))
+	}
+}
+
+func mustNotError(err error) {
+	if err != nil {
+		if cluster != nil {
+			if cleanupErr := cluster.Cleanup(ctx); cleanupErr != nil {
+				panic(fmt.Sprintf("deployment failed with %s, and then cleanup failed: %s", err, cleanupErr))
+			}
+		}
+		panic(fmt.Errorf("failed to deploy e2e environment: %w", err))
+	}
+}

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# TODO: for now our e2e tests are effectively just our integration tests run
+#       against a conformant, production grade cluster. In the future we will
+#       add a dedicated e2e test suite.
+#
+#       See: https://github.com/Kong/kubernetes-ingress-controller/issues/1605
+
+set -euo pipefail
+
+WORKDIR="$(dirname "${BASH_SOURCE}")/../.."
+cd "${WORKDIR}"
+
+CLUSTER_NAME="e2e-$(uuidgen)"
+KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/main.go
+
+function cleanup() {
+    KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/main.go cleanup
+}
+trap cleanup EXIT SIGINT SIGQUIT
+
+GOFLAGS="-tags=integration_tests" KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" go test -count 1 -timeout 45m -v ./test/integration/...

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -131,17 +131,22 @@ QLAtVaZd9SSi4Z/RX6B4L3Rj0Mwfn+tbrtYO5Pyhi40hiXf4aMgbVDFYMR0MMmH0
 	}
 )
 
+var (
+	testIngressHTTPSNamespace         = "ingress-https"
+	testIngressHTTPSRedirectNamespace = "ingress-redirect"
+)
+
 func TestHTTPSRedirect(t *testing.T) {
 	ctx := context.Background()
 	opts := metav1.CreateOptions{}
 
-	t.Logf("creating namespace %s for testing", testIngressNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressNamespace}}
+	t.Logf("creating namespace %s for testing", testIngressHTTPSRedirectNamespace)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressHTTPSRedirectNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressNamespace)
+		t.Logf("cleaning up namespace %s", testIngressHTTPSRedirectNamespace)
 		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
 		require.Eventually(t, func() bool {
 			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
@@ -232,13 +237,13 @@ func TestHTTPSIngress(t *testing.T) {
 		Transport: &testTransport,
 	}
 
-	t.Logf("creating namespace %s for testing", testIngressNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressNamespace}}
+	t.Logf("creating namespace %s for testing", testIngressHTTPSNamespace)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressHTTPSNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressNamespace)
+		t.Logf("cleaning up namespace %s", testIngressHTTPSNamespace)
 		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
 		require.Eventually(t, func() bool {
 			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -21,18 +21,19 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/annotations"
 )
 
-var testIngressNamespace = "ingress"
+var testIngressEssentialsNamespace = "ingress-essentials"
+var testIngressClassNameSpecNamespace = "ingress-class-name-spec"
 
 func TestIngressEssentials(t *testing.T) {
 	ctx := context.Background()
 
-	t.Logf("creating namespace %s for testing", testIngressNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressNamespace}}
+	t.Logf("creating namespace %s for testing", testIngressEssentialsNamespace)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressEssentialsNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressNamespace)
+		t.Logf("cleaning up namespace %s", testIngressEssentialsNamespace)
 		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
 		require.Eventually(t, func() bool {
 			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
@@ -48,22 +49,22 @@ func TestIngressEssentials(t *testing.T) {
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressEssentialsNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressEssentialsNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(testIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(testIngressEssentialsNamespace).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressEssentialsNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -71,12 +72,12 @@ func TestIngressEssentials(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Create(ctx, ingress, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
-		if err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+		if err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -85,7 +86,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Logf("waiting for updated ingress status to include IP")
 	require.Eventually(t, func() bool {
-		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -113,10 +114,10 @@ func TestIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("removing the ingress.class annotation %q from ingress %s", ingressClass, ingress.Name)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("verifying that removing the ingress.class annotation %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
@@ -131,10 +132,10 @@ func TestIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the ingress.class annotation %q back on ingress %s", ingressClass, ingress.Name)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
@@ -158,7 +159,7 @@ func TestIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
-	require.NoError(t, env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	require.NoError(t, env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {
@@ -173,13 +174,13 @@ func TestIngressEssentials(t *testing.T) {
 func TestIngressClassNameSpec(t *testing.T) {
 	ctx := context.Background()
 
-	t.Logf("creating namespace %s for testing", testIngressNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressNamespace}}
+	t.Logf("creating namespace %s for testing", testIngressClassNameSpecNamespace)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressClassNameSpecNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressNamespace)
+		t.Logf("cleaning up namespace %s", testIngressClassNameSpecNamespace)
 		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
 		require.Eventually(t, func() bool {
 			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
@@ -195,33 +196,33 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressClassNameSpecNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressClassNameSpecNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(testIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(testIngressClassNameSpecNamespace).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressClassNameSpecNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
 	ingress := generators.NewIngressForService("/httpbin", map[string]string{"konghq.com/strip-path": "true"}, service)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Create(ctx, ingress, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
-		if err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+		if err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -249,10 +250,10 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("removing the IngressClassName %q from ingress %s", ingressClass, ingress.Name)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	ingress.Spec.IngressClassName = nil
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress %s causes routes to disconnect", ingressClass, ingress.Name)
@@ -267,10 +268,10 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("putting the IngressClassName %q back on ingress %s", ingressClass, ingress.Name)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("waiting for routes from Ingress %s to be operational after reintroducing ingress class annotation", ingress.Name)
@@ -294,7 +295,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
-	require.NoError(t, env.Cluster().Client().NetworkingV1().Ingresses(testIngressNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	require.NoError(t, env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,10 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("TODO: knative tests are only supported on KIND based environments right now")
+	}
+
 	cluster := env.Cluster()
 	proxy := proxyURL.Hostname()
 	assert.NotEmpty(t, proxy)

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -69,7 +69,10 @@ var (
 	watchNamespaces = strings.Join([]string{
 		elsewhere,
 		corev1.NamespaceDefault,
-		testIngressNamespace,
+		testIngressEssentialsNamespace,
+		testIngressClassNameSpecNamespace,
+		testIngressHTTPSNamespace,
+		testIngressHTTPSRedirectNamespace,
 		testBulkIngressNamespace,
 		testTCPIngressNamespace,
 		testUDPIngressNamespace,

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,9 +106,9 @@ var (
 	// clusterVersion indicates the version of Kubernetes to use for the tests (if the cluster was not provided by the caller)
 	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
 
-	// existingClusterName indicates whether or not the caller is providing their own kind cluster for running the tests,
-	// and if so what the name of that cluster is.
-	existingClusterName = os.Getenv("KIND_CLUSTER")
+	// existingCluster indicates whether or not the caller is providing their own cluster for running the tests.
+	// These need to come in the format <TYPE>:<NAME> (e.g. "kind:<NAME>", "gke:<NAME>", e.t.c.).
+	existingCluster = os.Getenv("KONG_TEST_CLUSTER")
 
 	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
 	maxBatchSize = determineMaxBatchSize()
@@ -128,21 +130,47 @@ func TestMain(m *testing.M) {
 	}
 	kongbuilder.WithControllerDisabled()
 	kongAddon := kongbuilder.Build()
-	builder := environments.NewBuilder().WithAddons(metallb.New(), kongAddon)
+	builder := environments.NewBuilder().WithAddons(kongAddon)
 
 	fmt.Println("INFO: checking for reusable environment components")
-	if existingClusterName != "" {
+	if existingCluster != "" {
 		if clusterVersionStr != "" {
 			fmt.Fprintf(os.Stderr, "Error: can't flag cluster version and provide an existing cluster at the same time")
 			os.Exit(ExitCodeIncompatibleOptions)
 		}
-		fmt.Printf("INFO: using existing cluster %s\n", existingClusterName)
-		cluster, err := kind.NewFromExisting(existingClusterName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: could not use existing cluster for test env: %s", err)
+
+		fmt.Println("INFO: parsing existing cluster name identifier")
+		clusterParts := strings.Split(existingCluster, ":")
+		if len(clusterParts) != 2 {
+			fmt.Fprintf(os.Stderr, "Error: existing cluster in wrong format (%s): format is <TYPE>:<NAME> (e.g. kind:test-cluster)", existingCluster)
 			os.Exit(ExitCodeCantUseExistingCluster)
 		}
-		builder = builder.WithExistingCluster(cluster)
+		clusterType, clusterName := clusterParts[0], clusterParts[1]
+
+		fmt.Printf("INFO: using existing %s cluster %s\n", clusterType, clusterName)
+		switch clusterType {
+		case string(kind.KindClusterType):
+			cluster, err := kind.NewFromExisting(clusterName)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: could not use existing %s cluster for test env: %s", clusterType, err)
+				os.Exit(ExitCodeCantUseExistingCluster)
+			}
+			builder.WithExistingCluster(cluster)
+			builder.WithAddons(metallb.New())
+		case string(gke.GKEClusterType):
+			cluster, err := gke.NewFromExistingWithEnv(ctx, clusterName)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: could not use existing %s cluster for test env: %s", clusterType, err)
+				os.Exit(ExitCodeCantUseExistingCluster)
+			}
+			builder.WithExistingCluster(cluster)
+		default:
+			fmt.Fprintf(os.Stderr, "Error: unknown cluster type: %s", clusterType)
+			os.Exit(ExitCodeCantUseExistingCluster)
+		}
+	} else {
+		fmt.Println("INFO: no existing cluster to be used, deploying using KIND")
+		builder.WithAddons(metallb.New())
 	}
 
 	fmt.Println("INFO: configuring kubernetes cluster")
@@ -166,16 +194,25 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "Error: could not create testing environment: %s", err)
 		os.Exit(ExitCodeCantCreateCluster)
 	}
-	fmt.Printf(
-		"INFO: environment built CLUSTER_NAME=(%s) CLUSTER_TYPE=(%s) ADDONS=(metallb, kong)\n",
-		env.Cluster().Name(), env.Cluster().Type(),
-	)
 	defer func() {
 		if err := env.Cleanup(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: could not cleanup testing environment: %s", err)
 			os.Exit(ExitCodeCleanupFailed)
 		}
 	}()
+
+	fmt.Printf("INFO: reconfiguring the kong admin service as LoadBalancer type\n")
+	svc, err := env.Cluster().Client().CoreV1().Services(kongAddon.Namespace()).Get(ctx, kong.DefaultAdminServiceName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: could not get proxy admin service from cluster: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
+	}
+	svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+	_, err = env.Cluster().Client().CoreV1().Services(kongAddon.Namespace()).Update(ctx, svc, metav1.UpdateOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: could not update proxy admin service: %s", err)
+		os.Exit(ExitCodeCantCreateCluster)
+	}
 
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
 	if err := <-env.WaitForReady(ctx); err != nil {
@@ -248,19 +285,27 @@ func deployControllers(ctx context.Context, namespace string) error {
 
 	// run the controller in the background
 	go func() {
+		// convert the cluster rest.Config into a kubeconfig
+		yaml, err := generators.NewKubeConfigForRestConfig(env.Cluster().Name(), env.Cluster().Config())
+		if err != nil {
+			panic(err)
+		}
+
 		// create a tempfile to hold the cluster kubeconfig that will be used for the controller
 		kubeconfig, err := ioutil.TempFile(os.TempDir(), "kubeconfig-")
 		if err != nil {
 			panic(err)
 		}
 		defer os.Remove(kubeconfig.Name())
+		defer kubeconfig.Close()
 
 		// dump the kubeconfig from kind into the tempfile
-		generateKubeconfig := exec.CommandContext(ctx, "kind", "get", "kubeconfig", "--name", env.Cluster().Name()) //nolint:gosec
-		generateKubeconfig.Stdout = kubeconfig
-		generateKubeconfig.Stderr = os.Stderr
-		if err := generateKubeconfig.Run(); err != nil {
+		c, err := kubeconfig.Write(yaml)
+		if err != nil {
 			panic(err)
+		}
+		if c != len(yaml) {
+			panic(fmt.Errorf("could not write entire kubeconfig file (%d/%d bytes)", c, len(yaml)))
 		}
 		kubeconfig.Close()
 

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admregv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,7 +38,7 @@ func TestValidationWebhook(t *testing.T) {
 			},
 		},
 	}, metav1.CreateOptions{})
-	assert.NoError(t, err, "creating webhook service")
+	require.NoError(t, err, "creating webhook service")
 
 	nodeName := "aaaa"
 	_, err = env.Cluster().Client().CoreV1().Endpoints(controllerNamespace).Create(ctx, &corev1.Endpoints{
@@ -61,7 +62,7 @@ func TestValidationWebhook(t *testing.T) {
 			},
 		},
 	}, metav1.CreateOptions{})
-	assert.NoError(t, err, "creating webhook endpoints")
+	require.NoError(t, err, "creating webhook endpoints")
 
 	fail := admregv1beta1.Fail
 	none := admregv1beta1.SideEffectClassNone
@@ -92,8 +93,8 @@ func TestValidationWebhook(t *testing.T) {
 				},
 			},
 		}, metav1.CreateOptions{})
-	assert.NoError(t, err, "creating webhook config")
-	assert.Eventually(t, func() bool {
+	require.NoError(t, err, "creating webhook config")
+	require.Eventually(t, func() bool {
 		_, err := net.DialTimeout("tcp", "172.17.0.1:49023", 1*time.Second)
 		return err == nil
 	}, ingressWait, waitTick, "waiting for the admission service to be up")

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admregv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -21,6 +22,9 @@ import (
 const defaultNs = "default"
 
 func TestValidationWebhook(t *testing.T) {
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("TODO: webhook tests are only supported on KIND based environments right now")
+	}
 	ctx := context.Background()
 
 	const webhookSvcName = "validations"


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds testing of conformant, production grade Kubernetes clusters as a pre-requisite for any release.

**Which issue this PR fixes**

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1095

**Special notes for your reviewer**:

This is only one iteration, there are several related and follow-up items:

- https://github.com/Kong/kubernetes-ingress-controller/issues/1613
- https://github.com/Kong/kubernetes-ingress-controller/issues/1614
- https://github.com/Kong/kubernetes-ingress-controller/issues/1617
- https://github.com/Kong/kubernetes-ingress-controller/issues/1616

<h1>Do Not Merge:</h1>
There's some git history cleanup that the author needs to perform before merging, please let the author merge this when its ready.