### PR TITLE
feat(ci): use github action to obtain kong license

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,11 +40,17 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
     - name: run e2e tests
       run: make test.e2e
       env:
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ matrix.kubernetes_version }}
         ISTIO_VERSION: ${{ matrix.istio_version }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -64,12 +64,18 @@ jobs:
         tags: kong/kubernetes-ingress-controller:ci
         target: distroless
 
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
     - name: run e2e tests
       run: make test.e2e
       if: ${{ github.event.inputs.controller-image != 'kong/kubernetes-ingress-controller:ci' }}
       env:
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ github.event.inputs.controller-image }}
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}
         ISTIO_VERSION: ${{ github.event.inputs.istio-version }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
@@ -81,7 +87,7 @@ jobs:
       env:
         TEST_KONG_CONTROLLER_IMAGE_LOAD: ${{ github.event.inputs.controller-image }}
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ github.event.inputs.controller-image }}
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}
         ISTIO_VERSION: ${{ github.event.inputs.istio-version }}
         NCPU: 1
@@ -109,8 +115,14 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
     - name: run integration tests
       run: make test.integration
       env:
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,22 +106,16 @@ jobs:
         name: coverage
         path: coverage.unit.out
 
-  runnable:
-    runs-on: ubuntu-latest
-    environment: "Configure ci"
-    outputs:
-      runnable: ${{ steps.check.outputs.result }}
-    steps:
-    - name: Check secret availability
-      id: check
-      run: echo ::set-output name=result::${{ secrets.KONG_LICENSE_DATA != ''}}
-
   integration-tests-enterprise-postgres:
     environment: "Configure ci"
     runs-on: ubuntu-latest
-    needs: runnable
-    if: "needs.runnable.outputs.runnable == 'true'"
     steps:
+
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -144,7 +138,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.enterprise.postgres
       env:
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

To make kong EE license management easier/more automated.

**Which issue this PR fixes**: related https://github.com/Kong/team-k8s/issues/27

In order to make this work, `PULP_PASSWORD` has been added to `Configure ci`'s environment secrets.