### PR TITLE
Release 2.2.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,8 +16,9 @@ jobs:
           - 'v1.22.4'
           - 'v1.23.3'
         istio-version:
-          - 'v1.11.4'
-          - 'v1.10.5'
+          - 'v1.12.2'
+          - 'v1.11.5'
+          - 'v1.10.6'
           - 'v1.9.9'
     steps:
     - name: setup golang

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         kubernetes-version:
           - 'v1.21.2'
-          - 'v1.22.0'
+          - 'v1.22.4'
+          - 'v1.23.3'
         istio-version:
           - 'v1.11.4'
           - 'v1.10.5'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - 'v1.22.0'
+          - 'v1.23.3'
         dbmode:
           - 'dbless'
           - 'postgres'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       run: go install github.com/mikefarah/yq/v4@latest
 
     - name: Setup golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
 
     - name: Run golangci-lint
       run: make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1561,6 +1561,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.6...v2.1.0
 [2.0.7]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.0.6...v2.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,16 +44,23 @@
 
 ## [2.2.0]
 
-> Release date: TBD
+> Release date: 2022/02/04
 
 #### Added
 
+- Support for Kubernetes [Gateway APIs][gwapis] is now available [by enabling 
+  the `Gateway` feature gate](https://docs.konghq.com/kubernetes-ingress-controller/2.2.x/guides/using-gateway-api/).
+  This is an alpha feature, with limited support for the `HTTPRoute` API.
+  [Gateway Milestone 1][gwm1]
 - Kubernetes client rate limiting can now be configured using `--apiserver-qps`
   (default 100) and `--apiserver-burst` (default 300) settings. Defaults have
   been increased to prevent ratelimiting under normal loads.
   [#2169](https://github.com/Kong/kubernetes-ingress-controller/issues/2169)
 - The KIC Grafana dashboard [is now published on grafana.com](https://grafana.com/grafana/dashboards/15662).
   [#2235](https://github.com/Kong/kubernetes-ingress-controller/issues/2235)
+
+[gwapis]:https://github.com/kubernetes-sigs/gateway-api
+[gwm1]:https://github.com/Kong/kubernetes-ingress-controller/milestone/21
 
 #### Fixed
 

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '2.7'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.1.1'
+  newTag: '2.2.0'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1381,7 +1381,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.1.1
+        image: kong/kubernetes-ingress-controller:2.2.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1376,7 +1376,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.1.1
+        image: kong/kubernetes-ingress-controller:2.2.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1450,7 +1450,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.1.1
+        image: kong/kubernetes-ingress-controller:2.2.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1394,7 +1394,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.1.1
+        image: kong/kubernetes-ingress-controller:2.2.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -109,7 +109,7 @@ func validateHTTPRouteFeatures(httproute *gatewayv1alpha2.HTTPRoute) error {
 
 		// we don't support any backendRef types except Kubernetes Services
 		for _, ref := range rule.BackendRefs {
-			if ref.BackendRef.Group != nil && *ref.BackendRef.Group != "core" {
+			if ref.BackendRef.Group != nil && *ref.BackendRef.Group != "core" && *ref.BackendRef.Group != "" {
 				return fmt.Errorf("%s is not a supported group for httproute backendRefs, only core is supported", *ref.BackendRef.Group)
 			}
 			if ref.BackendRef.Kind != nil && *ref.BackendRef.Kind != "Service" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Releases `v2.2.0` which notably includes a technical preview level of support for [Gateway APIs](https://github.com/kubernetes-sigs/gateway-api).

**Which issue this PR fixes**

Resolves #2231

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated