### PR TITLE
chore: refactor dp obj deletion ensure

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -439,7 +439,7 @@ func (r *{{.PackageAlias}}{{.Type}}Reconciler) Reconcile(ctx context.Context, re
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -73,7 +73,7 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -135,7 +135,7 @@ func (r *CoreV1EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -197,7 +197,7 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -262,7 +262,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -332,7 +332,7 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -397,7 +397,7 @@ func (r *NetV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -471,7 +471,7 @@ func (r *ExtV1Beta1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -542,7 +542,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -604,7 +604,7 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -669,7 +669,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -743,7 +743,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -817,7 +817,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -891,7 +891,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}
@@ -965,7 +965,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 		if errors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, obj)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 )
 
@@ -237,7 +236,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			debug(log, httproute, "object does not exist, ensuring it is not present in the proxy cache")
 			httproute.Namespace = req.Namespace
 			httproute.Name = req.Name
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, httproute)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(httproute)
 		}
 
 		// for any error other than 404, requeue
@@ -257,7 +256,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 		debug(log, httproute, "ensured object was removed from the data-plane (if ever present)")
-		return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, httproute)
+		return ctrl.Result{}, r.DataplaneClient.DeleteObject(httproute)
 	}
 
 	// we need to pull the Gateway parent objects for the HTTPRoute to verify
@@ -287,7 +286,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// ensure that it's removed from the proxy cache to avoid orphaned data-plane
 			// configurations.
 			debug(log, httproute, "ensuring that dataplane is updated to remove unsupported route (if applicable)")
-			return ctrlutils.EnsureProxyDeleteObject(r.DataplaneClient, httproute)
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(httproute)
 		}
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -7,13 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 )
 
 // HasAnnotation is a helper function to determine whether an object has a given annotation, and whether it's
@@ -101,29 +99,4 @@ func IsIngressClassSpecConfigured(obj client.Object, expectedIngressClassName st
 func CRDExists(client client.Client, gvr schema.GroupVersionResource) bool {
 	_, err := client.RESTMapper().KindFor(gvr)
 	return !meta.IsNoMatchError(err)
-}
-
-// EnsureProxyDeleteObject is a reconciliation helper to ensure that an object is removed from
-// the backend proxy cache so that it gets removed from data-plane configurations.
-func EnsureProxyDeleteObject(dataplaneClient *dataplane.KongClient, obj client.Object) (ctrl.Result, error) {
-	// check whether the object is at all present in the proxy cache.
-	objectExistsInCache, err := dataplaneClient.ObjectExists(obj)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// if the object is still present in the proxy cache, we need to keep trying to
-	// remove it until its gone so that it gets removed from backend data-plane.
-	if objectExistsInCache {
-		if err := dataplaneClient.DeleteObject(obj); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		// the caller should requeue until the object is no longer present in the cache
-		// to ensure removal was successful
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	// if the object is not present in the proxy cache, we're all set
-	return ctrl.Result{}, nil
 }

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -146,6 +146,9 @@ func (c *KongClient) UpdateObject(obj client.Object) error {
 // DeleteObject accepts a Kubernetes controller-runtime client.Object and removes it from the configuration cache.
 // The delete action will asynchronously be converted to Kong DSL and applied to the Kong Admin API.
 // A status will later be added to the object whether the configuration update succeeds or fails.
+//
+// under the hood the cache implementation will ignore deletions on objects
+// that are not present in the cache, so in those cases this is a no-op.
 func (c *KongClient) DeleteObject(obj client.Object) error {
 	return c.cache.Delete(obj)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

While working on #2295 I noticed that the `EnsureProxyDeleteObject()` method was superfluous: the underlying client go cache already does the existence checks and the underlying deletion is not asynchronous.