### PR TITLE
fix: reduce gh actions job resource contention for istio e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,5 +43,5 @@ jobs:
         KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
         KONG_CLUSTER_VERSION: ${{ matrix.kubernetes_version }}
         ISTIO_VERSION: ${{ matrix.istio_version }}
-        NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
-                # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
+        NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
+                # multiple kind clusters within a single job, so only 1 is allowed at a time.


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch disallows multiple cluster deployments in the nightly E2E tests to see if this helps with Istio test flakes.

**Which issue this PR fixes**

Partially Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2071

**Special notes for your reviewer**:

While I was able to reproduce and start work on the non-Istio test failures from #2071, I could not reproduce the Istio test failures on my local machine. As such I would like to see if those tests start passing consistently if there's less resource contention in the environment, because it is already known that the actions of the test (to deploy all of istio then perform large numbers of network requests) are resource intensive.