### PR TITLE
Implement Gateaway Listener allowedRoutes.namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@
   annotation is set). They also now support weights to enable more
   fine-tuning of the load-balancing between those backend services.
   [#2166](https://github.com/Kong/kubernetes-ingress-controller/issues/2166)
+- `Gateway` resources now honor [`listener.allowedRoutes.namespaces`
+  filters](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.RouteNamespaces).
+  Note that the unmanaged Kong Gateway implementation populates listeners
+  automatically based on the Kong Service and Deployment, and user-provided
+  `allowedRoutes` filters are merged into generated listeners with the same
+  protocol.
+  [#2389](https://github.com/Kong/kubernetes-ingress-controller/issues/2389)
 
 ## [2.3.1]
 

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -90,8 +90,28 @@ func getSupportedGatewayForRoute(ctx context.Context, mgrc client.Client, obj cl
 			// set true if we find any AllowedRoutes. there may be none, in which case any namespace is permitted
 			filtered := false
 			for _, listener := range gateway.Spec.Listeners {
+				// Only match if the listener type matches the protocol type
+				switch obj.(type) {
+				case *gatewayv1alpha2.HTTPRoute:
+					if !(listener.Protocol == gatewayv1alpha2.HTTPProtocolType || listener.Protocol == gatewayv1alpha2.HTTPSProtocolType) {
+						continue
+					}
+				case *gatewayv1alpha2.TCPRoute:
+					if listener.Protocol != gatewayv1alpha2.TCPProtocolType {
+						continue
+					}
+				case *gatewayv1alpha2.UDPRoute:
+					if listener.Protocol != gatewayv1alpha2.UDPProtocolType {
+						continue
+					}
+				case *gatewayv1alpha2.TLSRoute:
+					if listener.Protocol != gatewayv1alpha2.TLSProtocolType {
+						continue
+					}
+				default:
+					continue
+				}
 				if listener.AllowedRoutes != nil {
-					// TODO NS need to filter by kinds per https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.AllowedRoutes
 					filtered = true
 					if *listener.AllowedRoutes.Namespaces.From == gatewayv1alpha2.NamespacesFromAll {
 						// we allow "all" by just stuffing the namespace we want to find into the map

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -4,13 +4,18 @@
 package integration
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -401,4 +406,235 @@ func TestUnmanagedGatewayClass(t *testing.T) {
 		}
 		return false
 	}, gatewayUpdateWaitTime, time.Second)
+}
+
+func TestGatewayFilters(t *testing.T) {
+	ns, cleanup := namespace(t)
+	defer cleanup()
+	other, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name()+"other")
+	require.NoError(t, err)
+	defer func(t *testing.T) {
+		assert.NoError(t, clusters.CleanupGeneratedResources(ctx, env.Cluster(), t.Name()+"other"))
+	}(t)
+
+	t.Log("deploying a supported gatewayclass to the test cluster")
+	c, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+	gwc := &gatewayv1alpha2.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayv1alpha2.GatewayClassSpec{
+			ControllerName: gateway.ControllerName,
+		},
+	}
+	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Log("cleaning up gatewayclasses")
+		if err := c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Log("deploying a gateway that only allows routes in all namespaces")
+	fromSame := gatewayv1alpha2.NamespacesFromSame
+	fromAll := gatewayv1alpha2.NamespacesFromAll
+	fromSelector := gatewayv1alpha2.NamespacesFromSelector
+	gw := &gatewayv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kong",
+			Annotations: map[string]string{
+				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
+			},
+		},
+		Spec: gatewayv1alpha2.GatewaySpec{
+			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
+			Listeners: []gatewayv1alpha2.Listener{{
+				Name:     "http",
+				Protocol: gatewayv1alpha2.HTTPProtocolType,
+				Port:     gatewayv1alpha2.PortNumber(80),
+				AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+					Namespaces: &gatewayv1alpha2.RouteNamespaces{
+						From: &fromAll,
+					},
+				},
+			}},
+		},
+	}
+	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Log("cleaning up gateways")
+		if err := c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", httpBinImage, 80)
+	deploymentTemplate := generators.NewDeploymentForContainer(container)
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deploymentTemplate, metav1.CreateOptions{})
+	require.NoError(t, err)
+	otherDeployment, err := env.Cluster().Client().AppsV1().Deployments(other.Name).Create(ctx, deploymentTemplate, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the deployment %s", deployment.Name)
+		if err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+		if err := env.Cluster().Client().AppsV1().Deployments(other.Name).Delete(ctx, otherDeployment.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = env.Cluster().Client().CoreV1().Services(other.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the service %s", service.Name)
+		if err := env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+		if err := env.Cluster().Client().CoreV1().Services(other.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Logf("creating an httproute to access deployment %s via kong", deployment.Name)
+	httpPort := gatewayv1alpha2.PortNumber(80)
+	pathMatchPrefix := gatewayv1alpha2.PathMatchPathPrefix
+	refNamespace := gatewayv1alpha2.Namespace(gw.Namespace)
+	httprouteTemplate := &gatewayv1alpha2.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+			},
+		},
+		Spec: gatewayv1alpha2.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+				ParentRefs: []gatewayv1alpha2.ParentReference{{
+					Name:      gatewayv1alpha2.ObjectName(gw.Name),
+					Namespace: &refNamespace,
+				}},
+			},
+			Rules: []gatewayv1alpha2.HTTPRouteRule{{
+				Matches: []gatewayv1alpha2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1alpha2.HTTPPathMatch{
+							Type:  &pathMatchPrefix,
+							Value: kong.String("/httpbin"),
+						},
+					},
+				},
+				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
+					BackendRef: gatewayv1alpha2.BackendRef{
+						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+							Name: gatewayv1alpha2.ObjectName(service.Name),
+							Port: &httpPort,
+						},
+					},
+				}},
+			}},
+		},
+	}
+	httproute, err := c.GatewayV1alpha2().HTTPRoutes(ns.Name).Create(ctx, httprouteTemplate, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	otherRoute, err := c.GatewayV1alpha2().HTTPRoutes(other.Name).Create(ctx, httprouteTemplate, metav1.CreateOptions{})
+	require.NoError(t, err)
+	otherRoute.Spec.Rules[0].Matches[0].Path.Value = kong.String("/otherbin")
+	_, err = c.GatewayV1alpha2().HTTPRoutes(other.Name).Update(ctx, otherRoute, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	defer func() {
+		t.Logf("cleaning up the httproute %s", httproute.Name)
+		if err := c.GatewayV1alpha2().HTTPRoutes(ns.Name).Delete(ctx, httproute.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+		if err := c.GatewayV1alpha2().HTTPRoutes(other.Name).Delete(ctx, httproute.Name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Log("verifying that the Gateway gets linked to the route via status")
+	eventuallyGatewayIsLinkedInStatus(t, c, ns.Name, httproute.Name)
+
+	t.Log("waiting for routes from HTTPRoute to become operational")
+	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	t.Log("waiting for routes from HTTPRoute in other namespace to become operational")
+	eventuallyGETPath(t, "otherbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+
+	t.Log("changing to the same namespace filter")
+	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		Name:     "http",
+		Protocol: gatewayv1alpha2.HTTPProtocolType,
+		Port:     gatewayv1alpha2.PortNumber(80),
+		AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+			Namespaces: &gatewayv1alpha2.RouteNamespaces{
+				From: &fromSame,
+			},
+		},
+	}}
+	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("confirming other namespace route becomes inacessible")
+	eventuallyGETPath(t, "otherbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
+	t.Log("confirming same namespace route still operational")
+	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+
+	t.Log("changing to a selector filter")
+	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		Name:     "http",
+		Protocol: gatewayv1alpha2.HTTPProtocolType,
+		Port:     gatewayv1alpha2.PortNumber(80),
+		AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+			Namespaces: &gatewayv1alpha2.RouteNamespaces{
+				From: &fromSelector,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						clusters.TestResourceLabel: t.Name() + "other",
+					},
+				},
+			},
+		},
+	}}
+
+	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("confirming wrong selector namespace route becomes inacesible")
+	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
+	t.Log("confirming right selector namespace route becomes operational")
+	eventuallyGETPath(t, "otherbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 }

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -440,7 +440,7 @@ func TestGatewayFilters(t *testing.T) {
 		}
 	}()
 
