### PR TITLE
Kubernetes ingress controller does not start with mTLS when certificates are provided by files #2443

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -98,6 +98,7 @@ func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 			return nil, fmt.Errorf("failed to read certificate file %s: %w", tlsClientCertPath, err)
 		}
 		opts.TLSClientCert = string(tlsClientCert)
+		pts.TLSClientCertPath = ""
 	}
 	if opts.TLSClientKeyPath != "" {
 		tlsClientKeyPath := opts.TLSClientKeyPath
@@ -106,6 +107,7 @@ func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 			return nil, fmt.Errorf("failed to read key file %s: %w", tlsClientKeyPath, err)
 		}
 		opts.TLSClientKey = string(tlsClientKey)
+		opts.TLSClientKeyPath = ""
 	}
 
 	// if the caller has supplied either the cert or the key but not both, this is


### PR DESCRIPTION
Kubernetes ingress controller does not start with mTLS when certificates are provided by files #2443

Clenup options after reding from file location.

**What this PR does / why we need it**:

fixes #2443

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
