### PR TITLE
Add CLI flag for using networking.k8s.io/v1beta1 IngressClass resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
   [#2494](https://github.com/Kong/kubernetes-ingress-controller/pull/2494)
 - Added `kong-ingress-controller` category to CRDs
   [#2517](https://github.com/Kong/kubernetes-ingress-controller/pull/2517)
+- Added new command line flag `--use-v1beta1-ingress-class` for using `IngressClass` resources from `networking.k8s.io/v1beta1` namespace instead of `networking.k8s.io/v1`. [#2563](https://github.com/Kong/kubernetes-ingress-controller/issues/2563)
 
 #### Fixed
 

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -450,6 +450,7 @@ type {{.PackageAlias}}{{.Kind}}Reconciler struct {
 {{- if or .AcceptsIngressClassNameSpec .AcceptsIngressClassNameAnnotation}}
 
 	IngressClassName string
+	IngressClassType client.Object
 {{- end}}
 }
 
@@ -482,7 +483,7 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) SetupWithManager(mgr ctrl.Manager
 {{- end}}
 {{- if .AcceptsIngressClassNameAnnotation}}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -285,6 +285,7 @@ type NetV1IngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -312,7 +313,7 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -326,6 +327,7 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *NetV1IngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &netv1.IngressList{}
@@ -514,6 +516,7 @@ type NetV1Beta1IngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -541,7 +544,7 @@ func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -555,6 +558,7 @@ func (r *NetV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *NetV1Beta1IngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &netv1beta1.IngressList{}
@@ -671,6 +675,7 @@ type ExtV1Beta1IngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -698,7 +703,7 @@ func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -712,6 +717,7 @@ func (r *ExtV1Beta1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *ExtV1Beta1IngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &extv1beta1.IngressList{}
@@ -971,6 +977,7 @@ type KongV1KongClusterPluginReconciler struct {
 	DataplaneClient *dataplane.KongClient
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -985,7 +992,7 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 		return err
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -999,6 +1006,7 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1KongClusterPluginReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &kongv1.KongClusterPluginList{}
@@ -1090,6 +1098,7 @@ type KongV1KongConsumerReconciler struct {
 	DataplaneClient *dataplane.KongClient
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -1104,7 +1113,7 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		return err
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -1118,6 +1127,7 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1KongConsumerReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &kongv1.KongConsumerList{}
@@ -1212,6 +1222,7 @@ type KongV1Beta1TCPIngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -1239,7 +1250,7 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -1253,6 +1264,7 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1Beta1TCPIngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &kongv1beta1.TCPIngressList{}
@@ -1369,6 +1381,7 @@ type KongV1Beta1UDPIngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -1396,7 +1409,7 @@ func (r *KongV1Beta1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -1410,6 +1423,7 @@ func (r *KongV1Beta1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1Beta1UDPIngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &kongv1beta1.UDPIngressList{}
@@ -1526,6 +1540,7 @@ type Knativev1alpha1IngressReconciler struct {
 	StatusQueue            *status.Queue
 
 	IngressClassName string
+	IngressClassType client.Object
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -1553,7 +1568,7 @@ func (r *Knativev1alpha1IngressReconciler) SetupWithManager(mgr ctrl.Manager) er
 		}
 	}
 	err = c.Watch(
-		&source.Kind{Type: &netv1.IngressClass{}},
+		&source.Kind{Type: r.IngressClassType},
 		handler.EnqueueRequestsFromMapFunc(r.listClassless),
 		predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
 	)
@@ -1567,6 +1582,7 @@ func (r *Knativev1alpha1IngressReconciler) SetupWithManager(mgr ctrl.Manager) er
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *Knativev1alpha1IngressReconciler) listClassless(obj client.Object) []reconcile.Request {
 	resourceList := &knativev1alpha1.IngressList{}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/spf13/pflag"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -81,6 +83,7 @@ type Config struct {
 	KongPluginEnabled        bool
 	KongConsumerEnabled      bool
 	ServiceEnabled           bool
+	UseBeta1IngressClass     bool
 
 	// Admission Webhook server config
 	AdmissionServer admission.ServerConfig
@@ -185,6 +188,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.KongPluginEnabled, "enable-controller-kongplugin", true, "Enable the KongPlugin controller.")
 	flagSet.BoolVar(&c.KongConsumerEnabled, "enable-controller-kongconsumer", true, "Enable the KongConsumer controller. ")
 	flagSet.BoolVar(&c.ServiceEnabled, "enable-controller-service", true, "Enable the Service controller.")
+	flagSet.BoolVar(&c.UseBeta1IngressClass, "use-v1beta1-ingress-class", false, "Use older networking.k8s.io/v1beta1 IngressClass")
 
 	// Admission Webhook server config
 	flagSet.StringVar(&c.AdmissionServer.ListenAddr, "admission-webhook-listen", "off",
@@ -253,4 +257,11 @@ func (c *Config) GetKubeClient() (client.Client, error) {
 		return nil, err
 	}
 	return client.New(conf, client.Options{})
+}
+
+func (c *Config) GetIngressClassObject() client.Object {
+	if c.UseBeta1IngressClass {
+		return &netv1beta1.IngressClass{}
+	}
+	return &netv1.IngressClass{}
 }

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -101,6 +101,7 @@ func setupControllers(
 				IngressClassName:       c.IngressClassName,
 				StatusQueue:            kubernetesStatusQueue,
 				DataplaneAddressFinder: dataplaneAddressFinder,
+				IngressClassType:       c.GetIngressClassObject(),
 			},
 		},
 		{
@@ -114,6 +115,7 @@ func setupControllers(
 				IngressClassName:       c.IngressClassName,
 				StatusQueue:            kubernetesStatusQueue,
 				DataplaneAddressFinder: dataplaneAddressFinder,
+				IngressClassType:       c.GetIngressClassObject(),
 			},
 		},
 		{
@@ -127,6 +129,7 @@ func setupControllers(
 				IngressClassName:       c.IngressClassName,
 				StatusQueue:            kubernetesStatusQueue,
 				DataplaneAddressFinder: dataplaneAddressFinder,
+				IngressClassType:       c.GetIngressClassObject(),
 			},
 		},
 		{
@@ -169,6 +172,7 @@ func setupControllers(
 				IngressClassName:       c.IngressClassName,
 				StatusQueue:            kubernetesStatusQueue,
 				DataplaneAddressFinder: dataplaneAddressFinder,
+				IngressClassType:       c.GetIngressClassObject(),
 			},
 		},
 		{
@@ -209,6 +213,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				IngressClassName: c.IngressClassName,
+				IngressClassType: c.GetIngressClassObject(),
 			},
 		},
 		{
@@ -224,6 +229,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				IngressClassName: c.IngressClassName,
+				IngressClassType: c.GetIngressClassObject(),
 			},
 		},
 		// ---------------------------------------------------------------------------
@@ -247,6 +253,7 @@ func setupControllers(
 				IngressClassName:       c.IngressClassName,
 				StatusQueue:            kubernetesStatusQueue,
 				DataplaneAddressFinder: dataplaneAddressFinder,
+				IngressClassType:       c.GetIngressClassObject(),
 			},
 		},
 		// ---------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

As mentioned in #2563, the Ingress Controller fails when scanning for non-existing resource types. This PR adds a flag to avoid that issue by enabling the user to monitor a more backwards-compatible resource type. The root of the problem can be traced into the fact that `networking.k8s.io/v1` was basically hard-coded as the `IngressClass` namespace, even when it is used with older `Ingress` resources (from `extensions/v1beta1`) which are unlikely to exist in a cluster with full `networking.k8s.io/v1` support.

**Which issue this PR fixes**: fixes #2563 

**Special notes for your reviewer**: This PR only addresses the issue for a specific resource type. A more general solution, like not watching non-existent resources can be another option but it would be a more involved effort to implement with a wider surface for possible breakages.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
