### PR TITLE
chore(actions) move build and push image step to be after tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -99,7 +99,6 @@ jobs:
   # run integration test in latest version of kubernetes.
   test-current-kubernetes:
     runs-on: ubuntu-latest
-    needs: build-push-images
     strategy:
       matrix:
         kubernetes-version:
@@ -129,7 +128,6 @@ jobs:
   test-previous-kubernetes:
     environment: gcloud
     runs-on: ubuntu-latest
-    needs: build-push-images
     strategy:
       matrix:
         minor:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
 
   test-current-kubernetes:
     runs-on: ubuntu-latest
-    needs: build-push-images
+    needs: verify-manifest-tag
     strategy:
       matrix:
         kubernetes-version:
@@ -184,7 +184,7 @@ jobs:
   test-previous-kubernetes:
     environment: gcloud
     runs-on: ubuntu-latest
-    needs: build-push-images
+    needs: verify-manifest-tag
     strategy:
       matrix:
         minor:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

move the build and push image step in nightly and release actions to be after tests, since the building step on `linux/arm64` costs too long.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2744 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
affects to current actions: if the integration tests fails, the images for nightly build/release may not be pushed.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
