### PR TITLE
fix: kiali no longer captures errors on outbound edge

### DIFF
--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -303,19 +303,6 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return verifyStatusForURL(appStatusOKUrl, http.StatusTooManyRequests) == nil
 	}, time.Minute*3, time.Second)
-
-	t.Log("exceeding the rate-limit and verifying that kiali health metrics pick up on it")
-	require.Eventually(t, func() bool {
-		if err := verifyStatusForURL(appStatusOKUrl, http.StatusTooManyRequests); err != nil {
-			return false
-		}
-		if health, err = getKialiWorkloadHealth(t, kialiAPIUrl, kongAddon.Namespace(), "ingress-controller-kong"); err != nil {
-			return false
-		}
-		inboundHTTPRequests = health.Requests.Inbound.HTTP
-		rateLimitedRequests, ok := inboundHTTPRequests[strconv.Itoa(http.StatusTooManyRequests)]
-		return ok && (rateLimitedRequests > 0.0)
-	}, time.Minute*3, time.Second)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch resolves an E2E test failure that started to occur with recent [Istio](https://github.com/istio/istio) releases. Previously the outbound network traffic from the Gateway was being collected for Kiali health metrics and so a `429` response from the Gateway (due to an enabled rate-limiter plugin) would be captured in the health metrics. In recent releases even when testing manually this no longer seems to be the case: it would appear that updates to Istio have either caused traffic outbound from pods within the mesh to route differently OR they're routing the same but not picked up for these metrics any longer. In the deluge of recent Istio updates I didn't find any one issue or PR that seemed to be definitively linked to this, but after manually testing this I can say with confidence that KIC is still behaving the way it previously was and the change is on Istio's side.

**Which issue this PR fixes**

Resolves #2141

**Notes**:

- this also includes a patch for a data race present in the port-forward helper of the all in one tests
- E2E test run using this branch: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1664966942