### PR TITLE
fix(build): remove default for TARGETARCH which made arm64 builds end up with amd64 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,20 +167,22 @@ IMAGE ?= $(REGISTRY)/$(IMGNAME)
 .PHONY: container
 container:
 	docker buildx build \
-    -f Dockerfile \
-    --target distroless \
-    --build-arg TAG=${TAG} --build-arg COMMIT=${COMMIT} \
-    --build-arg REPO_INFO=${REPO_INFO} \
-    -t ${IMAGE}:${TAG} .
+		-f Dockerfile \
+		--target distroless \
+		--build-arg TAG=${TAG} \
+		--build-arg COMMIT=${COMMIT} \
+		--build-arg REPO_INFO=${REPO_INFO} \
+		-t ${IMAGE}:${TAG} .
 
 .PHONY: container
 debug-container:
 	docker buildx build \
-    -f Dockerfile \
-    --target debug \
-    --build-arg TAG=${TAG}-debug --build-arg COMMIT=${COMMIT} \
-    --build-arg REPO_INFO=${REPO_INFO} \
-    -t ${IMAGE}:${TAG} .
+		-f Dockerfile \
+		--target debug \
+		--build-arg TAG=${TAG}-debug \
+		--build-arg COMMIT=${COMMIT} \
+		--build-arg REPO_INFO=${REPO_INFO} \
+		-t ${IMAGE}:${TAG} .
 
 # ------------------------------------------------------------------------------
 # Testing


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed to make sure that arm64 container image builds end up having a binary built for arm64 arch and not amd64 like e.g. in [this build](https://hub.docker.com/layers/nightly-ingress-controller/kong/nightly-ingress-controller/2022-05-27/images/sha256-df1bd43b7f150bcbcb074092f995f464975b15b44ea4a8b5e1a40f075e8a2dcc?context=explore)

The reason for this is because the `--platform` flag doesn't seem to make any effect when `TARGETARCH`/`TARGETPLATFORM`/`TARGETOS` are set. It was already mentioned by @rainest in: https://github.com/Kong/kubernetes-ingress-controller/pull/2387#issuecomment-1106695450

The effect of this PR will be that by default, when starting image build, we'll get the image for the host arch not `linux/amd64`.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
