### PR TITLE
ci: unify imports aliases via importas

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,24 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/kong/kubernetes-ingress-controller/v2)
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/api/admission/v1
+        alias: admissionv1
+      - pkg: k8s.io/api/networking/v1
+        alias: netv1
+      - pkg: k8s.io/api/networking/v1beta1
+        alias: netv1beta1
+
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
+        alias: gateway${1}
 issues:
   fix: true
   exclude-rules:

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lithammer/dedent"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	admission "k8s.io/api/admission/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -86,7 +86,7 @@ func TestValidationWebhook(t *testing.T) {
 			validator KongValidator
 
 			wantRespCode        int
-			wantSuccessResponse admission.AdmissionResponse
+			wantSuccessResponse admissionv1.AdmissionResponse
 			wantFailureMessage  string
 		}{
 			{
@@ -116,7 +116,7 @@ func TestValidationWebhook(t *testing.T) {
 					}`),
 				validator:    KongFakeValidator{Result: true},
 				wantRespCode: http.StatusOK,
-				wantSuccessResponse: admission.AdmissionResponse{
+				wantSuccessResponse: admissionv1.AdmissionResponse{
 					UID:     "b2df61dd-ab5b-4cb4-9be0-878533c83892",
 					Allowed: true,
 					Result:  &metav1.Status{},
@@ -151,7 +151,7 @@ func TestValidationWebhook(t *testing.T) {
 				`),
 				validator:    KongFakeValidator{Result: true},
 				wantRespCode: http.StatusOK,
-				wantSuccessResponse: admission.AdmissionResponse{
+				wantSuccessResponse: admissionv1.AdmissionResponse{
 					UID:     "b2df61dd-ab5b-4cb4-9be0-878533c83892",
 					Allowed: true,
 					Result:  &metav1.Status{},
@@ -185,7 +185,7 @@ func TestValidationWebhook(t *testing.T) {
 					}`),
 				validator:    KongFakeValidator{Result: true},
 				wantRespCode: http.StatusOK,
-				wantSuccessResponse: admission.AdmissionResponse{
+				wantSuccessResponse: admissionv1.AdmissionResponse{
 					UID:     "b2df61dd-ab5b-4cb4-9be0-878533c83892",
 					Allowed: true,
 					Result:  &metav1.Status{},
@@ -213,7 +213,7 @@ func TestValidationWebhook(t *testing.T) {
 					}`),
 				validator:    KongFakeValidator{Result: false, Message: "consumer is not valid"},
 				wantRespCode: http.StatusOK,
-				wantSuccessResponse: admission.AdmissionResponse{
+				wantSuccessResponse: admissionv1.AdmissionResponse{
 					UID:     "b2df61dd-ab5b-4cb4-9be0-878533c83892",
 					Allowed: false,
 					Result: &metav1.Status{
@@ -321,7 +321,7 @@ func TestValidationWebhook(t *testing.T) {
 					}`),
 				validator:    KongFakeValidator{Result: true},
 				wantRespCode: http.StatusOK,
-				wantSuccessResponse: admission.AdmissionResponse{
+				wantSuccessResponse: admissionv1.AdmissionResponse{
 					UID:     "b2df61dd-ab5b-4cb4-9be0-878533c83892",
 					Allowed: true,
 					Result:  &metav1.Status{},
@@ -346,7 +346,7 @@ func TestValidationWebhook(t *testing.T) {
 				// assert
 				assert.Equal(tt.wantRespCode, res.Code)
 				if tt.wantRespCode == http.StatusOK {
-					var review admission.AdmissionReview
+					var review admissionv1.AdmissionReview
 					_, _, err = decoder.Decode(res.Body.Bytes(), nil, &review)
 					assert.Nil(err)
 					assert.EqualValues(&tt.wantSuccessResponse, review.Response)

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -19,7 +19,7 @@ package annotations
 import (
 	"strings"
 
-	networkingv1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,8 +98,8 @@ func IngressClassValidatorFuncFromObjectMeta(
 
 func IngressClassValidatorFuncFromV1Ingress(
 	ingressClass string,
-) func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
-	return func(ingress *networkingv1.Ingress, handling ClassMatching) bool {
+) func(ingress *netv1.Ingress, handling ClassMatching) bool {
+	return func(ingress *netv1.Ingress, handling ClassMatching) bool {
 		class := ingress.Spec.IngressClassName
 		className := ""
 		if class != nil {

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	networkingv1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,11 +56,11 @@ func TestIngressClassValidatorFunc(t *testing.T) {
 	ing := &extensions.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: v1.NamespaceDefault,
+			Namespace: corev1.NamespaceDefault,
 		},
 	}
 
-	ingv1 := &networkingv1.Ingress{
+	ingv1 := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
@@ -68,7 +68,7 @@ func TestIngressClassValidatorFunc(t *testing.T) {
 				IngressClassKey: DefaultIngressClass,
 			},
 		},
-		Spec: networkingv1.IngressSpec{
+		Spec: netv1.IngressSpec{
 			IngressClassName: nil,
 		},
 	}

--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
@@ -101,16 +101,16 @@ func newSecretNameToSNIs() SecretNameToSNIs {
 	return SecretNameToSNIs(map[string][]string{})
 }
 
-func (m SecretNameToSNIs) addFromIngressV1beta1TLS(tlsSections []networkingv1beta1.IngressTLS, namespace string) {
+func (m SecretNameToSNIs) addFromIngressV1beta1TLS(tlsSections []netv1beta1.IngressTLS, namespace string) {
 	// Assume that v1beta1 and v1 tlsSections have identical semantics and field-wise content.
-	var v1 []networkingv1.IngressTLS
+	var v1 []netv1.IngressTLS
 	for _, item := range tlsSections {
-		v1 = append(v1, networkingv1.IngressTLS{Hosts: item.Hosts, SecretName: item.SecretName})
+		v1 = append(v1, netv1.IngressTLS{Hosts: item.Hosts, SecretName: item.SecretName})
 	}
 	m.addFromIngressV1TLS(v1, namespace)
 }
 
-func (m SecretNameToSNIs) addFromIngressV1TLS(tlsSections []networkingv1.IngressTLS, namespace string) {
+func (m SecretNameToSNIs) addFromIngressV1TLS(tlsSections []netv1.IngressTLS, namespace string) {
 	for _, tls := range tlsSections {
 		if len(tls.Hosts) == 0 {
 			continue

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
@@ -110,7 +110,7 @@ func TestMergeIngressRules(t *testing.T) {
 
 func Test_addFromIngressV1beta1TLS(t *testing.T) {
 	type args struct {
-		tlsSections []networking.IngressTLS
+		tlsSections []netv1beta1.IngressTLS
 		namespace   string
 	}
 	tests := []struct {
@@ -120,7 +120,7 @@ func Test_addFromIngressV1beta1TLS(t *testing.T) {
 	}{
 		{
 			args: args{
-				tlsSections: []networking.IngressTLS{
+				tlsSections: []netv1beta1.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",
@@ -145,7 +145,7 @@ func Test_addFromIngressV1beta1TLS(t *testing.T) {
 		},
 		{
 			args: args{
-				tlsSections: []networking.IngressTLS{
+				tlsSections: []netv1beta1.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -208,11 +208,11 @@ func toCACerts(log logrus.FieldLogger, caCertSecrets []*corev1.Secret) []kong.CA
 	return caCerts
 }
 
-func knativeIngressToNetworkingTLS(tls []knative.IngressTLS) []networking.IngressTLS {
-	var result []networking.IngressTLS
+func knativeIngressToNetworkingTLS(tls []knative.IngressTLS) []netv1beta1.IngressTLS {
+	var result []netv1beta1.IngressTLS
 
 	for _, t := range tls {
-		result = append(result, networking.IngressTLS{
+		result = append(result, netv1beta1.IngressTLS{
 			Hosts:      t.Hosts,
 			SecretName: t.SecretName,
 		})
@@ -220,11 +220,11 @@ func knativeIngressToNetworkingTLS(tls []knative.IngressTLS) []networking.Ingres
 	return result
 }
 
-func tcpIngressToNetworkingTLS(tls []configurationv1beta1.IngressTLS) []networking.IngressTLS {
-	var result []networking.IngressTLS
+func tcpIngressToNetworkingTLS(tls []configurationv1beta1.IngressTLS) []netv1beta1.IngressTLS {
+	var result []netv1beta1.IngressTLS
 
 	for _, t := range tls {
-		result = append(result, networking.IngressTLS{
+		result = append(result, netv1beta1.IngressTLS{
 			Hosts:      t.Hosts,
 			SecretName: t.SecretName,
 		})

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -293,7 +293,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 				},
 			},
 		},
-		IngressesV1beta1: []*networkingv1beta1.Ingress{
+		IngressesV1beta1: []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -303,16 +303,16 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -333,16 +333,16 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.net",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -968,7 +968,7 @@ func TestCACertificate(t *testing.T) {
 func TestServiceClientCertificate(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("valid client-cert annotation", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -977,16 +977,16 @@ func TestServiceClientCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -996,7 +996,7 @@ func TestServiceClientCertificate(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networkingv1beta1.IngressTLS{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -1050,7 +1050,7 @@ func TestServiceClientCertificate(t *testing.T) {
 			*state.Services[0].ClientCertificate.ID)
 	})
 	t.Run("client-cert secret doesn't exist", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -1059,16 +1059,16 @@ func TestServiceClientCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1078,7 +1078,7 @@ func TestServiceClientCertificate(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networkingv1beta1.IngressTLS{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -1119,7 +1119,7 @@ func TestServiceClientCertificate(t *testing.T) {
 func TestKongRouteAnnotations(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("strip-path annotation is correctly processed (true)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1129,16 +1129,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						annotations.IngressClassKey: "kong",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1199,7 +1199,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("strip-path annotation is correctly processed (false)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1209,16 +1209,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						"konghq.com/strip-path":     "false",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1280,7 +1280,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 	})
 	t.Run("https-redirect-status-code annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1290,16 +1290,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/https-redirect-status-code": "301",
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1362,7 +1362,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("bad https-redirect-status-code annotation is ignored",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1372,16 +1372,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/https-redirect-status-code": "whoops",
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1443,7 +1443,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("preserve-host annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1453,16 +1453,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1524,7 +1524,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("preserve-host annotation with random string is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1534,16 +1534,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							"konghq.com/preserve-host":  "wiggle wiggle wiggle",
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1605,7 +1605,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("regex-priority annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1615,16 +1615,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1686,7 +1686,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 	t.Run("non-integer regex-priority annotation is ignored",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -1696,16 +1696,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -1766,7 +1766,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("route buffering options are processed (true)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-buffering-test",
@@ -1777,16 +1777,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						"konghq.com/response-buffering": "True",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1845,7 +1845,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route buffering options are processed (false)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-buffering-test",
@@ -1856,16 +1856,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						"konghq.com/response-buffering": "False",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1924,7 +1924,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route buffering options are not processed with bad annotation values", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-buffering-test",
@@ -1935,16 +1935,16 @@ func TestKongRouteAnnotations(t *testing.T) {
 						"konghq.com/response-buffering": "invalid-value",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -1987,7 +1987,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 func TestKongProcessClasslessIngress(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("Kong classless ingress evaluated (true)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -1996,16 +1996,16 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2041,22 +2041,22 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			"expected one service to be rendered")
 	})
 	t.Run("Kong classless ingress evaluated (false)", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "default",
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2459,7 +2459,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 func TestKongServiceAnnotations(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("path annotation is correctly processed", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -2468,16 +2468,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2542,7 +2542,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 	})
 
 	t.Run("host-header annotation is correctly processed", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -2551,16 +2551,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2633,7 +2633,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 
 	t.Run("methods annotation is correctly processed",
 		func(t *testing.T) {
-			ingresses := []*networkingv1beta1.Ingress{
+			ingresses := []*netv1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -2643,16 +2643,16 @@ func TestKongServiceAnnotations(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Spec: networkingv1beta1.IngressSpec{
-						Rules: []networkingv1beta1.IngressRule{
+					Spec: netv1beta1.IngressSpec{
+						Rules: []netv1beta1.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: networkingv1beta1.IngressRuleValue{
-									HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-										Paths: []networkingv1beta1.HTTPIngressPath{
+								IngressRuleValue: netv1beta1.IngressRuleValue{
+									HTTP: &netv1beta1.HTTPIngressRuleValue{
+										Paths: []netv1beta1.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: networkingv1beta1.IngressBackend{
+												Backend: netv1beta1.IngressBackend{
 													ServiceName: "foo-svc",
 													ServicePort: intstr.FromInt(80),
 												},
@@ -2718,7 +2718,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 func TestDefaultBackend(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("default backend is processed correctly", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ing-with-default-backend",
@@ -2727,8 +2727,8 @@ func TestDefaultBackend(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Backend: &networkingv1beta1.IngressBackend{
+				Spec: netv1beta1.IngressSpec{
+					Backend: &netv1beta1.IngressBackend{
 						ServiceName: "default-svc",
 						ServicePort: intstr.FromInt(80),
 					},
@@ -2764,7 +2764,7 @@ func TestDefaultBackend(t *testing.T) {
 	})
 
 	t.Run("client-cert secret doesn't exist", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2773,16 +2773,16 @@ func TestDefaultBackend(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -2792,7 +2792,7 @@ func TestDefaultBackend(t *testing.T) {
 							},
 						},
 					},
-					TLS: []networkingv1beta1.IngressTLS{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2833,7 +2833,7 @@ func TestDefaultBackend(t *testing.T) {
 func TestParserSecret(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("invalid TLS secret", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2842,8 +2842,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2856,8 +2856,8 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "default",
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"bar.com"},
@@ -2892,7 +2892,7 @@ func TestParserSecret(t *testing.T) {
 			"expected no certificates to be rendered with empty secret")
 	})
 	t.Run("duplicate certificates order by time", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2901,8 +2901,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -2918,8 +2918,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret2",
 							Hosts:      []string{"bar.com"},
@@ -2987,7 +2987,7 @@ func TestParserSecret(t *testing.T) {
 		}, state.Certificates[0])
 	})
 	t.Run("duplicate certificates order by uid", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -2996,8 +2996,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -3013,8 +3013,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret2",
 							Hosts:      []string{"bar.com"},
@@ -3030,8 +3030,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret3",
 							Hosts:      []string{"baz.com"},
@@ -3114,7 +3114,7 @@ func TestParserSecret(t *testing.T) {
 		}, state.Certificates[0])
 	})
 	t.Run("duplicate SNIs", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3123,8 +3123,8 @@ func TestParserSecret(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -3137,8 +3137,8 @@ func TestParserSecret(t *testing.T) {
 					Name:      "bar",
 					Namespace: "ns1",
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret2",
 							Hosts:      []string{"foo.com"},
@@ -3187,7 +3187,7 @@ func TestParserSecret(t *testing.T) {
 func TestParserSNI(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("route includes SNI when TLS info present, but not for wildcard hostnames", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3196,22 +3196,22 @@ func TestParserSNI(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"example.com", "*.example.com"},
 						},
 					},
-					Rules: []networkingv1beta1.IngressRule{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3222,12 +3222,12 @@ func TestParserSNI(t *testing.T) {
 						},
 						{
 							Host: "*.example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3287,7 +3287,7 @@ func TestParserSNI(t *testing.T) {
 		}, state.Services[0].Routes[1].Route)
 	})
 	t.Run("route does not include SNI when TLS info absent", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3296,16 +3296,16 @@ func TestParserSNI(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3346,7 +3346,7 @@ func TestParserHostAliases(t *testing.T) {
 	assert := assert.New(t)
 	annHostAliasesKey := annotations.AnnotationPrefix + annotations.HostAliasesKey
 	t.Run("route Hosts includes Host-Aliases when Host-Aliases are present", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3356,16 +3356,16 @@ func TestParserHostAliases(t *testing.T) {
 						annHostAliasesKey:           "*.example.com,*.sample.com,*.illustration.com",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3400,7 +3400,7 @@ func TestParserHostAliases(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route Hosts remain unmodified when Host-Aliases are not present", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3409,16 +3409,16 @@ func TestParserHostAliases(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3453,7 +3453,7 @@ func TestParserHostAliases(t *testing.T) {
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route Hosts will not contain duplicates when Host-Aliases duplicates the host", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3463,16 +3463,16 @@ func TestParserHostAliases(t *testing.T) {
 						annHostAliasesKey:           "example.com,*.example.com",
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3520,7 +3520,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3530,16 +3530,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3612,7 +3612,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3622,16 +3622,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3697,7 +3697,7 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3707,16 +3707,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -3759,7 +3759,7 @@ func TestPluginAnnotations(t *testing.T) {
 		assert.Equal("grpc", *state.Plugins[0].Protocols[0])
 	})
 	t.Run("missing plugin", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -3769,16 +3769,16 @@ func TestPluginAnnotations(t *testing.T) {
 						annotations.IngressClassKey:                           annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					Rules: []networkingv1beta1.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkingv1beta1.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -4397,7 +4397,7 @@ func TestPickPort(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		objs store.FakeObjects
-		port networkingv1.ServiceBackendPort
+		port netv1.ServiceBackendPort
 
 		wantTarget string
 	}{
@@ -4407,26 +4407,26 @@ func TestPickPort(t *testing.T) {
 				Services:  []*corev1.Service{&svc0},
 				Endpoints: endpointList,
 
-				IngressesV1: []*networkingv1.Ingress{
+				IngressesV1: []*netv1.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "foo",
 							Namespace:   "foo-namespace",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{
+						Spec: netv1.IngressSpec{
+							Rules: []netv1.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: networkingv1.IngressRuleValue{
-										HTTP: &networkingv1.HTTPIngressRuleValue{
-											Paths: []networkingv1.HTTPIngressPath{
+									IngressRuleValue: netv1.IngressRuleValue{
+										HTTP: &netv1.HTTPIngressRuleValue{
+											Paths: []netv1.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: networkingv1.IngressBackend{
-														Service: &networkingv1.IngressServiceBackend{
+													Backend: netv1.IngressBackend{
+														Service: &netv1.IngressServiceBackend{
 															Name: "service-0",
-															Port: networkingv1.ServiceBackendPort{Number: 111},
+															Port: netv1.ServiceBackendPort{Number: 111},
 														},
 													},
 												},
@@ -4447,26 +4447,26 @@ func TestPickPort(t *testing.T) {
 				Services:  []*corev1.Service{&svc2},
 				Endpoints: endpointList,
 
-				IngressesV1: []*networkingv1.Ingress{
+				IngressesV1: []*netv1.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "foo",
 							Namespace:   "foo-namespace",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{
+						Spec: netv1.IngressSpec{
+							Rules: []netv1.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: networkingv1.IngressRuleValue{
-										HTTP: &networkingv1.HTTPIngressRuleValue{
-											Paths: []networkingv1.HTTPIngressPath{
+									IngressRuleValue: netv1.IngressRuleValue{
+										HTTP: &netv1.HTTPIngressRuleValue{
+											Paths: []netv1.HTTPIngressPath{
 												{
 													Path: "/externalname",
-													Backend: networkingv1.IngressBackend{
-														Service: &networkingv1.IngressServiceBackend{
+													Backend: netv1.IngressBackend{
+														Service: &netv1.IngressServiceBackend{
 															Name: "service-2",
-															Port: networkingv1.ServiceBackendPort{Number: 222},
+															Port: netv1.ServiceBackendPort{Number: 222},
 														},
 													},
 												},
@@ -4487,26 +4487,26 @@ func TestPickPort(t *testing.T) {
 				Services:  []*corev1.Service{&svc0},
 				Endpoints: endpointList,
 
-				IngressesV1: []*networkingv1.Ingress{
+				IngressesV1: []*netv1.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "foo",
 							Namespace:   "foo-namespace",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{
+						Spec: netv1.IngressSpec{
+							Rules: []netv1.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: networkingv1.IngressRuleValue{
-										HTTP: &networkingv1.HTTPIngressRuleValue{
-											Paths: []networkingv1.HTTPIngressPath{
+									IngressRuleValue: netv1.IngressRuleValue{
+										HTTP: &netv1.HTTPIngressRuleValue{
+											Paths: []netv1.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: networkingv1.IngressBackend{
-														Service: &networkingv1.IngressServiceBackend{
+													Backend: netv1.IngressBackend{
+														Service: &netv1.IngressServiceBackend{
 															Name: "service-0",
-															Port: networkingv1.ServiceBackendPort{Name: "port3"},
+															Port: netv1.ServiceBackendPort{Name: "port3"},
 														},
 													},
 												},
@@ -4527,24 +4527,24 @@ func TestPickPort(t *testing.T) {
 				Services:  []*corev1.Service{&svc1},
 				Endpoints: endpointList,
 
-				IngressesV1: []*networkingv1.Ingress{
+				IngressesV1: []*netv1.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "foo",
 							Namespace:   "foo-namespace",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{
+						Spec: netv1.IngressSpec{
+							Rules: []netv1.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: networkingv1.IngressRuleValue{
-										HTTP: &networkingv1.HTTPIngressRuleValue{
-											Paths: []networkingv1.HTTPIngressPath{
+									IngressRuleValue: netv1.IngressRuleValue{
+										HTTP: &netv1.HTTPIngressRuleValue{
+											Paths: []netv1.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: networkingv1.IngressBackend{
-														Service: &networkingv1.IngressServiceBackend{
+													Backend: netv1.IngressBackend{
+														Service: &netv1.IngressServiceBackend{
 															Name: "service-1",
 														},
 													},
@@ -4577,7 +4577,7 @@ func TestPickPort(t *testing.T) {
 func TestCertificate(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("same host with multiple namespace return the first namespace/secret by asc ", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -4586,8 +4586,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -4603,8 +4603,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -4620,8 +4620,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret1",
 							Hosts:      []string{"foo.com"},
@@ -4688,7 +4688,7 @@ func TestCertificate(t *testing.T) {
 		assert.Contains(state.Certificates, fooCertificate)
 	})
 	t.Run("SNIs slice with same certificate should be ordered by asc", func(t *testing.T) {
-		ingresses := []*networkingv1beta1.Ingress{
+		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo3",
@@ -4697,8 +4697,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret",
 							Hosts:      []string{"foo3.xxx.com"},
@@ -4714,8 +4714,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret",
 							Hosts:      []string{"foo2.xxx.com"},
@@ -4731,8 +4731,8 @@ func TestCertificate(t *testing.T) {
 						annotations.IngressClassKey: annotations.DefaultIngressClass,
 					},
 				},
-				Spec: networkingv1beta1.IngressSpec{
-					TLS: []networkingv1beta1.IngressTLS{
+				Spec: netv1beta1.IngressSpec{
+					TLS: []netv1beta1.IngressTLS{
 						{
 							SecretName: "secret",
 							Hosts:      []string{"foo1.xxx.com"},

--- a/internal/dataplane/parser/translate.go
+++ b/internal/dataplane/parser/translate.go
@@ -5,22 +5,22 @@ import (
 	"strings"
 
 	"github.com/kong/go-kong/kong"
-	networkingv1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 )
 
-func serviceBackendPortToStr(port networkingv1.ServiceBackendPort) string {
+func serviceBackendPortToStr(port netv1.ServiceBackendPort) string {
 	if port.Name != "" {
 		return fmt.Sprintf("pname-%s", port.Name)
 	}
 	return fmt.Sprintf("pnum-%d", port.Number)
 }
 
-func pathsFromK8s(path string, pathType networkingv1.PathType) ([]*string, error) {
+func pathsFromK8s(path string, pathType netv1.PathType) ([]*string, error) {
 	switch pathType {
-	case networkingv1.PathTypePrefix:
+	case netv1.PathTypePrefix:
 		base := strings.Trim(path, "/")
 		if base == "" {
 			return kong.StringSlice("/"), nil
@@ -29,10 +29,10 @@ func pathsFromK8s(path string, pathType networkingv1.PathType) ([]*string, error
 			"/"+base+"$",
 			"/"+base+"/",
 		), nil
-	case networkingv1.PathTypeExact:
+	case netv1.PathTypeExact:
 		relative := strings.TrimLeft(path, "/")
 		return kong.StringSlice("/" + relative + "$"), nil
-	case networkingv1.PathTypeImplementationSpecific:
+	case netv1.PathTypeImplementationSpecific:
 		if path == "" {
 			return kong.StringSlice("/"), nil
 		}
@@ -42,13 +42,13 @@ func pathsFromK8s(path string, pathType networkingv1.PathType) ([]*string, error
 	return nil, fmt.Errorf("unknown pathType %v", pathType)
 }
 
-var priorityForPath = map[networkingv1.PathType]int{
-	networkingv1.PathTypeExact:                  300,
-	networkingv1.PathTypePrefix:                 200,
-	networkingv1.PathTypeImplementationSpecific: 100,
+var priorityForPath = map[netv1.PathType]int{
+	netv1.PathTypeExact:                  300,
+	netv1.PathTypePrefix:                 200,
+	netv1.PathTypeImplementationSpecific: 100,
 }
 
-func PortDefFromServiceBackendPort(sbp *networkingv1.ServiceBackendPort) kongstate.PortDef {
+func PortDefFromServiceBackendPort(sbp *netv1.ServiceBackendPort) kongstate.PortDef {
 	switch {
 	case sbp.Name != "":
 		return kongstate.PortDef{Mode: kongstate.PortModeByName, Name: sbp.Name}

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
@@ -20,7 +20,7 @@ func (p *Parser) ingressRulesFromIngressV1beta1() ingressRules {
 
 	ingressList := p.storer.ListIngressesV1beta1()
 
-	var allDefaultBackends []networkingv1beta1.Ingress
+	var allDefaultBackends []netv1beta1.Ingress
 	sort.SliceStable(ingressList, func(i, j int) bool {
 		return ingressList[i].CreationTimestamp.Before(
 			&ingressList[j].CreationTimestamp)
@@ -168,7 +168,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 
 	ingressList := p.storer.ListIngressesV1()
 
-	var allDefaultBackends []networkingv1.Ingress
+	var allDefaultBackends []netv1.Ingress
 	sort.SliceStable(ingressList, func(i, j int) bool {
 		return ingressList[i].CreationTimestamp.Before(
 			&ingressList[j].CreationTimestamp)
@@ -205,7 +205,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 						continue
 					}
 
-					pathType := networkingv1.PathTypeImplementationSpecific
+					pathType := netv1.PathTypeImplementationSpecific
 					if rulePath.PathType != nil {
 						pathType = *rulePath.PathType
 					}

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -17,7 +17,7 @@ import (
 
 func TestFromIngressV1beta1(t *testing.T) {
 	assert := assert.New(t)
-	ingressList := []*networkingv1beta1.Ingress{
+	ingressList := []*netv1beta1.Ingress{
 		// 0
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -27,16 +27,16 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -57,8 +57,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				TLS: []networkingv1beta1.IngressTLS{
+			Spec: netv1beta1.IngressSpec{
+				TLS: []netv1beta1.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",
@@ -74,15 +74,15 @@ func TestFromIngressV1beta1(t *testing.T) {
 						SecretName: "sooper-secret2",
 					},
 				},
-				Rules: []networkingv1beta1.IngressRule{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -103,8 +103,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Backend: &networkingv1beta1.IngressBackend{
+			Spec: netv1beta1.IngressSpec{
+				Backend: &netv1beta1.IngressBackend{
 					ServiceName: "default-svc",
 					ServicePort: intstr.FromInt(80),
 				},
@@ -119,16 +119,16 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/.well-known/acme-challenge/yolo",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "cert-manager-solver-pod",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -149,15 +149,15 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -178,11 +178,11 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host:             "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{},
+						IngressRuleValue: netv1beta1.IngressRuleValue{},
 					},
 				},
 			},
@@ -196,15 +196,15 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -215,11 +215,11 @@ func TestFromIngressV1beta1(t *testing.T) {
 					},
 					{
 						Host: "example.net",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(8000),
 										},
@@ -240,16 +240,16 @@ func TestFromIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/foo//bar",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -265,7 +265,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 
 	t.Run("no ingress returns empty info", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{},
+			IngressesV1beta1: []*netv1beta1.Ingress{},
 		})
 		assert.NoError(err)
 		p := NewParser(logrus.New(), store)
@@ -278,7 +278,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[0],
 			},
 		})
@@ -295,7 +295,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("ingress rule with default backend", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{ingressList[0], ingressList[2]},
+			IngressesV1beta1: []*netv1beta1.Ingress{ingressList[0], ingressList[2]},
 		})
 		assert.NoError(err)
 		p := NewParser(logrus.New(), store)
@@ -314,7 +314,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("ingress rule with TLS", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[1],
 			},
 		})
@@ -328,7 +328,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[3],
 			},
 		})
@@ -349,7 +349,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[4],
 			},
 		})
@@ -362,7 +362,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[5],
 			},
 		})
@@ -375,7 +375,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[6],
 			},
 		})
@@ -388,7 +388,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 	})
 	t.Run("Ingress rule with path containing multiple slashes ('//') is skipped", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*networkingv1beta1.Ingress{
+			IngressesV1beta1: []*netv1beta1.Ingress{
 				ingressList[7],
 			},
 		})
@@ -402,7 +402,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 
 func TestFromIngressV1(t *testing.T) {
 	assert := assert.New(t)
-	ingressList := []*networkingv1.Ingress{
+	ingressList := []*netv1.Ingress{
 		// 0
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -412,19 +412,19 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -444,8 +444,8 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				TLS: []networkingv1.IngressTLS{
+			Spec: netv1.IngressSpec{
+				TLS: []netv1.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",
@@ -461,18 +461,18 @@ func TestFromIngressV1(t *testing.T) {
 						SecretName: "sooper-secret2",
 					},
 				},
-				Rules: []networkingv1.IngressRule{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -492,11 +492,11 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				DefaultBackend: &networkingv1.IngressBackend{
-					Service: &networkingv1.IngressServiceBackend{
+			Spec: netv1.IngressSpec{
+				DefaultBackend: &netv1.IngressBackend{
+					Service: &netv1.IngressServiceBackend{
 						Name: "default-svc",
-						Port: networkingv1.ServiceBackendPort{Number: 80},
+						Port: netv1.ServiceBackendPort{Number: 80},
 					},
 				},
 			},
@@ -510,19 +510,19 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/.well-known/acme-challenge/yolo",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "cert-manager-solver-pod",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -542,18 +542,18 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -573,11 +573,11 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host:             "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{},
+						IngressRuleValue: netv1.IngressRuleValue{},
 					},
 				},
 			},
@@ -591,18 +591,18 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -612,14 +612,14 @@ func TestFromIngressV1(t *testing.T) {
 					},
 					{
 						Host: "example.net",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 8000},
+												Port: netv1.ServiceBackendPort{Number: 8000},
 											},
 										},
 									},
@@ -639,19 +639,19 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/foo//bar",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Number: 80},
+												Port: netv1.ServiceBackendPort{Number: 80},
 											},
 										},
 									},
@@ -671,28 +671,28 @@ func TestFromIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Name: "http"},
+												Port: netv1.ServiceBackendPort{Name: "http"},
 											},
 										},
 									},
 									{
 										Path: "/ws",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{Name: "ws"},
+												Port: netv1.ServiceBackendPort{Name: "ws"},
 											},
 										},
 									},
@@ -707,7 +707,7 @@ func TestFromIngressV1(t *testing.T) {
 
 	t.Run("no ingress returns empty info", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{},
+			IngressesV1: []*netv1.Ingress{},
 		})
 		assert.NoError(err)
 		p := NewParser(logrus.New(), store)
@@ -720,7 +720,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[0],
 			},
 		})
@@ -737,7 +737,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("ingress rule with default backend", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[0],
 				ingressList[2],
 			},
@@ -759,7 +759,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("ingress rule with TLS", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[1],
 			},
 		})
@@ -773,7 +773,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[3],
 			},
 		})
@@ -794,7 +794,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[4],
 			},
 		})
@@ -807,7 +807,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[5],
 			},
 		})
@@ -820,7 +820,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[6],
 			},
 		})
@@ -835,7 +835,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("Ingress rule with path containing multiple slashes ('//') is skipped", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[7],
 			},
 		})
@@ -847,7 +847,7 @@ func TestFromIngressV1(t *testing.T) {
 	})
 	t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*networkingv1.Ingress{
+			IngressesV1: []*netv1.Ingress{
 				ingressList[8],
 			},
 		})

--- a/internal/dataplane/parser/translate_test.go
+++ b/internal/dataplane/parser/translate_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/require"
-	networkingv1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 )
 
 func TestPathsFromK8s(t *testing.T) {
@@ -60,17 +60,17 @@ func TestPathsFromK8s(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			{
-				gotPrefix, gotErr := pathsFromK8s(tt.path, networkingv1.PathTypePrefix)
+				gotPrefix, gotErr := pathsFromK8s(tt.path, netv1.PathTypePrefix)
 				require.NoError(t, gotErr)
 				require.Equal(t, tt.wantPrefix, gotPrefix, "prefix match")
 			}
 			{
-				gotExact, gotErr := pathsFromK8s(tt.path, networkingv1.PathTypeExact)
+				gotExact, gotErr := pathsFromK8s(tt.path, netv1.PathTypeExact)
 				require.NoError(t, gotErr)
 				require.Equal(t, tt.wantExact, gotExact, "exact match")
 			}
 			{
-				gotImplSpec, gotErr := pathsFromK8s(tt.path, networkingv1.PathTypeImplementationSpecific)
+				gotImplSpec, gotErr := pathsFromK8s(tt.path, netv1.PathTypeImplementationSpecific)
 				require.NoError(t, gotErr)
 				require.Equal(t, tt.wantImplSpec, gotImplSpec, "implementation specific match")
 			}

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
@@ -14,35 +14,35 @@ import (
 )
 
 var (
-	pathTypeExact                  = networkingv1.PathTypeExact
-	pathTypeImplementationSpecific = networkingv1.PathTypeImplementationSpecific
-	pathTypePrefix                 = networkingv1.PathTypePrefix
+	pathTypeExact                  = netv1.PathTypeExact
+	pathTypeImplementationSpecific = netv1.PathTypeImplementationSpecific
+	pathTypePrefix                 = netv1.PathTypePrefix
 )
 
 func TestTranslateIngress(t *testing.T) {
 	tts := []struct {
 		name     string
-		ingress  *networkingv1.Ingress
+		ingress  *netv1.Ingress
 		expected []*kongstate.Service
 	}{
 		{
 			name: "a basic ingress resource with a single rule, and only one path results in a single kong service and route",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
 									Path: "/api",
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
 											Name: "test-service",
-											Port: networkingv1.ServiceBackendPort{
+											Port: netv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
 											},
@@ -97,23 +97,23 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "an ingress with path type exact gets a kong route with an exact path match",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
 									Path:     "/api",
 									PathType: &pathTypeExact,
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
 											Name: "test-service",
-											Port: networkingv1.ServiceBackendPort{
+											Port: netv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
 											},
@@ -168,23 +168,23 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "an Ingress resource with implementation specific path type doesn't modify the path",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
 									Path:     "/api",
 									PathType: &pathTypeImplementationSpecific,
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
 											Name: "test-service",
-											Port: networkingv1.ServiceBackendPort{
+											Port: netv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
 											},
@@ -239,22 +239,22 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "an Ingress resource with paths with double /'s gets flattened",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
 									Path: "/v1//api///",
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
 											Name: "test-service",
-											Port: networkingv1.ServiceBackendPort{
+											Port: netv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
 											},
@@ -309,22 +309,22 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "empty paths get treated as '/'",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
 									Path: "",
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
 											Name: "test-service",
-											Port: networkingv1.ServiceBackendPort{
+											Port: netv1.ServiceBackendPort{
 												Name:   "http",
 												Number: 80,
 											},
@@ -379,23 +379,23 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "multiple and various paths get compiled together properly",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/v1/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -404,10 +404,10 @@ func TestTranslateIngress(t *testing.T) {
 									},
 									{
 										Path: "/v2/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -416,10 +416,10 @@ func TestTranslateIngress(t *testing.T) {
 									},
 									{
 										Path: "/v3/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -429,10 +429,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "/other/path/1",
 										PathType: &pathTypeExact,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -442,10 +442,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "/other/path/2",
 										PathType: &pathTypeImplementationSpecific,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -455,10 +455,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "",
 										PathType: &pathTypeImplementationSpecific,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -521,22 +521,22 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "when no host is provided, all hosts are matched",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/v1/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -545,10 +545,10 @@ func TestTranslateIngress(t *testing.T) {
 									},
 									{
 										Path: "/v2/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -557,10 +557,10 @@ func TestTranslateIngress(t *testing.T) {
 									},
 									{
 										Path: "/v3/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -570,10 +570,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "/other/path/1",
 										PathType: &pathTypeExact,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -583,10 +583,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "/other/path/2",
 										PathType: &pathTypeImplementationSpecific,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -596,10 +596,10 @@ func TestTranslateIngress(t *testing.T) {
 									{
 										Path:     "",
 										PathType: &pathTypeImplementationSpecific,
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -661,23 +661,23 @@ func TestTranslateIngress(t *testing.T) {
 
 		{
 			name: "when there are multiple backends services, paths wont be combined and separate kong services will be provided",
-			ingress: &networkingv1.Ingress{
+			ingress: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
-				Spec: networkingv1.IngressSpec{
-					Rules: []networkingv1.IngressRule{{
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/v1/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service1",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -686,10 +686,10 @@ func TestTranslateIngress(t *testing.T) {
 									},
 									{
 										Path: "/v2/api",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "test-service2",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -800,12 +800,12 @@ func TestTranslateIngress(t *testing.T) {
 func Test_pathsFromIngressPaths(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		in   networkingv1.HTTPIngressPath
+		in   netv1.HTTPIngressPath
 		out  []*string
 	}{
 		{
 			name: "path type prefix will expand the match to a trailing slash if not provided",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "/v1/api/packages",
 				PathType: &pathTypePrefix,
 			},
@@ -816,7 +816,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type prefix will expand the match with a literal match if a slash is provided",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "/v1/api/packages/",
 				PathType: &pathTypePrefix,
 			},
@@ -827,7 +827,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type prefix will provide a default when no path is provided",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "",
 				PathType: &pathTypePrefix,
 			},
@@ -835,7 +835,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type exact will cause an exact matching path on a regular path",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "/v1/api/packages",
 				PathType: &pathTypeExact,
 			},
@@ -843,7 +843,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type exact will cause an exact matching path on a regular path with a / suffix",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "/v1/api/packages/",
 				PathType: &pathTypeExact,
 			},
@@ -851,7 +851,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type exact will supply a default if no path is provided",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "",
 				PathType: &pathTypeExact,
 			},
@@ -859,7 +859,7 @@ func Test_pathsFromIngressPaths(t *testing.T) {
 		},
 		{
 			name: "path type implementation-specific will leave the path alone",
-			in: networkingv1.HTTPIngressPath{
+			in: netv1.HTTPIngressPath{
 				Path:     "/asdfasd9jhf09432$",
 				PathType: &pathTypeImplementationSpecific,
 			},

--- a/internal/manager/ingressapi.go
+++ b/internal/manager/ingressapi.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,13 +25,13 @@ func negotiateIngressAPI(config *Config, client client.Client) (IngressAPI, erro
 	var allowedAPIs []IngressAPI
 	candidateAPIs := map[IngressAPI]schema.GroupVersionResource{
 		NetworkingV1: {
-			Group:    networkingv1.SchemeGroupVersion.Group,
-			Version:  networkingv1.SchemeGroupVersion.Version,
+			Group:    netv1.SchemeGroupVersion.Group,
+			Version:  netv1.SchemeGroupVersion.Version,
 			Resource: "ingresses",
 		},
 		NetworkingV1beta1: {
-			Group:    networkingv1beta1.SchemeGroupVersion.Group,
-			Version:  networkingv1beta1.SchemeGroupVersion.Version,
+			Group:    netv1beta1.SchemeGroupVersion.Group,
+			Version:  netv1beta1.SchemeGroupVersion.Version,
 			Resource: "ingresses",
 		},
 		ExtensionsV1beta1: {

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 
 	"github.com/sirupsen/logrus"
-	apiv1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -30,9 +30,9 @@ func clusterResourceKeyFunc(obj interface{}) (string, error) {
 
 // FakeObjects can be used to populate a fake Store.
 type FakeObjects struct {
-	IngressesV1beta1   []*networkingv1beta1.Ingress
-	IngressesV1        []*networkingv1.Ingress
-	IngressClassesV1   []*networkingv1.IngressClass
+	IngressesV1beta1   []*netv1beta1.Ingress
+	IngressesV1        []*netv1.Ingress
+	IngressClassesV1   []*netv1.IngressClass
 	HTTPRoutes         []*gatewayv1alpha2.HTTPRoute
 	UDPRoutes          []*gatewayv1alpha2.UDPRoute
 	TCPRoutes          []*gatewayv1alpha2.TCPRoute
@@ -41,9 +41,9 @@ type FakeObjects struct {
 	Gateways           []*gatewayv1alpha2.Gateway
 	TCPIngresses       []*configurationv1beta1.TCPIngress
 	UDPIngresses       []*configurationv1beta1.UDPIngress
-	Services           []*apiv1.Service
-	Endpoints          []*apiv1.Endpoints
-	Secrets            []*apiv1.Secret
+	Services           []*corev1.Service
+	Endpoints          []*corev1.Endpoints
+	Secrets            []*corev1.Secret
 	KongPlugins        []*configurationv1.KongPlugin
 	KongClusterPlugins []*configurationv1.KongClusterPlugin
 	KongIngresses      []*configurationv1.KongIngress

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -60,7 +60,7 @@ func Test_keyFunc(t *testing.T) {
 		{
 			want: "default/foo",
 			args: args{
-				obj: networkingv1beta1.Ingress{
+				obj: netv1beta1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -94,7 +94,7 @@ func TestFakeStoreIngressV1beta1(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	ingresses := []*networkingv1beta1.Ingress{
+	ingresses := []*netv1beta1.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -103,16 +103,16 @@ func TestFakeStoreIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "foo-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -132,16 +132,16 @@ func TestFakeStoreIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: "not-kong",
 				},
 			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{
+			Spec: netv1beta1.IngressSpec{
+				Rules: []netv1beta1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1beta1.IngressRuleValue{
-							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-								Paths: []networkingv1beta1.HTTPIngressPath{
+						IngressRuleValue: netv1beta1.IngressRuleValue{
+							HTTP: &netv1beta1.HTTPIngressRuleValue{
+								Paths: []netv1beta1.HTTPIngressPath{
 									{
 										Path: "/bar",
-										Backend: networkingv1beta1.IngressBackend{
+										Backend: netv1beta1.IngressBackend{
 											ServiceName: "bar-svc",
 											ServicePort: intstr.FromInt(80),
 										},
@@ -166,7 +166,7 @@ func TestFakeStoreIngressV1(t *testing.T) {
 	require := require.New(t)
 
 	defaultClass := annotations.DefaultIngressClass
-	ingresses := []*networkingv1.Ingress{
+	ingresses := []*netv1.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -175,19 +175,19 @@ func TestFakeStoreIngressV1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "foo-svc",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -209,19 +209,19 @@ func TestFakeStoreIngressV1(t *testing.T) {
 					annotations.IngressClassKey: "not-kong",
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
 					{
 						Host: "example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
 									{
 										Path: "/bar",
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
 												Name: "bar-svc",
-												Port: networkingv1.ServiceBackendPort{
+												Port: netv1.ServiceBackendPort{
 													Name:   "http",
 													Number: 80,
 												},
@@ -243,8 +243,8 @@ func TestFakeStoreIngressV1(t *testing.T) {
 					annotations.IngressClassKey: "skip-me-im-not-default",
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules:            []networkingv1.IngressRule{},
+			Spec: netv1.IngressSpec{
+				Rules:            []netv1.IngressRule{},
 				IngressClassName: &defaultClass,
 			},
 		},
@@ -253,8 +253,8 @@ func TestFakeStoreIngressV1(t *testing.T) {
 				Name:      "bar",
 				Namespace: "default",
 			},
-			Spec: networkingv1.IngressSpec{
-				Rules:            []networkingv1.IngressRule{},
+			Spec: netv1.IngressSpec{
+				Rules:            []netv1.IngressRule{},
 				IngressClassName: &defaultClass,
 			},
 		},
@@ -270,12 +270,12 @@ func TestFakeStoreIngressClassV1(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	classes := []*networkingv1.IngressClass{
+	classes := []*netv1.IngressClass{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: networkingv1.IngressClassSpec{
+			Spec: netv1.IngressClassSpec{
 				Controller: IngressClassKongController,
 			},
 		},
@@ -283,7 +283,7 @@ func TestFakeStoreIngressClassV1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "bar",
 			},
-			Spec: networkingv1.IngressClassSpec{
+			Spec: netv1.IngressClassSpec{
 				Controller: IngressClassKongController,
 			},
 		},
@@ -291,7 +291,7 @@ func TestFakeStoreIngressClassV1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "baz",
 			},
-			Spec: networkingv1.IngressClassSpec{
+			Spec: netv1.IngressClassSpec{
 				Controller: "some-other-controller.example.com/controller",
 			},
 		},
@@ -451,7 +451,7 @@ func TestFakeStoreService(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	services := []*apiv1.Service{
+	services := []*corev1.Service{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -476,7 +476,7 @@ func TestFakeStoreEndpiont(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	endpoints := []*apiv1.Endpoints{
+	endpoints := []*corev1.Endpoints{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -629,7 +629,7 @@ func TestFakeStoreSecret(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	secrets := []*apiv1.Secret{
+	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -679,7 +679,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	secrets := []*apiv1.Secret{
+	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -694,7 +694,7 @@ func TestFakeStore_ListCACerts(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(certs, 0)
 
-	secrets = []*apiv1.Secret{
+	secrets = []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,8 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/labels"
@@ -77,11 +77,11 @@ type Storer interface {
 	GetKongPlugin(namespace, name string) (*kongv1.KongPlugin, error)
 	GetKongClusterPlugin(name string) (*kongv1.KongClusterPlugin, error)
 	GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, error)
-	GetIngressClassV1(name string) (*networkingv1.IngressClass, error)
+	GetIngressClassV1(name string) (*netv1.IngressClass, error)
 
-	ListIngressesV1beta1() []*networkingv1beta1.Ingress
-	ListIngressesV1() []*networkingv1.Ingress
-	ListIngressClassesV1() []*networkingv1.IngressClass
+	ListIngressesV1beta1() []*netv1beta1.Ingress
+	ListIngressesV1() []*netv1.Ingress
+	ListIngressClassesV1() []*netv1.IngressClass
 	ListHTTPRoutes() ([]*gatewayv1alpha2.HTTPRoute, error)
 	ListUDPRoutes() ([]*gatewayv1alpha2.UDPRoute, error)
 	ListTCPRoutes() ([]*gatewayv1alpha2.TCPRoute, error)
@@ -111,7 +111,7 @@ type Store struct {
 	kongConsumerClassMatching   annotations.ClassMatching
 
 	isValidIngressClass   func(objectMeta *metav1.ObjectMeta, annotation string, handling annotations.ClassMatching) bool
-	isValidIngressV1Class func(ingress *networkingv1.Ingress, handling annotations.ClassMatching) bool
+	isValidIngressV1Class func(ingress *netv1.Ingress, handling annotations.ClassMatching) bool
 
 	logger logrus.FieldLogger
 }
@@ -228,11 +228,11 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
 		return c.IngressV1beta1.Get(obj)
-	case *networkingv1beta1.Ingress:
+	case *netv1beta1.Ingress:
 		return c.IngressV1beta1.Get(obj)
-	case *networkingv1.Ingress:
+	case *netv1.Ingress:
 		return c.IngressV1.Get(obj)
-	case *networkingv1.IngressClass:
+	case *netv1.IngressClass:
 		return c.IngressClassV1.Get(obj)
 	case *corev1.Service:
 		return c.Service.Get(obj)
@@ -291,11 +291,11 @@ func (c CacheStores) Add(obj runtime.Object) error {
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
 		return c.IngressV1beta1.Add(obj)
-	case *networkingv1beta1.Ingress:
+	case *netv1beta1.Ingress:
 		return c.IngressV1beta1.Add(obj)
-	case *networkingv1.Ingress:
+	case *netv1.Ingress:
 		return c.IngressV1.Add(obj)
-	case *networkingv1.IngressClass:
+	case *netv1.IngressClass:
 		return c.IngressClassV1.Add(obj)
 	case *corev1.Service:
 		return c.Service.Add(obj)
@@ -355,11 +355,11 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 	// ----------------------------------------------------------------------------
 	case *extensions.Ingress:
 		return c.IngressV1beta1.Delete(obj)
-	case *networkingv1beta1.Ingress:
+	case *netv1beta1.Ingress:
 		return c.IngressV1beta1.Delete(obj)
-	case *networkingv1.Ingress:
+	case *netv1.Ingress:
 		return c.IngressV1.Delete(obj)
-	case *networkingv1.IngressClass:
+	case *netv1.IngressClass:
 		return c.IngressClassV1.Delete(obj)
 	case *corev1.Service:
 		return c.Service.Delete(obj)
@@ -468,11 +468,11 @@ func (s Store) GetService(namespace, name string) (*corev1.Service, error) {
 }
 
 // ListIngressesV1 returns the list of Ingresses in the Ingress v1 store.
-func (s Store) ListIngressesV1() []*networkingv1.Ingress {
+func (s Store) ListIngressesV1() []*netv1.Ingress {
 	// filter ingress rules
-	var ingresses []*networkingv1.Ingress
+	var ingresses []*netv1.Ingress
 	for _, item := range s.stores.IngressV1.List() {
-		ing, ok := item.(*networkingv1.Ingress)
+		ing, ok := item.(*netv1.Ingress)
 		if !ok {
 			s.logger.Warnf("listIngressesV1: dropping object of unexpected type: %#v", item)
 			continue
@@ -507,11 +507,11 @@ func (s Store) ListIngressesV1() []*networkingv1.Ingress {
 }
 
 // ListIngressClassesV1 returns the list of Ingresses in the Ingress v1 store.
-func (s Store) ListIngressClassesV1() []*networkingv1.IngressClass {
+func (s Store) ListIngressClassesV1() []*netv1.IngressClass {
 	// filter ingress rules
-	var classes []*networkingv1.IngressClass
+	var classes []*netv1.IngressClass
 	for _, item := range s.stores.IngressClassV1.List() {
-		class, ok := item.(*networkingv1.IngressClass)
+		class, ok := item.(*netv1.IngressClass)
 		if !ok {
 			s.logger.Warnf("listIngressClassesV1: dropping object of unexpected type: %#v", item)
 			continue
@@ -530,9 +530,9 @@ func (s Store) ListIngressClassesV1() []*networkingv1.IngressClass {
 }
 
 // ListIngressesV1beta1 returns the list of Ingresses in the Ingress v1beta1 store.
-func (s Store) ListIngressesV1beta1() []*networkingv1beta1.Ingress {
+func (s Store) ListIngressesV1beta1() []*netv1beta1.Ingress {
 	// filter ingress rules
-	var ingresses []*networkingv1beta1.Ingress
+	var ingresses []*netv1beta1.Ingress
 	for _, item := range s.stores.IngressV1beta1.List() {
 		ing := s.networkingIngressV1Beta1(item)
 		if !s.isValidIngressClass(&ing.ObjectMeta, annotations.IngressClassKey, s.ingressV1Beta1ClassMatching) {
@@ -784,7 +784,7 @@ func (s Store) GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, er
 }
 
 // GetIngressClassV1 returns the 'name' IngressClass resource.
-func (s Store) GetIngressClassV1(name string) (*networkingv1.IngressClass, error) {
+func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
 	p, exists, err := s.stores.IngressClassV1.GetByKey(name)
 	if err != nil {
 		return nil, err
@@ -792,7 +792,7 @@ func (s Store) GetIngressClassV1(name string) (*networkingv1.IngressClass, error
 	if !exists {
 		return nil, ErrNotFound{fmt.Sprintf("IngressClass %v not found", name)}
 	}
-	return p.(*networkingv1.IngressClass), nil
+	return p.(*netv1.IngressClass), nil
 }
 
 // ListKongConsumers returns all KongConsumers filtered by the ingress.class
@@ -882,9 +882,9 @@ func (s Store) ListCACerts() ([]*corev1.Secret, error) {
 	return secrets, nil
 }
 
-func (s Store) networkingIngressV1Beta1(obj interface{}) *networkingv1beta1.Ingress {
+func (s Store) networkingIngressV1Beta1(obj interface{}) *netv1beta1.Ingress {
 	switch obj := obj.(type) {
-	case *networkingv1beta1.Ingress:
+	case *netv1beta1.Ingress:
 		return obj
 
 	case *extensions.Ingress:
@@ -915,16 +915,16 @@ func (s Store) getIngressClassHandling() annotations.ClassMatching {
 	return annotations.ExactClassMatch
 }
 
-func toNetworkingIngressV1Beta1(obj *extensions.Ingress) (*networkingv1beta1.Ingress, error) {
+func toNetworkingIngressV1Beta1(obj *extensions.Ingress) (*netv1beta1.Ingress, error) {
 	js, err := json.Marshal(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize object of type %v: %w", reflect.TypeOf(obj), err)
 	}
-	var out networkingv1beta1.Ingress
+	var out netv1beta1.Ingress
 	if err := json.Unmarshal(js, &out); err != nil {
 		return nil, fmt.Errorf("failed to deserialize json: %w", err)
 	}
-	out.APIVersion = networkingv1beta1.SchemeGroupVersion.String()
+	out.APIVersion = netv1beta1.SchemeGroupVersion.String()
 	return &out, nil
 }
 
@@ -955,8 +955,8 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	// ----------------------------------------------------------------------------
 	case extensions.SchemeGroupVersion.WithKind("Ingress"):
 		return &extensions.Ingress{}, nil
-	case networkingv1.SchemeGroupVersion.WithKind("Ingress"):
-		return &networkingv1.Ingress{}, nil
+	case netv1.SchemeGroupVersion.WithKind("Ingress"):
+		return &netv1.Ingress{}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("TCPIngress"):
 		return &kongv1beta1.TCPIngress{}, nil
 	case corev1.SchemeGroupVersion.WithKind("Service"):

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	netv1 "k8s.io/api/networking/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -26,14 +26,14 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *networking.Ingress
+		want *netv1beta1.Ingress
 	}{
 		{
 			name: "networking.Ingress is returned as is",
 			args: args{
-				obj: &networking.Ingress{},
+				obj: &netv1beta1.Ingress{},
 			},
-			want: &networking.Ingress{},
+			want: &netv1beta1.Ingress{},
 		},
 		{
 			name: "returns nil if a non-ingress object is passed in",
@@ -88,21 +88,21 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 					},
 				},
 			},
-			want: &networking.Ingress{
+			want: &netv1beta1.Ingress{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "networking.k8s.io/v1beta1",
 					Kind:       "Ingress",
 				},
-				Spec: networking.IngressSpec{
-					Rules: []networking.IngressRule{
+				Spec: netv1beta1.IngressSpec{
+					Rules: []netv1beta1.IngressRule{
 						{
 							Host: "example.com",
-							IngressRuleValue: networking.IngressRuleValue{
-								HTTP: &networking.HTTPIngressRuleValue{
-									Paths: []networking.HTTPIngressPath{
+							IngressRuleValue: netv1beta1.IngressRuleValue{
+								HTTP: &netv1beta1.HTTPIngressRuleValue{
+									Paths: []netv1beta1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networking.IngressBackend{
+											Backend: netv1beta1.IngressBackend{
 												ServiceName: "foo-svc",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -113,7 +113,7 @@ func Test_networkingIngressV1Beta1(t *testing.T) {
 						},
 					},
 				},
-				Status: networking.IngressStatus{
+				Status: netv1beta1.IngressStatus{
 					LoadBalancer: corev1.LoadBalancerStatus{
 						Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
 					},

--- a/internal/util/ingressapi.go
+++ b/internal/util/ingressapi.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/discovery"
 )
 
@@ -21,9 +21,9 @@ const (
 func (ia IngressAPI) String() string {
 	switch ia {
 	case NetworkingV1:
-		return networkingv1.SchemeGroupVersion.String()
+		return netv1.SchemeGroupVersion.String()
 	case NetworkingV1beta1:
-		return networkingv1beta1.SchemeGroupVersion.String()
+		return netv1beta1.SchemeGroupVersion.String()
 	case ExtensionsV1beta1:
 		return extensionsv1beta1.SchemeGroupVersion.String()
 	case OtherAPI:

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -47,7 +47,7 @@ func GetNodeIPOrName(ctx context.Context, kubeClient clientset.Interface, name s
 	ip := ""
 
 	for _, address := range node.Status.Addresses {
-		if address.Type == apiv1.NodeExternalIP {
+		if address.Type == corev1.NodeExternalIP {
 			if address.Address != "" {
 				ip = address.Address
 				break
@@ -61,7 +61,7 @@ func GetNodeIPOrName(ctx context.Context, kubeClient clientset.Interface, name s
 	}
 
 	for _, address := range node.Status.Addresses {
-		if address.Type == apiv1.NodeInternalIP {
+		if address.Type == corev1.NodeInternalIP {
 			if address.Address != "" {
 				ip = address.Address
 				break

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
@@ -69,14 +69,14 @@ func TestGetNodeIP(t *testing.T) {
 		{testclient.NewSimpleClientset(), "demo", ""},
 
 		// node not exist
-		{testclient.NewSimpleClientset(&apiv1.NodeList{Items: []apiv1.Node{{
+		{testclient.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "demo",
 			},
-			Status: apiv1.NodeStatus{
-				Addresses: []apiv1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    apiv1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "10.0.0.1",
 					},
 				},
@@ -84,14 +84,14 @@ func TestGetNodeIP(t *testing.T) {
 		}}}), "notexistnode", ""},
 
 		// node  exist
-		{testclient.NewSimpleClientset(&apiv1.NodeList{Items: []apiv1.Node{{
+		{testclient.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "demo",
 			},
-			Status: apiv1.NodeStatus{
-				Addresses: []apiv1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    apiv1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "10.0.0.1",
 					},
 				},
@@ -99,15 +99,15 @@ func TestGetNodeIP(t *testing.T) {
 		}}}), "demo", "10.0.0.1"},
 
 		// search the correct node
-		{testclient.NewSimpleClientset(&apiv1.NodeList{Items: []apiv1.Node{
+		{testclient.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "demo1",
 				},
-				Status: apiv1.NodeStatus{
-					Addresses: []apiv1.NodeAddress{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
 						{
-							Type:    apiv1.NodeInternalIP,
+							Type:    corev1.NodeInternalIP,
 							Address: "10.0.0.1",
 						},
 					},
@@ -117,10 +117,10 @@ func TestGetNodeIP(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "demo2",
 				},
-				Status: apiv1.NodeStatus{
-					Addresses: []apiv1.NodeAddress{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
 						{
-							Type:    apiv1.NodeInternalIP,
+							Type:    corev1.NodeInternalIP,
 							Address: "10.0.0.2",
 						},
 					},
@@ -129,17 +129,17 @@ func TestGetNodeIP(t *testing.T) {
 		}}), "demo2", "10.0.0.2"},
 
 		// get NodeExternalIP
-		{testclient.NewSimpleClientset(&apiv1.NodeList{Items: []apiv1.Node{{
+		{testclient.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "demo",
 			},
-			Status: apiv1.NodeStatus{
-				Addresses: []apiv1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    apiv1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "10.0.0.1",
 					}, {
-						Type:    apiv1.NodeExternalIP,
+						Type:    corev1.NodeExternalIP,
 						Address: "10.0.0.2",
 					},
 				},
@@ -147,17 +147,17 @@ func TestGetNodeIP(t *testing.T) {
 		}}}), "demo", "10.0.0.2"},
 
 		// get NodeInternalIP
-		{testclient.NewSimpleClientset(&apiv1.NodeList{Items: []apiv1.Node{{
+		{testclient.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "demo",
 			},
-			Status: apiv1.NodeStatus{
-				Addresses: []apiv1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    apiv1.NodeExternalIP,
+						Type:    corev1.NodeExternalIP,
 						Address: "",
 					}, {
-						Type:    apiv1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "10.0.0.2",
 					},
 				},
@@ -185,7 +185,7 @@ func TestGetPodDetails(t *testing.T) {
 
 	// POD_NAME not exist
 	os.Setenv("POD_NAME", "")
-	os.Setenv("POD_NAMESPACE", apiv1.NamespaceDefault)
+	os.Setenv("POD_NAMESPACE", corev1.NamespaceDefault)
 	_, err2 := GetPodDetails(ctx, testclient.NewSimpleClientset())
 	if err2 == nil {
 		t.Errorf("expected an error but returned nil")
@@ -201,7 +201,7 @@ func TestGetPodDetails(t *testing.T) {
 
 	// POD not exist
 	os.Setenv("POD_NAME", "testpod")
-	os.Setenv("POD_NAMESPACE", apiv1.NamespaceDefault)
+	os.Setenv("POD_NAMESPACE", corev1.NamespaceDefault)
 	_, err4 := GetPodDetails(ctx, testclient.NewSimpleClientset())
 	if err4 == nil {
 		t.Errorf("expected an error but returned nil")
@@ -209,24 +209,24 @@ func TestGetPodDetails(t *testing.T) {
 
 	// success to get PodInfo
 	fkClient := testclient.NewSimpleClientset(
-		&apiv1.PodList{Items: []apiv1.Pod{{
+		&corev1.PodList{Items: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testpod",
-				Namespace: apiv1.NamespaceDefault,
+				Namespace: corev1.NamespaceDefault,
 				Labels: map[string]string{
 					"first":  "first_label",
 					"second": "second_label",
 				},
 			},
 		}}},
-		&apiv1.NodeList{Items: []apiv1.Node{{
+		&corev1.NodeList{Items: []corev1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "demo",
 			},
-			Status: apiv1.NodeStatus{
-				Addresses: []apiv1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    apiv1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "10.0.0.1",
 					},
 				},

--- a/internal/util/objectmeta_test.go
+++ b/internal/util/objectmeta_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -17,7 +17,7 @@ func TestFromK8sObject(t *testing.T) {
 	}{
 		{
 			name: "empty annotations",
-			in: &networkingv1beta1.Ingress{
+			in: &netv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "namespace",
@@ -31,7 +31,7 @@ func TestFromK8sObject(t *testing.T) {
 		},
 		{
 			name: "has annotations",
-			in: &networkingv1beta1.Ingress{
+			in: &netv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "name",
 					Namespace:   "namespace",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses inconsistent import alias naming throughout the code base.

The proposed aliases and imports set are subject for debate.