### PR TITLE
chore(ci): add third_party dir to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,23 @@ updates:
   directory: /
   schedule:
     interval: daily
+  labels:
+  - dependencies
+- package-ecosystem: gomod
+  directory: /third_party/
+  schedule:
+    interval: daily
+  labels:
+  - dependencies
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
+  labels:
+  - github_actions
 - package-ecosystem: docker
   directory: /
   schedule:
     interval: daily
+  labels:
+  - docker


### PR DESCRIPTION
**What this PR does / why we need it**:

After #2600 has been merged, it seems that we need to add `third_party` directory explicitly to [dependabot's config](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/dependabot.yml) to make it update Go dependencies in that dir.

Additionally, this PR adds appropriate labels for dependabot's PRs.