### PR TITLE
feat: parallelize the integration test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,14 +176,14 @@ test.integration.legacy: container
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./...
+	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
 
 # TODO: race checking has been temporarily turned off because of race conditions found with deck. This will be resolved in an upcoming Alpha release of KIC 2.0.
 #       See: https://github.com/Kong/kubernetes-ingress-controller/issues/1324
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./...
+	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
 
 # ------------------------------------------------------------------------------
 # Operations

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ REPO_URL=github.com/kong/kubernetes-ingress-controller
 IMGNAME?=kubernetes-ingress-controller
 IMAGE = $(REGISTRY)/$(IMGNAME)
 IMG ?= controller:latest
+NCPU ?= $(shell getconf _NPROCESSORS_ONLN)
 
 # ------------------------------------------------------------------------------
 # Setup
@@ -176,14 +177,14 @@ test.integration.legacy: container
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -timeout 15m -race -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
+	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -parallel $(NCPU) -timeout 15m -race -v -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
 
 # TODO: race checking has been temporarily turned off because of race conditions found with deck. This will be resolved in an upcoming Alpha release of KIC 2.0.
 #       See: https://github.com/Kong/kubernetes-ingress-controller/issues/1324
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -timeout 15m -v -count=1 -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
+	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -parallel $(NCPU) -timeout 15m -v -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
 
 # ------------------------------------------------------------------------------
 # Operations

--- a/hack/e2e/run-tests.sh
+++ b/hack/e2e/run-tests.sh
@@ -19,4 +19,5 @@ function cleanup() {
 }
 trap cleanup EXIT SIGINT SIGQUIT
 
-GOFLAGS="-tags=integration_tests" KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" go test -count 1 -timeout 45m -v ./test/integration/...
+NCPU="$(getconf _NPROCESSORS_ONLN)"
+GOFLAGS="-tags=integration_tests" KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" go test -parallel "${NCPU}" -timeout 30m -v ./test/integration/...

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
+	t.Parallel()
 	assert.Eventually(t, func() bool {
 		healthzURL := fmt.Sprintf("http://localhost:%v/healthz", manager.HealthzPort)
 		resp, err := httpc.Get(healthzURL)
@@ -28,6 +29,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestMetricsEndpoint(t *testing.T) {
+	t.Parallel()
 	assert.Eventually(t, func() bool {
 		metricsURL := fmt.Sprintf("http://localhost:%v/metrics", manager.MetricsPort)
 		resp, err := httpc.Get(metricsURL)
@@ -55,6 +57,7 @@ func TestMetricsEndpoint(t *testing.T) {
 }
 
 func TestProfilingEndpoint(t *testing.T) {
+	t.Parallel()
 	assert.Eventually(t, func() bool {
 		profilingURL := fmt.Sprintf("http://localhost:%v/debug/pprof/", manager.DiagnosticsPort)
 		resp, err := httpc.Get(profilingURL)
@@ -68,6 +71,7 @@ func TestProfilingEndpoint(t *testing.T) {
 }
 
 func TestConfigEndpoint(t *testing.T) {
+	t.Parallel()
 	assert.Eventually(t, func() bool {
 		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)

--- a/test/integration/ingress_bulk_test.go
+++ b/test/integration/ingress_bulk_test.go
@@ -26,8 +26,6 @@ const testBulkIngressNamespace = "ingress-bulk-testing"
 
 // TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
-	ctx := context.Background()
-
 	t.Logf("creating namespace %s for testing", testBulkIngressNamespace)
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testBulkIngressNamespace}}
 	namespace, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})

--- a/test/integration/ingress_bulk_test.go
+++ b/test/integration/ingress_bulk_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -22,33 +21,15 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/annotations"
 )
 
-const testBulkIngressNamespace = "ingress-bulk-testing"
-
 // TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
-	t.Logf("creating namespace %s for testing", testBulkIngressNamespace)
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testBulkIngressNamespace}}
-	namespace, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testBulkIngressNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
+	ns, cleanup := namespace(t)
+	defer cleanup()
 
 	t.Log("deploying a minimal HTTP container to be exoposed via ingress")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testBulkIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Log("checking the cluster version to determine which ingress version to use")
@@ -64,14 +45,14 @@ func TestIngressBulk(t *testing.T) {
 		service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
 		service.Name = name
 		service.Spec.Type = corev1.ServiceTypeClusterIP
-		_, err = env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
+		_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, path, map[string]string{
 			annotations.IngressClassKey: ingressClass,
 			"konghq.com/strip-path":     "true",
 		}, service)
-		require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testBulkIngressNamespace, ingress))
+		require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 		ingresses[i] = ingress
 	}
 
@@ -101,10 +82,10 @@ func TestIngressBulk(t *testing.T) {
 	t.Log("cleaning up last batch of resources")
 	for i := 0; i < maxBatchSize; i++ {
 		name := fmt.Sprintf("bulk-httpbin-%d", i)
-		require.NoError(t, env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Delete(ctx, name, metav1.DeleteOptions{}))
-		require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testBulkIngressNamespace, ingresses[i]))
+		require.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, name, metav1.DeleteOptions{}))
+		require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingresses[i]))
 		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Get(ctx, name, metav1.GetOptions{})
+			_, err := env.Cluster().Client().CoreV1().Services(ns.Name).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				return errors.IsNotFound(err)
 			}
@@ -122,14 +103,14 @@ func TestIngressBulk(t *testing.T) {
 		service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
 		service.Name = name
 		service.Spec.Type = corev1.ServiceTypeClusterIP
-		_, err = env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
+		_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, path, map[string]string{
 			annotations.IngressClassKey: ingressClass,
 			"konghq.com/strip-path":     "true",
 		}, service)
-		require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testBulkIngressNamespace, ingress))
+		require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 		ingresses[i] = ingress
 
 		// every 10 items sleep for 1 second to stagger the updates to ~10/s
@@ -164,10 +145,10 @@ func TestIngressBulk(t *testing.T) {
 	t.Log("cleaning up last batch of resources")
 	for i := 0; i < maxBatchSize; i++ {
 		name := fmt.Sprintf("bulk-staggered-httpbin-%d", i)
-		require.NoError(t, env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Delete(ctx, name, metav1.DeleteOptions{}))
-		require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testBulkIngressNamespace, ingresses[i]))
+		require.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, name, metav1.DeleteOptions{}))
+		require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingresses[i]))
 		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Services(testBulkIngressNamespace).Get(ctx, name, metav1.GetOptions{})
+			_, err := env.Cluster().Client().CoreV1().Services(ns.Name).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				return errors.IsNotFound(err)
 			}

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -134,6 +134,7 @@ QLAtVaZd9SSi4Z/RX6B4L3Rj0Mwfn+tbrtYO5Pyhi40hiXf4aMgbVDFYMR0MMmH0
 )
 
 func TestHTTPSRedirect(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -192,6 +193,7 @@ func TestHTTPSRedirect(t *testing.T) {
 }
 
 func TestHTTPSIngress(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -139,7 +139,6 @@ var (
 )
 
 func TestHTTPSRedirect(t *testing.T) {
-	ctx := context.Background()
 	opts := metav1.CreateOptions{}
 
 	t.Logf("creating namespace %s for testing", testIngressHTTPSRedirectNamespace)
@@ -215,7 +214,6 @@ func TestHTTPSRedirect(t *testing.T) {
 }
 
 func TestHTTPSIngress(t *testing.T) {
-	ctx := context.Background()
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -133,52 +133,30 @@ QLAtVaZd9SSi4Z/RX6B4L3Rj0Mwfn+tbrtYO5Pyhi40hiXf4aMgbVDFYMR0MMmH0
 	}
 )
 
-var (
-	testIngressHTTPSNamespace         = "ingress-https"
-	testIngressHTTPSRedirectNamespace = "ingress-redirect"
-)
-
 func TestHTTPSRedirect(t *testing.T) {
-	opts := metav1.CreateOptions{}
-
-	t.Logf("creating namespace %s for testing", testIngressHTTPSRedirectNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressHTTPSRedirectNamespace}}
-	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressHTTPSRedirectNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
+	ns, cleanup := namespace(t)
+	defer cleanup()
 
 	t.Log("creating an HTTP container via deployment to test redirect functionality")
 	container := generators.NewContainer("alsohttpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	_, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, opts)
+	opts := metav1.CreateOptions{}
+	_, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, opts)
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via Service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-	service, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, opts)
+	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, opts)
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up Service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing Service %s via Ingress", service.Name)
@@ -189,11 +167,11 @@ func TestHTTPSRedirect(t *testing.T) {
 		"konghq.com/protocols":                  "https",
 		"konghq.com/https-redirect-status-code": "301",
 	}, service)
