### PR TITLE
chore: remove KongIngress support for Gateway API Route objects and Services referenced by those Routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,11 @@
   `networking.knative.dev/ingress-class` and the deprecated `networking.knative.dev/ingress.class` one
   to adapt to [what has already been done in knative](https://github.com/knative/networking/pull/522).
   [#2485](https://github.com/Kong/kubernetes-ingress-controller/issues/2485)
+- Remove KongIngress support for Gateway API Route objects and Services referenced
+  by those Routes. This disables an undocumented ability of customizing Gateway API
+  `*Route` objects and `Service`s that are set as backendRefs for those `*Route`s
+  via `konghq.com/override` annotations.
+  [#2554](https://github.com/Kong/kubernetes-ingress-controller/issues/2554)
 
 ## [2.3.1]
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -137,17 +137,20 @@ func (ks *KongState) FillOverrides(log logrus.FieldLogger, s store.Storer) {
 		// Services
 		kongIngress, err := getKongIngressForServices(s, ks.Services[i].K8sServices)
 		if err != nil {
-			log.WithError(err).Errorf("failed to fetch KongIngress resource for Services %s", PrettyPrintServiceList(ks.Services[i].K8sServices))
+			log.WithError(err).
+				Errorf("failed to fetch KongIngress resource for Services %s",
+					PrettyPrintServiceList(ks.Services[i].K8sServices),
+				)
 			continue
 		}
 
 		for _, svc := range ks.Services[i].K8sServices {
-			ks.Services[i].override(kongIngress, svc.Annotations)
+			ks.Services[i].override(log, kongIngress, svc)
 		}
 
 		// Routes
 		for j := 0; j < len(ks.Services[i].Routes); j++ {
-			kongIngress, err := getKongIngressFromObjectMeta(s, &ks.Services[i].Routes[j].Ingress)
+			kongIngress, err := getKongIngressFromObjectMeta(s, ks.Services[i].Routes[j].Ingress)
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"resource_name":      ks.Services[i].Routes[j].Ingress.Name,
@@ -163,12 +166,15 @@ func (ks *KongState) FillOverrides(log logrus.FieldLogger, s store.Storer) {
 	for i := 0; i < len(ks.Upstreams); i++ {
 		kongIngress, err := getKongIngressForServices(s, ks.Upstreams[i].Service.K8sServices)
 		if err != nil {
-			log.WithError(err).Errorf("failed to fetch KongIngress resource for Services %s", PrettyPrintServiceList(ks.Upstreams[i].Service.K8sServices))
+			log.WithError(err).
+				Errorf("failed to fetch KongIngress resource for Services %s",
+					PrettyPrintServiceList(ks.Upstreams[i].Service.K8sServices),
+				)
 			continue
 		}
 
 		for _, svc := range ks.Upstreams[i].Service.K8sServices {
-			ks.Upstreams[i].override(kongIngress, svc.Annotations)
+			ks.Upstreams[i].override(log, kongIngress, svc)
 		}
 	}
 }

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -1,6 +1,7 @@
 package kongstate
 
 import (
+	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -356,8 +357,11 @@ func TestNormalizeProtocols(t *testing.T) {
 	}
 
 	assert.NotPanics(func() {
+		log := logrus.New()
+		log.SetOutput(ioutil.Discard)
+
 		var nilUpstream *Upstream
-		nilUpstream.override(nil, make(map[string]string))
+		nilUpstream.override(log, nil, nil)
 	})
 }
 

--- a/internal/dataplane/kongstate/upstream.go
+++ b/internal/dataplane/kongstate/upstream.go
@@ -2,6 +2,9 @@ package kongstate
 
 import (
 	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -79,12 +82,44 @@ func (u *Upstream) overrideByKongIngress(kongIngress *configurationv1.KongIngres
 	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2075
 }
 
-// override sets Upstream fields by KongIngress first, then by annotation
-func (u *Upstream) override(kongIngress *configurationv1.KongIngress, anns map[string]string) {
+// override sets Upstream fields by KongIngress first, then by k8s Service's annotations
+func (u *Upstream) override(
+	log logrus.FieldLogger,
+	kongIngress *configurationv1.KongIngress,
+	svc *corev1.Service,
+) {
 	if u == nil {
 		return
 	}
 
+	if u.Service.Parent != nil && kongIngress != nil {
+		// If the parent object behind Kong Upstream's is a Gateway API object
+		// (probably *Route but log a warning for all other objects as well)
+		// then check if we're trying to override said Service configuration with
+		// a KongIngress object and if that's the case then skip it since those
+		// should not be affected.
+		gvk := u.Service.Parent.GetObjectKind().GroupVersionKind()
+		if gvk.Group == gatewayv1alpha2.GroupName {
+			obj := u.Service.Parent
+			fields := logrus.Fields{
+				"resource_name":      obj.GetName(),
+				"resource_namespace": obj.GetNamespace(),
+				"resource_kind":      gvk.Kind,
+			}
+			if svc != nil {
+				fields["service_name"] = svc.Name
+				fields["service_namespace"] = svc.Namespace
+			}
+			// No log needed here as there will be one issued already from Kong's
+			// Service override. The reason for this is that there is no other
+			// object in Kubernetes that creates a Kong's Upstream and Kubernetes
+			// Service will already trigger Kong's Service creation and log issuance.
+			return
+		}
+	}
+
 	u.overrideByKongIngress(kongIngress)
-	u.overrideByAnnotation(anns)
+	if svc != nil {
+		u.overrideByAnnotation(svc.Annotations)
+	}
 }

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -48,23 +48,30 @@ func getKongIngressForServices(
 	return nil, nil
 }
 
-func getKongIngressFromObjectMeta(s store.Storer, obj *util.K8sObjectInfo) (
-	*configurationv1.KongIngress, error) {
-	return getKongIngressFromIngressAnnotations(s, obj.Namespace, obj.Name, obj.Annotations)
+func getKongIngressFromObjectMeta(
+	s store.Storer,
+	obj util.K8sObjectInfo,
+) (
+	*configurationv1.KongIngress, error,
+) {
+	return getKongIngressFromObjAnnotations(s, obj)
 }
 
-func getKongIngressFromIngressAnnotations(s store.Storer, namespace, name string,
-	anns map[string]string) (
-	*configurationv1.KongIngress, error) {
-	confName := annotations.ExtractConfigurationName(anns)
+func getKongIngressFromObjAnnotations(
+	s store.Storer,
+	obj util.K8sObjectInfo,
+) (
+	*configurationv1.KongIngress, error,
+) {
+	confName := annotations.ExtractConfigurationName(obj.Annotations)
 	if confName != "" {
-		ki, err := s.GetKongIngress(namespace, confName)
+		ki, err := s.GetKongIngress(obj.Namespace, confName)
 		if err == nil {
 			return ki, nil
 		}
 	}
 
-	ki, err := s.GetKongIngress(namespace, name)
+	ki, err := s.GetKongIngress(obj.Namespace, obj.Name)
 	if err == nil {
 		return ki, nil
 	}

--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -55,10 +55,9 @@ func (ir *ingressRules) populateServices(log logrus.FieldLogger, s store.Storer)
 		// if the Kubernetes services have been deemed invalid, no need to continue
 		// they will all be dropped until the problem has been rectified.
 		if !servicesAllUseTheSameKongAnnotations(log, k8sServices, seenAnnotations) {
-			return fmt.Errorf("the following Kubernetes services were all configured together as the backends "+
-				"for a Kong Service named %s: %+v. These services had disparate KongIngress overrides which is not allowed: "+
-				" when configuring multiple Kubernetes Services as backends (e.g. backendRefs in HTTPRoutes) it is required "+
-				" that all of them have matching KongIngress override annotations", *service.Name, k8sServices)
+			return fmt.Errorf("the Kubernetes Services %v cannot have different sets of konghq.com annotations. "+
+				"These Services are used in the same Gateway Route BackendRef together to create the Kong Service %s"+
+				"and must use the same Kong annotations", k8sServices, *service.Name)
 		}
 
 		for _, k8sService := range k8sServices {

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -116,8 +116,50 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Name:        "basic-httproute",
 								Namespace:   corev1.NamespaceDefault,
 								Annotations: make(map[string]string),
+								GroupVersionKind: schema.GroupVersionKind{
+									Group:   "gateway.networking.k8s.io",
+									Version: "v1alpha2",
+									Kind:    "HTTPRoute",
+								},
 							},
 						}},
+						Parent: &gatewayv1alpha2.HTTPRoute{
+							Spec: gatewayv1alpha2.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+									ParentRefs: []gatewayv1alpha2.ParentReference{
+										{
+											Name: gatewayv1alpha2.ObjectName("fake-gateway"),
+										},
+									},
+								},
+								Hostnames: []gatewayv1alpha2.Hostname{
+									gatewayv1alpha2.Hostname("konghq.com"),
+									gatewayv1alpha2.Hostname("www.konghq.com"),
+								},
+								Rules: []gatewayv1alpha2.HTTPRouteRule{
+									{
+										BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1alpha2.BackendRef{
+													BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+														Name: gatewayv1alpha2.ObjectName("fake-service"),
+														Port: &httpPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "basic-httproute",
+								Namespace: "default",
+							},
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "HTTPRoute",
+								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+							},
+						},
 					},
 				},
 			},
@@ -225,8 +267,54 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Name:        "basic-httproute",
 								Namespace:   corev1.NamespaceDefault,
 								Annotations: make(map[string]string),
+								GroupVersionKind: schema.GroupVersionKind{
+									Group:   "gateway.networking.k8s.io",
+									Version: "v1alpha2",
+									Kind:    "HTTPRoute",
+								},
 							},
 						}},
+						Parent: &gatewayv1alpha2.HTTPRoute{
+							Spec: gatewayv1alpha2.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+									ParentRefs: []gatewayv1alpha2.ParentReference{
+										{
+											Name: gatewayv1alpha2.ObjectName("fake-gateway"),
+										},
+									},
+								},
+								Rules: []gatewayv1alpha2.HTTPRouteRule{
+									{
+										Matches: []gatewayv1alpha2.HTTPRouteMatch{
+											{
+												Path: &gatewayv1alpha2.HTTPPathMatch{
+													Type:  &pathMatchPrefix,
+													Value: kong.String("/httpbin"),
+												},
+											},
+										},
+										BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1alpha2.BackendRef{
+													BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+														Name: gatewayv1alpha2.ObjectName("fake-service"),
+														Port: &httpPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "basic-httproute",
+								Namespace: "default",
+							},
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "HTTPRoute",
+								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+							},
+						},
 					},
 				},
 			},
