### PR TITLE
fix(kic): updated error message of env binding to include environment variable name

### DIFF
--- a/internal/cmd/rootcmd/env.go
+++ b/internal/cmd/rootcmd/env.go
@@ -14,14 +14,15 @@ const envKeyPrefix = "CONTROLLER_"
 // bindEnvVars, for each flag defined on `cmd` (local or parent persistent), looks up the corresponding environment
 // variable and (if the flag is unset) takes that environment variable value as the flag value.
 func bindEnvVars(cmd *cobra.Command, _ []string) (err error) {
+	var envKey string
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("environment binding failed: %v", r)
+			err = fmt.Errorf("environment binding failed for variable %s: %v", envKey, r)
 		}
 	}()
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		envKey := fmt.Sprintf("%s%s", envKeyPrefix, strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_")))
+		envKey = fmt.Sprintf("%s%s", envKeyPrefix, strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_")))
 
 		if f.Changed {
 			return // flags take precedence over environment variables

--- a/internal/cmd/rootcmd/env_test.go
+++ b/internal/cmd/rootcmd/env_test.go
@@ -68,7 +68,7 @@ func TestBindEnvVarsValidation(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "bad value for var type testvar"))
+	assert.True(t, strings.Contains(err.Error(), "variable CONTROLLER_VALIDATION_TEST: bad value for var type testvar"))
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**: This pr introduces the environment variable name in the error message for better UX and understanding when an env fails to bind with its value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2412

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
