### PR TITLE
feat: implement matching support for HTTPRoute in parser

### DIFF
--- a/internal/parser/translate.go
+++ b/internal/parser/translate.go
@@ -327,84 +327,144 @@ func fromIngressV1(log logrus.FieldLogger, ingressList []*networkingv1.Ingress) 
 
 // fromHTTPRoutes processes all the HTTPRoute objects present in the cache and translates
 // them to Kong Gateway configurations.
-//
-// TODO: this function is a WIP and is only implemented at POC level currently. The code
-//       is not reachable unless the Gateway feature gate has been enabled and the relevant
-//       milestone for tracking completion is:
-//
-//         https://github.com/Kong/kubernetes-ingress-controller/issues/2079
-//
-//       you may see several TODO's scattered throughout this function, they are all covered by #2079
-func fromHTTPRoutes(_ logrus.FieldLogger, httpRouteList []*gatewayv1alpha2.HTTPRoute) ingressRules { // TODO: use log
+func fromHTTPRoutes(log logrus.FieldLogger, httpRouteList []*gatewayv1alpha2.HTTPRoute) ingressRules {
 	result := newIngressRules()
 
 	for _, httproute := range httpRouteList {
 		// first we grab the spec and gather some metdata about the object
-		spec := httproute.Spec
 		objectInfo := util.FromK8sObject(httproute)
+		spec := httproute.Spec
 
-		// next we need to gather all the matching information e.g. paths, methods, e.t.c.
-		methods := make([]*string, 0) // TODO: implement inclusive path/method matches
-		paths := make([]*string, 0)
+		// gather the hostnames that will be used (globally) for route matching
+		hostnames := make([]*string, 0, len(spec.Hostnames))
+		for _, hostname := range spec.Hostnames {
+			hostnames = append(hostnames, kong.String(string(hostname)))
+		}
+
+		// each rule may represent a different set of backend services that will be accepting
+		// traffic, so we make separate routes and Kong services for every present rule.
 		for _, rule := range spec.Rules {
-			for _, match := range rule.Matches {
-				paths = append(paths, match.Path.Value)
+			// the HTTPRoute specification upstream specifically defines matches as
+			// independent (e.g. each match is an OR with other matches, not an AND).
+			// Therefore we treat each match rule as a separate Kong Route, so we iterate through
+			// all matches to determine all the routes that will be needed for the services.
+			var routes []kongstate.Route
+			for matchNumber, match := range rule.Matches {
+				// determine the name of the route, identify it as a route that belongs
+				// to a Kubernetes HTTPRoute object.
+				routeName := kong.String(fmt.Sprintf(
+					"httproute.%s.%s.%d",
+					httproute.Namespace,
+					httproute.Name,
+					matchNumber, // TODO: avoid route thrash from re-ordering?
+				))
+
+				// TODO: implement query param matches
+				if len(match.QueryParams) > 0 {
+					errmsg := "query param matches are not yet supported"
+					log.Errorf("HTTPRoute %s/%s can't be routed for match %+v: %s", errmsg)
+					continue
+				}
+
+				// TODO: implement regex path matches
+				if *match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression {
+					errmsg := "regular expression path matches are not yet supported"
+					log.Errorf("HTTPRoute %s/%s can't be routed for match %+v: %s", errmsg)
+					continue
+				}
+
+				// build the route object using the method and pathing information
+				r := kongstate.Route{
+					Ingress: objectInfo,
+					Route: kong.Route{
+						Name:         routeName,
+						Protocols:    kong.StringSlice("http", "https"),
+						PreserveHost: kong.Bool(true),
+						Hosts:        hostnames,
+					},
+				}
+				log.Debugf("generated route %s for HTTPRoute %s/%s", routeName, httproute.Namespace, httproute.Name)
+
+				// configure path matching information about the route if paths
+				// matching was defined.
+				if match.Path != nil {
+					// determine the path match values
+					r.Route.Paths = []*string{match.Path.Value}
+
+					// determine whether path stripping needs to be enabled
+					r.Route.StripPath = kong.Bool(match.Path.Type == nil || *match.Path.Type == gatewayv1alpha2.PathMatchPathPrefix)
+				}
+
+				// configure method matching information about the route if method
+				// matching was defined.
+				if match.Method != nil {
+					r.Route.Methods = append(r.Route.Methods, kong.String(string(*match.Method)))
+				}
+
+				// convert header matching from HTTPRoute to Route format
+				headers, err := convertGatewayMatchHeadersToKongRouteMatchHeaders(match.Headers)
+				if err != nil {
+					log.Errorf("HTTPRoute %s/%s can't be routed for match %+v: %w", err)
+					continue
+				}
+				r.Route.Headers = headers
+
+				// add the route to the list of routes for the service(s)
+				routes = append(routes, r)
+			}
+
+			// once all routes have been determined based on matching rules
+			// we determine the Services they actually route to.
+			for _, backendRef := range rule.BackendRefs {
+				// determine the namespace for the service, or default to the same namespace
+				// as the HTTPRoute object.
+				//
+				// TODO: need to add validation to restrict namespaces in backendRefs
+				namespace := httproute.Namespace
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+
+				// determine the name of the Service
+				serviceName := fmt.Sprintf("%s.%s.%d", namespace, backendRef.Name, *backendRef.Port)
+
+				// determine the Service port
+				port := kongstate.PortDef{
+					Mode:   kongstate.PortModeByNumber,
+					Number: int32(*backendRef.Port),
+				}
+
+				// check if the service is already known, and if not create it
+				service, ok := result.ServiceNameToServices[serviceName]
+				if !ok {
+					service = kongstate.Service{
+						Service: kong.Service{
+							Name:           kong.String(serviceName),
+							Host:           kong.String(fmt.Sprintf("%s.%s.%s.svc", backendRef.Name, namespace, port.CanonicalString())),
+							Port:           kong.Int(int(*backendRef.Port)),
+							Protocol:       kong.String("http"),
+							Path:           kong.String("/"),
+							ConnectTimeout: kong.Int(60000),
+							ReadTimeout:    kong.Int(60000),
+							WriteTimeout:   kong.Int(60000),
+							Retries:        kong.Int(5),
+						},
+						Namespace: httproute.Namespace,
+						Backend: kongstate.ServiceBackend{
+							Name: string(backendRef.Name),
+							Port: port,
+						},
+					}
+					log.Debugf("generated kong service %s for HTTPRoute %s/%s", serviceName, httproute.Namespace, httproute.Name)
+				}
+
+				// add all generated routes to this service
+				service.Routes = append(service.Routes, routes...)
+
+				// cache the service to avoid duplicates in further loop iterations
+				result.ServiceNameToServices[serviceName] = service
 			}
 		}
-
-		// we create a kong route which will transact the traffic matching
-		// information for inbound gateway requests.
-		r := kongstate.Route{
-			Ingress: objectInfo,
-			Route: kong.Route{
-				Name:         kong.String(fmt.Sprintf("%s.%s.%s", httproute.Namespace, httproute.Name, httproute.UID)), // TODO: is UID the best way to do this universally?
-				Paths:        paths,
-				Methods:      methods,         // TODO: actually implement method matches
-				StripPath:    kong.Bool(true), // TODO: dynamic
-				PreserveHost: kong.Bool(true),
-				Protocols:    kong.StringSlice("http", "https"),
-				// TODO: RegexPriority
-			},
-		}
-		for _, host := range spec.Hostnames {
-			r.Hosts = append(r.Hosts, kong.String(string(host)))
-		}
-
-		// now that we've established the routing information and can match
-		// on the appropriate traffic, we need to determine the backend
-		// (Kubernetes Service) to direct the traffic to.
-		//
-		// TODO: right now for poc assuming only one backendref, will do all later
-		backend := spec.Rules[0].BackendRefs[0] // TODO: assuming 1 rule for poc
-		port := kongstate.PortDef{
-			Mode:   kongstate.PortModeByNumber, // TODO: assuming number for poc
-			Number: int32(*backend.Port),
-		}
-		serviceName := fmt.Sprintf("%s.%s.%d", httproute.Namespace, backend.Name, backend.Port)
-		service, ok := result.ServiceNameToServices[serviceName]
-		if !ok {
-			service = kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String(serviceName),
-					Host: kong.String(string(backend.Name) + "." + httproute.Namespace +
-						"." + port.CanonicalString() + ".svc"),
-					Port:           kong.Int(80),
-					Protocol:       kong.String("http"),
-					Path:           kong.String("/"),
-					ConnectTimeout: kong.Int(60000),
-					ReadTimeout:    kong.Int(60000),
-					WriteTimeout:   kong.Int(60000),
-					Retries:        kong.Int(5),
-				},
-				Namespace: httproute.Namespace,
-				Backend: kongstate.ServiceBackend{
-					Name: string(backend.Name),
-					Port: port,
-				},
-			}
-		}
-		service.Routes = append(service.Routes, r)
-		result.ServiceNameToServices[serviceName] = service
 	}
 
 	return result
@@ -738,4 +798,28 @@ func PortDefFromIntStr(is intstr.IntOrString) kongstate.PortDef {
 		return kongstate.PortDef{Mode: kongstate.PortModeByName, Name: is.StrVal}
 	}
 	return kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: is.IntVal}
