### PR TITLE
refactor: add generic Gateway Routes to kong.Route translation functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
+	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/kong/deck v1.13.0
 	github.com/kong/go-kong v0.30.0
@@ -87,7 +88,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/internal/dataplane/parser/translate_routes_helpers.go
+++ b/internal/dataplane/parser/translate_routes_helpers.go
@@ -1,0 +1,183 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kong/go-kong/kong"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// -----------------------------------------------------------------------------
+// Translate Gateway Routes - Utils
+// -----------------------------------------------------------------------------
+
+type tTCPorUDPorTLSRoute interface {
+	// Only accept TCP, UDP and TLS routes
+	*gatewayv1alpha2.UDPRoute | *gatewayv1alpha2.TCPRoute | *gatewayv1alpha2.TLSRoute
+}
+
+type tRoute interface {
+	tTCPorUDPorTLSRoute
+	// Route fullfills client.Object interface (necessary for e.g. GetObjectKind()).
+	client.Object
+}
+
+type tRouteRule interface {
+	gatewayv1alpha2.UDPRouteRule | gatewayv1alpha2.TCPRouteRule | gatewayv1alpha2.TLSRouteRule
+}
+
+// getBackendRefs returns BackendRefs from TCPRouteRule, UDPRouteRule or TLSRouteRule.
+func getBackendRefs[TRouteRule tRouteRule](t TRouteRule) ([]gatewayv1alpha2.BackendRef, error) {
+	// This is necessary because as of go1.18 (and go1.19) one cannot use common
+	// struct fields in generic code.
+	//
+	// Related golang issue: https://github.com/golang/go/issues/48522
+	switch tt := any(t).(type) {
+	case gatewayv1alpha2.UDPRouteRule:
+		if len(tt.BackendRefs) == 0 {
+			return nil, errors.New("UDPRoute rules must include at least one backendRef")
+		}
+		return tt.BackendRefs, nil
+	case gatewayv1alpha2.TCPRouteRule:
+		if len(tt.BackendRefs) == 0 {
+			return nil, errors.New("TCPRoute rules must include at least one backendRef")
+		}
+		return tt.BackendRefs, nil
+	case gatewayv1alpha2.TLSRouteRule:
+		// TLSRoutes don't require BackendRefs.
+		return tt.BackendRefs, nil
+	}
+
+	// This should never happen because we use type constraints on what types
+	// are accepted.
+	return nil, nil
+}
+
+// generateKongRoutesFromRouteRule converts a Gateway Route (TCP, UDP or TLS) rule
+// to one or more Kong Route objects to route traffic to services.
+func generateKongRoutesFromRouteRule[T tRoute, TRule tRouteRule](
+	route T,
+	ruleNumber int,
+	rule TRule,
+) ([]kongstate.Route, error) {
+	backendRefs, err := getBackendRefs(rule)
+	if err != nil {
+		return []kongstate.Route{}, err
+	}
+
+	return []kongstate.Route{
+		{
+			Ingress: util.FromK8sObject(route),
+			Route:   routeToKongRoute(route, backendRefs, ruleNumber),
+		},
+	}, nil
+}
+
+// routeToKongRoute converts Gateway Route to kong.Route.
+func routeToKongRoute[TRoute tTCPorUDPorTLSRoute](
+	r TRoute,
+	backendRefs []gatewayv1alpha2.BackendRef,
+	ruleNumber int,
+) kong.Route {
+	switch rr := any(r).(type) {
+	case *gatewayv1alpha2.UDPRoute:
+		return udpRouteToKongRoute(rr, backendRefs, ruleNumber)
+	case *gatewayv1alpha2.TCPRoute:
+		return tcpRouteToKongRoute(rr, backendRefs, ruleNumber)
+	case *gatewayv1alpha2.TLSRoute:
+		return tlsRouteToKongRoute(rr, ruleNumber)
+	}
+
+	return kong.Route{}
+}
+
+func udpRouteToKongRoute(
+	r *gatewayv1alpha2.UDPRoute,
+	backendRefs []gatewayv1alpha2.BackendRef,
+	ruleNumber int,
+) kong.Route {
+	return kong.Route{
+		Name: kong.String(
+			generateRouteName(udpRouteType, r.Namespace, r.Name, ruleNumber)),
+		Protocols:    kong.StringSlice("udp"),
+		Destinations: backendRefsToKongCIDRPorts(backendRefs),
+	}
+}
+
+func tcpRouteToKongRoute(
+	r *gatewayv1alpha2.TCPRoute,
+	backendRefs []gatewayv1alpha2.BackendRef,
+	ruleNumber int,
+) kong.Route {
+	return kong.Route{
+		Name: kong.String(
+			generateRouteName(tcpRouteType, r.Namespace, r.Name, ruleNumber)),
+		Protocols:    kong.StringSlice("tcp"),
+		Destinations: backendRefsToKongCIDRPorts(backendRefs),
+	}
+}
+
+func backendRefsToKongCIDRPorts(backendRefs []gatewayv1alpha2.BackendRef) []*kong.CIDRPort {
+	// For now, Gateway Routes provide no means of specifying a destination port
+	// other than the backend target port
+	//
+	// They will once https://gateway-api.sigs.k8s.io/geps/gep-957/ is stable.
+	// In the interim, this always uses the backend target.
+	//
+	// NOTE: The above is now implemented via:
+	// https://github.com/kubernetes-sigs/gateway-api/pull/1002 and here's the
+	// related issue in KIC:
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/2709
+	destinations := make([]*kong.CIDRPort, 0, len(backendRefs))
+	for _, backendRef := range backendRefs {
+		if backendRef.Port == nil {
+			continue // Should we propagate the error?
+		}
+
+		destinations = append(destinations,
+			&kong.CIDRPort{
+				Port: kong.Int(int(*backendRef.Port)),
+			},
+		)
+	}
+	return destinations
+}
+
+func tlsRouteToKongRoute(r *gatewayv1alpha2.TLSRoute, ruleNumber int) kong.Route {
+	hostnames := make([]*string, 0, len(r.Spec.Hostnames))
+	for _, hostname := range r.Spec.Hostnames {
+		hostnames = append(hostnames, kong.String(string(hostname)))
+	}
+
+	return kong.Route{
+		Name: kong.String(
+			generateRouteName(tlsRouteType, r.Namespace, r.Name, ruleNumber)),
+		Protocols: kong.StringSlice("tls"),
+		SNIs:      hostnames,
+	}
+}
+
+type routeType string
+
+const (
+	tlsRouteType routeType = "tlsroute"
+	tcpRouteType routeType = "tcproute"
+	udpRouteType routeType = "udproute"
+)
+
+// generateRouteName returns a route name for kong.Route given the provided params.
+func generateRouteName(typ routeType, namespace, name string, ruleNumber int) string {
+	return fmt.Sprintf(
+		"%s.%s.%s.%d.%d",
+		typ,
+		namespace,
+		name,
+		ruleNumber,
+		0,
+	)
+}