-	t.Log("deploying a gateway that only allows routes in all namespaces")
+	t.Log("deploying a gateway that allows routes in all namespaces")
 	fromSame := gatewayv1alpha2.NamespacesFromSame
 	fromAll := gatewayv1alpha2.NamespacesFromAll
 	fromSelector := gatewayv1alpha2.NamespacesFromSelector
@@ -498,7 +498,7 @@ func TestGatewayFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the deployment %s", deployment.Name)
+		t.Logf("cleaning up deployments %s/%s and %s/%s", ns.Name, deployment.Name, other.Name, otherDeployment.Name)
 		if err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				assert.NoError(t, err)
@@ -519,7 +519,7 @@ func TestGatewayFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the service %s", service.Name)
+		t.Logf("cleaning up the services %s/%s and %s/%s", ns.Name, service.Name, other.Name, service.Name)
 		if err := env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				assert.NoError(t, err)
@@ -629,7 +629,7 @@ func TestGatewayFilters(t *testing.T) {
 	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	t.Log("confirming other namespace route becomes inacessible")
+	t.Log("confirming other namespace route becomes inaccessible")
 	eventuallyGETPath(t, "otherbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
 	t.Log("confirming same namespace route still operational")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
@@ -674,7 +674,7 @@ func TestGatewayFilters(t *testing.T) {
 	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	t.Log("confirming wrong selector namespace route becomes inacesible")
+	t.Log("confirming wrong selector namespace route becomes inaccessible")
 	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
 	t.Log("confirming right selector namespace route becomes operational")
 	eventuallyGETPath(t, "otherbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -453,16 +453,28 @@ func TestGatewayFilters(t *testing.T) {
 		},
 		Spec: gatewayv1alpha2.GatewaySpec{
 			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "http",
-				Protocol: gatewayv1alpha2.HTTPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(80),
-				AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-					Namespaces: &gatewayv1alpha2.RouteNamespaces{
-						From: &fromAll,
+			Listeners: []gatewayv1alpha2.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1alpha2.HTTPProtocolType,
+					Port:     gatewayv1alpha2.PortNumber(80),
+					AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+						Namespaces: &gatewayv1alpha2.RouteNamespaces{
+							From: &fromAll,
+						},
 					},
 				},
-			}},
+				{
+					Name:     "https",
+					Protocol: gatewayv1alpha2.HTTPSProtocolType,
+					Port:     gatewayv1alpha2.PortNumber(443),
+					AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+						Namespaces: &gatewayv1alpha2.RouteNamespaces{
+							From: &fromAll,
+						},
+					},
+				},
+			},
 		},
 	}
 	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
