### PR TITLE
fix: serialize fgs in reports

### DIFF
--- a/internal/util/reports.go
+++ b/internal/util/reports.go
@@ -2,8 +2,10 @@ package util
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -50,6 +52,11 @@ func (r *Reporter) once() {
 	serializedInfo = serializedInfo + "db=" + r.Info.KongDB + ";"
 	serializedInfo = serializedInfo + "id=" + r.Info.ID + ";"
 	serializedInfo = serializedInfo + "hn=" + r.Info.Hostname + ";"
+
+	for feature, enabled := range r.Info.FeatureGates {
+		serializedInfo = fmt.Sprintf("%sfeature-%s=%t;", serializedInfo, strings.ToLower(feature), enabled)
+	}
+
 	r.serializedInfo = serializedInfo
 }
 

--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -86,6 +86,10 @@ func TestReporterOnce(t *testing.T) {
 		Hostname:          "example.local",
 		KongDB:            "off",
 		ID:                "6acb7447-eedf-4815-a193-d714c5108f7b",
+		FeatureGates: map[string]bool{
+			"Knative": false,
+			"Gateway": true,
+		},
 	}
 	reporter := Reporter{
 		Info:   info,
@@ -101,7 +105,7 @@ func TestReporterOnce(t *testing.T) {
 
 	reporter.once()
 	want := "v=kic.version;k8sv=k8s.version;kv=kong.version;db=off;" +
-		"id=6acb7447-eedf-4815-a193-d714c5108f7b;hn=example.local;"
+		"id=6acb7447-eedf-4815-a193-d714c5108f7b;hn=example.local;feature-knative=false;feature-gateway=true;"
 	assert.Equal(want, reporter.serializedInfo)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing serialization for feature gates in reports.

**Which issue this PR fixes**

Resolves #2376