### PR TITLE
fix: credentials validation for required data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ the `configuration.konghq.com` API group.
 
 #### Fixed
 
+- The validating webhook now validates that required fields data is not empty
+  [#1993](https://github.com/Kong/kubernetes-ingress-controller/issues/1993)
 - The validating webhook now validates unique key constraints for KongConsumer
   credentials secrets on update of secrets, and on create or update of
   KongConsumers.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Previous validation verified that any required fields
for a credentials type were present, but did not also
validate that the contents were not empty. This patch
adds a length check which matches the data-plane API
to validate that required fields are at least len 1.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1993

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated