### PR TITLE
tests: make verifyEnterprise helper more verbose on version string failure

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -348,7 +348,7 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		}
 		return adminOutput.Version != ""
 	}, adminAPIWait, time.Second)
-	require.True(t, strings.Contains(adminOutput.Version, "enterprise-edition"))
+	require.Contains(t, adminOutput.Version, "enterprise-edition")
 }
 
 func verifyEnterpriseWithPostgres(ctx context.Context, t *testing.T, env environments.Environment, adminPassword string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

To have move verbose e2e failures (w.r.t enterprise version string) so that one does not need to rerun the tests to get the log. This effectively changes

```
    helpers_test.go:351:
                Error Trace:    helpers_test.go:351
                                                        all_in_one_test.go:426
                Error:          Should be true
                Test:           TestDeployAllInOneEnterprisePostgres
```

into

```
    helpers_test.go:351:
                Error Trace:    helpers_test.go:351
                                                        all_in_one_test.go:432
                Error:          "2.8.1" does not contain "enterprise-edition"
                Test:           TestDeployAllInOneEnterprisePostgres
```
