### PR TITLE
fix: tcp ingress status updates

### DIFF
--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	statusUpdateRetry = 3
+	statusUpdateRetry    = 3
+	statusUpdateWaitTick = time.Second
 )
 
 // PullConfigUpdate is a dedicated function that process ingress/customer resource status update after configuration is updated within kong.
@@ -191,7 +192,7 @@ func UpdateIngress(
 
 				log.Errorf("failed to fetch Ingress %v/%v: %v. retrying...", namespace, name, err)
 				retry++
-				time.Sleep(time.Second)
+				time.Sleep(statusUpdateWaitTick)
 				continue
 			}
 
@@ -216,7 +217,7 @@ func UpdateIngress(
 			}
 
 			log.Errorf("failed to update Ingress V1 status. %v. retrying...", err)
-			time.Sleep(time.Second)
+			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
 	}
@@ -251,7 +252,7 @@ func UpdateIngressLegacy(
 
 				log.Errorf("failed to fetch Ingress %v/%v: %v. retrying...", namespace, name, err)
 				retry++
-				time.Sleep(time.Second)
+				time.Sleep(statusUpdateWaitTick)
 				continue
 			}
 
@@ -276,7 +277,7 @@ func UpdateIngressLegacy(
 			}
 
 			log.Errorf("failed to update Ingress V1beta1 status. %v. retrying...", err)
-			time.Sleep(time.Second)
+			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
 	}
@@ -303,7 +304,7 @@ func UpdateUDPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 				}
 
 				log.Errorf("failed to fetch UDP Ingress %v/%v: %v", namespace, name, err)
-				time.Sleep(time.Second)
+				time.Sleep(statusUpdateWaitTick)
 				retry++
 				continue
 			}
@@ -329,7 +330,7 @@ func UpdateUDPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 			}
 
 			log.Errorf("failed to update UDPIngress status: %v. retry...", err)
-			time.Sleep(time.Second)
+			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
 	}
@@ -407,7 +408,7 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 				}
 
 				log.Errorf("failed to fetch Knative Ingress %v/%v: %v", namespace, name, err)
-				time.Sleep(time.Second)
+				time.Sleep(statusUpdateWaitTick)
 				retry++
 				continue
 			}
@@ -444,7 +445,7 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 			}
 
 			log.Errorf("failed to update ingress status: %v. retrying...", err)
-			time.Sleep(time.Second)
+			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
 	}

