### PR TITLE
chore: seperate latest k8s release tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,44 @@ on:
       - 'next'
 
 jobs:
-  kubernetes-version-tests:
+  latest-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kubernetes-version:
+          - 'v1.21.2'
+        dbmode:
+          - 'dbless'
+          - 'postgres'
+    steps:
+      - name: setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+
+      - name: cache go modules
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
+
+      - name: checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Kubernetes ${{ matrix.kubernetes_version }} ${{ matrix.dbmode }} Integration Tests
+        run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes_version }} make test.integration.${{ matrix.dbmode }}
+
+  legacy-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         kubernetes-version:
           - 'v1.19.11'
           - 'v1.20.7'
-          - 'v1.21.2'
         dbmode:
           - 'dbless'
           - 'postgres'


### PR DESCRIPTION
**What this PR does / why we need it**:

In another upcoming change we're switching testing
of older kubernetes releases onto GKE (from KIND)
so that they're running against conformant production
quality cluster configurations. This patch moves
the tests which must remain in kind (for now) into
their own job as a blocker for releases.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1616