### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -227,7 +226,7 @@ func main() {
 func header() (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 
-	boilerPlate, err := ioutil.ReadFile("../../hack/boilerplate.go.txt")
+	boilerPlate, err := os.ReadFile("../../hack/boilerplate.go.txt")
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +279,7 @@ func (needed necessary) generate() error {
 		}
 	}
 
-	return ioutil.WriteFile(outputFile, contents.Bytes(), 0600)
+	return os.WriteFile(outputFile, contents.Bytes(), 0600)
 }
 
 type typeNeeded struct {

--- a/hack/generators/manifests/main.go
+++ b/hack/generators/manifests/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,7 +86,7 @@ func processFile(path string, info os.FileInfo, err error) error {
 	}
 
 	// read in the file contents
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -120,5 +119,5 @@ func processFile(path string, info os.FileInfo, err error) error {
 	patchedCRD := append([]byte("\n---\n"), stdout.Bytes()...)
 
 	// write the patched CRD back to the original file
-	return ioutil.WriteFile(path, patchedCRD, info.Mode().Perm())
+	return os.WriteFile(path, patchedCRD, info.Mode().Perm())
 }

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/kong/go-kong/kong"
 )
@@ -53,7 +53,7 @@ func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 	if opts.CACertPath != "" {
 		certPath := opts.CACertPath
 		certPool := x509.NewCertPool()
-		cert, err := ioutil.ReadFile(certPath)
+		cert, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read kong-admin-ca-cert from path '%s': %w", certPath, err)
 		}

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -5,8 +5,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	admission "k8s.io/api/admission/v1"
@@ -39,11 +40,11 @@ type ServerConfig struct {
 }
 
 func readKeyPairFiles(certPath, keyPath string) ([]byte, []byte, error) {
-	cert, err := ioutil.ReadFile(certPath)
+	cert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read cert from file %q: %w", certPath, err)
 	}
-	key, err := ioutil.ReadFile(keyPath)
+	key, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read key from file %q: %w", keyPath, err)
 	}
@@ -116,7 +117,7 @@ func (a RequestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.StatusBadRequest)
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.Logger.Errorf("failed to read request from client: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -172,7 +172,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return false
 			}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -173,7 +172,7 @@ func deployControllers(ctx context.Context, namespace string) error {
 		exitOnErr(err)
 
 		// create a tempfile to hold the cluster kubeconfig that will be used for the controller
-		kubeconfig, err := ioutil.TempFile(os.TempDir(), "kubeconfig-")
+		kubeconfig, err := os.CreateTemp(os.TempDir(), "kubeconfig-")
 		exitOnErr(err)
 		defer os.Remove(kubeconfig.Name())
 		defer kubeconfig.Close()

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -177,7 +176,7 @@ func namespace(t *testing.T) (*corev1.Namespace, func()) {
 
 // identifyTestCasesForDir finds the Go function names for any Go test files in the given directory
 func identifyTestCasesForDir(dir string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +207,7 @@ func identifyTestCasesForFile(filePath string) ([]string, error) {
 		return nil, fmt.Errorf("%s does not look like a Golang test file", filePath)
 	}
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

**Which issue this PR fixes**
N/A

**Special notes for your reviewer**:
N/A

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
