### PR TITLE
fix(manager) lock client creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ the `configuration.konghq.com` API group.
   credentials secrets on update of secrets, and on create or update of
   KongConsumers.
   [#729](https://github.com/Kong/kubernetes-ingress-controller/issues/729)
+- Fixed a race condition where multiple actors may simultaneously attempt to
+  create the configured Enterprise workspaces.
+  [#2070](https://github.com/Kong/kubernetes-ingress-controller/pull/2070)
 
 ## [2.0.6]
 

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/kong/go-kong/kong"
 )
+
+var clientSetup sync.Mutex
 
 // HTTPClientOpts defines parameters that configure an HTTP client.
 type HTTPClientOpts struct {
@@ -89,6 +92,7 @@ func GetKongClientForWorkspace(ctx context.Context, adminURL string, wsName stri
 	}
 
 	// if a workspace was provided, verify whether or not it exists.
+	clientSetup.Lock()
 	exists, err := client.Workspaces.ExistsByName(ctx, kong.String(wsName))
 	if err != nil {
 		return nil, fmt.Errorf("looking up workspace: %w", err)
@@ -104,6 +108,7 @@ func GetKongClientForWorkspace(ctx context.Context, adminURL string, wsName stri
 			return nil, fmt.Errorf("creating workspace: %w", err)
 		}
 	}
+	clientSetup.Unlock()
 
 	// ensure that we set the workspace appropriately
 	client.SetWorkspace(wsName)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/kong/go-kong/kong"
@@ -18,8 +17,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/proxy"
 )
-
-var clientSetup sync.Mutex
 
 // -----------------------------------------------------------------------------
 // Controller Manager - Config
@@ -205,9 +202,7 @@ func (c *Config) GetKongClient(ctx context.Context) (*kong.Client, error) {
 		return nil, err
 	}
 
-	clientSetup.Lock()
 	client, err := adminapi.GetKongClientForWorkspace(ctx, c.KongAdminURL, c.KongWorkspace, httpclient)
-	clientSetup.Unlock()
 	return client, err
 }
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -202,8 +202,7 @@ func (c *Config) GetKongClient(ctx context.Context) (*kong.Client, error) {
 		return nil, err
 	}
 
-	client, err := adminapi.GetKongClientForWorkspace(ctx, c.KongAdminURL, c.KongWorkspace, httpclient)
-	return client, err
+	return adminapi.GetKongClientForWorkspace(ctx, c.KongAdminURL, c.KongWorkspace, httpclient)
 }
 
 func (c *Config) GetKubeconfig() (*rest.Config, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a mutex and lock it when creating Kong admin clients. Attempting to
create multiple workspaced clients simultaneously can result in a race
condition where both clients check for the workspace before either
creates it, both clients will attempt to create the workspace, and the
second client to attempt creation will hit a unique violation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes CI errors like:

```
panic: creating workspace: HTTP status 409 (message: "UNIQUE violation detected on '{name=\"notdefault\"}'")
```

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
