### PR TITLE
fix(hack) add SAN to admission setup script

### DIFF
--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -7,7 +7,9 @@ fi
 
 # create a self-signed certificate
 openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365  \
-  -nodes -subj "/CN=kong-validation-webhook.kong.svc"
+    -nodes -subj "/CN=kong-validation-webhook.kong.svc" \
+    -extensions EXT -config <( \
+   printf "[dn]\nCN=kong-validation-webhook.kong.svc\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:kong-validation-webhook.kong.svc\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 # create a secret out of this self-signed cert-key pair
 kubectl create secret tls kong-validation-webhook -n kong \
       --key tls.key --cert tls.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds SAN in the admission hack script. Originally filed to docs, but intended for this repo. The script openssl invocation now matches the docs:

```
12:52:36-0700 esenin $ . ~/src/ingress-controller/hack/deploy-admission-controller.sh 
Generating a RSA private key
............................................................................................+++++
.......+++++
writing new private key to 'tls.key'
-----
error: failed to create secret namespaces "kong" not found
Error from server (NotFound): namespaces "kong" not found
validatingwebhookconfiguration.admissionregistration.k8s.io/kong-validations created
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/Kong/docs.konghq.com/issues/3211

**Special notes for your reviewer**:
IIRC the weird extension flag instead of `-addext` makes it compatible with OS X's old LibreSSL version (seriously, Monterey didn't update it? Apple please, why) but I don't have OS X myself to confirm.
