### PR TITLE
fix: remove redundant copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY pkg/ pkg/
-COPY pkg/ pkg/
 COPY internal/ internal/
 
 # Build
@@ -33,7 +32,6 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-COPY pkg/ pkg/
 COPY pkg/ pkg/
 COPY internal/ internal/
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A couple of extra `copy` lines were found in our `Dockerfile`, this patch resolves them.

**Which issue this PR fixes**

Resolves #2377 