### PR TITLE
fix: credentials validation for constraint violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Table of Contents
+
+ - [2.0.0](#200---tbd)
  - [2.0.0-beta.2](#200-beta2---202108016)
  - [2.0.0-beta.1](#200-beta1---20210806)
  - [2.0.0-alpha.3](#200-alpha3---20210802)
@@ -33,6 +35,18 @@
  - [0.1.0](#010---20180817)
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.0.0] - TBA
+
+#### Fixed
+
+- Previously when `KongConsumer` credentials were provided which were in violation
+  of unique constraints this would cause a hard lockup of the controller and it would
+  be unable to perform any updates on the gateway until the offending objects were
+  resolved. We've patched this to now _drop_ the offending credentials instead so that
+  other configurations can continue and log the error continually until the offending
+  objects are resolved.
+  [#729](https://github.com/Kong/kubernetes-ingress-controller/issues/729)
 
 ## [2.0.0-beta.2] - 2021/08/16
 

--- a/internal/adminapi/validators/consumer/credentials/constraints.go
+++ b/internal/adminapi/validators/consumer/credentials/constraints.go
@@ -1,0 +1,22 @@
+package credentials
+
+// -----------------------------------------------------------------------------
+// Private
+// -----------------------------------------------------------------------------
+
+// uniqueKeyConstraints a map of unique key constraints for any given credential type.
+// This map is the crux of all unique key constraint validation and is derived from
+// the relevant Lua code for the types in the backend Kong Admin API.
+//
+// Example: https://github.com/kong/kong/blob/master/kong/plugins/basic-auth/daos.lua
+//
+// So if you're in here doing maintenance and you need to add/remove constraints due
+// to upstream changes, check the "kong/plugins" directory of the upstream repo
+// for every given type.
+var uniqueKeyConstraints = map[string][]string{
+	"basic-auth": {"username"},
+	"hmac-auth":  {"username"},
+	"jwt":        {"key"},
+	"key-auth":   {"key"},
+	"oauth2":     {"client_id"},
+}

--- a/internal/adminapi/validators/consumer/credentials/validation.go
+++ b/internal/adminapi/validators/consumer/credentials/validation.go
@@ -1,0 +1,101 @@
+// Package credentials includes validators for the credentials provided for KongConsumers.
+package credentials
+
+import (
+	"github.com/kong/kubernetes-ingress-controller/internal/adminapi/validators"
+)
+
+// -----------------------------------------------------------------------------
+//  Validation - Public Functions
+// -----------------------------------------------------------------------------
+
+// IsKeyUniqueConstrained indicates whether or not a given key and its type there
+// are unique constraints in place.
+func IsKeyUniqueConstrained(keyType, key string) (constrained bool) {
+	constrainedKeys, credTypeHasConstraints := uniqueKeyConstraints[keyType]
+	if !credTypeHasConstraints {
+		return
+	}
+
+	for _, constrainedKey := range constrainedKeys {
+		if key == constrainedKey {
+			constrained = true
+			return
+		}
+	}
+
+	return
+}
+
+// -----------------------------------------------------------------------------
+//  Validation - Credentials
+// -----------------------------------------------------------------------------
+
+// Credential is a metadata struct to help validate the contents of
+// consumer credentials, particularly unique constraints on the underlying data.
+type Credential struct {
+	// ConsumerName indicates the name of the KongConsumer which this credential
+	// is supplied for.
+	ConsumerName string
+
+	// ConsumerNamespace indicates the namespace that the KongConsumer which this
+	// credential is supplied for.
+	ConsumerNamespace string
+
+	// Type indicates the credential type, which will reference one of the types
+	// in the SupportedTypes set.
+	Type string
+
+	// Key is the key for the credentials data
+	Key string
+
+	// Value is the data provided for the key
+	Value string
+}
+
+// -----------------------------------------------------------------------------
+// Validation - Validating Index
+// -----------------------------------------------------------------------------
+
+// Index is a map of credentials types to a map of credential keys to the underlying
+// values already seen for that type and key. This type is used as a history tracker
+// for validation so that callers can keep track of the credentials they've seen thus
+// far and validate whether new credentials they encounter are in violation of any
+// constraints on their respective types.
+type Index map[string]map[string]map[string]struct{}
+
+// Add will attempt to add a new Credential to the CredentialsTypeMap.
+// If that new credential is in violation of any constraints based on the
+// credentials already stored in the map, an error will be thrown.
+func (cs Index) Add(newCred Credential) error {
+	// retrieve all the keys which are constrained for this type
+	constraints, ok := uniqueKeyConstraints[newCred.Type]
+	if !ok {
+		return nil // there are no constraints for this credType
+	}
+
+	// for each key which is constrained for this type check the existing list
+	// to see if there are any violations of that constraint given the new credentials
+	for _, constrainedKey := range constraints {
+		if newCred.Key == constrainedKey { // this key has constraints on it, we need to check for violations
+			if _, ok := cs[newCred.Type][newCred.Key][newCred.Value]; ok {
+				return validators.UniqueConstraintViolationError{
+					ObjectType:      "KongConsumer",
+					ObjectName:      newCred.ConsumerName,
+					ObjectNamespace: newCred.ConsumerNamespace,
+					Type:            newCred.Type,
+					Key:             newCred.Key,
+				}
+			}
+		}
+	}
+
+	// if we make it here there's been no constraint violation, add it to the index
+	if cs[newCred.Type] == nil {
+		// if needed, initialize the index
+		cs[newCred.Type] = map[string]map[string]struct{}{newCred.Key: {newCred.Value: {}}}
+	}
+	cs[newCred.Type][newCred.Key][newCred.Value] = struct{}{}
+
+	return nil
+}

--- a/internal/adminapi/validators/consumer/credentials/validation_test.go
+++ b/internal/adminapi/validators/consumer/credentials/validation_test.go
@@ -1,0 +1,65 @@
+package credentials_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/internal/adminapi/validators"
+	"github.com/kong/kubernetes-ingress-controller/internal/adminapi/validators/consumer/credentials"
+)
+
+func TestUniqueConstraintsValidation(t *testing.T) {
+	t.Log("setting up an index of existing credentials which have unique constraints")
+	index := make(credentials.Index)
+	require.NoError(t, index.Add(credentials.Credential{
+		Key:   "username",
+		Value: "batman",
+		Type:  "basic-auth",
+	}))
+	require.NoError(t, index.Add(credentials.Credential{
+		Key:   "username",
+		Value: "robin",
+		Type:  "basic-auth",
+	}))
+
+	t.Log("verifying that a new basic-auth credential with a unique username doesn't violate constraints")
+	nonviolatingCredential := credentials.Credential{
+		Key:   "username",
+		Value: "nightwing",
+		Type:  "basic-auth",
+	}
+	assert.NoError(t, index.Add(nonviolatingCredential))
+
+	t.Log("verifying that a new basic-auth credential with a username that's already in use violates constraints")
+	violatingCredential := credentials.Credential{
+		Key:   "username",
+		Value: "batman",
+		Type:  "basic-auth",
+	}
+	assert.True(t, credentials.IsKeyUniqueConstrained(violatingCredential.Type, violatingCredential.Key))
+	err := index.Add(violatingCredential)
+	assert.Error(t, err)
+	assert.IsType(t, validators.UniqueConstraintViolationError{}, err)
+
+	t.Log("setting up a list of existing credentials which have no unique constraints")
+	index = make(credentials.Index)
+	assert.NoError(t, index.Add(credentials.Credential{
+		Key:   "key",
+		Value: "test",
+		Type:  "acl",
+	}))
+
+	t.Log("verifying that non-unique constrained credentials don't trigger a violation")
+	duplicate := credentials.Credential{
+		Key:   "key",
+		Value: "test",
+		Type:  "acl",
+	}
+	assert.False(t, credentials.IsKeyUniqueConstrained(duplicate.Type, duplicate.Key))
+	assert.NoError(t, index.Add(duplicate))
+
+	t.Log("verifying that unconstrained keys for types with constraints don't flag as violated")
+	assert.False(t, credentials.IsKeyUniqueConstrained("basic-auth", "unconstrained-key"))
+}

--- a/internal/adminapi/validators/consumer/credentials/vars.go
+++ b/internal/adminapi/validators/consumer/credentials/vars.go
@@ -1,0 +1,21 @@
+package credentials
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// -----------------------------------------------------------------------------
+// Validation - Vars
+// -----------------------------------------------------------------------------
+
+// TypeKey indicates the key in a consumer secret which identifies the type
+// of credential that is being provided for the consumer.
+const TypeKey = "kongCredType"
+
+// SupportedCreds indicates all the "kongCredType"s which are supported for KongConsumer credentials.
+var SupportedTypes = sets.NewString(
+	"basic-auth",
+	"hmac-auth",
+	"jwt",
+	"key-auth",
+	"oauth2",
+	"acl",
+)

--- a/internal/adminapi/validators/errors.go
+++ b/internal/adminapi/validators/errors.go
@@ -1,0 +1,26 @@
+package validators
+
+import "fmt"
+
+const uniqueConstraintViolationHeader = "unique constraints violation"
+
+// UniqueConstraintViolationError is an error that indicates that a unique
+// constraint was violated for a specific key. The error will indicate the
+// type of the key as well as the reference Kubernetes object name in the
+// error output.
+type UniqueConstraintViolationError struct {
+	ObjectType      string
+	ObjectName      string
+	ObjectNamespace string
+	Type            string
+	Key             string
+}
+
+func (u UniqueConstraintViolationError) Error() string {
+	return fmt.Sprintf(
+		"%s for type %s on key %s for object type %s named %s in namespace %s",
+		uniqueConstraintViolationHeader,
+		u.Type, u.Key,
+		u.ObjectType, u.ObjectName, u.ObjectNamespace,
+	)
+}

--- a/internal/kongstate/kongstate.go
+++ b/internal/kongstate/kongstate.go
@@ -7,8 +7,9 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/kong/kubernetes-ingress-controller/internal/adminapi/validators"
+	credvalidators "github.com/kong/kubernetes-ingress-controller/internal/adminapi/validators/consumer/credentials"
 	"github.com/kong/kubernetes-ingress-controller/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/internal/util"
@@ -48,10 +49,13 @@ func (ks *KongState) SanitizedCopy() *KongState {
 	}
 }
 
+// FillConsumersAndCredentials builds indices of all consumers and credentials within its purview.
+// If violations for constraints between credentials are found, this function will log those as errors
+// but will attempt to drop the offending data and otherwise move past them until a time when the
+// problem has been rectified by an operator.
 func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store.Storer) {
 	consumerIndex := make(map[string]Consumer)
-
-	// build consumer index
+	credentialsIndex := make(credvalidators.Index)
 	for _, consumer := range s.ListKongConsumers() {
 		var c Consumer
 		if consumer.Username == "" && consumer.CustomID == "" {
@@ -69,11 +73,21 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 			"kongconsumer_name":      consumer.Name,
 			"kongconsumer_namespace": consumer.Namespace,
 		})
+
+		// ---------------------------------------------------------------------------
+		// KongConsumer Credentials - Processing & Validation
+		// ---------------------------------------------------------------------------
+
 		for _, cred := range consumer.Credentials {
 			log = log.WithFields(logrus.Fields{
 				"secret_name":      cred,
 				"secret_namespace": consumer.Namespace,
 			})
+
+			// --------------------------------------------------------------------------
+			// Credentials Retrieval
+			// --------------------------------------------------------------------------
+
 			secret, err := s.GetSecret(consumer.Namespace, cred)
 			if err != nil {
 				log.Errorf("failed to fetch secret: %v", err)
@@ -89,22 +103,97 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 				}
 				credConfig[k] = string(v)
 			}
-			credType, ok := credConfig["kongCredType"].(string)
+
+			// --------------------------------------------------------------------------
+			// Credentials Validation
+			// --------------------------------------------------------------------------
+
+			// if any validation fails the credentials will be marked as invalid and not
+			// applied, however validation continues after each failure so as to get the
+			// benefit of reporting ALL validation issues that were found with this
+			// credential, so the operator can make all the required changes and not
+			// update one only to find there were more the whole time.
+			invalid := false
+
+			// if any failure occur when validating the credentials, the error will contain
+			// this prefix in the message body to make it easier to search for this class
+			// of errors (KongConsumer credentials validation errors) in the manager logs.
+			failHeader := fmt.Sprintf("failed to provision credentials for consumer %s", consumer.Name)
+
+			// validate that the required "kongCredType" key is present in the creds.
+			credType, ok := credConfig[credvalidators.TypeKey].(string)
 			if !ok {
-				log.Errorf("failed to provision credential: invalid credType: %v", credType)
+				log.Errorf("%s: secret %s provided no %s", failHeader, secret.Name, credvalidators.TypeKey)
+				invalid = true
 			}
-			if !supportedCreds.Has(credType) {
-				log.Errorf("failed to provision credential: invalid credType: %v", credType)
-				continue
+			if !credvalidators.SupportedTypes.Has(credType) {
+				supportedCredsString := fmt.Sprintf("valid options are: %s", strings.Join(credvalidators.SupportedTypes.List(), ","))
+				log.Errorf("%s: invalid credType: %s (%s)", failHeader, credType, supportedCredsString)
+				invalid = true
 			}
-			if len(credConfig) <= 1 { // 1 key of credType itself
-				log.Errorf("failed to provision credential: empty secret")
-				continue
+
+			// validate that the credentials actually includes configuration, not just the type
+			if len(credConfig) <= 1 {
+				log.Errorf("%s: secret %s has no data", failHeader, secret.Name)
+				continue // if this is true, there's nothing left to validate anyway
 			}
-			err = c.SetCredential(credType, credConfig, ks.Version)
-			if err != nil {
-				log.Errorf("failed to provision credential: %v", err)
-				continue
+
+			// consumer credentials can technically be configured with two (different)
+			// secrets that contain the same key. For some types there are unique
+			// contraints on the key. Here we validate the unique constraints for
+			// several types.
+			for k, v := range credConfig {
+				if k == credvalidators.TypeKey {
+					continue // the type key doesn't need to be validated, it's only organizational
+				}
+
+				// check whether the type for this key is one that includes unique
+				// constraints. Ultimately if there are no constraints on the type
+				// we don't need to bother using system memory to keep track of it
+				// in the index because it will be inconsequential.
+				if credvalidators.IsKeyUniqueConstrained(credType, k) {
+					// we will need a copy of the actual data for this key in order to validate it.
+					value, ok := v.(string)
+					if !ok {
+						log.Errorf("%s: invalid credential %s: key value can't be %T", failHeader, consumer.Name, cred, v)
+						invalid = true
+						continue // invalid data can't be validated
+					}
+
+					// generate a credential validation object reference
+					credential := credvalidators.Credential{
+						ConsumerName:      consumer.Name,
+						ConsumerNamespace: consumer.Namespace,
+						Key:               k,
+						Value:             value,
+						Type:              credType,
+					}
+
+					// try to add the newly found credential to the credentials index.
+					// if the new credential is in violation of any constraints in reference
+					// to the existing credentials in the list it will throw an error.
+					if err := credentialsIndex.Add(credential); err != nil {
+						if violationErr, ok := err.(validators.UniqueConstraintViolationError); ok {
+							log.Errorf("%s: %w", failHeader, violationErr)
+							invalid = true
+						} else {
+							log.Errorf("%s: unexpected error when validating constraints for key %s: %w", failHeader, k, err)
+							invalid = true
+						}
+					}
+				}
+			}
+
+			// --------------------------------------------------------------------------
+			// Credentials Updates
+			// --------------------------------------------------------------------------
+
+			if !invalid {
+				err = c.SetCredential(credType, credConfig, ks.Version)
+				if err != nil {
+					log.Errorf("%s: %w", failHeader, err)
+					continue
+				}
 			}
 		}
 
@@ -326,12 +415,3 @@ func globalPlugins(log logrus.FieldLogger, s store.Storer) ([]Plugin, error) {
 func (ks *KongState) FillPlugins(log logrus.FieldLogger, s store.Storer) {
 	ks.Plugins = buildPlugins(log, s, ks.getPluginRelations())
 }
-
-var supportedCreds = sets.NewString(
-	"acl",
-	"basic-auth",
-	"hmac-auth",
-	"jwt",
-	"key-auth",
-	"oauth2",
-)


### PR DESCRIPTION
**What this PR does / why we need it**:

Up until now if violations of unique key constraints occurred while processing the credentials for `KongConsumer` objects the result would be a hard lockup of the controller as updates to the Kong Admin API would fail until the offending resources were removed or updated.

This patch references the Admin API's own constraints to enable pre-validation of consumer credentials and changes the behavior to drop the offending credentials and avoid the hard lockup and instead only log the errors continually until the offending resources are corrected.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/729

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
