### PR TITLE
Release 2.3.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,14 +12,13 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - 'v1.21.2'
-          - 'v1.22.4'
-          - 'v1.23.3'
+          - 'v1.21.10'
+          - 'v1.22.7'
+          - 'v1.23.5'
         istio-version:
-          - 'v1.12.2'
-          - 'v1.11.5'
-          - 'v1.10.6'
-          - 'v1.9.9'
+          - 'v1.13.2'
+          - 'v1.12.5'
+          - 'v1.11.8'
     steps:
     - name: setup golang
       uses: actions/setup-go@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - 'v1.23.3'
+          - 'v1.23.5'
         dbmode:
           - 'dbless'
           - 'postgres'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ## [2.3.0]
 
-> Release date: TBD
+> Release date: 2022-04-05
 
 #### Breaking changes
 
@@ -1645,6 +1645,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.3.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.1.0...v2.1.1

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '2.8'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.2.1'
+  newTag: '2.3.0'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1404,7 +1404,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.1
+        image: kong/kubernetes-ingress-controller:2.3.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1399,7 +1399,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.1
+        image: kong/kubernetes-ingress-controller:2.3.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1473,7 +1473,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.1
+        image: kong/kubernetes-ingress-controller:2.3.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1417,7 +1417,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.2.1
+        image: kong/kubernetes-ingress-controller:2.3.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Tentative 2.3.0 release, for tomorrow, 2022-04-05.

**Special notes for your reviewer**:
Awaiting https://github.com/Kong/kubernetes-ingress-controller/actions/runs/2091424181
