### PR TITLE
feat(gateway) support HTTPRoute regex and exact matches

### DIFF
--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -122,11 +122,6 @@ func generateKongRoutesFromHTTPRouteRule(httproute *gatewayv1alpha2.HTTPRoute, r
 				return nil, fmt.Errorf("query param matches are not yet supported")
 			}
 
-			// TODO: implement regex path matches
-			if *match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression {
-				return nil, fmt.Errorf("regular expression path matches are not yet supported")
-			}
-
 			// build the route object using the method and pathing information
 			r := kongstate.Route{
 				Ingress: objectInfo,
@@ -149,7 +144,9 @@ func generateKongRoutesFromHTTPRouteRule(httproute *gatewayv1alpha2.HTTPRoute, r
 				r.Route.Paths = []*string{match.Path.Value}
 
 				// determine whether path stripping needs to be enabled
-				r.Route.StripPath = kong.Bool(match.Path.Type == nil || *match.Path.Type == gatewayv1alpha2.PathMatchPathPrefix)
+				r.Route.StripPath = kong.Bool(match.Path.Type == nil ||
+					*match.Path.Type == gatewayv1alpha2.PathMatchPathPrefix ||
+					*match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression)
 			}
 
 			// configure method matching information about the route if method

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -142,11 +142,6 @@ func generateKongRoutesFromHTTPRouteRule(httproute *gatewayv1alpha2.HTTPRoute, r
 			if match.Path != nil {
 				// determine the path match values
 				r.Route.Paths = []*string{match.Path.Value}
-
-				// determine whether path stripping needs to be enabled
-				r.Route.StripPath = kong.Bool(match.Path.Type == nil ||
-					*match.Path.Type == gatewayv1alpha2.PathMatchPathPrefix ||
-					*match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression)
 			}
 
 			// configure method matching information about the route if method

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -137,11 +137,17 @@ func generateKongRoutesFromHTTPRouteRule(httproute *gatewayv1alpha2.HTTPRoute, r
 				r.Hosts = hostnames
 			}
 
-			// configure path matching information about the route if paths
-			// matching was defined.
+			// configure path matching information about the route if paths matching was defined
+			// Kong automatically infers whether or not a path is a regular expression and uses a prefix match by
+			// default it it is not. For those types, we use the path value as-is and let Kong determine the type.
+			// For exact matches, we transform the path into a regular expression that terminates after the value
 			if match.Path != nil {
-				// determine the path match values
-				r.Route.Paths = []*string{match.Path.Value}
+				if *match.Path.Type == gatewayv1alpha2.PathMatchExact {
+					terminated := *match.Path.Value + "$"
+					r.Route.Paths = []*string{&terminated}
+				} else if *match.Path.Type == gatewayv1alpha2.PathMatchRegularExpression || *match.Path.Type == gatewayv1alpha2.PathMatchPathPrefix {
+					r.Route.Paths = []*string{match.Path.Value}
+				}
 			}
 
 			// configure method matching information about the route if method

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -209,7 +209,6 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 									kong.String("http"),
 									kong.String("https"),
 								},
-								StripPath: kong.Bool(true),
 							},
 							Ingress: util.K8sObjectInfo{
 								Name:        "basic-httproute",
@@ -350,7 +349,6 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 									kong.String("http"),
 									kong.String("https"),
 								},
-								StripPath: kong.Bool(true),
 							},
 							Ingress: util.K8sObjectInfo{
 								Name:        "basic-httproute",

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -112,6 +112,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	httpPort := gatewayv1alpha2.PortNumber(80)
 	pathMatchPrefix := gatewayv1alpha2.PathMatchPathPrefix
 	pathMatchRegularExpression := gatewayv1alpha2.PathMatchRegularExpression
+	pathMatchExact := gatewayv1alpha2.PathMatchExact
 	httproute := &gatewayv1alpha2.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
@@ -137,6 +138,12 @@ func TestHTTPRouteEssentials(t *testing.T) {
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchRegularExpression,
 							Value: kong.String(`/regex-\d{3}-httpbin`),
+						},
+					},
+					{
+						Path: &gatewayv1alpha2.HTTPPathMatch{
+							Type:  &pathMatchExact,
+							Value: kong.String(`/exact-httpbin`),
 						},
 					},
 				},
@@ -168,7 +175,11 @@ func TestHTTPRouteEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>")
+	eventuallyGETPath(t, "httpbin/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
+		http.StatusOK, "«yoʻq» dan boshqa bir javobimiz yoʻqdir.")
 	eventuallyGETPath(t, "regex-123-httpbin", http.StatusOK, "<title>httpbin.org</title>")
+	eventuallyGETPath(t, "exact-httpbin", http.StatusOK, "<title>httpbin.org</title>")
+	eventuallyGETPath(t, "exact-httpbina", http.StatusNotFound, "no Route matched")
 
 	t.Log("removing the parentrefs from the HTTPRoute")
 	oldParentRefs := httproute.Spec.ParentRefs

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -19,6 +19,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/gateway/versioned"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 )
 
@@ -114,6 +115,9 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	httproute := &gatewayv1alpha2.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+			},
 		},
 		Spec: gatewayv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
@@ -132,7 +136,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 					{
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchRegularExpression,
-							Value: kong.String("/regex-\\d{3}-httpbin"),
+							Value: kong.String(`/regex-\d{3}-httpbin`),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for HTTPRoute regex path and exact matches. This basically does nothing other than add tests, as Kong determines the path type automatically and will use regex matching if you give it a path that looks like a regex.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2153 

**Special notes for your reviewer**:
I was unsure how to handle [the automatic selection of strip_path on our end](https://github.com/Kong/kubernetes-ingress-controller/blob/d8274a81b75a941c9eecfacca9df58063c7e3f54/internal/dataplane/parser/translate_httproute.go#L151-L152). Is there part of the Gateway specification that generally requires paths in matches never be sent upstream?

I didn't find anything in https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.PathMatchType and conformance tests don't indicate one way or the other (they currently only test with `/` as the match). By default I'd expect that we don't do any kind-based or spec-based automatic strip-path value and only honor the annotation.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
