### PR TITLE
chore(tests) update KNative min version

### DIFF
--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -39,7 +39,7 @@ var knativeMinKubernetesVersion = semver.MustParse("1.22.0")
 
 func TestKnativeIngress(t *testing.T) {
 	if clusterVersion.LT(knativeMinKubernetesVersion) {
-		t.Skip("knative tests can't be run on cluster versions prior to 1.22")
+		t.Skip("knative tests can't be run on cluster versions prior to", knativeMinKubernetesVersion)
 	}
 
 	t.Parallel()

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -35,11 +35,11 @@ const (
 
 // knativeMinKubernetesVersion indicates the minimum Kubernetes version
 // required in order to successfully run Knative tests.
-var knativeMinKubernetesVersion = semver.MustParse("1.21.0")
+var knativeMinKubernetesVersion = semver.MustParse("1.22.0")
 
 func TestKnativeIngress(t *testing.T) {
 	if clusterVersion.LT(knativeMinKubernetesVersion) {
-		t.Skip("knative tests can't be run on cluster versions prior to 1.21")
+		t.Skip("knative tests can't be run on cluster versions prior to 1.22")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the KNative minimum test cluster version. The current KNative version we use requires 1.22 or higher.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes broken 2.4 release jobs.

**Special notes for your reviewer**:
Reviewing a GKE cluster that never got past the cluster setup phase showed:

```
2022/06/15 17:55:51 Failed to get k8s version kubernetes version "1.21.12-gke.2200" is not compatible, need at least "1.22.0-0" (this can be overridden with the env var "KUBERNETES_MIN_VERSION")
```
on most of the KNative Pods.
