### PR TITLE
chore: use `networking.knative.dev/ingress-class` additionally to `networking.knative.dev/ingress.class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
 - diff logging now honors log level instead of printing at all log levels. It
   will only print at levels `debug` and `trace`.
   [#2422](https://github.com/Kong/kubernetes-ingress-controller/issues/2422)
+- Rename kubernetes.io/ingress.class to kubernetes.io/ingress-class #2485
+  [#2485](https://github.com/Kong/kubernetes-ingress-controller/issues/2485)
 
 ## [2.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@
 - diff logging now honors log level instead of printing at all log levels. It
   will only print at levels `debug` and `trace`.
   [#2422](https://github.com/Kong/kubernetes-ingress-controller/issues/2422)
-- Rename kubernetes.io/ingress.class to kubernetes.io/ingress-class #2485
+- Use `networking.knative.dev/ingress-class` additionally to `networking.knative.dev/ingress.class`
+  to adapt to [what has already been done in knative](https://github.com/knative/networking/pull/522).
   [#2485](https://github.com/Kong/kubernetes-ingress-controller/issues/2485)
 
 ## [2.3.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@
 - diff logging now honors log level instead of printing at all log levels. It
   will only print at levels `debug` and `trace`.
   [#2422](https://github.com/Kong/kubernetes-ingress-controller/issues/2422)
-- Use `networking.knative.dev/ingress-class` additionally to `networking.knative.dev/ingress.class`
+- For KNative Ingress resources, KIC now reads both the new style annotation
+  `networking.knative.dev/ingress-class` and the deprecated `networking.knative.dev/ingress.class` one
   to adapt to [what has already been done in knative](https://github.com/knative/networking/pull/522).
   [#2485](https://github.com/Kong/kubernetes-ingress-controller/issues/2485)
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -32,9 +32,9 @@ const (
 )
 
 const (
-	IngressClassKey           = "kubernetes.io/ingress.class"
-	KnativeIngressClassKey    = "networking.knative.dev/ingress-class"
-	KnativeIngressClassAltKey = "networking.knative.dev/ingress.class"
+	IngressClassKey                  = "kubernetes.io/ingress.class"
+	KnativeIngressClassKey           = "networking.knative.dev/ingress-class"
+	KnativeIngressClassDeprecatedKey = "networking.knative.dev/ingress.class"
 
 	AnnotationPrefix = "konghq.com"
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -32,8 +32,9 @@ const (
 )
 
 const (
-	IngressClassKey        = "kubernetes.io/ingress.class"
-	KnativeIngressClassKey = "networking.knative.dev/ingress.class"
+	IngressClassKey           = "kubernetes.io/ingress.class"
+	KnativeIngressClassKey    = "networking.knative.dev/ingress-class"
+	KnativeIngressClassAltKey = "networking.knative.dev/ingress.class"
 
 	AnnotationPrefix = "konghq.com"
 

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -25,7 +25,7 @@ func IsDefaultIngressClass(obj client.Object) bool {
 func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDefault bool) bool {
 	objectIngressClass := obj.GetAnnotations()[annotations.IngressClassKey]
 	objectKnativeClass := obj.GetAnnotations()[annotations.KnativeIngressClassKey]
-	objectKnativeClassAlt := obj.GetAnnotations()[annotations.KnativeIngressClassAltKey]
+	objectKnativeClassAlt := obj.GetAnnotations()[annotations.KnativeIngressClassDeprecatedKey]
 	if isDefault && IsIngressClassEmpty(obj) {
 		return true
 	}
@@ -75,7 +75,7 @@ func IsIngressClassEmpty(obj client.Object) bool {
 		if _, ok := obj.GetAnnotations()[annotations.KnativeIngressClassKey]; ok {
 			return false
 		}
-		if _, ok := obj.GetAnnotations()[annotations.KnativeIngressClassAltKey]; ok {
+		if _, ok := obj.GetAnnotations()[annotations.KnativeIngressClassDeprecatedKey]; ok {
 			return false
 		}
 		return true

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -36,7 +36,11 @@ func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDef
 	}
 
 	switch controllerIngressClass {
-	case objectIngressClass, objectKnativeClass, objectKnativeClassAlt:
+	case objectIngressClass:
+		return true
+	case objectKnativeClass:
+		return true
+	case objectKnativeClassAlt:
 		return true
 	}
 

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -25,6 +25,7 @@ func IsDefaultIngressClass(obj client.Object) bool {
 func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDefault bool) bool {
 	objectIngressClass := obj.GetAnnotations()[annotations.IngressClassKey]
 	objectKnativeClass := obj.GetAnnotations()[annotations.KnativeIngressClassKey]
+	objectKnativeClassAlt := obj.GetAnnotations()[annotations.KnativeIngressClassAltKey]
 	if isDefault && IsIngressClassEmpty(obj) {
 		return true
 	}
@@ -33,9 +34,12 @@ func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDef
 			return true
 		}
 	}
-	if objectIngressClass == controllerIngressClass || objectKnativeClass == controllerIngressClass {
+
+	switch controllerIngressClass {
+	case objectIngressClass, objectKnativeClass, objectKnativeClassAlt:
 		return true
 	}
+
 	return false
 }
 
@@ -69,6 +73,9 @@ func IsIngressClassEmpty(obj client.Object) bool {
 			return false
 		}
 		if _, ok := obj.GetAnnotations()[annotations.KnativeIngressClassKey]; ok {
+			return false
+		}
+		if _, ok := obj.GetAnnotations()[annotations.KnativeIngressClassAltKey]; ok {
 			return false
 		}
 		return true

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -2101,7 +2101,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "knative-ingress-with-override",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"networking.knative.dev/ingress.class":                      annotations.DefaultIngressClass,
+						"networking.knative.dev/ingress-class":                      annotations.DefaultIngressClass,
 						annotations.AnnotationPrefix + annotations.ConfigurationKey: "https-only",
 					},
 				},
@@ -2181,7 +2181,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "knative-ingress-without-override",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+						"networking.knative.dev/ingress-class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: knative.IngressSpec{
@@ -2260,7 +2260,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "knative-ingress-with-annotations",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"networking.knative.dev/ingress.class":                          annotations.DefaultIngressClass,
+						"networking.knative.dev/ingress-class":                          annotations.DefaultIngressClass,
 						annotations.AnnotationPrefix + annotations.ProtocolsKey:         "https",
 						annotations.AnnotationPrefix + annotations.HTTPSRedirectCodeKey: "308",
 						annotations.AnnotationPrefix + annotations.StripPathKey:         "true",
@@ -2332,7 +2332,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Name:      "knative-ingress",
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
-						"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+						"networking.knative.dev/ingress-class": annotations.DefaultIngressClass,
 					},
 				},
 				Spec: knative.IngressSpec{
@@ -2371,7 +2371,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 					Namespace: "foo-ns",
 					Annotations: map[string]string{
 						annotations.AnnotationPrefix + annotations.PluginsKey: "knative-key-auth",
-						"networking.knative.dev/ingress.class":                annotations.DefaultIngressClass,
+						"networking.knative.dev/ingress-class":                annotations.DefaultIngressClass,
 					},
 				},
 			},

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -379,7 +379,7 @@ func TestFakeStoreListKnativeIngress(t *testing.T) {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"networking.knative.dev/ingress.class": annotations.DefaultIngressClass,
+					"networking.knative.dev/ingress-class": annotations.DefaultIngressClass,
 				},
 			},
 			Spec: knative.IngressSpec{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -672,9 +672,12 @@ func (s Store) ListKnativeIngresses() ([]*knative.Ingress, error) {
 		labels.NewSelector(),
 		func(ob interface{}) {
 			ing, ok := ob.(*knative.Ingress)
-			if ok && s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassKey,
-				s.getIngressClassHandling()) {
-				ingresses = append(ingresses, ing)
+			if ok {
+				handlingClass := s.getIngressClassHandling()
+				if s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassKey, handlingClass) ||
+					s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassAltKey, handlingClass) {
+					ingresses = append(ingresses, ing)
+				}
 			}
 		})
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -675,7 +675,7 @@ func (s Store) ListKnativeIngresses() ([]*knative.Ingress, error) {
 			if ok {
 				handlingClass := s.getIngressClassHandling()
 				if s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassKey, handlingClass) ||
-					s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassAltKey, handlingClass) {
+					s.isValidIngressClass(&ing.ObjectMeta, annotations.KnativeIngressClassDeprecatedKey, handlingClass) {
 					ingresses = append(ingresses, ing)
 				}
 			}

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -148,7 +148,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 			return false
 		}
 		if curIng == nil {
-			t.Log("got nil when getting knative ingress")
+			t.Log("getting knative ingress: got nil, want non-nil")
 			return false
 		}
 

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -57,7 +57,7 @@ func TestKnativeIngress(t *testing.T) {
 	knativeClient := dynamicClient.Resource(knativeGVR).Namespace(ns.Name)
 
 	t.Logf("configure knative network for ingress class %s", ingressClass)
-	payloadBytes := []byte(fmt.Sprintf("{\"data\": {\"ingress.class\": \"%s\"}}", ingressClass))
+	payloadBytes := []byte(fmt.Sprintf("{\"data\": {\"ingress-class\": \"%s\"}}", ingressClass))
 	_, err = env.Cluster().Client().CoreV1().ConfigMaps(knative.DefaultNamespace).Patch(ctx, "config-network", types.MergePatchType, payloadBytes, metav1.PatchOptions{})
 	require.NoError(t, err)
 	require.NoError(t, configKnativeDomain(ctx, proxyURL.Hostname(), knative.DefaultNamespace, env.Cluster()))
@@ -143,16 +143,23 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 	ingCli := knativec.NetworkingV1alpha1().Ingresses(nsn)
 	assert.Eventually(t, func() bool {
 		curIng, err := ingCli.Get(ctx, "helloworld-go", metav1.GetOptions{})
-		if err != nil || curIng == nil {
+		if err != nil {
+			t.Logf("error getting knative ingress: %v", err)
 			return false
 		}
+		if curIng == nil {
+			t.Log("got nil when getting knative ingress")
+			return false
+		}
+
 		conds := curIng.Status.Status.GetConditions()
 		for _, cond := range conds {
 			if cond.Type == apis.ConditionReady && cond.Status == v1.ConditionTrue {
-				t.Log("knative ingress status is ready.")
+				t.Logf("knative ingress %s/%s status is ready.", curIng.Namespace, curIng.Name)
 				return true
 			}
 		}
+		t.Logf("knative ingress %s/%s not ready yet", curIng.Namespace, curIng.Name)
 		return false
 	}, statusWait, waitTick, true)
 
@@ -177,19 +184,25 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 	return assert.Eventually(t, func() bool {
 		resp, err := client.Do(req)
 		if err != nil {
+			t.Logf("error requesting %s: %v", req.URL, err)
 			return false
 		}
 		defer resp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Logf("error reading response body (url: %s): %v", req.URL, err)
+			return false
+		}
+
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return false
-			}
 			bodyString := string(bodyBytes)
 			t.Logf(bodyString)
 			t.Log("service is successfully accessed through kong.")
 			return true
 		}
+
+		t.Logf("expected HTTP 200 but got %d, with body: %s", resp.StatusCode, bodyBytes)
 		return false
 	}, knativeWaitTime, waitTick)
 }

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -184,7 +184,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 	return assert.Eventually(t, func() bool {
 		resp, err := client.Do(req)
 		if err != nil {
-			t.Logf("error requesting %s: %v", req.URL, err)
+			t.Logf("error requesting %q: %v", req.URL, err)
 			return false
 		}
 		defer resp.Body.Close()

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -202,7 +202,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 			return true
 		}
 
-		t.Logf("expected HTTP 200 but got %d, with body: %s", resp.StatusCode, bodyBytes)
+		t.Logf("expected HTTP 200 but got %d, with body: %q", resp.StatusCode, bodyBytes)
 		return false
 	}, knativeWaitTime, waitTick)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `networking.knative.dev/ingress-class` as well as `networking.knative.dev/ingress-class` annotations (with the priority on the former - added in this PR) since knative has already added support for `networking.knative.dev/ingress-class` in https://github.com/knative/networking/pull/522

**Which issue this PR fixes** :

fixes #2344

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