@@ -592,16 +604,28 @@ func TestGatewayFilters(t *testing.T) {
 	t.Log("changing to the same namespace filter")
 	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
-		Name:     "http",
-		Protocol: gatewayv1alpha2.HTTPProtocolType,
-		Port:     gatewayv1alpha2.PortNumber(80),
-		AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-			Namespaces: &gatewayv1alpha2.RouteNamespaces{
-				From: &fromSame,
+	gw.Spec.Listeners = []gatewayv1alpha2.Listener{
+		{
+			Name:     "http",
+			Protocol: gatewayv1alpha2.HTTPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(80),
+			AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+				Namespaces: &gatewayv1alpha2.RouteNamespaces{
+					From: &fromSame,
+				},
 			},
 		},
-	}}
+		{
+			Name:     "https",
+			Protocol: gatewayv1alpha2.HTTPSProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(443),
+			AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+				Namespaces: &gatewayv1alpha2.RouteNamespaces{
+					From: &fromSame,
+				},
+			},
+		},
+	}
 	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -614,21 +638,38 @@ func TestGatewayFilters(t *testing.T) {
 	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
-	gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
-		Name:     "http",
-		Protocol: gatewayv1alpha2.HTTPProtocolType,
-		Port:     gatewayv1alpha2.PortNumber(80),
-		AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-			Namespaces: &gatewayv1alpha2.RouteNamespaces{
-				From: &fromSelector,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						clusters.TestResourceLabel: t.Name() + "other",
+	gw.Spec.Listeners = []gatewayv1alpha2.Listener{
+		{
+			Name:     "http",
+			Protocol: gatewayv1alpha2.HTTPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(80),
+			AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+				Namespaces: &gatewayv1alpha2.RouteNamespaces{
+					From: &fromSelector,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							clusters.TestResourceLabel: t.Name() + "other",
+						},
 					},
 				},
 			},
 		},
