### PR TITLE
fix(manifests) mount namespace from downward API

### DIFF
--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -30,6 +30,12 @@ spec:
             path: token
           - key: ca.crt
             path: ca.crt
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: "namespace"
+            fieldRef:
+              fieldPath: metadata.namespace
       containers:
       - name: proxy
         image: kong-placeholder:placeholder # This is replaced by the config/image.yaml component
@@ -143,6 +149,15 @@ spec:
           failureThreshold: 3
         volumeMounts:
         - name: kong-serviceaccount-token
-          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
+          subPath: token
+          readOnly: true
+        - name: kong-serviceaccount-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          subPath: ca.crt
+          readOnly: true
+        - name: podinfo
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+          subPath: namespace
           readOnly: true
 

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1571,9 +1571,18 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
           name: kong-serviceaccount-token
           readOnly: true
+          subPath: token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          name: kong-serviceaccount-token
+          readOnly: true
+          subPath: ca.crt
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+          name: podinfo
+          readOnly: true
+          subPath: namespace
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
       serviceAccountName: kong-serviceaccount
@@ -1586,6 +1595,12 @@ spec:
           - key: ca.crt
             path: ca.crt
           secretName: kong-serviceaccount-token
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.namespace
+            path: namespace
+        name: podinfo
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1566,9 +1566,18 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
           name: kong-serviceaccount-token
           readOnly: true
+          subPath: token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          name: kong-serviceaccount-token
+          readOnly: true
+          subPath: ca.crt
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+          name: podinfo
+          readOnly: true
+          subPath: namespace
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
@@ -1579,6 +1588,12 @@ spec:
           - key: ca.crt
             path: ca.crt
           secretName: kong-serviceaccount-token
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.namespace
+            path: namespace
+        name: podinfo
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1640,9 +1640,18 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
           name: kong-serviceaccount-token
           readOnly: true
+          subPath: token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          name: kong-serviceaccount-token
+          readOnly: true
+          subPath: ca.crt
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+          name: podinfo
+          readOnly: true
+          subPath: namespace
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
       initContainers:
@@ -1673,6 +1682,12 @@ spec:
           - key: ca.crt
             path: ca.crt
           secretName: kong-serviceaccount-token
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.namespace
+            path: namespace
+        name: podinfo
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1584,9 +1584,18 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
           name: kong-serviceaccount-token
           readOnly: true
+          subPath: token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          name: kong-serviceaccount-token
+          readOnly: true
+          subPath: ca.crt
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+          name: podinfo
+          readOnly: true
+          subPath: namespace
       initContainers:
       - command:
         - /bin/sh
@@ -1610,6 +1619,12 @@ spec:
           - key: ca.crt
             path: ca.crt
           secretName: kong-serviceaccount-token
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.namespace
+            path: namespace
+        name: podinfo
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the Pod namespace to the manual ServiceAccount token mount. Without this mount, controller-runtime cannot automatically determine the leadership election namespace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #251

**Special notes for your reviewer**:
E2E run on this branch: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/2572549219

After merge, we need to create a 2.4.x branch, cherry-pick this into it, and release 2.4.2, and finally cherry-pick the release commit into main.

Based on the filesystem from 2.3 there shouldn't be any other items we need:

```
/ $ ls /var/run/secrets/kubernetes.io/serviceaccount/
ca.crt     namespace  token
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ to be handled in the 2.4.2 release changelog.
