### PR TITLE
feat(logging) use logrus.WithFields in logging errors 

### DIFF
--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -184,7 +184,10 @@ func (r *Route) overrideMethods(log logrus.FieldLogger, anns map[string]string) 
 		} else {
 			// if any method is invalid (not an uppercase alpha string),
 			// discard everything
-			log.WithField("kongroute", r.Name).Errorf("invalid method: %v", method)
+			log.WithFields(logrus.Fields{
+				"kongroute": r.Name,
+				"method":    method,
+			}).Error("invalid method")
 			return
 		}
 	}
@@ -208,7 +211,10 @@ func (r *Route) overrideSNIs(log logrus.FieldLogger, anns map[string]string) {
 			snis = append(snis, kong.String(sanitizedSNI))
 		} else {
 			// SNI is not a valid hostname
-			log.WithField("kongroute", r.Name).Errorf("invalid SNI: %v", sni)
+			log.WithFields(logrus.Fields{
+				"kongroute": r.Name,
+				"SNI":       sni,
+			}).Error("invalid SNI")
 			return
 		}
 	}
@@ -304,7 +310,10 @@ func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *confi
 				SNIs = append(SNIs, kong.String(SNI))
 			} else {
 				// SNI is not a valid hostname
-				log.WithField("kongroute", r.Name).Errorf("invalid SNI: %v", unsanitizedSNI)
+				log.WithFields(logrus.Fields{
+					"kongroute": r.Name,
+					"SNI":       unsanitizedSNI,
+				}).Errorf("invalid SNI")
 				return
 			}
 		}

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -48,7 +48,7 @@ func (p *Parser) ingressRulesFromIngressV1beta1() ingressRules {
 				path := rule.Path
 
 				if strings.Contains(path, "//") {
-					log.Errorf("rule skipped: invalid path: '%v'", path)
+					log.WithField("ingress_rule_path", path).Error("rule skipped: invalid path")
 					continue
 				}
 				if path == "" {
@@ -193,7 +193,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 			}
 			for j, rulePath := range rule.HTTP.Paths {
 				if strings.Contains(rulePath.Path, "//") {
-					log.Errorf("rule skipped: invalid path: '%v'", rulePath.Path)
+					log.WithField("ingress_rule_path", rulePath.Path).Errorf("rule skipped: invalid path")
 					continue
 				}
 

--- a/internal/dataplane/parser/translate_kong_l4.go
+++ b/internal/dataplane/parser/translate_kong_l4.go
@@ -39,7 +39,7 @@ func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
 		var objectSuccessfullyParsed bool
 		for i, rule := range ingressSpec.Rules {
 			if !util.IsValidPort(rule.Port) {
-				log.Errorf("invalid TCPIngress: invalid port: %v", rule.Port)
+				log.WithField("tcpingess_rule_port", rule.Port).Error("invalid TCPIngress: invalid port")
 				continue
 			}
 			r := kongstate.Route{
@@ -127,7 +127,7 @@ func (p *Parser) ingressRulesFromUDPIngressV1beta1() ingressRules {
 		for i, rule := range ingressSpec.Rules {
 			// validate the ports and servicenames for the rule
 			if !util.IsValidPort(rule.Port) {
-				log.Errorf("invalid UDPIngress: invalid port: %d", rule.Port)
+				log.WithField("udpingress_rule_port", rule.Port).Error("invalid UDPIngress: invalid port")
 				continue
 			}
 			if rule.Backend.ServiceName == "" {
@@ -135,7 +135,7 @@ func (p *Parser) ingressRulesFromUDPIngressV1beta1() ingressRules {
 				continue
 			}
 			if !util.IsValidPort(rule.Backend.ServicePort) {
-				log.Errorf("invalid UDPIngress: invalid servicePort: %d", rule.Backend.ServicePort)
+				log.WithField("udpingress_rule_serviceport", rule.Backend.ServicePort).Error("invalid UDPIngress: invalid servicePort")
 				continue
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
use `logrus.WithFields` for logging variables in logs for structured logging 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1013

**Special notes for your reviewer**:
Searched for all `log.*` and replaced all `log.*.Errorf("... xxx: %v",yyy)` to `log.WithFields(logrus.Fields{"xxx":yyy}).Error("...")`

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
