### PR TITLE
chore(ci) update older Kubernetes versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,9 +183,9 @@ jobs:
     strategy:
       matrix:
         minor:
-          - '19'
           - '20'
           - '21'
+          - '22'
         dbmode:
           - 'dbless'
           - 'postgres'


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables Kubernetes 1.19 and adds 1.22 in older version tests.

**Special notes for your reviewer**:
Gateway tests are failing on 1.19 consistently, though they shouldn't per https://gateway-api.sigs.k8s.io/faq/