--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -187,10 +187,11 @@ func UpdateIngress(
 			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
 			if err != nil || curIng == nil {
 				if errors.IsNotFound(err) {
+					log.Debugf("failed to retrieve Ingress V1: the object (%s/%s) is gone, status update stopped.", namespace, name)
 					return nil
 				}
 
-				log.Errorf("failed to fetch Ingress %v/%v: %v. retrying...", namespace, name, err)
+				log.Errorf("failed to fetch Ingress %v/%v due to error: %v. retrying...", namespace, name, err)
 				retry++
 				time.Sleep(statusUpdateWaitTick)
 				continue
@@ -213,10 +214,14 @@ func UpdateIngress(
 				break
 			}
 			if errors.IsNotFound(err) {
+				log.Debugf("failed to update Ingress V1 status because the object (%s/%s) is gone, status update stopped.", namespace, name)
 				return nil
 			}
-
-			log.Errorf("failed to update Ingress V1 status. %v. retrying...", err)
+			if errors.IsConflict(err) {
+				log.Debugf("failed to update Ingress V1 status because the object (%s/%s) changed: %v retrying...", namespace, name, err)
+			} else {
+				log.Errorf("failed to update Ingress V1 status. %v. retrying...", err)
+			}
 			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
@@ -247,10 +252,11 @@ func UpdateIngressLegacy(
 			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
 			if err != nil || curIng == nil {
 				if errors.IsNotFound(err) {
+					log.Debugf("failed to retrieve Legacy Ingress: the object (%s/%s) is gone, status update stopped.", namespace, name)
 					return nil
 				}
 
-				log.Errorf("failed to fetch Ingress %v/%v: %v. retrying...", namespace, name, err)
+				log.Errorf("failed to fetch Ingress %v/%v due to error: %v. retrying...", namespace, name, err)
 				retry++
 				time.Sleep(statusUpdateWaitTick)
 				continue
@@ -273,10 +279,14 @@ func UpdateIngressLegacy(
 				break
 			}
 			if errors.IsNotFound(err) {
+				log.Debugf("failed to update Ingress V1 status because the object (%s/%s) is gone, status update stopped.", namespace, name)
 				return nil
 			}
-
-			log.Errorf("failed to update Ingress V1beta1 status. %v. retrying...", err)
+			if errors.IsConflict(err) {
+				log.Debugf("failed to update Ingress V1Beta1 status because the object (%s/%s) changed: %v retrying...", namespace, name, err)
+			} else {
+				log.Errorf("failed to update Ingress V1Beta1 status. %v. retrying...", err)
+			}
 			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
@@ -300,10 +310,11 @@ func UpdateUDPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
 			if err != nil || curIng == nil {
 				if errors.IsNotFound(err) {
+					log.Debugf("failed to retrieve UDPIngress: the object (%s/%s) is gone, status update stopped.", namespace, name)
 					return nil
 				}
 
-				log.Errorf("failed to fetch UDP Ingress %v/%v: %v", namespace, name, err)
+				log.Errorf("failed to fetch UDP Ingress %v/%v due to error: %v", namespace, name, err)
 				time.Sleep(statusUpdateWaitTick)
 				retry++
 				continue
@@ -326,10 +337,14 @@ func UpdateUDPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 				break
 			}
 			if errors.IsNotFound(err) {
+				log.Debugf("failed to update UDPIngress status because the object (%s/%s) is gone, status update stopped.", namespace, name)
 				return nil
 			}
-
-			log.Errorf("failed to update UDPIngress status: %v. retry...", err)
+			if errors.IsConflict(err) {
+				log.Debugf("failed to update UDPIngress status because the object (%s/%s) changed: %v retrying...", namespace, name, err)
+			} else {
+				log.Errorf("failed to update UDPIngress status. %v. retrying...", err)
+			}
 			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}
@@ -354,10 +369,11 @@ func UpdateTCPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
 			if err != nil || curIng == nil {
 				if errors.IsNotFound(err) {
+					log.Debugf("failed to retrieve TCPIngress: the object (%s/%s) is gone, status update stopped.", namespace, name)
 					return nil
 				}
 
-				log.Errorf("failed to fetch TCPIngress %v/%v: %v", namespace, name, err)
+				log.Errorf("failed to fetch TCPIngress %v/%v due to error: %v", namespace, name, err)
 				time.Sleep(statusUpdateWaitTick)
 				retry++
 				continue
@@ -376,10 +392,11 @@ func UpdateTCPIngress(ctx context.Context, logger logr.Logger, svc file.FService
 				break
 			}
 			if errors.IsNotFound(err) {
+				log.Debugf("failed to update TCPIngress status because the object (%s/%s) is gone, status update stopped.", namespace, name)
 				return nil
 			}
 			if errors.IsConflict(err) {
-				log.Debugf("failed to update TCPIngress status because the object (%s/%s) changed. retrying...", namespace, name)
+				log.Debugf("failed to update TCPIngress status because the object (%s/%s) changed: %v retrying...", namespace, name, err)
 			} else {
 				log.Errorf("failed to update TCPIngress status. %v. retrying...", err)
 			}
@@ -414,10 +431,11 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 			curIng, err := ingClient.Get(ctx, name, metav1.GetOptions{})
 			if err != nil || curIng == nil {
 				if errors.IsNotFound(err) {
+					log.Debugf("failed to retrieve Knative Ingress: the object (%s/%s) is gone, status update stopped.", namespace, name)
 					return nil
 				}
 
-				log.Errorf("failed to fetch Knative Ingress %v/%v: %v", namespace, name, err)
+				log.Errorf("failed to fetch Knative Ingress %v/%v due to error: %v", namespace, name, err)
 				time.Sleep(statusUpdateWaitTick)
 				retry++
 				continue
@@ -451,10 +469,14 @@ func UpdateKnativeIngress(ctx context.Context, logger logr.Logger, svc file.FSer
 				break
 			}
 			if errors.IsNotFound(err) {
+				log.Debugf("failed to update Knative Ingress status because the object (%s/%s) is gone, status update stopped.", namespace, name)
 				return nil
 			}
-
-			log.Errorf("failed to update ingress status: %v. retrying...", err)
+			if errors.IsConflict(err) {
+				log.Debugf("failed to update Knative Ingress status because the object (%s/%s) changed: %v. retrying...", namespace, name, err)
+			} else {
+				log.Errorf("failed to update Knative Ingress status. %v. retrying...", err)
+			}
 			time.Sleep(statusUpdateWaitTick)
 			retry++
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

- makes logging updates when objects are out of date debug instead of info
- adds missing retry logic to the `TCPIngress` status update implementation

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1639