### PR TITLE
fix(ci) rename nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,4 @@
-name: release
+name: nightly
 
 on:
   schedule:


### PR DESCRIPTION
Job worked, but forgot to rename it something different than the actual release job.