### PR TITLE
Rename roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   successfully applied configuration at least once. This ensures that proxies
   do not start handling traffic until they are configured.
   [#1720](https://github.com/Kong/kubernetes-ingress-controller/issues/1720)
+- Renamed roles and bindings to reflect their association with Kong.
+  [#1801](https://github.com/Kong/kubernetes-ingress-controller/issues/1801)
 
 ## [2.0.0-beta.2] - 2021/08/16
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ verify.manifests:
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=kong-ingress webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	go run hack/generators/manifests/main.go --directory config/crd/bases/
 
 .PHONY: manifests.single

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kong-leader-election
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kong-leader-election
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-dbless.yaml
+++ b/deploy/single-v2/all-in-one-dbless.yaml
@@ -959,7 +959,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
@@ -1191,11 +1191,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-dbless.yaml
+++ b/deploy/single-v2/all-in-one-dbless.yaml
@@ -930,7 +930,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kong-leader-election
   namespace: kong
 rules:
 - apiGroups:
@@ -1177,12 +1177,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kong-leader-election
   namespace: kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-enterprise-dbless.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-dbless.yaml
@@ -959,7 +959,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
@@ -1191,11 +1191,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-enterprise-dbless.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-dbless.yaml
@@ -930,7 +930,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kong-leader-election
   namespace: kong
 rules:
 - apiGroups:
@@ -1177,12 +1177,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kong-leader-election
   namespace: kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-enterprise-postgres.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-postgres.yaml
@@ -959,7 +959,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
@@ -1191,11 +1191,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-enterprise-postgres.yaml
+++ b/deploy/single-v2/all-in-one-enterprise-postgres.yaml
@@ -930,7 +930,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kong-leader-election
   namespace: kong
 rules:
 - apiGroups:
@@ -1177,12 +1177,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kong-leader-election
   namespace: kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-postgres.yaml
+++ b/deploy/single-v2/all-in-one-postgres.yaml
@@ -959,7 +959,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
@@ -1191,11 +1191,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single-v2/all-in-one-postgres.yaml
+++ b/deploy/single-v2/all-in-one-postgres.yaml
@@ -930,7 +930,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kong-leader-election
   namespace: kong
 rules:
 - apiGroups:
@@ -1177,12 +1177,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kong-leader-election
   namespace: kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames roles per discussion in review doc and chat. Resources now include `kong-` in the name and are more descriptive. Dropped superfluous -role and -rolebinding suffixes for brevity. Review of other stock roles from a GKE cluster indicates that this redundant info isn't usually included in names, so we shouldn't include it either.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
