### PR TITLE
ci(lint): do check errors in tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,10 +73,6 @@ issues:
   fix: true
   exclude-rules:
   - linters:
-    - staticcheck
-    text:  "SA4006" # ignore err not checked in test files
-    path: _test\.go
-  - linters:
     - ineffassign
     text:  "ineffectual assignment" # ignore err not checked in test files
     path: _test\.go

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -78,13 +78,15 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngress(ctx, t, env)
 	service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
+	require.NoError(t, err)
 
 	t.Logf("service %#v", service)
 	if service.ObjectMeta.Annotations == nil {
 		service.ObjectMeta.Annotations = map[string]string{}
 	}
 	service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
-	service, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
+	require.NoError(t, err)
 	verifyIngress(ctx, t, env)
 }
 
@@ -156,7 +158,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 		service.ObjectMeta.Annotations = map[string]string{}
 	}
 	service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
-	service, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
+	_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
 	require.NoError(t, err,
 		func() string {
 			service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -601,7 +601,7 @@ func TestTLSRouteReferencePolicy(t *testing.T) {
 
 	t.Log("verifying the certificate returns when using a ReferencePolicy with no name restrictions")
 	policy.Spec.To[0].Name = nil
-	policy, err = gatewayClient.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
+	_, err = gatewayClient.GatewayV1alpha2().ReferencePolicies(otherNs.Name).Update(ctx, policy, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes an exception from `golangci-lint`'s config which allowed to not check errors in test files.
