### PR TITLE
fix: broken log lines in ingress status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [2.0.2](#203---tbd)
  - [2.0.2](#202---20211014)
  - [2.0.1](#201---20211011)
  - [2.0.0](#200---20211007)
@@ -33,6 +34,14 @@
  - [0.1.0](#010---20180817)
  - [0.0.5](#005---20180602)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.0.3] - TBD
+
+#### Fixed
+
+- Debug logging for resource status updates have been fixed to ensure that
+  debug output isn't silently lost and to fix some formatting issues.
+  [#1930](https://github.com/Kong/kubernetes-ingress-controller/pull/1930)
 
 ## [2.0.2] - 2021/10/14
 
@@ -1273,6 +1282,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.0.3]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.0-beta.2...v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,6 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
@@ -117,7 +115,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

Turns out there were several ineffectual log entries that were causing an improper import of an unrelated dependency and making it difficult to debug the status updates code. This switches to using logr in all those places, enables debug level appropriately, and fixes up formatting and data for several of the log entries. These problems were making it particularly hard to debug #1925.

**Which issue this PR fixes**

Partially resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1925

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated