### PR TITLE
feat: converted loglevels for logrus -> go-logr

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -350,6 +350,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/internal/proxy"
+	"github.com/kong/kubernetes-ingress-controller/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1beta1"
 )
@@ -408,7 +409,7 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted {{.Type}} object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted {{.Type}} object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -416,11 +417,11 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "{{.Type}}", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "{{.Type}}", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -436,7 +437,7 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 {{if .AcceptsIngressClassNameAnnotation}}
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/internal/ctrlutils"
 	"github.com/kong/kubernetes-ingress-controller/internal/proxy"
+	"github.com/kong/kubernetes-ingress-controller/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1beta1"
 )
@@ -74,7 +75,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Service object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Service object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -82,11 +83,11 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -143,7 +144,7 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Endpoints object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Endpoints object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -151,11 +152,11 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Endpoints", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Endpoints", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -212,7 +213,7 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Secret object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Secret object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -220,11 +221,11 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Secret", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Secret", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -284,7 +285,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -292,11 +293,11 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -312,7 +313,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -365,7 +366,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -373,11 +374,11 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -393,7 +394,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -446,7 +447,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -454,11 +455,11 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -474,7 +475,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -524,7 +525,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted KongIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted KongIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -532,11 +533,11 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "KongIngress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongIngress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -593,7 +594,7 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted KongPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted KongPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -601,11 +602,11 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "KongPlugin", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongPlugin", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -665,7 +666,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted KongClusterPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted KongClusterPlugin object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -673,11 +674,11 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "KongClusterPlugin", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongClusterPlugin", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -693,7 +694,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -746,7 +747,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted KongConsumer object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted KongConsumer object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -754,11 +755,11 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "KongConsumer", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongConsumer", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -774,7 +775,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -827,7 +828,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted TCPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted TCPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -835,11 +836,11 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "TCPIngress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "TCPIngress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -855,7 +856,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -908,7 +909,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted UDPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted UDPIngress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -916,11 +917,11 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -936,7 +937,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -989,7 +990,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 			return ctrl.Result{}, err
 		}
 		if objectExistsInCache {
-			log.Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
+			log.V(util.DebugLevel).Info("deleted Ingress object remains in proxy cache, removing", "namespace", req.Namespace, "name", req.Name)
 			if err := r.Proxy.DeleteObject(obj); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -997,11 +998,11 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
-		log.Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
 		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -1017,7 +1018,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClassName(obj, r.IngressClassName) {
-		log.Info("object missing ingress class, ensuring it's removed from configuration", req.Namespace, req.Name)
+		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration", "namespace", req.Namespace, "name", req.Name)
 		if err := r.Proxy.DeleteObject(obj); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -72,13 +72,11 @@ func PullConfigUpdate(
 		return
 	}
 
-	log.Info("Launching Ingress Status Update Thread.")
-
 	var wg sync.WaitGroup
 	for {
 		select {
 		case updateDone := <-kongConfig.ConfigDone:
-			log.V(4).Info("receive configuration information. Update ingress status %v \n", updateDone)
+			log.V(util.DebugLevel).Info("data-plane updates completed, updating resource statuses")
 			wg.Add(1)
 			go func() {
 				if err := UpdateStatuses(ctx, &updateDone, log, cli, kiccli, &wg, ips, hostname, kubeConfig, kubernetesVersion); err != nil {
@@ -110,7 +108,7 @@ func UpdateStatuses(
 
 	for _, svc := range targetContent.Services {
 		for _, plugin := range svc.Plugins {
-			log.V(5).Info("\n service host %s name %s plugin enablement %v\n", *svc.Service.Host, *svc.Service.Name, *svc.Plugins[0].Enabled)
+			log.V(util.DebugLevel).Info("\n service host %s name %s plugin enablement %v\n", *svc.Service.Host, *svc.Service.Name, *svc.Plugins[0].Enabled)
 			if *plugin.Enabled {
 				if config, ok := plugin.Config["add"]; ok {
 					for _, header := range config.(map[string]interface{})["headers"].([]interface{}) {

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -81,7 +81,7 @@ func (s *Server) receiveConfig(ctx context.Context) {
 			if err := ctx.Err(); err != nil {
 				s.Logger.Error(err, "shutting down diagnostic config collection: context completed with error")
 			}
-			s.Logger.V(3).Info("shutting down diagnostic config collection: context completed")
+			s.Logger.V(util.InfoLevel).Info("shutting down diagnostic config collection: context completed")
 			return
 		}
 	}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -32,10 +32,9 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		return err
 	}
 	setupLog := ctrl.Log.WithName("setup")
-	setupLog.Info("starting controller manager", "release", Release, "repo", Repo, "commit", Commit)
-	setupLog.Info("the ingress class name has been set", "value", c.IngressClassName)
-
-	setupLog.Info("building the manager runtime scheme and loading apis into the scheme")
+	setupLog.V(util.DebugLevel).Info("starting controller manager", "release", Release, "repo", Repo, "commit", Commit)
+	setupLog.V(util.DebugLevel).Info("the ingress class name has been set", "value", c.IngressClassName)
+	setupLog.V(util.DebugLevel).Info("building the manager runtime scheme and loading apis into the scheme")
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(konghqcomv1.AddToScheme(scheme))

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -60,13 +60,13 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		return fmt.Errorf("unable to start controller manager: %w", err)
 	}
 
-	setupLog.Info("configuring and building the proxy cache server")
+	setupLog.Info("Starting Proxy Cache Server")
 	proxy, err := setupProxyServer(ctx, setupLog, deprecatedLogger, mgr, kongConfig, diagnostic, c)
 	if err != nil {
 		return fmt.Errorf("unable to start proxy cache server: %w", err)
 	}
 
-	setupLog.Info("deploying all enabled controllers")
+	setupLog.Info("Starting Enabled Controllers")
 	controllers, err := setupControllers(mgr, proxy, c)
 	if err != nil {
 		return fmt.Errorf("unable to setup controller as expected %w", err)
@@ -81,7 +81,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	// See https://github.com/kubernetes-sigs/kubebuilder/issues/932
 	//+kubebuilder:scaffold:builder
 
-	setupLog.Info("enabling health checks")
+	setupLog.Info("Starting health check servers")
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to setup healthz: %w", err)
 	}
@@ -95,7 +95,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	}
 
 	if c.AnonymousReports {
-		setupLog.Info("running anonymous reports")
+		setupLog.Info("Starting anonymous reports")
 		if err := mgrutils.RunReport(ctx, kubeconfig, kongConfig, Release); err != nil {
 			setupLog.Error(err, "anonymous reporting failed")
 		}
@@ -104,12 +104,12 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	}
 
 	if c.UpdateStatus {
-		setupLog.Info("status updates enabled, status update routine is being started in the background.")
+		setupLog.Info("Starting resource status updater")
 		go ctrlutils.PullConfigUpdate(ctx, kongConfig, logger, kubeconfig, c.PublishService, c.PublishStatusAddress)
 	} else {
 		setupLog.Info("WARNING: status updates were disabled, resources like Ingress objects will not receive updates to their statuses.")
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("Starting manager")
 	return mgr.Start(ctx)
 }

--- a/internal/sendconfig/sendconfig.go
+++ b/internal/sendconfig/sendconfig.go
@@ -50,9 +50,9 @@ func PerformUpdate(ctx context.Context,
 		// use the previous SHA to determine whether or not to perform an update
 		if equalSHA(oldSHA, newSHA) {
 			if !hasSHAUpdateAlreadyBeenReported(newSHA) {
-				log.Infof("sha %s has been reported", hex.EncodeToString(newSHA))
+				log.Debugf("sha %s has been reported", hex.EncodeToString(newSHA))
 			}
-			log.Info("no configuration change, skipping sync to kong")
+			log.Debug("no configuration change, skipping sync to kong")
 			return oldSHA, nil
 		}
 	}

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -114,7 +114,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("starting the controller manager")
-	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, env.Cluster(), "--log-level=error"))
+	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, env.Cluster(), "--log-level=debug"))
 
 	t.Log("creating a new mesh-enabled namespace for testing http traffic")
 	namespace := &corev1.Namespace{


### PR DESCRIPTION
**What this PR does / why we need it**:

For 2.0 we're launching with multiple logging implementations under the hood, which isn't much of any problem from the end-user perspective and is [something we'll converge in time](https://github.com/Kong/kubernetes-ingress-controller/issues/1893) but in the interim we were not properly configuring how we did log levels between the two implementations and had several places that were too noisy and repetitive and needed to be made into debug entries instead of info. This PR takes care of both problems.

**Which issue this PR fixes**

Resolves #1810

**Special notes for your reviewer**:

- feat: add converted loglevels for go-logr vs logrus
- chore: reconfig debug logging for new converter
- chore: cleanup some startup log language
- chore: run generators