### PR TITLE
Address TCPIngress and UDPIngress collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Table of Contents
--  [2.0.0](#200---tbd)
+-  [2.0.0](#200---tba)
  - [2.0.0-beta.1](#200-beta1---20210806)
  - [2.0.0-alpha.3](#200-alpha3---20210802)
  - [2.0.0-alpha.2](#200-alpha2---20210707)
@@ -39,6 +39,12 @@
 
 - Upgraded Kong Gateway from 2.4 to 2.5
   [#1684](https://github.com/Kong/kubernetes-ingress-controller/issues/1684)
+
+#### Fixed
+
+- Resolved an issue where certain UDPIngress and TCPIngress configurations
+  resulted in overlapping incompatible Kong configuration.
+  [#1702](https://github.com/Kong/kubernetes-ingress-controller/issues/1702)
 
 ## [2.0.0-beta.1] - 2021/08/06
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/kong/go-kong v0.20.0
 	github.com/kong/kubernetes-testing-framework v0.6.1
 	github.com/lithammer/dedent v1.1.0
-	github.com/miekg/dns v1.1.43 // indirect
+	github.com/miekg/dns v1.1.43
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/kong/go-kong v0.20.0
 	github.com/kong/kubernetes-testing-framework v0.6.1
 	github.com/lithammer/dedent v1.1.0
+	github.com/miekg/dns v1.1.43 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.17/go.mod h1:WgzbA6oji13JREwiNsRDNfl7jYdPnmz+VEuLrA+/48M=
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -1347,6 +1349,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/kongstate/types.go
+++ b/internal/kongstate/types.go
@@ -44,7 +44,6 @@ func (p *PortDef) CanonicalString() string {
 type ServiceBackend struct {
 	Name string
 	Port PortDef
-	// TODO TR this probably needs proto. we use it to construct the upstream name
 }
 
 // Target is a wrapper around Target object in Kong.

--- a/internal/kongstate/types.go
+++ b/internal/kongstate/types.go
@@ -44,6 +44,7 @@ func (p *PortDef) CanonicalString() string {
 type ServiceBackend struct {
 	Name string
 	Port PortDef
+	// TODO TR this probably needs proto. we use it to construct the upstream name
 }
 
 // Target is a wrapper around Target object in Kong.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -207,7 +207,7 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 
 func getUpstreams(
 	log logrus.FieldLogger, s store.Storer, serviceMap map[string]kongstate.Service) []kongstate.Upstream {
-	upstreamDedup := make(map[string]struct{})
+	upstreamDedup := make(map[string]struct{}, len(serviceMap))
 	var empty struct{}
 	upstreams := make([]kongstate.Upstream, 0, len(serviceMap))
 	for _, service := range serviceMap {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -220,6 +220,7 @@ func getUpstreams(
 		upstream := kongstate.Upstream{
 			Upstream: kong.Upstream{
 				Name: kong.String(
+					// TODO TR we determine the upstream name here
 					fmt.Sprintf("%s.%s.%s.svc", service.Backend.Name, service.Namespace, service.Backend.Port.CanonicalString())),
 			},
 			Service: service,

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -112,7 +112,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, 30*time.Second, 1*time.Second, true)
 
 	t.Logf("verifying TCP Ingress %s operationalable", tcp.Name)
 	tcpProxyURL, err := url.Parse(fmt.Sprintf("http://%s:8888/", proxyURL.Hostname()))

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -143,7 +143,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, 30*time.Second, 1*time.Second, true)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udp.Name)
 	assert.Eventually(t, func() bool {
@@ -278,7 +278,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, 30*time.Second, 1*time.Second, true)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udp.Name)
 	assert.Eventually(t, func() bool {
@@ -333,7 +333,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, 30*time.Second, 1*time.Second, true)
 
 	t.Logf("checking DNS to resolve via TCPIngress %s", tcp.Name)
 	assert.Eventually(t, func() bool {

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,8 +25,19 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/pkg/clientset"
 )
 
+var udpMutex sync.Mutex
+
 func TestUDPIngressEssentials(t *testing.T) {
 	t.Parallel()
+	// Ensure no other UDP tests run concurrently to avoid fights over the port
+	t.Log("locking UDP port")
+	udpMutex.Lock()
+	defer func() {
+		// Free up the UDP port
+		t.Log("unlocking UDP port")
+		udpMutex.Unlock()
+	}()
+
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -144,6 +157,217 @@ func TestUDPIngressEssentials(t *testing.T) {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		if err != nil {
 			if strings.Contains(err.Error(), "i/o timeout") {
+				return true
+			}
+		}
+		return false
+	}, ingressWait, waitTick)
+}
+
+func TestUDPIngressTCPIngressCollision(t *testing.T) {
+	t.Parallel()
+	t.Log("locking TCP and UDP ports")
+	udpMutex.Lock()
+	tcpMutex.Lock()
+	defer func() {
+		t.Log("unlocking TCP and UDP ports")
+		tcpMutex.Unlock()
+		udpMutex.Unlock()
+	}()
+
+	ns, cleanup := namespace(t)
+	defer cleanup()
+
+	t.Log("configuring coredns corefile")
+	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}
+	cfgmap, err := env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Create(ctx, cfgmap, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the coredns corefile %s", cfgmap.Name)
+		assert.NoError(t, env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Delete(ctx, cfgmap.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Log("configuring a coredns deployent to deploy for UDP testing")
+	container := generators.NewContainer("coredns", "coredns/coredns", 53)
+	container.Ports[0].Protocol = corev1.ProtocolUDP
+	container.Ports[0].Name = "dnsudp"
+	container.Ports = append(container.Ports, corev1.ContainerPort{Name: "dnstcp", ContainerPort: 53, Protocol: corev1.ProtocolTCP})
+	container.VolumeMounts = []corev1.VolumeMount{{Name: "config-volume", MountPath: "/etc/coredns"}}
+	container.Args = []string{"-conf", "/etc/coredns/Corefile"}
+	deployment := generators.NewDeploymentForContainer(container)
+
+	t.Log("configuring the coredns pod with a custom corefile")
+	configVolume := corev1.Volume{
+		Name: "config-volume",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: cfgmap.Name},
+			Items:                []corev1.KeyToPath{{Key: "Corefile", Path: "Corefile"}}}}}
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, configVolume)
+
+	t.Log("deploying coredns")
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up deployment %s", deployment.Name)
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeNodePort)
+	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the service %s", service.Name)
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+	}()
+
+	// Test initial configuration with UDP only
+	t.Log("exposing DNS service via UDPIngress")
+	udp := &kongv1beta1.UDPIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "minudp",
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Spec: kongv1beta1.UDPIngressSpec{Rules: []kongv1beta1.UDPIngressRule{
+			{
+				Port: 9999,
+				Backend: v1beta1.IngressBackend{
+					ServiceName: service.Name,
+					ServicePort: int(service.Spec.Ports[0].Port),
+				},
+			},
+		}},
+	}
+	c, err := clientset.NewForConfig(env.Cluster().Config())
+	assert.NoError(t, err)
+	udp, err = c.ConfigurationV1beta1().UDPIngresses(ns.Name).Create(ctx, udp, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("ensuring UDPIngress %s is cleaned up", udp.Name)
+		if err := c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Log("configurating a dns query and clients")
+	query := new(dns.Msg)
+	query.Id = dns.Id()
+	query.Question = make([]dns.Question, 1)
+	query.Question[0] = dns.Question{Name: "kernel.org.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	dnsUDPClient := new(dns.Client)
+	dnsTCPClient := dns.Client{Net: "tcp"}
+
+	t.Logf("checking udpingress %s status readiness.", udp.Name)
+	ingCli := c.ConfigurationV1beta1().UDPIngresses(ns.Name)
+	assert.Eventually(t, func() bool {
+		curIng, err := ingCli.Get(ctx, udp.Name, metav1.GetOptions{})
+		if err != nil || curIng == nil {
+			return false
+		}
+		ingresses := curIng.Status.LoadBalancer.Ingress
+		for _, ingress := range ingresses {
+			if len(ingress.Hostname) > 0 || len(ingress.IP) > 0 {
+				t.Logf("udpingress hostname %s or ip %s is ready to redirect traffic.", ingress.Hostname, ingress.IP)
+				return true
+			}
+		}
+		return false
+	}, 120*time.Second, 1*time.Second, true)
+
+	t.Logf("checking DNS to resolve via UDPIngress %s", udp.Name)
+	assert.Eventually(t, func() bool {
+		_, _, err := dnsUDPClient.Exchange(query, fmt.Sprintf("%s:9999", proxyUDPURL.Hostname()))
+		return err == nil
+	}, ingressWait, waitTick)
+
+	// Add a TCPIngress with the same port integer as the TCPIngress, pointing to the same Service
+	t.Log("exposing DNS service via TCPIngress")
+	tcp := &kongv1beta1.TCPIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mintcp",
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Spec: kongv1beta1.TCPIngressSpec{Rules: []kongv1beta1.IngressRule{
+			{
+				Port: 8888,
+				Backend: v1beta1.IngressBackend{
+					ServiceName: service.Name,
+					ServicePort: int(service.Spec.Ports[1].Port),
+				},
+			},
+		}},
+	}
+	assert.NoError(t, err)
+	tcp, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	defer func() {
+		t.Logf("ensuring TCPIngress %s is cleaned up", tcp.Name)
+		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Logf("checking tcpingress %s status readiness.", tcp.Name)
+	tcpIngCli := c.ConfigurationV1beta1().TCPIngresses(ns.Name)
+	assert.Eventually(t, func() bool {
+		curIng, err := tcpIngCli.Get(ctx, tcp.Name, metav1.GetOptions{})
+		if err != nil || curIng == nil {
+			return false
+		}
+		ingresses := curIng.Status.LoadBalancer.Ingress
+		for _, ingress := range ingresses {
+			if len(ingress.Hostname) > 0 || len(ingress.IP) > 0 {
+				t.Logf("tcpingress hostname %s or ip %s is ready to redirect traffic.", ingress.Hostname, ingress.IP)
+				return true
+			}
+		}
+		return false
+	}, 120*time.Second, 1*time.Second, true)
+
+	t.Logf("checking DNS to resolve via TCPIngress %s", tcp.Name)
+	assert.Eventually(t, func() bool {
+		_, _, err := dnsTCPClient.Exchange(query, fmt.Sprintf("%s:8888", proxyURL.Hostname()))
+		return err == nil
+	}, ingressWait, waitTick)
+
+	t.Logf("checking DNS to resolve via UDPIngress %s still works also", udp.Name)
+	assert.Eventually(t, func() bool {
+		_, _, err := dnsUDPClient.Exchange(query, fmt.Sprintf("%s:9999", proxyUDPURL.Hostname()))
+		return err == nil
+	}, ingressWait, waitTick)
+
+	// Cleanup
+	t.Logf("tearing down UDPIngress %s and ensuring backends are torn down", udp.Name)
+	assert.NoError(t, c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}))
+	assert.Eventually(t, func() bool {
+		_, _, err := dnsUDPClient.Exchange(query, fmt.Sprintf("%s:9999", proxyUDPURL.Hostname()))
+		if err != nil {
+			if strings.Contains(err.Error(), "i/o timeout") {
+				return true
+			}
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("tearing down TCPIngress %s and ensuring backends are torn down", tcp.Name)
+	assert.NoError(t, c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
+	assert.Eventually(t, func() bool {
+		_, _, err := dnsTCPClient.Exchange(query, fmt.Sprintf("%s:8888", proxyURL.Hostname()))
+		if err != nil {
+			if strings.Contains(err.Error(), "connection reset by peer") {
 				return true
 			}
 		}

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -169,11 +169,9 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	t.Log("locking TCP and UDP ports")
 	udpMutex.Lock()
 	tcpMutex.Lock()
-	defer func() {
-		t.Log("unlocking TCP and UDP ports")
-		tcpMutex.Unlock()
-		udpMutex.Unlock()
-	}()
+
+	defer udpMutex.Unlock()
+	defer tcpMutex.Unlock()
 
 	ns, cleanup := namespace(t)
 	defer cleanup()


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add a test for a TCPIngress and UDPIngress that point to the same integer port (but different protocols) on the same Service.
- Add a map to de-duplicate upstreams by name. Upstreams use names of the form "<service>.<namespace>.<port>.svc". Kong upstreams _do not_ differentiate by protocol (despite, yes, the fact that including a port implies that they probably should) and thus TCP and UDP Service ports with the same port number should indeed both generate the same upstream.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #1446 

**Special notes for your reviewer**:
The new tests also add locks to the TCP and UDP tests. This ensures that the tests can still run parallelized, just not specifically concurrently with one another. They cannot run concurrently due to limited port availability; running them concurrently would create overlapping routes or prevent cleanup confirmation from working.

This avoids creating additional port listens on the KTF side while still retaining most of the parallel testing speed benefits. Full parallelization requires a unique port for each test, so if we were to add additional TCP/UDP tests in the future, we'd probably still end up needing locks with multiple ports available unless we keep adding new ports each time.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
