### PR TITLE
ci(license) skip secret-required steps when secrets unavailable

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -5,8 +5,17 @@ on:
   pull_request: {}
 
 jobs:
+  runnable:
+    runs-on: ubuntu-latest
+    outputs:
+      runnable: ${{ steps.check.outputs.result }}
+    steps:
+    - name: Check secret availability
+      id: check
+      run: echo ::set-output name=result::${{ secrets.GITHUB_TOKEN != ''}}
   licenses:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license/changed')"
+    needs: runnable
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci/license/changed') && needs.runnable.outputs.runnable == 'true'"
     env:
       GOPATH: ${{ github.workspace }}
       GOBIN: ${{ github.workspace }}/bin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,9 +109,21 @@ jobs:
         name: coverage.unit.out
         path: coverage.unit.out
 
+  runnable:
+    runs-on: ubuntu-latest
+    environment: "Configure ci"
+    outputs:
+      runnable: ${{ steps.check.outputs.result }}
+    steps:
+    - name: Check secret availability
+      id: check
+      run: echo ::set-output name=result::${{ secrets.KONG_LICENSE_DATA != ''}}
+
   integration-tests-enterprise-postgres:
     environment: "Configure ci"
     runs-on: ubuntu-latest
+    needs: runnable
+    if: "needs.runnable.outputs.runnable == 'true'"
     steps:
 
     - name: setup golang


### PR DESCRIPTION
**What this PR does / why we need it**:
Only perform steps that require secrets if those secrets are available.

**Special notes for your reviewer**:
This lacks a means to test behavior for the negative case, since we're all org members, but it at least does not break for us. We will soon be informed if it functions as intended when Dependabot opens something.