### PR TITLE
docs: KEP updates for KIC v2.0.0-beta release

### DIFF
--- a/keps/0003-kic-kubebuilder-re-architecture.md
+++ b/keps/0003-kic-kubebuilder-re-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: KIC Kubebuilder Rearchitecture
-status: implementable
+status: implemented
 ---
 
 # Notes

--- a/keps/0004-kong-kubernetes-testing.md
+++ b/keps/0004-kong-kubernetes-testing.md
@@ -1,5 +1,5 @@
 ---
-status: implementable
+status: implemented
 ---
 
 **NOTE**: this will be considered `implemented` once [Milestone 1][m1] is completed.
@@ -29,7 +29,7 @@ status: implementable
 
 ## Release Signoff Checklist
 
-- [ ] [v0.1.0 Milestone][ms1]
+- [x] [v0.1.0 Milestone][ms1]
 
 [ms1]:https://github.com/Kong/kubernetes-testing-framework/milestone/1
 
@@ -105,7 +105,7 @@ Integration tests written in the testing framework will also serve the purpose o
 
 - [X] Testing Framework Prototype
 - [X] Testing Framework plugged into KIC
-- [ ] KTF `v0.1.0` milestone completed & `v0.1.0` released
+- [x] KTF `v0.1.0` milestone completed & `v0.1.0` released
 
 ## Implementation History
 

--- a/keps/0006-officially-supported-platforms.md
+++ b/keps/0006-officially-supported-platforms.md
@@ -1,7 +1,12 @@
 ---
-status: on-hold
-WARNING: this is an early draft and we are NOT ready to commit to any process that results from it, it's only ideas "on paper" for now.
+status: declined
 ---
+
+# NOTES
+
+This is considered "declined" and the maintainers are not intending to take further action at this time due to a lack of demand for the functionality.
+
+If you're reading this and you desire for this work to continue, please check with us in discussions and let us know your use case so it can help to inform the priority.
 
 # Official Support for new Platforms and Integrations with KIC
 

--- a/keps/0007-kic-performance-test.md
+++ b/keps/0007-kic-performance-test.md
@@ -4,8 +4,10 @@ status: provisional
 ---
 
 # Notes
+
 For references see the dependencies related to this proprosal to check the progress of related efforts:
-- solution 
+
+- solution
 - deployment and configuration
 - code/repo
 - configuration and execution
@@ -14,8 +16,9 @@ For references see the dependencies related to this proprosal to check the progr
 
 
 ## Summary
-  We want a performance test solution that can be executed collecting metrics (cpu, memory, workqueue, business logic etc) per release, which also provides controller profiling helping evaluating bottleneck and scalabilities. The execution could be based on configuration, or code change trigger. 
-  Performance tests should be able to integrate with different kubernetes cluster and cloud provider, and scale according to controller scalability. 
+
+We want a performance test solution that can be executed collecting metrics (cpu, memory, workqueue, business logic etc) per release, which also provides controller profiling helping evaluating bottleneck and scalabilities. The execution could be based on configuration, or code change trigger.
+Performance tests should be able to integrate with different kubernetes cluster and cloud provider, and scale according to controller scalability.
 
 [kic]:https://github.com/kong/kubernetes-ingress-controller
 [ktf]:https://github.com/Kong/kubernetes-testing-framework
@@ -25,11 +28,13 @@ For references see the dependencies related to this proprosal to check the progr
 [docker]: https://www.docker.com/ 
 
 ## Motivation
+
  - we currently have no data, documentation, or determined performance characteristics for the KIC in any Kubernetes or infrastructure environment
  - we want libraries and tooling that can be run against a Kubernetes cluster and its underlying infrastructure to analyze the performance characteristics of the KIC in that environment
  - we want our tooling to be open source so end-users can run a performance analysis themselves in their environment
- 
+
 ### Goals
+
  - provide an isolated and reproducible environment for performance testing
  - continue integration and continue test
  - Visualize testing configuration and results.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a maintenance task to update our existing KEPs in response to what has been delivered with the KIC 2.0.0 BETA releases.

**Special notes for your reviewer**:

- docs: mark ktf and kubebuilder keps implemented
- docs: spacing cleanup for performance testing KEP
- docs: decline arm64 KEP