### PR TITLE
chore(tests) add retry on setting ingress class

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -10,7 +10,11 @@ import (
 	"time"
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -182,4 +186,35 @@ func gatewayLinkStatusMatches(t *testing.T, c *gatewayclient.Clientset, verifyLi
 	// supported Gateway link was not found, hence if we want to ensure
 	// the link existence return false
 	return !verifyLinked
+}
+
+// setIngressClassNameWithRetry changes Ingress.Spec.IngressClassName to specified value
+// and retries if update conflict happens.
+func setIngressClassNameWithRetry(ctx context.Context, namespace string, obj runtime.Object, ingressClassName *string) error {
+	switch ingress := obj.(type) {
+	case *netv1.Ingress:
+		ingressClient := env.Cluster().Client().NetworkingV1().Ingresses(namespace)
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			ingress, err := ingressClient.Get(ctx, ingress.ObjectMeta.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			ingress.Spec.IngressClassName = ingressClassName
+			_, err = ingressClient.Update(ctx, ingress, metav1.UpdateOptions{})
+			return err
+		})
+	case *netv1beta1.Ingress:
+		ingressClient := env.Cluster().Client().NetworkingV1beta1().Ingresses(namespace)
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			ingress, err := ingressClient.Get(ctx, ingress.ObjectMeta.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			ingress.Spec.IngressClassName = ingressClassName
+			_, err = ingressClient.Update(ctx, ingress, metav1.UpdateOptions{})
+			return err
+		})
+
+	}
+	return fmt.Errorf("unsupported GroupVersionKind %v", obj.GetObjectKind())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

use retry on setting `ingress.spec.class` in `TestIngressClassNameSpec` because nightly build failed:
https://github.com/Kong/kubernetes-ingress-controller/runs/7596036145?check_suite_focus=true
```
    ingress_test.go:352: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/ingress_test.go:352
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on ingresses.networking.k8s.io "httpbin": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestIngressClassNameSpec
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
