### PR TITLE
feat: ingress translator w/ combined routes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -214,6 +214,39 @@ jobs:
         name: coverage
         path: coverage.postgres.out
 
+  integration-tests-feature-gates:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: run integration tests
+      run: make test.integration.dbless
+      env:
+        KONG_CONTROLLER_FEATURE_GATES: "Gateway=true,CombinedRoutes=true"
+
+    - name: collect test coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: coverage.featuregates.out
+
   conformance-tests:
     runs-on: ubuntu-latest
     steps:
@@ -246,6 +279,7 @@ jobs:
       - "integration-tests-dbless"
       - "integration-tests-postgres"
       - "integration-tests-enterprise-postgres"
+      - "integration-tests-feature-gates"
     runs-on: ubuntu-latest
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,23 @@
 
 #### Added
 
+- A new gated feature called `CombinedRoutes` has been added. Historically
+  a `kong.Route` would be created for _each path_ on an `Ingress` resource
+  in the phase where Kubernetes resources are translated to Kong Admin API
+  configuration. This new feature changes how `Ingress` resources are
+  translated so that a single route can be created for any unique combination
+  of ingress object, hostname, service and port which has multiple paths.
+  This option is helpful for end-users who are making near constant changes
+  to their configs (e.g. constantly adding, updating, and removing `Ingress`
+  resources) at scale, and users that have enormous numbers of paths all
+  pointing to a single Kubernetes `Service` as it can significantly reduce
+  the overall size of the dataplane configuration that is pushed to the Kong
+  Admin API. This feature is expected to be disruptive (routes may be dropped
+  briefly in postgres mode when switching to this mode) so for the moment it
+  is behind a feature gate while we continue to iterate on it and evaluate it
+  and seek a point where it would become the default behavior. Enable it with
+  the controller argument `--feature-gates=CombinedRoutes`.
+  [#2490](https://github.com/Kong/kubernetes-ingress-controller/issues/2490)
 - `UDPRoute` resources now support multiple backendRefs for load-balancing.
   [#2405](https://github.com/Kong/kubernetes-ingress-controller/issues/2405)
 - `TCPRoute` resources now support multiple backendRefs for load-balancing.

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -60,9 +60,10 @@ Features that reach GA and over time become stable will be removed from this tab
 
 {{< table caption="Feature gates for features in Alpha or Beta states" >}}
 
-| Feature | Default | Stage | Since | Until |
-|---------|---------|-------|-------|-------|
-| Knative | `true`  | Alpha | 0.8.0 | TBD   |
-| Gateway | `false` | Alpha | TBD   | TBD   |
+| Feature        | Default | Stage | Since | Until |
+|---------       |---------|-------|-------|-------|
+| Knative        | `true`  | Alpha | 0.8.0 | TBD   |
+| Gateway        | `false` | Alpha | 2.2.0 | TBD   |
+| CombinedRoutes | `false` | Alpha | 2.4.0 | TBD   |
 
 {{< /table > }}

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: httpbin
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: httpbin

--- a/internal/dataplane/kongstate/service.go
+++ b/internal/dataplane/kongstate/service.go
@@ -11,6 +11,33 @@ import (
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
+// Services is a list of kongstate.Service objects with sorting enabled based
+// on a lexographical comparison of the underlying kong.Service names which are
+// always expected to be unique.
+type Services []*Service
+
+func (s Services) Len() int {
+	return len(s)
+}
+
+func (s Services) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Services) Less(i, j int) bool {
+	a := ""
+	if s[i].Service.Name != nil {
+		a = *s[i].Service.Name
+	}
+
+	b := ""
+	if s[j].Service.Name != nil {
+		b = *s[j].Service.Name
+	}
+
+	return strings.Compare(a, b) == -1
+}
+
 // Service represents a service in Kong and holds routes associated with the
 // service and other k8s metadata.
 type Service struct {

--- a/internal/dataplane/parser/translators/ingress.go
+++ b/internal/dataplane/parser/translators/ingress.go
@@ -1,0 +1,248 @@
+package translators
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kong/go-kong/kong"
+	networkingv1 "k8s.io/api/networking/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// -----------------------------------------------------------------------------
+// Ingress Translation - Public Functions
+// -----------------------------------------------------------------------------
+
+// TranslateIngress receives a Kubernetes ingress object and from it will
+// produce a translated set of kong.Services and kong.Routes which will come
+// wrapped in a kongstate.Service object.
+func TranslateIngress(ingress *networkingv1.Ingress) []*kongstate.Service {
+	index := &ingressTranslationIndex{cache: make(map[string]*ingressTranslationMeta)}
+	index.add(ingress)
+	kongStateServices := kongstate.Services(index.translate())
+	sort.Sort(kongStateServices)
+	return kongStateServices
+}
+
+// -----------------------------------------------------------------------------
+// Ingress Translation - Private Consts & Vars
+// -----------------------------------------------------------------------------
+
+var defaultHTTPIngressPathType = networkingv1.PathTypePrefix
+
+const (
+	defaultHTTPPort = 80
+	defaultRetries  = 5
+
+	// defaultServiceTimeout indicates the amount of time by default that we wait
+	// for connections to an underlying Kubernetes service to complete in the
+	// data-plane. The current value is based on a historical default that started
+	// in version 0 of the ingress controller.
+	defaultServiceTimeout = time.Second * 60
+)
+
+// -----------------------------------------------------------------------------
+// Ingress Translation - Private - Index
+// -----------------------------------------------------------------------------
+
+// ingressTranslationIndex is a de-duplicating index of the contents of a
+// Kubernetes Ingress resource, where the key is a combination of data from
+// that resource which makes it unique for the purpose of translating it into
+// kong.Services and kong.Routes and the value is a combination of various
+// metadata needed to configure and name those kong.Services and kong.Routes
+// plus the URL paths which make those routes actionable. This index is used
+// to enable compiling a minimal set of kong.Routes when translating into
+// Kong resources for each rule in the ingress spec, where the combination of:
+//
+// - ingress.Namespace
+// - ingress.Name
+// - host for the Ingress rule
+// - Kubernetes Service for the Ingress rule
+// - the port for the Kubernetes Service
+//
+// are unique. For ingress spec rules which are not unique along those
+// data-points, a separate kong.Service and separate kong.Routes will be created
+// for each unique combination.
+type ingressTranslationIndex struct {
+	cache map[string]*ingressTranslationMeta
+}
+
+func (i *ingressTranslationIndex) add(ingress *networkingv1.Ingress) {
+	for _, ingressRule := range ingress.Spec.Rules {
+		if ingressRule.HTTP == nil || len(ingressRule.HTTP.Paths) < 1 {
+			continue
+		}
+
+		for _, httpIngressPath := range ingressRule.HTTP.Paths {
+			httpIngressPath.Path = flattenMultipleSlashes(httpIngressPath.Path)
+
+			if httpIngressPath.Path == "" {
+				httpIngressPath.Path = "/"
+			}
+
+			if httpIngressPath.PathType == nil {
+				httpIngressPath.PathType = &defaultHTTPIngressPathType
+			}
+
+			serviceName := httpIngressPath.Backend.Service.Name
+			servicePort := httpIngressPath.Backend.Service.Port.Number
+
+			cacheKey := fmt.Sprintf("%s%s%s%s%d", ingress.Namespace, ingress.Name, ingressRule.Host, serviceName, servicePort)
+			meta, ok := i.cache[cacheKey]
+			if !ok {
+				meta = &ingressTranslationMeta{
+					ingressNamespace: ingress.Namespace,
+					ingressName:      ingress.Name,
+					ingressHost:      ingressRule.Host,
+					serviceName:      serviceName,
+					servicePort:      servicePort,
+				}
+			}
+
+			meta.paths = append(meta.paths, httpIngressPath)
+			meta.ingressAnnotations = ingress.Annotations
+			i.cache[cacheKey] = meta
+		}
+	}
+}
+
+func (i *ingressTranslationIndex) translate() []*kongstate.Service {
+	kongStateServiceCache := make(map[string]*kongstate.Service)
+	for _, meta := range i.cache {
+		portDef := kongstate.PortDef{
+			Number: meta.servicePort,
+			Mode:   kongstate.PortModeByNumber,
+		}
+
+		kongServiceName := fmt.Sprintf("%s.%s.%s.%s", meta.ingressNamespace, meta.ingressName, meta.serviceName, portDef.CanonicalString())
+		kongStateService, ok := kongStateServiceCache[kongServiceName]
+		if !ok {
+			kongStateService = meta.translateIntoKongStateService(kongServiceName, portDef)
+		}
+
+		route := meta.translateIntoKongRoutes()
+		kongStateService.Routes = append(kongStateService.Routes, *route)
+
+		kongStateServiceCache[kongServiceName] = kongStateService
+	}
+
+	kongStateServices := make([]*kongstate.Service, 0, len(kongStateServiceCache))
+	for _, kongStateService := range kongStateServiceCache {
+		kongStateServices = append(kongStateServices, kongStateService)
+	}
+
+	return kongStateServices
+}
+
+// -----------------------------------------------------------------------------
+// Ingress Translation - Private - Metadata
+// -----------------------------------------------------------------------------
+
+type ingressTranslationMeta struct {
+	ingressAnnotations map[string]string
+	ingressNamespace   string
+	ingressName        string
+	ingressHost        string
+	serviceName        string
+	servicePort        int32
+	paths              []networkingv1.HTTPIngressPath
+}
+
+func (m *ingressTranslationMeta) translateIntoKongStateService(kongServiceName string, portDef kongstate.PortDef) *kongstate.Service {
+	return &kongstate.Service{
+		Namespace: m.ingressNamespace,
+		Service: kong.Service{
+			Name:           kong.String(kongServiceName),
+			Host:           kong.String(fmt.Sprintf("%s.%s.%d.svc", m.serviceName, m.ingressNamespace, portDef.Number)),
+			Port:           kong.Int(defaultHTTPPort),
+			Protocol:       kong.String("http"),
+			Path:           kong.String("/"),
+			ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+			ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+			WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+			Retries:        kong.Int(defaultRetries),
+		},
+		Backends: []kongstate.ServiceBackend{{
+			Name:      m.serviceName,
+			Namespace: m.ingressNamespace,
+			PortDef:   portDef,
+		}},
+	}
+}
+
+func (m *ingressTranslationMeta) translateIntoKongRoutes() *kongstate.Route {
+	routeName := fmt.Sprintf("%s.%s.%s.%s.%d", m.ingressNamespace, m.ingressName, m.serviceName, m.ingressHost, m.servicePort)
+	route := &kongstate.Route{
+		Ingress: util.K8sObjectInfo{
+			Namespace:   m.ingressNamespace,
+			Name:        m.ingressName,
+			Annotations: m.ingressAnnotations,
+		},
+		Route: kong.Route{
+			Name:              kong.String(routeName),
+			StripPath:         kong.Bool(false),
+			PreserveHost:      kong.Bool(true),
+			Protocols:         kong.StringSlice("http", "https"),
+			RegexPriority:     kong.Int(0),
+			RequestBuffering:  kong.Bool(true),
+			ResponseBuffering: kong.Bool(true),
+		},
+	}
+
+	if m.ingressHost != "" {
+		route.Route.Hosts = append(route.Route.Hosts, kong.String(m.ingressHost))
+	}
+
+	for _, httpIngressPath := range m.paths {
+		paths := pathsFromIngressPaths(httpIngressPath)
+		route.Paths = append(route.Paths, paths...)
+	}
+
+	return route
+}
+
+// -----------------------------------------------------------------------------
+// Ingress Translation - Private - Helper Functions
+// -----------------------------------------------------------------------------
+
+func pathsFromIngressPaths(httpIngressPath networkingv1.HTTPIngressPath) []*string {
+	switch *httpIngressPath.PathType { //nolint:exhaustive
+	case networkingv1.PathTypeExact:
+		relative := strings.TrimLeft(httpIngressPath.Path, "/")
+		if httpIngressPath.Path == "" {
+			return kong.StringSlice("/")
+		}
+		return kong.StringSlice("/" + relative + "$")
+	case networkingv1.PathTypeImplementationSpecific:
+		return kong.StringSlice(httpIngressPath.Path)
+	default:
+		// path type is prefix
+		base := strings.Trim(httpIngressPath.Path, "/")
+		if base == "" {
+			return kong.StringSlice("/")
+		}
+		return kong.StringSlice(
+			"/"+base+"$",
+			"/"+base+"/",
+		)
+	}
+}
+
+func flattenMultipleSlashes(path string) string {
+	var out []rune
+	in := []rune(path)
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		if c == '/' {
+			for i < len(in)-1 && in[i+1] == '/' {
+				i++
+			}
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -1,0 +1,848 @@
+package translators
+
+import (
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+var (
+	pathTypeExact                  = networkingv1.PathTypeExact
+	pathTypeImplementationSpecific = networkingv1.PathTypeImplementationSpecific
+	pathTypePrefix                 = networkingv1.PathTypePrefix
+)
+
+func TestTranslateIngress(t *testing.T) {
+	tts := []struct {
+		name     string
+		ingress  *networkingv1.Ingress
+		expected []*kongstate.Service
+	}{
+		{
+			name: "a basic ingress resource with a single rule, and only one path results in a single kong service and route",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path: "/api",
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											}}}}}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/api$", "/api/"), // Prefix pathing is the default behavior when no pathtype is defined
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "an ingress with path type exact gets a kong route with an exact path match",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path:     "/api",
+									PathType: &pathTypeExact,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											}}}}}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/api$"), // No Prefix Pathing
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "an Ingress resource with implementation specific path type doesn't modify the path",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path:     "/api",
+									PathType: &pathTypeImplementationSpecific,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											}}}}}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/api"), // No path mods
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "an Ingress resource with paths with double /'s gets flattened",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path: "/v1//api///",
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											}}}}}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/v1/api$", "/v1/api/"),
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "empty paths get treated as '/'",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{{
+									Path: "",
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											}}}}}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/"),
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "multiple and various paths get compiled together properly",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path: "/v1/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path: "/v2/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path: "/v3/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "/other/path/1",
+										PathType: &pathTypeExact,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "/other/path/2",
+										PathType: &pathTypeImplementationSpecific,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "",
+										PathType: &pathTypeImplementationSpecific,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+								}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:  kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts: kong.StringSlice("konghq.com"),
+						Paths: kong.StringSlice(
+							"/v1/api$", "/v1/api/",
+							"/v2/api$", "/v2/api/",
+							"/v3/api$", "/v3/api/",
+							"/other/path/1$",
+							"/other/path/2",
+							"/",
+						),
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "when no host is provided, all hosts are matched",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path: "/v1/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path: "/v2/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path: "/v3/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "/other/path/1",
+										PathType: &pathTypeExact,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "/other/path/2",
+										PathType: &pathTypeImplementationSpecific,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path:     "",
+										PathType: &pathTypeImplementationSpecific,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+								}}}}}}},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name: kong.String("default.test-ingress.test-service..80"),
+						Paths: kong.StringSlice(
+							"/v1/api$", "/v1/api/",
+							"/v2/api$", "/v2/api/",
+							"/v3/api$", "/v3/api/",
+							"/other/path/1$",
+							"/other/path/2",
+							"/",
+						),
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+			}},
+		},
+
+		{
+			name: "when there are multiple backends services, paths wont be combined and separate kong services will be provided",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path: "/v1/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service1",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+									{
+										Path: "/v2/api",
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service2",
+												Port: networkingv1.ServiceBackendPort{
+													Name:   "http",
+													Number: 80,
+												}}},
+									},
+								}}}}}}},
+			expected: []*kongstate.Service{
+				{
+					Namespace: corev1.NamespaceDefault,
+					Service: kong.Service{
+						Name:           kong.String("default.test-ingress.test-service1.80"),
+						Host:           kong.String("test-service1.default.80.svc"),
+						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						Path:           kong.String("/"),
+						Port:           kong.Int(80),
+						Protocol:       kong.String("http"),
+						Retries:        kong.Int(defaultRetries),
+						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					},
+					Routes: []kongstate.Route{
+						{
+							Ingress: util.K8sObjectInfo{
+								Name:      "test-ingress",
+								Namespace: corev1.NamespaceDefault,
+							},
+							Route: kong.Route{
+								Name:              kong.String("default.test-ingress.test-service1.konghq.com.80"),
+								Hosts:             kong.StringSlice("konghq.com"),
+								Paths:             kong.StringSlice("/v1/api$", "/v1/api/"),
+								PreserveHost:      kong.Bool(true),
+								Protocols:         kong.StringSlice("http", "https"),
+								RegexPriority:     kong.Int(0),
+								StripPath:         kong.Bool(false),
+								ResponseBuffering: kong.Bool(true),
+								RequestBuffering:  kong.Bool(true),
+							},
+						},
+					},
+					Backends: []kongstate.ServiceBackend{{
+						Name:      "test-service1",
+						Namespace: corev1.NamespaceDefault,
+						PortDef: kongstate.PortDef{
+							Mode:   kongstate.PortModeByNumber,
+							Number: 80,
+						},
+					}},
+				},
+
+				{
+					Namespace: corev1.NamespaceDefault,
+					Service: kong.Service{
+						Name:           kong.String("default.test-ingress.test-service2.80"),
+						Host:           kong.String("test-service2.default.80.svc"),
+						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						Path:           kong.String("/"),
+						Port:           kong.Int(80),
+						Protocol:       kong.String("http"),
+						Retries:        kong.Int(defaultRetries),
+						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					},
+					Routes: []kongstate.Route{
+						{
+							Ingress: util.K8sObjectInfo{
+								Name:      "test-ingress",
+								Namespace: corev1.NamespaceDefault,
+							},
+							Route: kong.Route{
+								Name:              kong.String("default.test-ingress.test-service2.konghq.com.80"),
+								Hosts:             kong.StringSlice("konghq.com"),
+								Paths:             kong.StringSlice("/v2/api$", "/v2/api/"),
+								PreserveHost:      kong.Bool(true),
+								Protocols:         kong.StringSlice("http", "https"),
+								RegexPriority:     kong.Int(0),
+								StripPath:         kong.Bool(false),
+								ResponseBuffering: kong.Bool(true),
+								RequestBuffering:  kong.Bool(true),
+							},
+						},
+					},
+					Backends: []kongstate.ServiceBackend{{
+						Name:      "test-service2",
+						Namespace: corev1.NamespaceDefault,
+						PortDef: kongstate.PortDef{
+							Mode:   kongstate.PortModeByNumber,
+							Number: 80,
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, TranslateIngress(tt.ingress), tt.expected)
+		})
+	}
+}
+
+func Test_pathsFromIngressPaths(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   networkingv1.HTTPIngressPath
+		out  []*string
+	}{
+		{
+			name: "path type prefix will expand the match to a trailing slash if not provided",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "/v1/api/packages",
+				PathType: &pathTypePrefix,
+			},
+			out: kong.StringSlice(
+				"/v1/api/packages$",
+				"/v1/api/packages/",
+			),
+		},
+		{
+			name: "path type prefix will expand the match with a literal match if a slash is provided",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "/v1/api/packages/",
+				PathType: &pathTypePrefix,
+			},
+			out: kong.StringSlice(
+				"/v1/api/packages$",
+				"/v1/api/packages/",
+			),
+		},
+		{
+			name: "path type prefix will provide a default when no path is provided",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "",
+				PathType: &pathTypePrefix,
+			},
+			out: kong.StringSlice("/"),
+		},
+		{
+			name: "path type exact will cause an exact matching path on a regular path",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "/v1/api/packages",
+				PathType: &pathTypeExact,
+			},
+			out: kong.StringSlice("/v1/api/packages$"),
+		},
+		{
+			name: "path type exact will cause an exact matching path on a regular path with a / suffix",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "/v1/api/packages/",
+				PathType: &pathTypeExact,
+			},
+			out: kong.StringSlice("/v1/api/packages/$"),
+		},
+		{
+			name: "path type exact will supply a default if no path is provided",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "",
+				PathType: &pathTypeExact,
+			},
+			out: kong.StringSlice("/"),
+		},
+		{
+			name: "path type implementation-specific will leave the path alone",
+			in: networkingv1.HTTPIngressPath{
+				Path:     "/asdfasd9jhf09432$",
+				PathType: &pathTypeImplementationSpecific,
+			},
+			out: kong.StringSlice("/asdfasd9jhf09432$"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, pathsFromIngressPaths(tt.in))
+		})
+	}
+}
+
+func Test_flattenMultipleSlashes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{
+			name: "a path with no slashes gets left alone",
+			in:   "api",
+			out:  "api",
+		},
+		{
+			name: "a normal path gets left alone",
+			in:   "/v1/api/packages/",
+			out:  "/v1/api/packages/",
+		},
+		{
+			name: "a path with two starting slashes gets flattened",
+			in:   "//",
+			out:  "/",
+		},
+		{
+			name: "a path with many slashes gets flattened",
+			in:   "/////////////////",
+			out:  "/",
+		},
+		{
+			name: "a path with multiple groups of double slashes gets flattened",
+			in:   "//api//packages//",
+			out:  "/api/packages/",
+		},
+		{
+			name: "a path with multiple groups of various sized groups of slashes gets flattened",
+			in:   "////////v1////api//packages///and/stuff//////////////////",
+			out:  "/v1/api/packages/and/stuff/",
+		},
+		{
+			name: "a path with multiple slashes but none at the end gets flattened",
+			in:   "////////v1////api//packages///and/stuff",
+			out:  "/v1/api/packages/and/stuff",
+		},
+		{
+			name: "a path with multiple slashes but none at the beginning gets flattened",
+			in:   "v1/////api//packages///and/stuff//////",
+			out:  "v1/api/packages/and/stuff/",
+		},
+		{
+			name: "a path with multiple slashes but none at the beginning or end gets flattened",
+			in:   "v1/////api//packages//////////////////////////and/stuff",
+			out:  "v1/api/packages/and/stuff",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, flattenMultipleSlashes(tt.in))
+		})
+	}
+}

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -17,6 +17,11 @@ const (
 	// gatewayFeature is the name of the feature-gate for enabling/disabling Gateway APIs
 	gatewayFeature = "Gateway"
 
+	// combinedRoutesFeature is the name of the feature-gate for the newer object
+	// translation logic that will combine routes for kong services when translating
+	// objects like Ingress instead of creating a route per path.
+	combinedRoutesFeature = "CombinedRoutes"
+
 	// featureGatesDocsURL provides a link to the documentation for feature gates in the KIC repository
 	featureGatesDocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
 )
