### PR TITLE
README header for KIC 2.0 public beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 
-# Kong for Kubernetes
+# Kong Kubernetes Ingress Controller
 
 Use [Kong][kong] for Kubernetes [Ingress][ingress].
 Configure [plugins][kong-hub], health checking,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 
-# Kong Kubernetes Ingress Controller
+# Kong Ingress Controller for Kubernetes
 
 Use [Kong][kong] for Kubernetes [Ingress][ingress].
 Configure [plugins][kong-hub], health checking,
@@ -13,6 +13,21 @@ for Kubernetes Services, all using
 Custom Resource Definitions(CRDs) and Kubernetes-native tooling.
 
 [**Features**](#features) | [**Get started**](#get-started) | [**Documentation**](#documentation) | [**main branch builds**](#main-branch-builds) | [**Seeking help**](#seeking-help)
+
+## KIC 2.0 is in beta now!
+
+We're happy to announce that Kong Ingress Controller 2.0 is in public beta.
+
+This new release comes with a major internal rearchitecture, and the following added features:
+- Support for UDP ingress resources and the new `UDPIngress` CRD,
+- Ingress controller runtime metrics compatible with Prometheus, for easier monitoring and alerting.
+
+For a quick start, just deploy KIC 2.0 beta to your cluster:
+```console
+$ https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/main/deploy/single-v2/all-in-one-dbless.yaml
+```
+
+See the [documentation](https://docs.konghq.com/kubernetes-ingress-controller-beta) for Kong Ingress Controller 2.0 beta.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 # Kong for Kubernetes
 
-⚠️ **Due to Bintray image registries going out of service, we've moved our Docker images to [Docker Hub](https://hub.docker.com/r/kong/kubernetes-ingress-controller/tags).** ⚠️
-
 Use [Kong][kong] for Kubernetes [Ingress][ingress].
 Configure [plugins][kong-hub], health checking,
 load balancing and more in Kong

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This new release comes with a major internal rearchitecture, and the following a
 
 For a quick start, just deploy KIC 2.0 beta to your cluster:
 ```console
-$ https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/main/deploy/single-v2/all-in-one-dbless.yaml
+$ kubectl apply -f "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/main/deploy/single-v2/all-in-one-dbless.yaml"
 ```
 
 See the [documentation](https://docs.konghq.com/kubernetes-ingress-controller-beta) for Kong Ingress Controller 2.0 beta.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Custom Resource Definitions(CRDs) and Kubernetes-native tooling.
 
 [**Features**](#features) | [**Get started**](#get-started) | [**Documentation**](#documentation) | [**main branch builds**](#main-branch-builds) | [**Seeking help**](#seeking-help)
 
-## KIC 2.0 is in beta now!
+## ✨ KIC 2.0 is in public beta! ✨
 
 We're happy to announce that Kong Ingress Controller 2.0 is in public beta.
 


### PR DESCRIPTION
Related to https://github.com/Kong/docs.konghq.com/pull/3099#issuecomment-896968376

Adds a section to the top of the readme to announce that KIC 2.0 is in public beta, including a link to the interim documentation site.

**Do not merge** before https://github.com/Kong/kubernetes-ingress-controller/pull/1689 is released and the deploy manifests run the newly released version.