### PR TITLE
test(e2e) print pod logs if the flaky test fails

### DIFF
--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -320,3 +320,27 @@ func getKubernetesLogs(t *testing.T, env environments.Environment, namespace, na
 	}
 	return string(out), nil
 }
+
+// httpGetResponseContains returns true if the response body of GETting the URL contains specified substring.
+func httpGetResponseContains(t *testing.T, url string, client *http.Client, substring string) bool {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Logf("failed to create request: %v", err)
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Logf("failed to get response: %v", err)
+		return false
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Logf("failed to read response body: %v", err)
+		return false
+	}
+
+	return strings.Contains(string(body), substring)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
dump pod logs if the flaky e2e test case `TestDeployAllInOnePostgresWithMultipleReplicas` fails

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
related to #2670
**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
