### PR TITLE
feat: enterprise license utilities for testing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: run e2e tests
       run: make test.e2e
       env:
-        KONG_ENTERPRISE_LICENSE_SECRET: ${{ secrets.KONG_ENTERPRISE_LICENSE_SECRET }}
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
         KONG_CLUSTER_VERSION: ${{ matrix.kubernetes_version }}
         ISTIO_VERSION: ${{ matrix.istio_version }}
         NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,7 +132,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.enterprise.postgres
       env:
-        KONG_LICENSE_DATA: ${{ secrets.KONG_ENTERPRISE_LICENSE }}
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v2.2.4

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kong/deck v1.7.0
 	github.com/kong/go-kong v0.23.0
-	github.com/kong/kubernetes-testing-framework v0.8.3
+	github.com/kong/kubernetes-testing-framework v0.9.1
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.43
 	github.com/mitchellh/mapstructure v1.4.2
@@ -53,7 +53,7 @@ require (
 	github.com/containerd/containerd v1.5.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v20.10.9+incompatible // indirect
+	github.com/docker/docker v20.10.10+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021 // indirect

--- a/go.sum
+++ b/go.sum
@@ -343,8 +343,8 @@ github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.9+incompatible h1:JlsVnETOjM2RLQa0Cc1XCIspUdXW3Zenq9P54uXBm6k=
-github.com/docker/docker v20.10.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.10+incompatible h1:GKkP0T7U4ks6X3lmmHKC2QDprnpRJor2Z5a8m62R9ZM=
+github.com/docker/docker v20.10.10+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -686,8 +686,8 @@ github.com/kong/go-kong v0.19.0/go.mod h1:HyNtOxzh/tzmOV//ccO5NAdmrCnq8b86YUPjmd
 github.com/kong/go-kong v0.22.0/go.mod h1:Nce3QBEKF49kxlocaElvlMSfJ+Eux7PVe65Php7/Psc=
 github.com/kong/go-kong v0.23.0 h1:N+SnN16zkq81z6aH7LqcvK5daMMYHHhxmObDu1OsXok=
 github.com/kong/go-kong v0.23.0/go.mod h1:zS6jO3n07vFPI5trn3Exmxa9zpEVjYGmDI2u9Z15TYs=
-github.com/kong/kubernetes-testing-framework v0.8.3 h1:7h49usUPEc5BioX/dRtReK+FD3vzeLkP/vTvP5O2FYI=
-github.com/kong/kubernetes-testing-framework v0.8.3/go.mod h1:U/IEMCAXTQWiteOlKQnyMturEfZu4Spb69KaoyTxMzw=
+github.com/kong/kubernetes-testing-framework v0.9.1 h1:rX9rZoXK9U1iglRo2iAHpDw//EjmWpfHNbSUglywLJg=
+github.com/kong/kubernetes-testing-framework v0.9.1/go.mod h1:nn2p8JKaTwRVCFTRlxSSn6KqCqGkY7L+IUfJpd9qt70=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1345,7 +1345,6 @@ golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1558,7 +1557,6 @@ google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20211008145708-270636b82663/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211016002631-37fc39342514/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211021150943-2b146023228c h1:FqrtZMB5Wr+/RecOM3uPJNPfWR8Upb5hAPnt7PU6i4k=
 google.golang.org/genproto v0.0.0-20211021150943-2b146023228c/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -15,13 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/test/utils"
 )
@@ -121,7 +121,7 @@ func TestMain(m *testing.M) {
 	testCases, err := identifyTestCasesForDir("./")
 	exitOnErr(err)
 	for _, testCase := range testCases {
-		namespaceForTestCase, err := generators.GenerateNamespace(ctx, env.Cluster(), testCase)
+		namespaceForTestCase, err := clusters.GenerateNamespace(ctx, env.Cluster(), testCase)
 		exitOnErr(err)
 		namespaces[testCase] = namespaceForTestCase
 		watchNamespaces = fmt.Sprintf("%s,%s", watchNamespaces, namespaceForTestCase.Name)

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -38,10 +38,8 @@ func TestMain(m *testing.M) {
 	kongbuilder := kong.NewBuilder()
 	extraControllerArgs := []string{}
 	if kongEnterpriseEnabled == "true" {
-		licenseJSON := os.Getenv("KONG_LICENSE_DATA")
-		if licenseJSON == "" {
-			exitOnErr(fmt.Errorf(("KONG_LICENSE_DATA must be set for Enterprise tests")))
-		}
+		licenseJSON, err := kong.GetLicenseJSONFromEnv()
+		exitOnErr(err)
 		extraControllerArgs = append(extraControllerArgs, fmt.Sprintf("--kong-admin-token=%s", kongTestPassword))
 		extraControllerArgs = append(extraControllerArgs, "--kong-workspace=notdefault")
 		kongbuilder = kongbuilder.WithProxyEnterpriseEnabled(licenseJSON).

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -172,7 +172,7 @@ func namespace(t *testing.T) (*corev1.Namespace, func()) {
 	}
 
 	cleanup := func() {
-		assert.NoError(t, generators.CleanupGeneratedResources(ctx, env.Cluster(), t.Name()))
+		assert.NoError(t, clusters.CleanupGeneratedResources(ctx, env.Cluster(), t.Name()))
 	}
 
 	return namespace, cleanup

--- a/test/utils/controller_manager.go
+++ b/test/utils/controller_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
 // -----------------------------------------------------------------------------
@@ -60,7 +59,7 @@ func DeployControllerManagerForCluster(ctx context.Context, cluster clusters.Clu
 
 	// create a tempfile to hold the cluster kubeconfig that will be used for the controller
 	// generate a temporary kubeconfig since we're going to be using the helm CLI
-	kubeconfig, err := generators.TempKubeconfig(cluster)
+	kubeconfig, err := clusters.TempKubeconfig(cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes some inconsistencies with how enterprise licenses were handled across testing suites, and uses a single common implementation (and environment variable)

## Prerequisites

- [x] https://github.com/Kong/kubernetes-testing-framework/pull/144

## Notes

- I tested E2E tests locally and they succeeded with this patch