### PR TITLE
[feat] legacy fixes & release tests for v1.17 & v1.18

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,8 @@ jobs:
     strategy:
       matrix:
         minor:
+          - '17'
+          - '18'
           - '19'
           - '20'
         dbmode:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.20.0
-	github.com/kong/kubernetes-testing-framework v0.3.3
+	github.com/kong/kubernetes-testing-framework v0.4.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,10 @@ cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go v0.83.0/go.mod h1:Z7MJUsANfY0pYPdw0lbnivPx4/vhy/e2FEkSkF7vAVY=
 cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
-cloud.google.com/go v0.88.0 h1:MZ2cf9Elnv1wqccq8ooKO2MqHQLc+ChCp/+QWObCpxg=
+cloud.google.com/go v0.87.0/go.mod h1:TpDYlFy7vuLzZMMZ+B6iRiELaY7z/gJPaqbMx6mlWcY=
 cloud.google.com/go v0.88.0/go.mod h1:dnKwfYbP9hQhefiUvpbcAyoGSHUrOxR20JVElLiUvEY=
+cloud.google.com/go v0.89.0 h1:ZT4GU+y59fC95Mfdn2RtxuzN2gc69dzlVevQK8Ykyqs=
+cloud.google.com/go v0.89.0/go.mod h1:kRX0mNRHe0e2rC6oNakvwQqzyDmg57xJ+SZU1eT2aDQ=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -542,7 +544,9 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -673,8 +677,8 @@ github.com/kong/deck v1.7.0/go.mod h1:o2letQaSpXVnDNoXehEibOF6q7v46qtbsKOCC+1owA
 github.com/kong/go-kong v0.19.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmdy5aog=
 github.com/kong/go-kong v0.20.0 h1:KiPsJORNs9UbjU8m1Tr3MZkIiKkzcVHIz0EYeT7SD3c=
 github.com/kong/go-kong v0.20.0/go.mod h1:eQP22bzJVeiEH77hYdWD019WjecJFVFHm77kPXquC28=
-github.com/kong/kubernetes-testing-framework v0.3.3 h1:UgWjsApvxD/86DnwLQnr6OIk/sgDi+C2lcgFEFw7Buk=
-github.com/kong/kubernetes-testing-framework v0.3.3/go.mod h1:O9ARzRPAnEBURREH4fiGmCBhEUxj3HRIyUEjR9eYIVU=
+github.com/kong/kubernetes-testing-framework v0.4.0 h1:QFUUiNSxnKfOKGbgmooXMhFnL+CQRxQcLFVxKCKB8o0=
+github.com/kong/kubernetes-testing-framework v0.4.0/go.mod h1:Rh4H0hY5t7hSkaaIqO7lwx/jRykOGaQeI1JgTg5p9UU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1460,6 +1464,7 @@ google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1Avk
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
 google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
+google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.52.0 h1:m5FLEd6dp5CU1F0tMWyqDi2XjchviIz8ntzOSz7w8As=
 google.golang.org/api v0.52.0/go.mod h1:Him/adpjt0sxtkWViy0b6xyKW/SD71CwdJ7HqJo7SrU=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -1525,10 +1530,12 @@ google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxH
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
+google.golang.org/genproto v0.0.0-20210713002101-d411969a0d9a/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
+google.golang.org/genproto v0.0.0-20210716133855-ce7ef5c701ea/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
 google.golang.org/genproto v0.0.0-20210721163202-f1cecdd8b78a/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/genproto v0.0.0-20210722135532-667f2b7c528f/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
