### PR TITLE
test(e2e) add log retrieval utility

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -89,6 +89,11 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 	require.Eventually(t, func() bool {
 		deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace).Get(ctx, "ingress-kong", metav1.GetOptions{})
 		require.NoError(t, err)
+		log, err := getKubernetesLogs(t, env, deployment.Namespace, "deploy/"+deployment.Name)
+		if err != nil {
+			t.Logf("failed retrieving Deployment logs: %s", err)
+		}
+		t.Logf("%s/%s logs: %s", deployment.Namespace, deployment.Name, log)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}, kongComponentWait, time.Second)
 	return deployment

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -300,3 +300,24 @@ func startPortForwarder(ctx context.Context, t *testing.T, env environments.Envi
 		return false
 	}, kongComponentWait, time.Second)
 }
+
+func getKubernetesLogs(t *testing.T, env environments.Environment, namespace, name string) (string, error) {
+	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
+	require.NoError(t, err)
+	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "deploy-logs-tests-kubeconfig-")
+	require.NoError(t, err)
+	defer os.Remove(kubeconfigFile.Name())
+	defer kubeconfigFile.Close()
+	written, err := kubeconfigFile.Write(kubeconfig)
+	require.NoError(t, err)
+	require.Equal(t, len(kubeconfig), written)
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigFile.Name(), "logs", "-n", namespace, name,
+		"--all-containers")
+	cmd.Stderr = stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("%s", stderr.String())
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a utility to retrieve container logs for E2E tests.

**Special notes for your reviewer**:
This was originally part of https://github.com/Kong/kubernetes-ingress-controller/pull/2258 but I accidentally rebased it out. Per the original comments it's not actually used because it's noisy; it's around in case you want to use it temporarily for debugging and/or for us to possibly incorporate in a less noisy fashion using https://pkg.go.dev/github.com/stretchr/testify/suite?utm_source=godoc#AfterTest or something.

Edit: now it does include usage, because we have an ongoing issue we want to use it to debug.