### PR TITLE
fix: race condition for ingress resource status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 - Debug logging for resource status updates have been fixed to ensure that
   debug output isn't silently lost and to fix some formatting issues.
   [#1930](https://github.com/Kong/kubernetes-ingress-controller/pull/1930)
+- Fixed a bug where Ingress resources would not be able to receive status
+  updates containing relevant addresses in environments where LoadBalancer
+  type services provision slowly.
+  [#1931](https://github.com/Kong/kubernetes-ingress-controller/pull/1931)
 
 ## [2.0.2] - 2021/10/14
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A race condition was found when using a `LoadBalancer` type service for the Kong proxy which in some deployments could trigger a permanent failure to resolve `Ingress` resource statuses. This patch ensures that we don't expect the `LoadBalancer` to be immediately ready when the controller manager first starts, and waits to start the status update goroutine until it's resolved. Informational logging is also provided to help indicate if the controller manager is "stuck" because the `LoadBalancer` is not being provisioned, instead of the previous behavior where this would just fail silently.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/1925

**Special notes for your reviewer**:

I could only trigger this issue on GKE because the `LoadBalancer` provisioning can be quite slow there, this fix has been tested and verified in that environment manually. I'm looking into why our GKE tests missed this problem, but that's more about protecting against future regressions so I don't think that should hold up the patch given the light touch and laser focus of this patch, and the manual testing and verification.

It is my opinion that we might want to consider an alternative status update implementation for future releases, but for this PR I simply stuck with a light touch and a fix for the immediate problem at hand. I previously reported on the potential issues with our current implementation in https://github.com/Kong/kubernetes-ingress-controller/issues/1492 and that may be considered a follow up.

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
- [x] waiting for https://github.com/Kong/kubernetes-ingress-controller/pull/1930
