### PR TITLE
feat(sendconfig) send config if none present

### DIFF
--- a/internal/sendconfig/sendconfig.go
+++ b/internal/sendconfig/sendconfig.go
@@ -50,8 +50,18 @@ func PerformUpdate(ctx context.Context,
 			if !hasSHAUpdateAlreadyBeenReported(newSHA) {
 				log.Debugf("sha %s has been reported", hex.EncodeToString(newSHA))
 			}
-			log.Debug("no configuration change, skipping sync to kong")
-			return oldSHA, nil
+			// TODO un-fake this once new go-kong functionality is available
+			ready := true
+			//ready, err := kongConfig.Client.Info.IsConfigReady()
+			//if err != nil {
+			//	log.Errorf("checking config status failed: %w", err)
+			//	log.Debug("configuration state unknown, skipping sync to kong")
+			//	return oldSHA, nil
+			//}
+			if ready {
+				log.Debug("no configuration change, skipping sync to kong")
+				return oldSHA, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Restore configuration after a crash or if it otherwise disappears for some reason. Test recovery by killing a container in an E2E test and checking routes after.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2107 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
