### PR TITLE
doc(changelog) add missing KCP 2.x breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,12 @@ previous `v1.3.x` releases to this release.
   seconds has passed to enforce rate limiting, now instead it configures a
   non-blocking [time.Ticker][go-tick] that runs at the provided seconds
   interval. Input remains a float that indicates seconds.
+- Per documentation and by design, KongClusterPlugin resources require an
+  `kubernetes.io/ingress.class` annotation, but this was not fully enforced. In
+  2.0, all KongClusterPlugin resources require this annotation set to the
+  controller's ingress class. Check your resources to confirm they are annotated
+  before upgrading.
+  [#2090](https://github.com/Kong/kubernetes-ingress-controller/issues/2090)
 
 [upgrade-1-3-to-2-0]:https://docs.konghq.com/kubernetes-ingress-controller/2.0.x/guides/upgrade/
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Per discussion with the team, we're going to keep the 2.x behavior as-is and add a retroactive changelog entry.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2090 