### PR TITLE
Test HTTPRoute plugin support

### DIFF
--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -259,13 +259,8 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		return true
 	}, ingressWait, waitTick)
 
-	t.Log("verifying that weighted loadbalancing strategy is implemented properly and the nginx service is only getting 25% of the load")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>Welcome to nginx!</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2452 need to verify weight distribution
+	t.Log("verifying that both backends receive requests")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>Welcome to nginx!</title>", emptyHeaderSet)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Tests that we can bind plugins to HTTPRoutes.

Removes some test content that was just making the test take longer (see #2452) as written.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2391 