@@ -362,8 +450,54 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Name:        "basic-httproute",
 								Namespace:   corev1.NamespaceDefault,
 								Annotations: make(map[string]string),
+								GroupVersionKind: schema.GroupVersionKind{
+									Group:   "gateway.networking.k8s.io",
+									Version: "v1alpha2",
+									Kind:    "HTTPRoute",
+								},
 							},
 						}},
+						Parent: &gatewayv1alpha2.HTTPRoute{
+							Spec: gatewayv1alpha2.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+									ParentRefs: []gatewayv1alpha2.ParentReference{
+										{
+											Name: gatewayv1alpha2.ObjectName("fake-gateway"),
+										},
+									},
+								},
+								Rules: []gatewayv1alpha2.HTTPRouteRule{
+									{
+										Matches: []gatewayv1alpha2.HTTPRouteMatch{
+											{
+												Path: &gatewayv1alpha2.HTTPPathMatch{
+													Type:  &pathMatchRegex,
+													Value: kong.String("/httpbin$"),
+												},
+											},
+										},
+										BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1alpha2.BackendRef{
+													BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+														Name: gatewayv1alpha2.ObjectName("fake-service"),
+														Port: &httpPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "basic-httproute",
+								Namespace: "default",
+							},
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "HTTPRoute",
+								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+							},
+						},
 					},
 				},
 			},
