### PR TITLE
Add flag to skip CA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
   `allowedRoutes` filters are merged into generated listeners with the same
   protocol.
   [#2389](https://github.com/Kong/kubernetes-ingress-controller/issues/2389)
+- Added `--skip-ca-certificates` flag to ignore CA certificate resources for
+  [use with multi-workspace environments](https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1120).
+  [#2341](https://github.com/Kong/kubernetes-ingress-controller/issues/2341)
 
 #### Fixed
 

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -35,6 +35,7 @@ func PerformUpdate(ctx context.Context,
 	kongConfig *Kong,
 	inMemory bool,
 	reverseSync bool,
+	skipCACertificates bool,
 	targetContent *file.Content,
 	selectorTags []string,
 	customEntities []byte,
@@ -77,7 +78,7 @@ func PerformUpdate(ctx context.Context,
 		err = onUpdateInMemoryMode(ctx, log, targetContent, customEntities, kongConfig)
 	} else {
 		metricsProtocol = metrics.ProtocolDeck
-		err = onUpdateDBMode(ctx, targetContent, kongConfig, selectorTags)
+		err = onUpdateDBMode(ctx, targetContent, kongConfig, selectorTags, skipCACertificates)
 	}
 	timeEnd := time.Now()
 
@@ -199,8 +200,9 @@ func onUpdateDBMode(ctx context.Context,
 	targetContent *file.Content,
 	kongConfig *Kong,
 	selectorTags []string,
+	skipCACertificates bool,
 ) error {
-	dumpConfig := dump.Config{SelectorTags: selectorTags}
+	dumpConfig := dump.Config{SelectorTags: selectorTags, SkipCACerts: skipCACertificates}
 	// read the current state
 	rawState, err := dump.Get(ctx, kongConfig.Client, dumpConfig)
 	if err != nil {

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	AnonymousReports                  bool
 	EnableReverseSync                 bool
 	SyncPeriod                        time.Duration
+	SkipCACertificates                bool
 
 	// Kong Proxy configurations
 	APIServerHost            string
@@ -122,6 +123,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", time.Hour*48, `Relist and confirm cloud resources this often`) // 48 hours derived from controller-runtime defaults
+	flagSet.BoolVar(&c.SkipCACertificates, "skip-ca-certificates", false, `disable syncing CA certificate syncing (for use with multi-workspace environments)`)
 
 	flagSet.StringVar(&c.KongAdminAPIConfig.TLSClientCertPath, "kong-admin-tls-client-cert-file", "", "mTLS client certificate file for authentication.")
 	flagSet.StringVar(&c.KongAdminAPIConfig.TLSClientKeyPath, "kong-admin-tls-client-key-file", "", "mTLS client key file for authentication.")

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -104,6 +104,9 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	if !ok {
 		return fmt.Errorf("invalid database configuration, expected a string got %T", kongRootConfig["database"])
 	}
+	if dbmode == "off" && c.SkipCACertificates {
+		return fmt.Errorf("--skip-ca-certificates is not available for use with DB-less Kong instances")
+	}
 
 	setupLog.Info("configuring and building the controller manager")
 	controllerOpts, err := setupControllerOptions(setupLog, c, scheme, dbmode)
@@ -125,7 +128,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	if err != nil {
 		return fmt.Errorf("%f is not a valid number of seconds to the timeout config for the kong client: %w", c.ProxyTimeoutSeconds, err)
 	}
-	dataplaneClient, err := dataplane.NewKongClient(deprecatedLogger, timeoutDuration, c.IngressClassName, c.EnableReverseSync, diagnostic, kongConfig)
+	dataplaneClient, err := dataplane.NewKongClient(deprecatedLogger, timeoutDuration, c.IngressClassName, c.EnableReverseSync, c.SkipCACertificates, diagnostic, kongConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize kong data-plane client: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a flag to control the deck behavior added in https://github.com/Kong/deck/pull/617

**Special notes for your reviewer**:
- ~At present, deck doesn't provide an option to skip these in file parsing (i.e. generating the target config), so it and this draft strip the certificates out after the fact. We should add an option to the `file.RenderConfig` to handle this instead so that the controller doesn't duplicate logic.~ https://github.com/Kong/deck/pull/622 changes this and the draft has been updated to remove the duplicated logic.
- This currently uses an unreleased deck tag.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
