### PR TITLE
chore: remove deprecated `ioutil` usage

### DIFF
--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -254,7 +254,7 @@ func validate(t *testing.T,
 	defer response.Body.Close()
 
 	// verify the response
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("HTTP client failed to process a GET request %s", err.Error())
 		return err

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -1,7 +1,7 @@
 package kongstate
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -359,7 +359,7 @@ func TestNormalizeProtocols(t *testing.T) {
 
 	assert.NotPanics(func() {
 		log := logrus.New()
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		var nilUpstream *Upstream
 		nilUpstream.override(log, nil, nil)

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -1,7 +1,7 @@
 package kongstate
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -364,7 +364,7 @@ func TestOverrideService(t *testing.T) {
 
 	for _, testcase := range testTable {
 		log := logrus.New()
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		k8sServices := testcase.inService.K8sServices
 		for _, svc := range k8sServices {
@@ -375,7 +375,7 @@ func TestOverrideService(t *testing.T) {
 
 	assert.NotPanics(func() {
 		log := logrus.New()
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		var nilService *Service
 		nilService.override(log, nil, nil)

--- a/internal/dataplane/kongstate/upstream_test.go
+++ b/internal/dataplane/kongstate/upstream_test.go
@@ -1,7 +1,7 @@
 package kongstate
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -77,7 +77,7 @@ func TestOverrideUpstream(t *testing.T) {
 
 	for _, testcase := range testTable {
 		log := logrus.New()
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		testcase.inUpstream.override(log, testcase.inKongIngresss, testcase.svc)
 		assert.Equal(testcase.inUpstream, testcase.outUpstream)
@@ -85,7 +85,7 @@ func TestOverrideUpstream(t *testing.T) {
 
 	assert.NotPanics(func() {
 		log := logrus.New()
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		var nilUpstream *Upstream
 		nilUpstream.override(log, nil, nil)

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -161,16 +160,16 @@ func patchControllerImage(baseManifestPath string, image string, tag string) (io
 		return nil, err
 	}
 	defer os.RemoveAll(workDir)
-	orig, err := ioutil.ReadFile(baseManifestPath)
+	orig, err := os.ReadFile(baseManifestPath)
 	if err != nil {
 		return nil, err
 	}
-	err = ioutil.WriteFile(filepath.Join(workDir, "base.yaml"), orig, 0600)
+	err = os.WriteFile(filepath.Join(workDir, "base.yaml"), orig, 0o600)
 	if err != nil {
 		return nil, err
 	}
 	kustomization := []byte(fmt.Sprintf(imageKustomizationContents, image, tag))
-	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), kustomization, 0600)
+	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), kustomization, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +273,8 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 // startPortForwarder runs "kubectl port-forward" in the background. It stops the forward when the provided context
 // ends
 func startPortForwarder(ctx context.Context, t *testing.T, env environments.Environment, namespace, name, localPort,
-	targetPort string) {
+	targetPort string,
+) {
 	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
 	require.NoError(t, err)
 	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "portforward-tests-kubeconfig-")


### PR DESCRIPTION
**What this PR does / why we need it**:

`ioutil` got [deprecated in go1.16](https://go.dev/doc/go1.16#ioutil) and started failing when experimenting with go1.19 (specifically running `make lint`.

Didn't dig into the subject but it seems this will necessary regardless.

Exemplar failure: (related `staticcheck` rule: https://staticcheck.io/docs/checks/#SA1019)

```
internal/adminapi/client_test.go:12:2: SA1019: package io/ioutil is deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
```

