### PR TITLE
chore(ci) make nightly tests conditional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,58 +154,6 @@ jobs:
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
 
-  integration-tests-enterprise-postgres-nightly:
-    environment: "Configure ci"
-    runs-on: ubuntu-latest
-    steps:
-
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
-        password: ${{ secrets.PULP_PASSWORD }}
-
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.18'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: run integration tests
-      run: make test.integration.enterprise.postgres
-      env:
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: "kong/kong-gateway-internal"
-        TEST_KONG_TAG: "master-nightly-alpine"
-        TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
-        TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: coverage.enterprisepostgres.out
-
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-integration-tests-enterprise-postgres-nightly
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-
   integration-tests-dbless:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,0 +1,62 @@
+name: tests-nightly
+
+on:
+  pull_request:
+    types:
+      - labeled
+  workflow_dispatch: {}
+
+jobs:
+  integration-tests-enterprise-postgres-nightly:
+    if: ${{ github.event.label.name == 'ci/run-nightly' }}
+    environment: "Configure ci"
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: run integration tests
+      run: make test.integration.enterprise.postgres
+      env:
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        TEST_KONG_IMAGE: "kong/kong-gateway-internal"
+        TEST_KONG_TAG: "master-nightly-alpine"
+        TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
+        TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
+
+    - name: collect test coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: coverage.enterprisepostgres.out
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests-enterprise-postgres-nightly
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the nightly Kong image tests from the normal test run.

Run nightly Kong image tests when the PR has a "ci/run-nightly" label or via dispatch.

**Special notes for your reviewer**:

As reviewers have probably observed, the nightly image tests fail rather often, because the nightly image is apparently less stable for existing functionality than we'd have hoped, and not reporting much in terms of useful failures (most of the failed nightly runs I've reviewed just exceeded the timeout for some reason, instead of indicating some particular failure).

We only _need_ these tests on PRs that introduce features to support as-yet unreleased Kong functionality, so I think this is probably the best option. I plan to discuss this in tomorrow's team meeting, but figured I'd prepare this in advance.

PR demos itself; you'll have to trust me that I reviewed the list before adding the label and confirmed that nightly was absent.