### PR TITLE
fix: rate limit by hour in e2e tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,8 +195,8 @@ jobs:
       run: make test.e2e
       env:
         KONG_ENTERPRISE_LICENSE_SECRET: ${{ secrets.KONG_ENTERPRISE_LICENSE_SECRET }}
-        NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
-                # multiple kind clusters within a single job so this is hardcoded to 1 to avoid those problems.
+        NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
+                # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
 
   coverage:
     environment: "Configure ci"


### PR DESCRIPTION
It was found in Github Actions when the environment is
very slow that rate-limiting by the minute could sometimes
break due to slowness of the underlying environment.
This makes the rate-limit for the Istio e2e tests longer
than the tests themselves are allowed to take to compensate
and ensure that the ratelimits work as intended.

Based on some findings of how Github Actions seems to work
when running kind clusters, this PR also bumps the 