### PR TITLE
only global registry publisize data through controller-runtime metrics ports

### DIFF
--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 type CtrlFuncMetrics struct {
@@ -47,10 +47,8 @@ const (
 func ControllerMetricsInit() *CtrlFuncMetrics {
 	controllerMetrics := &CtrlFuncMetrics{}
 
-	reg := prometheus.NewRegistry()
-
 	controllerMetrics.ConfigCounter =
-		promauto.With(reg).NewCounterVec(
+		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "send_configuration_count",
 				Help: "Counts the success/failure events of converting kubernetes resources to a KongState, including conversion.",
@@ -59,7 +57,7 @@ func ControllerMetricsInit() *CtrlFuncMetrics {
 		)
 
 	controllerMetrics.ParseCounter =
-		promauto.With(reg).NewCounterVec(
+		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "ingress_parse_count",
 				Help: "number of ingress parse.",
@@ -68,13 +66,15 @@ func ControllerMetricsInit() *CtrlFuncMetrics {
 		)
 
 	controllerMetrics.ConfigureDurationHistogram =
-		promauto.With(reg).NewHistogram(
+		prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "proxy_configuration_duration_milliseconds",
 				Help:    "Duration of last successful configuration.",
 				Buckets: prometheus.ExponentialBuckets(100, 1.33, 30),
 			},
 		)
+
+	metrics.Registry.MustRegister(controllerMetrics.ConfigCounter, controllerMetrics.ParseCounter, controllerMetrics.ConfigureDurationHistogram)
 
 	return controllerMetrics
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
  fix exposing business logic metrics using controller-runtime metrics
**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
