### PR TITLE
fix: skip logging errors for usage reports

### DIFF
--- a/internal/util/reports.go
+++ b/internal/util/reports.go
@@ -94,17 +94,17 @@ func (r *Reporter) send(signal string, uptime int) {
 	conn, err := tls.DialWithDialer(&dialer, "tcp", net.JoinHostPort(reportsHost,
 		strconv.FormatUint(uint64(reportsPort), 10)), &tlsConf)
 	if err != nil {
-		r.Logger.Errorf("failed to connect to reporting server: %s", err)
+		r.Logger.Debugf("failed to connect to reporting server: %s", err)
 		return
 	}
 	err = conn.SetDeadline(time.Now().Add(time.Minute))
 	if err != nil {
-		r.Logger.Errorf("failed to set report connection deadline: %s", err)
+		r.Logger.Debugf("failed to set report connection deadline: %s", err)
 		return
 	}
 	defer conn.Close()
 	_, err = conn.Write([]byte(message))
 	if err != nil {
-		r.Logger.Errorf("failed to send report: %s", err)
+		r.Logger.Debugf("failed to send report: %s", err)
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

When usage reporting calls encounter an error, the code logs an error. 
These errors are not actionable for users and cause unnecessary confusion.
Hence, this patch disables those log statements.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes none

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

No changelog entry required. 