### PR TITLE
fix: strings in gh wf

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
   # ----------------------------------------------------------------------------
 
   build-push-images:
-    if: ${{ github.event.inputs.noimages != "true" }}
+    if: ${{ github.event.inputs.noimages != 'true' }}
     needs: [test-current-kubernetes, test-previous-kubernetes]
     environment: 'Docker Push'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Third times the charm? should fix https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1361221025 according to https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-contexts, tested it in a fork this time: https://github.com/shaneutt/kubernetes-ingress-controller/actions/runs/1361264188