-	assert.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
+	assert.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {
 		t.Log("cleaning up Ingress resource")
-		assert.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
+		assert.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	}()
 
 	t.Log("waiting for Ingress to be operational and properly redirect")
@@ -214,6 +192,9 @@ func TestHTTPSRedirect(t *testing.T) {
 }
 
 func TestHTTPSIngress(t *testing.T) {
+	ns, cleanup := namespace(t)
+	defer cleanup()
+
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
@@ -238,44 +219,25 @@ func TestHTTPSIngress(t *testing.T) {
 		Transport: &testTransport,
 	}
 
-	t.Logf("creating namespace %s for testing", testIngressHTTPSNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressHTTPSNamespace}}
-	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressHTTPSNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
-
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -314,7 +276,7 @@ func TestHTTPSIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 				Name:      "secret1",
-				Namespace: "default",
+				Namespace: ns.Name,
 			},
 			Data: map[string][]byte{
 				"tls.crt": []byte(tlsPairs[0].Cert),
@@ -325,7 +287,7 @@ func TestHTTPSIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e5"),
 				Name:      "secret2",
-				Namespace: "default",
+				Namespace: ns.Name,
 			},
 			Data: map[string][]byte{
 				"tls.crt": []byte(tlsPairs[1].Cert),
@@ -335,35 +297,35 @@ func TestHTTPSIngress(t *testing.T) {
 	}
 
 	t.Log("deploying secrets")
-	secret1, err := env.Cluster().Client().CoreV1().Secrets(corev1.NamespaceDefault).Create(ctx, secrets[0], metav1.CreateOptions{})
+	secret1, err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, secrets[0], metav1.CreateOptions{})
 	assert.NoError(t, err)
-	secret2, err := env.Cluster().Client().CoreV1().Secrets(corev1.NamespaceDefault).Create(ctx, secrets[1], metav1.CreateOptions{})
+	secret2, err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, secrets[1], metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	t.Log("deploying ingress resources")
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress1))
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress2))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress1))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress2))
 
 	defer func() {
 		t.Log("ensuring that Ingress resources are cleaned up")
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress1); err != nil {
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress1); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
 		}
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress2); err != nil {
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress2); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
 		}
 		t.Logf("ensuring that Secret %s is cleaned up", secret1.Name)
