### PR TITLE
chore: correctly format logger fields on admin api connection retries

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -80,7 +80,10 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		retry.Delay(c.KongAdminInitializationRetryDelay),
 		retry.DelayType(retry.FixedDelay),
 		retry.OnRetry(func(n uint, err error) {
-			setupLog.Info("Retrying kong admin api client call #%d/%d after error: %w", n, c.KongAdminInitializationRetries, err)
+			setupLog.Info("Retrying kong admin api client call after error",
+				"#", fmt.Sprintf("%d/%d", n, c.KongAdminInitializationRetries),
+				"error", fmt.Sprintf("%v", err),
+			)
 		}),
 	)
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -81,7 +81,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		retry.DelayType(retry.FixedDelay),
 		retry.OnRetry(func(n uint, err error) {
 			setupLog.Info("Retrying kong admin api client call after error",
-				"#", fmt.Sprintf("%d/%d", n, c.KongAdminInitializationRetries),
+				"retries", fmt.Sprintf("%d/%d", n, c.KongAdminInitializationRetries),
 				"error", fmt.Sprintf("%v", err),
 			)
 		}),

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -82,7 +82,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 		retry.OnRetry(func(n uint, err error) {
 			setupLog.Info("Retrying kong admin api client call after error",
 				"retries", fmt.Sprintf("%d/%d", n, c.KongAdminInitializationRetries),
-				"error", fmt.Sprintf("%v", err),
+				"error", err.Error(),
 			)
 		}),
 	)


### PR DESCRIPTION
This PR fixes an incorrect usage of logger `logr.Logger`, specifically the formatting in the `Info()`, which does not support format strings.

Before this PR the changes log looked like:

```console
INFO[0007] Retrying kong admin api client call #%d/%d after error: %w  logger=setup
```

and after:

```console
INFO[0002] Retrying kong admin api client call after error  #=2/60 error="making HTTP request: Get \"https://172.18.0.23:444/\": x509: “localhost” certificate is not standards compliant" logger=setup
```