-	}}
+		{
+			Name:     "https",
+			Protocol: gatewayv1alpha2.HTTPSProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(443),
+			AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
+				Namespaces: &gatewayv1alpha2.RouteNamespaces{
+					From: &fromSelector,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							clusters.TestResourceLabel: t.Name() + "other",
+						},
+					},
+				},
+			},
+		},
+	}
 
 	_, err = c.GatewayV1alpha2().Gateways(ns.Name).Update(ctx, gw, metav1.UpdateOptions{})
 	require.NoError(t, err)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -402,17 +402,11 @@ func TestIngressNamespaces(t *testing.T) {
 
 	t.Log("creating extra testing namespaces")
 	elsewhereNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: extraIngressNamespace}}
-	nowhere := "nowhere"
-	nowhereNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nowhere}}
-	_, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, nowhereNamespace, metav1.CreateOptions{})
-	require.NoError(t, err)
-	_, err = env.Cluster().Client().CoreV1().Namespaces().Create(ctx, elsewhereNamespace, metav1.CreateOptions{})
+	_, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx, elsewhereNamespace, metav1.CreateOptions{})
 	require.NoError(t, err)
 	defer func() {
 		t.Logf("cleaning up namespace %s", elsewhereNamespace.Name)
 		assert.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, elsewhereNamespace.Name, metav1.DeleteOptions{}))
