### PR TITLE
fix(ci): make it possible to run nightly builds on request

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,14 +13,14 @@ jobs:
       - name: Add standard tags
         run: |
           echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=schedule,pattern=nightly' >> $GITHUB_ENV
-          echo "type=schedule,pattern={{date 'YYYY-MM-DD'}}" >> $GITHUB_ENV
+          echo 'type=raw,value=nightly' >> $GITHUB_ENV
+          echo "type=raw,value={{date 'YYYY-MM-DD'}}" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Add Red Hat standard tags
         run: |
           echo 'REDHAT_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=schedule,pattern=nightly,suffix=-redhat' >> $GITHUB_ENV
-          echo "type=schedule,pattern={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_ENV
+          echo 'type=raw,value=nightly,suffix=-redhat' >> $GITHUB_ENV
+          echo "type=raw,value={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

To be able to run nightly builds on request. Without this patch the metadata is not generated because it's only configured to do so on schedule.

Hence use [`type=raw`](https://github.com/docker/metadata-action#typeraw) instead of `type=schedule`.

**Special notes for your reviewer**:

Perhaps we could change the nightly tag format to include e.g. a SHA? Not sure if that can be easily done with https://github.com/docker/metadata-action
