### PR TITLE
chore: replace kennethreitz/httpbin with arm64 enabled arnaudlacour/httpbin

### DIFF
--- a/deploy/manifests/httpbin.yaml
+++ b/deploy/manifests/httpbin.yaml
@@ -28,7 +28,7 @@ spec:
         app: httpbin
     spec:
       containers:
-      - image: docker.io/kennethreitz/httpbin
+      - image: docker.io/arnaudlacour/httpbin
         name: httpbin
         ports:
         - containerPort: 80

--- a/examples/gateway-httproute.yaml
+++ b/examples/gateway-httproute.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: httpbin
-        image: kennethreitz/httpbin
+        image: arnaudlacour/httpbin
         ports:
         - containerPort: 80
 ---

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: httpbin
-        image: kennethreitz/httpbin
+        image: arnaudlacour/httpbin
         ports:
         - containerPort: 80
 ---

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	httpBinImage     = "kennethreitz/httpbin"
+	httpBinImage     = "arnaudlacour/httpbin"
 	ingressClass     = "kong"
 	namespace        = "kong"
 	adminServiceName = "kong-admin"

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -60,7 +60,7 @@ var (
 	// httpBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
 	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/postmanlabs/httpbin
-	httpBinImage = "kennethreitz/httpbin"
+	httpBinImage = "arnaudlacour/httpbin"
 
 	// tcpEchoImage echoes TCP text sent to it after printing out basic information about its environment, e.g.
 	// Welcome, you are connected to node kind-control-plane.


### PR DESCRIPTION
**What this PR does / why we need it**:

NOTE: This supersedes #2547 in the sense that this replace all the occurrences of `kennethreitz/httpbin` into `arnaudlacour/httpbin` not only those in tests.

This PR address the fact that as of now we're using [`kennethreitz/httpbin`](https://hub.docker.com/r/kennethreitz/httpbin) which provides only `linux/amd64`.

Since the [github repo](https://github.com/postmanlabs/httpbin) that hosts code for that image seems to be unmaintained, and since there is [an issue](https://github.com/postmanlabs/httpbin/issues/643) that raises the lack of arm64 support let's use [a repo](https://hub.docker.com/r/arnaudlacour/httpbin/tags) that hosts images for a fork of the original one.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tested in a `kind` cluster on an arm64 Mac M1 
