### PR TITLE
feat(controllers) add IngressClass v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@
 
 > Release date: TBD
 
+#### Added
+
+- Deployment manifests now include an IngressClass resource and permissions to
+  read IngressClass resources.
+  [#2292](https://github.com/Kong/kubernetes-ingress-controller/pull/2292)
+
 #### Fixed
 
 - Unconfigured fields now use their default value according to the Kong proxy

--- a/config/base/ingressclass.yaml
+++ b/config/base/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: ingress-controllers.konghq.com/kong

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - namespace.yaml
 - ../crd
 - ../rbac
+- ingressclass.yaml
 - service.yaml
 - serviceaccount.yaml
 - validation-service.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -251,6 +251,22 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -259,14 +259,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1201,6 +1201,22 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get
@@ -1414,3 +1430,10 @@ spec:
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
       serviceAccountName: kong-serviceaccount
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: ingress-controllers.konghq.com/kong

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1209,14 +1209,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1201,6 +1201,22 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get
@@ -1407,3 +1423,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       serviceAccountName: kong-serviceaccount
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: ingress-controllers.konghq.com/kong

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1209,14 +1209,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1201,6 +1201,22 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get
@@ -1597,3 +1613,10 @@ spec:
         image: busybox
         name: wait-for-postgres
       restartPolicy: OnFailure
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: ingress-controllers.konghq.com/kong

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1209,14 +1209,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1201,6 +1201,22 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get
@@ -1522,3 +1538,10 @@ spec:
         image: busybox
         name: wait-for-postgres
       restartPolicy: OnFailure
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: ingress-controllers.konghq.com/kong

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1209,14 +1209,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -80,6 +80,18 @@ var inputControllersNeeded = &typesNeeded{
 		RBACVerbs:                         []string{"get", "list", "watch"},
 	},
 	typeNeeded{
+		PackageImportAlias:                "netv1",
+		PackageAlias:                      "NetV1",
+		Package:                           netv1,
+		Type:                              "IngressClass",
+		Plural:                            "ingressclasses",
+		URL:                               "networking.k8s.io",
+		CacheType:                         "IngressV1",
+		AcceptsIngressClassNameAnnotation: false,
+		AcceptsIngressClassNameSpec:       false,
+		RBACVerbs:                         []string{"get", "list", "watch"},
+	},
+	typeNeeded{
 		PackageImportAlias:                "netv1beta1",
 		PackageAlias:                      "NetV1Beta1",
 		Package:                           netv1beta1,

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -39,6 +39,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "services",
 		URL:                               "\"\"",
 		CacheType:                         "Service",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -51,6 +52,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "endpoints",
 		URL:                               "\"\"",
 		CacheType:                         "Endpoint",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"list", "watch"},
@@ -63,6 +65,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "secrets",
 		URL:                               "\"\"",
 		CacheType:                         "Secret",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"list", "watch"},
@@ -75,6 +78,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "ingresses",
 		URL:                               "networking.k8s.io",
 		CacheType:                         "IngressV1",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       true,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -87,6 +91,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "ingressclasses",
 		URL:                               "networking.k8s.io",
 		CacheType:                         "IngressV1",
+		NeedsStatusPermissions:            false,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -99,6 +104,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "ingresses",
 		URL:                               "networking.k8s.io",
 		CacheType:                         "IngressV1beta1",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       true,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -111,6 +117,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "ingresses",
 		URL:                               "extensions",
 		CacheType:                         "IngressV1beta1",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       true,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -123,6 +130,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongingresses",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "KongIngress",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -135,6 +143,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongplugins",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "Plugin",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -147,6 +156,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongclusterplugins",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "ClusterPlugin",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -159,6 +169,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongconsumers",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "Consumer",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -171,6 +182,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "tcpingresses",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "TCPIngress",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -183,6 +195,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "udpingresses",
 		URL:                               "configuration.konghq.com",
 		CacheType:                         "UDPIngress",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -195,6 +208,7 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "ingresses",
 		URL:                               "networking.internal.knative.dev",
 		CacheType:                         "KnativeIngress",
