### PR TITLE
Gateway resources consolidation

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,0 +1,173 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
+)
+
+const (
+	// defaultGatewayName is the default name for the Gateways created during tests
+	defaultGatewayName = "kong"
+	// managedGatewayClassName is the name of the default GatewayClass created during the test environment setup
+	managedGatewayClassName = "kong-managed"
+	// unmanagedControllerName is the name of the controller used for those gateways that are not supported
+	// by an actual controller (i.e., they won't be scheduled)
+	unmanagedControllerName gatewayv1alpha2.GatewayController = "example.com/unmanaged-gateway-controller"
+)
+
+// DeployGateway creates a default gatewayClass, accepts a variadic set of options,
+// and finally deploys it on the Kubernetes cluster by means of the gateway client given as arg.
+func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, gatewayClassName string, opts ...func(*gatewayv1alpha2.GatewayClass)) (*gatewayv1alpha2.GatewayClass, error) {
+	gwc := &gatewayv1alpha2.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gatewayClassName,
+		},
+		Spec: gatewayv1alpha2.GatewayClassSpec{
+			ControllerName: gateway.ControllerName,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(gwc)
+	}
+
+	return client.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+}
+
+// DeployGateway creates a default gateway, accepts a variadic set of options,
+// and finally deploys it on the Kubernetes cluster by means of the gateway client given as arg.
+func DeployGateway(ctx context.Context, client *gatewayclient.Clientset, namespace, gatewayClassName string, opts ...func(*gatewayv1alpha2.Gateway)) (*gatewayv1alpha2.Gateway, error) {
+	// create a default gateway with a listener set to port 80 for HTTP traffic
+	gw := &gatewayv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultGatewayName,
+			Annotations: map[string]string{
+				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
+			},
+		},
+		Spec: gatewayv1alpha2.GatewaySpec{
+			GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClassName),
+			Listeners: []gatewayv1alpha2.Listener{{
+				Name:     "http",
+				Protocol: gatewayv1alpha2.HTTPProtocolType,
+				Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultProxyTCPServicePort),
+			}},
+		},
+	}
+
+	// call all the modifiers passed as args
+	for _, opt := range opts {
+		opt(gw)
+	}
+
+	return client.GatewayV1alpha2().Gateways(namespace).Create(ctx, gw, metav1.CreateOptions{})
+}
+
+// gatewayHealthCheck checks the gateway has been scheduled by KIC. This function is inspired by
+// assert.eventually (https://github.com/stretchr/testify/blob/v1.7.5/assert/assertions.go#L1669-L1700)
+// and patched with custom behavior to determine the health of the gateway and to return an error
+// instead of failing (at the time of its call, we don't have any test instance to make fail yet).
+func gatewayHealthCheck(ctx context.Context, client *gatewayclient.Clientset, gatewayName, namespace string) error {
+	ch := make(chan bool, 1)
+
+	timer := time.NewTimer(gatewayWaitTimeToVerifyScheduling)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(time.Millisecond * 200)
+	defer ticker.Stop()
+
+	for tick := ticker.C; ; {
+		select {
+		case <-timer.C:
+			return fmt.Errorf("the gateway %s/%s did not become scheduled after %s", namespace, defaultGatewayName, gatewayWaitTimeToVerifyScheduling)
+		case <-tick:
+			tick = nil
+			ch <- func() bool {
+				gw, err := client.GatewayV1alpha2().Gateways(namespace).Get(ctx, gatewayName, metav1.GetOptions{})
+				exitOnErr(err)
+				for _, cond := range gw.Status.Conditions {
+					if cond.Reason == string(gatewayv1alpha2.GatewayReasonReady) {
+						return true
+					}
+				}
+				return false
+			}()
+		case v := <-ch:
+			if v {
+				return nil
+			}
+			tick = ticker.C
+		}
+	}
+}
+
+// GetGatewayIsLinkedCallback returns a callback that checks if the specific Route (HTTP, TCP, TLS, or UDP)
+// is correctly linked to a supported gateway
+func GetGatewayIsLinkedCallback(t *testing.T, c *gatewayclient.Clientset, protocolType gatewayv1alpha2.ProtocolType, namespace, name string) func() bool {
+	return func() bool {
+		return gatewayLinkStatusMatches(t, c, true, protocolType, namespace, name)
+	}
+}
+
+// GetGatewayIsUnlinkedCallback returns a callback that checks if the specific Route (HTTP, TCP, TLS, or UDP)
+// is correctly unlinked from a supported gateway
+func GetGatewayIsUnlinkedCallback(t *testing.T, c *gatewayclient.Clientset, protocolType gatewayv1alpha2.ProtocolType, namespace, name string) func() bool {
+	return func() bool {
+		return gatewayLinkStatusMatches(t, c, false, protocolType, namespace, name)
+	}
+}
+
+// gatewayLinkStatusMatches checks if the specific Route (HTTP, TCP, TLS, or UDP)
+// is correctly linked to (or unlinked from) a supported gateway. In order to assert
+// that the route must be linked to the gateway, or unlinked from the gateway, the
+// verifyLinked boolean arg must be set accordingly.
+func gatewayLinkStatusMatches(t *testing.T, c *gatewayclient.Clientset, verifyLinked bool, protocolType gatewayv1alpha2.ProtocolType, namespace, name string) bool {
+	var routeParents []gatewayv1alpha2.RouteParentStatus
+
+	// gather a fresh copy of the route, given the specific protocol type
+	switch protocolType {
+	case gatewayv1alpha2.HTTPProtocolType:
+		route, err := c.GatewayV1alpha2().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		t.Logf("error getting http route: %v", err)
+		routeParents = route.Status.Parents
+	case gatewayv1alpha2.TCPProtocolType:
+		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		t.Logf("error getting tcp route: %v", err)
+		routeParents = route.Status.Parents
+	case gatewayv1alpha2.UDPProtocolType:
+		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		t.Logf("error getting udp route: %v", err)
+		routeParents = route.Status.Parents
+	case gatewayv1alpha2.TLSProtocolType:
+		route, err := c.GatewayV1alpha2().TLSRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		t.Logf("error getting tls route: %v", err)
+		routeParents = route.Status.Parents
+	default:
+		t.Fatalf("protocol %s not supported", string(protocolType))
+	}
+
+	// determine if there is a link to a supported Gateway
+	for _, parentStatus := range routeParents {
+		if parentStatus.ControllerName == gateway.ControllerName {
+			// supported Gateway link was found, hence if we want to ensure
+			// the link existence return true
+			return verifyLinked
+		}
+	}
+
+	// supported Gateway link was not found, hence if we want to ensure
+	// the link existence return false
+	return !verifyLinked
+}

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -22,7 +22,6 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -33,61 +32,26 @@ import (
 var emptyHeaderSet = make(map[string]string)
 
 func TestHTTPRouteEssentials(t *testing.T) {
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
 
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-	t.Log("deploying a supported gatewayclass to the test cluster")
-	c, err := gatewayclient.NewForConfig(env.Cluster().Config())
-	require.NoError(t, err)
-	gwc := &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	t.Log("getting a gateway client")
+	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
-	defer func() {
-		t.Log("cleaning up gatewayclasses")
-		if err := c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
-
-	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gw := &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kong",
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "http",
-				Protocol: gatewayv1alpha2.HTTPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(80),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	t.Log("deploying a new gatewayClass")
+	gatewayClassName := uuid.NewString()
+	gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
+	cleaner.Add(gwc)
 
-	defer func() {
-		t.Log("cleaning up gateways")
-		if err := c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
+	t.Log("deploying a new gateway")
+	gatewayName := uuid.NewString()
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+	})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container1 := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -159,7 +123,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	pathMatchRegularExpression := gatewayv1alpha2.PathMatchRegularExpression
 	pathMatchExact := gatewayv1alpha2.PathMatchExact
 	headerMatchRegex := gatewayv1alpha2.HeaderMatchRegularExpression
-	httproute := &gatewayv1alpha2.HTTPRoute{
+	httpRoute := &gatewayv1alpha2.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
@@ -170,7 +134,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		Spec: gatewayv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName(gw.Name),
+					Name: gatewayv1alpha2.ObjectName(gateway.Name),
 				}},
 			},
 			Rules: []gatewayv1alpha2.HTTPRouteRule{{
@@ -206,7 +170,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		},
 	}
 	if util.GetKongVersion().GTE(parser.MinRegexHeaderKongVersion) {
-		httproute.Spec.Rules[0].Matches = append(httproute.Spec.Rules[0].Matches, gatewayv1alpha2.HTTPRouteMatch{
+		httpRoute.Spec.Rules[0].Matches = append(httpRoute.Spec.Rules[0].Matches, gatewayv1alpha2.HTTPRouteMatch{
 			Headers: []gatewayv1alpha2.HTTPHeaderMatch{
 				{
 					Type:  &headerMatchRegex,
@@ -216,12 +180,12 @@ func TestHTTPRouteEssentials(t *testing.T) {
 			},
 		})
 	}
-	httproute, err = c.GatewayV1alpha2().HTTPRoutes(ns.Name).Create(ctx, httproute, metav1.CreateOptions{})
+	httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Create(ctx, httpRoute, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the httproute %s", httproute.Name)
-		if err := c.GatewayV1alpha2().HTTPRoutes(ns.Name).Delete(ctx, httproute.Name, metav1.DeleteOptions{}); err != nil {
+		t.Logf("cleaning up the httproute %s", httpRoute.Name)
+		if err := gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Delete(ctx, httpRoute.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				assert.NoError(t, err)
 			}
@@ -229,7 +193,8 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}()
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	eventuallyGatewayIsLinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
@@ -266,9 +231,9 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	var httpbinWeight int32 = 75
 	var nginxWeight int32 = 25
 	require.Eventually(t, func() bool {
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(httproute.Namespace).Get(ctx, httproute.Name, metav1.GetOptions{})
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(httpRoute.Namespace).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		httproute.Spec.Rules[0].BackendRefs = []gatewayv1alpha2.HTTPBackendRef{
+		httpRoute.Spec.Rules[0].BackendRefs = []gatewayv1alpha2.HTTPBackendRef{
 			{
 				BackendRef: gatewayv1alpha2.BackendRef{
 					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
@@ -289,7 +254,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 			},
 		}
 
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(httproute.Namespace).Update(ctx, httproute, metav1.UpdateOptions{})
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(httpRoute.Namespace).Update(ctx, httpRoute, metav1.UpdateOptions{})
 		if err != nil {
 			t.Logf("WARNING: could not update httproute with an additional backendRef: %s (retrying)", err)
 			return false
@@ -333,151 +298,90 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	)
 
 	t.Log("removing the parentrefs from the HTTPRoute")
-	oldParentRefs := httproute.Spec.ParentRefs
+	oldParentRefs := httpRoute.Spec.ParentRefs
 	require.Eventually(t, func() bool {
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(ns.Name).Get(ctx, httproute.Name, metav1.GetOptions{})
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		httproute.Spec.ParentRefs = nil
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(ns.Name).Update(ctx, httproute, metav1.UpdateOptions{})
+		httpRoute.Spec.ParentRefs = nil
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	eventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the parentRefs now removed")
 	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the parentRefs back")
 	require.Eventually(t, func() bool {
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(ns.Name).Get(ctx, httproute.Name, metav1.GetOptions{})
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		httproute.Spec.ParentRefs = oldParentRefs
-		httproute, err = c.GatewayV1alpha2().HTTPRoutes(ns.Name).Update(ctx, httproute, metav1.UpdateOptions{})
+		httpRoute.Spec.ParentRefs = oldParentRefs
+		httpRoute, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	eventuallyGatewayIsLinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting the GatewayClass")
-	oldGWCName := gwc.Name
-	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	eventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, httproute.Name)
-
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the GatewayClass now removed")
 	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the GatewayClass back")
-	gwc = &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWCName,
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
+	cleaner.Add(gwc)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	eventuallyGatewayIsLinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of HTTPRoutes and the route becomes available again")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting the Gateway")
-	oldGWName := gw.Name
-	require.NoError(t, c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	eventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the Gateway now removed")
 	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the Gateway back")
-	gw = &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWName,
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "http",
-				Protocol: gatewayv1alpha2.HTTPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(80),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	eventuallyGatewayIsLinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of HTTPRoutes and the route becomes available again")
 	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	eventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, httproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
-}
-
-// -----------------------------------------------------------------------------
-// HTTPRoute Tests - Status Utilities
-// -----------------------------------------------------------------------------
-
-// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-func eventuallyGatewayIsLinkedInStatus(t *testing.T, c *gatewayclient.Clientset, namespace, name string) {
-	require.Eventually(t, func() bool {
-		// gather a fresh copy of the HTTPRoute
-		httproute, err := c.GatewayV1alpha2().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		// determine if there is a link to a supported Gateway
-		for _, parentStatus := range httproute.Status.Parents {
-			if parentStatus.ControllerName == gateway.ControllerName {
-				// supported Gateway link was found
-				return true
-			}
-		}
-
-		// if no link was found yet retry
-		return false
-	}, ingressWait, waitTick)
-}
-
-// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-func eventuallyGatewayIsUnlinkedInStatus(t *testing.T, c *gatewayclient.Clientset, namespace, name string) {
-	require.Eventually(t, func() bool {
-		// gather a fresh copy of the HTTPRoute
-		httproute, err := c.GatewayV1alpha2().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		// determine if there is a link to a supported Gateway
-		for _, parentStatus := range httproute.Status.Parents {
-			if parentStatus.ControllerName == gateway.ControllerName {
-				// a supported Gateway link was found retry
-				return false
-			}
-		}
-
-		// linked gateway is not present, all set
-		return true
-	}, ingressWait, waitTick)
 }

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -47,7 +47,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 
 	t.Log("setting up the TCPIngress tests")
 	testName := "tcpingress"
-	c, err := clientset.NewForConfig(env.Cluster().Config())
+	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -91,11 +91,11 @@ func TestTCPIngressEssentials(t *testing.T) {
 			},
 		},
 	}
-	tcp, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
+	tcp, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
 	require.NoError(t, err)
 	defer func() {
 		t.Logf("ensuring that TCPIngress %s is cleaned up", tcp.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -103,7 +103,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 	}()
 
 	t.Logf("checking tcpingress %s status readiness.", tcp.Name)
-	ingCli := c.ConfigurationV1beta1().TCPIngresses(ns.Name)
+	ingCli := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name)
 	assert.Eventually(t, func() bool {
 		curIng, err := ingCli.Get(ctx, tcp.Name, metav1.GetOptions{})
 		if err != nil || curIng == nil {
@@ -141,7 +141,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("tearing down TCPIngress %s and ensuring that the relevant backend routes are removed", tcp.Name)
-	require.NoError(t, c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(tcpProxyURL.String())
 		if err != nil {
@@ -166,7 +166,7 @@ func TestTCPIngressTLS(t *testing.T) {
 
 	t.Log("setting up the TCPIngress tests")
 	testName := "tcpingress-%s"
-	c, err := clientset.NewForConfig(env.Cluster().Config())
+	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
 	testServiceSuffixes := []string{"alpha", "bravo", "charlie"}
@@ -234,11 +234,11 @@ func TestTCPIngressTLS(t *testing.T) {
 			},
 		},
 	}
-	tcpX, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcpX, metav1.CreateOptions{})
+	tcpX, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcpX, metav1.CreateOptions{})
 	require.NoError(t, err)
 	defer func() {
 		t.Logf("ensuring that TCPIngress %s is cleaned up", tcpX.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcpX.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcpX.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -266,11 +266,11 @@ func TestTCPIngressTLS(t *testing.T) {
 			},
 		},
 	}
-	tcpY, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcpY, metav1.CreateOptions{})
+	tcpY, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcpY, metav1.CreateOptions{})
 	require.NoError(t, err)
 	defer func() {
 		t.Logf("ensuring that TCPIngress %s is cleaned up", tcpY.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcpY.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcpY.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -303,9 +303,9 @@ func TestTCPIngressTLS(t *testing.T) {
 
 	// Update wipes out tcpY if actually assigned, breaking the deferred delete. we have no use for it, so discard it
 	require.Eventually(t, func() bool {
-		tcpY, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Get(ctx, tcpY.Name, metav1.GetOptions{})
+		tcpY, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Get(ctx, tcpY.Name, metav1.GetOptions{})
 		tcpY.Spec.Rules[0].Backend.ServiceName = testServiceSuffixes[0]
-		_, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Update(ctx, tcpY, metav1.UpdateOptions{})
+		_, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Update(ctx, tcpY, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)
 
@@ -352,7 +352,7 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 
 	t.Log("setting up the TCPIngress TLS passthrough tests")
 	testName := "tlspass"
-	c, err := clientset.NewForConfig(env.Cluster().Config())
+	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
 	t.Log("configuring secrets")
@@ -457,11 +457,11 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 			},
 		},
 	}
-	tcp, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
+	tcp, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
 	require.NoError(t, err)
 	defer func() {
 		t.Log("ensuring that TCPIngress is cleaned up", tcp.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -25,15 +25,14 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 )
 
-const tcpEchoPort = 1025
+const (
+	tcpEchoPort = 1025
+)
 
 func TestTCPRouteEssentials(t *testing.T) {
-	ns, cleanup := namespace(t)
-	defer cleanup()
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	defer func() {
@@ -42,59 +41,31 @@ func TestTCPRouteEssentials(t *testing.T) {
 		tcpMutex.Unlock()
 	}()
 
-	// TODO consolidate into suite and use for all GW tests?
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/2461
+	ns, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
+	t.Log("getting gateway client")
+	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
 	t.Log("deploying a supported gatewayclass to the test cluster")
-	c, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	gatewayClassName := uuid.NewString()
+	gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
-	gwc := &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	cleaner.Add(gwc)
+
+	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode and port 8888")
+	gatewayName := uuid.NewString()
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+			Name:     "tcp",
+			Protocol: gatewayv1alpha2.TCPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+		}}
+	})
 	require.NoError(t, err)
-
-	defer func() {
-		t.Log("cleaning up gatewayclasses")
-		if err := c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
-
-	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gw := &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kong",
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "tcp",
-				Protocol: gatewayv1alpha2.TCPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	defer func() {
-		t.Log("cleaning up gateways")
-		if err := c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
+	cleaner.Add(gateway)
 
 	t.Log("creating a tcpecho pod to test TCPRoute traffic routing")
 	container1 := generators.NewContainer("tcpecho-1", test.TCPEchoImage, tcpEchoPort)
@@ -170,7 +141,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Logf("creating a tcproute to access deployment %s via kong", deployment1.Name)
 	tcpPortDefault := gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort)
-	tcproute := &gatewayv1alpha2.TCPRoute{
+	tcpRoute := &gatewayv1alpha2.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        uuid.NewString(),
 			Annotations: map[string]string{},
@@ -178,7 +149,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 		Spec: gatewayv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName(gw.Name),
+					Name: gatewayv1alpha2.ObjectName(gatewayName),
 				}},
 			},
 			Rules: []gatewayv1alpha2.TCPRouteRule{{
@@ -191,12 +162,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 			}},
 		},
 	}
-	tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Create(ctx, tcproute, metav1.CreateOptions{})
+	tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Create(ctx, tcpRoute, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
-		t.Logf("cleaning up the tcproute %s", tcproute.Name)
-		if err := c.GatewayV1alpha2().TCPRoutes(ns.Name).Delete(ctx, tcproute.Name, metav1.DeleteOptions{}); err != nil {
+		t.Logf("cleaning up the tcproute %s", tcpRoute.Name)
+		if err := gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Delete(ctx, tcpRoute.Name, metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				assert.NoError(t, err)
 			}
@@ -204,7 +175,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}()
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	tcpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is responding properly")
 	require.Eventually(t, func() bool {
@@ -213,17 +185,18 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("removing the parentrefs from the TCPRoute")
-	oldParentRefs := tcproute.Spec.ParentRefs
+	oldParentRefs := tcpRoute.Spec.ParentRefs
 	require.Eventually(t, func() bool {
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcproute.Name, metav1.GetOptions{})
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		tcproute.Spec.ParentRefs = nil
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcproute, metav1.UpdateOptions{})
+		tcpRoute.Spec.ParentRefs = nil
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	tcpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is no longer responding")
 	require.Eventually(t, func() bool {
@@ -233,15 +206,16 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("putting the parentRefs back")
 	require.Eventually(t, func() bool {
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcproute.Name, metav1.GetOptions{})
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		tcproute.Spec.ParentRefs = oldParentRefs
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcproute, metav1.UpdateOptions{})
+		tcpRoute.Spec.ParentRefs = oldParentRefs
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	tcpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	require.Eventually(t, func() bool {
@@ -250,11 +224,11 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
-	oldGWCName := gwc.Name
-	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	tcpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the GatewayClass now removed")
 	require.Eventually(t, func() bool {
@@ -263,19 +237,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
-	gwc = &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWCName,
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	tcpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
@@ -284,11 +251,11 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
-	oldGWName := gw.Name
-	require.NoError(t, c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	tcpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the Gateway now removed")
 	require.Eventually(t, func() bool {
@@ -297,27 +264,19 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
-	gw = &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWName,
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "tcp",
-				Protocol: gatewayv1alpha2.TCPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(9999),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+			Name:     "tcp",
+			Protocol: gatewayv1alpha2.TCPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+		}}
+	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	tcpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
@@ -326,11 +285,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	tcpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
@@ -339,39 +299,23 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
-	gwc = &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWCName,
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
 
 	t.Log("putting the Gateway back")
-	gw = &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: oldGWName,
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true", // trigger the unmanaged gateway mode
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "tcp",
-				Protocol: gatewayv1alpha2.TCPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(9999),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+			Name:     "tcp",
+			Protocol: gatewayv1alpha2.TCPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+		}}
+	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	tcpeventuallyGatewayIsLinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
@@ -381,10 +325,10 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("adding an additional backendRef to the TCPRoute")
 	require.Eventually(t, func() bool {
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcproute.Name, metav1.GetOptions{})
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Get(ctx, tcpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 
-		tcproute.Spec.Rules[0].BackendRefs = []gatewayv1alpha2.BackendRef{
+		tcpRoute.Spec.Rules[0].BackendRefs = []gatewayv1alpha2.BackendRef{
 			{
 				BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
 					Name: gatewayv1alpha2.ObjectName(service1.Name),
@@ -399,7 +343,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			},
 		}
 
-		tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcproute, metav1.UpdateOptions{})
+		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, ingressWait, waitTick)
 
@@ -422,11 +366,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	tcpeventuallyGatewayIsUnlinkedInStatus(t, c, ns.Name, tcproute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
@@ -436,8 +381,6 @@ func TestTCPRouteEssentials(t *testing.T) {
 }
 
 func TestTCPRouteReferencePolicy(t *testing.T) {
-	ns, cleanup := namespace(t)
-	defer cleanup()
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	defer func() {
@@ -445,62 +388,33 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 		tcpMutex.Unlock()
 	}()
 
+	ns, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
 	otherNs, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
 	require.NoError(t, err)
 
-	// TODO consolidate into suite and use for all GW tests?
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-	t.Log("deploying a supported gatewayclass to the test cluster")
-	c, err := gatewayclient.NewForConfig(env.Cluster().Config())
-	require.NoError(t, err)
-	gwc := &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
-		},
-	}
-	gwc, err = c.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
-	defer func() {
-		t.Log("cleaning up gatewayclasses")
-		if err := c.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
+	t.Log("deploying a gatewayclass to the test cluster")
+	gatewayClassName := uuid.NewString()
+	gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
+	require.NoError(t, err)
+	cleaner.Add(gwc)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gw := &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kong",
-			Annotations: map[string]string{
-				unmanagedAnnotation: "true",
-			},
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gwc.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "tcp",
-				Protocol: gatewayv1alpha2.TCPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
-			}},
-		},
-	}
-	gw, err = c.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, gw, metav1.CreateOptions{})
+	gatewayName := uuid.NewString()
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+		gw.Name = gatewayName
+		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+			Name:     "tcp",
+			Protocol: gatewayv1alpha2.TCPProtocolType,
+			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+		}}
+	})
 	require.NoError(t, err)
-
-	defer func() {
-		t.Log("cleaning up gateways")
-		if err := c.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gw.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				assert.NoError(t, err)
-			}
-		}
-	}()
+	cleaner.Add(gateway)
 
 	t.Log("creating a tcpecho pod to test TCPRoute traffic routing")
 	container1 := generators.NewContainer("tcpecho-1", test.TCPEchoImage, tcpEchoPort)
@@ -580,7 +494,7 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 		Spec: gatewayv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName(gw.Name),
+					Name: gatewayv1alpha2.ObjectName(gatewayName),
 				}},
 			},
 			Rules: []gatewayv1alpha2.TCPRouteRule{{
@@ -602,12 +516,12 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 			}},
 		},
 	}
