### PR TITLE
fix: de-duplicate codeql runs on PRs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,9 +1,10 @@
-name: "Common Static Check: CodeQL"
+name: codeql
 
 on:
   push:
     branches:
-      - '*'
+      - 'main'
+      - 'next'
   pull_request:
     branches:
       - '*'
@@ -12,7 +13,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes an extra run of codeql on each PR by
only running on specific branches for "push" triggers.

Additionally this does some cleanup on the workflow
to make the namings and logging simpler to fit better
with the rest of our CI workflows.