-		t.Logf("cleaning up namespace %s", nowhereNamespace.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, nowhereNamespace.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -420,26 +414,20 @@ func TestIngressNamespaces(t *testing.T) {
 	deployment := generators.NewDeploymentForContainer(container)
 	elsewhereDeployment, err := env.Cluster().Client().AppsV1().Deployments(extraIngressNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
-	nowhereDeployment, err := env.Cluster().Client().AppsV1().Deployments(nowhere).Create(ctx, deployment, metav1.CreateOptions{})
-	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the deployment %s", elsewhereDeployment.Name)
 		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(extraIngressNamespace).Delete(ctx, elsewhereDeployment.Name, metav1.DeleteOptions{}))
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(nowhere).Delete(ctx, nowhereDeployment.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
 	_, err = env.Cluster().Client().CoreV1().Services(extraIngressNamespace).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = env.Cluster().Client().CoreV1().Services(nowhere).Create(ctx, service, metav1.CreateOptions{})
-	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the service %s", service.Name)
 		assert.NoError(t, env.Cluster().Client().CoreV1().Services(extraIngressNamespace).Delete(ctx, service.Name, metav1.DeleteOptions{}))
-		assert.NoError(t, env.Cluster().Client().CoreV1().Services(nowhere).Delete(ctx, service.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
@@ -449,21 +437,11 @@ func TestIngressNamespaces(t *testing.T) {
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
-	nowhereIngress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/nowhere", map[string]string{
-		annotations.IngressClassKey: ingressClass,
-		"konghq.com/strip-path":     "true",
-	}, service)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), extraIngressNamespace, elsewhereIngress))
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), nowhere, nowhereIngress))
 
 	defer func() {
 		t.Log("ensuring that Ingress resources are cleaned up")
 		if err := clusters.DeleteIngress(ctx, env.Cluster(), extraIngressNamespace, elsewhereIngress); err != nil {
-			if !errors.IsNotFound(err) {
-				require.NoError(t, err)
-			}
-		}
-		if err := clusters.DeleteIngress(ctx, env.Cluster(), nowhere, nowhereIngress); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -488,16 +466,6 @@ func TestIngressNamespaces(t *testing.T) {
 			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
-	}, ingressWait, waitTick)
-
-	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/nowhere", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return expect404WithNoRoute(t, proxyURL.String(), resp)
 	}, ingressWait, waitTick)
 }
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -148,7 +148,6 @@ func TestMain(m *testing.M) {
 			fmt.Sprintf("--ingress-class=%s", ingressClass),
 			fmt.Sprintf("--admission-webhook-cert=%s", testutils.KongSystemServiceCert),
 			fmt.Sprintf("--admission-webhook-key=%s", testutils.KongSystemServiceKey),
-			fmt.Sprintf("--watch-namespace=%s", watchNamespaces),
 			fmt.Sprintf("--admission-webhook-listen=%s:%d", testutils.AdmissionWebhookListenHost, testutils.AdmissionWebhookListenPort),
 			"--profiling",
 			"--dump-config",


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.RouteNamespaces filter. This allows a Gateway Listener to filter the routes it will accept by namespace (any namespace, same namespace as Gateway, or namespaces identified by a selector).

Merges allowedRoutes section from user Listener sections into the generated managed Gateway Listeners. An allowedRoute in a user Listener whose procotol matches a generated Listener will be copied into that generated Listener.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2080. Some tasks were moved to separate issues.

I move to separate the BackendRef namespace filtering (see https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.BackendObjectReference) into its own issue, as it works with a completely different set of objects (BackendRefs and ReferencePolicys versus Gateways and XRoutes) in a different part of the code (mostly in the parser translate functions, not in the Gateway controller).

**Special notes for your reviewer**:

**Test changes**
Removed `--watch-namespaces` from integration without a replacement. Tests for this require creating a custom test namespace, which wouldn't be watched because it didn't exist at start time. We could create an E2E test for this, but it doesn't seem particularly worth the extra time cost: we just stuff the contents of a flag into a controller-runtime config option, so regression on our side is unlikely.

**Managed Gateway throws a wrench in this**
_From initial review, go with the merge approach, with some additional validation._

Dealing with config that lives inside a Listener is a difficult problem for our managed gateway approach. Currently, we ignore the original Listener configuration altogether and infer the entire correct Listener set from the proxy Service/Deployment, which would clobber any `allowedRoutes` section a user created. There are a couple options I can think of for handling this, all bad:

- Only call `r.determineListenersFromDataPlane()` on creation. Allow free manipulation of Listeners after a Gateway has passed through our initial managed Gateway mutation. If you wish to add `allowedRoutes`, you must wait until we populate Listeners and edit them in after. Simple, but I'm unsure if there's anything that relies on our currently updating Listeners on _every_ change to the Gateway.
- Attempt to "merge" as shown in this initial draft. Choose some criteria (here, protocol) used to match user Listeners to a generated Listener, then cut the `allowedRoutes` out of the user Listener and stuff it into the generated Listener before discarding the original user Listener. This works for the test example chosen, but feels like it opens a potential world of pain for cases that the merger can't handle correctly for some reason. It's also semi-hidden weird vendor behavior, which is not great.
- Annotate something we use to build the generated Listener to indicate the appropriate `allowedRoutes` configuration. Didn't explore much since you can't annotate individual ports, so this would presumably be limited to using the same thing across a Service.

**No kinds implementation**
_Per initial review with Shane, there's no immediate use for this. Deferred to #2408 whenever we add a route type that warrants it._

AllowedRoutes provides both `namespaces` and `kinds`. The latter lets you filter by Group+Kind combinations and is not implemented here (no problem! #2080 didn't ask for it!). I wasn't quite sure what the intended use of this was: it seems like you wouldn't be able to do much with it, since when would your UDP listener handle anything other than `gateway.networking.k8s.io/UDPRoute` and/or why would you want to write a filter that says it can't? If I write a condition saying that my UDP listen allows `gateway.networking.k8s.io/HTTPRoute`, or get really crazy and say it allows `configuration.konghq.com/KongConsumer`, what the heck does that even mean? It won't be able to do anything with them after.

Was this maybe intended for later, when you have say, an HTTPS listen that you only want to allow a hypothetical GRPCRoute through, not HTTPRoute? If that's indeed the case, do we know of anything that'd make use of this currently, and if not should we defer this?

The draft does de facto implement this sort of, albeit forcibly: it skips Listens whose protocols don't match the route when finding a matching Gateway, as that's necessary to ensure that you don't ingest an HTTPRoute on a Gateway that has an HTTP Listen that filters out its namespace, but also has a TCP Listen that allows any namespace.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
