### PR TITLE
fix(sendconfig) suppress deck diff logs at info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
   [#2389](https://github.com/Kong/kubernetes-ingress-controller/issues/2389)
 
 #### Fixed
+
 - Added a mechanism to retry the initial connection to the Kong
   Admin API on controller start to fix an issue where the controller
   pod could crash loop on start when waiting for Gateway readiness 
@@ -79,6 +80,9 @@
   The new retry mechanism can be manually configured using the 
   `--kong-admin-init-retries` and `--kong-admin-init-retry-delay` flags.
   [#2274](https://github.com/Kong/kubernetes-ingress-controller/issues/2274)
+- diff logging now honors log level instead of printing at all log levels. It
+  will only print at levels `debug` and `trace`.
+  [#2422](https://github.com/Kong/kubernetes-ingress-controller/issues/2422)
 
 ## [2.3.1]
 

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bombsimon/logrusr/v2"
 	"github.com/go-logr/logr"
+	"github.com/kong/deck/cprint"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +43,11 @@ func setupLoggers(c *Config) (logrus.FieldLogger, logr.Logger, error) {
 
 	logger := logrusr.New(deprecatedLogger)
 	ctrl.SetLogger(logger)
+
+	if c.LogLevel != "trace" && c.LogLevel != "debug" {
+		// disable deck's per-change diff output
+		cprint.DisableOutput = true
+	}
 
 	return deprecatedLogger, logger, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable deck's full diff output at log level info and above. diffs will only print at debug or trace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2411 

**Special notes for your reviewer**:
deck doesn't run this output through the regular logging pipeline, so it has no log level, and is controlled independently by the `--silence-events` flag.

I opted to limit it to debug and lower since AFAIK it doesn't have any type-specific logic for anything other than Konnect Documents, so it prints changes to certificates and credentials and such, which we don't want at info.

Ideally deck would return diff text to a callers to allow them to determine how to print it (so we could pass it through our logger while the deck CLI does what it does currently), but as it's a direct call to console print from the diff loop, we can only suppress these logs, not add proper level/timestamp/fields formatting (multi-line output makes that a pain even if we could).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
