### PR TITLE
Feature: Add `--term-delay` option to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,11 @@
   [#1766](https://github.com/Kong/kubernetes-ingress-controller/issues/1766)
 - Added support for `TLSRoute` resources.
   [#2476](https://github.com/Kong/kubernetes-ingress-controller/issues/2476)
-- Added `--term-delay` flag to support setting a delay before processing SIGTERM signal.
+- Added `--term-delay` flag to support setting a time delay before processing
+  `SIGTERM` and `SIGINT` signals. This was added to specifically help in
+  situations where the Kong Gateway has a load-balancer in front of it to help
+  stagger and stabilize the shutdown procedure when the load-balancer is
+  draining or otherwise needs to remove the Gateway from it's rotation.
   [#2494](https://github.com/Kong/kubernetes-ingress-controller/pull/2494)
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
   [#1766](https://github.com/Kong/kubernetes-ingress-controller/issues/1766)
 - Added support for `TLSRoute` resources.
   [#2476](https://github.com/Kong/kubernetes-ingress-controller/issues/2476)
+- Added `--term-delay` flag to support setting a delay before processing SIGTERM signal.
+  [#2494](https://github.com/Kong/kubernetes-ingress-controller/pull/2494)
 
 #### Fixed
 

--- a/internal/cmd/fips/main.go
+++ b/internal/cmd/fips/main.go
@@ -6,13 +6,11 @@ package main
 import (
 	_ "crypto/tls/fipsonly"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd"
 )
 
 //go:generate go run github.com/kong/kubernetes-ingress-controller/v2/hack/generators/controllers/networking
 
 func main() {
-	rootcmd.Execute(ctrl.SetupSignalHandler())
+	rootcmd.Execute()
 }

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd"
 )
 
 //go:generate go run github.com/kong/kubernetes-ingress-controller/v2/hack/generators/controllers/networking
 
 func main() {
-	rootcmd.Execute(ctrl.SetupSignalHandler())
+	rootcmd.Execute()
 }

--- a/internal/cmd/rootcmd/rootcmd.go
+++ b/internal/cmd/rootcmd/rootcmd.go
@@ -2,8 +2,6 @@
 package rootcmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
@@ -18,12 +16,12 @@ func init() {
 var rootCmd = &cobra.Command{
 	PersistentPreRunE: bindEnvVars,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return Run(cmd.Context(), &cfg)
+		return Run(&cfg)
 	},
 	SilenceUsage: true,
 }
 
 // Execute is the entry point to the controller manager.
-func Execute(ctx context.Context) {
-	cobra.CheckErr(rootCmd.ExecuteContext(ctx))
+func Execute() {
+	cobra.CheckErr(rootCmd.Execute())
 }

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -1,13 +1,14 @@
 package rootcmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 )
 
-func Run(ctx context.Context, c *manager.Config) error {
+func Run(c *manager.Config) error {
+	ctx := SetupSignalHandler(c.TermDelay)
+
 	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c)
 	if err != nil {
 		return fmt.Errorf("failed to start diagnostics server: %w", err)

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -7,7 +7,10 @@ import (
 )
 
 func Run(c *manager.Config) error {
-	ctx := SetupSignalHandler(c.TermDelay)
+	ctx, err := SetupSignalHandler(c)
+	if err != nil {
+		return fmt.Errorf("failed to setup signal handler: %w", err)
+	}
 
 	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c)
 	if err != nil {

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -1,0 +1,37 @@
+package rootcmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+// which is canceled on one of these signals. If a second signal is not caught, the program
+// will delay for the configured period of time before terminating. If a second signal is caught,
+// the program is terminated with exit code 1.
+func SetupSignalHandler(delay time.Duration) context.Context {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		cancel()
+		select {
+		case <-time.After(delay):
+		case <-c:
+		}
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return ctx
+}

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -2,10 +2,15 @@ package rootcmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/bombsimon/logrusr/v2"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
@@ -16,7 +21,14 @@ var onlyOneSignalHandler = make(chan struct{})
 // which is canceled on one of these signals. If a second signal is not caught, the program
 // will delay for the configured period of time before terminating. If a second signal is caught,
 // the program is terminated with exit code 1.
-func SetupSignalHandler(delay time.Duration) context.Context {
+func SetupSignalHandler(cfg *manager.Config) (context.Context, error) {
+
+	deprecatedLogger, err := util.MakeLogger(cfg.LogLevel, cfg.LogFormat)
+	if err != nil {
+		return nil, err
+	}
+	logger := logrusr.New(deprecatedLogger)
+
 	close(onlyOneSignalHandler) // panics when called twice
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -25,13 +37,18 @@ func SetupSignalHandler(delay time.Duration) context.Context {
 	signal.Notify(c, shutdownSignals...)
 	go func() {
 		<-c
-		cancel()
+		logger.Info("Signal received, shutting down", "timeout", fmt.Sprint(cfg.TermDelay))
+		defer cancel()
+
 		select {
-		case <-time.After(delay):
+		case <-time.After(cfg.TermDelay):
+			os.Exit(0)
 		case <-c:
+			logger.Info("Second signal received, exiting immediately")
+			os.Exit(1) // second signal. Exit directly.
 		}
-		os.Exit(1) // second signal. Exit directly.
+
 	}()
 
-	return ctx
+	return ctx, nil
 }

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -48,11 +48,12 @@ func SetupSignalHandler(cfg *manager.Config) (context.Context, error) {
 		case <-time.After(cfg.TermDelay):
 			cancel()
 		case <-c:
-			logger.Info("Second signal received, exiting immediately")
+			logger.Info("Signal received during termination delay, exiting immediately")
 			os.Exit(1) // second signal. Exit directly.
 		}
 
-		logger.Info("Second signal received, exiting immediately")
+		<-c
+		logger.Info("Signal received during graceful shutdown, exiting immediately")
 		os.Exit(1) // second signal. Exit directly.
 	}()
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -93,7 +93,10 @@ type Config struct {
 	// Feature Gates
 	FeatureGates map[string]bool
 
-	// Delay Signal Handler
+	// TermDelay is the time.Duration which the controller manager will wait
+	// after receiving SIGTERM or SIGINT before shutting down. This can be
+	// helpful for advanced cases with load-balancers so that the ingress
+	// controller can be gracefully removed/drained from their rotation.
 	TermDelay time.Duration
 }
 
@@ -206,8 +209,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/beta/experimental features. "+
 		fmt.Sprintf("See the Feature Gates documentation for information and available options: %s", featureGatesDocsURL))
 
-	// SIGTERM signal delay
-	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before sending a SIGTERM to the Ingress Controller")
+	// SIGTERM or SIGINT signal delay
+	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before SIGTERM or SIGINT will shut down the Ingress Controller")
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", dataplane.DefaultSyncSeconds,

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -92,6 +92,9 @@ type Config struct {
 
 	// Feature Gates
 	FeatureGates map[string]bool
+
+	// Delay Signal Handler
+	TermDelay time.Duration
 }
 
 // -----------------------------------------------------------------------------
@@ -202,6 +205,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// Feature Gates (see FEATURE_GATES.md)
 	flagSet.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/beta/experimental features. "+
 		fmt.Sprintf("See the Feature Gates documentation for information and available options: %s", featureGatesDocsURL))
+
+	// SIGTERM signal delay
+	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before sending a SIGTERM signal to the Ingress Controller")
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", dataplane.DefaultSyncSeconds,

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -207,7 +207,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		fmt.Sprintf("See the Feature Gates documentation for information and available options: %s", featureGatesDocsURL))
 
 	// SIGTERM signal delay
-	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before sending a SIGTERM signal to the Ingress Controller")
+	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before sending a SIGTERM to the Ingress Controller")
 
 	// Deprecated (to be removed in future releases)
 	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", dataplane.DefaultSyncSeconds,

--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -79,7 +79,7 @@ func DeployControllerManagerForCluster(ctx context.Context, cluster clusters.Clu
 	go func() {
 		defer os.Remove(kubeconfig.Name())
 		fmt.Fprintf(os.Stderr, "INFO: Starting Controller Manager for Cluster %s with Configuration: %+v\n", cluster.Name(), config)
-		if err := rootcmd.Run(ctx, &config); err != nil {
+		if err := rootcmd.Run(&config); err != nil {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
This PR adds a `--term-delay` option to the CLI for the ingress-controller.

**Context:** 
There are cases where due to network load balancer (NLB) configuration that a delay needs to be introduced to the containers, this delay is configurable for the Kong Proxy container through the helm chart, however it is not possible to configure this delay for the ingress-controller. This can result in stale upstreams during NLB draining and downtime for services. Making this delay configurable seems the easiest approach to addressing this limitation.

With the ingress-controller gone, any changes to the underlying services that the proxy is routing to would be missed. Due to limitations with AWS NLB deregistration delays, we've had to configure a sleep of up to 4 minutes for the proxy container before shutting down. This currently means when we are scaling down, or rolling Kong pods there is a 3-4 minute window where the proxy container is  running with no ingress-controller to monitor for updates with our underlying services. 

**Impact**: This can result in stale upstreams, and errors for clients during this window. 😞  

This PR makes multiple changes:
1. Adds a new `--term-delay` argument to the CLI
This makes it possible for users to configure the SIGTERM delay value by passing a CLI argument, or an environment variable. The default is set to zero so it won't impact existing users.

2. Adjusts where the SignalHandler is called:
Originally this was in the entry point to the controller manager, however in order to pass through the CLI argument and make the term-delay configurable, this needed moved down into the rootcmd package.

3. Supports adding a delay to the SignalHandler
This takes the original SetupSignalHandler, and modifies the logic to support setting a time delay. It should still support overriding that time-delay by sending a second signal. This involved copying and altering the existing k8s controller-runtime signal package.

**Special notes for your reviewer**:

Alternative option considered:
* Add a lifecycle value for the ingress-controller container to [kong/charts](https://github.com/Kong/charts) so that we can pass a preStop command similar to the proxy container. Naming this would be hard because the existing value is `kong.lifecycle` rather than `kong.proxy.lifecycle`. It would also require a sleep binary in the proxy container which doesn’t currently exist from the [distroless/static](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md) base image - we could mount one from an initContainer but it would be fiddly.

**Testing**
I've tested this locally, running with the following commands:

```
go run -tags gcp ./internal/cmd/main.go \
--kubeconfig ~/.kube/config \
--publish-service=kong/kong-proxy \
--apiserver-host=http://localhost:8002 \
--kong-admin-url https://localhost:8444 \
--kong-admin-tls-skip-verify blah \
--term-delay 10s
```
From this I've been able to exercise trying to CTRL + C to kill the process, and validated that the delay is working as expected. I've also validated that by sending a second signal it does exit with code 1. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
