### PR TITLE
fix(ci): run red image cert validation on nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,6 +9,8 @@ jobs:
   build-push-images:
     environment: 'Docker Push'
     runs-on: ubuntu-latest
+    outputs: 
+      redhat_tag: ${{ steps.redhat_tag.outputs.tag }}
     steps:
       - name: Add standard tags
         run: |
@@ -96,3 +98,18 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: setup output 
+        id: redhat_tag
+        run: |
+          echo "::set-output name=tag::${{ steps.meta_redhat.outputs.tags }}"
+
+
+  rh-image-cert: 
+    runs-on: ubuntu-latest
+    needs: build-push-images
+    container: 
+      image: quay.io/opdev/preflight:stable
+      options: --security-opt=label=disable
+    steps: 
+      - name: redhat preflight container check 
+        run: preflight check container ${{ needs.build-push-images.outputs.redhat_tag }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**: No issue number. This pr is to execute redhat's preflight check container process to evaluate the health of the kic image. It is required to stay updated with  the RedHat certification process to support the operator in the Red Hat OCP ecosystem. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
