### PR TITLE
feat: cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,31 @@
+name: cleanup
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  gcloud:
+    environment: gcloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+
+      - name: cache go modules
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
+
+      - name: checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: cleanup orphaned test clusters
+        run: go run hack/e2e/cluster/cleanup/main.go all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: test ${{ matrix.dbmode }} on GKE v1.${{ matrix.minor }}
-        run: ./hack/e2e/run.sh
+        run: ./hack/e2e/run-tests.sh
         env:
           KUBERNETES_MAJOR_VERSION: 1
           KUBERNETES_MINOR_VERSION: ${{ matrix.minor }}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kong/kubernetes-ingress-controller
 go 1.16
 
 require (
+	cloud.google.com/go v0.89.0
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
@@ -16,7 +17,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.20.0
-	github.com/kong/kubernetes-testing-framework v0.4.0
+	github.com/kong/kubernetes-testing-framework v0.5.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
@@ -26,6 +27,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.8.1
+	google.golang.org/api v0.52.0
+	google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f
 	k8s.io/api v0.21.3
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -677,8 +677,8 @@ github.com/kong/deck v1.7.0/go.mod h1:o2letQaSpXVnDNoXehEibOF6q7v46qtbsKOCC+1owA
 github.com/kong/go-kong v0.19.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmdy5aog=
 github.com/kong/go-kong v0.20.0 h1:KiPsJORNs9UbjU8m1Tr3MZkIiKkzcVHIz0EYeT7SD3c=
 github.com/kong/go-kong v0.20.0/go.mod h1:eQP22bzJVeiEH77hYdWD019WjecJFVFHm77kPXquC28=
-github.com/kong/kubernetes-testing-framework v0.4.0 h1:QFUUiNSxnKfOKGbgmooXMhFnL+CQRxQcLFVxKCKB8o0=
-github.com/kong/kubernetes-testing-framework v0.4.0/go.mod h1:Rh4H0hY5t7hSkaaIqO7lwx/jRykOGaQeI1JgTg5p9UU=
+github.com/kong/kubernetes-testing-framework v0.5.0 h1:eX9KKxr8S2ZALglGJ63azGCyPbNFA9fzOcfJ8Ex4ODA=
+github.com/kong/kubernetes-testing-framework v0.5.0/go.mod h1:Rh4H0hY5t7hSkaaIqO7lwx/jRykOGaQeI1JgTg5p9UU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/hack/e2e/cluster/cleanup/main.go
+++ b/hack/e2e/cluster/cleanup/main.go
@@ -1,0 +1,148 @@
+package main
+
+// this script can either:
+//
+//  1) clean up specific named clusters
+//  2) clean up "all" clusters
+//
+// when "all" is chosen (e.g. "go run main.go all") the behavior is to
+// identify all clusters in the current GKE project and location which
+// are tagged as having been created by KTF and delete them if they are
+// older than 30m (because all tests generally pass in ~20m) or if they
+// are currently being created.
+//
+// this script is meant to be installed as a cronjob and run repeatedly
+// throughout the day to catch any orphaned clusters: however tests should
+// be trying to delete the clusters they create themselves.
+//
+// TODO: this is temporary: it was created for speed but will be replaced
+//       by upstream functionality in KTF.
+//       See: https://github.com/Kong/kubernetes-testing-framework/issues/61
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	container "cloud.google.com/go/container/apiv1"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
+	"google.golang.org/api/option"
+	containerpb "google.golang.org/genproto/googleapis/container/v1"
+)
+
+const timeUntilClusterOrphaned = time.Minute * 30
+
+var (
+	gcloudClientID string
+
+	ctx         = context.Background()
+	gkeCreds    = os.Getenv(gke.GKECredsVar)
+	gkeProject  = os.Getenv(gke.GKEProjectVar)
+	gkeLocation = os.Getenv(gke.GKELocationVar)
+)
+
+func main() {
+	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
+	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
+	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)
+
+	var creds map[string]string
+	if err := json.Unmarshal([]byte(gkeCreds), &creds); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid credentials: %s\n", err)
+		os.Exit(10)
+	}
+
+	var ok bool
+	gcloudClientID, ok = creds["client_id"]
+	if !ok || gcloudClientID == "" {
+		fmt.Fprintln(os.Stderr, "invalid credentials: missing 'client_id'")
+		os.Exit(10)
+	}
+
+	if len(os.Args) < 1 {
+		fmt.Fprintln(os.Stdout, "Usage: cleanup all | <list of cluster names...>")
+		os.Exit(1)
+	}
+
+	var clusterNames []string
+	if len(os.Args) == 2 && os.Args[1] == "all" {
+		var err error
+		clusterNames, err = findOrphanedClusters()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not find orphaned clusters: %s", err)
+			os.Exit(2)
+		}
+	} else {
+		clusterNames = os.Args[1:]
+	}
+
+	if len(clusterNames) < 1 {
+		fmt.Println("INFO: no clusters to clean up")
+		os.Exit(0)
+	}
+
+	var errs []error
+	for _, clusterName := range clusterNames {
+		cluster, err := gke.NewFromExistingWithEnv(ctx, clusterName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("could not retrieve cluster %s: %w", clusterName, err))
+			continue
+		}
+		fmt.Printf("INFO: cleaning up cluster %s\n", cluster.Name())
+		if err := cluster.Cleanup(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("could not delete cluster %s: %w", clusterName, err))
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		fmt.Fprintf(os.Stderr, "failed to cleanup all clusters: %v\n", errs)
+		os.Exit(3)
+	}
+}
+
+func mustNotBeEmpty(name, value string) {
+	if value == "" {
+		panic(fmt.Sprintf("%s was empty", name))
+	}
+}
+
+func findOrphanedClusters() ([]string, error) {
+	credsOpt := option.WithCredentialsJSON([]byte(gkeCreds))
+	mgrc, err := container.NewClusterManagerClient(ctx, credsOpt)
+	if err != nil {
+		return nil, err
+	}
+	defer mgrc.Close()
+
+	clusterListReq := containerpb.ListClustersRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", gkeProject, gkeLocation),
+	}
+	clusterListResp, err := mgrc.ListClusters(ctx, &clusterListReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var orphanedClusterNames []string
+	for _, cluster := range clusterListResp.Clusters {
+		if createdBy, ok := cluster.ResourceLabels[gke.GKECreateLabel]; ok {
+			if gcloudClientID == createdBy {
+				createdAt, err := time.Parse(time.RFC3339, cluster.CreateTime)
+				if err != nil {
+					return nil, err
+				}
+
+				orphanTime := createdAt.Add(timeUntilClusterOrphaned)
+				if time.Now().UTC().After(orphanTime) {
+					orphanedClusterNames = append(orphanedClusterNames, cluster.Name)
+				} else {
+					fmt.Printf("INFO: cluster %s skipped (built in the last %s)\n", cluster.Name, timeUntilClusterOrphaned)
+				}
+			}
+		}
+	}
+
+	return orphanedClusterNames, nil
+}

