### PR TITLE
fix: knative ingress tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.20.0
-	github.com/kong/kubernetes-testing-framework v0.5.0
+	github.com/kong/kubernetes-testing-framework v0.6.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,8 @@ github.com/kong/deck v1.7.0/go.mod h1:o2letQaSpXVnDNoXehEibOF6q7v46qtbsKOCC+1owA
 github.com/kong/go-kong v0.19.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmdy5aog=
 github.com/kong/go-kong v0.20.0 h1:KiPsJORNs9UbjU8m1Tr3MZkIiKkzcVHIz0EYeT7SD3c=
 github.com/kong/go-kong v0.20.0/go.mod h1:eQP22bzJVeiEH77hYdWD019WjecJFVFHm77kPXquC28=
-github.com/kong/kubernetes-testing-framework v0.5.0 h1:eX9KKxr8S2ZALglGJ63azGCyPbNFA9fzOcfJ8Ex4ODA=
-github.com/kong/kubernetes-testing-framework v0.5.0/go.mod h1:Rh4H0hY5t7hSkaaIqO7lwx/jRykOGaQeI1JgTg5p9UU=
+github.com/kong/kubernetes-testing-framework v0.6.0 h1:oToldZnT5bdItwOEfBqLnF4MjxYEP/Luaqv8qgVzeN8=
+github.com/kong/kubernetes-testing-framework v0.6.0/go.mod h1:Rh4H0hY5t7hSkaaIqO7lwx/jRykOGaQeI1JgTg5p9UU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -3,19 +3,17 @@
 package integration
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -32,83 +30,46 @@ const (
 	// knativeWaitTime indicates how long to wait for knative components to be up and running
 	// on the cluster. The current value is based on deployment times seen in a GKE environment.
 	knativeWaitTime = time.Minute * 2
-
-	// knativeNamespace is the testing namespace where Knative components will be deployed
-	knativeNamespace = "knative-serving"
-
-	knativeCrds = "https://github.com/knative/serving/releases/download/v0.13.0/serving-crds.yaml"
-	knativeCore = "https://github.com/knative/serving/releases/download/v0.13.0/serving-core.yaml"
 )
 
 func TestKnativeIngress(t *testing.T) {
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("TODO: knative tests are only supported on KIND based environments right now")
 	}
-
-	cluster := env.Cluster()
-	proxy := proxyURL.Hostname()
-	assert.NotEmpty(t, proxy)
-	t.Logf("proxy url %s", proxy)
-
 	ctx := context.Background()
 
-	t.Log("Deploying all resources that are required to run knative")
-	require.NoError(t, deployManifest(ctx, knativeCrds, t))
-	require.NoError(t, deployManifest(ctx, knativeCore, t))
-	require.True(t, isKnativeReady(ctx, cluster, t), true)
+	t.Log("generating a knative clientset")
+	knativec, err := knativeversioned.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
 
-	t.Log("Configure Knative NetworkLayer as Kong")
-	require.NoError(t, configKnativeNetwork(ctx, cluster, t))
-	require.NoError(t, configKnativeDomain(ctx, proxy, cluster, t))
+	t.Logf("configure knative network for ingress class %s", ingressClass)
+	payloadBytes := []byte(fmt.Sprintf("{\"data\": {\"ingress.class\": \"%s\"}}", ingressClass))
+	_, err = env.Cluster().Client().CoreV1().ConfigMaps(knative.DefaultNamespace).Patch(ctx, "config-network", types.MergePatchType, payloadBytes, metav1.PatchOptions{})
+	require.NoError(t, err)
+	require.NoError(t, configKnativeDomain(ctx, proxyURL.Hostname(), env.Cluster()))
 
-	t.Log("Install knative service")
+	t.Log("deploying a native service to test routing")
+	var service *knservingv1.Service
 	require.Eventually(t, func() bool {
-		err := installKnativeSrv(ctx, t)
-		if err != nil {
-			t.Log("checking knativing webhook readiness.")
-			return false
-		}
-		return true
-	}, 30*time.Second, 2*time.Second, true)
+		service, err = installKnativeSrv(ctx, knativec)
+		return err == nil
+	}, knativeWaitTime, waitTick, true)
+
+	defer func() {
+		t.Log("cleaning up knative services used for testing")
+		assert.NoError(t, knativec.ServingV1().Services("default").Delete(ctx, service.Name, metav1.DeleteOptions{}))
+	}()
 
 	t.Log("Test knative service using kong.")
