### PR TITLE
tests: add HTTPRouteCrossNamespace Gateway conformance test 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@
 
 #### Added
 
+- `Gateway` resources which have a `LoadBalancer` address among their list of
+  addresses will have those addresses listed on the top for convenience, and
+  so that those addresses are made prominent in the `kubectl get gateways`
+  short view.
+  [#2339](https://github.com/Kong/kubernetes-ingress-controller/pull/2339)
 - The controller manager can now be flagged with a client certificate to use
   for mTLS authentication with the Kong Admin API.
   [#1958](https://github.com/Kong/kubernetes-ingress-controller/issues/1958)
@@ -74,6 +79,18 @@
 
 #### Fixed
 
+- Status updates for `HTTPRoute` objects no longer mark the resource as
+  `ConditionRouteAccepted` until the object has been successfully configured
+  in Kong Gateway at least once, as long as `--update-status`
+  is enabled (enabled by default).
+  [#2339](https://github.com/Kong/kubernetes-ingress-controller/pull/2339)
+- Status updates for `HTTPRoute` now properly use the `ConditionRouteAccepted`
+  value for parent `Gateway` conditions when the route becomes configured in
+  the `Gateway` rather than the previous random `"attached"` string.
+  [#2339](https://github.com/Kong/kubernetes-ingress-controller/pull/2339)
+- Fixed a minor issue where addresses on `Gateway` resources would be
+  duplicated depending on how many listeners are configured.
+  [#2339](https://github.com/Kong/kubernetes-ingress-controller/pull/2339)
 - Unconfigured fields now use their default value according to the Kong proxy
   instance's reported schema. This addresses an issue where configuration
   updates would send unnecessary requests to clear a default value.

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -437,11 +437,12 @@ func (r *GatewayReconciler) determineL4ListenersFromService(
 	addresses := make([]gatewayv1alpha2.GatewayAddress, 0, len(svc.Spec.ClusterIPs))
 	listeners := make([]gatewayv1alpha2.Listener, 0, len(svc.Spec.Ports))
 	for _, clusterIP := range svc.Spec.ClusterIPs {
+		addresses = append(addresses, gatewayv1alpha2.GatewayAddress{
+			Type:  &gatewayIPAddrType,
+			Value: clusterIP,
+		})
+
 		for _, port := range svc.Spec.Ports {
-			addresses = append(addresses, gatewayv1alpha2.GatewayAddress{
-				Type:  &gatewayIPAddrType,
-				Value: clusterIP,
-			})
 			listeners = append(listeners, gatewayv1alpha2.Listener{
 				Name:          gatewayv1alpha2.SectionName(port.Name),
 				Protocol:      gatewayv1alpha2.ProtocolType(port.Protocol),

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -461,19 +461,21 @@ func (r *GatewayReconciler) determineL4ListenersFromService(
 		}
 
 		// otherwise gather any IPs or Hosts provisioned for the LoadBalancer
-		// and record them as Gateway Addresses.
+		// and record them as Gateway Addresses. The LoadBalancer addresses
+		// are pre-pended to the address list to make them prominent, as they
+		// are often the most common address used for traffic.
 		for _, ingress := range svc.Status.LoadBalancer.Ingress {
 			if ingress.IP != "" {
-				addresses = append(addresses, gatewayv1alpha2.GatewayAddress{
+				addresses = append([]gatewayv1alpha2.GatewayAddress{{
 					Type:  &gatewayIPAddrType,
 					Value: ingress.IP,
-				})
+				}}, addresses...)
 			}
 			if ingress.Hostname != "" {
-				addresses = append(addresses, gatewayv1alpha2.GatewayAddress{
+				addresses = append([]gatewayv1alpha2.GatewayAddress{{
 					Type:  &gatewayHostAddrType,
 					Value: ingress.Hostname,
-				})
+				}}, addresses...)
 			}
 		}
 	}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -366,7 +366,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 			},
 			ControllerName: ControllerName,
 			Conditions: []metav1.Condition{{
-				Type:               "attached",
+				Type:               string(gatewayv1alpha2.ConditionRouteAccepted),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: httproute.Generation,
 				LastTransitionTime: metav1.Now(),

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -4,22 +4,27 @@
 package conformance
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 )
 
 var (
-	showDebug                     = true
-	shouldCleanup                 = true
-	conformanceTestsBaseManifests = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/conformance/base/manifests.yaml"
+	showDebug     = true
+	shouldCleanup = true
+
+	manifestRepo                  = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/"
+	conformanceTestsBaseManifests = fmt.Sprintf("%s/conformance/base/manifests.yaml", manifestRepo)
 )
 
 func TestGatewayConformance(t *testing.T) {
@@ -50,5 +55,25 @@ func TestGatewayConformance(t *testing.T) {
 		BaseManifests:    conformanceTestsBaseManifests,
 	})
 	cSuite.Setup(t)
-	// TODO: cSuite.Run(t, tests.ConformanceTests)
+
+	t.Log("configuring gateway conformance tests")
+	for i := range tests.ConformanceTests {
+		for j, manifest := range tests.ConformanceTests[i].Manifests {
+			tests.ConformanceTests[i].Manifests[j] = fmt.Sprintf("%s/conformance/%s", manifestRepo, manifest)
+		}
+	}
+
+	t.Log("running gateway conformance tests")
+	for _, tt := range tests.ConformanceTests {
+		if enabledGatewayConformanceTests.Has(tt.ShortName) {
+			t.Run(tt.Description, func(t *testing.T) { tt.Run(t, cSuite) })
+		}
+	}
 }
+
+// Today we run only the subset below of all Gateway conformance tests.
+// TODO: ensure that this module runs all Gateway conformance tests
+// https://github.com/Kong/kubernetes-ingress-controller/issues/2210
+var enabledGatewayConformanceTests = sets.NewString(
+	"HTTPRouteCrossNamespace",
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables the `HTTPRouteCrossNamespace` conformance test from upstream [Gateway API](https://github.com/kubernetes-sigs/gateway-api).

**Special notes for your reviewer**:

This PR also fixes some issues that were relevant to adding that test:

- fix: remove duplicate addrs on unmanaged gateways (a random bug I noticed)
- fix: prepend LB addrs in unmanaged GWs (fixes #2050, I was already working in that code and it was easy)
- fix: use ConditionRouteAccepted for HTTPRoute accept (specifically for HTTPRoute conformance)
- fix: wait for dataplane before reporting httproute accepted status (specifically for HTTPRoute conformance)

**Which issue this PR fixes**

Partially resolves #2210 

Fully resolves #2050

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated