### PR TITLE
tests: more L7 gateway API conformance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@
 
 #### Fixed
 
+- Fixed an issue where duplicated route names in `HTTPRoute` resources with
+  multiple matches would cause the Kong Admin API to collide the routes into
+  one, effectively dropping routes for services beyond the first.
+  [#2345](https://github.com/Kong/kubernetes-ingress-controller/pull/2345)
 - Status updates for `HTTPRoute` objects no longer mark the resource as
   `ConditionRouteAccepted` until the object has been successfully configured
   in Kong Gateway at least once, as long as `--update-status`

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -88,7 +88,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 						Namespace: "default",
 						Routes: []kongstate.Route{{ // only 1 route should be created
 							Route: kong.Route{
-								Name:         kong.String("httproute.default.basic-httproute.0"),
+								Name:         kong.String("httproute.default.basic-httproute.0.0"),
 								PreserveHost: kong.Bool(true),
 								Protocols: []*string{
 									kong.String("http"),
@@ -201,7 +201,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 						Namespace: "default",
 						Routes: []kongstate.Route{{ // only 1 route should be created
 							Route: kong.Route{
-								Name: kong.String("httproute.default.basic-httproute.0"),
+								Name: kong.String("httproute.default.basic-httproute.0.0"),
 								Paths: []*string{
 									kong.String("/httpbin"),
 								},
@@ -341,7 +341,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 						Namespace: "default",
 						Routes: []kongstate.Route{{ // only 1 route should be created
 							Route: kong.Route{
-								Name: kong.String("httproute.default.basic-httproute.0"),
+								Name: kong.String("httproute.default.basic-httproute.0.0"),
 								Paths: []*string{
 									kong.String("/httpbin$"),
 								},
@@ -418,7 +418,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 						Namespace: "default",
 						Routes: []kongstate.Route{{ // only 1 route should be created
 							Route: kong.Route{
-								Name: kong.String("httproute.default.basic-httproute.0"),
+								Name: kong.String("httproute.default.basic-httproute.0.0"),
 								Paths: []*string{
 									kong.String("/httpbin$"),
 								},

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -76,4 +76,10 @@ func TestGatewayConformance(t *testing.T) {
 // https://github.com/Kong/kubernetes-ingress-controller/issues/2210
 var enabledGatewayConformanceTests = sets.NewString(
 	"HTTPRouteCrossNamespace",
+	// "HTTPRouteInvalidCrossNamespace" is the last one we need to get working
+	// before we can delete this set and simply run ALL, but requires:
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/2080
+	"HTTPRouteMatchingAcrossRoutes",
+	"HTTPRouteMatching",
+	"HTTPRouteSimpleSameNamespace",
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds most of the rest of the L7 Gateway conformance tests, minus cross namespace ones that will be taken care of later as a part of #2080.

**Which issue this PR fixes**

Resolves #2210 

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated