### PR TITLE
chore(ci) omit tests from license scan

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        # we do not want to include test-only dependencies
+        # that will not be compiled into release artifacts
+      - shell: bash
+        run: sudo rm -vrf test
       - uses: fossas/fossa-action@v1
         with:
           api-key: ${{secrets.fossaApiKey}}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -9,11 +9,17 @@ jobs:
     environment: "FOSSA"
     runs-on: ubuntu-latest
     steps:
+      - name: setup golang                     
+        uses: actions/setup-go@v3          
+        with:                                     
+          go-version: '^1.18'    
       - uses: actions/checkout@v3
         # we do not want to include test-only dependencies
         # that will not be compiled into release artifacts
       - shell: bash
         run: sudo rm -vrf test
+      - shell: bash
+        run: go mod tidy
       - uses: fossas/fossa-action@v1
         with:
           api-key: ${{secrets.fossaApiKey}}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 
-	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
+	testutils "github.com/kong/kubernetes-ingress-controller/v2/test/internal/util"
 )
 
 var (

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -28,10 +28,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	testutils "github.com/kong/kubernetes-ingress-controller/v2/test/internal/util"
 )
 
 var (

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
-	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
+	testutils "github.com/kong/kubernetes-ingress-controller/v2/test/internal/util"
 )
 
 var k8sClient *kubernetes.Clientset

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
+	testutils "github.com/kong/kubernetes-ingress-controller/v2/test/internal/util"
 )
 
 // extraWebhookNamespace is an additional namespace used by tests when needing

--- a/test/internal/util/controller_manager.go
+++ b/test/internal/util/controller_manager.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import (
 	"context"

--- a/test/internal/util/crds.go
+++ b/test/internal/util/crds.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import (
 	"bytes"

--- a/test/internal/util/webhooks.go
+++ b/test/internal/util/webhooks.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 const (
 	// KongSystemServiceCert is a testing TLS certificate with SAN *.kong-system.svc.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `test` directory before initiating the license scan, to omit test-only dependencies from license reports.

We include our application and its tests in the same repo. The tests aren't compiled into any release artifacts, so it doesn't make sense to include them in the license report we ship with those artifacts. They're also the source of a fair number of license issue reports that we need to investigate and ignore.

Per FOSSA, there's no Go-specific functionality to ignore certain build tags, but deleting those files has the same effect, and we conveniently have those under the same directory (not units, but they're not usually the source of spurious reports because they usually don't add dependencies their package didn't already have).

See [test.txt](https://github.com/Kong/kubernetes-ingress-controller/files/9245901/test.txt) for a POC example with some extra `ls` calls thrown into the job.