### PR TITLE
fix: status updates for svc with > 1 ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ under the `resources` block for the `configuration.konghq.com` API group.
 
 #### Fixed
 
+- Fixed an issue where statuses would not update properly when a single service
+  had multiple Ingress resources associated with it.
+  [#2013](https://github.com/Kong/kubernetes-ingress-controller/pull/2013)
+- Fixed an issue where statuses would not update for Ingress resources with
+  periods in the name.
+  [#2012](https://github.com/Kong/kubernetes-ingress-controller/issues/2012)
 - The template admission webhook configuration now includes KongClusterPlugins.
   [#2000](https://github.com/Kong/kubernetes-ingress-controller/issues/2000)
 

--- a/internal/ctrlutils/ingress-status.go
+++ b/internal/ctrlutils/ingress-status.go
@@ -120,7 +120,9 @@ func UpdateStatuses(
 ) error {
 	defer wg.Done()
 
+	log.V(util.DebugLevel).Info("found services for status update", "count", len(targetContent.Services))
 	for _, svc := range targetContent.Services {
+		log.V(util.DebugLevel).Info("handling service for status update", "name", svc.Name, "protocol", svc.Protocol)
 		for _, plugin := range svc.Plugins {
 			if *plugin.Enabled {
 				if config, ok := plugin.Config["add"]; ok {
@@ -151,12 +153,16 @@ func UpdateStatuses(
 			// for compatibility with clusters older than v1.19.x.
 			// TODO: this can go away once we drop support for Kubernetes older than v1.19
 			if kubernetesVersion.Major >= uint64(1) && kubernetesVersion.Minor > uint64(18) {
-				if err := UpdateIngress(ctx, log, svc, cli, ips); err != nil {
-					return fmt.Errorf("failed to update ingressv1: %w", err)
+				for _, route := range svc.Routes {
+					if err := UpdateIngress(ctx, log, route, cli, ips); err != nil {
+						return fmt.Errorf("failed to update ingressv1: %w", err)
+					}
 				}
 			} else {
-				if err := UpdateIngressLegacy(ctx, log, svc, cli, ips); err != nil {
-					return fmt.Errorf("failed to update ingressv1: %w", err)
+				for _, route := range svc.Routes {
+					if err := UpdateIngressLegacy(ctx, log, route, cli, ips); err != nil {
+						return fmt.Errorf("failed to update ingressv1: %w", err)
+					}
 				}
 			}
 		default:
@@ -182,63 +188,63 @@ func toKnativeLBStatus(coreLBStatus []apiv1.LoadBalancerIngress) []knative.LoadB
 func UpdateIngress(
 	ctx context.Context,
 	log logr.Logger,
-	svc file.FService,
+	route *file.FRoute,
 	cli *clientset.Clientset,
 	ips []string,
 ) error {
-	for _, route := range svc.Routes {
-		routeInf := strings.Split(*((*route).Name), ".")
-		namespace := routeInf[0]
-		name := routeInf[1]
-		log.V(util.DebugLevel).Info("updating status for v1/Ingress", "namespace", namespace, "name", name)
+	log.V(util.DebugLevel).Info("handling status updates for kong route", "route", route.Name)
+	routeInf := strings.Split(*((*route).Name), ".")
+	routeInf = routeInf[:len(routeInf)-1] // strip the last element to leave only the Ingress namespace/name reference for the route
+	namespace := routeInf[0]
+	name := strings.Join(routeInf[1:], ".") // there may be multiple parts because route names can contain periods
 
-		ingCli := cli.NetworkingV1().Ingresses(namespace)
-		retry := 0
-		for retry < statusUpdateRetry {
-			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
-			if err != nil || curIng == nil {
-				if errors.IsNotFound(err) {
-					log.V(util.DebugLevel).Info("failed to retrieve v1/Ingress: the object is gone, quitting status updates", "namespace", namespace, "name", name)
-					return nil
-				}
-
-				log.V(util.DebugLevel).Info("failed to fetch v1/Ingress due to error, retrying...", "namespace", namespace, "name", name, "error", err.Error())
-				retry++
-				time.Sleep(statusUpdateWaitTick)
-				continue
-			}
-
-			var status []apiv1.LoadBalancerIngress
-			sort.SliceStable(status, lessLoadBalancerIngress(status))
-			curIPs := curIng.Status.LoadBalancer.Ingress
-
-			status = SliceToStatus(ips)
-			if ingressSliceEqual(status, curIPs) {
-				log.V(util.DebugLevel).Info("no change in status, skipping updates for v1/Ingress", "namespace", namespace, "name", name)
-				return nil
-			}
-
-			curIng.Status.LoadBalancer.Ingress = status
-
-			_, err = ingCli.UpdateStatus(ctx, curIng, metav1.UpdateOptions{})
-			if err == nil {
-				break
-			}
+	log.V(util.DebugLevel).Info("updating status for v1/Ingress", "namespace", namespace, "name", name)
+	ingCli := cli.NetworkingV1().Ingresses(namespace)
+	retry := 0
+	for retry < statusUpdateRetry {
+		curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
+		if err != nil || curIng == nil {
 			if errors.IsNotFound(err) {
-				log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object because it is gone, status update stopped", "namespace", namespace, "name", name)
+				log.V(util.DebugLevel).Info("failed to retrieve v1/Ingress: the object is gone, quitting status updates", "namespace", namespace, "name", name)
 				return nil
 			}
-			if errors.IsConflict(err) {
-				log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object because the object has changed: retrying...", "namespace", namespace, "name", name)
-			} else {
-				log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object due to an unexpected error, retrying...", "namespace", namespace, "name", name)
-			}
-			time.Sleep(statusUpdateWaitTick)
+
+			log.V(util.DebugLevel).Info("failed to fetch v1/Ingress due to error, retrying...", "namespace", namespace, "name", name, "error", err.Error())
 			retry++
+			time.Sleep(statusUpdateWaitTick)
+			continue
 		}
 
-		log.V(util.DebugLevel).Info("updated status for v1/Ingress", "namespace", namespace, "name", name)
+		var status []apiv1.LoadBalancerIngress
+		sort.SliceStable(status, lessLoadBalancerIngress(status))
+		curIPs := curIng.Status.LoadBalancer.Ingress
+
+		status = SliceToStatus(ips)
+		if ingressSliceEqual(status, curIPs) {
+			log.V(util.DebugLevel).Info("no change in status, skipping updates for v1/Ingress", "namespace", namespace, "name", name)
+			return nil
+		}
+
+		curIng.Status.LoadBalancer.Ingress = status
+
+		_, err = ingCli.UpdateStatus(ctx, curIng, metav1.UpdateOptions{})
+		if err == nil {
+			break
+		}
+		if errors.IsNotFound(err) {
+			log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object because it is gone, status update stopped", "namespace", namespace, "name", name)
+			return nil
+		}
+		if errors.IsConflict(err) {
+			log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object because the object has changed: retrying...", "namespace", namespace, "name", name)
+		} else {
+			log.V(util.DebugLevel).Info("failed to update the status for v1/Ingress object due to an unexpected error, retrying...", "namespace", namespace, "name", name)
+		}
+		time.Sleep(statusUpdateWaitTick)
+		retry++
 	}
+
+	log.V(util.DebugLevel).Info("updated status for v1/Ingress", "namespace", namespace, "name", name)
 
 	return nil
 }
@@ -248,63 +254,63 @@ func UpdateIngress(
 func UpdateIngressLegacy(
 	ctx context.Context,
 	log logr.Logger,
-	svc file.FService,
+	route *file.FRoute,
 	cli *clientset.Clientset,
 	ips []string,
 ) error {
-	for _, route := range svc.Routes {
-		routeInf := strings.Split(*((*route).Name), ".")
-		namespace := routeInf[0]
-		name := routeInf[1]
-		log.V(util.DebugLevel).Info("updating status for v1beta1/Ingress", "namespace", namespace, "name", name)
+	log.V(util.DebugLevel).Info("handling status updates for kong route", "route", route.Name)
+	routeInf := strings.Split(*((*route).Name), ".")
+	routeInf = routeInf[:len(routeInf)-1] // strip the last element to leave only the Ingress namespace/name reference for the route
+	namespace := routeInf[0]
+	name := strings.Join(routeInf[1:], ".") // there may be multiple parts because route names can contain periods
 
-		ingCli := cli.NetworkingV1beta1().Ingresses(namespace)
-		retry := 0
-		for retry < statusUpdateRetry {
-			curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
-			if err != nil || curIng == nil {
-				if errors.IsNotFound(err) {
-					log.V(util.DebugLevel).Info("failed to retrieve v1beta1/Ingress: the object is gone, quitting status updates", "namespace", namespace, "name", name)
-					return nil
-				}
-
-				log.V(util.DebugLevel).Info("failed to fetch v1beta1/Ingress due to error, retrying...", "namespace", namespace, "name", name, "error", err.Error())
-				retry++
-				time.Sleep(statusUpdateWaitTick)
-				continue
-			}
-
-			var status []apiv1.LoadBalancerIngress
-			sort.SliceStable(status, lessLoadBalancerIngress(status))
-			curIPs := curIng.Status.LoadBalancer.Ingress
-
-			status = SliceToStatus(ips)
-			if ingressSliceEqual(status, curIPs) {
-				log.V(util.DebugLevel).Info("no change in status, skipping updates for v1beta1/Ingress", "namespace", namespace, "name", name)
-				return nil
-			}
-
-			curIng.Status.LoadBalancer.Ingress = status
-
-			_, err = ingCli.UpdateStatus(ctx, curIng, metav1.UpdateOptions{})
-			if err == nil {
-				break
-			}
+	log.V(util.DebugLevel).Info("updating status for v1beta1/Ingress", "namespace", namespace, "name", name)
+	ingCli := cli.NetworkingV1beta1().Ingresses(namespace)
+	retry := 0
+	for retry < statusUpdateRetry {
+		curIng, err := ingCli.Get(ctx, name, metav1.GetOptions{})
+		if err != nil || curIng == nil {
 			if errors.IsNotFound(err) {
-				log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object because it is gone, status update stopped", "namespace", namespace, "name", name)
+				log.V(util.DebugLevel).Info("failed to retrieve v1beta1/Ingress: the object is gone, quitting status updates", "namespace", namespace, "name", name)
 				return nil
 			}
-			if errors.IsConflict(err) {
-				log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object because the object has changed: retrying...", "namespace", namespace, "name", name)
-			} else {
-				log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object due to an unexpected error, retrying...", "namespace", namespace, "name", name)
-			}
-			time.Sleep(statusUpdateWaitTick)
+
+			log.V(util.DebugLevel).Info("failed to fetch v1beta1/Ingress due to error, retrying...", "namespace", namespace, "name", name, "error", err.Error())
 			retry++
+			time.Sleep(statusUpdateWaitTick)
+			continue
 		}
 
-		log.V(util.DebugLevel).Info("updated status for v1beta1/Ingress", "namespace", namespace, "name", name)
+		var status []apiv1.LoadBalancerIngress
+		sort.SliceStable(status, lessLoadBalancerIngress(status))
+		curIPs := curIng.Status.LoadBalancer.Ingress
+
+		status = SliceToStatus(ips)
+		if ingressSliceEqual(status, curIPs) {
+			log.V(util.DebugLevel).Info("no change in status, skipping updates for v1beta1/Ingress", "namespace", namespace, "name", name)
+			return nil
+		}
+
+		curIng.Status.LoadBalancer.Ingress = status
+
+		_, err = ingCli.UpdateStatus(ctx, curIng, metav1.UpdateOptions{})
+		if err == nil {
+			break
+		}
+		if errors.IsNotFound(err) {
+			log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object because it is gone, status update stopped", "namespace", namespace, "name", name)
+			return nil
+		}
+		if errors.IsConflict(err) {
+			log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object because the object has changed: retrying...", "namespace", namespace, "name", name)
+		} else {
+			log.V(util.DebugLevel).Info("failed to update the status for v1beta1/Ingress object due to an unexpected error, retrying...", "namespace", namespace, "name", name)
+		}
+		time.Sleep(statusUpdateWaitTick)
+		retry++
 	}
+
+	log.V(util.DebugLevel).Info("updated status for v1beta1/Ingress", "namespace", namespace, "name", name)
 
 	return nil
 }

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
@@ -489,4 +490,129 @@ func TestIngressNamespaces(t *testing.T) {
 		defer resp.Body.Close()
 		return expect404WithNoRoute(t, proxyURL.String(), resp)
 	}, ingressWait, waitTick)
+}
+
+func TestIngressStatusUpdatesExtended(t *testing.T) {
+	t.Parallel()
+	ns, cleanup := namespace(t)
+	defer cleanup()
+
+	if clusterVersion.Major == uint64(1) && clusterVersion.Minor < uint64(19) {
+		t.Skip("status test disabled for old cluster versions")
+	}
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", httpBinImage, 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the deployment %s", deployment.Name)
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the service %s", service.Name)
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+	}()
+
+	t.Log("creating a variety of Ingress resources for the service to verify status updates")
+	pathType := netv1.PathTypePrefix
+	ingNameWithPeriods := "status.check.with.periods"
+	ingNameExtraForService := "statuscheck1"
+	for _, ing := range []*netv1.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ingNameWithPeriods,
+				Annotations: map[string]string{
+					annotations.IngressClassKey: ingressClass,
+					"konghq.com/strip-path":     "true",
+				},
+			},
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path:     "/statuscheck2",
+										PathType: &pathType,
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: service.Name,
+												Port: netv1.ServiceBackendPort{
+													Number: service.Spec.Ports[0].Port,
+												}}}}}}}}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ingNameExtraForService,
+				Annotations: map[string]string{
+					annotations.IngressClassKey: ingressClass,
+					"konghq.com/strip-path":     "true",
+				},
+			},
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path:     "/statuscheck1",
+										PathType: &pathType,
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: service.Name,
+												Port: netv1.ServiceBackendPort{
+													Number: service.Spec.Ports[0].Port,
+												}}}}}}}}}},
+		},
+	} {
+		t.Logf("creating ingress %s and verifying status updates", ing.Name)
+		createdIngress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Create(ctx, ing, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		defer func() {
+			t.Logf("cleaning up ingress %s", createdIngress.Name)
+			if err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Delete(ctx, createdIngress.Name, metav1.DeleteOptions{}); err != nil {
+				if !errors.IsNotFound(err) {
+					assert.NoError(t, err)
+				}
+			}
+		}()
+	}
+
+	t.Log("verifying that an ingress with periods in the name has its status populated")
+	require.Eventually(t, func() bool {
+		ing, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, ingNameWithPeriods, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), ns.Name, ing)
+		if err != nil {
+			return false
+		}
+		return len(lbstatus.Ingress) > 0
+	}, time.Minute, time.Second)
+
+	t.Log("verifying that when a service has more than one ingress, the status updates for those beyond the first")
+	require.Eventually(t, func() bool {
+		ing, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, ingNameExtraForService, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, env.Cluster(), ns.Name, ing)
+		if err != nil {
+			return false
+		}
+		return len(lbstatus.Ingress) > 0
+	}, time.Minute, time.Second)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch takes care of a problem where status updates would
never complete for more than one ingress connected to a single
service. It also fixes a problem where ingress resources with
periods in the name (e.g. "my.ingress.resource") would fail to
have their statuses updated due to a parsing error. Additionally
this adds some regression tests which will prevent us reduce the
possibility that these problems would be reintroduced.

**Which issue this PR fixes**

fixes #2012

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
