### PR TITLE
ci: enable gofumpt in golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
   - exportloopref
   - gci
   - gofmt
+  - gofumpt
   - goimports
   - gosec
   - gosimple

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -325,7 +325,7 @@ func (needed necessary) generate() error {
 		}
 	}
 
-	return os.WriteFile(outputFile, contents.Bytes(), 0600)
+	return os.WriteFile(outputFile, contents.Bytes(), 0o600)
 }
 
 type typeNeeded struct {

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -146,7 +146,8 @@ func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 // GetKongClientForWorkspace returns a Kong API client for a given root API URL and workspace.
 // If the workspace does not already exist, GetKongClientForWorkspace will create it.
 func GetKongClientForWorkspace(ctx context.Context, adminURL string, wsName string,
-	httpclient *http.Client) (*kong.Client, error) {
+	httpclient *http.Client,
+) (*kong.Client, error) {
 	// create the base client, and if no workspace was provided then return that.
 	client, err := kong.NewClient(kong.String(adminURL), httpclient)
 	if err != nil {

--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestMakeHTTPClientWithTLSOpts(t *testing.T) {
-
 	var caPEM *bytes.Buffer
 	var certPEM *bytes.Buffer
 	var certPrivateKeyPEM *bytes.Buffer
@@ -35,7 +34,7 @@ func TestMakeHTTPClientWithTLSOpts(t *testing.T) {
 		t.Errorf("Fail to build TLS certificates - %s", err.Error())
 	}
 
-	var opts = HTTPClientOpts{
+	opts := HTTPClientOpts{
 		TLSSkipVerify:     true,
 		TLSServerName:     "",
 		CACertPath:        "",
@@ -54,11 +53,9 @@ func TestMakeHTTPClientWithTLSOpts(t *testing.T) {
 
 	err = validate(t, httpclient, caPEM, certPEM, certPrivateKeyPEM)
 	require.NoError(t, err)
-
 }
 
 func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
-
 	var caPEM *bytes.Buffer
 	var certPEM *bytes.Buffer
 	var certPrivateKeyPEM *bytes.Buffer
@@ -112,7 +109,6 @@ func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
 }
 
 func buildTLS(t *testing.T) (caPEM *bytes.Buffer, certPEM *bytes.Buffer, certPrivateKeyPEM *bytes.Buffer, err error) {
-
 	var ca *x509.Certificate
 	var caPrivateKeyPEM *bytes.Buffer
 
@@ -223,8 +219,8 @@ func validate(t *testing.T,
 	httpclient *http.Client,
 	caPEM *bytes.Buffer,
 	certPEM *bytes.Buffer,
-	certPrivateKeyPEM *bytes.Buffer) (err error) {
-
+	certPrivateKeyPEM *bytes.Buffer,
+) (err error) {
 	serverCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivateKeyPEM.Bytes())
 	if err != nil {
 		t.Errorf("Fail to load server certificates %s", err.Error())

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -90,7 +90,8 @@ func (sc *ServerConfig) toTLSConfig(ctx context.Context, log logrus.FieldLogger)
 }
 
 func MakeTLSServer(ctx context.Context, config *ServerConfig, handler http.Handler,
-	log logrus.FieldLogger) (*http.Server, error) {
+	log logrus.FieldLogger,
+) (*http.Server, error) {
 	tlsConfig, err := config.toTLSConfig(ctx, log)
 	if err != nil {
 		return nil, err
@@ -188,7 +189,8 @@ var (
 )
 
 func (a RequestHandler) handleValidation(ctx context.Context, request admission.AdmissionRequest) (
-	*admission.AdmissionResponse, error) {
+	*admission.AdmissionResponse, error,
+) {
 	var response admission.AdmissionResponse
 
 	var ok bool

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -29,17 +29,20 @@ type KongFakeValidator struct {
 }
 
 func (v KongFakeValidator) ValidateConsumer(_ context.Context,
-	consumer configuration.KongConsumer) (bool, string, error) {
+	consumer configuration.KongConsumer,
+) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 
 func (v KongFakeValidator) ValidatePlugin(_ context.Context,
-	k8sPlugin configuration.KongPlugin) (bool, string, error) {
+	k8sPlugin configuration.KongPlugin,
+) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 
 func (v KongFakeValidator) ValidateClusterPlugin(_ context.Context,
-	k8sPlugin configuration.KongClusterPlugin) (bool, string, error) {
+	k8sPlugin configuration.KongClusterPlugin,
+) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -88,8 +88,8 @@ func validIngress(ingressAnnotationValue, ingressClass string, handling ClassMat
 // IngressClassValidatorFuncFromObjectMeta returns a function which
 // can validate if an ObjectMeta belongs to an the ingressClass or not.
 func IngressClassValidatorFuncFromObjectMeta(
-	ingressClass string) func(obj *metav1.ObjectMeta, annotation string, handling ClassMatching) bool {
-
+	ingressClass string,
+) func(obj *metav1.ObjectMeta, annotation string, handling ClassMatching) bool {
 	return func(obj *metav1.ObjectMeta, annotation string, handling ClassMatching) bool {
 		class := obj.GetAnnotations()[annotation]
 		return validIngress(class, ingressClass, handling)
@@ -97,8 +97,8 @@ func IngressClassValidatorFuncFromObjectMeta(
 }
 
 func IngressClassValidatorFuncFromV1Ingress(
-	ingressClass string) func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
-
+	ingressClass string,
+) func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
 	return func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
 		class := ingress.Spec.IngressClassName
 		className := ""

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -16,15 +16,16 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
-var mutex sync.Mutex
-var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+var (
+	mutex           sync.Mutex
+	shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+)
 
 // SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
 // which is canceled on one of these signals. If a second signal is not caught, the program
 // will delay for the configured period of time before terminating. If a second signal is caught,
 // the program is terminated with exit code 1.
 func SetupSignalHandler(cfg *manager.Config) (context.Context, error) {
-
 	// This will prevent multiple signal handlers from being created
 	if ok := mutex.TryLock(); !ok {
 		return nil, errors.New("signal handler can only be setup once")

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -125,10 +125,12 @@ func NewListenerTracker() ListenerTracker {
 	}
 }
 
-type protocolPortMap map[gatewayv1alpha2.ProtocolType]map[gatewayv1alpha2.PortNumber]bool
-type portProtocolMap map[gatewayv1alpha2.PortNumber]gatewayv1alpha2.ProtocolType
-type portHostnameMap map[gatewayv1alpha2.PortNumber]map[gatewayv1alpha2.Hostname]bool
-type listenerAttachedMap map[gatewayv1alpha2.SectionName]int32
+type (
+	protocolPortMap     map[gatewayv1alpha2.ProtocolType]map[gatewayv1alpha2.PortNumber]bool
+	portProtocolMap     map[gatewayv1alpha2.PortNumber]gatewayv1alpha2.ProtocolType
+	portHostnameMap     map[gatewayv1alpha2.PortNumber]map[gatewayv1alpha2.Hostname]bool
+	listenerAttachedMap map[gatewayv1alpha2.SectionName]int32
+)
 
 func buildKongPortMap(listens []gatewayv1alpha2.Listener) protocolPortMap {
 	p := make(map[gatewayv1alpha2.ProtocolType]map[gatewayv1alpha2.PortNumber]bool, len(listens))

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -14,8 +14,8 @@ import (
 // GenerateSHA generates a SHA256 checksum of the (targetContent, customEntities) tuple, with the purpose of change
 // detection.
 func GenerateSHA(targetContent *file.Content,
-	customEntities []byte) ([]byte, error) {
-
+	customEntities []byte,
+) ([]byte, error) {
 	var buffer bytes.Buffer
 
 	jsonConfig, err := json.Marshal(targetContent)
@@ -120,7 +120,8 @@ func PluginString(plugin file.FPlugin) string {
 
 // FillPluginConfig returns a copy of `config` that has default values filled in from `schema`.
 func FillPluginConfig(schema map[string]interface{},
-	config kong.Configuration) (kong.Configuration, error) {
+	config kong.Configuration,
+) (kong.Configuration, error) {
 	jsonb, err := json.Marshal(&schema)
 	if err != nil {
 		return nil, err

--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -10,9 +10,7 @@ import (
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
-var (
-	minMTLSCredentialVersion = semver.MustParse("2.3.2")
-)
+var minMTLSCredentialVersion = semver.MustParse("2.3.2")
 
 // Consumer holds a Kong consumer and its plugins and credentials.
 type Consumer struct {

--- a/internal/dataplane/kongstate/credentials.go
+++ b/internal/dataplane/kongstate/credentials.go
@@ -222,10 +222,12 @@ func (c *Oauth2Credential) SanitizedCopy() *Oauth2Credential {
 }
 
 func decodeCredential(credConfig interface{},
-	credStructPointer interface{}) error {
+	credStructPointer interface{},
+) error {
 	decoder, err := mapstructure.NewDecoder(
-		&mapstructure.DecoderConfig{TagName: "json",
-			Result: credStructPointer,
+		&mapstructure.DecoderConfig{
+			TagName: "json",
+			Result:  credStructPointer,
 		})
 	if err != nil {
 		return fmt.Errorf("failed to create a decoder: %w", err)

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -276,6 +276,7 @@ func TestOverrideRouteByKongIngress(t *testing.T) {
 		nilRoute.override(logrus.New(), nil)
 	})
 }
+
 func TestOverrideRouteByAnnotation(t *testing.T) {
 	assert := assert.New(t)
 	var route Route
@@ -452,7 +453,8 @@ func Test_overrideRouteStripPath(t *testing.T) {
 			name: "set to false",
 			args: args{
 				route: Route{
-					Route: kong.Route{}},
+					Route: kong.Route{},
+				},
 				anns: map[string]string{
 					"konghq.com/strip-path": "false",
 				},
@@ -870,7 +872,8 @@ func Test_overrideRequestBuffering(t *testing.T) {
 			name: "set to false",
 			args: args{
 				route: Route{
-					Route: kong.Route{}},
+					Route: kong.Route{},
+				},
 				anns: map[string]string{
 					"konghq.com/request-buffering": "false",
 				},
@@ -942,7 +945,8 @@ func Test_overrideResponseBuffering(t *testing.T) {
 			name: "set to false",
 			args: args{
 				route: Route{
-					Route: kong.Route{}},
+					Route: kong.Route{},
+				},
 				anns: map[string]string{
 					"konghq.com/response-buffering": "false",
 				},

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -113,7 +113,8 @@ func getPlugin(s store.Storer, namespace, name string) (kong.Plugin, error) {
 
 func kongPluginFromK8SClusterPlugin(
 	s store.Storer,
-	k8sPlugin configurationv1.KongClusterPlugin) (kong.Plugin, error) {
+	k8sPlugin configurationv1.KongClusterPlugin,
+) (kong.Plugin, error) {
 	var config kong.Configuration
 	config, err := RawConfigToConfiguration(k8sPlugin.Config)
 	if err != nil {
@@ -163,7 +164,8 @@ func protocolsToStrings(protocols []configurationv1.KongProtocol) (res []string)
 
 func kongPluginFromK8SPlugin(
 	s store.Storer,
-	k8sPlugin configurationv1.KongPlugin) (kong.Plugin, error) {
+	k8sPlugin configurationv1.KongPlugin,
+) (kong.Plugin, error) {
 	var config kong.Configuration
 	config, err := RawConfigToConfiguration(k8sPlugin.Config)
 	if err != nil {
@@ -212,10 +214,12 @@ func RawConfigToConfiguration(config apiextensionsv1.JSON) (kong.Configuration, 
 func namespacedSecretToConfiguration(
 	s store.Storer,
 	reference configurationv1.NamespacedSecretValueFromSource) (
-	kong.Configuration, error) {
+	kong.Configuration, error,
+) {
 	bareReference := configurationv1.SecretValueFromSource{
 		Secret: reference.Secret,
-		Key:    reference.Key}
+		Key:    reference.Key,
+	}
 	return SecretToConfiguration(s, bareReference, reference.Namespace)
 }
 
@@ -226,7 +230,8 @@ type SecretGetter interface {
 func SecretToConfiguration(
 	s SecretGetter,
 	reference configurationv1.SecretValueFromSource, namespace string) (
-	kong.Configuration, error) {
+	kong.Configuration, error,
+) {
 	secret, err := s.GetSecret(namespace, reference.Secret)
 	if err != nil {
 		return kong.Configuration{}, fmt.Errorf(

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -622,7 +622,6 @@ func getServiceEndpoints(
 	svc *corev1.Service,
 	servicePort *corev1.ServicePort,
 ) []kongstate.Target {
-
 	log = log.WithFields(logrus.Fields{
 		"service_name":      svc.Name,
 		"service_namespace": svc.Namespace,
@@ -657,7 +656,6 @@ func getEndpoints(
 	proto corev1.Protocol,
 	getEndpoints func(string, string) (*corev1.Endpoints, error),
 ) []util.Endpoint {
-
 	upsServers := []util.Endpoint{}
 
 	if s == nil || port == nil {
@@ -697,7 +695,6 @@ func getEndpoints(
 			Address: s.Name + "." + s.Namespace + ".svc",
 			Port:    fmt.Sprintf("%v", port.Port),
 		})
-
 	}
 
 	log.Debugf("fetching endpoints")

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -354,7 +354,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					},
 				},
 			},
-		}}
+		},
+	}
 	t.Run("plugins with secret configuration are processed correctly",
 		func(t *testing.T) {
 			objects := stock
@@ -4683,7 +4684,7 @@ func TestCertificate(t *testing.T) {
 		assert.Nil(err)
 		assert.NotNil(state)
 		assert.Equal(3, len(state.Certificates))
-		//foo.com with cert should be fixed
+		// foo.com with cert should be fixed
 		assert.Contains(state.Certificates, fooCertificate)
 	})
 	t.Run("SNIs slice with same certificate should be ordered by asc", func(t *testing.T) {

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -95,7 +95,8 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 // generateKongRoutesFromUDPRouteRule converts an UDPRoute rule to one or more
 // Kong Route objects to route traffic to services.
 func generateKongRoutesFromUDPRouteRule(udproute *gatewayv1alpha2.UDPRoute, ruleNumber int,
-	rule gatewayv1alpha2.UDPRouteRule) ([]kongstate.Route, error) {
+	rule gatewayv1alpha2.UDPRouteRule,
+) ([]kongstate.Route, error) {
 	// gather the k8s object information and hostnames from the udproute
 	objectInfo := util.FromK8sObject(udproute)
 

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -85,7 +85,8 @@ func isRefAllowedByPolicy(
 // from a namespace to a slice of ReferencePolicy Tos. When a To is included in the slice, the key namespace has a
 // ReferencePolicy with those Tos and the input From.
 func getPermittedForReferencePolicyFrom(from gatewayv1alpha2.ReferencePolicyFrom,
-	policies []*gatewayv1alpha2.ReferencePolicy) map[gatewayv1alpha2.Namespace][]gatewayv1alpha2.ReferencePolicyTo {
+	policies []*gatewayv1alpha2.ReferencePolicy,
+) map[gatewayv1alpha2.Namespace][]gatewayv1alpha2.ReferencePolicyTo {
 	allowed := make(map[gatewayv1alpha2.Namespace][]gatewayv1alpha2.ReferencePolicyTo)
 	// loop over all From values in all policies. if we find a match, add all Tos to the list of Tos allowed for the
 	// policy namespace. this technically could add duplicate copies of the Tos if there are duplicate Froms (it makes

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -45,7 +45,15 @@ func TestTranslateIngress(t *testing.T) {
 											Port: networkingv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
-											}}}}}}}}}}},
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -108,7 +116,15 @@ func TestTranslateIngress(t *testing.T) {
 											Port: networkingv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
-											}}}}}}}}}}},
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -171,7 +187,15 @@ func TestTranslateIngress(t *testing.T) {
 											Port: networkingv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
-											}}}}}}}}}}},
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -233,7 +257,15 @@ func TestTranslateIngress(t *testing.T) {
 											Port: networkingv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
-											}}}}}}}}}}},
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -295,7 +327,15 @@ func TestTranslateIngress(t *testing.T) {
 											Port: networkingv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
-											}}}}}}}}}}},
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -358,7 +398,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path: "/v2/api",
@@ -368,7 +410,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path: "/v3/api",
@@ -378,7 +422,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "/other/path/1",
@@ -389,7 +435,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "/other/path/2",
@@ -400,7 +448,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "",
@@ -411,9 +461,16 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
-								}}}}}}},
+								},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -482,7 +539,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path: "/v2/api",
@@ -492,7 +551,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path: "/v3/api",
@@ -502,7 +563,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "/other/path/1",
@@ -513,7 +576,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "/other/path/2",
@@ -524,7 +589,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path:     "",
@@ -535,9 +602,16 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
-								}}}}}}},
+								},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
@@ -606,7 +680,9 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
 									{
 										Path: "/v2/api",
@@ -616,9 +692,16 @@ func TestTranslateIngress(t *testing.T) {
 												Port: networkingv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
-												}}},
+												},
+											},
+										},
 									},
