### PR TITLE
chore: bump golangci-lint to v1.46.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ client-gen: ## Download client-gen locally if necessary.
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2)
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/internal/controllers/gateway/utils.go
+++ b/internal/controllers/gateway/utils.go
@@ -21,7 +21,7 @@ func debug(log logr.Logger, obj client.Object, msg string, keysAndValues ...inte
 }
 
 // info is an alias for the longer log.V(util.InfoLevel).Info for convenience
-func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) { //nolint:unparam
+func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) {
 	keysAndValues = append([]interface{}{
 		"namespace", obj.GetNamespace(),
 		"name", obj.GetName(),


### PR DESCRIPTION
Related release: https://github.com/golangci/golangci-lint/releases/tag/v1.46.2

### Open questions:

- As of now the current implementation [`go-get-tool`](https://github.com/Kong/kubernetes-ingress-controller/blob/22e53cdcb23c3bf908b4e4ae951eedb0b4b671fd/Makefile#L48-L58) doesn't check for the version of the tool it "gets" which requires users to manually remove the binary in order to get the update. Perhaps it would be nice to add a mechanism which would replace `go-get-tool` which would account for current tool's version and the "in-tree" version and in case those differ, to download the "in-tree" version.