### PR TITLE
docs: fix alpha changelog for flag breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
 - autonegotiation of the Ingress API version (extensions v1beta1, networking
   v1beta1, networking v1) has been disabled. Instead, the user is expected to
   set **exactly** one of `--controller-ingress-networkingv1`,
+- `--dump-config` is now a boolean. `true` is equivalent to the old `enabled` value. `false` is equivalent to the old `disabled` value. `true` with the additional new `--dump-sensitive-config=true` flag is equivalent to the old `sensitive` value.
   `--controller-ingress-networkingv1beta1`,
   `--controller-ingress-extensionsv1beta1` flags to `enabled`. There will be an
   `auto` mode implemented soon that will add the autonegotiation capability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,9 +141,9 @@
 
 - several miscellaneous flags have been removed.
   The following flags are no longer usable:
-  - `--disable-ingress-extensionsv1beta1`
-  - `--disable-ingress-networkingv1`
-  - `--disable-ingress-networkingv1beta1`
+  - `--disable-ingress-extensionsv1beta1` (replaced by `--enable-controller-ingress-extensionsv1beta1=false`)
+  - `--disable-ingress-networkingv1` (replaced by `--enable-controller-ingress-networkingv1=false`)
+  - `--disable-ingress-networkingv1beta1` (replaced by `--enable-controller-ingress-networkingv1beta1=false`)
   - `--version`
   - `--alsologtostderr`
   - `--logtostderr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,9 +139,21 @@
 
 #### Breaking changes
 
-- support for "classless" ingress types has been removed: the controller flags
-  `--process-classless-ingress-v1beta1`, `--process-classless-ingress-v1` and
-  `--process-classless-kong-consumer` flags are no longer valid
+- several miscellaneous flags have been removed.
+  The following flags are no longer usable:
+  - `--disable-ingress-extensionsv1beta1`
+  - `--disable-ingress-networkingv1`
+  - `--disable-ingress-networkingv1beta1`
+  - `--version`
+  - `--alsologtostderr`
+  - `--logtostderr`
+  - `--v`
+  - `--vmodule`
+- support for "classless" ingress types has been removed.
+  The following flags are no longer usable:
+  - `--process-classless-ingress-v1beta1`
+  - `--process-classless-ingress-v1`
+  - `--process-classless-kong-consumer`
 - autonegotiation of the Ingress API version (extensions v1beta1, networking
   v1beta1, networking v1) has been disabled. Instead, the user is expected to
   set **exactly** one of `--controller-ingress-networkingv1`,

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -126,15 +126,11 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.ProbeAddr, "health-probe-bind-address", fmt.Sprintf(":%v", HealthzPort), "The address the probe endpoint binds to.")
 	flagSet.StringVar(&c.KongAdminURL, "kong-admin-url", "http://localhost:8001", `The Kong Admin URL to connect to in the format "protocol://address:port".`)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "proxy-sync-seconds", proxy.DefaultSyncSeconds,
-		fmt.Sprintf(
-			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds)",
-			proxy.DefaultSyncSeconds,
-		))
+		"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API.",
+	)
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", proxy.DefaultProxyTimeoutSeconds,
-		fmt.Sprintf(
-			"Define the rate (in seconds) in which the timeout configuration will be applied to the Kong client. (default: %g seconds)",
-			proxy.DefaultSyncSeconds,
-		))
+		"Define the rate (in seconds) in which the timeout configuration will be applied to the Kong client.",
+	)
 	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `A Secret containing custom entities for DB-less mode, in "namespace/name" format`)
 
 	// Kubernetes configurations
@@ -192,10 +188,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,
-		fmt.Sprintf(
-			"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. (default: %g seconds) (DEPRECATED, use --proxy-sync-seconds instead)",
-			proxy.DefaultSyncSeconds,
-		))
+		"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API (DEPRECATED, use --proxy-sync-seconds instead)",
+	)
 	flagSet.Int("stderrthreshold", 0, "DEPRECATED: has no effect and will be removed in future releases (see github issue #1297)")
 	flagSet.Bool("update-status-on-shutdown", false, `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #1304)`)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We removed several flags in the first alpha release
that we forgot to add to the release notes. After
doing a comparison of v1 and v2 flags this patch
checks in the remaining flags that aren't coming
forward into v2.

Additionally removed some superflous default notes
in flag descriptions (flagset will produce defaults in
the `--help` output anyway, so these are redundant).

**Which issue this PR fixes**

Supports https://github.com/Kong/docs.konghq.com/issues/2904

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