-	require.True(t, accessKnativeSrv(ctx, proxy, t), true)
+	require.True(t, accessKnativeSrv(ctx, proxyURL.Hostname(), t), true)
 }
 
 // -----------------------------------------------------------------------------
 // Knative Deployment Functions
 // -----------------------------------------------------------------------------
 
-// TODO: in future iterations Knative components will become deployable as an "addon" for test clusters
-//       in our testing framework, and then we can remove this deployment logic and just have the tests.
-//       See: https://github.com/Kong/kubernetes-testing-framework/issues/75
-
-func deployManifest(ctx context.Context, yml string, t *testing.T) error {
-	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", yml)
-	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintln(os.Stdout, stdout.String())
-		return err
-	}
-	t.Logf("successfully deploy manifest " + yml)
-	return nil
-}
-
-func configKnativeNetwork(ctx context.Context, cluster clusters.Cluster, t *testing.T) error {
-	payloadBytes := []byte(fmt.Sprintf("{\"data\": {\"ingress.class\": \"%s\"}}", ingressClass))
-	_, err := cluster.Client().CoreV1().ConfigMaps(knativeNamespace).Patch(ctx, "config-network", types.MergePatchType, payloadBytes, metav1.PatchOptions{})
-	if err != nil {
-		t.Logf("failed updating config map %v", err)
-		return err
-	}
-
-	t.Log("successfully configured knative network.")
-	return nil
-}
-
-func installKnativeSrv(ctx context.Context, t *testing.T) error {
+func installKnativeSrv(ctx context.Context, knativec *knativeversioned.Clientset) (*knservingv1.Service, error) {
+	// generate the knative service resource
 	tobeDeployedService := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "helloworld-go",
@@ -126,35 +87,19 @@ func installKnativeSrv(ctx context.Context, t *testing.T) error {
 										{
 											Name:  "TARGET",
 											Value: "Go Sample v1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	knativeCli, err := knativeversioned.NewForConfig(env.Cluster().Config())
+										}}}}}}}}}}
+
+	// deploy the new service to the cluster
+	service, err := knativec.ServingV1().Services("default").Create(ctx, tobeDeployedService, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create knative service. %v", err)
+		return nil, fmt.Errorf("failed to create knative service. %w", err)
 	}
 
-	_, err = knativeCli.ServingV1().Services("default").Create(ctx, tobeDeployedService, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create knative service. %v", err)
-	}
-
-	t.Log("successfully installed knative service.")
-	return nil
+	return service, nil
 }
 