+}
+
+// -----------------------------------------------------------------------------
+// Utilities - Gateway APIs
+// -----------------------------------------------------------------------------
+
+// convertGatewayMatchHeadersToKongRouteMatchHeaders takes an input list of Gateway APIs HTTPHeaderMatch
+// and converts these header matching rules to the format expected by go-kong.
+func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayv1alpha2.HTTPHeaderMatch) (map[string][]string, error) {
+	// iterate through each provided header match checking for invalid
+	// options and otherwise converting to kong type format.
+	convertedHeaders := make(map[string][]string)
+	for _, header := range headers {
+		// TODO: implement regex header matching
+		if header.Type != nil && *header.Type == gatewayv1alpha2.HeaderMatchRegularExpression {
+			return nil, fmt.Errorf("regular expression header matches are not yet supported")
+		}
+
+		// split the header values by comma
+		values := strings.Split(header.Value, ",")
+		convertedHeaders[string(header.Name)] = values
+	}
+
+	return convertedHeaders, nil
 }

--- a/internal/parser/translate_test.go
+++ b/internal/parser/translate_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -12,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/kongstate"
@@ -1232,5 +1234,87 @@ func TestPathsFromK8s(t *testing.T) {
 				require.Equal(t, tt.wantImplSpec, gotImplSpec, "implementation specific match")
 			}
 		})