-	tcproute, err = c.GatewayV1alpha2().TCPRoutes(ns.Name).Create(ctx, tcproute, metav1.CreateOptions{})
+	tcproute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Create(ctx, tcproute, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	defer func() {
 		t.Logf("cleaning up the tcproute %s", tcproute.Name)
-		if err := c.GatewayV1alpha2().TCPRoutes(ns.Name).Delete(ctx, tcproute.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Delete(ctx, tcproute.Name, metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				assert.NoError(t, err)
 			}
@@ -658,7 +572,7 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 		},
 	}
 
-	policy, err = c.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Create(ctx, policy, metav1.CreateOptions{})
+	policy, err = gatewayClient.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Create(ctx, policy, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Log("verifying that requests reach both the local and remote namespace echo instances")
@@ -679,7 +593,7 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 		Name:  &serviceName,
 	}
 
-	policy, err = c.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
+	policy, err = gatewayClient.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -690,7 +604,7 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 	t.Logf("testing incorrect name does not match")
 	blueguyName := gatewayv1alpha2.ObjectName("blueguy")
 	policy.Spec.To[1].Name = &blueguyName
-	_, err = c.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
+	_, err = gatewayClient.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -698,47 +612,6 @@ func TestTCPRouteReferencePolicy(t *testing.T) {
 		return err != nil && responded == false
 	}, ingressWait, waitTick)
 