-func configKnativeDomain(ctx context.Context, proxy string, cluster clusters.Cluster, t *testing.T) error {
-	configMapData := make(map[string]string)
-	configMapData[proxy] = ""
-	labels := make(map[string]string)
-	labels["serving.knative.dev/release"] = "v0.13.0"
+func configKnativeDomain(ctx context.Context, proxy string, cluster clusters.Cluster) error {
+	// generate the new config-domain configmap
 	configMap := v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -162,26 +107,31 @@ func configKnativeDomain(ctx context.Context, proxy string, cluster clusters.Clu
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "config-domain",
-			Namespace: knativeNamespace,
-			Labels:    labels,
+			Namespace: knative.DefaultNamespace,
+			Labels: map[string]string{
+				"serving.knative.dev/release": "v0.13.0",
+			},
 		},
-		Data: configMapData,
+		Data: map[string]string{
+			proxy: "",
+		},
 	}
-	_, err := cluster.Client().CoreV1().ConfigMaps(knativeNamespace).Update(ctx, &configMap, metav1.UpdateOptions{})
+
+	// update the config-domain configmap with the new values
+	_, err := cluster.Client().CoreV1().ConfigMaps(knative.DefaultNamespace).Update(ctx, &configMap, metav1.UpdateOptions{})
 	if err != nil {
-		t.Logf("failed updating config map %v", err)
 		return err
 	}
-	t.Log("successfully update knative config domain.")
+
 	return nil
 }
 
 func accessKnativeSrv(ctx context.Context, proxy string, t *testing.T) bool {
-	knativeCli, err := knativenetworkingversioned.NewForConfig(env.Cluster().Config())
+	knativec, err := knativenetworkingversioned.NewForConfig(env.Cluster().Config())
 	if err != nil {
 		return false
 	}
-	ingCli := knativeCli.NetworkingV1alpha1().Ingresses("default")
+	ingCli := knativec.NetworkingV1alpha1().Ingresses("default")
 	assert.Eventually(t, func() bool {
 		curIng, err := ingCli.Get(ctx, "helloworld-go", metav1.GetOptions{})
 		if err != nil || curIng == nil {
@@ -233,50 +183,5 @@ func accessKnativeSrv(ctx context.Context, proxy string, t *testing.T) bool {
 			return true
 		}
 		return false
-
-	}, 120*time.Second, 1*time.Second)
-}
-
-func isKnativeReady(ctx context.Context, cluster clusters.Cluster, t *testing.T) bool {
-	// the deployment manifests for knative include some CPU and Memory limits which
-	// are good for production, but mostly just problematic when running simple tests
-	// where these components are going to be brought up and torn down quickly.
-	// we tear out these requirements ad as long as the pods start we will likely have
-	// all the CPU and memory we need to complete the tests (whereafter we will tear
-	// all of the knative components down anyhow).
-	deploymentList, err := cluster.Client().AppsV1().Deployments(knativeNamespace).List(ctx, metav1.ListOptions{})
-	require.NoError(t, err)
-	for i := 0; i < len(deploymentList.Items); i++ {
-		deployment := deploymentList.Items[i]
-		require.Eventually(t, func() bool {
-			for j := 0; j < len(deployment.Spec.Template.Spec.Containers); j++ {
-				deployment.Spec.Template.Spec.Containers[j].Resources = corev1.ResourceRequirements{}
-			}
-			_, err = cluster.Client().AppsV1().Deployments(knativeNamespace).Update(ctx, &deployment, metav1.UpdateOptions{})
-			return err == nil
-		}, knativeWaitTime, waitTick)
-	}
-
-	return assert.Eventually(t, func() bool {
-		podList, err := cluster.Client().CoreV1().Pods(knativeNamespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			t.Logf("failed retrieving knative pods. %v", err)
-			return false
-		}
-
-		if len(podList.Items) != 4 {
-			t.Logf("expected 4 pods, found %d", len(podList.Items))
-			return false
-		}
-
-		for _, pod := range podList.Items {
-			if pod.Status.Phase != v1.PodRunning {
-				return false
-			}
-		}
-
-		t.Log("All knative pods are up and ready.")
-		return true
-
-	}, knativeWaitTime, waitTick, true)
+	}, knativeWaitTime, waitTick)
 }

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,9 +32,6 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
-	if env.Cluster().Type() != kind.KindClusterType {
-		t.Skip("TODO: knative tests are only supported on KIND based environments right now")
-	}
 	ctx := context.Background()
 
 	t.Log("generating a knative clientset")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -273,7 +273,6 @@ var crds = []string{
 	"../../config/crd/bases/configuration.konghq.com_kongingresses.yaml",
 	"../../config/crd/bases/configuration.konghq.com_kongconsumers.yaml",
 	"../../config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml",
-	knativeCrds,
 }
 
 // deployControllers ensures that relevant CRDs and controllers are deployed to the test cluster

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
@@ -133,7 +134,7 @@ func TestMain(m *testing.M) {
 	}
 	kongbuilder.WithControllerDisabled()
 	kongAddon := kongbuilder.Build()
-	builder := environments.NewBuilder().WithAddons(kongAddon)
+	builder := environments.NewBuilder().WithAddons(kongAddon, knative.New())
 
 	fmt.Println("INFO: checking for reusable environment components")
 	if existingCluster != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

When releasing `v2.0.0-alpha.3` some problems were encountered with the Knative ingress tests, which turned out to be flakes caused by timing issues with deploying Knative components. This PR removes all provisioning of Knative components in favor of leaving that up to the testing environment's Knative addon, fixes some issues, does some refactoring of the tests and ultimately re-enables the tests in release testing CI in support of upcoming `v2.x` releases.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1637

**Special notes for your reviewer**:

Blocked by https://github.com/Kong/kubernetes-testing-framework/pull/77

I have tested this manually with both `v1.17` and `v1.18` GKE clusters locally to to ensure they pass. I made sure to run the tests multiple times in a row to validate cleanup and ensure test idempotency, and did not run into any errors.
