### PR TITLE
fix(admission) correct no-cert condition and release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [2.3.1](#231)
  - [2.3.0](#230)
  - [2.2.1](#221)
  - [2.2.0](#220)
@@ -44,6 +45,17 @@
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.3.1]
+
+> Release date: 2022-04-07
+
+#### Fixed
+
+- Fixed an issue where admission controllers configured without certificates
+  would incorrectly detect invalid configuration and prevent the controller
+  from starting.
+  [#2403](https://github.com/Kong/kubernetes-ingress-controller/pull/2403)
 
 ## [2.3.0]
 
@@ -1646,6 +1658,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.3.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.1.1...v2.2.0

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '2.8'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.3.0'
+  newTag: '2.3.1'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1404,7 +1404,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.3.0
+        image: kong/kubernetes-ingress-controller:2.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1399,7 +1399,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.3.0
+        image: kong/kubernetes-ingress-controller:2.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1473,7 +1473,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.3.0
+        image: kong/kubernetes-ingress-controller:2.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1417,7 +1417,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.3.0
+        image: kong/kubernetes-ingress-controller:2.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -66,7 +66,7 @@ func (sc *ServerConfig) toTLSConfig(ctx context.Context, log logrus.FieldLogger)
 		}
 
 	// the caller provided no certificate configuration, assume the default paths and enable certwatcher for them
-	case sc.CertPath != "" && sc.KeyPath != "" && sc.Cert == "" && sc.Key == "":
+	case sc.CertPath == "" && sc.KeyPath == "" && sc.Cert == "" && sc.Key == "":
 		var err error
 		watcher, err = certwatcher.New(DefaultAdmissionWebhookCertPath, DefaultAdmissionWebhookKeyPath)
 		if err != nil {

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 )
 
 // -----------------------------------------------------------------------------
@@ -54,6 +59,7 @@ nodes:
 `
 	validationWebhookName = "kong-validation-webhook"
 	kongNamespace         = "kong"
+	admissionScriptPath   = "../../hack/deploy-admission-controller.sh"
 )
 
 var (
@@ -287,18 +293,40 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	require.NoError(t, err)
 	deployment := deployKong(ctx, t, env, manifest)
 
+	t.Log("running the admission webhook setup script")
+	cmd := exec.Command("bash", admissionScriptPath)
+	require.NoError(t, cmd.Run())
+
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	require.NoError(t, err)
 	t.Log("updating kong deployment to enable Gateway feature gate and admission controller")
 	for i, container := range deployment.Spec.Template.Spec.Containers {
 		if container.Name == "ingress-controller" {
 			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "Gateway=true"},
-				corev1.EnvVar{Name: "CONTROLLER_ADMISSION_WEBHOOK_LISTEN", Value: ":8080"})
+				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "Gateway=true"})
 		}
 	}
 
 	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
 		deployment, metav1.UpdateOptions{})
-	require.NoError(t, err)
+
+	// vov it's easier than tracking the deployment state
+	t.Log("creating a consumer to ensure the admission webhook is online")
+	consumer := &kongv1.KongConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nihoniy",
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Username: "nihoniy",
+	}
+
+	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
+	require.Eventually(t, func() bool {
+		_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
+		return err == nil
+	}, time.Minute*2, time.Second*1)
 
 	t.Log("verifying controller updates associated Gateway resoures")
 	gw := deployGateway(ctx, t, env)

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -251,6 +251,8 @@ func TestWebhookUpdate(t *testing.T) {
 	}, time.Minute*10, time.Second)
 }
 
+// TestDeployAllInOneDBLESSGateway tests the Gateway feature flag and the admission controller with no user-provided
+// certificate (all other tests with the controller provide certificates, so that behavior isn't tested otherwise)
 func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test for Gateway")
 	t.Parallel()
@@ -285,11 +287,12 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	require.NoError(t, err)
 	deployment := deployKong(ctx, t, env, manifest)
 
-	t.Log("updating kong deployment to enable Gateway feature gate")
+	t.Log("updating kong deployment to enable Gateway feature gate and admission controller")
 	for i, container := range deployment.Spec.Template.Spec.Containers {
 		if container.Name == "ingress-controller" {
 			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "Gateway=true"})
+				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "Gateway=true"},
+				corev1.EnvVar{Name: "CONTROLLER_ADMISSION_WEBHOOK_LISTEN", Value: ":8080"})
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Release a 2.3.1 hotfix

Correct the admission webhook TLS configuration cases to check that all
configuration is empty for the case that handles empty configuration.
Previously it was identical to the case that handled certificate files.

This fixes a bug where admission controllers with no certificate
configuration would prevent the controller from starting.

**Special notes for your reviewer**:

Modified an unrelated E2E test (the tested configuration doesn't overlap, so this is to save time by not needing an additional E2E test that modifies the deployment) to enable the admission controller without any certificate configuration. Previously we only tested this after the fact in the Helm chart tests.

The E2E tests now run the admission webhook setup script because we do still need a certificate, it just needs to be in the default location (Helm gets it because the chart includes a cert generator), so bonus, we get to test that now too!

Wait for https://github.com/Kong/kubernetes-ingress-controller/actions/runs/2112028513 to succeed to confirm them fix.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
