### PR TITLE
chore: update daysUntilStale as 7

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 14
+daysUntilStale: 7
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 7


### PR DESCRIPTION
**What this PR does / why we need it**:

We've previously had 14 as the number of days before stalebot would mark an issue as stale, which I feel is pretty long for something to remain entirely dormant after marking it `pending-author-feedback`. Given that this doesn't do anything but notify the collaborators it seems more appropriate to shorten this to a week, meaning stale issues that _remain_ stale will be autoclosed within a 14 day period of no activity (but again, only if we mark them as `pending-author-feedback` explicitly).