### PR TITLE
chore: delete old unneeded doc redir

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,3 +1,0 @@
-# 301 Moved
-
-This document is now moved to [Deployment Overview on `docs.konghq.com`](https://docs.konghq.com/kubernetes-ingress-controller/latest/deployment/overview/).


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an old no longer needed redirect page.