### PR TITLE
fix: deduplicate consumer credential secret keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@
   will thereafter otherwise be skipped for backend configuration
   until the resource has been corrected.
   [#550](https://github.com/Kong/kubernetes-ingress-controller/issues/550)
+- Previously `KongConsumer` resources which were configured with
+  credentials that reference secrets which between them have a
+  duplicate key with a unique constraint would cause a hard error and lock
+  up updates to the Kong Admin API. This has now been patched to drop the
+  duplicates and provide a soft error that will be logged by the controller
+  manager until the `KongConsumer`'s credentials secret objects are fixed.
+  [#729](https://github.com/Kong/kubernetes-ingress-controller/issues/729)
 
 #### Breaking changes
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Any `KongConsumer` resource which includes credentials secrets with a duplicate Key which is unique constrained will not be able to properly configure (and will halt all configuration to Kong until it's fixed) currently. This is a stopgap short of future fixes to validation to change this failure from a hard error to a soft error.

This also improves logging when errors occur in `KongConsumer` validation so that they're consistent and easier to search for in manager logs.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/729

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
