### PR TITLE
fix(log): change logger in reporter to logr.Logger to make the log appear in pod logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
   [#2642](https://github.com/Kong/kubernetes-ingress-controller/pull/2642)
 
 #### Fixed
+- Fixed the problem that logs from reporter does not appear in the pod log.
+  [#2645](https://github.com/Kong/kubernetes-ingress-controller/pull/2645)
 
 ## [2.4.2]
 

--- a/internal/manager/utils/reports.go
+++ b/internal/manager/utils/reports.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bombsimon/logrusr/v2"
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/meshdetect"
@@ -80,12 +79,13 @@ func RunReport(ctx context.Context, kubeCfg *rest.Config, kongCfg sendconfig.Kon
 	// run the reporter in the background
 	reporter := util.Reporter{
 		Info:   info,
-		Logger: logrus.New(),
+		Logger: ctrl.Log.WithName("reporter"),
 	}
 
 	// add mesh detector to reporter
 	detector, err := meshdetect.NewDetectorByConfig(kubeCfg, podInfo.Namespace, podInfo.Name, publishServiceName,
-		logrusr.New(reporter.Logger),
+		// logger=reporter.mesh
+		reporter.Logger.WithName("mesh"),
 	)
 	if err == nil {
 		reporter.MeshDetectionEnabled = true

--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -94,7 +94,7 @@ func TestReporterOnce(t *testing.T) {
 	}
 	reporter := Reporter{
 		Info:   info,
-		Logger: logrus.New(),
+		Logger: logr.Discard(),
 	}
 	reqs := make(chan []byte)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -140,7 +140,7 @@ func TestReporterSendStart(t *testing.T) {
 	}
 	reporter := Reporter{
 		Info:   info,
-		Logger: logrus.New(),
+		Logger: logr.Discard(),
 	}
 
 	reqs := make(chan []byte)
@@ -177,7 +177,7 @@ func TestReporterSendPing(t *testing.T) {
 	}
 	reporter := Reporter{
 		Info:   info,
-		Logger: logrus.New(),
+		Logger: logr.Discard(),
 	}
 
 	reqs := make(chan []byte)
@@ -214,7 +214,7 @@ func TestReporterRun(t *testing.T) {
 	}
 	reporter := Reporter{
 		Info:   info,
-		Logger: logrus.New(),
+		Logger: logr.Discard(),
 	}
 
 	reqs := make(chan []byte)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
logs from telemetry reporter in `internal/utils.Reporter` does not appear in pod logs. 
Here I changed the logger `logr.Logger` and initialize it with `ctrl.Log.WithName()`, instead of the deprecated `logrus.Logger`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
