### PR TITLE
Re-add pushing to dockerhub on pushes to `main`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
   # ----------------------------------------------------------------------------
 
   test-current-kubernetes:
+    if: ${{ contains(github.ref, 'tags') }} # run only for tags
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,6 +47,7 @@ jobs:
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes_version }} make test.integration.${{ matrix.dbmode }}
 
   test-previous-kubernetes:
+    if: ${{ contains(github.ref, 'tags') }} # run only for tags
     environment: gcloud
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ name: release
 
 on:
   push:
+    branches:
+      - 'main'
+      - 'next'
     tags:
       - 'v2.*'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
     tags:
       - 'v2.*'
 


### PR DESCRIPTION
Fixes a regression introduced in 9d719cc61f670dc0035e193cfd3582f192cc71ca:

An unintended consequence of the change above is that pushes of the `main` tag to Docker Hub stopped working.

This PR:
- reenables the release job for `main`
- adds a triggering condition for gcloud tests that address the primary motivation of the referenced commit (to run the gcloud test only on tag pushes)