### PR TITLE
test(admission) reject creds missing fields

### DIFF
--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -135,6 +135,16 @@ func TestValidationWebhook(t *testing.T) {
 			wantErr:        true,
 			wantPartialErr: "invalid credential type: nonexistent",
 		},
+		{
+			name: "secret with missing fields",
+			obj: corev1.Secret{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+				ObjectMeta: metav1.ObjectMeta{Name: "basic-auth"},
+				StringData: map[string]string{"kongCredType": "basic-auth", "username": "foo"},
+			},
+			wantErr:        true,
+			wantPartialErr: "missing required field(s): password",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, &tt.obj, metav1.CreateOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor additional integration test for credential field validation.

**Which issue this PR fixes**
Internally reported as FTI-1886. Couldn't replicate issue; created test in the course of validation attempt. Submitting it because hey, why not.

**PR Readiness Checklist**:

Test only, no changelog.
