### PR TITLE
fix: validation for update-in-place unique constrained credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## [2.1.2]
+
+> Release date: TBD
+
+- Fixed an issue where validation could fail for credentials secrets if the
+  `value` for a unique constrained `key` were updated in place while linked
+  to a managed `KongConsumer`.
+  [#2190](https://github.com/Kong/kubernetes-ingress-controller/issues/2190)
+
 ## [2.1.1]
 
 > Release date: 2022/01/05

--- a/internal/admission/utils.go
+++ b/internal/admission/utils.go
@@ -40,11 +40,24 @@ func listManagedConsumersReferencingCredentialsSecret(secret corev1.Secret, mana
 // using a given controller-runtime client. This provides an index based on
 // ALL namespaces in the cluster. This can be very expensive with high numbers
 // of consumer credentials, particularly if the client you provide is not cached
-func globalValidationIndexForCredentials(ctx context.Context, managerClient client.Client, consumers []*kongv1.KongConsumer) (credsvalidation.Index, error) {
+//
+// if the caller is building the index to validate updates for specific secrets
+// and those secrets should be excluded from the index because they will be added
+// later, a map of the namespace and name of those secrets can be provided to exclude them.
+func globalValidationIndexForCredentials(ctx context.Context, managerClient client.Client, consumers []*kongv1.KongConsumer, ignoredSecrets map[string]map[string]struct{}) (credsvalidation.Index, error) {
 	// pull the reference secrets for credentials from each consumer in the list
 	index := make(credsvalidation.Index)
 	for _, consumer := range consumers {
 		for _, secretName := range consumer.Credentials {
+			// if its been requested that this secret be specifically ignored
+			// (e.g. that secret is being updated and will soon have new values)
+			// then don't add it to the index.
+			if secrets, namespaceContainsSkippedSecrets := ignoredSecrets[consumer.Namespace]; namespaceContainsSkippedSecrets {
+				if _, secretShouldBeSkipped := secrets[secretName]; secretShouldBeSkipped {
+					continue
+				}
+			}
+
 			// grab a copy of the credential secret
 			secret := &corev1.Secret{}
 			if err := managerClient.Get(ctx, client.ObjectKey{
@@ -58,7 +71,7 @@ func globalValidationIndexForCredentials(ctx context.Context, managerClient clie
 			}
 
 			// add the credential secret to the index
-			if err := index.ValidateCredentialsForUniqueKeyConstraints(consumer.Name, secret); err != nil {
+			if err := index.ValidateCredentialsForUniqueKeyConstraints(secret); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -135,7 +135,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 		// validate unique key constraints. That index should omit the secrets that
 		// are referenced by this consumer to avoid duplication.
 		if _, ok := ignoredSecrets[consumer.Namespace]; !ok {
-			ignoredSecrets[consumer.Namespace] = make(map[string]struct{})
+			ignoredSecrets[consumer.Namespace] = make(map[string]struct{}, len(consumer.Credentials))
 		}
 		ignoredSecrets[consumer.Namespace][secretName] = struct{}{}
 	}
@@ -194,12 +194,12 @@ func (validator KongHTTPValidator) ValidateCredential(
 	}
 
 	// now that we know at least one managed consumer is referencing this
-	// secret we perform the base level credentials secret validation.
+	// secret we perform the base-level credentials secret validation.
 	if err := credsvalidation.ValidateCredentials(&secret); err != nil {
 		return false, ErrTextConsumerCredentialValidationFailed, err
 	}
 
-	// if base level validation passes we move on to create an index of
+	// if base-level validation passes we move on to create an index of
 	// all managed credentials so that we can verify that the updates to
 	// this secret are not in violation of any unique key constraints.
 	ignoreSecrets := map[string]map[string]struct{}{secret.Namespace: {secret.Name: {}}}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -123,7 +123,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 		}
 
 		// do the basic credentials validation
-		if err := credsvalidation.ValidateCredentials(consumer.Name, secret); err != nil {
+		if err := credsvalidation.ValidateCredentials(secret); err != nil {
 			return false, ErrTextConsumerCredentialValidationFailed, err
 		}
 

--- a/internal/validation/consumers/credentials/validation.go
+++ b/internal/validation/consumers/credentials/validation.go
@@ -14,7 +14,7 @@ import (
 
 // ValidateCredentials performs basic validation on a credential secret given
 // the Kubernetes secret which contains credentials data.
-func ValidateCredentials(consumerName string, secret *corev1.Secret) error {
+func ValidateCredentials(secret *corev1.Secret) error {
 	// the indication of credential type is required to be present on all credentials.
 	credentialTypeB, ok := secret.Data[TypeKey]
 	if !ok {
@@ -87,14 +87,6 @@ func IsKeyUniqueConstrained(keyType, key string) (constrained bool) {
 // Credential is a metadata struct to help validate the contents of
 // consumer credentials, particularly unique constraints on the underlying data.
 type Credential struct {
-	// ConsumerName indicates the name of the KongConsumer which this credential
-	// is supplied for.
-	ConsumerName string
-
-	// ConsumerNamespace indicates the namespace that the KongConsumer which this
-	// credential is supplied for.
-	ConsumerNamespace string
-
 	// Type indicates the credential type, which will reference one of the types
 	// in the SupportedTypes set.
 	Type string
@@ -120,7 +112,7 @@ type Index map[string]map[string]map[string]struct{}
 // ValidateCredentialsForUniqueKeyConstraints will attempt to add a new Credential to the CredentialsTypeMap
 // and will validate it for both normal structure validation and for
 // unique key constraint violations.
-func (cs Index) ValidateCredentialsForUniqueKeyConstraints(consumerName string, secret *corev1.Secret) error {
+func (cs Index) ValidateCredentialsForUniqueKeyConstraints(secret *corev1.Secret) error {
 	// the indication of credential type is required to be present on all credentials.
 	credentialTypeB, ok := secret.Data[TypeKey]
 	if !ok {
@@ -134,11 +126,9 @@ func (cs Index) ValidateCredentialsForUniqueKeyConstraints(consumerName string, 
 	// from this include the unique key constraint errors.
 	for k, v := range secret.Data {
 		if err := cs.add(Credential{
-			ConsumerName:      consumerName,
-			ConsumerNamespace: secret.Namespace,
-			Type:              credentialType,
-			Key:               k,
-			Value:             string(v),
+			Type:  credentialType,
+			Key:   k,
+			Value: string(v),
 		}); err != nil {
 			return err
 		}

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -559,6 +559,11 @@ func TestValidationWebhook(t *testing.T) {
 	_, err = kongClient.ConfigurationV1().KongConsumers(ns.Name).Create(ctx, validConsumerLinkedToInvalidCredentials, metav1.CreateOptions{})
 	require.NoError(t, err)
 
+	t.Log("verifying that the valid credentials which include a unique-constrained key can be updated in place")
+	validCredential.Data["value"] = []byte("newpassword")
+	validCredential, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Update(ctx, validCredential, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
 	t.Log("verifying that validation fails if the now referenced and valid credential gets updated to become invalid")
 	validCredential.Data["kongCredType"] = []byte("invalid-auth")
 	_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Update(ctx, validCredential, metav1.UpdateOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

We had a previous oversight in our recent validation code and tests which missed the case where a credential `Secret` referenced by a managed `KongConsumer` could wrongly fail validation if it employed a unique constrained key and the value was updated. This patch fixes that issue and adds an integration test item for the missing coverage.

**Which issue this PR fixes**

Resolves #2190 

**Special notes for your reviewer**:

I tested the new integration test for this against in `main`, where it failed (expected) prior to this branch where it now passes.

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated 
