### PR TITLE
chore: add extra validation for supported httproute features

### DIFF
--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -100,6 +100,12 @@ func validateHTTPRouteFeatures(httproute *gatewayv1alpha2.HTTPRoute) error {
 				}
 			}
 		}
+
+		// we don't currently support multiple backendRefs
+		// See: https://github.com/Kong/kubernetes-ingress-controller/issues/2166
+		if len(rule.BackendRefs) > 1 {
+			return fmt.Errorf("multiple backendRefs is not yet supported for httproute")
+		}
 	}
 	return nil
 }

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -106,6 +106,16 @@ func validateHTTPRouteFeatures(httproute *gatewayv1alpha2.HTTPRoute) error {
 		if len(rule.BackendRefs) > 1 {
 			return fmt.Errorf("multiple backendRefs is not yet supported for httproute")
 		}
+
+		// we don't support any backendRef types except Kubernetes Services
+		for _, ref := range rule.BackendRefs {
+			if ref.BackendRef.Group != nil && *ref.BackendRef.Group != "core" {
+				return fmt.Errorf("%s is not a supported group for httproute backendRefs, only core is supported", *ref.BackendRef.Group)
+			}
+			if ref.BackendRef.Kind != nil && *ref.BackendRef.Kind != "Service" {
+				return fmt.Errorf("%s is not a supported kind for httproute backendRefs, only Service is supported", *ref.BackendRef.Kind)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -81,16 +81,19 @@ func validateHTTPRouteFeatures(httproute *gatewayv1alpha2.HTTPRoute) error {
 	for _, rule := range httproute.Spec.Rules {
 		for _, match := range rule.Matches {
 			// we don't support queryparam matching rules
+			// See: https://github.com/Kong/kubernetes-ingress-controller/issues/2152
 			if len(match.QueryParams) != 0 {
 				return fmt.Errorf("queryparam matching is not yet supported for httproute")
 			}
 
 			// we don't support regex path matching rules
+			// See: https://github.com/Kong/kubernetes-ingress-controller/issues/2153
 			if match.Path != nil && match.Path.Type != nil && *match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression {
 				return fmt.Errorf("regex path matching is not yet supported for httproute")
 			}
 
 			// we don't support regex header matching rules
+			// See: https://github.com/Kong/kubernetes-ingress-controller/issues/2154
 			for _, hdr := range match.Headers {
 				if hdr.Type != nil && *hdr.Type == gatewayv1alpha2.HeaderMatchRegularExpression {
 					return fmt.Errorf("regex header matching is not yet supported for httproute")

--- a/internal/validation/gateway/httproute_test.go
+++ b/internal/validation/gateway/httproute_test.go
@@ -17,6 +17,8 @@ func TestValidateHTTPRoute(t *testing.T) {
 	defaultGWNamespace := gatewayv1alpha2.Namespace(corev1.NamespaceDefault)
 	pathMatchRegex := gatewayv1alpha2.PathMatchRegularExpression
 	headerMatchRegex := gatewayv1alpha2.HeaderMatchRegularExpression
+	exampleGroup := gatewayv1alpha2.Group("example")
+	podKind := gatewayv1alpha2.Kind("Pod")
 
 	for _, tt := range []struct {
 		msg           string
@@ -421,6 +423,121 @@ func TestValidateHTTPRoute(t *testing.T) {
 			valid:         false,
 			validationMsg: "httproute spec did not pass validation",
 			err:           fmt.Errorf("multiple backendRefs is not yet supported for httproute"),
+		},
+		{
+			msg: "we don't support any group except core kubernetes for backendRefs",
+			route: &gatewayv1alpha2.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-httproute",
+				},
+				Spec: gatewayv1alpha2.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentRef{{
+							Name: "testing-gateway",
+						}},
+					},
+					Rules: []gatewayv1alpha2.HTTPRouteRule{{
+						Matches: []gatewayv1alpha2.HTTPRouteMatch{{
+							Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
+								Name:  "Content-Type",
+								Value: "audio/vorbis",
+							}},
+						}},
+						BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1alpha2.BackendRef{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Group:     &exampleGroup,
+										Kind:      &podKind,
+										Namespace: &defaultGWNamespace,
+										Name:      "service1",
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			gateways: []*gatewayv1alpha2.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-gateway",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					Listeners: []gatewayv1alpha2.Listener{{
+						Name:     "http",
+						Port:     80,
+						Protocol: gatewayv1alpha2.HTTPProtocolType,
+						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+								Group: &group,
+								Kind:  "HTTPRoute",
+							}},
+						},
+					}},
+				},
+			}},
+			valid:         false,
+			validationMsg: "httproute spec did not pass validation",
+			err:           fmt.Errorf("example is not a supported group for httproute backendRefs, only core is supported"),
+		},
+		{
+			msg: "we don't support any core kind except Service for backendRefs",
+			route: &gatewayv1alpha2.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-httproute",
+				},
+				Spec: gatewayv1alpha2.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentRef{{
+							Name: "testing-gateway",
+						}},
+					},
+					Rules: []gatewayv1alpha2.HTTPRouteRule{{
+						Matches: []gatewayv1alpha2.HTTPRouteMatch{{
+							Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
+								Name:  "Content-Type",
+								Value: "audio/vorbis",
+							}},
+						}},
+						BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1alpha2.BackendRef{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Kind:      &podKind,
+										Namespace: &defaultGWNamespace,
+										Name:      "service1",
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			gateways: []*gatewayv1alpha2.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-gateway",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					Listeners: []gatewayv1alpha2.Listener{{
+						Name:     "http",
+						Port:     80,
+						Protocol: gatewayv1alpha2.HTTPProtocolType,
+						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+								Group: &group,
+								Kind:  "HTTPRoute",
+							}},
+						},
+					}},
+				},
+			}},
+			valid:         false,
+			validationMsg: "httproute spec did not pass validation",
+			err:           fmt.Errorf("Pod is not a supported kind for httproute backendRefs, only Service is supported"),
 		},
 	} {
 		valid, validMsg, err := ValidateHTTPRoute(tt.route, tt.gateways...)


### PR DESCRIPTION
**What this PR does / why we need it**:

Some validation was missing for unsupported `HTTPRoute` features which this PR adds.