@@ -436,8 +570,54 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Name:        "basic-httproute",
 								Namespace:   corev1.NamespaceDefault,
 								Annotations: make(map[string]string),
+								GroupVersionKind: schema.GroupVersionKind{
+									Group:   "gateway.networking.k8s.io",
+									Version: "v1alpha2",
+									Kind:    "HTTPRoute",
+								},
 							},
 						}},
+						Parent: &gatewayv1alpha2.HTTPRoute{
+							Spec: gatewayv1alpha2.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+									ParentRefs: []gatewayv1alpha2.ParentReference{
+										{
+											Name: gatewayv1alpha2.ObjectName("fake-gateway"),
+										},
+									},
+								},
+								Rules: []gatewayv1alpha2.HTTPRouteRule{
+									{
+										Matches: []gatewayv1alpha2.HTTPRouteMatch{
+											{
+												Path: &gatewayv1alpha2.HTTPPathMatch{
+													Type:  &pathMatchExact,
+													Value: kong.String("/httpbin"),
+												},
+											},
+										},
+										BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1alpha2.BackendRef{
+													BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+														Name: gatewayv1alpha2.ObjectName("fake-service"),
+														Port: &httpPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "basic-httproute",
+								Namespace: "default",
+							},
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "HTTPRoute",
+								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+							},
+						},
 					},
 				},
 			},

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -177,6 +177,7 @@ func (p *Parser) generateKongServiceFromBackendRef(
 			},
 			Namespace: route.GetNamespace(),
 			Backends:  backends,
