### PR TITLE
chore(deploy) add Kuma token annotation

### DIFF
--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         traffic.sidecar.istio.io/includeInboundPorts: ""
         kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
       labels:
         app: ingress-kong
     spec:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1452,6 +1452,7 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1452,6 +1452,7 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1498,6 +1498,7 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1466,6 +1466,7 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong


### PR DESCRIPTION
**What this PR does / why we need it**:
Further iterates on  #2620. Copies the change from https://github.com/Kong/charts/pull/623

This is not really necessary in this repo, since it only applies to Deployments with no controller container, and we don't actually offer that in the all-in-one manifests here. However, it doesn't really hurt us to add it, so I added it for consistency with the chart.

