### PR TITLE
chore: enable k8s v1.22.0 release testing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         kubernetes-version:
           - 'v1.21.2'
+          - 'v1.22.0'
         dbmode:
           - 'dbless'
           - 'postgres'


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables the newly added `v1.22.0` [Kind Image](https://hub.docker.com/layers/kindest/node/v1.22.0) to ensure release testing is done against the new Kubernetes `1.22.x` release.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1725

**Notes**

The following issues were found when testing `v1.22` and were reported as follow-ups:

- https://github.com/Kong/kubernetes-ingress-controller/issues/1728
- https://github.com/Kong/kubernetes-ingress-controller/issues/1730