### PR TITLE
chore(*) release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ## [2.2.1]
 
-> Release date: TBD
+> Release date: 2022/02/15
 
 #### Fixed
 

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '2.7'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.2.0'
+  newTag: '2.2.1'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1381,7 +1381,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.0
+        image: kong/kubernetes-ingress-controller:2.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1376,7 +1376,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.0
+        image: kong/kubernetes-ingress-controller:2.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1450,7 +1450,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.0
+        image: kong/kubernetes-ingress-controller:2.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1394,7 +1394,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.0
+        image: kong/kubernetes-ingress-controller:2.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Update changelog and manifests for a 2.2.1 release.

**Special notes for your reviewer**:
Only contains the cache warm delay workaround, which I want to get out in a 2.2 release without a backport, before we start merging new 2.3 features.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
