### PR TITLE
feat(log): log the KIC version by default

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -32,7 +32,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		return err
 	}
 	setupLog := ctrl.Log.WithName("setup")
-	setupLog.V(util.DebugLevel).Info("starting controller manager", "release", Release, "repo", Repo, "commit", Commit)
+	setupLog.Info("starting controller manager", "release", Release, "repo", Repo, "commit", Commit)
 	setupLog.V(util.DebugLevel).Info("the ingress class name has been set", "value", c.IngressClassName)
 	setupLog.V(util.DebugLevel).Info("building the manager runtime scheme and loading apis into the scheme")
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
#1894 changed the log levels for many log prints in KIC, including a header that prints the version number.

I do think that the version number can be very useful in a log output, though. Among others, it allows the reader to identify the version of KIC running, and identify the situation when the version running isn't the one that is expected to be.

This PR proposes that we change the log level of the "version print" back to "logged by default".