### PR TITLE
test(e2e) dump logs of KIC pods and pass the test if there is one leader

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,3 +55,11 @@ jobs:
         ISTIO_VERSION: ${{ matrix.istio_version }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job, so only 1 is allowed at a time.
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-e2e-tests
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -92,6 +92,14 @@ jobs:
         ISTIO_VERSION: ${{ github.event.inputs.istio-version }}
         NCPU: 1
 
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-e2e-tests
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+
   integration-tests:
     if: ${{ github.event.inputs.include-integration == 'true' }}
     environment: "Configure ci"
@@ -126,3 +134,11 @@ jobs:
       env:
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -301,26 +301,6 @@ func startPortForwarder(ctx context.Context, t *testing.T, env environments.Envi
 	}, kongComponentWait, time.Second)
 }
 
-func getKubernetesLogs(t *testing.T, env environments.Environment, namespace, name string) (string, error) {
-	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
-	require.NoError(t, err)
-	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "deploy-logs-tests-kubeconfig-")
-	require.NoError(t, err)
-	defer os.Remove(kubeconfigFile.Name())
-	defer kubeconfigFile.Close()
-	written, err := kubeconfigFile.Write(kubeconfig)
-	require.NoError(t, err)
-	require.Equal(t, len(kubeconfig), written)
-	stderr := new(bytes.Buffer)
-	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigFile.Name(), "logs", "-n", namespace, name, "--all-containers") //nolint:gosec
-	cmd.Stderr = stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("%s", stderr.String())
-	}
-	return string(out), nil
-}
-
 // httpGetResponseContains returns true if the response body of GETting the URL contains specified substring.
 func httpGetResponseContains(t *testing.T, url string, client *http.Client, substring string) bool {
 	req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- dump logs of pods in KIC deployment in `TestDeployAllInOnePostgresWithMultipleReplicas` it it fails, to see the status of leader election.
- pass the test if any one of the pod became the leader to solve the flakiness
.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
related:  #2670 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
