### PR TITLE
Fix mismatched migration/deployment versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Setup yq
+      run: go install github.com/mikefarah/yq/v4@latest
+
     - name: Setup golangci-lint
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
 

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,12 @@ verify.repo:
 verify.diff:
 	./hack/verify-diff.sh
 
+.PHONY: verify.diff
+verify.versions:
+	./hack/verify-versions.sh
+
 .PHONY: verify.manifests
-verify.manifests: verify.repo manifests manifests.single verify.diff
+verify.manifests: verify.repo manifests manifests.single verify.diff verify.versions
 
 .PHONY: verify.generators
 verify.generators: verify.repo generate verify.diff

--- a/config/variants/postgres/kong-ingress-postgres.yaml
+++ b/config/variants/postgres/kong-ingress-postgres.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-migrations
-        image: kong:2.5
+        image: kong:2.7
         command:
         - "/bin/sh"
         - "-c"

--- a/config/variants/postgres/migration.yaml
+++ b/config/variants/postgres/migration.yaml
@@ -20,7 +20,7 @@ spec:
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
-        image: kong:2.5
+        image: kong:2.7
         env:
         - name: KONG_PG_PASSWORD
           value: kong

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1431,7 +1431,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:2.5
+        image: kong:2.7
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
 ---
@@ -1502,7 +1502,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:2.5
+        image: kong:2.7
         name: kong-migrations
       initContainers:
       - command:

--- a/hack/verify-versions.sh
+++ b/hack/verify-versions.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
+MANIFEST_ROOT="$REPO_ROOT/deploy/single"
+FAILED=0
+
+MANIFESTS="$MANIFEST_ROOT/*"
+for MANIFEST in ${MANIFESTS}
+do
+	CONTAINERS=$(yq eval-all ".spec.template.spec.containers[].image" "${MANIFEST}" -N)
+	INITCONTAINERS=$(yq eval-all ".spec.template.spec.initContainers[].image" "${MANIFEST}" -N)
+	KONGS=$(printf "%s\n%s" "$CONTAINERS" "$INITCONTAINERS" | sort | uniq | grep -oP "kong(\/kong-gateway)?:[\d\.]+")
+	if [ "$(echo "${KONGS}" | wc -l)" -gt 1 ]
+	then
+		echo "multiple Kong images in $MANIFEST, verify image consistency in source:"
+		echo "$KONGS"
+		FAILED=$((FAILED+1))
+	fi
+	if [ $FAILED -gt 0 ]
+	then
+		exit 1
+	fi
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
Kong version updates must be made in multiple locations within the base and variant manifests, or Kong will not start due to missing migrations. That didn't happen. Now it has happened.

Add a new hack script to ensure it doesn't happen no more: 
[demo.txt](https://github.com/Kong/kubernetes-ingress-controller/files/7821635/demo.txt)

**Special notes for your reviewer**:
I'd wanted to do this in Kustomize, but I don't think there's a good way to do it with `image` blocks that doesn't just then shift the problem to needing to update each kustomization.yaml's `image` section, so alert bash script instead.