### PR TITLE
doc(release) reorganize troubleshooting guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -1,4 +1,4 @@
-name:  Release
+name: Release
 description: Release checklist
 title: "Replace with your release version (e.g: 2.4.0)"
 labels: [release]
@@ -26,7 +26,7 @@ body:
   id: release_branch
   attributes:
     label: "**For all releases** Create Release Branch"
-    options: 
+    options:
       - label: "ensure that you have up to date copy of `main`: git checkout main; git pull"
       - label: "create the release branch for the version (e.g. `release/1.3.1`): `git branch -m release/x.y.z`"
       - label: Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
@@ -46,7 +46,7 @@ body:
   id: release_documents
   attributes:
     label: "**For major/minor releases only** Update Release documents"
-    options: 
+    options:
       - label: Create a new branch in the [documentation site repo](https://github.com/Kong/docs.konghq.com).
       - label: Copy `app/kubernetes-ingress-controller/OLD_VERSION` to `app/kubernetes-ingress-controller/NEW_VERSION`.
       - label: Update articles in the new version as needed.
@@ -58,11 +58,16 @@ body:
   id: release_trouble_shooting
   attributes:
     label: Release Troubleshooting
-    value:  If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually
+    value: The [Release Troubleshooting guide](https://github.com/Kong/kubernetes-ingress-controller/blob/main/RELEASE.md#release-troubleshooting) covers strategies for dealing with a release that has failed.
+- type: textarea
+  id: release_trouble_shooting
+  attributes:
+    label: Manual Docker image build
+    value: If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually
 - type: checkboxes
   id: release_manual_docker_build
   attributes:
-    label: Manual Docker image build
+    label: Steps
     options:
       - label: Check out your release tag.
       - label: Run `make container`. Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,59 +1,8 @@
 # Release Process
 
-## Prerequisites
+To release, [create a new issue](https://github.com/Kong/kubernetes-ingress-controller/issues/new/choose) from the "Release" [template](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/release.yaml).
 
-- [Docker](https://docs.docker.com/get-docker/) `v20.10.x`
-- [GNU Make](https://www.gnu.org/software/make/) `v4.x`
-- [Kustomize](https://github.com/kubernetes-sigs/kustomize) `v1.3.x`
-
-## Github Workflow Test Matrix Checkup
-
-**For all releases**
-
-We maintain some integration tests with 3rd party components which we need to manually verify and update before cutting any release.
-
-- [ ] check the testing workflow (`.github/workflows/test.yaml`) and ensure that all matrix versions (`.github/workflows/e2e.yaml` and `.github/workflows/release.yaml`) are up to date for various component releases. If there have been any new releases (major, minor or patch) of those components since the latest version seen in that configuration make sure the new versions get added before proceeding with the release. Remove any versions that are no longer supported by the environment provider.
-  - [ ] Kubernetes
-  - [ ] Istio
-
-An issue exists to automate the above actions: https://github.com/Kong/kubernetes-ingress-controller/issues/1886
-
-**Wait for tests to pass before continuing with any release**, if any problems are found hold on the release until patches are provided and then run the tests again.
-
-## Release Branch
-
-**For all releases**
-
-For this step we're going to start with the `main` branch to create our release branch (e.g. `release/X.Y.Z`) which will later be submitted as a pull request back to `main`.
-
-- [ ] ensure that you have up to date copy of `main`: `git fetch --all`
-- [ ] create the release branch for the version (e.g. `release/1.3.1`): `git branch -m release/x.y.z`
-- [ ] Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
-- [ ] retrieve the latest license report from FOSSA and save it to LICENSES
-- [ ] ensure base manifest versions use the new version (`config/image/enterprise/kustomization.yaml` and `config/image/oss/kustomization.yaml`) and update manifest files: `make manifests`
-- [ ] push the branch up to the remote: `git push --set-upstream origin release/x.y.z`
-
-## Release Pull Request
-
-**For all releases**
-
-- [ ] Check the [latest nightly job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/nightly.yaml) to confirm that E2E is succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml).
-- [ ] Open a PR from your branch to `main`.
-- [ ] Once the PR is merged, [initiate a release job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/release.yaml). Your tag must use `vX.Y.Z` format. Set `latest` to true if this will be the latest release.
-- [ ] CI will validate the requested version, build and push an image, and run tests against the image before finally creating a tag and publishing a release.
-- [ ] For new major and minor version releases create a new branch (e.g. `1.3.x`) from the release tag and push it.
-
-## Documentation
-
-**For major/minor releases only**
-
-- [ ] Create a new branch in the [documentation site repo](https://github.com/Kong/docs.konghq.com).
-- [ ] Copy `app/kubernetes-ingress-controller/OLD_VERSION` to `app/kubernetes-ingress-controller/NEW_VERSION`.
-- [ ] Update articles in the new version as needed.
-- [ ] Update `references/version-compatibility.md` to include the new versions (make sure you capture any new Kubernetes/Istio versions that have been tested)
-- [ ] Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml`. Add entries for any new articles.
-- [ ] Add a section to `app/_data/kong_versions.yml` for your version.
-- [ ] Open a PR from your branch.
+Fill out the issue title and release type, create the issue, and proceed through the release steps, marking them done as you go.
 
 # Release Troubleshooting
 
@@ -61,8 +10,20 @@ For this step we're going to start with the `main` branch to create our release 
 
 If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually:
 
-- [ ] Check out your release tag.
-- [ ] Run `make container`. Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.
-- [ ] Add additional tags for your container (e.g. `docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2.0; docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2`)
-- [ ] Create a temporary token for the `kongbot` user (see 1Password) and log in using it.
-- [ ] Push each of your tags (e.g. `docker push kong/kubernetes-ingress-controller:1.2.0-alpine`)
+- Check out your release tag.
+- Run `make container`. Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.
+- Add additional tags for your container (e.g. `docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2.0; docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2`)
+- Create a temporary token for the `kongbot` user (see 1Password) and log in using it.
+- Push each of your tags (e.g. `docker push kong/kubernetes-ingress-controller:1.2.0-alpine`)
+
+## GKE test failures
+
+If GKE test clusters are not successfully starting, you can review their Pod logs from the Kubernetes Engine section of https://console.cloud.google.com/
+
+You can run GKE tests locally by [creating a service account and token](https://cloud.google.com/docs/authentication/getting-started) and running, for example:
+
+```
+KUBERNETES_MAJOR_VERSION=1 KUBERNETES_MINOR_VERSION=21 GOOGLE_APPLICATION_CREDENTIALS=`cat /tmp/credentials.json` GOOGLE_PROJECT='<project name>' GOOGLE_LOCATION=us-central1 hack/e2e/dlv-tests.sh
+```
+
+You may wish to run a modified version of the script to start it with dlv and/or run a single test only. Spawning clusters is also fairly slow, so you can remove the `trap cleanup EXIT SIGINT SIGQUIT` and change `CLUSTER_NAME="e2e-$(uuidgen)"` to a static value to reuse the same cluster for multiple runs. Remember to run the cleanup function after to discard the cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove most of RELEASE.md, since it's now handled by the form and
there's no way to easily keep both up to date. It now links to the form
and includes some troubleshooting steps that do not easily fit into the
form.

Link the troubleshooting guide from the form.

Add information on running GKE tests from a local machine.