-								}}}}}}},
+								},
+							},
+						},
+					}},
+				},
+			},
 			expected: []*kongstate.Service{
 				{
 					Namespace: corev1.NamespaceDefault,

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -40,7 +40,8 @@ func PerformUpdate(ctx context.Context,
 	selectorTags []string,
 	customEntities []byte,
 	oldSHA []byte,
-	promMetrics *metrics.CtrlFuncMetrics) ([]byte, error) {
+	promMetrics *metrics.CtrlFuncMetrics,
+) ([]byte, error) {
 	newSHA, err := deckgen.GenerateSHA(targetContent, customEntities)
 	if err != nil {
 		return oldSHA, err
@@ -111,8 +112,8 @@ func PerformUpdate(ctx context.Context,
 // -----------------------------------------------------------------------------
 
 func renderConfigWithCustomEntities(log logrus.FieldLogger, state *file.Content,
-	customEntitiesJSONBytes []byte) ([]byte, error) {
-
+	customEntitiesJSONBytes []byte,
+) ([]byte, error) {
 	var kongCoreConfig []byte
 	var err error
 

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -23,12 +23,13 @@ type Server struct {
 	ConfigLock       *sync.RWMutex
 }
 
-var successfulConfigDump file.Content
-var failedConfigDump file.Content
+var (
+	successfulConfigDump file.Content
+	failedConfigDump     file.Content
+)
 
 // Listen starts up the HTTP server and blocks until ctx expires.
 func (s *Server) Listen(ctx context.Context, port int) error {
-
 	mux := http.NewServeMux()
 	if s.ConfigDumps != (util.ConfigDumpDiagnostic{}) {
 		s.installDumpHandlers(mux)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -106,7 +106,6 @@ type Config struct {
 
 // FlagSet binds the provided Config to commandline flags.
 func (c *Config) FlagSet() *pflag.FlagSet {
-
 	flagSet := pflag.NewFlagSet("", pflag.ExitOnError)
 
 	// Logging configurations

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -271,7 +271,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "gateways",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.GatewayReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName(gatewayFeature),
@@ -288,7 +289,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "referencepolicies",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.ReferencePolicyReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("ReferencePolicy"),
@@ -303,7 +305,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "httproutes",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.HTTPRouteReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("HTTPRoute"),
@@ -318,7 +321,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "udproutes",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.UDPRouteReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("UDPRoute"),
@@ -333,7 +337,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "tcproutes",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.TCPRouteReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("TCPRoute"),
@@ -348,7 +353,8 @@ func setupControllers(
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "tlsroutes",
-				}}.CRDExists,
+				},
+			}.CRDExists,
 			Controller: &gateway.TLSRouteReconciler{
 				Client:          mgr.GetClient(),
 				Log:             ctrl.Log.WithName("controllers").WithName("TLSRoute"),

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -53,7 +53,8 @@ func setupLoggers(c *Config) (logrus.FieldLogger, logr.Logger, error) {
 }
 
 func setupControllerOptions(logger logr.Logger, c *Config, scheme *runtime.Scheme,
-	dbmode string) (ctrl.Options, error) {
+	dbmode string,
+) (ctrl.Options, error) {
 	// some controllers may require additional namespaces to be cached and this
 	// is currently done using the global manager client cache.
 	//

--- a/internal/meshdetect/detector.go
+++ b/internal/meshdetect/detector.go
@@ -39,7 +39,8 @@ type Detector struct {
 // for ingress traffic to the Kong Gateway.
 func NewDetectorByConfig(kubeCfg *rest.Config,
 	podNamespace, podName, publishServiceName string,
-	logger logr.Logger) (*Detector, error) {
+	logger logr.Logger,
+) (*Detector, error) {
 	c, err := client.New(kubeCfg, client.Options{})
 	if err != nil {
 		return nil, err
@@ -177,7 +178,6 @@ func isPodSidecarInjected(meshKind MeshKind, pod *corev1.Pod) bool {
 	}
 	for _, container := range pod.Spec.Containers {
 		if container.Name == sidecarName {
-
 			switch meshKind { // nolint:exhaustive
 			case MeshKindAWSAppMesh:
 				// special judgement for AWS appmesh here:

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -45,43 +45,40 @@ const (
 func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 	controllerMetrics := &CtrlFuncMetrics{}
 
-	controllerMetrics.ConfigPushCount =
-		prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: MetricNameConfigPushCount,
-				Help: "Count of successful/failed configuration pushes to Kong. `" +
-					ProtocolKey + "` describes the configuration protocol (" + ProtocolDBLess + " or " +
-					ProtocolDeck + ") in use. `" +
-					SuccessKey + "` describes whether there were unrecoverable errors (`" +
-					SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
-			},
-			[]string{SuccessKey, ProtocolKey},
-		)
+	controllerMetrics.ConfigPushCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameConfigPushCount,
+			Help: "Count of successful/failed configuration pushes to Kong. `" +
+				ProtocolKey + "` describes the configuration protocol (" + ProtocolDBLess + " or " +
+				ProtocolDeck + ") in use. `" +
+				SuccessKey + "` describes whether there were unrecoverable errors (`" +
+				SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
+		},
+		[]string{SuccessKey, ProtocolKey},
+	)
 
-	controllerMetrics.TranslationCount =
-		prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: MetricNameTranslationCount,
-				Help: "Count of translations from Kubernetes state to Kong state. `" +
-					SuccessKey + "` describes whether there were unrecoverable errors (`" +
-					SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
-			},
-			[]string{SuccessKey},
-		)
+	controllerMetrics.TranslationCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameTranslationCount,
+			Help: "Count of translations from Kubernetes state to Kong state. `" +
+				SuccessKey + "` describes whether there were unrecoverable errors (`" +
+				SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
+		},
+		[]string{SuccessKey},
+	)
 
-	controllerMetrics.ConfigPushDuration =
-		prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Name: MetricNameConfigPushDuration,
-				Help: "How long it took to push the configuration to Kong, in milliseconds. `" +
-					ProtocolKey + "` describes the configuration protocol (" + ProtocolDBLess + " or " +
-					ProtocolDeck + ") in use. `" +
-					SuccessKey + "` describes whether there were unrecoverable errors (`" +
-					SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
-				Buckets: prometheus.ExponentialBuckets(100, 1.33, 30),
-			},
-			[]string{SuccessKey, ProtocolKey},
-		)
+	controllerMetrics.ConfigPushDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: MetricNameConfigPushDuration,
+			Help: "How long it took to push the configuration to Kong, in milliseconds. `" +
+				ProtocolKey + "` describes the configuration protocol (" + ProtocolDBLess + " or " +
+				ProtocolDeck + ") in use. `" +
+				SuccessKey + "` describes whether there were unrecoverable errors (`" +
+				SuccessFalse + "`) or not (`" + SuccessTrue + "`).",
+			Buckets: prometheus.ExponentialBuckets(100, 1.33, 30),
+		},
+		[]string{SuccessKey, ProtocolKey},
+	)
 
 	metrics.Registry.MustRegister(controllerMetrics.ConfigPushCount, controllerMetrics.TranslationCount, controllerMetrics.ConfigPushDuration)
 

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -51,7 +51,6 @@ func Test_keyFunc(t *testing.T) {
 			args: args{
 				obj: B{
 					F: F{
-
 						Name:      "Fu",
 						Namespace: "Bar",
 					},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -409,7 +409,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 
 // New creates a new object store to be used in the ingress controller
 func New(cs CacheStores, ingressClass string, processClasslessIngressV1Beta1 bool, processClasslessIngressV1 bool,
-	processClasslessKongConsumer bool, logger logrus.FieldLogger) Storer {
+	processClasslessKongConsumer bool, logger logrus.FieldLogger,
+) Storer {
 	var ingressV1Beta1ClassMatching annotations.ClassMatching
 	var ingressV1ClassMatching annotations.ClassMatching
 	var kongConsumerClassMatching annotations.ClassMatching
@@ -814,7 +815,6 @@ func (s Store) ListKongConsumers() []*kongv1.KongConsumer {
 // Support for these global namespaced KongPlugins was removed in 0.10.0
 // This function remains only to provide warnings to users with old configuration
 func (s Store) ListGlobalKongPlugins() ([]*kongv1.KongPlugin, error) {
-
 	var plugins []*kongv1.KongPlugin
 	// var globalPlugins []*configurationv1.KongPlugin
 	req, err := labels.NewRequirement("global", selection.Equals, []string{"true"})

--- a/internal/util/ingressapi_test.go
+++ b/internal/util/ingressapi_test.go
@@ -98,7 +98,6 @@ func TestServerHasGVK(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestNegotiateResourceAPI(t *testing.T) {

--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -31,17 +31,15 @@ const (
 	WarnLevel = int(logrus.WarnLevel) - logrusrDiff
 )
 
-var (
-	logrusLevels = map[string]logrus.Level{
-		"panic": logrus.PanicLevel,
-		"fatal": logrus.FatalLevel,
-		"error": logrus.ErrorLevel,
-		"warn":  logrus.WarnLevel,
-		"info":  logrus.InfoLevel,
-		"debug": logrus.DebugLevel,
-		"trace": logrus.TraceLevel,
-	}
-)
+var logrusLevels = map[string]logrus.Level{
+	"panic": logrus.PanicLevel,
+	"fatal": logrus.FatalLevel,
+	"error": logrus.ErrorLevel,
+	"warn":  logrus.WarnLevel,
+	"info":  logrus.InfoLevel,
+	"debug": logrus.DebugLevel,
+	"trace": logrus.TraceLevel,
+}
 
 func MakeLogger(level string, formatter string) (logrus.FieldLogger, error) {
 	log := logrus.New()

--- a/internal/util/relations.go
+++ b/internal/util/relations.go
@@ -9,7 +9,6 @@ type Rel struct {
 }
 
 func (relations *ForeignRelations) GetCombinations() []Rel {
-
 	var cartesianProduct []Rel
 
 	if len(relations.Consumer) > 0 {

--- a/internal/util/reports.go
+++ b/internal/util/reports.go
@@ -104,7 +104,6 @@ func (r *Reporter) send(signal string, uptime int) {
 			// log the error if mesh detection fails,
 			// but still send the messages without mesh detection results.
 			r.Logger.V(DebugLevel).Info("failed to run mesh detection", "error", err)
-
 		} else {
 			// append results from mesh detection to reported message if returned any.
 			if meshMessage != "" {

--- a/internal/util/reports_mesh.go
+++ b/internal/util/reports_mesh.go
@@ -19,7 +19,8 @@ var meshKindShortNames = map[meshdetect.MeshKind]string{
 }
 
 func serializeMeshDeploymentResults(
-	results map[meshdetect.MeshKind]*meshdetect.DeploymentResults) string {
+	results map[meshdetect.MeshKind]*meshdetect.DeploymentResults,
+) string {
 	if results == nil {
 		return ""
 	}
@@ -47,7 +48,8 @@ func serializeMeshDeploymentResults(
 }
 
 func serializeMeshRunUnderResults(
-	results map[meshdetect.MeshKind]*meshdetect.RunUnderResults) string {
+	results map[meshdetect.MeshKind]*meshdetect.RunUnderResults,
+) string {
 	if results == nil {
 		return ""
 	}
@@ -82,7 +84,8 @@ func serializeMeshRunUnderResults(
 }
 
 func serializeMeshServiceDistribution(
-	result *meshdetect.ServiceDistributionResults) string {
+	result *meshdetect.ServiceDistributionResults,
+) string {
 	if result == nil {
 		return ""
 	}

--- a/internal/util/reports_mesh_test.go
+++ b/internal/util/reports_mesh_test.go
@@ -18,7 +18,6 @@ func TestSerializeMeshDeploymentResults(t *testing.T) {
 			caseName: "deployment:kong-mesh",
 			results: map[meshdetect.MeshKind]*meshdetect.DeploymentResults{
 				meshdetect.MeshKindKongMesh: {
-
 					ServiceExists: true,
 				},
 			},
@@ -102,7 +101,6 @@ func TestSerializeMeshRunUnderResult(t *testing.T) {
 			caseName: "run_under:traefik,aws-app-mesh",
 			results: map[meshdetect.MeshKind]*meshdetect.RunUnderResults{
 				meshdetect.MeshKindTraefik: {
-
 					PodOrServiceAnnotation: true,
 				},
 				meshdetect.MeshKindAWSAppMesh: {

--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -20,9 +20,8 @@ type TLSPair struct {
 	Key, Cert string
 }
 
-var (
-	reportTestTLSCert = TLSPair{
-		Cert: `-----BEGIN CERTIFICATE-----
+var reportTestTLSCert = TLSPair{
+	Cert: `-----BEGIN CERTIFICATE-----
 MIIC2DCCAcACCQC32eFOsWpKojANBgkqhkiG9w0BAQsFADAuMRcwFQYDVQQDDA5z
 ZWN1cmUtZm9vLWJhcjETMBEGA1UECgwKa29uZ2hxLm9yZzAeFw0xODEyMTgyMTI4
 MDBaFw0xOTEyMTgyMTI4MDBaMC4xFzAVBgNVBAMMDnNlY3VyZS1mb28tYmFyMRMw
@@ -40,7 +39,7 @@ QSnWu1nQLyohnrB9qLZhe2+jOQZnkKuCcWJQ5njvU6SxT3SOKE5XaOZCezEQ6IVL
 U47YCCXsq+7wKWXBhKl4H2Ztk6x3HOC56l0noXWezsMfrou/kjwGuuViGnrjqelS
 WQ7uVeNCUBY+l+qY
 -----END CERTIFICATE-----`,
-		Key: `-----BEGIN PRIVATE KEY-----
+	Key: `-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCqGX8dLBXo9sy/
 5wwVT1f4e4ztBs00+Hf0YprimTHMWCICe64niPD1X9vOwTJL5kjKPOj5AoHUvOaB
 1xfi+R0jbYGPFR30c8d1nG2/deKVs2ZKT1Q6XYeHV85EmhLtgf5Vu9XCLPmWjuop
@@ -68,8 +67,7 @@ hncXsgyzK6QUzak6HmFji/CMZ6EU9q6A67JkiEWrYoKqIAKZ2Og8+Eucr/rDdGWc
 kqlmLPBJAJeUsP/9KidBjTE5mIbn/2n089VPMBvnlt2xIcuB6+zrf2NjvlcZEyKS
 Gn+T2uCyOP4a1DTUoPyoNJXo
 -----END PRIVATE KEY-----`,
-	}
-)
+}
 
 func TestMain(m *testing.M) {
 	reportsHost = "localhost"


### PR DESCRIPTION
**What this PR does / why we need it**: enables [`gofumpt`](https://github.com/mvdan/gofumpt) in [golangci-lint config](https://golangci-lint.run/usage/linters/#gofumpt)

