### PR TITLE
fix: combine coverage and CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,7 +100,13 @@ jobs:
     - name: run unit tests
       run: make test
 
-  integration-test-dbless:
+    - name: collect test coverage
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: coverage.unit.out
+        path: coverage.unit.out
+
+  integration-tests-dbless:
     runs-on: ubuntu-latest
     steps:
 
@@ -125,13 +131,13 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2.0.2
+    - name: collect test coverage
+      uses: actions/upload-artifact@v2.2.4
       with:
-        flags: integration-test
-        fail_ci_if_error: true
+        name: coverage.dbless.out
+        path: coverage.dbless.out
 
-  integration-test-postgres:
+  integration-tests-postgres:
     runs-on: ubuntu-latest
     steps:
 
@@ -156,8 +162,43 @@ jobs:
     - name: run integration tests
       run: make test.integration.postgres
 
+    - name: collect test coverage
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: coverage.postgres.out
+        path: coverage.postgres.out
+
+  coverage:
+    environment: "Configure ci"
+    needs:
+      - "unit-tests"
+      - "integration-tests-dbless"
+      - "integration-tests-postgres"
+    runs-on: ubuntu-latest
+    steps:
+    - name: collect unit test coverage artifacts
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: coverage.unit.out
+        path: coverage.unit.out
+
+    - name: collect dbless test coverage artifacts
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: coverage.dbless.out
+        path: coverage.dbless.out
+
+    - name: collect postgres test coverage artifacts
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: coverage.postgres.out
+        path: coverage.postgres.out
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.0.2
       with:
-        flags: integration-test
+        name: combined-coverage
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.unit.out,./coverage.dbless.out,./coverage.postgres.out
         fail_ci_if_error: true
+        verbose: true

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,6 @@ container:
 # ------------------------------------------------------------------------------
 
 PKG_LIST = ./pkg/...,./internal/...
-COVERAGE_PROFILE=coverage.out
 KIND_CLUSTER_NAME ?= "integration-tests"
 
 .PHONY: test.all
@@ -168,23 +167,39 @@ test.integration: test.integration.dbless test.integration.postgres
 
 .PHONY: test
 test:
-	@go test -race -v ./...
-
-.PHONY: test.integration.legacy
-test.integration.legacy: container
-	KIC_IMAGE="${IMAGE}:${TAG}" KUBE_VERSION=${KUBE_VERSION} ./hack/legacy/test/test.sh
+	@go test -v -race \
+		-covermode=atomic \
+		-coverpkg=$(PKG_LIST) \
+		-coverprofile=coverage.unit.out \
+		./...
 
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -parallel $(NCPU) -timeout 15m -race -v -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
+	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=integration_tests" go test -v -race \
+		-timeout 15m \
+		-parallel $(NCPU) \
+		-covermode=atomic \
+		-coverpkg=$(PKG_LIST) \
+		-coverprofile=coverage.dbless.out \
+		./test/integration
 
 # TODO: race checking has been temporarily turned off because of race conditions found with deck. This will be resolved in an upcoming Alpha release of KIC 2.0.
 #       See: https://github.com/Kong/kubernetes-ingress-controller/issues/1324
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@./scripts/check-container-environment.sh
-	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -parallel $(NCPU) -timeout 15m -v -covermode=atomic -coverpkg=$(PKG_LIST) -coverprofile=$(COVERAGE_PROFILE) ./test/integration/...
+	@TEST_DATABASE_MODE="postgres" GOFLAGS="-tags=integration_tests" go test -v \
+		-timeout 15m \
+		-parallel $(NCPU) \
+		-covermode=atomic \
+		-coverpkg=$(PKG_LIST) \
+		-coverprofile=coverage.postgres.out \
+		./test/integration
+
+.PHONY: test.integration.legacy
+test.integration.legacy: container
+	KIC_IMAGE="${IMAGE}:${TAG}" KUBE_VERSION=${KUBE_VERSION} ./hack/legacy/test/test.sh
 
 # ------------------------------------------------------------------------------
 # Operations


### PR DESCRIPTION
**What this PR does / why we need it**:

Our codecov integration is noisy and gets multiple profiles at different times, causing it to drop multiple messages on PRs.

Additionally, we want to be able to capture coverage output from multiple different test types (unit, integration, e.t.c.)

This PR fixes these problems by having each test target in the `Makefile` provide it's own coverage profile, and adds a CI workflow which will wait for all tests to finish before combining them and uploading them to codecov.

Additionally this enables the use of our codecov API token instead of doing anonymous updates.