### PR TITLE
test(e2e) dump service status if failed to update in kuma test

### DIFF
--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -86,7 +86,16 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	}
 	service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
 	_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
-	require.NoError(t, err)
+	require.NoError(t, err,
+		// dump the status of service if the error happens on updating service.
+		func() string {
+			service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
+			if err != nil {
+				return fmt.Sprintf("failed to dump service, error %v", err)
+			}
+			return fmt.Sprintf("current status of service: %#v", service)
+		}(),
+	)
 	verifyIngress(ctx, t, env)
 }
 
@@ -160,6 +169,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
 	_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
 	require.NoError(t, err,
+		// dump the status of service if the error happens on updating service.
 		func() string {
 			service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

https://github.com/Kong/kubernetes-ingress-controller/runs/7513607112?check_suite_focus=true 

```
    kuma_test.go:89: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/kuma_test.go:89
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on services "httpbin": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestDeployAllInOneDBLESSKuma
```

error happens in e2e run of `TestDeployAllInOneDBLESSKuma`. added function dumping service when updating fails.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

related: #2733 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
