### PR TITLE
feat(controllers) add ReferencePolicy controller

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -79,4 +79,9 @@ resources:
   kind: UDPRoute
   path: github.com/kubernetes-sigs/gateway-api/apis/v1alpha2
   version: v1alpha2
+- controller: true
+  domain: networking.k8s.io
+  group: gateway
+  kind: ReferencePolicy
+  version: v1alpha2
 version: "3"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -235,6 +235,32 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - tcproutes
   verbs:
   - get

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1185,6 +1185,32 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - tcproutes
   verbs:
   - get

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1185,6 +1185,32 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - tcproutes
   verbs:
   - get

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1185,6 +1185,32 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - tcproutes
   verbs:
   - get

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1185,6 +1185,32 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - tcproutes
   verbs:
   - get

--- a/internal/controllers/gateway/referencepolicy_controller.go
+++ b/internal/controllers/gateway/referencepolicy_controller.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+)
+
+// ReferencePolicyReconciler reconciles a ReferencePolicy object
+type ReferencePolicyReconciler struct {
+	client.Client
+	Log             logr.Logger
+	Scheme          *runtime.Scheme
+	DataplaneClient *dataplane.KongClient
+
+	PublishService  string
+	WatchNamespaces []string
+}
+
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencepolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencepolicies/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencepolicies/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *ReferencePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("NetV1Alpha2ReferencePolicy", req.NamespacedName)
+	policy := new(gatewayv1alpha2.ReferencePolicy)
+	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
+		// if the queued object is no longer present in the proxy cache we need
+		// to ensure that if it was ever added to the cache, it gets removed.
+		if errors.IsNotFound(err) {
+			debug(log, policy, "object does not exist, ensuring it is not present in the proxy cache")
+			policy.Namespace = req.Namespace
+			policy.Name = req.Name
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(policy)
+		}
+
+		// for any error other than 404, requeue
+		return ctrl.Result{}, err
+	}
+	debug(log, policy, "processing referencepolicy")
+
+	debug(log, policy, "checking deletion timestamp")
+	if policy.DeletionTimestamp != nil {
+		debug(log, policy, "referencepolicy is being deleted, re-configuring data-plane")
+		if err := r.DataplaneClient.DeleteObject(policy); err != nil {
+			debug(log, policy, "failed to delete object from data-plane, requeuing")
+			return ctrl.Result{}, err
+		}
+		debug(log, policy, "ensured object was removed from the data-plane (if ever present)")
+		return ctrl.Result{}, r.DataplaneClient.DeleteObject(policy)
+	}
+
+	if err := r.DataplaneClient.UpdateObject(policy); err != nil {
+		debug(log, policy, "failed to update object in data-plane, requeueing")
+		return ctrl.Result{}, err
+	}
+	info(log, policy, "referencepolicy has been configured on the data-plane")
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ReferencePolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("referencepolicy-controller", mgr, controller.Options{
+		Reconciler: r,
+		Log:        r.Log,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(
+		&source.Kind{Type: &gatewayv1alpha2.ReferencePolicy{}},
+		&handler.EnqueueRequestForObject{},
+	)
+}

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -277,7 +277,7 @@ func setupControllers(
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "referencepolicies",
 				}}.CRDExists,