-}
-
-// TODO consolidate shared util gateway linked funcs
-// https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-func tcpeventuallyGatewayIsLinkedInStatus(t *testing.T, c *gatewayclient.Clientset, namespace, name string) {
-	require.Eventually(t, func() bool {
-		// gather a fresh copy of the TCPRoute
-		tcproute, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		// determine if there is a link to a supported Gateway
-		for _, parentStatus := range tcproute.Status.Parents {
-			if parentStatus.ControllerName == gateway.ControllerName {
-				// supported Gateway link was found
-				return true
-			}
-		}
-
-		// if no link was found yet retry
-		return false
-	}, ingressWait, waitTick)
-}
-
-// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2461
-func tcpeventuallyGatewayIsUnlinkedInStatus(t *testing.T, c *gatewayclient.Clientset, namespace, name string) {
-	require.Eventually(t, func() bool {
-		// gather a fresh copy of the TCPRoute
-		tcproute, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		// determine if there is a link to a supported Gateway
-		for _, parentStatus := range tcproute.Status.Parents {
-			if parentStatus.ControllerName == gateway.ControllerName {
-				// a supported Gateway link was found retry
-				return false
-			}
-		}
-
-		// linked gateway is not present, all set
-		return true
-	}, ingressWait, waitTick)
 }
 
 // tcpEchoResponds takes a TCP address URL and a Pod name and checks if a

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -108,14 +108,14 @@ func TestUDPIngressEssentials(t *testing.T) {
 			},
 		}},
 	}
