### PR TITLE
Refactor test coverage download and upload steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,7 +103,7 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
-        name: coverage.unit.out
+        name: coverage
         path: coverage.unit.out
 
   runnable:
@@ -149,7 +149,7 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
-        name: coverage.enterprisepostgres.out
+        name: coverage
         path: coverage.enterprisepostgres.out
 
   integration-tests-dbless:
@@ -180,7 +180,7 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
-        name: coverage.dbless.out
+        name: coverage
         path: coverage.dbless.out
 
   integration-tests-postgres:
@@ -211,7 +211,7 @@ jobs:
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
-        name: coverage.postgres.out
+        name: coverage
         path: coverage.postgres.out
 
   conformance-tests:
@@ -248,41 +248,19 @@ jobs:
       - "integration-tests-enterprise-postgres"
     runs-on: ubuntu-latest
     steps:
-      # TODO: deduplicate the download-artifact steps by implementing a `matrix` workflow step instead
-    - name: collect unit test coverage artifacts
-      id: download-unit
-      uses: actions/download-artifact@v3
-      with:
-        name: coverage.unit.out
-        path: coverage.unit.out
 
-    - name: collect dbless test coverage artifacts
-      id: download-dbless
+    - name: collect test coverage artifacts
+      id: download-coverage
       uses: actions/download-artifact@v3
       with:
-        name: coverage.dbless.out
-        path: coverage.dbless.out
-
-    - name: collect postgres test coverage artifacts
-      id: download-postgres
-      uses: actions/download-artifact@v3
-      with:
-        name: coverage.postgres.out
-        path: coverage.postgres.out
-
-    - name: collect enterprisepostgres test coverage artifacts
-      id: download-enterprisepostgres
-      uses: actions/download-artifact@v3
-      with:
-        name: coverage.enterprisepostgres.out
-        path: coverage.enterprisepostgres.out
+        name: coverage
+        path: coverage
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         name: combined-coverage
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ${{steps.download-unit.outputs.download-path}}/coverage.unit.out,${{steps.download-dbless.outputs.download-path}}/coverage.dbless.out,${{steps.download-postgres.outputs.download-path}}/coverage.postgres.out,
-               ${{steps.download-enterprisepostgres.outputs.download-path}}/coverage.enterprisepostgres.out
+        directory: ${{steps.download-coverage.outputs.download-path}}
         fail_ci_if_error: true
         verbose: true


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Looking at the Github actions code I saw `# TODO: deduplicate the download-artifact steps by implementing a matrix workflow step instead`.

Instead of using the `matrix` to solve this problem of duplicating the artifact download step, it's possible to use a better approach.
1. Store coverage files to the same upload artifact folder called `coverage`.
```yaml
- name: collect test coverage
      uses: actions/upload-artifact@v3
      with:
        name: coverage
        path: coverage.postgres.out
```

2. When it comes to downloading, we can simply download all coverage reports from this artifact folder and store to a subfolder defined using the variable `path`
```yaml
- name: collect test coverage artifacts
      id: download-coverage
      uses: actions/download-artifact@v3
      with:
        name: coverage
        path: coverage
```

3. To make the step of uploading artifacts mode dynamic we can replace the variable `files` with `directory` and point to the `download-path` from the last step using `${{steps.download-coverage.outputs.download-path}}`. `codecov-action` will try to read all files and upload to codecov. :)
```yaml
- name: Upload coverage to Codecov
      uses: codecov/codecov-action@v3
      with:
        name: combined-coverage
        token: ${{ secrets.CODECOV_TOKEN }}
        directory: ${{steps.download-coverage.outputs.download-path}}
        fail_ci_if_error: true
        verbose: true
```

I have created a small lab inside my GitHub account to test this approach and it work like a charm.
https://github.com/arthurbdiniz/kong-test-ci-improvement

**Which issue this PR fixes**:

no issue related