### PR TITLE
chore(ci): don't review code for labels checker

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -13,3 +13,4 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           invalid-labels: 'do not merge,on-hold'
           pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR [disables reviews](https://github.com/pmalek/verify-pr-label-action#disable-reviews) from [labels checker](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/check_pr_labels.yaml) so that now whenever a "blocking label" is used, the GH action would fail instead of submitting a review requesting changes.