### PR TITLE
Revert "chore(deps): bump actions/github-script from 4.1 to 5 (#1863)"

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -42,7 +42,7 @@ jobs:
         diff -u target_licenses.csv pr_licenses.csv >> $GITHUB_ENV || true
         echo 'EOF' >> $GITHUB_ENV
     - name: Update PR - go-license output differs
-      uses: actions/github-script@v5
+      uses: actions/github-script@v4.1
       if: ${{ env.DIFF_OUT != '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
             })
     - name: Update PR - remove unchanged label
       continue-on-error: true
-      uses: actions/github-script@v5
+      uses: actions/github-script@v4.1
       if: ${{ env.DIFF_OUT != '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
               name: ['ci/license/unchanged']
             })
     - name: Update PR - go-license output equal
-      uses: actions/github-script@v5
+      uses: actions/github-script@v4.1
       if: ${{ env.DIFF_OUT == '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit cc7098829797deaa3e1db475b5e9255804a4b281 (#1863).

Reason: `actions/github-script@v5` has a [breaking API change](https://github.com/actions/github-script#breaking-changes-in-v5) which is incompatible with our script.