+		NeedsStatusPermissions:            true,
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
@@ -311,6 +325,10 @@ type typeNeeded struct {
 	// AcceptsIngressClassNameSpec indicates the the object indicates the ingress.class that should support it via
 	// an attribute in its specification named .IngressClassName
 	AcceptsIngressClassNameSpec bool
+
+	// NeedsStatusPermissions indicates whether permissions for the object should also include permissions to update
+	// its status
+	NeedsStatusPermissions bool
 }
 
 func (t *typeNeeded) generate(contents *bytes.Buffer) error {
@@ -406,7 +424,9 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) SetupWithManager(mgr ctrl.Manager
 }
 
 //+kubebuilder:rbac:groups={{.URL}},resources={{.Plural}},verbs={{ .RBACVerbs | join ";" }}
+{{- if .NeedsStatusPermissions}}
 //+kubebuilder:rbac:groups={{.URL}},resources={{.Plural}}/status,verbs=get;update;patch
+{{- end}}
 
 // Reconcile processes the watched objects
 func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -316,7 +316,6 @@ func (r *NetV1IngressClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses/status,verbs=get;update;patch
 
 // Reconcile processes the watched objects
 func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -298,6 +298,67 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 // -----------------------------------------------------------------------------
+// NetV1 IngressClass
+// -----------------------------------------------------------------------------
+
+// NetV1IngressClass reconciles IngressClass resources
+type NetV1IngressClassReconciler struct {
+	client.Client
+
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Proxy  proxy.Proxy
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NetV1IngressClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&netv1.IngressClass{}).Complete(r)
+}
+
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses/status,verbs=get;update;patch
+
+// Reconcile processes the watched objects
+func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("NetV1IngressClass", req.NamespacedName)
+
+	// get the relevant object
+	obj := new(netv1.IngressClass)
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+		if errors.IsNotFound(err) {
+			obj.Namespace = req.Namespace
+			obj.Name = req.Name
+			return ctrlutils.EnsureProxyDeleteObject(r.Proxy, obj)
+		}
+		return ctrl.Result{}, err
+	}
+	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	// clean the object up if it's being deleted
+	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
+		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "IngressClass", "namespace", req.Namespace, "name", req.Name)
+		objectExistsInCache, err := r.Proxy.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.Proxy.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// update the kong Admin API with the changes
+	if err := r.Proxy.UpdateObject(obj); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// -----------------------------------------------------------------------------
 // NetV1Beta1 Ingress
 // -----------------------------------------------------------------------------
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	IngressExtV1beta1Enabled bool
 	IngressNetV1beta1Enabled bool
 	IngressNetV1Enabled      bool
+	IngressClassNetV1Enabled bool
 	UDPIngressEnabled        bool
 	TCPIngressEnabled        bool
 	KongIngressEnabled       bool
@@ -155,6 +156,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 
 	// Kubernetes API toggling
 	flagSet.BoolVar(&c.IngressNetV1Enabled, "enable-controller-ingress-networkingv1", true, "Enable the networking.k8s.io/v1 Ingress controller.")
