### PR TITLE
Add dataplane client to IngressClass controller

### DIFF
--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -87,9 +87,10 @@ func setupControllers(mgr manager.Manager, dataplaneClient *dataplane.KongClient
 			Enabled:     c.IngressClassNetV1Enabled,
 			AutoHandler: ingressPicker.IsNetV1,
 			Controller: &configuration.NetV1IngressClassReconciler{
-				Client: mgr.GetClient(),
-				Log:    ctrl.Log.WithName("controllers").WithName("IngressClass").WithName("netv1"),
-				Scheme: mgr.GetScheme(),
+				Client:          mgr.GetClient(),
+				Log:             ctrl.Log.WithName("controllers").WithName("IngressClass").WithName("netv1"),
+				DataplaneClient: dataplaneClient,
+				Scheme:          mgr.GetScheme(),
 			},
 		},
 		{

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -65,7 +65,7 @@ var (
 MIICTDCCAdKgAwIBAgIUOe9HN8v1eedsZXur5uXAwJkOSG4wCgYIKoZIzj0EAwIw
 XTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu
 dGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEWMBQGA1UEAwwNZmlyc3QuZXhhbXBsZTAe
-Fw0yMjAyMTAxOTIzNDhaFw0zMjAyMDgxOTIzNDhaMF0xCzAJBgNVBAYTAkFVMRMw
+Fw0yMjA2MTAxOTIzNDhaFw0zMjAyMDgxOTIzNDhaMF0xCzAJBgNVBAYTAkFVMRMw
 EQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0
 eSBMdGQxFjAUBgNVBAMMDWZpcnN0LmV4YW1wbGUwdjAQBgcqhkjOPQIBBgUrgQQA
 IgNiAAR2pbLcSQhX4gD6IyPJiRN7lxZ8aPbi6qyPyjvoTJc6DPjMuJuJgkdSC8wy
@@ -229,7 +229,7 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Log("checking initial certificate")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", admissionAddress+":443",
-			&tls.Config{MinVersion: tls.VersionTLS13, InsecureSkipVerify: true}) // nolint:gosec
+			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) // nolint:gosec
 		if err != nil {
 			return false
 		}
@@ -243,7 +243,7 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Log("checking second certificate")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", admissionAddress+":443",
-			&tls.Config{MinVersion: tls.VersionTLS13, InsecureSkipVerify: true}) // nolint:gosec
+			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) // nolint:gosec
 		if err != nil {
 			return false
 		}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -89,11 +89,6 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 	require.Eventually(t, func() bool {
 		deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace).Get(ctx, "ingress-kong", metav1.GetOptions{})
 		require.NoError(t, err)
-		log, err := getKubernetesLogs(t, env, deployment.Namespace, "deploy/"+deployment.Name)
-		if err != nil {
-			t.Logf("failed retrieving Deployment logs: %s", err)
-		}
-		t.Logf("%s/%s logs: %s", deployment.Namespace, deployment.Name, log)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}, kongComponentWait, time.Second)
 	return deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/Kong/kubernetes-ingress-controller/pull/2292 added a new controller around the same time https://github.com/Kong/kubernetes-ingress-controller/pull/2296 changed the controller configuration. The new IngressClass controller did not include the new required DataplaneClient, which resulted in nil dereference panics when the controller attempted to use it.

This sets the IngressClass controller DataplaneClient.

Reverts the noisy E2E logging change we made to diagnose this.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Fixes E2E test failures.

**Special notes for your reviewer**:
Wait for success on https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1935242153 to confirm.
