### PR TITLE
chore(tests) pin Gateway CRD version

### DIFF
--- a/internal/util/test/crds.go
+++ b/internal/util/test/crds.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	kongCRDsKustomize    = "../../config/crd/"
-	gatewayCRDsKustomize = "https://github.com/kubernetes-sigs/gateway-api/config/crd"
+	gatewayCRDsKustomize = "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.2"
 )
 
 func DeployCRDsForCluster(ctx context.Context, cluster clusters.Cluster) error {

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -51,7 +51,7 @@ const (
 	// parent Service to fully resolve into ready state.
 	gatewayUpdateWaitTime = time.Minute * 3
 
-	gatewayCRDsURL = "github.com/kubernetes-sigs/gateway-api/config/crd"
+	gatewayCRDsURL = "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.2"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin the Gateway APIs CRD version, currently to 0.4.2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

Addresses CI failures like

```
2022-06-07T13:56:57.0069650Z     tcproute_test.go:661: 
2022-06-07T13:56:57.0072564Z         	Error Trace:	tcproute_test.go:661
2022-06-07T13:56:57.0072985Z         	Error:      	Received unexpected error:
2022-06-07T13:56:57.0074015Z         	            	the server could not find the requested resource (post referencepolicies.gateway.networking.k8s.io)
2022-06-07T13:56:57.0074575Z         	Test:       	TestTCPRouteReferencePolicy
```
**Special notes for your reviewer**:

Upstream master changed this in https://github.com/kubernetes-sigs/gateway-api/pull/1188 and the unversioned CRD URL uses master. This presents a bit of a conundrum for if we want to test unreleased stuff, but I think I'm okay living with that and just not merging anything for unreleased Gateway API versions. If we want to do that we probably want to write a draft and run tests locally or change back to master temporarily in the draft.