### PR TITLE
ci: add tests build tags to golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,13 @@
 run:
   timeout: 5m
   skip-dirs:
-  - pkg/client
+  - pkg/clientset
   - pkg/apis
+  - config
+  build-tags:
+  - integration_tests
+  - e2e_tests
+  - conformance_tests
 linters:
   enable:
   - asciicheck

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -301,7 +301,7 @@ func startPortForwarder(ctx context.Context, t *testing.T, env environments.Envi
 	}, kongComponentWait, time.Second)
 }
 
-func getKubernetesLogs(t *testing.T, env environments.Environment, namespace, name string) (string, error) { //nolint:deadcode,unused
+func getKubernetesLogs(t *testing.T, env environments.Environment, namespace, name string) (string, error) {
 	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
 	require.NoError(t, err)
 	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "deploy-logs-tests-kubeconfig-")

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -137,7 +137,7 @@ func gatewayLinkStatusMatches(t *testing.T, c *gatewayclient.Clientset, verifyLi
 	var routeParents []gatewayv1alpha2.RouteParentStatus
 
 	// gather a fresh copy of the route, given the specific protocol type
-	switch protocolType {
+	switch protocolType { //nolint:exhaustive
 	case gatewayv1alpha2.HTTPProtocolType:
 		route, err := c.GatewayV1alpha2().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -109,7 +109,7 @@ func TestKnativeIngress(t *testing.T) {
 
 func configKnativeDomain(ctx context.Context, proxy, nsn string, cluster clusters.Cluster) error {
 	// generate the new config-domain configmap
-	configMap := v1.ConfigMap{
+	configMap := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -154,7 +154,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 
 		conds := curIng.Status.Status.GetConditions()
 		for _, cond := range conds {
-			if cond.Type == apis.ConditionReady && cond.Status == v1.ConditionTrue {
+			if cond.Type == apis.ConditionReady && cond.Status == corev1.ConditionTrue {
 				t.Logf("knative ingress %s/%s status is ready.", curIng.Namespace, curIng.Name)
 				return true
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the following builds tags to `golangci-lint` invocation so that tests code is also linted:

- `integration_tests`
- `e2e_tests`
- `conformance_tests`

It also fixes the excluded dirs in the config: `pkg/client` doesn't exist so it was replaced by `pkg/clientset` which contains generated code and `config` dir was also added as it only contains the k8s manifests.
