### PR TITLE
chore: remove boilerplate in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
+<!-- Thanks for sending a pull request! Here are some tips for you:
 1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
 2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
@@ -6,9 +6,27 @@
 
 **What this PR does / why we need it**:
 
-**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
+<!-- Please describe why this particular PR is necessary or why do you see it as a nice addition -->
+
+**Which issue this PR fixes**:
+
+<!--
+Here you can add any links to issues that this PR is relevant for.
+You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
+the linked issue(s) when this PR gets merged.
+-->
+
+<!--
+Here you can add any links to issues that this PR is relevant for.
+You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
+the linked issue(s) when this PR gets merged.
+
+For example: fixes #<issue number>
+-->
 
 **Special notes for your reviewer**:
+
+<!-- Here you can add any open questions or notes that you might have for reviewers -->
 
 **PR Readiness Checklist**:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the unnecessary PR template boilerplate which often ends up in the final PR description. Specifically this removes:

```
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```

from `Which issue this PR fixes` section and adds comments documenting what is expected in particular section. Thanks to the usage of comments, there should be no boilerplate being added to the final PR description and one can hope that the contributors will place their comments in designated places.
