### PR TITLE
ci: add godot and golint linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,9 +16,11 @@ linters:
   - exhaustive
   - exportloopref
   - gci
+  - godot
   - gofmt
   - gofumpt
   - goimports
+  - golint
   - gosec
   - gosimple
   - govet

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -297,7 +297,7 @@ type typesNeeded []typeNeeded
 
 // rbacsNeeded is a list of Kubernetes API objects which the Kong
 // Kubernetes Ingress Controller interacts with, but does not need a
-// controller for, only permissions
+// controller for, only permissions.
 type rbacsNeeded []rbacNeeded
 
 type necessary struct {
@@ -365,7 +365,7 @@ func (t *typeNeeded) generate(contents *bytes.Buffer) error {
 	return tmpl.Execute(contents, t)
 }
 
-// rbacNeeded represents a resource that we only require RBAC permissions for
+// rbacNeeded represents a resource that we only require RBAC permissions for.
 type rbacNeeded struct {
 	Group     string
 	Plural    string

--- a/internal/admission/utils.go
+++ b/internal/admission/utils.go
@@ -16,7 +16,7 @@ import (
 // -----------------------------------------------------------------------------
 
 // listManagedConsumersReferencingCredentialsSecret takes a Secret and a list of KongConsumers.
-// It returns a list of KongConsumers that reference that Secret as a credential
+// It returns a list of KongConsumers that reference that Secret as a credential.
 func listManagedConsumersReferencingCredentialsSecret(secret corev1.Secret, managedConsumers []*kongv1.KongConsumer) []*kongv1.KongConsumer {
 	// determine if this credential is being actively referenced by a consumer
 	consumersWhichReferenceSecret := make([]*kongv1.KongConsumer, 0)

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -263,7 +263,7 @@ func (validator KongHTTPValidator) ValidatePlugin(
 }
 
 // ValidateClusterPlugin transfers relevant fields from a KongClusterPlugin into a KongPlugin and then returns
-// the result of ValidatePlugin for the derived KongPlugin
+// the result of ValidatePlugin for the derived KongPlugin.
 func (validator KongHTTPValidator) ValidateClusterPlugin(
 	ctx context.Context,
 	k8sPlugin kongv1.KongClusterPlugin,

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -132,17 +132,17 @@ func ExtractKongPluginsFromAnnotations(anns map[string]string) []string {
 }
 
 // ExtractConfigurationName extracts the name of the KongIngress object that holds
-// information about the configuration to use in Routes, Services and Upstreams
+// information about the configuration to use in Routes, Services and Upstreams.
 func ExtractConfigurationName(anns map[string]string) string {
 	return anns[AnnotationPrefix+ConfigurationKey]
 }
 
-// ExtractProtocolName extracts the protocol supplied in the annotation
+// ExtractProtocolName extracts the protocol supplied in the annotation.
 func ExtractProtocolName(anns map[string]string) string {
 	return anns[AnnotationPrefix+ProtocolKey]
 }
 
-// ExtractProtocolNames extracts the protocols supplied in the annotation
+// ExtractProtocolNames extracts the protocols supplied in the annotation.
 func ExtractProtocolNames(anns map[string]string) []string {
 	val := anns[AnnotationPrefix+ProtocolsKey]
 	return strings.Split(val, ",")

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -30,18 +30,18 @@ import (
 // -----------------------------------------------------------------------------
 
 var (
-	// ManagedGatewaysUnsupported is an error used whenever a failure occurs
+	// ErrManagedGatewaysUnsupported is an error used whenever a failure occurs
 	// due to a Gateway that is not properly configured for unmanaged mode.
-	ManagedGatewaysUnsupported = fmt.Errorf("invalid gateway spec: managed gateways are not currently supported") //nolint:revive
-	gatewayV1alpha2Group       = gatewayv1alpha2.Group(gatewayv1alpha2.GroupName)
+	ErrManagedGatewaysUnsupported = fmt.Errorf("invalid gateway spec: managed gateways are not currently supported")
+	gatewayV1alpha2Group          = gatewayv1alpha2.Group(gatewayv1alpha2.GroupName)
 )
 
 // -----------------------------------------------------------------------------
 // Gateway Controller - GatewayReconciler
 // -----------------------------------------------------------------------------
 
-// GatewayReconciler reconciles a Gateway object
-type GatewayReconciler struct { //nolint:revive
+// GatewayReconciler reconciles a Gateway object.
+type GatewayReconciler struct { //nolint:revive,golint
 	client.Client
 
 	Log             logr.Logger
@@ -377,12 +377,12 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 // -----------------------------------------------------------------------------
 
 var (
-	// supportedKinds indicates which gateway kinds are supported by this implementation
+	// supportedKinds indicates which gateway kinds are supported by this implementation.
 	supportedKinds = []gatewayv1alpha2.Kind{
 		gatewayv1alpha2.Kind("HTTPRoute"),
 	}
 
-	// supportedRouteGroupKinds indicates the full kinds with GVK that are supported by this implementation
+	// supportedRouteGroupKinds indicates the full kinds with GVK that are supported by this implementation.
 	supportedRouteGroupKinds []gatewayv1alpha2.RouteGroupKind
 )
 

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -95,7 +95,7 @@ func reconcileGatewaysIfClassMatches(gatewayClass client.Object, gateways []gate
 }
 
 // ListenerTracker holds Gateway Listeners and their statuses, and provides methods to update statuses upon
-// reconciliation
+// reconciliation.
 type ListenerTracker struct {
 	// actual listeners
 	Listeners map[gatewayv1alpha2.SectionName]gatewayv1alpha2.Listener
@@ -114,7 +114,7 @@ type ListenerTracker struct {
 // we just keep the existing maps around
 // need to detect changes, will still receive the full set
 
-// NewListenerTracker returns a ListenerTracker with empty maps
+// NewListenerTracker returns a ListenerTracker with empty maps.
 func NewListenerTracker() ListenerTracker {
 	return ListenerTracker{
 		Statuses:         map[gatewayv1alpha2.SectionName]gatewayv1alpha2.ListenerStatus{},
@@ -146,7 +146,7 @@ func buildKongPortMap(listens []gatewayv1alpha2.Listener) protocolPortMap {
 
 // initializeListenerMaps takes a Gateway and builds indices used in status updates and conflict detection. It returns
 // empty maps from port to protocol to listener name and from port to hostnames, and a populated map from listener name
-// to attached route count from their status
+// to attached route count from their status.
 func initializeListenerMaps(gateway *gatewayv1alpha2.Gateway) (
 	portProtocolMap,
 	portHostnameMap,

--- a/internal/controllers/gateway/gatewayclass_controller.go
+++ b/internal/controllers/gateway/gatewayclass_controller.go
@@ -33,8 +33,8 @@ const (
 // GatewayClass Controller - Reconciler
 // -----------------------------------------------------------------------------
 
-// GatewayClassReconciler reconciles a GatewayClass object
-type GatewayClassReconciler struct { //nolint:revive
+// GatewayClassReconciler reconciles a GatewayClass object.
+type GatewayClassReconciler struct { //nolint:revive,golint
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -27,7 +27,7 @@ import (
 // HTTPRoute Controller - HTTPRouteReconciler
 // -----------------------------------------------------------------------------
 
-// HTTPRouteReconciler reconciles an HTTPRoute object
+// HTTPRouteReconciler reconciles an HTTPRoute object.
 type HTTPRouteReconciler struct {
 	client.Client
 

--- a/internal/controllers/gateway/referencepolicy_controller.go
+++ b/internal/controllers/gateway/referencepolicy_controller.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 )
 
-// ReferencePolicyReconciler reconciles a ReferencePolicy object
+// ReferencePolicyReconciler reconciles a ReferencePolicy object.
 type ReferencePolicyReconciler struct {
 	client.Client
 	Log             logr.Logger

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -27,7 +27,7 @@ import (
 // TCPRoute Controller - TCPRouteReconciler
 // -----------------------------------------------------------------------------
 
-// TCPRouteReconciler reconciles an TCPRoute object
+// TCPRouteReconciler reconciles an TCPRoute object.
 type TCPRouteReconciler struct {
 	client.Client
 

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -27,7 +27,7 @@ import (
 // TLSRoute Controller - TLSRouteReconciler
 // -----------------------------------------------------------------------------
 
-// TLSRouteReconciler reconciles an TLSRoute object
+// TLSRouteReconciler reconciles an TLSRoute object.
 type TLSRouteReconciler struct {
 	client.Client
 

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -27,7 +27,7 @@ import (
 // UDPRoute Controller - UDPRouteReconciler
 // -----------------------------------------------------------------------------
 
-// UDPRouteReconciler reconciles an UDPRoute object
+// UDPRouteReconciler reconciles an UDPRoute object.
 type UDPRouteReconciler struct {
 	client.Client
 

--- a/internal/controllers/gateway/utils.go
+++ b/internal/controllers/gateway/utils.go
@@ -11,7 +11,7 @@ import (
 // Logging Utilities
 // -----------------------------------------------------------------------------
 
-// debug is an alias for the longer log.V(util.DebugLevel).Info for convenience
+// debug is an alias for the longer log.V(util.DebugLevel).Info for convenience.
 func debug(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) {
 	keysAndValues = append([]interface{}{
 		"namespace", obj.GetNamespace(),
@@ -20,7 +20,7 @@ func debug(log logr.Logger, obj client.Object, msg string, keysAndValues ...inte
 	log.V(util.DebugLevel).Info(msg, keysAndValues...)
 }
 
-// info is an alias for the longer log.V(util.InfoLevel).Info for convenience
+// info is an alias for the longer log.V(util.InfoLevel).Info for convenience.
 func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) {
 	keysAndValues = append([]interface{}{
 		"namespace", obj.GetNamespace(),

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -13,7 +13,7 @@ import (
 
 const defaultIngressClassAnnotation = "ingressclass.kubernetes.io/is-default-class"
 
-// IsDefaultIngressClass returns whether an IngressClass is the default IngressClass
+// IsDefaultIngressClass returns whether an IngressClass is the default IngressClass.
 func IsDefaultIngressClass(obj client.Object) bool {
 	if ingressClass, ok := obj.(*netv1.IngressClass); ok {
 		return ingressClass.ObjectMeta.Annotations[defaultIngressClassAnnotation] == "true"
@@ -21,7 +21,7 @@ func IsDefaultIngressClass(obj client.Object) bool {
 	return false
 }
 
-// MatchesIngressClass indicates whether or not an object belongs to a given ingress class
+// MatchesIngressClass indicates whether or not an object belongs to a given ingress class.
 func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDefault bool) bool {
 	objectIngressClass := obj.GetAnnotations()[annotations.IngressClassKey]
 	objectKnativeClass := obj.GetAnnotations()[annotations.KnativeIngressClassKey]
@@ -48,7 +48,7 @@ func MatchesIngressClass(obj client.Object, controllerIngressClass string, isDef
 }
 
 // GeneratePredicateFuncsForIngressClassFilter builds a controller-runtime reconciliation predicate function which filters out objects
-// which have their ingress class set to the a value other than the controller class
+// which have their ingress class set to the a value other than the controller class.
 func GeneratePredicateFuncsForIngressClassFilter(name string) predicate.Funcs {
 	preds := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		// we assume true for isDefault here because the predicates have no client and cannot check if the class is
@@ -61,7 +61,7 @@ func GeneratePredicateFuncsForIngressClassFilter(name string) predicate.Funcs {
 	return preds
 }
 
-// IsIngressClassEmpty returns true if an object has no ingress class information or false otherwise
+// IsIngressClassEmpty returns true if an object has no ingress class information or false otherwise.
 func IsIngressClassEmpty(obj client.Object) bool {
 	switch obj := obj.(type) {
 	case *netv1.Ingress:
@@ -86,7 +86,7 @@ func IsIngressClassEmpty(obj client.Object) bool {
 	}
 }
 
-// CRDExists returns false if CRD does not exist
+// CRDExists returns false if CRD does not exist.
 func CRDExists(client client.Client, gvr schema.GroupVersionResource) bool {
 	_, err := client.RESTMapper().KindFor(gvr)
 	return !meta.IsNoMatchError(err)

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -276,7 +276,7 @@ func (c *KongClient) AreCombinedServiceRoutesEnabled() bool {
 // Dataplane Client - Kong - Interface Implementation
 // -----------------------------------------------------------------------------
 
-// DBMode indicates which database the Kong Gateway is using
+// DBMode indicates which database the Kong Gateway is using.
 func (c *KongClient) DBMode() string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/internal/dataplane/kongstate/credentials.go
+++ b/internal/dataplane/kongstate/credentials.go
@@ -40,7 +40,7 @@ type Oauth2Credential struct {
 	kong.Oauth2Credential
 }
 
-// MTLSAuth represents an MTLS auth credential
+// MTLSAuth represents an MTLS auth credential.
 type MTLSAuth struct {
 	kong.MTLSAuth
 }

--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -27,12 +27,12 @@ var (
 	validMethods = regexp.MustCompile(`\A[A-Z]+$`)
 
 	// hostnames are complicated. shamelessly cribbed from https://stackoverflow.com/a/18494710
-	// TODO if the Kong core adds support for wildcard SNI route match criteria, this should change
+	// TODO if the Kong core adds support for wildcard SNI route match criteria, this should change.
 	validSNIs  = regexp.MustCompile(`^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$`)
 	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
-// normalizeProtocols prevents users from mismatching grpc/http
+// normalizeProtocols prevents users from mismatching grpc/http.
 func (r *Route) normalizeProtocols() {
 	protocols := r.Protocols
 	var http, grpc bool
@@ -54,7 +54,7 @@ func (r *Route) normalizeProtocols() {
 	}
 }
 
-// useSSLProtocol updates the protocol of the route to either https or grpcs, or https and grpcs
+// useSSLProtocol updates the protocol of the route to either https or grpcs, or https and grpcs.
 func (r *Route) useSSLProtocol() {
 	var http, grpc bool
 	var prots []*string
@@ -216,7 +216,7 @@ func (r *Route) overrideSNIs(log logrus.FieldLogger, anns map[string]string) {
 	r.SNIs = snis
 }
 
-// overrideByAnnotation sets Route protocols via annotation
+// overrideByAnnotation sets Route protocols via annotation.
 func (r *Route) overrideByAnnotation(log logrus.FieldLogger) {
 	r.overrideProtocols(r.Ingress.Annotations)
 	r.overrideStripPath(r.Ingress.Annotations)
@@ -230,7 +230,7 @@ func (r *Route) overrideByAnnotation(log logrus.FieldLogger) {
 	r.overrideHosts(log, r.Ingress.Annotations)
 }
 
-// override sets Route fields by KongIngress first, then by annotation
+// override sets Route fields by KongIngress first, then by annotation.
 func (r *Route) override(log logrus.FieldLogger, kongIngress *configurationv1.KongIngress) {
 	if r == nil {
 		return
@@ -262,7 +262,7 @@ func (r *Route) override(log logrus.FieldLogger, kongIngress *configurationv1.Ko
 	}
 }
 
-// overrideByKongIngress sets Route fields by KongIngress
+// overrideByKongIngress sets Route fields by KongIngress.
 func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *configurationv1.KongIngress) {
 	if kongIngress == nil || kongIngress.Route == nil {
 		return
@@ -333,7 +333,7 @@ func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *confi
 	}
 }
 
-// overrideRequestBuffering ensures defaults for the request_buffering option
+// overrideRequestBuffering ensures defaults for the request_buffering option.
 func (r *Route) overrideRequestBuffering(log logrus.FieldLogger, anns map[string]string) {
 	annotationValue, ok := annotations.ExtractRequestBuffering(anns)
 	if !ok {
@@ -351,7 +351,7 @@ func (r *Route) overrideRequestBuffering(log logrus.FieldLogger, anns map[string
 	r.RequestBuffering = kong.Bool(isEnabled)
 }
 
-// overrideResponseBuffering ensures defaults for the response_buffering option
+// overrideResponseBuffering ensures defaults for the response_buffering option.
 func (r *Route) overrideResponseBuffering(log logrus.FieldLogger, anns map[string]string) {
 	annotationValue, ok := annotations.ExtractResponseBuffering(anns)
 	if !ok {
@@ -369,7 +369,7 @@ func (r *Route) overrideResponseBuffering(log logrus.FieldLogger, anns map[strin
 	r.ResponseBuffering = kong.Bool(isEnabled)
 }
 
-// overrideHosts appends Host-Aliases to Hosts
+// overrideHosts appends Host-Aliases to Hosts.
 func (r *Route) overrideHosts(log logrus.FieldLogger, anns map[string]string) {
 	var hosts []*string
 	var annHostAliases []string

--- a/internal/dataplane/kongstate/service.go
+++ b/internal/dataplane/kongstate/service.go
@@ -54,7 +54,7 @@ type Service struct {
 	Parent      client.Object
 }
 
-// overrideByKongIngress sets Service fields by KongIngress
+// overrideByKongIngress sets Service fields by KongIngress.
 func (s *Service) overrideByKongIngress(kongIngress *configurationv1.KongIngress) {
 	if kongIngress == nil || kongIngress.Proxy == nil {
 		return
@@ -116,7 +116,7 @@ func (s *Service) overrideByAnnotation(anns map[string]string) {
 	s.overridePath(anns)
 }
 
-// override sets Service fields by KongIngress first, then by k8s Service's annotations
+// override sets Service fields by KongIngress first, then by k8s Service's annotations.
 func (s *Service) override(
 	log logrus.FieldLogger,
 	kongIngress *configurationv1.KongIngress,

--- a/internal/dataplane/kongstate/upstream.go
+++ b/internal/dataplane/kongstate/upstream.go
@@ -82,7 +82,7 @@ func (u *Upstream) overrideByKongIngress(kongIngress *configurationv1.KongIngres
 	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2075
 }
 
-// override sets Upstream fields by KongIngress first, then by k8s Service's annotations
+// override sets Upstream fields by KongIngress first, then by k8s Service's annotations.
 func (u *Upstream) override(
 	log logrus.FieldLogger,
 	kongIngress *configurationv1.KongIngress,

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -273,7 +273,7 @@ func PrettyPrintServiceList(services map[string]*corev1.Service) string {
 	return serviceList
 }
 
-// plugin is a intermediate type to hold plugin related configuration
+// plugin is a intermediate type to hold plugin related configuration.
 type plugin struct {
 	Name   string
 	Config kong.Configuration

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -14,10 +14,10 @@ import (
 )
 
 // kongHeaderRegexPrefix is a reserved prefix string that Kong uses to determine if it should parse a header value
-// as a regex
+// as a regex.
 const kongHeaderRegexPrefix = "~*"
 
-// MinRegexHeaderKongVersion is the minimum Kong version that supports regex header matches
+// MinRegexHeaderKongVersion is the minimum Kong version that supports regex header matches.
 var MinRegexHeaderKongVersion = semver.MustParse("2.8.0")
 
 // -----------------------------------------------------------------------------
@@ -53,7 +53,7 @@ func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayv1alpha2
 
 // isRefAllowedByPolicy checks if backendRef is permitted by the provided namespace-indexed ReferencePolicyTo set,
 // allowed. allowed is assumed to contain Tos that only match the backendRef's parent's From, as returned by
-// getPermittedForReferencePolicyFrom
+// getPermittedForReferencePolicyFrom.
 func isRefAllowedByPolicy(
 	namespace *gatewayv1alpha2.Namespace,
 	name gatewayv1alpha2.ObjectName,
@@ -104,7 +104,7 @@ func getPermittedForReferencePolicyFrom(from gatewayv1alpha2.ReferencePolicyFrom
 }
 
 // generateKongServiceFromBackendRef translates backendRefs for rule ruleNumber into a Kong service for use with the
-// rules generated from a Gateway APIs route
+// rules generated from a Gateway APIs route.
 func (p *Parser) generateKongServiceFromBackendRef(
 	rules *ingressRules,
 	route client.Object,

--- a/internal/dataplane/sendconfig/kong.go
+++ b/internal/dataplane/sendconfig/kong.go
@@ -11,7 +11,7 @@ import (
 // Sendconfig - Public Types
 // -----------------------------------------------------------------------------
 
-// Kong Represents a Kong client and connection information
+// Kong Represents a Kong client and connection information.
 type Kong struct {
 	URL        string
 	FilterTags []string

--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -51,7 +51,7 @@ type Synchronizer struct {
 
 // NewSynchronizer will provide a new Synchronizer object. Note that this
 // starts some background goroutines and the caller is resonsible for marking
-// the provided context.Context as "Done()" to shut down the background routines
+// the provided context.Context as "Done()" to shut down the background routines.
 func NewSynchronizer(logger logrus.FieldLogger, dataplaneClient Client) (*Synchronizer, error) {
 	stagger, err := time.ParseDuration(fmt.Sprintf("%gs", DefaultSyncSeconds))
 	if err != nil {
@@ -63,7 +63,7 @@ func NewSynchronizer(logger logrus.FieldLogger, dataplaneClient Client) (*Synchr
 // NewSynchronizer will provide a new Synchronizer object with a specified
 // stagger time for data-plane updates to occur. Note that this starts some
 // background goroutines and the caller is resonsible for marking the provided
-// context.Context as "Done()" to shut down the background routines
+// context.Context as "Done()" to shut down the background routines.
 func NewSynchronizerWithStagger(logger logrus.FieldLogger, dataplaneClient Client, stagger time.Duration) (*Synchronizer, error) {
 	synchronizer := &Synchronizer{
 		logger:          logrusr.New(logger),
@@ -172,7 +172,7 @@ func (p *Synchronizer) startUpdateServer(ctx context.Context) {
 // Synchronizer - Private Methods - Helper
 // -----------------------------------------------------------------------------
 
-// markConfigApplied marks that config has been applied
+// markConfigApplied marks that config has been applied.
 func (p *Synchronizer) markConfigApplied() {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -66,7 +66,7 @@ func (s *Server) Listen(ctx context.Context, port int) error {
 	}
 }
 
-// receiveConfig watches the config update channel
+// receiveConfig watches the config update channel.
 func (s *Server) receiveConfig(ctx context.Context) {
 	for {
 		select {

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -44,7 +44,7 @@ func (c *ControllerDef) Name() string {
 }
 
 // MaybeSetupWithManager runs SetupWithManager on the controller if it is enabled
-// and its AutoHandler (if any) indicates that it can load
+// and its AutoHandler (if any) indicates that it can load.
 func (c *ControllerDef) MaybeSetupWithManager(mgr ctrl.Manager) error {
 	if !c.Enabled {
 		return nil

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -11,10 +11,10 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	// knativeFeature is the name of the feature-gate for enabling/disabling Knative
+	// knativeFeature is the name of the feature-gate for enabling/disabling Knative.
 	knativeFeature = "Knative"
 
-	// gatewayFeature is the name of the feature-gate for enabling/disabling Gateway APIs
+	// gatewayFeature is the name of the feature-gate for enabling/disabling Gateway APIs.
 	gatewayFeature = "Gateway"
 
 	// combinedRoutesFeature is the name of the feature-gate for the newer object
@@ -22,11 +22,11 @@ const (
 	// objects like Ingress instead of creating a route per path.
 	combinedRoutesFeature = "CombinedRoutes"
 
-	// featureGatesDocsURL provides a link to the documentation for feature gates in the KIC repository
+	// featureGatesDocsURL provides a link to the documentation for feature gates in the KIC repository.
 	featureGatesDocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
 )
 
-// setupFeatureGates converts feature gates to controller enablement
+// setupFeatureGates converts feature gates to controller enablement.
 func setupFeatureGates(setupLog logr.Logger, c *Config) (map[string]bool, error) {
 	// generate a map of feature gates by string names to their controller enablement
 	ctrlMap := getFeatureGatesDefaults()

--- a/internal/manager/metadata/metadata.go
+++ b/internal/manager/metadata/metadata.go
@@ -12,9 +12,9 @@ var (
 	// Release returns the release version, generally a semver like v2.0.0.
 	Release = "NOT_SET"
 
-	// Repo returns the git repository URL
+	// Repo returns the git repository URL.
 	Repo = "NOT_SET"
 
-	// Commit returns the SHA from the current branch HEAD
+	// Commit returns the SHA from the current branch HEAD.
 	Commit = "NOT_SET"
 )

--- a/internal/meshdetect/detector.go
+++ b/internal/meshdetect/detector.go
@@ -253,7 +253,7 @@ func (d *Detector) listAllSevices(ctx context.Context, pageSize int) ([]*corev1.
 // 		},
 //		Subsets: ...,
 //		...
-// }
+// }.
 func (d *Detector) listAllEndpoints(ctx context.Context, pageSize int) (
 	map[client.ObjectKey]*corev1.Endpoints, error,
 ) {
@@ -291,7 +291,7 @@ func (d *Detector) listAllEndpoints(ctx context.Context, pageSize int) (
 // 		},
 //		Spec: ...,
 //		...
-// }
+// }.
 func (d *Detector) listAllPods(ctx context.Context, pageSize int) (
 	map[client.ObjectKey]*corev1.Pod, error,
 ) {

--- a/internal/meshdetect/mesh_kind.go
+++ b/internal/meshdetect/mesh_kind.go
@@ -60,7 +60,7 @@ var meshPodAnnotations = map[MeshKind]*labels.Requirement{
 }
 
 // meshServiceAnnotations is the annotation of service indicating that
-// the service in managed by the service mesh. (currently only for traefik)
+// the service in managed by the service mesh. (currently only for traefik).
 var meshServiceAnnotations = map[MeshKind]*labels.Requirement{
 	MeshKindTraefik: mustMakeRequirement("mesh.traefik.io/traffic-type", selection.In, []string{"HTTP", "TCP"}),
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	caCertKey = "konghq.com/ca-cert"
-	// IngressClassKongController is the string used for the Controller field of a recognized IngressClass
+	// IngressClassKongController is the string used for the Controller field of a recognized IngressClass.
 	IngressClassKongController = "ingress-controllers.konghq.com/kong"
 )
 
@@ -149,7 +149,7 @@ type CacheStores struct {
 	l *sync.RWMutex
 }
 
-// NewCacheStores is a convenience function for CacheStores to initialize all attributes with new cache stores
+// NewCacheStores is a convenience function for CacheStores to initialize all attributes with new cache stores.
 func NewCacheStores() CacheStores {
 	return CacheStores{
 		IngressV1beta1:  cache.NewStore(keyFunc),
@@ -407,7 +407,7 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 	}
 }
 
-// New creates a new object store to be used in the ingress controller
+// New creates a new object store to be used in the ingress controller.
 func New(cs CacheStores, ingressClass string, processClasslessIngressV1Beta1 bool, processClasslessIngressV1 bool,
 	processClasslessKongConsumer bool, logger logrus.FieldLogger,
 ) Storer {
@@ -441,7 +441,7 @@ func New(cs CacheStores, ingressClass string, processClasslessIngressV1Beta1 boo
 	}
 }
 
-// GetSecret returns a Secret using the namespace and name as key
+// GetSecret returns a Secret using the namespace and name as key.
 func (s Store) GetSecret(namespace, name string) (*corev1.Secret, error) {
 	key := fmt.Sprintf("%v/%v", namespace, name)
 	secret, exists, err := s.stores.Secret.GetByKey(key)
@@ -454,7 +454,7 @@ func (s Store) GetSecret(namespace, name string) (*corev1.Secret, error) {
 	return secret.(*corev1.Secret), nil
 }
 
-// GetService returns a Service using the namespace and name as key
+// GetService returns a Service using the namespace and name as key.
 func (s Store) GetService(namespace, name string) (*corev1.Service, error) {
 	key := fmt.Sprintf("%v/%v", namespace, name)
 	service, exists, err := s.stores.Service.GetByKey(key)
@@ -664,7 +664,7 @@ func (s Store) ListTCPIngresses() ([]*kongv1beta1.TCPIngress, error) {
 	return ingresses, nil
 }
 
-// ListUDPIngresses returns the list of UDP Ingresses
+// ListUDPIngresses returns the list of UDP Ingresses.
 func (s Store) ListUDPIngresses() ([]*kongv1beta1.UDPIngress, error) {
 	ingresses := []*kongv1beta1.UDPIngress{}
 	if s.stores.UDPIngress == nil {
@@ -783,7 +783,7 @@ func (s Store) GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, er
 	return p.(*kongv1.KongConsumer), nil
 }
 
-// GetIngressClassV1 returns the 'name' IngressClass resource
+// GetIngressClassV1 returns the 'name' IngressClass resource.
 func (s Store) GetIngressClassV1(name string) (*networkingv1.IngressClass, error) {
 	p, exists, err := s.stores.IngressClassV1.GetByKey(name)
 	if err != nil {
@@ -813,7 +813,7 @@ func (s Store) ListKongConsumers() []*kongv1.KongConsumer {
 // filtered by the ingress.class annotation and with the
 // label global:"true".
 // Support for these global namespaced KongPlugins was removed in 0.10.0
-// This function remains only to provide warnings to users with old configuration
+// This function remains only to provide warnings to users with old configuration.
 func (s Store) ListGlobalKongPlugins() ([]*kongv1.KongPlugin, error) {
 	var plugins []*kongv1.KongPlugin
 	// var globalPlugins []*configurationv1.KongPlugin
@@ -902,7 +902,7 @@ func (s Store) networkingIngressV1Beta1(obj interface{}) *networkingv1beta1.Ingr
 }
 
 // getIngressClassHandling returns annotations.ExactOrEmptyClassMatch if an IngressClass is the default class, or
-// annotations.ExactClassMatch if the IngressClass is not default or does not exist
+// annotations.ExactClassMatch if the IngressClass is not default or does not exist.
 func (s Store) getIngressClassHandling() annotations.ClassMatching {
 	class, err := s.GetIngressClassV1(s.ingressClass)
 	if err != nil {

--- a/internal/util/configdiag.go
+++ b/internal/util/configdiag.go
@@ -2,13 +2,13 @@ package util
 
 import "github.com/kong/deck/file"
 
-// ConfigDump contains a config dump and a flag indicating that the config was not successfully applid
+// ConfigDump contains a config dump and a flag indicating that the config was not successfully applid.
 type ConfigDump struct {
 	Config file.Content
 	Failed bool
 }
 
-// ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps
+// ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps.
 type ConfigDumpDiagnostic struct {
 	DumpsIncludeSensitive bool
 	Configs               chan ConfigDump

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -27,7 +27,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-// ParseNameNS parses a string searching a namespace and name
+// ParseNameNS parses a string searching a namespace and name.
 func ParseNameNS(input string) (string, string, error) {
 	nsName := strings.Split(input, "/")
 	if len(nsName) != 2 {
@@ -37,7 +37,7 @@ func ParseNameNS(input string) (string, string, error) {
 	return nsName[0], nsName[1], nil
 }
 
-// GetNodeIPOrName returns the IP address or the name of a node in the cluster
+// GetNodeIPOrName returns the IP address or the name of a node in the cluster.
 func GetNodeIPOrName(ctx context.Context, kubeClient clientset.Interface, name string) string {
 	node, err := kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -72,7 +72,7 @@ func GetNodeIPOrName(ctx context.Context, kubeClient clientset.Interface, name s
 	return ip
 }
 
-// PodInfo contains runtime information about the pod running the Ingres controller
+// PodInfo contains runtime information about the pod running the Ingres controller.
 type PodInfo struct {
 	Name      string
 	Namespace string
@@ -83,7 +83,7 @@ type PodInfo struct {
 }
 
 // GetPodDetails returns runtime information about the pod:
-// name, namespace and IP of the node where it is running
+// name, namespace and IP of the node where it is running.
 func GetPodDetails(ctx context.Context, kubeClient clientset.Interface) (*PodInfo, error) {
 	podName := os.Getenv("POD_NAME")
 	podNs := os.Getenv("POD_NAMESPACE")

--- a/internal/util/kongversion.go
+++ b/internal/util/kongversion.go
@@ -12,14 +12,14 @@ var (
 )
 
 // SetKongVersion sets the Kong version. It can only be used once. Repeated calls will not update the Kong
-// version
+// version.
 func SetKongVersion(version semver.Version) {
 	kongVersionOnce.Do(func() {
 		kongVersion = version
 	})
 }
 
-// GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version
+// GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version.
 func GetKongVersion() semver.Version {
 	return kongVersion
 }

--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -27,7 +27,7 @@ const (
 	// debug level logging.
 	DebugLevel = int(logrus.DebugLevel) - logrusrDiff
 
-	// WarnLevel is the converted logrus level to go-logr for warnings
+	// WarnLevel is the converted logrus level to go-logr for warnings.
 	WarnLevel = int(logrus.WarnLevel) - logrusrDiff
 )
 

--- a/internal/util/protocol.go
+++ b/internal/util/protocol.go
@@ -2,7 +2,7 @@ package util
 
 import "regexp"
 
-// ValidateProtocol returns a bool of whether string is a valid protocol
+// ValidateProtocol returns a bool of whether string is a valid protocol.
 func ValidateProtocol(protocol string) bool {
 	match := validProtocols.MatchString(protocol)
 	return match

--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -260,7 +260,7 @@ func TestReporterRun(t *testing.T) {
 	wg.Wait()
 }
 
-// getTLSListener builds a TLS listener using the test certificates
+// getTLSListener builds a TLS listener using the test certificates.
 func getTLSListener() (net.Listener, error) {
 	testCertificate, err := tls.X509KeyPair([]byte(reportTestTLSCert.Cert), []byte(reportTestTLSCert.Key))
 	if err != nil {
@@ -285,7 +285,7 @@ func getTLSListener() (net.Listener, error) {
 }
 
 // runTLSServer creates a new test TLS server for the reporting system. It accepts connections using the provided
-// listener and sends all requests it receives over the reqs channel
+// listener and sends all requests it receives over the reqs channel.
 func runTestTLSServer(ctx context.Context, t *testing.T, listen net.Listener, reqs chan []byte) {
 	defer close(reqs)
 	for {

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -28,7 +28,7 @@ type Endpoint struct {
 	Port string `json:"port"`
 }
 
-// RawSSLCert represnts TLS cert and key in bytes
+// RawSSLCert represnts TLS cert and key in bytes.
 type RawSSLCert struct {
 	Cert []byte
 	Key  []byte

--- a/internal/validation/consumers/credentials/vars.go
+++ b/internal/validation/consumers/credentials/vars.go
@@ -10,7 +10,7 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // of credential that is being provided for the consumer.
 const TypeKey = "kongCredType"
 
-// SupportedCreds indicates all the "kongCredType"s which are supported for KongConsumer credentials.
+// SupportedTypes indicates all the "kongCredType"s which are supported for KongConsumer credentials.
 var SupportedTypes = sets.NewString(
 	"basic-auth",
 	"hmac-auth",


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds `godot` and `golint` linters to `golangci-lint`'s config

