### PR TITLE
Only become ready after proxy configured

### DIFF
--- a/internal/proxy/clientgo_cached_proxy_resolver.go
+++ b/internal/proxy/clientgo_cached_proxy_resolver.go
@@ -155,6 +155,17 @@ func (p *clientgoCachedProxyResolver) ObjectExists(obj client.Object) (bool, err
 	return exists, err
 }
 
+func (p *clientgoCachedProxyResolver) IsReady() bool {
+	// If the proxy is has no database, it is only ready after a successful sync
+	// Otherwise, it has no configuration loaded
+	if p.dbmode == "off" {
+		return len(p.lastConfigSHA) > 0
+	}
+	// If the proxy has a database, it is ready immediately
+	// It will load existing configuration from the database
+	return true
+}
+
 // -----------------------------------------------------------------------------
 // Client Go Cached Proxy Resolver - Private Methods - Servers
 // -----------------------------------------------------------------------------

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -59,6 +59,10 @@ type Proxy interface {
 
 	// ObjectExists indicates whether or not any version of the provided object is already present in the proxy.
 	ObjectExists(obj client.Object) (bool, error)
+
+	// IsReady returns true if the proxy is considered ready.
+	// A ready proxy has configuration available and can handle traffic.
+	IsReady() bool
 }
 
 // KongUpdater is a type of function that describes how to provide updates to the Kong Admin API


### PR DESCRIPTION
**What this PR does / why we need it**:
Only mark the controller ready after it can assume that the proxy has configuration available, either immediately if the proxy has a database or after the first config push if the proxy has no database.

Replaces the no-op Ping function with a dynamically-scoped `ConfigReady()` function. `ConfigReady()` returns a nil error if the previously instantiated Proxy's `IsReady()` function returns `true` or returns a "proxy not yet configured" error if `IsReady()` returns `false`

`IsReady()` returns `true` if:
- `proxy.dbmode == "off"` and `len(proxy.lastConfigSHA) > 0` (i.e. we have applied config at least once).
- `proxy.dbmode` is any other value (we assume config is probably already available in the DB). This doesn't handle the initial start edge case where the database is empty, but is usually good enough. Handling the edge case requires some complex nonsense with figuring out if the cluster controller leader has applied configuration (since non-leaders never apply config themselves).

It returns `false` otherwise.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1504 

**Special notes for your reviewer**:
I haven't the foggiest how you test this consistently and meaningfully.

Unit tests seem not particularly useful since we'd need to stuff a fake value into `lastConfigSHA` rather than allowing it to populate naturally. Effectively all we confirm is that string comparisons and slice length checks work as expected.

Integration tests are complicated by many factors:
- Empty configuration is valid and will populate `lastConfigSHA`. The controller will sync even before you've created any Ingresses and such. We can only make it not sync by either not starting the proxy (more or less what we had before, but not easily doable in our test environment because we don't get to let Kubernetes restart the container if the initial connection attempt fails) or by creating resources that result in invalid configuration before anything else applies (not sure how to do this with the test parallelization), confirm not ready, rectify the error, and confirm ready.
- We don't have any way to observe the proxy internals even if we can control the expected config state with initially intentionally broken config. I think we either scrape logs and check for the success message (not sure if we can do this), look at the config diagnostic failed/successful outputs (reasonable enough, I guess), or look at the proxy admin API (can't distinguish between successful empty config and unsuccessful config).

A manual test of the image does at least confirm that the controller becomes ready, but even in manual runs I don't know how I can confirm its behavior that it doesn't become ready when it shouldn't.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
