### PR TITLE
ci(*) add integration test to targeted job

### DIFF
--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -17,6 +17,10 @@ on:
         description: 'KIC Docker image to test with. The default "localhost:5000/kong/kubernetes-ingress-controller:ci" builds an image from the dispatch branch'
         required: true
         default: 'localhost:5000/kong/kubernetes-ingress-controller:ci'
+      include-integration:
+        description: 'Set to "true" to run integration tests also'
+        required: true
+        default: 'false'
 
 jobs:
   e2e-tests:
@@ -76,3 +80,32 @@ jobs:
         ISTIO_VERSION: ${{ github.event.inputs.istio-version }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job, so only 1 is allowed at a time.
+
+  integration-tests:
+    if: ${{ github.event.inputs.include-integration == 'true' }}
+    environment: "Configure ci"
+    runs-on: ubuntu-latest
+    steps:
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.17'
+
+    - name: cache go modules
+      uses: actions/cache@v2.1.7
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: run integration tests
+      run: make test.integration
+      env:
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an option to run integration tests to the targeted job, disabled by default. This allows running integration tests in CI against an arbitrary Kubernetes version.