--- a/internal/dataplane/parser/translate_routes_helpers_test.go
+++ b/internal/dataplane/parser/translate_routes_helpers_test.go
@@ -1,0 +1,225 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+func addressOf[T any](t T) *T {
+	return &t
+}
+
+func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
+	testcases := []struct {
+		name      string
+		route     *gatewayv1alpha2.TCPRoute
+		routeRule gatewayv1alpha2.TCPRouteRule
+		expected  []kongstate.Route
+	}{
+		{
+			name: "TCPRoute gets translated correctly to kong.Route",
+			route: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytcproute-name",
+					Namespace: "mynamespace",
+				},
+			},
+			routeRule: gatewayv1alpha2.TCPRouteRule{
+				BackendRefs: []gatewayv1alpha2.BackendRef{
+					{
+						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+							Port: addressOf(gatewayv1alpha2.PortNumber(1234)),
+						},
+					},
+				},
+			},
+			expected: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:        "mytcproute-name",
+						Namespace:   "mynamespace",
+						Annotations: map[string]string{},
+					},
+					Route: kong.Route{
+						Name: addressOf("tcproute.mynamespace.mytcproute-name.0.0"),
+						Destinations: []*kong.CIDRPort{
+							{
+								Port: addressOf(1234),
+							},
+						},
+						Protocols: []*string{
+							addressOf("tcp"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, 0, tc.routeRule)
+			require.NoError(t, err)
+			require.NotNil(t, kongRoutes)
+			if !cmp.Equal(tc.expected, kongRoutes) {
+				t.Logf("actual []kongstate.Route differs from expected\n%s", cmp.Diff(tc.expected, kongRoutes))
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
+	testcases := []struct {
+		name      string
+		route     *gatewayv1alpha2.UDPRoute
+		routeRule gatewayv1alpha2.UDPRouteRule
+		expected  []kongstate.Route
+	}{
+		{
+			name: "UDPRoute gets translated correctly to kong.Route",
+			route: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myudproute-name",
+					Namespace: "mynamespace",
+				},
+			},
+			routeRule: gatewayv1alpha2.UDPRouteRule{
+				BackendRefs: []gatewayv1alpha2.BackendRef{
+					{
+						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+							Port: addressOf(gatewayv1alpha2.PortNumber(1234)),
+						},
+					},
+				},
+			},
+			expected: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:        "myudproute-name",
+						Namespace:   "mynamespace",
+						Annotations: map[string]string{},
+					},
+					Route: kong.Route{
+						Name: addressOf("udproute.mynamespace.myudproute-name.0.0"),
+						Destinations: []*kong.CIDRPort{
+							{
+								Port: addressOf(1234),
+							},
+						},
+						Protocols: []*string{
+							addressOf("udp"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, 0, tc.routeRule)
+			require.NoError(t, err)
+			require.NotNil(t, kongRoutes)
+			if !cmp.Equal(tc.expected, kongRoutes) {
+				t.Logf("actual []kongstate.Route differs from expected\n%s", cmp.Diff(tc.expected, kongRoutes))
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
+	testcases := []struct {
+		name      string
+		route     *gatewayv1alpha2.TLSRoute
+		routeRule gatewayv1alpha2.TLSRouteRule
+		expected  []kongstate.Route
+	}{
+		{
+			name: "TLSRoute gets translated correctly to kong.Route",
+			route: &gatewayv1alpha2.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytlsroute-name",
+					Namespace: "mynamespace",
+				},
+				Spec: gatewayv1alpha2.TLSRouteSpec{
+					Hostnames: []gatewayv1alpha2.Hostname{
+						"hostname.com",
+						"hostname2.com",
+					},
+				},
+			},
+			routeRule: gatewayv1alpha2.TLSRouteRule{},
+			expected: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:        "mytlsroute-name",
+						Namespace:   "mynamespace",
+						Annotations: map[string]string{},
+					},
+					Route: kong.Route{
+						Name: addressOf("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						SNIs: []*string{
+							addressOf("hostname.com"),
+							addressOf("hostname2.com"),
+						},
+						Protocols: []*string{
+							addressOf("tls"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TLSRoute without hostnames gets translated correctly to kong.Route without SNIs",
+			route: &gatewayv1alpha2.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytlsroute-name",
+					Namespace: "mynamespace",
+				},
+				Spec: gatewayv1alpha2.TLSRouteSpec{},
+			},
+			routeRule: gatewayv1alpha2.TLSRouteRule{},
+			expected: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:        "mytlsroute-name",
+						Namespace:   "mynamespace",
+						Annotations: map[string]string{},
+					},
+					Route: kong.Route{
+						Name: addressOf("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						SNIs: []*string{},
+						Protocols: []*string{
+							addressOf("tls"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, 0, tc.routeRule)
+			require.NoError(t, err)
+			require.NotNil(t, kongRoutes)
+			if !cmp.Equal(tc.expected, kongRoutes) {
+				t.Logf("actual []kongstate.Route differs from expected\n%s", cmp.Diff(tc.expected, kongRoutes))
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This extracts the common bits of Gateway Routes to `kong.Route` translation into common functions (which could also be extended to other types like `HTTPRoute`).

