### PR TITLE
chore(ci) add example to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The version to release'
+        description: 'The version to release (e.g. v1.2.3)'
         required: true
       latest:
         description: 'Whether to tag this release latest'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an example version format to the release workflow

**Special notes for your reviewer**:
This will actually accept any valid semver if I'm reading it correctly, and appropriately use the v prefix for the tag and not the image, but whatever, this makes it so you don't have to think about it.