@@ -46,7 +51,8 @@ func setupFeatureGates(setupLog logr.Logger, c *Config) (map[string]bool, error)
 // NOTE: if you're adding a new feature gate, it needs to be added here.
 func getFeatureGatesDefaults() map[string]bool {
 	return map[string]bool{
-		knativeFeature: false,
-		gatewayFeature: false,
+		knativeFeature:        false,
+		gatewayFeature:        false,
+		combinedRoutesFeature: false,
 	}
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -139,6 +139,11 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		return fmt.Errorf("unable to initialize dataplane synchronizer: %w", err)
 	}
 
+	if enabled, ok := featureGates[combinedRoutesFeature]; ok && enabled {
+		dataplaneClient.EnableCombinedServiceRoutes()
+		setupLog.Info("combined routes mode has been enabled")
+	}
+
 	var kubernetesStatusQueue *status.Queue
 	if c.UpdateStatus {
 		setupLog.Info("Starting Status Updater")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -143,6 +143,11 @@ func TestMain(m *testing.M) {
 				exitOnErr(err)
 			}
 		}
+		fmt.Println("INFO: configuring feature gates")
+		if controllerFeatureGates == "" {
+			controllerFeatureGates = defaultFeatureGates
+		}
+		fmt.Printf("INFO: feature gates enabled: %s\n", controllerFeatureGates)
 		fmt.Println("INFO: starting the controller manager")
 		standardControllerArgs := []string{
 			fmt.Sprintf("--ingress-class=%s", ingressClass),
@@ -153,7 +158,7 @@ func TestMain(m *testing.M) {
 			"--dump-config",
 			"--log-level=trace",
 			"--debug-log-reduce-redundancy",
-			"--feature-gates=Gateway=true",
+			fmt.Sprintf("--feature-gates=%s", controllerFeatureGates),
 			fmt.Sprintf("--election-namespace=%s", kongAddon.Namespace()),
 		}
 		allControllerArgs := append(standardControllerArgs, extraControllerArgs...)

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -689,7 +689,7 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 	t.Logf("testing incorrect name does not match")
 	blueguyName := gatewayv1alpha2.ObjectName("blueguy")
 	policy.Spec.To[1].Name = &blueguyName
-	policy, err = c.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
+	_, err = c.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -104,6 +104,14 @@ var (
 	clusterVersion semver.Version
 )
 
+const (
+	// defaultFeatureGates is the default feature gates setting that should be
+	// provided if none are provided by the user. This generally includes features
+	// that are innocuous, or otherwise don't actually get triggered unless the
+	// user takes further action.
+	defaultFeatureGates = "Gateway=true"
+)
+
 // -----------------------------------------------------------------------------
 // Testing Variables - Environment Overrides
 // -----------------------------------------------------------------------------
@@ -126,6 +134,10 @@ var (
 
 	// kongEnterpriseEnabled enables Enterprise-specific tests when set to "true"
 	kongEnterpriseEnabled = os.Getenv("TEST_KONG_ENTERPRISE")
+
+	// controllerFeatureGates contains the feature gates that should be enabled
+	// for test runs.
+	controllerFeatureGates = os.Getenv("KONG_CONTROLLER_FEATURE_GATES")
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Historically a `kong.Route` was made for _every path_ that was present in an `Ingress` resource. This patch adds an option for an alternative `Ingress` object translation in the `dataplane/parser` code that will combine those paths into a single `kong.Route` if their `ingress.Namespace`, `ingress.Name`, `ingress.Host`, `service.Name`, and `service.Port` match. The result is smaller configuration sizes which is particularly helpful for end-users who configure their `Ingress` resources with incredibly large numbers of paths all pointing to the same Kubernetes `Service`.

**Which issue this PR fixes**

Fixes #2490

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
