### PR TITLE
Release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Table of Contents
 
  - [2.0.0-alpha.1](#200-alpha1---20210527)
+ - [1.3.2](#132---20210812)
  - [1.3.1](#131---20210603)
  - [1.3.0](#130---20210527)
  - [1.2.0](#120---20210324)
@@ -94,6 +95,14 @@ released and the release notes may change significantly before then.
 [controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
 [go]:https://golang.org
 [ktf]:https://github.com/kong/kubernetes-testing-framework
+
+## [1.3.2] - 2021/08/12
+
+#### Under the hood
+
+- Updated Alpine image to 3.14.
+  [#1691](https://github.com/Kong/kubernetes-ingress-controller/pull/1691/)
+- Update Kong images to 2.5.
 
 ## [1.3.1] - 2021/06/03
 
@@ -1100,6 +1109,7 @@ Please read the changelog and test in your environment.
    a working ingress controller.
 
 [2.0.0-alpha.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...2.0.0-alpha.1
+[1.3.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/kong/kubernetes-ingress-controller/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/1.1.1...1.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG?=1.3.1
+TAG?=1.3.2
 RG_TAG?=2.0.0-alpha.1
 REGISTRY?=kong
 REPO_INFO=$(shell git config --get remote.origin.url)

--- a/deploy/manifests/base/kong-ingress-dbless.yaml
+++ b/deploy/manifests/base/kong-ingress-dbless.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kong-serviceaccount
       containers:
       - name: proxy
-        image: kong:2.4
+        image: kong:2.5
         env:
           # servers
         - name: KONG_PROXY_LISTEN

--- a/deploy/manifests/enterprise-k8s/kustomization.yaml
+++ b/deploy/manifests/enterprise-k8s/kustomization.yaml
@@ -5,4 +5,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: 2.4.1.0-alpine
+  newTag: "2.5"

--- a/deploy/manifests/enterprise/kustomization.yaml
+++ b/deploy/manifests/enterprise/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: 2.4.1.0-alpine
+  newTag: "2.5"

--- a/deploy/manifests/postgres/kong-ingress-postgres.yaml
+++ b/deploy/manifests/postgres/kong-ingress-postgres.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-migrations
-        image: kong:2.4
+        image: kong:2.5
         command:
         - "/bin/sh"
         - "-c"

--- a/deploy/manifests/postgres/migration.yaml
+++ b/deploy/manifests/postgres/migration.yaml
@@ -20,7 +20,7 @@ spec:
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
-        image: kong:2.4
+        image: kong:2.5
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -650,7 +650,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -645,7 +645,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.4
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -708,7 +708,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         lifecycle:
           preStop:
             exec:
@@ -820,7 +820,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---
@@ -901,7 +901,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -663,7 +663,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.4
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:
@@ -757,7 +757,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:2.4
+        image: kong:2.5
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---
@@ -828,7 +828,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:2.4
+        image: kong:2.5
         name: kong-migrations
       initContainers:
       - command:


### PR DESCRIPTION
**What this PR does / why we need it**:
Releases 1.3.2. Primary motivator was #1691. We need to run through a backport (sorta--2.0.0 isn't actually out yet) release. Also bumps to Kong 2.5 because may as well.

**Special notes for your reviewer**:
We have not previously done any releases from version branches. This may not work. We need to confirm CI results and address any issues after pushing the tag.

We don't yet have a procedure for updating content in main when changes occur in other branches but only main matters. Here, the changelog and single manifests need to be in main. I've set up the commits so that cherry-picking should be an option after. Changes to the internals (the manifest sources and Makefile) can be left on this branch alone.
