### PR TITLE
Manually manage Kong<TYPE> CRDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,7 @@ __debug_bin
 
 # tmp files
 client-gen-tmp/*
+build/*
+
 # ignore personal TODO lists
 TODO

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ all: build
 
 .PHONY: clean
 clean:
+	@rm -rf build/
 	@rm -rf testbin/
 	@rm -rf bin/*
 	@rm -f coverage*.out
@@ -114,12 +115,15 @@ verify.generators: verify.repo generate verify.diff
 # ------------------------------------------------------------------------------
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=kong-ingress webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	go run hack/generators/manifests/main.go --directory config/crd/bases/
+manifests: manifests.crds manifests.single
+
+.PHONY: manifests.crds
+manifests.crds: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=kong-ingress webhook paths="./..." output:crd:artifacts:config=build/config/crd/bases
+	go run hack/generators/manifests/main.go --input-directory build/config/crd/bases/ --output-directory config/crd/bases
 
 .PHONY: manifests.single
-manifests.single: ## Compose single-file deployment manifests from building blocks
+manifests.single: kustomize ## Compose single-file deployment manifests from building blocks
 	./hack/deploy/build-single-manifests.sh
 
 # ------------------------------------------------------------------------------

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -1,11 +1,6 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -43,11 +38,6 @@ spec:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -55,35 +45,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -103,13 +70,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -117,15 +77,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -1,11 +1,6 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -33,11 +28,6 @@ spec:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -48,13 +38,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -1,11 +1,6 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -24,126 +19,64 @@ spec:
       openAPIV3Schema:
         description: KongIngress is the Schema for the kongingresses API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           proxy:
             description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
             properties:
-              ca_certificates:
-                items:
-                  type: string
-                type: array
-              client_certificate:
-                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                properties:
-                  cert:
-                    type: string
-                  created_at:
-                    format: int64
-                    type: integer
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  snis:
-                    items:
-                      type: string
-                    type: array
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                type: object
               connect_timeout:
-                type: integer
-              created_at:
-                type: integer
-              host:
-                type: string
-              id:
-                type: string
-              name:
-                type: string
-              path:
-                type: string
-              port:
+                minimum: 0
                 type: integer
               protocol:
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               read_timeout:
+                minimum: 0
                 type: integer
               retries:
+                minimum: 0
                 type: integer
-              tags:
-                items:
-                  type: string
-                type: array
-              tls_verify:
-                type: boolean
-              tls_verify_depth:
-                type: integer
-              updated_at:
-                type: integer
-              url:
-                type: string
               write_timeout:
+                minimum: 0
                 type: integer
             type: object
           route:
             description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
             properties:
-              created_at:
-                type: integer
-              destinations:
-                items:
-                  description: CIDRPort represents a set of CIDR and a port.
-                  properties:
-                    ip:
-                      type: string
-                    port:
-                      type: integer
-                  type: object
-                type: array
               headers:
                 additionalProperties:
                   items:
                     type: string
                   type: array
                 type: object
-              hosts:
-                items:
-                  type: string
-                type: array
               https_redirect_status_code:
                 type: integer
-              id:
-                type: string
               methods:
                 items:
                   type: string
                 type: array
-              name:
-                type: string
               path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              paths:
-                items:
-                  type: string
-                type: array
               preserve_host:
                 type: boolean
               protocols:
                 items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
                   type: string
                 type: array
               regex_priority:
@@ -158,122 +91,22 @@ spec:
                 type: boolean
               response_buffering:
                 type: boolean
-              service:
-                description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
-                properties:
-                  ca_certificates:
-                    items:
-                      type: string
-                    type: array
-                  client_certificate:
-                    description: Certificate represents a Certificate in Kong. Read
-                      https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                    properties:
-                      cert:
-                        type: string
-                      created_at:
-                        format: int64
-                        type: integer
-                      id:
-                        type: string
-                      key:
-                        type: string
-                      snis:
-                        items:
-                          type: string
-                        type: array
-                      tags:
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  connect_timeout:
-                    type: integer
-                  created_at:
-                    type: integer
-                  host:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  path:
-                    type: string
-                  port:
-                    type: integer
-                  protocol:
-                    type: string
-                  read_timeout:
-                    type: integer
-                  retries:
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                  tls_verify:
-                    type: boolean
-                  tls_verify_depth:
-                    type: integer
-                  updated_at:
-                    type: integer
-                  url:
-                    type: string
-                  write_timeout:
-                    type: integer
-                type: object
               snis:
                 items:
                   type: string
                 type: array
-              sources:
-                items:
-                  description: CIDRPort represents a set of CIDR and a port.
-                  properties:
-                    ip:
-                      type: string
-                    port:
-                      type: integer
-                  type: object
-                type: array
               strip_path:
                 type: boolean
-              tags:
-                items:
-                  type: string
-                type: array
-              updated_at:
-                type: integer
             type: object
           upstream:
             description: Upstream represents an Upstream in Kong.
             properties:
               algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
                 type: string
-              client_certificate:
-                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                properties:
-                  cert:
-                    type: string
-                  created_at:
-                    format: int64
-                    type: integer
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  snis:
-                    items:
-                      type: string
-                    type: array
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              created_at:
-                format: int64
-                type: integer
               hash_fallback:
                 type: string
               hash_fallback_header:
@@ -295,6 +128,7 @@ spec:
                       probing.
                     properties:
                       concurrency:
+                        minimum: 1
                         type: integer
                       healthy:
                         description: Healthy configures thresholds and HTTP status
@@ -305,17 +139,17 @@ spec:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           successes:
+                            minimum: 0
                             type: integer
                         type: object
                       http_path:
+                        pattern: ^/.*$
                         type: string
-                      https_sni:
-                        type: string
-                      https_verify_certificate:
-                        type: boolean
                       timeout:
+                        minimum: 0
                         type: integer
                       type:
                         type: string
@@ -324,16 +158,20 @@ spec:
                           codes to mark targets unhealthy.
                         properties:
                           http_failures:
+                            minimum: 0
                             type: integer
                           http_statuses:
                             items:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           tcp_failures:
+                            minimum: 0
                             type: integer
                           timeouts:
+                            minimum: 0
                             type: integer
                         type: object
                     type: object
@@ -350,45 +188,42 @@ spec:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           successes:
+                            minimum: 0
                             type: integer
                         type: object
-                      type:
-                        type: string
                       unhealthy:
                         description: Unhealthy configures thresholds and HTTP status
                           codes to mark targets unhealthy.
                         properties:
                           http_failures:
+                            minimum: 0
                             type: integer
                           http_statuses:
                             items:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           tcp_failures:
+                            minimum: 0
                             type: integer
                           timeouts:
+                            minimum: 0
                             type: integer
                         type: object
                     type: object
                   threshold:
-                    type: number
+                    type: integer
                 type: object
               host_header:
                 type: string
-              id:
-                type: string
-              name:
-                type: string
               slots:
+                minimum: 10
                 type: integer
-              tags:
-                items:
-                  type: string
-                type: array
             type: object
         type: object
     served: true

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -1,11 +1,6 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -43,11 +38,6 @@ spec:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -55,35 +45,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -93,19 +60,9 @@ spec:
                 - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -113,15 +70,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/deploy/single-v2/all-in-one-dbless.yaml
+++ b/deploy/single-v2/all-in-one-dbless.yaml
@@ -6,9 +6,6 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -46,11 +43,6 @@ spec:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -58,35 +50,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -106,13 +75,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -120,15 +82,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
@@ -156,9 +118,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -186,11 +145,6 @@ spec:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -201,13 +155,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string
@@ -226,8 +173,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -436,9 +381,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -476,11 +418,6 @@ spec:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -488,35 +425,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -526,19 +440,9 @@ spec:
                 - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -546,15 +450,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/deploy/single-v2/all-in-one-enterprise-dbless.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-dbless.yaml
@@ -6,9 +6,6 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -46,11 +43,6 @@ spec:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -58,35 +50,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -106,13 +75,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -120,15 +82,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
@@ -156,9 +118,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -186,11 +145,6 @@ spec:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -201,13 +155,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string
@@ -226,8 +173,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -436,9 +381,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -476,11 +418,6 @@ spec:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -488,35 +425,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -526,19 +440,9 @@ spec:
                 - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -546,15 +450,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/deploy/single-v2/all-in-one-enterprise-postgres.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-postgres.yaml
@@ -6,9 +6,6 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -46,11 +43,6 @@ spec:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -58,35 +50,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -106,13 +75,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -120,15 +82,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
@@ -156,9 +118,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -186,11 +145,6 @@ spec:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -201,13 +155,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string
@@ -226,8 +173,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -436,9 +381,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -476,11 +418,6 @@ spec:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -488,35 +425,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -526,19 +440,9 @@ spec:
                 - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -546,15 +450,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/deploy/single-v2/all-in-one-postgres.yaml
+++ b/deploy/single-v2/all-in-one-postgres.yaml
@@ -6,9 +6,6 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -46,11 +43,6 @@ spec:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -58,35 +50,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -106,13 +75,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -120,15 +82,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
@@ -156,9 +118,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -186,11 +145,6 @@ spec:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -201,13 +155,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string
@@ -226,8 +173,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -436,9 +381,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -476,11 +418,6 @@ spec:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
             type: object
@@ -488,35 +425,12 @@ spec:
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -526,19 +440,9 @@ spec:
                 - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -546,15 +450,15 @@ spec:
           protocols:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
-            - udp
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:

--- a/hack/deploy/build-single-manifests.sh
+++ b/hack/deploy/build-single-manifests.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(dirname ${BASH_SOURCE})/../..
 
 cd $REPO_ROOT
 
-kustomize build config/base > deploy/single-v2/all-in-one-dbless.yaml
-kustomize build config/variants/postgres > deploy/single-v2/all-in-one-postgres.yaml
-kustomize build config/variants/enterprise > deploy/single-v2/all-in-one-enterprise-dbless.yaml
-kustomize build config/variants/enterprise-postgres > deploy/single-v2/all-in-one-enterprise-postgres.yaml
+${REPO_ROOT}/bin/kustomize build config/base > deploy/single-v2/all-in-one-dbless.yaml
+${REPO_ROOT}/bin/kustomize build config/variants/postgres > deploy/single-v2/all-in-one-postgres.yaml
+${REPO_ROOT}/bin/kustomize build config/variants/enterprise > deploy/single-v2/all-in-one-enterprise-dbless.yaml
+${REPO_ROOT}/bin/kustomize build config/variants/enterprise-postgres > deploy/single-v2/all-in-one-enterprise-postgres.yaml

--- a/hack/generators/manifests/main.go
+++ b/hack/generators/manifests/main.go
@@ -8,26 +8,26 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // -----------------------------------------------------------------------------
-// Vars
-// -----------------------------------------------------------------------------
-
-var (
-	// directory that will be used for walking the filesystem to find CRDs.
-	directory string
-
-	// patchfile is the patch that will be used for each CRD file
-	patchfile = "config/crd/patches/upgrade_compat.yaml"
-)
-
-// -----------------------------------------------------------------------------
-// Main
+// This script exists as a workaround for some problems which came up between
+// v1 and v2 of the KIC regarding upgrading and generating CRDs:
 //
-// This script exists as a workaround for some problems that arouse between the
-// apiextensions.k8s.io/v1beta1 and apiextensions.k8s.io/v1 versions of the
-// CustomResourceDefinition API.
+// 1. upgrades from v1beta1 CRD to v1 needed a fix for a backwards incompatible
+//    change made in upstream that makes "preserveUnknownFields" no longer usable
+//    in the same form that it previously was
+// 2. controller-gen automatic generation of CRDs did not work out of the box for
+//    some of our complex "Kong<TYPE>" resources, and so this script has a list
+//    of types to filter out as we're still manually managing those CRDs
+//
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// Details on CRD v1's "PreserveUnknownFields"
 //
 // In the v1beta1 version of the API a field called "preserveUnknownFields" was
 // used to trigger pruning for API fields that are sent in the request payload
@@ -59,14 +59,43 @@ var (
 //
 // -----------------------------------------------------------------------------
 
+// -----------------------------------------------------------------------------
+// Vars
+// -----------------------------------------------------------------------------
+
+var (
+	// inputDir that will be used for walking the filesystem to find CRDs.
+	inputDir string
+
+	// outputDir is where this script will emit completed CRDs
+	outputDir string
+
+	// patchfile is the patch that will be used for each CRD file
+	patchfile = "config/crd/patches/upgrade_compat.yaml"
+
+	// excludedTypes is the list of API types which we DON'T want to automatically
+	// generate CRDs for, as those CRDs are currently manually maintained.
+	excludedTypes = [4]string{
+		"KongClusterPlugin",
+		"KongPlugin",
+		"KongConsumer",
+		"KongIngress",
+	}
+)
+
+// -----------------------------------------------------------------------------
+// Main
+// -----------------------------------------------------------------------------
+
 func main() {
 	// handle arguments
-	flag.StringVar(&directory, "directory", ".", "which directory to find CRDs in")
+	flag.StringVar(&inputDir, "input-directory", ".", "which directory to find CRDs in")
+	flag.StringVar(&outputDir, "output-directory", ".", "which directory to emit completed CRDs to")
 	flag.Parse()
 
 	// find all the YAML CRDs in the provided directory and patch them
-	if err := filepath.Walk(directory, processFile); err != nil {
-		fmt.Fprintf(os.Stderr, "Error processing files in %s: %s\n", directory, err)
+	if err := filepath.Walk(inputDir, processFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Error processing files in %s: %s\n", inputDir, err)
 		os.Exit(1)
 	}
 }
@@ -102,6 +131,21 @@ func processFile(path string, info os.FileInfo, err error) error {
 		return fmt.Errorf("file %s contained multiple objects (%d) which this script doesn't yet support", path, len(yamlCRDs))
 	}
 
+	// filter out YAML files for CRDs we specifically want to exclude from automatic generation
+	for _, excludedType := range excludedTypes {
+		// check whether the excluded type is even present
+		if bytes.Contains(b, []byte(excludedType)) {
+			// the excluded type is present in this file, marshal it into YAML
+			crd := v1.CustomResourceDefinition{}
+			if err := yaml.Unmarshal(b, &crd); err != nil {
+				return err
+			}
+			if crd.Spec.Names.Kind == excludedType {
+				return nil
+			}
+		}
+	}
+
 	// generate a patch command to ensure "preserveUnknownFields" is set to false
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	patchCMD := exec.Command("kubectl", "patch", "--type", "merge", "--local", "-o", "yaml", "-f", path, "--patch-file", patchfile)
@@ -119,5 +163,6 @@ func processFile(path string, info os.FileInfo, err error) error {
 	patchedCRD := append([]byte("\n---\n"), stdout.Bytes()...)
 
 	// write the patched CRD back to the original file
-	return os.WriteFile(path, patchedCRD, info.Mode().Perm())
+	outputPath := fmt.Sprintf("%s/%s", outputDir, info.Name())
+	return os.WriteFile(outputPath, patchedCRD, info.Mode().Perm())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Filters some CRDs out of the CRD auto-generation tooling so they can be manually managed, as our tooling needs some investigation and potential fixes (that we intend to do at a later time) to ensure the auto-generation for these types is working properly.

**Which issue this PR fixes**

Resolves Task 1 in https://github.com/Kong/kubernetes-ingress-controller/issues/1762