-google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0 h1:VpRFBmFg/ol+rqJnkKLPjVebPNFbSxuj17B7bH1xMc8=
-google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
+google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f h1:4m1jFN3fHeKo0UvpraW2ipO2O0rgp5w2ugXeggtecAk=
+google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -89,7 +89,7 @@ var inputControllersNeeded = &typesNeeded{
 		URL:                               "networking.k8s.io",
 		CacheType:                         "IngressV1beta1",
 		AcceptsIngressClassNameAnnotation: true,
-		AcceptsIngressClassNameSpec:       false,
+		AcceptsIngressClassNameSpec:       true,
 		RBACVerbs:                         []string{"get", "list", "watch"},
 	},
 	typeNeeded{
@@ -101,7 +101,7 @@ var inputControllersNeeded = &typesNeeded{
 		URL:                               "extensions",
 		CacheType:                         "IngressV1beta1",
 		AcceptsIngressClassNameAnnotation: true,
-		AcceptsIngressClassNameSpec:       false,
+		AcceptsIngressClassNameSpec:       true,
 		RBACVerbs:                         []string{"get", "list", "watch"},
 	},
 	typeNeeded{

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -356,7 +356,7 @@ type NetV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, true, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&netv1beta1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 
@@ -440,7 +440,7 @@ type ExtV1Beta1IngressReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, false, true)
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName, true, true)
 	return ctrl.NewControllerManagedBy(mgr).For(&extv1beta1.Ingress{}, builder.WithPredicates(preds)).Complete(r)
 }
 

--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/deck/file"
 	"github.com/prometheus/common/log"
@@ -32,8 +33,14 @@ const (
 )
 
 // PullConfigUpdate is a dedicated function that process ingress/customer resource status update after configuration is updated within kong.