--- a/hack/e2e/cluster/deploy/main.go
+++ b/hack/e2e/cluster/deploy/main.go
@@ -33,7 +33,6 @@ var (
 )
 
 func main() {
-	fmt.Println("INFO: configuring GKE cloud environment for tests")
 	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
 	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
 	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)

--- a/hack/e2e/run-tests.sh
+++ b/hack/e2e/run-tests.sh
@@ -12,10 +12,10 @@ WORKDIR="$(dirname "${BASH_SOURCE}")/../.."
 cd "${WORKDIR}"
 
 CLUSTER_NAME="e2e-$(uuidgen)"
-KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/main.go
+KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/deploy/main.go
 
 function cleanup() {
-    KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/main.go cleanup
+    go run hack/e2e/cleanup/main.go ${CLUSTER_NAME}
 }
 trap cleanup EXIT SIGINT SIGQUIT
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a cleanup workflow cronjob which will regularly check for and delete orphaned CI resources.

**Which issue this PR fixes**

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1095
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1627

**Special notes for your reviewer**:

Blocked by https://github.com/Kong/kubernetes-testing-framework/pull/73

The rules for cleanup are restricted:

1. the cluster must have been specifically created by [KTF](https://github.com/kong/kubernetes-testing-framework)
2. the cluster must be older than 30m
3. the cluster must be in the same project and location specified in the `gcloud` CI environment
4. the cluster must have been created by the same Google Cloud IAM Service Account as used in the `gcloud` CI environment

I expect these conditions will be good to start with, and we can make tweaks to these over time if we make other changes to how we deploy clusters in CI.