### PR TITLE
feat(make) determine the tag automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Configuration
 # ------------------------------------------------------------------------------
 
-TAG?=2.0.5
+TAG?=$(shell git describe --tags)
 REGISTRY?=kong
 REPO_INFO=$(shell git config --get remote.origin.url)
 REPO_URL=github.com/kong/kubernetes-ingress-controller


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of writing a static tag variable in the Makefile, automatically infer it from the Git tag. Guess which piece of the release configuration we often forget to update.

**Special notes for your reviewer**:
See [tags.txt](https://github.com/Kong/kubernetes-ingress-controller/files/7589988/tags.txt) for example runs.


If there is no tag, this chooses the parent tag and appends a short hash onto the end. This works for both the most recent tag and older tags. If there is a tag, this uses that tag. If there are multiple tags for the same commit, it apparently chooses whichever tag was created last.