### PR TITLE
fix(admission) add KongClusterPlugin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,14 @@
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
-## [2.0.5]
+## [2.1.0]
 
-> Release date: 2021/11/02
+> Release date: TBD
+
+**Note:** the admission webhook updates are _not_ applied automatically by the
+upgrade. If you set one up previously, you should edit it (`kubectl edit
+validatingwebhookconfiguration kong-validations` and add `kongclusterplugins`
+under the `resources` block fro the `configuration.konghq.com` apiGroup.
 
 #### Added
 
@@ -51,6 +56,15 @@
 
 [k8s-fg]:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 [kic-fg]:https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md
+
+#### Fixed
+
+- The template admission webhook configuration now includes KongClusterPlugins.
+  [#2000](https://github.com/Kong/kubernetes-ingress-controller/issues/2000)
+
+## [2.0.5]
+
+> Release date: 2021/11/02
 
 #### Fixed
 
@@ -1401,6 +1415,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.1.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.5...v2.1.0
 [2.0.5]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.2...v2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 **Note:** the admission webhook updates are _not_ applied automatically by the
 upgrade. If you set one up previously, you should edit it (`kubectl edit
 validatingwebhookconfiguration kong-validations` and add `kongclusterplugins`
-under the `resources` block fro the `configuration.konghq.com` apiGroup.
+under the `resources` block for the `configuration.konghq.com` API group.
 
 #### Added
 

--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -35,6 +35,7 @@ webhooks:
     resources:
     - kongconsumers
     - kongplugins
+    - kongclusterplugins
   - apiGroups:
     - ''
     apiVersions:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add KongClusterPlugin to the rules of the template ValidatingWebhookConfiguration. We omitted this earlier when adding support for KCP to the admission server code

**Special notes for your reviewer**:
Also moves content out of the 2.0.5 changelog since it wasn't actually part of 2.0.5.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
