### PR TITLE
ci: add labels checker

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,0 +1,15 @@
+name: PRs labels check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pmalek/verify-pr-label-action@v1.4.5
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          invalid-labels: 'do not merge,on-hold'
+          pull-request-number: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to prevent accidentally merging PRs that shouldn't be merged - due to labels set on them - but have all the checks pass successfully which might make it tempting to merge.

For now it only blocks PRs with those labels:

- `do not merge`
- `on-hold`