### PR TITLE
chore: remove old ing types from httpbin example

### DIFF
--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -3,6 +3,7 @@
 # go run internal/cmd/main.go
 # kubectl apply -f examples/httpbin.yaml
 # kubectl get secrets kong-config -o=go-template='{{index .data "networking.k8s.io-v1-Ingress-default-httpbin-ingress" }}' | base64 -d
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,35 +59,3 @@ spec:
             name: httpbin-deployment
             port:
               number: 80
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: httpbin-ingress-v1beta1
-  annotations:
-    httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: httpbin-deployment
-          servicePort: 80
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: httpbin-ingress-extensions-v1beta1
-  annotations:
-    httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: httpbin-deployment
-          servicePort: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up the old httpbin ingress example, including removing the ancient ingress resource versions.