-			Controller: &gateway.HTTPRouteReconciler{
+			Controller: &gateway.ReferencePolicyReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("ReferencePolicy"),
 				Scheme:          mgr.GetScheme(),

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -275,6 +275,21 @@ func setupControllers(
 				GVR: schema.GroupVersionResource{
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
+					Resource: "referencepolicies",
+				}}.CRDExists,
+			Controller: &gateway.HTTPRouteReconciler{
+				Client:          mgr.GetClient(),
+				Log:             ctrl.Log.WithName("controllers").WithName("ReferencePolicy"),
+				Scheme:          mgr.GetScheme(),
+				DataplaneClient: dataplaneClient,
+			},
+		},
+		{
+			Enabled: featureGates[gatewayFeature],
+			AutoHandler: crdExistsChecker{
+				GVR: schema.GroupVersionResource{
+					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
+					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "httproutes",
 				}}.CRDExists,
 			Controller: &gateway.HTTPRouteReconciler{

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -36,6 +36,7 @@ type FakeObjects struct {
 	HTTPRoutes         []*gatewayv1alpha2.HTTPRoute
 	UDPRoutes          []*gatewayv1alpha2.UDPRoute
 	TCPRoutes          []*gatewayv1alpha2.TCPRoute
+	ReferencePolicies  []*gatewayv1alpha2.ReferencePolicy
 	TCPIngresses       []*configurationv1beta1.TCPIngress
 	UDPIngresses       []*configurationv1beta1.UDPIngress
 	Services           []*apiv1.Service
@@ -91,6 +92,12 @@ func NewFakeStore(
 	tcprouteStore := cache.NewStore(keyFunc)
 	for _, tcproute := range objects.UDPRoutes {
 		if err := tcprouteStore.Add(tcproute); err != nil {
+			return nil, err
+		}
+	}
+	referencepolicyStore := cache.NewStore(keyFunc)
+	for _, referencepolicy := range objects.ReferencePolicies {
+		if err := referencepolicyStore.Add(referencepolicy); err != nil {
 			return nil, err
 		}
 	}
@@ -166,17 +173,18 @@ func NewFakeStore(
 	}
 	s = Store{
 		stores: CacheStores{
-			IngressV1beta1: ingressV1beta1Store,
-			IngressV1:      ingressV1Store,
-			IngressClassV1: ingressClassV1Store,
-			HTTPRoute:      httprouteStore,
-			UDPRoute:       udprouteStore,
-			TCPRoute:       tcprouteStore,
-			TCPIngress:     tcpIngressStore,
-			UDPIngress:     udpIngressStore,
-			Service:        serviceStore,
-			Endpoint:       endpointStore,
-			Secret:         secretsStore,
+			IngressV1beta1:  ingressV1beta1Store,
+			IngressV1:       ingressV1Store,
+			IngressClassV1:  ingressClassV1Store,
+			HTTPRoute:       httprouteStore,
+			UDPRoute:        udprouteStore,
+			TCPRoute:        tcprouteStore,
+			ReferencePolicy: referencepolicyStore,
+			TCPIngress:      tcpIngressStore,
+			UDPIngress:      udpIngressStore,
+			Service:         serviceStore,
+			Endpoint:        endpointStore,
+			Secret:          secretsStore,
 
 			Plugin:        kongPluginsStore,
 			ClusterPlugin: kongClusterPluginsStore,

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -764,3 +764,28 @@ func TestFakeStoreUDPRoute(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(routes, 2, "expect two UDPRoutes")
 }
+
+func TestFakeStoreReferencePolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	policies := []*gatewayv1alpha2.ReferencePolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: gatewayv1alpha2.ReferencePolicySpec{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+			Spec: gatewayv1alpha2.ReferencePolicySpec{},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{ReferencePolicies: policies})
+	assert.Nil(err)
+	assert.NotNil(store)
+	routes, err := store.ListReferencePolicies()
+	assert.Nil(err)
+	assert.Len(routes, 2, "expect two ReferencePolicies")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a controller to watch Gateway ReferencePolicies and associated store functions and RBAC permissions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: part of #2407 

**Special notes for your reviewer**:
Just controller scaffolding, doesn't actually do anything with the policies we ingest yet.

This controller is simple enough (just ingest everything we can see, no cross-resource validation needed) that it probably could be handled by the generator, but none of the other Gateway resources use it, so I hand-rolled it.

This drops policies into the store for (future PR) evaluation at configuration generation time. It's probably technically possible to filter out Routes based on their BackendRefs and the ReferencePolicy set entirely within the controllers, but we'd need to requeue stuff like crazy on ReferencePolicy changes, so config gen time seems cleaner to implement in our current architecture. May be a reasonable open question which is better, but it's easy to rip out the store parts if we want to handle everything during controller reconciles.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ no user-facing change from this yet