+	}
+}
+
+func Test_convertGatewayMatchHeadersToKongRouteMatchHeaders(t *testing.T) {
+	t.Log("defining available header matching types for gateway")
+	regexType := gatewayv1alpha2.HeaderMatchRegularExpression
+	exactType := gatewayv1alpha2.HeaderMatchExact
+
+	t.Log("generating several gateway header matches")
+	tests := []struct {
+		msg    string
+		input  []gatewayv1alpha2.HTTPHeaderMatch
+		output map[string][]string
+		err    error
+	}{
+		{
+			msg: "regex header matches will fail due to lack of support",
+			input: []gatewayv1alpha2.HTTPHeaderMatch{{
+				Type:  &regexType,
+				Name:  "Content-Type",
+				Value: "^audio/*",
+			}},
+			output: nil,
+			err:    fmt.Errorf("regular expression header matches are not yet supported"),
+		},
+		{
+			msg: "a single exact header match with no type defaults to exact type and converts properly",
+			input: []gatewayv1alpha2.HTTPHeaderMatch{{
+				Name:  "Content-Type",
+				Value: "audio/vorbis",
+			}},
+			output: map[string][]string{
+				"Content-Type": {"audio/vorbis"},
+			},
+		},
+		{
+			msg: "a single exact header match with a single value converts properly",
+			input: []gatewayv1alpha2.HTTPHeaderMatch{{
+				Type:  &exactType,
+				Name:  "Content-Type",
+				Value: "audio/vorbis",
+			}},
+			output: map[string][]string{
+				"Content-Type": {"audio/vorbis"},
+			},
+		},
+		{
+			msg: "a single exact header match with multiple values converts properly",
+			input: []gatewayv1alpha2.HTTPHeaderMatch{{
+				Type:  &exactType,
+				Name:  "Content-Type",
+				Value: "audio/vorbis,audio/mpeg",
+			}},
+			output: map[string][]string{
+				"Content-Type": {"audio/vorbis", "audio/mpeg"},
+			},
+		},
+		{
+			msg: "multiple header matches with a mixture of value counts convert properly",
+			input: []gatewayv1alpha2.HTTPHeaderMatch{
+				{
+					Type:  &exactType,
+					Name:  "Content-Type",
+					Value: "audio/vorbis,audio/mpeg",
+				},
+				{
+					Name:  "Content-Length",
+					Value: "999999999",
+				},
+			},
+			output: map[string][]string{
+				"Content-Type":   {"audio/vorbis", "audio/mpeg"},
+				"Content-Length": {"999999999"},
+			},
+		},
+	}
+
+	t.Log("verifying header match conversions")
+	for _, tt := range tests {
+		output, err := convertGatewayMatchHeadersToKongRouteMatchHeaders(tt.input)
+		assert.Equal(t, tt.err, err)
+		assert.Equal(t, tt.output, output, tt.msg)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch takes an iterative step towards implementing the `HTTPRoute` spec more completely in the backend `parser/`, including adding full path matching support, header matching support, and generally cleaning up the code.

**Which issue this PR fixes**

Partially resolves #2079

**Special notes for your reviewer**:

This iteration makes improvements and passes the existing tests, but it is not complete. Follow up items include:

- implementing query param matches
- implementing regex path matches
- implementing regex header matching
- namespace restricted backendRefs
- expanded integration tests
- webhook validation for `HTTPRoute` to block options which we don't support
- code refactoring and cleanup

These are all now covered in #2079. Some of these may not actually be possible with the current release of Kong Gateway and may require pursuit of additional data-plane features.

I'm also still not done with determining how multiple backendRefs are going to work yet, that's something that will need to be documented in an upcoming iteration.