### PR TITLE
chore: bump kong-gateway image from 2.7 to 2.8 in enterprise manifest

### DIFF
--- a/config/variants/enterprise/kustomization.yaml
+++ b/config/variants/enterprise/kustomization.yaml
@@ -5,4 +5,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '2.7'
+  newTag: '2.8'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1484,7 +1484,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.7
+        image: kong/kong-gateway:2.8
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
**What this PR does / why we need it**: To have consistent version of kong-gateway in manifests

**Special notes for your reviewer**:

Related PR that bumped it in other manifests: https://github.com/Kong/kubernetes-ingress-controller/pull/2343


