### PR TITLE
feat: multi backendref load-balancing for UDPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 #### Added
 
+- `UDPRoute` resources now support multiple backendRefs for load-balancing.
+  [#2405](https://github.com/Kong/kubernetes-ingress-controller/issues/2405)
 - `TCPRoute` resources now support multiple backendRefs for load-balancing.
   [#2405](https://github.com/Kong/kubernetes-ingress-controller/issues/2405)
 - `TCPRoute` resources are now supported.

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -409,6 +409,14 @@ func TestTCPRouteEssentials(t *testing.T) {
 		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
+	require.Eventually(t, func() bool {
+		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return err == nil && responded == true
+	}, ingressWait, waitTick)
+	require.Eventually(t, func() bool {
+		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		return err == nil && responded == true
+	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -397,6 +397,10 @@ const corefile = `
     loop
     reload
     loadbalance
+    hosts {
+      10.0.0.1 konghq.com
+      fallthrough
+    }
 }
 .:9999 {
     errors
@@ -416,5 +420,9 @@ const corefile = `
     loop
     reload
     loadbalance
+    hosts {
+      10.0.0.1 konghq.com
+      fallthrough
+    }
 }
 `

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,8 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 )
+
+const testdomain = "konghq.com"
 
 func TestUDPRouteEssentials(t *testing.T) {
 	ns, cleanup := namespace(t)
@@ -89,50 +92,84 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}()
 
 	t.Log("configuring coredns corefile")
-	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}
-	cfgmap, err = env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Create(ctx, cfgmap, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	cfgmap1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}
+	cfgmap1, err = env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Create(ctx, cfgmap1, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("configuring alternative coredns corefile for load-balanced setup")
+	alternativeCorefile := strings.Replace(corefile, "10.0.0.1 konghq.com", "10.0.0.2 konghq.com", -1)
+	cfgmap2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns2"}, Data: map[string]string{"Corefile": alternativeCorefile}}
+	cfgmap2, err = env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Create(ctx, cfgmap2, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the coredns corefile %s", cfgmap.Name)
-		assert.NoError(t, env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Delete(ctx, cfgmap.Name, metav1.DeleteOptions{}))
+		t.Logf("cleaning up the coredns corefiles %s/%s and %s/%s", cfgmap1.Namespace, cfgmap1.Name, cfgmap2.Namespace, cfgmap2.Name)
+		assert.NoError(t, env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Delete(ctx, cfgmap1.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().ConfigMaps(ns.Name).Delete(ctx, cfgmap2.Name, metav1.DeleteOptions{}))
 	}()
 
 	t.Log("configuring a coredns deployent to deploy for UDP testing")
-	container := generators.NewContainer("coredns", coreDNSImage, ktfkong.DefaultUDPServicePort)
-	container.Ports[0].Protocol = corev1.ProtocolUDP
-	container.VolumeMounts = []corev1.VolumeMount{{Name: "config-volume", MountPath: "/etc/coredns"}}
-	container.Args = []string{"-conf", "/etc/coredns/Corefile"}
-	deployment := generators.NewDeploymentForContainer(container)
+	container1 := generators.NewContainer("coredns", coreDNSImage, ktfkong.DefaultUDPServicePort)
+	container1.Ports[0].Protocol = corev1.ProtocolUDP
+	container1.VolumeMounts = []corev1.VolumeMount{{Name: "config-volume", MountPath: "/etc/coredns"}}
+	container1.Args = []string{"-conf", "/etc/coredns/Corefile"}
+	deployment1 := generators.NewDeploymentForContainer(container1)
 
 	t.Log("configuring the coredns pod with a custom corefile")
-	configVolume := corev1.Volume{
+	configVolume1 := corev1.Volume{
 		Name: "config-volume",
 		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: cfgmap.Name},
+			LocalObjectReference: corev1.LocalObjectReference{Name: cfgmap1.Name},
 			Items:                []corev1.KeyToPath{{Key: "Corefile", Path: "Corefile"}}}}}
-	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, configVolume)
+	deployment1.Spec.Template.Spec.Volumes = append(deployment1.Spec.Template.Spec.Volumes, configVolume1)
 
 	t.Log("deploying coredns")
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	deployment1, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment1, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("configuring alternative coredns deployent for load-balanced UDP testing")
+	container2 := generators.NewContainer("coredns", coreDNSImage, ktfkong.DefaultUDPServicePort)
+	container2.Ports[0].Protocol = corev1.ProtocolUDP
+	container2.VolumeMounts = []corev1.VolumeMount{{Name: "config-volume", MountPath: "/etc/coredns"}}
+	container2.Args = []string{"-conf", "/etc/coredns/Corefile"}
+	deployment2 := generators.NewDeploymentForContainer(container2)
+	deployment2.ObjectMeta.Name = "coredns2"
+
+	t.Log("configuring the coredns pod with a custom corefile")
+	configVolume2 := corev1.Volume{
+		Name: "config-volume",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: cfgmap2.Name},
+			Items:                []corev1.KeyToPath{{Key: "Corefile", Path: "Corefile"}}}}}
+	deployment2.Spec.Template.Spec.Volumes = append(deployment2.Spec.Template.Spec.Volumes, configVolume2)
+
+	t.Log("deploying alternative coredns")
+	deployment2, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment2, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up deployment %s", deployment.Name)
-		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+		t.Logf("cleaning up deployments %s/%s and %s/%s", deployment1.Namespace, deployment1.Name, deployment2.Namespace, deployment2.Name)
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment1.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().AppsV1().Deployments(ns.Name).Delete(ctx, deployment2.Name, metav1.DeleteOptions{}))
 	}()
 
-	t.Logf("exposing deployment %s via service", deployment.Name)
-	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	t.Logf("exposing deployment %s/%s via service", deployment1.Namespace, deployment1.Name)
+	service := generators.NewServiceForDeployment(deployment1, corev1.ServiceTypeLoadBalancer)
 	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	t.Logf("exposing alternative deployment %s/%s via service", deployment1.Namespace, deployment1.Name)
+	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
+	service2, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service2, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the service %s", service.Name)
+		t.Logf("cleaning up services %s/%s and %s/%s", service.Namespace, service.Name, service2.Namespace, service2.Name)
 		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service.Name, metav1.DeleteOptions{}))
+		assert.NoError(t, env.Cluster().Client().CoreV1().Services(ns.Name).Delete(ctx, service2.Name, metav1.DeleteOptions{}))
 	}()
 
-	t.Logf("creating a udproute to access deployment %s via kong", deployment.Name)
+	t.Logf("creating a udproute to access deployment %s via kong", deployment1.Name)
 	udpPortDefault := gatewayv1alpha2.PortNumber(ktfkong.DefaultUDPServicePort)
 	udproute := &gatewayv1alpha2.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -183,7 +220,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, udproute.Name)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udproute.Name)
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err == nil
 	}, ingressWait, waitTick)
@@ -205,7 +242,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	// negative checks for these tests check that DNS queries eventually start to fail, presumably because they time
 	// out. we assume there shouldn't be unrelated failure reasons because they always follow a test that confirm
 	// resolution was working before. we can't use never here because there may be some delay in deleting the route
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err != nil
 	}, ingressWait, waitTick)
@@ -224,7 +261,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	t.Logf("checking DNS to resolve via UDPIngress %s", udproute.Name)
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err == nil
 	}, ingressWait, waitTick)
@@ -237,7 +274,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, udproute.Name)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the GatewayClass now removed")
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err != nil
 	}, ingressWait, waitTick)
@@ -259,7 +296,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of UDPRoutes and the route becomes available again")
 	t.Logf("checking DNS to resolve via UDPIngress %s", udproute.Name)
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err == nil
 	}, ingressWait, waitTick)
@@ -272,7 +309,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, udproute.Name)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the Gateway now removed")
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err != nil
 	}, ingressWait, waitTick)
@@ -301,11 +338,40 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, udproute.Name)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of UDPRoutes and the route becomes available again")
-	t.Logf("checking DNS to resolve via UDPIngress %s", udproute.Name)
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err == nil
 	}, ingressWait, waitTick)
+
+	t.Log("adding another backendRef to load-balance the DNS between multiple CoreDNS pods")
+	require.Eventually(t, func() bool {
+		udproute, err = c.GatewayV1alpha2().UDPRoutes(ns.Name).Get(ctx, udproute.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		udproute.Spec.Rules[0].BackendRefs = []gatewayv1alpha2.BackendRef{
+			{
+				BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					Name: gatewayv1alpha2.ObjectName(service.Name),
+					Port: &udpPortDefault,
+				},
+			},
+			{
+				BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					Name: gatewayv1alpha2.ObjectName(service2.Name),
+					Port: &udpPortDefault,
+				},
+			},
+		}
+
+		udproute, err = c.GatewayV1alpha2().UDPRoutes(ns.Name).Update(ctx, udproute, metav1.UpdateOptions{})
+		return err == nil
+	}, ingressWait, waitTick)
+
+	t.Log("verifying that DNS queries are being load-balanced between multiple CoreDNS pods")
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -315,7 +381,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, udproute.Name)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute does not get orphaned with the GatewayClass and Gateway gone")
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		return err != nil
 	}, ingressWait, waitTick)
@@ -358,4 +424,15 @@ func udpeventuallyGatewayIsUnlinkedInStatus(t *testing.T, c *gatewayclient.Clien
 		// linked gateway is not present, all set
 		return true
 	}, ingressWait, waitTick)
+}
+
+func isDNSResolverReturningExpectedResult(resolver *net.Resolver, host, addr string) bool { //nolint:unparam
+	addrs, err := resolver.LookupHost(ctx, host)
+	if err != nil {
+		return false
+	}
+	if len(addrs) != 1 {
+		return false
+	}
+	return addrs[0] == addr
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for load-balancing `UDPRoutes` with multiple `backendRefs`.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2405

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
