### PR TITLE
test: global webhook for integration tests

### DIFF
--- a/internal/test/util/admission.go
+++ b/internal/test/util/admission.go
@@ -1,0 +1,178 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	admregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// -----------------------------------------------------------------------------
+// Test Utilities - Admission Webhooks - Public Vars & Consts
+// -----------------------------------------------------------------------------
+
+const (
+	// XXX (this hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613):
+	//
+	// The test process (`go test github.com/Kong/kubernetes-ingress-controller/test/integration/...`) serves the webhook
+	// endpoints to be consumed by the apiserver (so that the tests can apply a ValidatingWebhookConfiguration and test
+	// those validations).
+	// In order to make that possible, we needed to allow the apiserver (that gets spun up by the test harness) to access
+	// the system under test (which runs as a part of the `go test` process).
+	// In the constants below, we're making an audacious assumption that the host running the `go test` process is also
+	// the Docker host on the default bridge (therefore it can listen on 172.17.0.1), and that the apiserver
+	// is running within a context (such as KIND running on that same docker bridge), from which 172.17.0.1 is routable.
+	// This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
+	AdmissionWebhookListenHost = "172.17.0.1"
+	AdmissionWebhookListenPort = 49023
+
+	webhookTimeout = time.Minute * 3
+)
+
+// -----------------------------------------------------------------------------
+// Test Utilities - Admission Webhooks - Public Functions
+// -----------------------------------------------------------------------------
+
+// EnsureAdmissionRegistration ensures that for a provided list of admission
+// rules with operations a webhook is registered in the provided test cluster
+// and creates a Service where that webhook will be exposed.
+//
+// A cleanup function is returned which will delete the registered webhook
+// when the caller is ready.
+func EnsureAdmissionRegistration(ctx context.Context, cluster clusters.Cluster, namespace string, rules ...admregv1.RuleWithOperations) (func() error, error) {
+	svcName := "webhook-kong-integration-tests"
+	svcCloser, err := ensureWebhookService(ctx, cluster, namespace, svcName)
+	if err != nil {
+		return nil, err
+	}
+
+	fail := admregv1.Fail
+	none := admregv1.SideEffectClassNone
+	webhook, err := cluster.Client().AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx,
+		&admregv1.ValidatingWebhookConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "admissionregistration.k8s.io/v1",
+				Kind:       "ValidatingWebhookConfiguration",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kong-integration-tests",
+			},
+			Webhooks: []admregv1.ValidatingWebhook{
+				{
+					Name:                    "validations.kong.konghq.com",
+					FailurePolicy:           &fail,
+					SideEffects:             &none,
+					AdmissionReviewVersions: []string{"v1beta1", "v1"},
+					Rules:                   rules,
+					ClientConfig: admregv1.WebhookClientConfig{
+						Service: &admregv1.ServiceReference{
+							Namespace: namespace,
+							Name:      svcName,
+						},
+						CABundle: []byte(KongSystemServiceCert),
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	closer := func() error {
+		if err := cluster.Client().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhook.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		return svcCloser()
+	}
+
+	return closer, waitForWebhookService()
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities - Admission Webhooks - Private Functions
+// -----------------------------------------------------------------------------
+
+func ensureWebhookService(ctx context.Context, cluster clusters.Cluster, namespace, name string) (func() error, error) {
+	validationsService, err := cluster.Client().CoreV1().Services(namespace).Create(ctx, &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "default",
+					Port:       443,
+					TargetPort: intstr.FromInt(AdmissionWebhookListenPort),
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating webhook service: %w", err)
+	}
+
+	nodeName := "aaaa"
+	endpoints, err := cluster.Client().CoreV1().Endpoints(namespace).Create(ctx, &corev1.Endpoints{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Endpoints"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP:       AdmissionWebhookListenHost,
+						NodeName: &nodeName,
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "default",
+						Port:     AdmissionWebhookListenPort,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating webhook endpoints: %w", err)
+	}
+
+	closer := func() error {
+		if err := cluster.Client().CoreV1().Services(namespace).Delete(ctx, validationsService.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		if err := cluster.Client().CoreV1().Endpoints(namespace).Delete(ctx, endpoints.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	return closer, nil
+}
+
+func waitForWebhookService() error {
+	timeout := time.Now().Add(webhookTimeout)
+	consistentReplies := 0
+	for timeout.After(time.Now()) {
+		_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", AdmissionWebhookListenHost, AdmissionWebhookListenPort), 1*time.Second)
+		if err == nil {
+			// if we've gotten at least 3 success replies in a row, consider the webhook service ready
+			consistentReplies++
+			if consistentReplies >= 3 {
+				return nil
+			}
+			continue // if we haven't quite reached 3 successes in a row, keep trying
+		}
+		consistentReplies = 0 // any failures reset the consistent replies check
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("admission webhook did not become responsive within %s", webhookTimeout)
+}

--- a/internal/test/util/admission_cert.go
+++ b/internal/test/util/admission_cert.go
@@ -1,10 +1,7 @@
-//go:build integration_tests
-// +build integration_tests
-
-package integration
+package util
 
 const (
-	// kongSystemServiceCert is a testing TLS certificate with SAN *.kong-system.svc.
+	// KongSystemServiceCert is a testing TLS certificate with SAN *.kong-system.svc.
 	//
 	// created with:
 	//
@@ -23,7 +20,7 @@ const (
 	//     echo 'distinguished_name=req'; \
 	//     echo '[san]'; \
 	//     echo 'subjectAltName=DNS:*.kong-system.svc')
-	kongSystemServiceCert = `-----BEGIN CERTIFICATE-----
+	KongSystemServiceCert = `-----BEGIN CERTIFICATE-----
 MIIE5jCCAs6gAwIBAgIUCAQsA6yH5M6/LgmSg/89y4NPB8UwDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRKi5rb25nLXN5c3RlbS5zdmMwHhcNMjIwMTA1MTY0MjE4
 WhcNMzExMDA1MTY0MjE4WjAcMRowGAYDVQQDDBEqLmtvbmctc3lzdGVtLnN2YzCC
@@ -52,8 +49,8 @@ ftDKUoUKvhFhetW5VsTVGESWP26LhmQ6oaz6eJPC26skKq+w2rAeZ2EU8fhBwzCX
 vv2SWWk6xtzxMyD2w3IXPlUCzpkTwkT6tC7qf5RYA/y+Qr81pbbp6q3OEQ51BaKI
 nyC7Cdnomxtx6A==
 -----END CERTIFICATE-----`
-	// kongSystemServiceKey is the private key for the testing certificate kongSystemServiceCert.
-	kongSystemServiceKey = `-----BEGIN PRIVATE KEY-----
+	// KongSystemServiceKey is the private key for the testing certificate kongSystemServiceCert.
+	KongSystemServiceKey = `-----BEGIN PRIVATE KEY-----
 MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQC+nwgZHTpTr5hq
 F8Vu2bDEA5xDSdwUQnnKOCXs29EiWBv3qVx95nl7YodBObaxdS1hlTnxj4Ev99jQ
 gBpz1S3q3IUMQFS/6a4e/vz42Jvtlr8Q4KC6rSPojnWu6Llz55eeELadKwfdOghM
@@ -105,20 +102,4 @@ aTT92eGFDCftg0FohOm6LX2bteuhREbVIycWy/I67kJ/M2F/70gCEdBw2LJsiGyO
 FK4IYsWdsJCKft+/IlUSgYYWY6GHOcfP3R34ibx7P244kqwknmTzxBKYnybGeyVT
 ctFsgXhf5+tDgbBZpcuTMpd3KnaDUYg=
 -----END PRIVATE KEY-----`
-)
-
-const (
-	// XXX (this hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613):
-	//
-	// The test process (`go test github.com/Kong/kubernetes-ingress-controller/test/integration/...`) serves the webhook
-	// endpoints to be consumed by the apiserver (so that the tests can apply a ValidatingWebhookConfiguration and test
-	// those validations).
-	// In order to make that possible, we needed to allow the apiserver (that gets spun up by the test harness) to access
-	// the system under test (which runs as a part of the `go test` process).
-	// In the constants below, we're making an audacious assumption that the host running the `go test` process is also
-	// the Docker host on the default bridge (therefore it can listen on 172.17.0.1), and that the apiserver
-	// is running within a context (such as KIND running on that same docker bridge), from which 172.17.0.1 is routable.
-	// This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
-	admissionWebhookListenHost = "172.17.0.1"
-	admissionWebhookListenPort = 49023
 )

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -109,7 +109,7 @@ func validateHTTPRouteFeatures(httproute *gatewayv1alpha2.HTTPRoute) error {
 
 		// we don't support any backendRef types except Kubernetes Services
 		for _, ref := range rule.BackendRefs {
-			if ref.BackendRef.Group != nil && *ref.BackendRef.Group != "core" {
+			if ref.BackendRef.Group != nil && *ref.BackendRef.Group != "core" && *ref.BackendRef.Group != "" {
 				return fmt.Errorf("%s is not a supported group for httproute backendRefs, only core is supported", *ref.BackendRef.Group)
 			}
 			if ref.BackendRef.Kind != nil && *ref.BackendRef.Kind != "Service" {

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,26 +28,6 @@ func TestGatewayValidationWebhook(t *testing.T) {
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")
 	}
-
-	closer, err := ensureAdmissionRegistration(
-		"kong-validations-gateway",
-		[]admregv1.RuleWithOperations{
-			{
-				Rule: admregv1.Rule{
-					APIGroups:   []string{"gateway.networking.k8s.io"},
-					APIVersions: []string{"v1alpha2"},
-					Resources:   []string{"gateways"},
-				},
-				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
-			},
-		},
-	)
-	assert.NoError(t, err, "creating webhook config")
-	defer func() {
-		assert.NoError(t, closer())
-	}()
-
-	waitForWebhookService(t)
 
 	t.Log("creating a gatewayclass to verify gateway validation")
 	gatewayc, err := gatewayclient.NewForConfig(env.Cluster().Config())

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -29,26 +28,6 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 	}
 
 	pathMatchRegex := gatewayv1alpha2.PathMatchRegularExpression
-
-	closer, err := ensureAdmissionRegistration(
-		"kong-validations-gateway",
-		[]admregv1.RuleWithOperations{
-			{
-				Rule: admregv1.Rule{
-					APIGroups:   []string{"gateway.networking.k8s.io"},
-					APIVersions: []string{"v1alpha2"},
-					Resources:   []string{"httproutes"},
-				},
-				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
-			},
-		},
-	)
-	assert.NoError(t, err, "creating webhook config")
-	defer func() {
-		assert.NoError(t, closer())
-	}()
-
-	waitForWebhookService(t)
 
 	t.Log("creating a managed gatewayclass")
 	gatewayc, err := gatewayclient.NewForConfig(env.Cluster().Config())

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -15,11 +14,9 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -54,34 +51,6 @@ func TestValidationWebhook(t *testing.T) {
 			}
 		}
 	}()
-
-	closer, err := ensureAdmissionRegistration(
-		"kong-validations-consumer",
-		[]admregv1.RuleWithOperations{
-			{
-				Rule: admregv1.Rule{
-					APIGroups:   []string{""},
-					APIVersions: []string{"v1"},
-					Resources:   []string{"secrets"},
-				},
-				Operations: []admregv1.OperationType{admregv1.Update},
-			},
-			{
-				Rule: admregv1.Rule{
-					APIGroups:   []string{"configuration.konghq.com"},
-					APIVersions: []string{"v1"},
-					Resources:   []string{"kongconsumers"},
-				},
-				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
-			},
-		},
-	)
-	assert.NoError(t, err, "creating webhook config")
-	defer func() {
-		assert.NoError(t, closer())
-	}()
-
-	waitForWebhookService(t)
 
 	t.Log("creating a large number of consumers on the cluster to verify the performance of the cached client during validation")
 	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
@@ -606,111 +575,4 @@ func TestValidationWebhook(t *testing.T) {
 	_, err = kongClient.ConfigurationV1().KongConsumers(ns.Name).Create(ctx, jwtConsumer, metav1.CreateOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "some fields were invalid due to missing data: rsa_public_key, key, secret")
-}
-
-func ensureWebhookService(name string) (func() error, error) {
-	validationsService, err := env.Cluster().Client().CoreV1().Services(controllerNamespace).Create(ctx, &corev1.Service{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "default",
-					Port:       443,
-					TargetPort: intstr.FromInt(admissionWebhookListenPort),
-				},
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("creating webhook service: %w", err)
-	}
-
-	nodeName := "aaaa"
-	endpoints, err := env.Cluster().Client().CoreV1().Endpoints(controllerNamespace).Create(ctx, &corev1.Endpoints{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Endpoints"},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Subsets: []corev1.EndpointSubset{
-			{
-				Addresses: []corev1.EndpointAddress{
-					{
-						IP:       admissionWebhookListenHost,
-						NodeName: &nodeName,
-					},
-				},
-				Ports: []corev1.EndpointPort{
-					{
-						Name:     "default",
-						Port:     admissionWebhookListenPort,
-						Protocol: corev1.ProtocolTCP,
-					},
-				},
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("creating webhook endpoints: %w", err)
-	}
-
-	closer := func() error {
-		if err := env.Cluster().Client().CoreV1().Services(controllerNamespace).Delete(ctx, validationsService.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
-		if err := env.Cluster().Client().CoreV1().Endpoints(controllerNamespace).Delete(ctx, endpoints.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-		return nil
-	}
-
-	return closer, nil
-}
-
-func waitForWebhookService(t *testing.T) {
-	require.Eventually(t, func() bool {
-		_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", admissionWebhookListenHost, admissionWebhookListenPort), 1*time.Second)
-		return err == nil
-	}, ingressWait, waitTick, "waiting for the admission service to be up")
-}
-
-func ensureAdmissionRegistration(configResourceName string, rules []admregv1.RuleWithOperations) (func() error, error) {
-	svcName := fmt.Sprintf("webhook-%s", configResourceName)
-	svcCloser, err := ensureWebhookService(svcName)
-	if err != nil {
-		return nil, err
-	}
-
-	fail := admregv1.Fail
-	none := admregv1.SideEffectClassNone
-	webhook, err := env.Cluster().Client().AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx,
-		&admregv1.ValidatingWebhookConfiguration{
-			TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
-			ObjectMeta: metav1.ObjectMeta{Name: configResourceName},
-			Webhooks: []admregv1.ValidatingWebhook{
-				{
-					Name:                    "validations.kong.konghq.com",
-					FailurePolicy:           &fail,
-					SideEffects:             &none,
-					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					Rules:                   rules,
-					ClientConfig: admregv1.WebhookClientConfig{
-						Service:  &admregv1.ServiceReference{Namespace: controllerNamespace, Name: svcName},
-						CABundle: []byte(kongSystemServiceCert),
-					},
-				},
-			},
-		}, metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	closer := func() error {
-		if err := env.Cluster().Client().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhook.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-		return svcCloser()
-	}
-
-	return closer, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we only tested the webhook in specific tests and set up a separate validating webhook for each test. This patch combines all webhook operations into a single validatingwebhook and pre-deploys it before any integration tests run. The benefits of this include simpler code and easier maintenance, but also this means we'll be running validation on ALL tests going forward, so tests can not be written in a way that would be otherwise invalid because the webhook isn't enabled.

- [ ] TODO separate handling of some tests for kind vs other cluster types