### PR TITLE
fix(creds) coerce oauth hash_secret to bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 - Fixed a bug where version reported for the controller manager was missing
   due to incorrect linker flags and missing build args in image builds.
   [#1943](https://github.com/Kong/kubernetes-ingress-controller/issues/1943)
+- `hash_secret` strings in OAuth2 credentials now correctly convert to bools
+  in the generated Kong configuration.
+  [#1984](https://github.com/Kong/kubernetes-ingress-controller/issues/1984)
 
 ## [2.0.4] - 2021/10/22
 

--- a/internal/kongstate/kongstate.go
+++ b/internal/kongstate/kongstate.go
@@ -2,6 +2,7 @@ package kongstate
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -85,6 +86,19 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 				// and remove this workaround
 				if k == "redirect_uris" {
 					credConfig[k] = strings.Split(string(v), ",")
+					continue
+				}
+				// TODO this is a kongCredType-agnostic mutation that should only apply to Oauth2 credentials.
+				// However, the credential-specific code after deals only in interface{}s, and we can't fix individual
+				// keys. To handle this properly we'd need to refactor the types used in all following code.
+				if k == "hash_secret" {
+					boolVal, err := strconv.ParseBool(string(v))
+					if err != nil {
+						log.Errorf("failed to parse hash_secret to bool: %v. defaulting to false", err)
+						credConfig[k] = false
+					} else {
+						credConfig[k] = boolVal
+					}
 					continue
 				}
 				credConfig[k] = string(v)

--- a/internal/kongstate/kongstate_test.go
+++ b/internal/kongstate/kongstate_test.go
@@ -315,6 +315,20 @@ func Test_FillConsumersAndCredentials(t *testing.T) {
 				"key":          []byte("whatever"),
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "barCredSecret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"kongCredType":  []byte("oauth2"),
+				"name":          []byte("whatever"),
+				"client_id":     []byte("whatever"),
+				"client_secret": []byte("whatever"),
+				"redirect_uris": []byte("http://example.com"),
+				"hash_secret":   []byte("true"),
+			},
+		},
 	}
 	consumers := []*configurationv1.KongConsumer{
 		{
@@ -329,6 +343,7 @@ func Test_FillConsumersAndCredentials(t *testing.T) {
 			CustomID: "foo",
 			Credentials: []string{
 				"fooCredSecret",
+				"barCredSecret",
 			},
 		},
 	}
@@ -344,6 +359,17 @@ func Test_FillConsumersAndCredentials(t *testing.T) {
 				CustomID: kong.String("foo"),
 			},
 			KeyAuths: []*KeyAuth{{kong.KeyAuth{Key: kong.String("whatever")}}},
+			Oauth2Creds: []*Oauth2Credential{
+				{
+					kong.Oauth2Credential{
+						Name:         kong.String("whatever"),
+						ClientID:     kong.String("whatever"),
+						ClientSecret: kong.String("whatever"),
+						HashSecret:   kong.Bool(true),
+						RedirectURIs: []*string{kong.String("http://example.com")},
+					},
+				},
+			},
 		}},
 		Version: semver.MustParse("2.3.2"),
 	}
@@ -356,5 +382,9 @@ func Test_FillConsumersAndCredentials(t *testing.T) {
 		assert.Equal(t, want.Consumers[0].Consumer.Username, state.Consumers[0].Consumer.Username)
 		assert.Equal(t, want.Consumers[0].Consumer.CustomID, state.Consumers[0].Consumer.CustomID)
 		assert.Equal(t, want.Consumers[0].KeyAuths[0].Key, state.Consumers[0].KeyAuths[0].Key)
+		assert.Equal(t, want.Consumers[0].Oauth2Creds[0].ClientID, state.Consumers[0].Oauth2Creds[0].ClientID)
+		assert.Equal(t, want.Consumers[0].Oauth2Creds[0].ClientSecret, state.Consumers[0].Oauth2Creds[0].ClientSecret)
+		assert.Equal(t, want.Consumers[0].Oauth2Creds[0].HashSecret, state.Consumers[0].Oauth2Creds[0].HashSecret)
+		assert.Equal(t, want.Consumers[0].Oauth2Creds[0].RedirectURIs, state.Consumers[0].Oauth2Creds[0].RedirectURIs)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetetes Secrets do not support boolean values. We store all
credentials in Secrets. OAuth2 credentials contain a boolean field,
"hash_secret".

When filling credentials, this change detects "hash_secret" fields and
converts them to boolean values if they successfully convert, or if the
value cannot convert, to the field default, false.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes internally reported issue. With a string:

```
ingress-controller time="2021-10-31T05:34:06Z" level=error msg="failed to provision credential: failed to decode oauth2 credential: failed to decode credential: 1 error(s) decoding:\n\n* 'has
h_secret' expected type 'bool', got unconvertible type 'string', value: 'true'" kongconsumer_name=oauth2-tester kongconsumer_namespace=default secret_name=oauth2-credential secret_namespace=d
efault subsystem=proxy-cache-resolver
```
With a bool:
```
Error from server (BadRequest): error when creating "STDIN": Secret in version "v1" cannot be handled as a Secret: v1.Secret.StringData: ReadString: expects " or n, but found t, error found in #10 byte of ...|_secret":true,"kongC|..., bigger context ...|ecret":"oauth2-demo-client-secret","hash_secret":true,"kongCredType":"oauth2","name":"Oauth2 Demo Ap|...
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
