### PR TITLE
fix: race conditions for object status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 
 #### Fixed
 
+- Fixed a race condition in the newer Gateway route controllers which could
+  trigger when an object's status was updated shortly after the object was
+  cached in the dataplane client.
+  [#2446](https://github.com/Kong/kubernetes-ingress-controller/issues/2446)
 - Added a mechanism to retry the initial connection to the Kong
   Admin API on controller start to fix an issue where the controller
   pod could crash loop on start when waiting for Gateway readiness 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -164,7 +164,9 @@ func NewKongClient(
 // It will be asynchronously converted into the upstream Kong DSL and applied to the Kong Admin API.
 // A status will later be added to the object whether the configuration update succeeds or fails.
 func (c *KongClient) UpdateObject(obj client.Object) error {
-	return c.cache.Add(obj)
+	// we do a deep copy of the object here so that the caller can continue to use
+	// the original object in a threadsafe manner.
+	return c.cache.Add(obj.DeepCopyObject())
 }
 
 // DeleteObject accepts a Kubernetes controller-runtime client.Object and removes it from the configuration cache.


### PR DESCRIPTION
**What this PR does / why we need it**:

This resolves race conditions that can occur when updating the status of an object in a controller shortly after caching it in the dataplane client.

**Which issue this PR fixes**

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2446

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
