### PR TITLE
docs: add v2 go reference to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![][kong-logo]][kong-url]
 [![Build Status](https://github.com/kong/kubernetes-ingress-controller/workflows/Test/badge.svg)](https://github.com/kong/kubernetes-ingress-controller/actions?query=branch%3Amaster+event%3Apush)
-[![codecov](https://codecov.io/gh/Kong/kubernetes-ingress-controller/branch/main/graph/badge.svg?token=S1aqcXiGEo)](https://codecov.io/gh/Kong/kubernetes-ingress-controller)
+[![Go Reference](https://pkg.go.dev/badge/github.com/kong/kubernetes-ingress-controller/v2.svg)](https://pkg.go.dev/github.com/kong/kubernetes-ingress-controller/v2)
+[![Codecov](https://codecov.io/gh/Kong/kubernetes-ingress-controller/branch/main/graph/badge.svg?token=S1aqcXiGEo)](https://codecov.io/gh/Kong/kubernetes-ingress-controller)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/Kong/kubernetes-ingress-controller/pull/1936 it has been possible to use our `v2.x` KIC APIs and API clients from other Go projects via `import`. This patch simply adds a badge to the generated godoc for convenience.

![1](https://user-images.githubusercontent.com/5332524/139088766-441bea48-b4f3-43de-83d0-b2c6fcf4e83c.png)

![2](https://user-images.githubusercontent.com/5332524/139088786-9f1b6056-bc8f-4900-8ce9-71c7b011996e.png)