+	flagSet.BoolVar(&c.IngressClassNetV1Enabled, "enable-controller-ingress-class-networkingv1", true, "Enable the networking.k8s.io/v1 IngressClass controller.")
 	flagSet.BoolVar(&c.IngressNetV1beta1Enabled, "enable-controller-ingress-networkingv1beta1", true, "Enable the networking.k8s.io/v1beta1 Ingress controller.")
 	flagSet.BoolVar(&c.IngressExtV1beta1Enabled, "enable-controller-ingress-extensionsv1beta1", true, "Enable the extensions/v1beta1 Ingress controller.")
 	flagSet.BoolVar(&c.UDPIngressEnabled, "enable-controller-udpingress", true, "Enable the UDPIngress controller.")

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -84,6 +84,16 @@ func setupControllers(mgr manager.Manager, proxy proxy.Proxy, c *Config, feature
 			},
 		},
 		{
+			Enabled:     c.IngressClassNetV1Enabled,
+			AutoHandler: ingressPicker.IsNetV1,
+			Controller: &configuration.NetV1IngressClassReconciler{
+				Client: mgr.GetClient(),
+				Log:    ctrl.Log.WithName("controllers").WithName("IngressClass").WithName("netv1"),
+				Scheme: mgr.GetScheme(),
+				Proxy:  proxy,
+			},
+		},
+		{
 			Enabled:     c.IngressNetV1beta1Enabled,
 			AutoHandler: ingressPicker.IsNetV1beta1,
 			Controller: &configuration.NetV1Beta1IngressReconciler{

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -31,6 +31,7 @@ func clusterResourceKeyFunc(obj interface{}) (string, error) {
 type FakeObjects struct {
 	IngressesV1beta1   []*networkingv1beta1.Ingress
 	IngressesV1        []*networkingv1.Ingress
+	IngressClassesV1   []*networkingv1.IngressClass
 	HTTPRoute          []*gatewayv1alpha2.HTTPRoute
 	TCPIngresses       []*configurationv1beta1.TCPIngress
 	UDPIngresses       []*configurationv1beta1.UDPIngress
@@ -60,6 +61,13 @@ func NewFakeStore(
 	ingressV1Store := cache.NewStore(keyFunc)
 	for _, ingress := range objects.IngressesV1 {
 		err := ingressV1Store.Add(ingress)
+		if err != nil {
+			return nil, err
+		}
+	}
+	ingressClassV1Store := cache.NewStore(keyFunc)
+	for _, ingress := range objects.IngressClassesV1 {
+		err := ingressClassV1Store.Add(ingress)
 		if err != nil {
 			return nil, err
 		}
@@ -144,6 +152,7 @@ func NewFakeStore(
 		stores: CacheStores{
 			IngressV1beta1: ingressV1beta1Store,
 			IngressV1:      ingressV1Store,
+			IngressClassV1: ingressClassV1Store,
 			HTTPRoute:      httprouteStore,
 			TCPIngress:     tcpIngressStore,
 			UDPIngress:     udpIngressStore,

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -263,6 +263,41 @@ func TestFakeStoreIngressV1(t *testing.T) {
 	assert.Len(store.ListIngressesV1beta1(), 0)
 }
 
+func TestFakeStoreIngressClassV1(t *testing.T) {
+	assert := assert.New(t)
+
+	classes := []*networkingv1.IngressClass{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: networkingv1.IngressClassSpec{
+				Controller: ingressClassKongController,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+			Spec: networkingv1.IngressClassSpec{
+				Controller: ingressClassKongController,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "baz",
+			},
+			Spec: networkingv1.IngressClassSpec{
+				Controller: "some-other-controller.example.com/controller",
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{IngressClassesV1: classes})
+	assert.Nil(err)
+	assert.NotNil(store)
+	assert.Len(store.ListIngressClassesV1(), 2)
+}
+
 func TestFakeStoreListTCPIngress(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an IngressClass controller and store to ingest and cache IngressClasses. Does not actually do anything with IngressClasses after adding them; parser functionality will be added separately.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: This handles the first bullet from #2177 

**Special notes for your reviewer**:

IMO there are two things we should consider here:

- Do we support IngressClass on networking.k8s.io/v1beta1? As proposed this only handles networking.k8s.io/v1, though partly to get feedback on anything we need to change before writing v1beta1 if we implement it (the code will end up being essentially identical). We could reasonably say that IngressClass functionality is only available for v1 and leave v1beta1 support as-is (i.e. it's no different than the old annotation and we only look at ingressClassName in the Ingress). Given the development history I wouldn't expect that there are many users that can use v1beta1 but not v1--they were released within a short timeframe and are identical AFAIK. On our end it's less copy-pasta code to deal with.
- Do we support more than one controller string? As proposed this accepts only `ingress-controllers.konghq.com/kong` IngressClasses (note that we have a difference between the docs and chart--the latter currently uses `konghq.com/ingress-controller`). Whether this is configurable or not varies in other controllers based on brief review. The use case would be a single controller ingesting multiple Ingress classes. We could do this, but adding support for that would require refactoring, so it seems like it makes sense to enforce a single IngressClass controller for now to reflect the reality that we still honor `--ingress-class` and do not allow you to specify multiple or ingest all classes with a given controller string.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

This only mentions the manifests for now because the code doesn't result in user-facing changes. The controller args are there, but you won't usually use those, and IMO it makes sense to defer mentioning anything other than the manifest to a PR that adds actual IngressClass-based functionality.