### PR TITLE
fix: change admissionWebhook.failurePolicy value to Ignore

### DIFF
--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -30,7 +30,7 @@ webhooks:
       operator: NotIn
       values:
       - helm
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
   admissionReviewVersions: [\"v1\", \"v1beta1\"]
   rules:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Ports changes made in helms charts in [#612](https://github.com/Kong/charts/pull/612) to the `hack/deploy-admission-controller.sh` deploy script.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #2501 

**Special notes for your reviewer**:
As suggested in [kubernetes-ingress-controller/issues/2501](https://github.com/Kong/kubernetes-ingress-controller/issues/2501) PR was tested manually:

##### Testing done:
1. Verified that unique constraint of secrets does trigger failure when admission failure policy is `Ignore` as described in [kubernetes-ingress-controller/issues/2431. Verified that `Fail` policy prevents config from being applied
](https://github.com/Kong/kubernetes-ingress-controller/issues/2431
)
2. Verified that when controller is unreachable, the config is accepted if policy is `Ignore`.

- Installed kic with admission failure policy enabled, failure policy `Ignore` and faked the controller connectivity problem by setting `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` to `off` in helm charts.



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