-		if err := env.Cluster().Client().CoreV1().Secrets(corev1.NamespaceDefault).Delete(ctx, secret1.Name, metav1.DeleteOptions{}); err != nil {
+		if err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Delete(ctx, secret1.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
 		}
 		t.Logf("ensuring that Secret %s is cleaned up", secret2.Name)
-		if err := env.Cluster().Client().CoreV1().Secrets(corev1.NamespaceDefault).Delete(ctx, secret2.Name, metav1.DeleteOptions{}); err != nil {
+		if err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Delete(ctx, secret2.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -372,7 +334,7 @@ func TestHTTPSIngress(t *testing.T) {
 
 	t.Log("checking first ingress status readiness")
 	require.Eventually(t, func() bool {
-		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), corev1.NamespaceDefault, ingress1)
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), ns.Name, ingress1)
 		if err != nil {
 			return false
 		}
@@ -387,7 +349,7 @@ func TestHTTPSIngress(t *testing.T) {
 
 	t.Log("checking second ingress status readiness")
 	assert.Eventually(t, func() bool {
-		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), corev1.NamespaceDefault, ingress2)
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), ns.Name, ingress2)
 		if err != nil {
 			return false
 		}
@@ -459,16 +421,16 @@ func TestHTTPSIngress(t *testing.T) {
 
 	switch obj := ingress2.(type) {
 	case *netv1.Ingress:
-		ingress2, err := env.Cluster().Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress2, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		assert.NoError(t, err)
 		ingress2.ObjectMeta.Annotations["konghq.com/snis"] = "bar.example"
-		_, err = env.Cluster().Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress2, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress2, metav1.UpdateOptions{})
 		assert.NoError(t, err)
 	case *netv1beta1.Ingress:
-		ingress2, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(corev1.NamespaceDefault).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress2, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		assert.NoError(t, err)
 		ingress2.ObjectMeta.Annotations["konghq.com/snis"] = "bar.example"
-		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress2, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress2, metav1.UpdateOptions{})
 		assert.NoError(t, err)
 	}
 

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -28,8 +28,6 @@ var testIngressEssentialsNamespace = "ingress-essentials"
 var testIngressClassNameSpecNamespace = "ingress-class-name-spec"
 
 func TestIngressEssentials(t *testing.T) {
-	ctx := context.Background()
-
 	t.Logf("creating namespace %s for testing", testIngressEssentialsNamespace)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressEssentialsNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
@@ -198,8 +196,6 @@ func TestIngressClassNameSpec(t *testing.T) {
 		t.Skip("ingress spec tests can not be properly validated against old clusters")
 	}
 
-	ctx := context.Background()
-
 	t.Logf("creating namespace %s for testing", testIngressClassNameSpecNamespace)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressClassNameSpecNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
@@ -359,8 +355,6 @@ func TestIngressClassNameSpec(t *testing.T) {
 }
 
 func TestIngressNamespaces(t *testing.T) {
-	ctx := context.Background()
-
 	// ensure the alternative namespace is created
 	elsewhereNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: elsewhere}}
 	nowhere := "nowhere"

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,48 +23,29 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/annotations"
 )
 
-var testIngressEssentialsNamespace = "ingress-essentials"
-var testIngressClassNameSpecNamespace = "ingress-class-name-spec"
-
 func TestIngressEssentials(t *testing.T) {
-	t.Logf("creating namespace %s for testing", testIngressEssentialsNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressEssentialsNamespace}}
-	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressEssentialsNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
+	ns, cleanup := namespace(t)
+	defer cleanup()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressEssentialsNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressEssentialsNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(testIngressEssentialsNamespace).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressEssentialsNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -75,11 +55,11 @@ func TestIngressEssentials(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testIngressEssentialsNamespace, ingress))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {
 		t.Log("cleaning up Ingress resource")
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), testIngressEssentialsNamespace, ingress); err != nil {
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -88,7 +68,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("waiting for updated ingress status to include IP")
 	require.Eventually(t, func() bool {
-		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), testIngressEssentialsNamespace, ingress)
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), ns.Name, ingress)
 		if err != nil {
 			return false
 		}
