### PR TITLE
fix: properly set Docker version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,12 +219,14 @@ jobs:
       - name: Build and push Red Hat
         id: docker_build_redhat
         env:
-          TAG: ${{ steps.meta_redhat.outputs.version }}
+          TAG: ${{ steps.meta.outputs.version }}
         uses: docker/build-push-action@v2
         with:
           push: true
           file: Dockerfile
           tags: ${{ steps.meta_redhat.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
+          build-args: |
+            TAG=${{ env.TAG }}
           target: redhat
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the Red Hat TAG variable to the version from the non-Red Hat
metadata. This version lacks the "-redhat" suffix (it only contains the
controller version). We want this suffix for the Docker tags but not for
the image label, which should just reflect the application version.

Set TAG in build_args so that Docker actually uses it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1922 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
**n/a, CI only**
