### PR TITLE
chore: update CHANGELOG.md for mtls flags from #1958

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 
 #### Added
 
+- The controller manager can now be flagged with a client certificate to use
+  for mTLS authentication with the Kong Admin API.
+  [#1958](https://github.com/Kong/kubernetes-ingress-controller/issues/1958)
 - Deployment manifests now include an IngressClass resource and permissions to
   read IngressClass resources.
   [#2292](https://github.com/Kong/kubernetes-ingress-controller/pull/2292)


### PR DESCRIPTION
**What this PR does / why we need it**:

A changelog entry was missing for the new Kong Admin mTLS flags, this patch adds it.

**Which issue this PR fixes**

Fixes #1958 

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated