### PR TITLE
Orders similar certs by uuid when their creation timestamps are identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@
   instance's reported schema. This addresses an issue where configuration
   updates would send unnecessary requests to clear a default value.
   [#2286](https://github.com/Kong/kubernetes-ingress-controller/pull/2286)
+- Certificate selection for hostnames is no longer random if both certificate
+  Secrets have the same creation timestamp, and no longer results in
+  unnecessary configuration updates.
+  [#2338](https://github.com/Kong/kubernetes-ingress-controller/pull/2338)
 
 ## [2.2.1]
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -345,8 +345,12 @@ func getCerts(log logrus.FieldLogger, s store.Storer, secretsToSNIs map[string][
 				CreationTimestamp: secret.CreationTimestamp,
 			}
 		} else {
+			secretID := string(secret.UID)
 			if kongCert.CreationTimestamp.After(secret.CreationTimestamp.Time) {
-				kongCert.cert.ID = kong.String(string(secret.UID))
+				kongCert.cert.ID = kong.String(secretID)
+				kongCert.CreationTimestamp = secret.CreationTimestamp
+			} else if kongCert.CreationTimestamp.Time.Equal(secret.CreationTimestamp.Time) && (kongCert.cert.ID == nil || *kongCert.cert.ID > secretID) {
+				kongCert.cert.ID = kong.String(secretID)
 				kongCert.CreationTimestamp = secret.CreationTimestamp
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Orders identical certs with the same creation timestamp by their uuid. This fixes an issue where the ordering of such certs can be nondeterministic and cause the sync loop to post updates on subsequent iterations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2248

**Special notes for your reviewer**:

Idiomatic go recommendations are welcomed! I have zero go background.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
