### PR TITLE
Add and test nightly builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,6 +40,7 @@ jobs:
     - name: run e2e tests
       run: make test.e2e
       env:
+        TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
         KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
         KONG_CLUSTER_VERSION: ${{ matrix.kubernetes_version }}
         ISTIO_VERSION: ${{ matrix.istio_version }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,93 @@
+name: release
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  build-push-images:
+    environment: 'Docker Push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add standard tags
+        run: |
+          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
+          echo 'type=schedule,pattern=nightly' >> $GITHUB_ENV
+          echo "type=schedule,pattern={{date 'YYYY-MM-DD'}}" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Add Red Hat standard tags
+        run: |
+          echo 'REDHAT_STANDARD<<EOF' >> $GITHUB_ENV
+          echo 'type=schedule,pattern=nightly,suffix=-redhat' >> $GITHUB_ENV
+          echo "type=schedule,pattern={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.7
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: kong/kubernetes-ingress-controller
+          tags: ${{ env.TAGS_STANDARD }}
+      - name: Docker meta (redhat)
+        id: meta_redhat
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: kong/nightly-ingress-controller
+          flavor: |
+            latest=false
+          tags: ${{ env.REDHAT_STANDARD }}
+      - name: Build binary
+        id: docker_build_binary
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          target: builder
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          target: distroless
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: Build and push Red Hat
+        id: docker_build_redhat
+        env:
+          TAG: ${{ steps.meta.outputs.version }}
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta_redhat.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          target: redhat
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,7 +40,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3.6.2
         with:
-          images: kong/kubernetes-ingress-controller
+          images: kong/nightly-ingress-controller
           tags: ${{ env.TAGS_STANDARD }}
       - name: Docker meta (redhat)
         id: meta_redhat

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -69,7 +69,10 @@ const (
 	adminAPIWait = time.Minute * 2
 )
 
-var imageOverride = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
+var (
+	imageOverride = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
+	imageLoad     = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_LOAD")
+)
 
 // -----------------------------------------------------------------------------
 // All-In-One Manifest Tests - Suite
@@ -95,7 +98,7 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -140,7 +143,7 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -180,7 +183,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -219,7 +222,7 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -269,7 +272,7 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -306,7 +309,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -421,7 +424,7 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	t.Log("building test cluster and environment")
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageOverride); err == nil {
+	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
 	builder := environments.NewBuilder().WithAddons(addons...)
@@ -833,7 +836,12 @@ func exposeAdminAPI(ctx context.Context, t *testing.T, env environments.Environm
 // returns the modified manifest path. If there is any issue patching the manifest, it will log the issue and return
 // the original provided path
 func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
-	imagetag := imageOverride
+	var imagetag string
+	if imageLoad != "" {
+		imagetag = imageLoad
+	} else {
+		imagetag = imageOverride
+	}
 	if imagetag == "" {
 		return os.Open(baseManifestPath)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Nightly builds and E2E tests using nightly builds. The nightly build is available on demand, so we can also run it during the day for release testing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2143

**Special notes for your reviewer**:
This requires coordination with other teams to create the new `kong/nightly-ingress-controller` Docker repo and grant our Docker token permission to it. This must be held until that is ready.
