### PR TITLE
fix(build) enable arm64 for Red Hat images

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -91,6 +91,7 @@ jobs:
           tags: ${{ steps.meta_redhat.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           target: redhat
+          platforms: linux/amd64, linux/arm64
           build-args: |
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,6 +146,7 @@ jobs:
           tags: ${{ steps.meta_redhat.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           target: redhat
+          platforms: linux/amd64, linux/arm64
           build-args: |
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION
We missed this in the earlier PR. Found after looking at nightly and seeing that RH was still single-arch.