### PR TITLE
fix(status) update non-http upstream Ingresses

### DIFF
--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -146,7 +146,7 @@ func UpdateStatuses(
 				return fmt.Errorf("failed to update udp ingress: %w", err)
 			}
 
-		case "http":
+		case "http", "https", "grpc", "grpcs":
 			// if the cluster is on a very old version, we fall back to legacy Ingress support
 			// for compatibility with clusters older than v1.19.x.
 			// TODO: this can go away once we drop support for Kubernetes older than v1.19

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -215,7 +215,7 @@ func TestGRPCIngressEssentials(t *testing.T) {
 		t.Log("cleaning up Ingress resource")
 		if err := clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress); err != nil {
 			if !errors.IsNotFound(err) {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we don't update Ingresses or Ingress-likes unless their associated Kong service's protocol is tcp, udp, or http. This adds the rest of the protocols (https, grpc, grpcs) that should result in an Ingress update.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1991

**Special notes for your reviewer**:

The test confirms the status update now works, but not much anything else, largely owing to my lack of familiarity with gRPC. I initially tried this after the status check:

```
	t.Log("waiting for routes from Ingress to be operational")
	require.Eventually(t, func() bool {
		conn, err := grpc.Dial(fmt.Sprintf("%s:%s", proxyURL.Hostname(), "443"), grpc.WithInsecure())
		if err != nil {
			t.Logf("error connecting to %s:%s: %v", proxyURL.Hostname(), "443", err)
			return false
		}
		defer conn.Close()
		client := pb.NewGRPCBinClient(conn)
		res, err := client.DummyUnary(ctx, &pb.DummyMessage{
			FString: "hello",
			FInt32:  42,
		})
		if err != nil {
			t.Logf("failed to send gRPC request: %v", err)
			return false
		}
		fmt.Println(res)
		return true
	}, ingressWait, waitTick)

	t.Log("deleting Ingress")
	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
```
using [grpcbin](https://github.com/moul/grpcbin)'s test client stuff (as `pb`) to avoid the (considerable) boilerplate in the grpc-go examples. This just nets me a "connection closed before server preface received" error. Though the route looks similar to our [standard gRPC documentation](https://docs.konghq.com/gateway-oss/2.6.x/getting-started/configuring-a-grpc-service/), but it doesn't respond to the example grpcurl there (it gets a 503 on requests for `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo` instead, but without errors in the proxy that would suggest a DNS failure).

So not really sure how to make the rest of that work, but it's not necessary for the change this tests.

An additional note: we have a `grpc` option for routes, but I don't think it can ever work--we don't support plaintext HTTP/2 at all because NGINX doesn't support it, so any attempt to do that results in a 400.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
