### PR TITLE
fix: test gateway integrations sequentially

### DIFF
--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -32,7 +32,6 @@ const (
 )
 
 func TestUnmanagedGatewayBasics(t *testing.T) {
-	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -138,7 +137,6 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 }
 
 func TestUnmanagedGatewayServiceUpdates(t *testing.T) {
-	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -275,7 +273,6 @@ func TestUnmanagedGatewayServiceUpdates(t *testing.T) {
 }
 
 func TestUnmanagedGatewayControllerSupport(t *testing.T) {
-	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 
@@ -374,7 +371,6 @@ func TestUnmanagedGatewayControllerSupport(t *testing.T) {
 }
 
 func TestUnmanagedGatewayClass(t *testing.T) {
-	t.Parallel()
 	ns, cleanup := namespace(t)
 	defer cleanup()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I continue to be unable to reproduce the gateway test issues of late, but I have my suspicions based on the failure output I've seen in CI that they're due to the parallelization of tests and the timing of when the `PublishService` gets updated for some of those tests. This patch turns off the parallelization for these temporarily, and if that ends up fixing the problem then I will create a follow up issue to re-parallelize them later after making adjustments to avoid collisions.

**Which issue this PR fixes**

Fixes #2065 