@@ -118,16 +98,16 @@ func TestIngressEssentials(t *testing.T) {
 	t.Logf("removing the ingress.class annotation %q from ingress", ingressClass)
 	switch obj := ingress.(type) {
 	case *netv1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
-		_, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	case *netv1beta1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressEssentialsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		delete(ingress.ObjectMeta.Annotations, annotations.IngressClassKey)
-		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	}
 
@@ -145,16 +125,16 @@ func TestIngressEssentials(t *testing.T) {
 	t.Logf("putting the ingress.class annotation %q back on ingress", ingressClass)
 	switch obj := ingress.(type) {
 	case *netv1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
-		_, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	case *netv1beta1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressEssentialsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.ObjectMeta.Annotations[annotations.IngressClassKey] = ingressClass
-		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressEssentialsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	}
 
@@ -179,7 +159,7 @@ func TestIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
-	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testIngressEssentialsNamespace, ingress))
+	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {
@@ -192,48 +172,32 @@ func TestIngressEssentials(t *testing.T) {
 }
 
 func TestIngressClassNameSpec(t *testing.T) {
+	ns, cleanup := namespace(t)
+	defer cleanup()
+
 	if clusterVersion.Major < uint64(2) && clusterVersion.Minor < uint64(19) {
 		t.Skip("ingress spec tests can not be properly validated against old clusters")
 	}
 
-	t.Logf("creating namespace %s for testing", testIngressClassNameSpecNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testIngressClassNameSpecNamespace}}
-	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testIngressClassNameSpecNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
-
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testIngressClassNameSpecNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testIngressClassNameSpecNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(testIngressClassNameSpecNamespace).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testIngressClassNameSpecNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -246,11 +210,11 @@ func TestIngressClassNameSpec(t *testing.T) {
 	case *netv1beta1.Ingress:
 		obj.Spec.IngressClassName = kong.String(ingressClass)
 	}
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testIngressClassNameSpecNamespace, ingress))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {
 		t.Log("ensuring that Ingress is cleaned up")
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), testIngressClassNameSpecNamespace, ingress); err != nil {
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -280,16 +244,16 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Logf("removing the IngressClassName %q from ingress", ingressClass)
 	switch obj := ingress.(type) {
 	case *netv1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.Spec.IngressClassName = nil
-		_, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	case *netv1beta1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.Spec.IngressClassName = nil
-		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	}
 
@@ -307,16 +271,16 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Logf("putting the IngressClassName %q back on ingress", ingressClass)
 	switch obj := ingress.(type) {
 	case *netv1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.Spec.IngressClassName = kong.String(ingressClass)
-		_, err = env.Cluster().Client().NetworkingV1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	case *netv1beta1.Ingress:
-		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressClassNameSpecNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ingress.Spec.IngressClassName = kong.String(ingressClass)
-		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testIngressClassNameSpecNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+		_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	}
 
@@ -341,7 +305,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
-	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testIngressClassNameSpecNamespace, ingress))
+	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestIngressEssentials(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -172,6 +173,7 @@ func TestIngressEssentials(t *testing.T) {
 }
 
 func TestIngressClassNameSpec(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -319,7 +321,9 @@ func TestIngressClassNameSpec(t *testing.T) {
 }
 
 func TestIngressNamespaces(t *testing.T) {
-	// ensure the alternative namespace is created
+	t.Parallel()
+
+	t.Log("creating extra testing namespaces")
 	elsewhereNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: elsewhere}}
 	nowhere := "nowhere"
 	nowhereNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nowhere}}

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -32,8 +32,6 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
-	ctx := context.Background()
-
 	t.Log("generating a knative clientset")
 	knativec, err := knativeversioned.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -32,6 +32,7 @@ const (
 )
 
 func TestKnativeIngress(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -23,17 +23,18 @@ import (
 )
 
 func TestKongIngressEssentials(t *testing.T) {
-	namespace := "default"
-	testName := "minking"
+	ns, cleanup := namespace(t)
+	defer cleanup()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	testName := "minking"
 	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, httpBinImage, 80))
-	_, err := env.Cluster().Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	_, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
@@ -41,12 +42,12 @@ func TestKongIngressEssentials(t *testing.T) {
 	assert.NoError(t, err)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
 	service.Annotations = map[string]string{"konghq.com/override": testName}
-	service, err = env.Cluster().Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(namespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("routing to service %s via Ingress", service.Name)
@@ -56,19 +57,18 @@ func TestKongIngressEssentials(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {
 		t.Log("ensuring that Ingress resources are cleaned up")
-		assert.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
-
+		assert.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	}()
 
 	t.Logf("applying service overrides to Service %s via KongIngress", service.Name)
 	king := &kongv1.KongIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
-			Namespace: namespace,
+			Namespace: ns.Name,
 			Annotations: map[string]string{
 				annotations.IngressClassKey: ingressClass,
 			},
@@ -77,12 +77,12 @@ func TestKongIngressEssentials(t *testing.T) {
 			ReadTimeout: kong.Int(1000),
 		},
 	}
-	king, err = c.ConfigurationV1().KongIngresses(namespace).Create(ctx, king, metav1.CreateOptions{})
+	king, err = c.ConfigurationV1().KongIngresses(ns.Name).Create(ctx, king, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring that KongIngress %s is cleaned up", king.Name)
-		if err := c.ConfigurationV1().KongIngresses(namespace).Delete(ctx, king.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.ConfigurationV1().KongIngresses(ns.Name).Delete(ctx, king.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -101,12 +101,12 @@ func TestKongIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("removing Service %s overrides", service.Name)
-	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, service.Name, metav1.GetOptions{})
+	svc, err := env.Cluster().Client().CoreV1().Services(ns.Name).Get(ctx, service.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	anns := svc.GetAnnotations()
 	delete(anns, "konghq.com/override")
 	svc.SetAnnotations(anns)
-	_, err = env.Cluster().Client().CoreV1().Services(namespace).Update(ctx, svc, metav1.UpdateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Update(ctx, svc, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	t.Logf("ensuring that Service %s overrides are eventually removed", service.Name)

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,8 +25,6 @@ import (
 func TestKongIngressEssentials(t *testing.T) {
 	namespace := "default"
 	testName := "minking"
-	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
-	defer cancel()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, httpBinImage, 80))

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestKongIngressEssentials(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,47 +25,29 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/pkg/clientset"
 )
 
-const testPluginsNamespace = "kongplugins"
-
 func TestPluginEssentials(t *testing.T) {
-	t.Logf("creating namespace %s for testing", testPluginsNamespace)
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testPluginsNamespace}}
-	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Logf("cleaning up namespace %s", testPluginsNamespace)
-		require.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}))
-		require.Eventually(t, func() bool {
-			_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
-			}
-			return false
-		}, ingressWait, waitTick)
-	}()
+	ns, cleanup := namespace(t)
+	defer cleanup()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(testPluginsNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(testPluginsNamespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(testPluginsNamespace).Create(ctx, service, metav1.CreateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(testPluginsNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -76,11 +57,11 @@ func TestPluginEssentials(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), testPluginsNamespace, ingress))
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {
 		t.Log("ensuring that Ingress is cleaned up")
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), testPluginsNamespace, ingress); err != nil {
+		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -109,7 +90,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	kongplugin := &kongv1.KongPlugin{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testPluginsNamespace,
+			Namespace: ns.Name,
 			Name:      "teapot",
 		},
 		PluginName: "request-termination",
@@ -131,14 +112,14 @@ func TestPluginEssentials(t *testing.T) {
 	}
 	c, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
-	kongplugin, err = c.ConfigurationV1().KongPlugins(testPluginsNamespace).Create(ctx, kongplugin, metav1.CreateOptions{})
+	kongplugin, err = c.ConfigurationV1().KongPlugins(ns.Name).Create(ctx, kongplugin, metav1.CreateOptions{})
 	require.NoError(t, err)
 	kongclusterplugin, err = c.ConfigurationV1().KongClusterPlugins().Create(ctx, kongclusterplugin, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Log("cleaning up plugins")
-		if err := c.ConfigurationV1().KongPlugins(testPluginsNamespace).Delete(ctx, kongplugin.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.ConfigurationV1().KongPlugins(ns.Name).Delete(ctx, kongplugin.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				assert.NoError(t, err)
 			}
@@ -154,20 +135,20 @@ func TestPluginEssentials(t *testing.T) {
 	require.Eventually(t, func() bool {
 		switch obj := ingress.(type) {
 		case *netv1.Ingress:
-			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
 			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
-			_, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 			return err == nil
 		case *netv1beta1.Ingress:
-			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
 			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
-			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 			return err == nil
 		}
 		return false
@@ -188,20 +169,20 @@ func TestPluginEssentials(t *testing.T) {
 	require.Eventually(t, func() bool {
 		switch obj := ingress.(type) {
 		case *netv1.Ingress:
-			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
 			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongclusterplugin.Name
-			_, err = env.Cluster().Client().NetworkingV1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 			return err == nil
 		case *netv1beta1.Ingress:
-			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Get(ctx, obj.Name, metav1.GetOptions{})
+			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
 			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongclusterplugin.Name
-			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(testPluginsNamespace).Update(ctx, ingress, metav1.UpdateOptions{})
+			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
 			return err == nil
 		}
 		return false
@@ -219,7 +200,7 @@ func TestPluginEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
-	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), testPluginsNamespace, ingress))
+	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	assert.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
 		if err != nil {

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -29,8 +29,6 @@ import (
 const testPluginsNamespace = "kongplugins"
 
 func TestPluginEssentials(t *testing.T) {
-	ctx := context.Background()
-
 	t.Logf("creating namespace %s for testing", testPluginsNamespace)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testPluginsNamespace}}
 	ns, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestPluginEssentials(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -111,6 +111,16 @@ func TestMain(m *testing.M) {
 	proxyUDPURL, err = kongAddon.ProxyUDPURL(ctx, env.Cluster())
 	exitOnErr(err)
 
+	fmt.Println("INFO: generating unique namespaces for each test case")
+	testCases, err := identifyTestCasesForDir("./")
+	exitOnErr(err)
+	for _, testCase := range testCases {
+		namespaceForTestCase, err := generators.GenerateNamespace(ctx, env.Cluster(), testCase)
+		exitOnErr(err)
+		namespaces[testCase] = namespaceForTestCase
+		watchNamespaces = fmt.Sprintf("%s,%s", watchNamespaces, namespaceForTestCase.Name)
+	}
+
 	if v := os.Getenv("KONG_BRING_MY_OWN_KIC"); v == "true" {
 		fmt.Println("WARNING: caller indicated that they will manage their own controller")
 	} else {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestMain(m *testing.M) {
 	var err error
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
 	fmt.Println("INFO: configuring testing environment")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -33,7 +33,6 @@ import (
 // -----------------------------------------------------------------------------
 
 func TestMain(m *testing.M) {
-	var err error
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
@@ -90,6 +89,7 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Println("INFO: building test environment (note: can take some time)")
+	var err error
 	env, err = builder.Build(ctx)
 	exitOnErr(err)
 

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestTCPIngressEssentials(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -31,8 +31,6 @@ func TestTCPIngressEssentials(t *testing.T) {
 	testName := "tcpingress"
 	c, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
-	defer cancel()
 
 	t.Logf("creating namespace %s for testing", testTCPIngressNamespace)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testTCPIngressNamespace}}

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -27,8 +27,6 @@ const testUDPIngressNamespace = "udpingress"
 
 func TestUDPIngressEssentials(t *testing.T) {
 	testName := "minudp"
-	ctx, cancel := context.WithTimeout(context.Background(), ingressWait)
-	defer cancel()
 
 	t.Logf("creating namespace %s for testing", testUDPIngressNamespace)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testUDPIngressNamespace}}

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestUDPIngressEssentials(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -115,9 +114,6 @@ var (
 	// to persist after the test for inspection. This has a nil effect when an existing cluster
 	// is provided, as cleanup is not performed for existing clusters.
 	keepTestCluster = os.Getenv("KONG_TEST_CLUSTER_PERSIST")
-
-	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
-	maxBatchSize = determineMaxBatchSize()
 )
 
 // -----------------------------------------------------------------------------
@@ -257,18 +253,6 @@ func expect404WithNoRoute(t *testing.T, proxyURL string, resp *http.Response) bo
 		return body.Message == "no Route matched with those values"
 	}
 	return false
-}
-
-// determineMaxBatchSize provides a size limit for the number of resources to POST in a single second during tests, and can be overridden with an ENV var if desired.
-func determineMaxBatchSize() int {
-	if v := os.Getenv("KONG_BULK_TESTING_BATCH_SIZE"); v != "" {
-		i, err := strconv.Atoi(v)
-		if err != nil {
-			panic(fmt.Sprintf("Error: invalid batch size %s: %s", v, err))
-		}
-		return i
-	}
-	return 50
 }
 
 // -----------------------------------------------------------------------------

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -77,14 +77,6 @@ var (
 	watchNamespaces = strings.Join([]string{
 		elsewhere,
 		corev1.NamespaceDefault,
-		testIngressEssentialsNamespace,
-		testIngressClassNameSpecNamespace,
-		testIngressHTTPSNamespace,
-		testIngressHTTPSRedirectNamespace,
-		testBulkIngressNamespace,
-		testTCPIngressNamespace,
-		testUDPIngressNamespace,
-		testPluginsNamespace,
 	}, ",")
 
 	// env is the primary testing environment object which includes access to the Kubernetes cluster

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -74,10 +74,10 @@ var (
 	httpc = http.Client{Timeout: httpcTimeout}
 
 	// watchNamespaces is a list of namespaces the controller watches
-	watchNamespaces = strings.Join([]string{
-		elsewhere,
-		corev1.NamespaceDefault,
-	}, ",")
+	// NOTE: more namespaces will be loaded dynamically by the test.Main
+	//       during runtime. In general, avoid adding hardcoded namespaces
+	//       to this list as that's reserved for special cases.
+	watchNamespaces = elsewhere
 
 	// env is the primary testing environment object which includes access to the Kubernetes cluster
 	// and all the addons deployed in support of the tests.

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -45,6 +45,13 @@ const (
 // -----------------------------------------------------------------------------
 
 var (
+	// ctx the topical context of the test suite, can be used by test cases if they don't need
+	// any special context as a function of the test
+	ctx context.Context
+
+	// cancel is the cancel function for the above global test context
+	cancel context.CancelFunc
+
 	// httpBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
 	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/postmanlabs/httpbin

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestValidationWebhook(t *testing.T) {
+	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -18,9 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const defaultNs = "default"
-
 func TestValidationWebhook(t *testing.T) {
+	ns, cleanup := namespace(t)
+	defer cleanup()
+
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("TODO: webhook tests are only supported on KIND based environments right now")
 	}
@@ -134,9 +135,9 @@ func TestValidationWebhook(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := env.Cluster().Client().CoreV1().Secrets(defaultNs).Create(ctx, &tt.obj, metav1.CreateOptions{})
+			_, err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, &tt.obj, metav1.CreateOptions{})
 			defer func() {
-				if err := env.Cluster().Client().CoreV1().Secrets(defaultNs).Delete(ctx, tt.obj.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+				if err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Delete(ctx, tt.obj.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
 					if !errors.IsNotFound(err) {
 						assert.NoError(t, err)
 					}

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"net"
 	"strings"
 	"testing"
@@ -25,7 +24,6 @@ func TestValidationWebhook(t *testing.T) {
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("TODO: webhook tests are only supported on KIND based environments right now")
 	}
-	ctx := context.Background()
 
 	const webhookSvcName = "validations"
 	_, err := env.Cluster().Client().CoreV1().Services(controllerNamespace).Create(ctx, &corev1.Service{

--- a/test/performance/ingress_bulk_test.go
+++ b/test/performance/ingress_bulk_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/internal/annotations"
 )
 
-// TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
 	ctx := context.Background()
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: corev1.NamespaceDefault}}

--- a/test/performance/ingress_bulk_test.go
+++ b/test/performance/ingress_bulk_test.go
@@ -1,9 +1,10 @@
-//+build integration_tests
+//+build performance_tests
 
-package integration
+package performance
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -23,8 +24,8 @@ import (
 
 // TestIngressBulk attempts to validate functionality at scale by rapidly deploying a large number of ingress resources.
 func TestIngressBulk(t *testing.T) {
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ctx := context.Background()
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: corev1.NamespaceDefault}}
 
 	t.Log("deploying a minimal HTTP container to be exoposed via ingress")
 	container := generators.NewContainer("httpbin", httpBinImage, 80)

--- a/test/performance/suite_test.go
+++ b/test/performance/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -36,6 +37,9 @@ var (
 	proxyURL      *url.URL
 	proxyAdminURL *url.URL
 	proxyUDPURL   *url.URL
+
+	// maxBatchSize indicates the maximum number of objects that should be POSTed per second during testing
+	maxBatchSize = determineMaxBatchSize()
 )
 
 func TestMain(m *testing.M) {
@@ -181,4 +185,16 @@ func CleanUpNamespace(ctx context.Context, namespace string, t *testing.T) error
 		return nil
 	}
 	return nil
+}
+
+// determineMaxBatchSize provides a size limit for the number of resources to POST in a single second during tests, and can be overridden with an ENV var if desired.
+func determineMaxBatchSize() int {
+	if v := os.Getenv("KONG_BULK_TESTING_BATCH_SIZE"); v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			panic(fmt.Sprintf("Error: invalid batch size %s: %s", v, err))
+		}
+		return i
+	}
+	return 50
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes several changes to our integration test suite:

- general cleanup and refactoring
- ensures all tests receive (and use) their own unique namespace (namespace `default` is no longer supported)
- ensures all tests cleanup after themselves and tear down their resources
- enables parallelization of the integration test cases
- moves the bulk ingress tests into `test/performance` as these tests are costly and noisy, and now with parallelization of tests some of their value has been replaced

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1592

**Notes**

I ran `./hack/e2e/run-tests.sh` locally to verify these changes in our release testing, and it's working properly on GKE.