### PR TITLE
fix: support minimum TLS v1.2 for webhook admission server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
   until the resource has been corrected.
   [#550](https://github.com/Kong/kubernetes-ingress-controller/issues/550)
 
+#### Breaking changes
+
+- TLS v1.2+ compatible clients are required now going forward in order
+  to do SSL negotiations with the webhook admission server.
+  [#1065](https://github.com/Kong/kubernetes-ingress-controller/issues/1065)
+
 ## [2.0.0-alpha.3] - 2021/08/02
 
 #### Breaking changes

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -79,7 +79,8 @@ func (sc *ServerConfig) toTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("X509KeyPair error: %w", err)
 	}
-	return &tls.Config{ //nolint:gosec
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{keyPair},
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is in direct response to the gosec lint which
we disabled due to backwards compatibility issues
in the v1.3.x releases of KIC, but now with KIC v2
on the horizon it's time to pull off the band-aid.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1065

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
