### PR TITLE
Fix test flakes

### DIFF
--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"os"
 	"strconv"
@@ -270,6 +271,9 @@ func runTestTLSServer(ctx context.Context, t *testing.T, listen net.Listener, re
 			conn, err := listen.Accept()
 			if err != nil {
 				// we expect "use of closed network connection" when the test ends, since it will be blocked on accept
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
 				t.Logf("could not accept TLS connection: %v", err)
 				return
 			}

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -348,7 +348,7 @@ func TestHTTPSIngress(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Log("checking second ingress status readiness")
 	assert.Eventually(t, func() bool {
@@ -363,7 +363,7 @@ func TestHTTPSIngress(t *testing.T) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Log("waiting for routes from Ingress to be operational with expected certificate")
 	assert.Eventually(t, func() bool {

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -28,6 +28,8 @@ import (
 // extraIngressNamespace is the name of an alternative namespace used for ingress tests
 const extraIngressNamespace = "elsewhere"
 
+var statusWait = time.Minute * 3
+
 func TestIngressEssentials(t *testing.T) {
 	t.Parallel()
 	ns, cleanup := namespace(t)
@@ -79,7 +81,7 @@ func TestIngressEssentials(t *testing.T) {
 			return false
 		}
 		return len(lbstatus.Ingress) > 0
-	}, ingressWait, waitTick)
+	}, statusWait, waitTick)
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
@@ -231,7 +233,7 @@ func TestGRPCIngressEssentials(t *testing.T) {
 			return false
 		}
 		return len(lbstatus.Ingress) > 0
-	}, ingressWait, waitTick)
+	}, statusWait, waitTick)
 
 	// So far this only tests that the ingress is created and receives status information, to confirm the fix for
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/1991
@@ -604,7 +606,7 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 			return false
 		}
 		return len(lbstatus.Ingress) > 0
-	}, time.Minute, time.Second)
+	}, statusWait, waitTick)
 
 	t.Log("verifying that when a service has more than one ingress, the status updates for those beyond the first")
 	require.Eventually(t, func() bool {
@@ -617,5 +619,5 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 			return false
 		}
 		return len(lbstatus.Ingress) > 0
-	}, time.Minute, time.Second)
+	}, statusWait, waitTick)
 }

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -154,7 +154,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	url := "http://" + proxy
 	tr := &http.Transport{

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -116,7 +116,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Logf("verifying TCP Ingress %s operational", tcp.Name)
 	tcpProxyURL, err := url.Parse(fmt.Sprintf("http://%s:8888/", proxyURL.Hostname()))

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -143,7 +143,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udp.Name)
 	assert.Eventually(t, func() bool {
@@ -278,7 +278,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udp.Name)
 	assert.Eventually(t, func() bool {
@@ -333,7 +333,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 1*time.Second, true)
+	}, statusWait, waitTick, true)
 
 	t.Logf("checking DNS to resolve via TCPIngress %s", tcp.Name)
 	assert.Eventually(t, func() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses two unrelated test flakes:
- We log an expected error during reporter unit tests using the test logger, but outside the test goroutine. This can run after the test completes successfully, and if so it results in a panic because the test logger is no longer available. This change disables logging if the error is the expected type.
- Standardize and lengthen the time allowed for status updates in integration tests. For whatever reason, status updates in CI appear to be particularly slow, and time out randomly after unrelated changes. I can never replicate these when running the individual test, so this appears to be a side effect of limited resources and concurrency in CI rather than any actual problem in the code.
