### PR TITLE
fix(admission) allow mtls-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
 - Added support for plugin ordering (requires Kong Enterprise 3.0 or higher).
   [#2657](https://github.com/Kong/kubernetes-ingress-controller/pull/2657)
 
+#### Fixed
+
+- Added `mtls-auth` to the admission webhook supported credential types list.
+  [#2739](https://github.com/Kong/kubernetes-ingress-controller/pull/2739)
+
 ## [2.5.0]
 
 > Release date: 2022-07-11

--- a/internal/validation/consumers/credentials/vars.go
+++ b/internal/validation/consumers/credentials/vars.go
@@ -18,6 +18,7 @@ var SupportedTypes = sets.NewString(
 	"key-auth",
 	"oauth2",
 	"acl",
+	"mtls-auth"
 )
 
 var (

--- a/internal/validation/consumers/credentials/vars.go
+++ b/internal/validation/consumers/credentials/vars.go
@@ -18,7 +18,7 @@ var SupportedTypes = sets.NewString(
 	"key-auth",
 	"oauth2",
 	"acl",
-	"mtls-auth"
+	"mtls-auth",
 )
 
 var (


### PR DESCRIPTION

**What this PR does / why we need it**:

`mtls-auth` was omitted from the supported types list since the inception of this validator, although we added supported fields for it.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR