### PR TITLE
tests: make TestHTTPRouteExample pass on arm64 by using an arm64 enabled image of httpbin

### DIFF
--- a/examples/gateway-httproute.yaml
+++ b/examples/gateway-httproute.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: httpbin
-        image: kennethreitz/httpbin
+        image: arnaudlacour/httpbin
         ports:
         - containerPort: 80
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR address the fact that `TestHTTPRouteExample` test uses [`kennethreitz/httpbin`](https://hub.docker.com/r/kennethreitz/httpbin) which provides only `linux/amd64`.

Since the [github repo](https://github.com/postmanlabs/httpbin) that hosts code for that image seems to be unmaintained, and since there is [an issue](https://github.com/postmanlabs/httpbin/issues/643) that raises the lack of arm64 support let's use [a repo](https://hub.docker.com/r/arnaudlacour/httpbin/tags) that hosts images for a fork of the original one.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tested in a `kind` cluster on an arm64 Mac M1 
