### PR TITLE
feature gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@
 
 ## [2.0.5] - TBD
 
+#### Added
+
+- [Feature Gates][k8s-fg] have been added to the controller manager in order to
+  enable alpha/beta/experimental features and provide documentation about those
+  features and their maturity over time. For more information see the
+  [KIC Feature Gates Documentation][kic-fg].
+  [#1970](https://github.com/Kong/kubernetes-ingress-controller/pull/1970)
+
+[k8s-fg]:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+[kic-fg]:https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md
+
 #### Fixed
 
 - Fixed a bug where version reported for the controller manager was missing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,12 @@ In general the maintainers here feel establishing these things in a KEP should b
 
 [template]:https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md
 
+## Feature Gates
+
+New features should be added to the [Feature Gates][kic-fg] documentation and `internal/manager/feature_gates.go`.
+
+[kic-fg]:https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md
+
 ## Development environment
 
 ## Environment

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -1,0 +1,61 @@
+# Feature Gates
+
+Upstream [Kubernetes][k8s] includes [Feature Gates][gates] to enable or disable features with flags and track the maturity of a feature using [Feature Stages][stages]. Here in the Kubernetes Ingress Controller (KIC) we use the same definitions of `Feature Gates` and `Feature Stages` from upstream Kubernetes, but with our own list of features.
+
+Using `Feature Gates` enables contributors to add and manage new (and potentially) experimental functionality to the KIC in a controlled manner: the features will be "hidden" until generally available (GA) and the progress and maturity of features on their path to GA will be documented. Feature gates also create a clear path for deprecating features.
+
+See below for current features and their statuses, and follow the links to the relevant feature documentation.
+
+[k8s]:https://kubernetes.io
+[gates]:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+[stages]:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages
+
+## Feature gates
+
+Below you will find the overviews of features at various maturity levels:
+
+- [Feature gates for graduated or deprecated features](/#feature-gates-for-graduated-or-deprecated-features)
+- [Feature gates for Alpha or Beta features](/#feature-gates-for-alpha-or-beta-features)
+
+Please read the [Important Notes](/#important-notes) section before using any `Alpha` or `Beta` features.
+
+### Important notes
+
+- Most features will be planned and detailed using [Kubernetes Enhancement Proposals (KEP)][k8s-kep]: If you're interested in the development side of features familiarize yourself with our [KEPs][kic-keps]
+- The `Since` and `Until` rows in below tables refer to [KIC Releases][releases]
+- For `GA` features the documentation exists in the main [Kong Documentation][kong-docs], see the [API reference][api-ref] and [Guides][kic-guides]
+
+An additional **warning** for end-users who are reading this documentation and trying to enable `Alpha` or `Beta` features: it is **very important** to understand that features that are currently in an `Alpha` or `Beta` state may **become `Deprecated` at any time** and **may be removed as part of the next consecutive minor release**. This is especially true for `Alpha` maturity features. In other words, **until a feature becomes GA there are no guarantees that it's going to continue being available**. To avoid disruption to your services engage with the community and read the [CHANGELOG](/CHANGELOG.md) carefully to track progress. Alternatively **do not use features until they have reached a GA status**.
+
+[k8s-keps]:https://github.com/kubernetes/enhancements
+[kic-keps]:https://github.com/Kong/kubernetes-ingress-controller/tree/main/keps
+[releases]:https://github.com/Kong/kubernetes-ingress-controller/releases
+[kong-docs]:https://github.com/Kong/docs.konghq.com
+[api-ref]:https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/
+[kic-guides]:https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/overview/
+
+### Feature gates for graduated or deprecated features
+
+{{< table caption="Feature Gates for Graduated or Deprecated Features" >}}
+
+| Feature                    | Default | Stage      | Since | Until |
+|----------------------------|---------|------------|-------|-------|
+
+{{< /table >}}
+
+Features that reach GA and over time become stable will be removed from this table, they can be found in the main [KIC CRD Documentation][specs] and [Guides][guides].
+
+[specs]:https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/
+[guides]:https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/overview/
+
+### Feature gates for Alpha or Beta features
+
+{{< table caption="Feature gates for features in Alpha or Beta states" >}}
+
+| Feature                    | Default | Stage | Since | Until |
+|----------------------------|---------|-------|-------|-------|
+| [Knative](#Knative)        | `true`  | Alpha | 0.8.0 | TBD   |
+| [GatewayAPI](#Gateway-API) | `false` | Alpha | TBD   | TBD   |
+
+{{< /table > }}
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 
-# Kong Ingress Controller for Kubernetes
+# Kong Ingress Controller for Kubernetes (KIC)
 
 Use [Kong][kong] for Kubernetes [Ingress][ingress].
 Configure [plugins][kong-hub], health checking,

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.3
 	k8s.io/apimachinery v0.22.3
 	k8s.io/client-go v0.22.3
+	k8s.io/component-base v0.22.3
 	knative.dev/networking v0.0.0-20210914225408-69ad45454096
 	knative.dev/pkg v0.0.0-20210919202233-5ae482141474
 	knative.dev/serving v0.26.0
@@ -123,7 +124,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/component-base v0.22.3 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	cliflag "k8s.io/component-base/cli/flag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
@@ -81,6 +82,9 @@ type Config struct {
 	EnableProfiling     bool
 	EnableConfigDumps   bool
 	DumpSensitiveConfig bool
+
+	// Feature Gates
+	FeatureGates map[string]bool
 }
 
 // -----------------------------------------------------------------------------
@@ -174,6 +178,10 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.EnableProfiling, "profiling", false, fmt.Sprintf("Enable profiling via web interface host:%v/debug/pprof/", DiagnosticsPort))
 	flagSet.BoolVar(&c.EnableConfigDumps, "dump-config", false, fmt.Sprintf("Enable config dumps via web interface host:%v/debug/config", DiagnosticsPort))
 	flagSet.BoolVar(&c.DumpSensitiveConfig, "dump-sensitive-config", false, "Include credentials and TLS secrets in configs exposed with --dump-config")
+
+	// Feature Gates (see FEATURE_GATES.md)
+	flagSet.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/beta/experimental features. "+
+		fmt.Sprintf("See the Feature Gates documentation for information and available options: %s", featureGatesDocsURL))
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", proxy.DefaultSyncSeconds,

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -1,0 +1,39 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// featureGatesDocsURL provides a link to the documentation for feature gates in the KIC repository
+const featureGatesDocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
+
+// setupFeatureGates converts feature gates to controller enablement
+func setupFeatureGates(setupLog logr.Logger, c *Config) (map[string]bool, error) {
+	// generate a map of feature gates by string names to their controller enablement
+	ctrlMap := getFeatureGatesDefaults()
+
+	// override the default settings
+	for feature, enabled := range c.FeatureGates {
+		setupLog.Info("found configuration option for gated feature", "feature", feature, "enabled", enabled)
+		_, ok := ctrlMap[feature]
+		if !ok {
+			return ctrlMap, fmt.Errorf("%s is not a valid feature, please see the documentation: %s", feature, featureGatesDocsURL)
+		}
+		ctrlMap[feature] = enabled
+	}
+
+	return ctrlMap, nil
+}
+
+// getFeatureGatesDefaults initializes a feature gate map given the currently
+// supported feature gates options and derives defaults for them based on
+// manager configuration options if present.
+//
+// NOTE: if you're adding a new feature gate, it needs to be added here.
+func getFeatureGatesDefaults() map[string]bool {
+	return map[string]bool{
+		"Knative": false,
+	}
+}

--- a/internal/manager/feature_gates_test.go
+++ b/internal/manager/feature_gates_test.go
@@ -1,0 +1,39 @@
+package manager
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bombsimon/logrusr"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureGates(t *testing.T) {
+	t.Log("setting up configurations and logging for feature gates testing")
+	out := new(bytes.Buffer)
+	baseLogger := logrus.New()
+	baseLogger.SetOutput(out)
+	baseLogger.SetLevel(logrus.DebugLevel)
+	setupLog := logrusr.NewLogger(baseLogger)
+	config := new(Config)
+
+	t.Log("verifying feature gates setup defaults when no feature gates are configured")
+	fgs, err := setupFeatureGates(setupLog, config)
+	assert.NoError(t, err)
+	assert.Len(t, fgs, len(getFeatureGatesDefaults()))
+
+	t.Log("verifying feature gates setup results when valid feature gates options are present")
+	config.FeatureGates = map[string]bool{"Knative": true}
+	fgs, err = setupFeatureGates(setupLog, config)
+	assert.NoError(t, err)
+	assert.True(t, fgs["Knative"])
+
+	t.Log("configuring several invalid feature gates options")
+	config.FeatureGates = map[string]bool{"Batman": true}
+
+	t.Log("verifying feature gates setup results when invalid feature gates options are present")
+	_, err = setupFeatureGates(setupLog, config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Batman is not a valid feature")
+}

--- a/internal/mgrutils/reports.go
+++ b/internal/mgrutils/reports.go
@@ -15,7 +15,7 @@ import (
 )
 
 // RunReport runs the anonymous data report and reports any errors that have occurred.
-func RunReport(ctx context.Context, kubeCfg *rest.Config, kongCfg sendconfig.Kong, kicVersion string) error {
+func RunReport(ctx context.Context, kubeCfg *rest.Config, kongCfg sendconfig.Kong, kicVersion string, featureGates map[string]bool) error {
 	// if anonymous reports are enabled this helps provide Kong with insights about usage of the ingress controller
 	// which is non-sensitive and predominantly informs us of the controller and cluster versions in use.
 	// This data helps inform us what versions, features, e.t.c. end-users are actively using which helps to inform
@@ -67,6 +67,7 @@ func RunReport(ctx context.Context, kubeCfg *rest.Config, kongCfg sendconfig.Kon
 		Hostname:          hostname,
 		ID:                uuid,
 		KongDB:            kongDB,
+		FeatureGates:      featureGates,
 	}
 
 	// run the reporter in the background

--- a/internal/util/reports.go
+++ b/internal/util/reports.go
@@ -26,6 +26,7 @@ type Info struct {
 	Hostname          string
 	KongDB            string
 	ID                string
+	FeatureGates      map[string]bool
 }
 
 // Reporter sends anonymous reports of runtime properties and


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch documents and enables feature gates for KIC to add tooling which helps to manage the lifecycle of new and/or experimental features for the KIC.

This was meant to solve two problems:

- strongly communicate the lifecycle and trajectory of features, and give us a path to graduate as well as deprecate while significantly reducing any surprises for end-users
- provide a safe/isolated way to iteratively develop Gateway support without putting it directly in end-users hands day 1
- allow Gateway development to start quickly but without being locked in forever if the long term implementation lives partially or wholly elsewhere in time (e.g. operator code)

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