-	c, err := clientset.NewForConfig(env.Cluster().Config())
+	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	assert.NoError(t, err)
-	udp, err = c.ConfigurationV1beta1().UDPIngresses(ns.Name).Create(ctx, udp, metav1.CreateOptions{})
+	udp, err = gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Create(ctx, udp, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring UDPIngress %s is cleaned up", udp.Name)
-		if err := c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -134,7 +134,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 	}
 
 	t.Logf("checking udpingress %s status readiness.", udp.Name)
-	ingCli := c.ConfigurationV1beta1().UDPIngresses(ns.Name)
+	ingCli := gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name)
 	assert.Eventually(t, func() bool {
 		curIng, err := ingCli.Get(ctx, udp.Name, metav1.GetOptions{})
 		if err != nil || curIng == nil {
@@ -157,7 +157,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("tearing down UDPIngress %s and ensuring backends are torn down", udp.Name)
-	assert.NoError(t, c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		_, err := resolver.LookupHost(ctx, "kernel.org")
 		if err != nil {
@@ -246,14 +246,14 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 			},
 		}},
 	}
-	c, err := clientset.NewForConfig(env.Cluster().Config())
+	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	assert.NoError(t, err)
-	udp, err = c.ConfigurationV1beta1().UDPIngresses(ns.Name).Create(ctx, udp, metav1.CreateOptions{})
+	udp, err = gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Create(ctx, udp, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring UDPIngress %s is cleaned up", udp.Name)
-		if err := c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -269,7 +269,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	dnsTCPClient := dns.Client{Net: "tcp"}
 
 	t.Logf("checking udpingress %s status readiness.", udp.Name)
-	ingCli := c.ConfigurationV1beta1().UDPIngresses(ns.Name)
+	ingCli := gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name)
 	assert.Eventually(t, func() bool {
 		curIng, err := ingCli.Get(ctx, udp.Name, metav1.GetOptions{})
 		if err != nil || curIng == nil {
@@ -311,12 +311,12 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 		}},
 	}
 	assert.NoError(t, err)
-	tcp, err = c.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
+	tcp, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	defer func() {
 		t.Logf("ensuring TCPIngress %s is cleaned up", tcp.Name)
-		if err := c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
+		if err := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
@@ -324,7 +324,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	}()
 
 	t.Logf("checking tcpingress %s status readiness.", tcp.Name)
-	tcpIngCli := c.ConfigurationV1beta1().TCPIngresses(ns.Name)
+	tcpIngCli := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name)
 	assert.Eventually(t, func() bool {
 		curIng, err := tcpIngCli.Get(ctx, tcp.Name, metav1.GetOptions{})
 		if err != nil || curIng == nil {
@@ -354,7 +354,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 
 	// Cleanup
 	t.Logf("tearing down UDPIngress %s and ensuring backends are torn down", udp.Name)
-	assert.NoError(t, c.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, gatewayClient.ConfigurationV1beta1().UDPIngresses(ns.Name).Delete(ctx, udp.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		_, _, err := dnsUDPClient.Exchange(query, fmt.Sprintf("%s:%d", proxyUDPURL.Hostname(), ktfkong.DefaultUDPServicePort))
 		if err != nil {
@@ -366,7 +366,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Logf("tearing down TCPIngress %s and ensuring backends are torn down", tcp.Name)
-	assert.NoError(t, c.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
+	assert.NoError(t, gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
 	assert.Eventually(t, func() bool {
 		_, _, err := dnsTCPClient.Exchange(query, fmt.Sprintf("%s:8888", proxyURL.Hostname()))
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
This PR aims at consolidating and factorizing the `gatewayClass` and `Gateway` resources across all the integration tests, to remove duplicated code and improve code quality.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2461 

**Special notes for your reviewer**:
You can find the PR's change list below:
* All the explicit instantiation of `GatewayClass` and `Gateway` objects, followed by the respective `GatewayV1alpha2().GatewayClasses().Create()` and `GatewayV1alpha2().Gateway().Create()`  function calls have been replaced by a helper call. These helpers are in the `helpers_test.go` file.
* Each function that needed a `gatewayClass`, created it at the beginning and deleted it at the end of the test (via a deferred function). Since about 90% of these objects were copypasta from one test function to another, a unique shared GatewayClass is now created at environment setup time; this object creation is in the `suite_test.go` file. Each needed `GatewayClass` different from the default one is created through the aforementioned helper.
* The files `tlsroute_test.go`, `tcproute_test.go`, `httproute_test.go`, and `udproute_test.go` used specific helpers to check the linking or unlinking of the routes from the Gateway. They were copypasta one from another. They have been deleted and factorized in a unique function with two additional parameters:
  * `protocolType`: to specify the protocol to check
  * `ensureLinked`: to specify whether to check the linking or the unlinking 
* The cleanup in each test case has been made uniform by using the utility suggested in the comment below. **NOTE**: only the files under refactoring have been subjected to this change.
* Minor name refactoring throughout the touched files.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