-func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.Logger, kubeConfig *rest.Config,
-	publishService string, publishAddresses []string) {
+func PullConfigUpdate(
+	ctx context.Context,
+	kongConfig sendconfig.Kong,
+	log logr.Logger,
+	kubeConfig *rest.Config,
+	publishService string,
+	publishAddresses []string,
+) {
 	ips, hostname, err := RunningAddresses(ctx, kubeConfig, publishService, publishAddresses)
 	if err != nil {
 		log.Error(err, "failed to determine kong proxy external ips/hostnames.")
@@ -43,6 +50,18 @@ func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.
 	cli, err := clientset.NewForConfig(kubeConfig)
 	if err != nil {
 		log.Error(err, "failed to create k8s client.")
+		return
+	}
+
+	versionInfo, err := cli.ServerVersion()
+	if err != nil {
+		log.Error(err, "failed to retrieve cluster version")
+		return
+	}
+
+	kubernetesVersion, err := semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
+	if err != nil {
+		log.Error(err, "could not parse cluster version")
 		return
 	}
 
@@ -61,7 +80,7 @@ func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.
 			log.V(4).Info("receive configuration information. Update ingress status %v \n", updateDone)
 			wg.Add(1)
 			go func() {
-				if err := UpdateIngress(ctx, &updateDone, log, cli, kiccli, &wg, ips, hostname, kubeConfig); err != nil {
+				if err := UpdateStatuses(ctx, &updateDone, log, cli, kiccli, &wg, ips, hostname, kubeConfig, kubernetesVersion); err != nil {
 					log.Error(err, "failed to update resource statuses")
 				}
 			}()
@@ -73,11 +92,19 @@ func PullConfigUpdate(ctx context.Context, kongConfig sendconfig.Kong, log logr.
 	}
 }
 
-// UpdateIngress update ingress status according to generated rules and specs
-func UpdateIngress(ctx context.Context, targetContent *file.Content, log logr.Logger, cli *clientset.Clientset,
+// UpdateStatuses update resources statuses according to generated rules and specs
+func UpdateStatuses(
+	ctx context.Context,
+	targetContent *file.Content,
+	log logr.Logger,
+	cli *clientset.Clientset,
 	kiccli *kicclientset.Clientset,
-	wg *sync.WaitGroup, ips []string, hostname string,
-	kubeConfig *rest.Config) error {
+	wg *sync.WaitGroup,
+	ips []string,
+	hostname string,
+	kubeConfig *rest.Config,
+	kubernetesVersion semver.Version,
+) error {
 	defer wg.Done()
 
 	for _, svc := range targetContent.Services {
@@ -91,7 +118,6 @@ func UpdateIngress(ctx context.Context, targetContent *file.Content, log logr.Lo
 							if err := UpdateKnativeIngress(ctx, log, svc, kubeConfig, ips, hostname); err != nil {
 								return fmt.Errorf("failed to update knative ingress err %v", err)
 							}
-
 						}
 					}
 				}
@@ -109,8 +135,17 @@ func UpdateIngress(ctx context.Context, targetContent *file.Content, log logr.Lo
 			}
 
 		case "http":
-			if err := UpdateIngressV1(ctx, log, svc, cli, ips); err != nil {
-				return fmt.Errorf("failed to update ingressv1. err %v", err)
+			// if the cluster is on a very old version, we fall back to legacy Ingress support
+			// for compatibility with clusters older than v1.19.x.
+			// TODO: this can go away once we drop support for Kubernetes older than v1.19
+			if kubernetesVersion.Major >= uint64(1) && kubernetesVersion.Minor > uint64(18) {
+				if err := UpdateIngress(ctx, log, svc, cli, ips); err != nil {
+					return fmt.Errorf("failed to update ingressv1. err %v", err)
+				}
+			} else {
+				if err := UpdateIngressLegacy(ctx, log, svc, cli, ips); err != nil {
+					return fmt.Errorf("failed to update ingressv1. err %v", err)
+				}
 			}
 		default:
 			log.Info("protocol " + proto + " is not supported")
@@ -131,9 +166,14 @@ func toKnativeLBStatus(coreLBStatus []apiv1.LoadBalancerIngress) []knative.LoadB
 	return res
 }
 
-// UpdateIngressV1 networking v1 ingress status
-func UpdateIngressV1(ctx context.Context, logger logr.Logger, svc file.FService, cli *clientset.Clientset,
-	ips []string) error {
+// UpdateIngress networking v1 ingress status
+func UpdateIngress(
+	ctx context.Context,
+	logger logr.Logger,
+	svc file.FService,
+	cli *clientset.Clientset,
+	ips []string,
+) error {
 	for _, route := range svc.Routes {
 		routeInf := strings.Split(*((*route).Name), ".")
 		namespace := routeInf[0]
@@ -182,6 +222,66 @@ func UpdateIngressV1(ctx context.Context, logger logr.Logger, svc file.FService,
 	}
 
 	log.Debugf("successfully updated networkingv1 Ingress status")
+	return nil
+}
+
+// UpdateIngressLegacy networking v1beta1 ingress status
+// TODO: this can be removed once we no longer support old kubernetes < v1.19
+func UpdateIngressLegacy(
+	ctx context.Context,
+	logger logr.Logger,
+	svc file.FService,
+	cli *clientset.Clientset,
+	ips []string,
+) error {
+	for _, route := range svc.Routes {
+		routeInf := strings.Split(*((*route).Name), ".")
+		namespace := routeInf[0]
+		name := routeInf[1]
+		log.Debugf("updating status for v1beta1.Ingress route name %s  namespace %s", name, namespace)
+
+		ingCli := cli.NetworkingV1beta1().Ingresses(namespace)
+		retry := 0
+		for retry < statusUpdateRetry {
+			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
+			if err != nil || curIng == nil {
+				if errors.IsNotFound(err) {
+					return nil
+				}
+
+				log.Errorf("failed to fetch Ingress %v/%v: %v. retrying...", namespace, name, err)
+				retry++
+				time.Sleep(time.Second)
+				continue
+			}
+
+			var status []apiv1.LoadBalancerIngress
+			sort.SliceStable(status, lessLoadBalancerIngress(status))
+			curIPs := curIng.Status.LoadBalancer.Ingress
+
+			status = SliceToStatus(ips)
+			if ingressSliceEqual(status, curIPs) {
+				log.Debugf("no change in status, update ingress v1beta1 skipped")
+				return nil
+			}
+
+			curIng.Status.LoadBalancer.Ingress = status
+
+			_, err = ingCli.UpdateStatus(ctx, curIng, metav1.UpdateOptions{})
+			if err == nil {
+				break
+			}
+			if errors.IsNotFound(err) {
+				return nil
+			}
+
+			log.Errorf("failed to update Ingress V1beta1 status. %v. retrying...", err)
+			time.Sleep(time.Second)
+			retry++
+		}
+	}
+
+	log.Debugf("successfully updated networkingv1beta1 Ingress status")
 	return nil
 }
 

--- a/internal/ctrlutils/utils.go
+++ b/internal/ctrlutils/utils.go
@@ -1,7 +1,9 @@
 package ctrlutils
 
 import (
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -84,6 +86,10 @@ func IsIngressClassAnnotationConfigured(obj client.Object, expectedIngressClassN
 func IsIngressClassSpecConfigured(obj client.Object, expectedIngressClassName string) bool {
 	switch obj := obj.(type) {
 	case *netv1.Ingress:
+		return obj.Spec.IngressClassName != nil && *obj.Spec.IngressClassName == expectedIngressClassName
+	case *netv1beta1.Ingress:
+		return obj.Spec.IngressClassName != nil && *obj.Spec.IngressClassName == expectedIngressClassName
+	case *extv1beta1.Ingress:
 		return obj.Spec.IngressClassName != nil && *obj.Spec.IngressClassName == expectedIngressClassName
 	}
 	return false

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -198,6 +198,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
 		return c.IngressV1beta1.Get(obj)
+	case *networkingv1beta1.Ingress:
+		return c.IngressV1beta1.Get(obj)
 	case *networkingv1.Ingress:
 		return c.IngressV1.Get(obj)
 	case *corev1.Service:
@@ -241,6 +243,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 	// Kubernetes Core API Support
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
+		return c.IngressV1beta1.Add(obj)
+	case *networkingv1beta1.Ingress:
 		return c.IngressV1beta1.Add(obj)
 	case *networkingv1.Ingress:
 		return c.IngressV1.Add(obj)
@@ -286,6 +290,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 	// Kubernetes Core API Support
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
+		return c.IngressV1beta1.Delete(obj)
+	case *networkingv1beta1.Ingress:
 		return c.IngressV1beta1.Delete(obj)
 	case *networkingv1.Ingress:
 		return c.IngressV1.Delete(obj)

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -72,17 +72,17 @@ func TestConfigEndpoint(t *testing.T) {
 		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)
 		successResp, err := httpc.Get(successURL)
-		defer successResp.Body.Close()
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", successURL, err)
 			return false
 		}
+		defer successResp.Body.Close()
 		failResp, err := httpc.Get(failURL)
-		defer failResp.Body.Close()
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", failURL, err)
 			return false
 		}
+		defer failResp.Body.Close()
 		return successResp.StatusCode == http.StatusOK && failResp.StatusCode == http.StatusOK
 	}, ingressWait, waitTick)
 }

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -58,7 +58,7 @@ func TestKnativeIngress(t *testing.T) {
 	require.Eventually(t, func() bool {
 		err := installKnativeSrv(ctx, t)
 		if err != nil {
-			t.Logf("checking knativing webhook readiness.")
+			t.Log("checking knativing webhook readiness.")
 			return false
 		}
 		return true
@@ -89,7 +89,7 @@ func configKnativeNetwork(ctx context.Context, cluster clusters.Cluster, t *test
 		return err
 	}
 
-	t.Logf("successfully configured knative network.")
+	t.Log("successfully configured knative network.")
 	return nil
 }
 
@@ -122,11 +122,16 @@ func installKnativeSrv(ctx context.Context, t *testing.T) error {
 		},
 	}
 	knativeCli, err := knativeversioned.NewForConfig(env.Cluster().Config())
+	if err != nil {
+		return fmt.Errorf("failed to create knative service. %v", err)
+	}
+
 	_, err = knativeCli.ServingV1().Services("default").Create(ctx, tobeDeployedService, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create knative service. %v", err)
 	}
-	t.Logf("successfully installed knative service.")
+
+	t.Log("successfully installed knative service.")
 	return nil
 }
 
@@ -152,7 +157,7 @@ func configKnativeDomain(ctx context.Context, proxy string, cluster clusters.Clu
 		t.Logf("failed updating config map %v", err)
 		return err
 	}
-	t.Logf("successfully update knative config domain.")
+	t.Log("successfully update knative config domain.")
 	return nil
 }
 
@@ -170,7 +175,7 @@ func accessKnativeSrv(ctx context.Context, proxy string, t *testing.T) bool {
 		conds := curIng.Status.Status.GetConditions()
 		for _, cond := range conds {
 			if cond.Type == apis.ConditionReady && cond.Status == v1.ConditionTrue {
-				t.Logf("knative ingress status is ready.")
+				t.Log("knative ingress status is ready.")
 				return true
 			}
 		}
@@ -209,7 +214,7 @@ func accessKnativeSrv(ctx context.Context, proxy string, t *testing.T) bool {
 			}
 			bodyString := string(bodyBytes)
 			t.Logf(bodyString)
-			t.Logf("service is successfully accessed through kong.")
+			t.Log("service is successfully accessed through kong.")
 			return true
 		}
 		return false
@@ -236,7 +241,7 @@ func isKnativeReady(ctx context.Context, cluster clusters.Cluster, t *testing.T)
 			}
 		}
 
-		t.Logf("All knative pods are up and ready.")
+		t.Log("All knative pods are up and ready.")
 		return true
 
 	}, 60*time.Second, 1*time.Second, true)

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -10,10 +10,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +54,7 @@ func TestPluginEssentials(t *testing.T) {
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(testPluginsNamespace).Create(ctx, deployment, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
@@ -61,7 +64,7 @@ func TestPluginEssentials(t *testing.T) {
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
 	_, err = env.Cluster().Client().CoreV1().Services(testPluginsNamespace).Create(ctx, service, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
@@ -69,23 +72,24 @@ func TestPluginEssentials(t *testing.T) {
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
-	ingress := generators.NewIngressForService("/httpbin", map[string]string{
+	kubernetesVersion, err := env.Cluster().Version()
+	require.NoError(t, err)
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Create(ctx, ingress, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testPluginsNamespace, ingress))
 
 	defer func() {
-		t.Logf("ensuring that Ingress %s is cleaned up", ingress.Name)
-		if err := env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}); err != nil {
+		t.Log("ensuring that Ingress is cleaned up")
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), testPluginsNamespace, ingress); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
 		}
 	}()
 
-	t.Logf("waiting for routes from Ingress %s to be operational", ingress.Name)
+	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {
@@ -128,24 +132,47 @@ func TestPluginEssentials(t *testing.T) {
 		},
 	}
 	c, err := clientset.NewForConfig(env.Cluster().Config())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	kongplugin, err = c.ConfigurationV1().KongPlugins(testPluginsNamespace).Create(ctx, kongplugin, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	kongclusterplugin, err = c.ConfigurationV1().KongClusterPlugins().Create(ctx, kongclusterplugin, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
-	assert.NoError(t, err)
-
-	t.Logf("updating Ingress %s to use plugin %s", ingress.Name, kongplugin.Name)
-	require.Eventually(t, func() bool {
-		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
-		if err != nil {
-			return false
+	defer func() {
+		t.Log("cleaning up plugins")
+		if err := c.ConfigurationV1().KongPlugins(testPluginsNamespace).Delete(ctx, kongplugin.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
 		}
-		ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
-		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
-		return err == nil
+		if err := c.ConfigurationV1().KongClusterPlugins().Delete(ctx, kongclusterplugin.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Logf("updating Ingress to use plugin %s", kongplugin.Name)
+	require.Eventually(t, func() bool {
+		switch obj := ingress.(type) {
+		case *netv1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
+		case *netv1beta1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
+		}
+		return false
 	}, ingressWait, waitTick)
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
@@ -159,15 +186,27 @@ func TestPluginEssentials(t *testing.T) {
 		return resp.StatusCode == http.StatusTeapot
 	}, ingressWait, waitTick)
 
-	t.Logf("updating Ingress %s to use cluster plugin %s", ingress.Name, kongclusterplugin.Name)
+	t.Logf("updating Ingress to use cluster plugin %s", kongclusterplugin.Name)
 	require.Eventually(t, func() bool {
-		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, ingress.Name, metav1.GetOptions{})
-		if err != nil {
-			return false
+		switch obj := ingress.(type) {
+		case *netv1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongclusterplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
+		case *netv1beta1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongclusterplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
 		}
-		ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongclusterplugin.Name
-		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
-		return err == nil
+		return false
 	}, ingressWait, waitTick)
 
 	t.Logf("validating that clusterplugin %s was successfully configured", kongclusterplugin.Name)
@@ -181,8 +220,8 @@ func TestPluginEssentials(t *testing.T) {
 		return resp.StatusCode == http.StatusUnavailableForLegalReasons
 	}, ingressWait, waitTick)
 
-	t.Logf("deleting Ingress %s and waiting for routes to be torn down", ingress.Name)
-	assert.NoError(t, env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{}))
+	t.Log("deleting Ingress and waiting for routes to be torn down")
+	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testPluginsNamespace, ingress))
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {
@@ -190,7 +229,6 @@ func TestPluginEssentials(t *testing.T) {
 			return false
 		}
 		defer resp.Body.Close()
-		t.Logf("WARNING: endpoint %s returned response STATUS=(%d)", fmt.Sprintf("%s/httpbin", proxyURL), resp.StatusCode)
 		return expect404WithNoRoute(t, proxyURL.String(), resp)
 	}, ingressWait, waitTick)
 }

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -43,7 +43,13 @@ const (
 
 	// httpcTimeout is the default client timeout for HTTP clients used in tests.
 	httpcTimeout = time.Second * 3
+)
 
+// -----------------------------------------------------------------------------
+// Testing Variables
+// -----------------------------------------------------------------------------
+
+var (
 	// httpBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
 	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/postmanlabs/httpbin
@@ -57,13 +63,7 @@ const (
 
 	// controllerNamespace is the Kubernetes namespace where the controller is deployed
 	controllerNamespace = "kong-system"
-)
 
-// -----------------------------------------------------------------------------
-// Testing Variables
-// -----------------------------------------------------------------------------
-
-var (
 	// httpc is the default HTTP client to use for tests
 	httpc = http.Client{Timeout: httpcTimeout}
 
@@ -93,6 +93,9 @@ var (
 
 	// proxyUDPURL provides access to the UDP API endpoint for the Kong Addon which is deployed to the test environment's cluster.
 	proxyUDPURL *url.URL
+
+	// clusterVersion is a convenience var where the found version of the env.Cluster is stored.
+	clusterVersion semver.Version
 )
 
 // -----------------------------------------------------------------------------
@@ -248,13 +251,13 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Printf("INFO: running final testing environment checks")
-	serverVersion, err := env.Cluster().Client().ServerVersion()
+	clusterVersion, err = env.Cluster().Version()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not retrieve server version for cluster: %s", err)
 		os.Exit(ExitCodeCantCreateCluster)
 	}
 
-	fmt.Printf("INFO: testing environment is ready KUBERNETES_VERSION=(%v): running tests\n", serverVersion)
+	fmt.Printf("INFO: testing environment is ready KUBERNETES_VERSION=(%v): running tests\n", clusterVersion)
 	code := m.Run()
 	os.Exit(code)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes broken compatibility with legacy `Ingress` from netv1beta1 & extv1beta1
- enables release testing against v1.17 and v1.18 clusters

**Which issue this PR fixes**

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1095
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1614

**Special notes for your reviewer**:

These changes have been tested:

![old-k8s-tests](https://user-images.githubusercontent.com/5332524/127901407-72dc68c8-00b7-4790-8fae-a23b8c1dc468.png)