### PR TITLE
do not merge: testing out codecov thresholds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  range: "99..100"


### PR DESCRIPTION
This toy PR verifies that the `.codecov.yaml` file in the repository is respected by the codecov GH Action.

It's a draft, not to be merged, to be closed after the test.