### PR TITLE
fix: knative tests on gke

### DIFF
--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -29,6 +29,10 @@ import (
 )
 
 const (
+	// knativeWaitTime indicates how long to wait for knative components to be up and running
+	// on the cluster. The current value is based on deployment times seen in a GKE environment.
+	knativeWaitTime = time.Minute * 2
+
 	// knativeNamespace is the testing namespace where Knative components will be deployed
 	knativeNamespace = "knative-serving"
 
@@ -247,5 +251,5 @@ func isKnativeReady(ctx context.Context, cluster clusters.Cluster, t *testing.T)
 		t.Log("All knative pods are up and ready.")
 		return true
 
-	}, 60*time.Second, 1*time.Second, true)
+	}, knativeWaitTime, waitTick, true)
 }

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -75,6 +75,14 @@ func TestKnativeIngress(t *testing.T) {
 	require.True(t, accessKnativeSrv(ctx, proxy, t), true)
 }
 
+// -----------------------------------------------------------------------------
+// Knative Deployment Functions
+// -----------------------------------------------------------------------------
+
+// TODO: in future iterations Knative components will become deployable as an "addon" for test clusters
+//       in our testing framework, and then we can remove this deployment logic and just have the tests.
+//       See: https://github.com/Kong/kubernetes-testing-framework/issues/75
+
 func deployManifest(ctx context.Context, yml string, t *testing.T) error {
 	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", yml)
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -41,10 +40,6 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
-	if env.Cluster().Type() != kind.KindClusterType {
-		t.Skip("TODO: knative tests are only supported on KIND based environments right now")
-	}
-
 	cluster := env.Cluster()
 	proxy := proxyURL.Hostname()
 	assert.NotEmpty(t, proxy)


### PR DESCRIPTION
**What this PR does / why we need it**:

This includes some fixes to our Knative integration tests so that they work properly against a GKE cluster.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1617

**Special notes for your reviewer**:

I have tested these changes _manually_ against a GKE cluster and they are working properly.