+			Parent:    route,
 		}
 	}
 

--- a/internal/dataplane/parser/translate_utils_test.go
+++ b/internal/dataplane/parser/translate_utils_test.go
@@ -579,6 +579,16 @@ func Test_generateKongServiceFromBackendRef(t *testing.T) {
 						},
 					},
 				},
+				Parent: &gatewayv1alpha2.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tong-sirlari",
+						Namespace: "cholpon",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: "gateway.networking.k8s.io/v1alpha2",
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -639,6 +649,16 @@ func Test_generateKongServiceFromBackendRef(t *testing.T) {
 							Mode:   kongstate.PortModeByNumber,
 							Number: int32(port),
 						},
+					},
+				},
+				Parent: &gatewayv1alpha2.UDPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "padarkush",
+						Namespace: "behbudiy",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "UDPRoute",
+						APIVersion: "gateway.networking.k8s.io/v1alpha2",
 					},
 				},
 			},
@@ -719,6 +739,16 @@ func Test_generateKongServiceFromBackendRef(t *testing.T) {
 							Mode:   kongstate.PortModeByNumber,
 							Number: int32(port),
 						},
+					},
+				},
+				Parent: &gatewayv1alpha2.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "muntaxabi-jugrofiyai-umumiy",
+						Namespace: "behbudiy",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "TCPRoute",
+						APIVersion: "gateway.networking.k8s.io/v1alpha2",
 					},
 				},
 			},

--- a/internal/util/objectmeta.go
+++ b/internal/util/objectmeta.go
@@ -1,14 +1,16 @@
 package util
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // K8sObjectInfo describes a Kubernetes object.
 type K8sObjectInfo struct {
-	Name        string
-	Namespace   string
-	Annotations map[string]string
+	Name             string
+	Namespace        string
+	Annotations      map[string]string
+	GroupVersionKind schema.GroupVersionKind
 }
 
 func deepCopy(m map[string]string) map[string]string {
@@ -19,10 +21,14 @@ func deepCopy(m map[string]string) map[string]string {
 	return result
 }
 
-func FromK8sObject(obj metav1.Object) K8sObjectInfo {
-	return K8sObjectInfo{
+func FromK8sObject(obj client.Object) K8sObjectInfo {
+	ret := K8sObjectInfo{
 		Name:        obj.GetName(),
 		Namespace:   obj.GetNamespace(),
 		Annotations: deepCopy(obj.GetAnnotations()),
 	}
+	if gvk := obj.GetObjectKind().GroupVersionKind(); gvk.String() != "" {
+		ret.GroupVersionKind = gvk
+	}
+	return ret
 }

--- a/internal/util/objectmeta_test.go
+++ b/internal/util/objectmeta_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestFromK8sObject(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		in   metav1.Object
+		in   client.Object
 		want K8sObjectInfo
 	}{
 		{
@@ -46,7 +47,7 @@ func TestFromK8sObject(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := FromK8sObject(tt.in)
-			assert.Equal(t, tt.want, got)
+			assert.EqualValues(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to prevent users on relying on `KongIngress` annotation overrides this PR disables the ability to do so for:

- Gateway API *`Route` objects
- kubernetes `Service`s defined as Gateway API *`Route`'s backends

**Which issue this PR fixes**:

fixes #2505 

**Special notes for your reviewer**:

N/A

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
