### PR TITLE
tests: add tests for example manifests

### DIFF
--- a/examples/udpingress.yaml
+++ b/examples/udpingress.yaml
@@ -4,8 +4,7 @@
 # In order to use this example make sure you're running the controller manager with the
 # following flags set:
 #
-#   --watch-namespace udpingress-example
-#   --controller-udpingress=enabled
+#   --enable-controller-udpingress=true
 #   --ingress-class=kong
 #
 # Before hand you will also need to configure the controller with a UDP listener and expose
@@ -19,15 +18,9 @@
 # on the proxy container or use a shortcut like `kubectl expose <options>`.
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: udpingress-example
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: coredns
-  namespace: udpingress-example
 data:
   Corefile: |-
     .:53 {
@@ -54,7 +47,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns
-  namespace: udpingress-example
   labels:
     app: coredns
 spec:
@@ -93,7 +85,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coredns
-  namespace: udpingress-example
 spec:
   ports:
   - port: 53
@@ -107,9 +98,8 @@ apiVersion: configuration.konghq.com/v1beta1
 kind: UDPIngress
 metadata:
   name: minudp
-  namespace: udpingress-example
   annotations:
-    kubernetes.io/ingress.class: kong
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
   - backend:

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -1,0 +1,74 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+)
+
+const examplesDIR = "../../examples"
+
+var httprouteExampleManifests = fmt.Sprintf("%s/gateway-httproute.yaml", examplesDIR)
+
+func TestHTTPRouteExample(t *testing.T) {
+	t.Logf("configuring test and setting up API clients")
+	gwc, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
+	t.Logf("applying yaml manifest %s", strings.TrimPrefix(httprouteExampleManifests, examplesDIR))
+	b, err := os.ReadFile(httprouteExampleManifests)
+	require.NoError(t, err)
+	require.NoError(t, clusters.ApplyYAML(ctx, env.Cluster(), string(b)))
+
+	defer func() {
+		require.NoError(t, clusters.DeleteYAML(ctx, env.Cluster(), string(b)))
+	}()
+
+	t.Logf("verifying that the Gateway receives listen addresses")
+	var gatewayAddr string
+	require.Eventually(t, func() bool {
+		obj, err := gwc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, "kong", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		for _, addr := range obj.Status.Addresses {
+			if addr.Type != nil && *addr.Type == gatewayv1alpha2.IPAddressType {
+				gatewayAddr = addr.Value
+				return true
+			}
+		}
+
+		return false
+	}, gatewayUpdateWaitTime, waitTick)
+
+	t.Logf("verifying that the HTTPRoute becomes routable")
+	require.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("http://%s/httpbin", gatewayAddr))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			b := new(bytes.Buffer)
+			n, err := b.ReadFrom(resp.Body)
+			require.NoError(t, err)
+			require.True(t, n > 0)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+}

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -85,7 +85,7 @@ var (
 	// NOTE: more namespaces will be loaded dynamically by the test.Main
 	//       during runtime. In general, avoid adding hardcoded namespaces
 	//       to this list as that's reserved for special cases.
-	watchNamespaces = fmt.Sprintf("%s,%s", extraIngressNamespace, extraWebhookNamespace)
+	watchNamespaces = fmt.Sprintf("%s,%s,%s", extraIngressNamespace, extraWebhookNamespace, corev1.NamespaceDefault)
 
 	// env is the primary testing environment object which includes access to the Kubernetes cluster
 	// and all the addons deployed in support of the tests.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds some tests which cover the fully testable `examples/` manifests.

**Which issue this PR fixes**

Partially resolves #1096