### PR TITLE
feat: promote Gateway feature gate to beta

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -309,7 +309,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
       env:
-        KONG_CONTROLLER_FEATURE_GATES: "Gateway=true,CombinedRoutes=true"
+        KONG_CONTROLLER_FEATURE_GATES: "GatewayAlpha=true,CombinedRoutes=true"
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@
   resources, allowing non-admin users to apply these manifests (minus the
   Gateway API role) on clusters without Gateway API CRDs installed.
   [#2529](https://github.com/Kong/kubernetes-ingress-controller/issues/2529)
+- Gateway API support which had previously been off by default behind a feature
+  gate (`--feature-gates=Gateway=true`) is now **on by default** and covers beta
+  stage APIs (`GatewayClass`, `Gateway`, and `HTTPRoute`). Alpha stage APIs
+  (`TCPRoute`, `UDPRoute`, `TLSRoute`, `ReferenceGrant`) have been moved behind
+  a different feature gate called `GatewayAlpha` and are off by default. When
+  upgrading if you're using the alpha APIs, switch your feature gate flags to
+  `--feature-gates=GatewayAlpha=true` to keep them enabled.
+  [#2781](https://github.com/Kong/kubernetes-ingress-controller/pull/2781)
 
 #### Fixed
 
@@ -73,6 +81,13 @@
   [#2724](https://github.com/Kong/kubernetes-ingress-controller/pull/2724)
 - ReferencePolicy support has been dropped in favor of the newer ReferenceGrant API.
   [#2775](https://github.com/Kong/kubernetes-ingress-controller/pull/2772)
+  Fixed a bug that cased the `Knative` feature gate to not be checked. Since our
+  knative integration is on by default and because it gets very little usage
+  this likely did not cause any troubles for anyone as all fixing this will do
+  is make it possible to disable the knative controller using the feature gate.
+  (it is also possible to control it via the `--enable-controller-knativeingress`
+  which was working properly).
+  [#2781](https://github.com/Kong/kubernetes-ingress-controller/pull/2781)
 
 ## [2.5.0]
 

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -57,6 +57,13 @@ Features that reach GA and over time become stable will be removed from this tab
 | Feature                | Default | Stage | Since | Until |
 |------------------------|---------|-------|-------|-------|
 | Knative                | `true`  | Alpha | 0.8.0 | TBD   |
-| Gateway                | `false` | Alpha | 2.2.0 | TBD   |
+| Gateway                | `true`  | Beta  | 2.2.0 | TBD   |
 | CombinedRoutes         | `false` | Alpha | 2.4.0 | TBD   |
 | IngressClassParameters | `false` | Alpha | 2.6.0 | TBD   |
+| GatewayAlpha           | `false` | Alpha | 2.6.0 | TBD   |
+
+**NOTE**: The `Gateway` feature gate refers to [Gateway
+ API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in
+ `v1beta1` or later. `GatewayAlpha` refers to APIs which are still in alpha.
+ These are separated to make a clear distinction in the support stage for these
+ APIs.

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ PKG_LIST = ./pkg/...,./internal/...
 KIND_CLUSTER_NAME ?= "integration-tests"
 INTEGRATION_TEST_TIMEOUT ?= "45m"
 E2E_TEST_TIMEOUT ?= "45m"
-KONG_CONTROLLER_FEATURE_GATES ?= Gateway=true
+KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 GOTESTFMT_CMD ?= gotestfmt -hide successful-downloads,empty-packages -showteststatus
 
 .PHONY: test

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -254,7 +254,7 @@ func setupControllers(
 			// knative is a special case because it existed before we added feature gates functionality
 			// for this controller (only) the existing --enable-controller-knativeingress flag overrides
 			// any feature gate configuration. See FEATURE_GATES.md for more information.
-			Enabled: featureGates[gatewayFeature] || c.KnativeIngressEnabled,
+			Enabled: featureGates[knativeFeature] || c.KnativeIngressEnabled,
 			AutoHandler: crdExistsChecker{GVR: schema.GroupVersionResource{
 				Group:    knativev1alpha1.SchemeGroupVersion.Group,
 				Version:  knativev1alpha1.SchemeGroupVersion.Version,
@@ -272,7 +272,7 @@ func setupControllers(
 			},
 		},
 		// ---------------------------------------------------------------------------
-		// GatewayAPI Controllers
+		// Gateway API Controllers - Beta APIs
 		// ---------------------------------------------------------------------------
 		{
 			Enabled: featureGates[gatewayFeature],
@@ -298,6 +298,25 @@ func setupControllers(
 				GVR: schema.GroupVersionResource{
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
 					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
+					Resource: "httproutes",
+				},
+			}.CRDExists,
+			Controller: &gateway.HTTPRouteReconciler{
+				Client:          mgr.GetClient(),
+				Log:             ctrl.Log.WithName("controllers").WithName("HTTPRoute"),
+				Scheme:          mgr.GetScheme(),
+				DataplaneClient: dataplaneClient,
+			},
+		},
+		// ---------------------------------------------------------------------------
+		// Gateway API Controllers - Alpha APIs
+		// ---------------------------------------------------------------------------
+		{
+			Enabled: featureGates[gatewayAlphaFeature],
+			AutoHandler: crdExistsChecker{
+				GVR: schema.GroupVersionResource{
+					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
+					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
 					Resource: "referencegrants",
 				},
 			}.CRDExists,
@@ -309,23 +328,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[gatewayFeature],
-			AutoHandler: crdExistsChecker{
-				GVR: schema.GroupVersionResource{
-					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
-					Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
-					Resource: "httproutes",
-				},
-			}.CRDExists,
-			Controller: &gateway.HTTPRouteReconciler{
-				Client:          mgr.GetClient(),
-				Log:             ctrl.Log.WithName("controllers").WithName("HTTPRoute"),
-				Scheme:          mgr.GetScheme(),
-				DataplaneClient: dataplaneClient,
-			},
-		},
-		{
-			Enabled: featureGates[gatewayFeature],
+			Enabled: featureGates[gatewayAlphaFeature],
 			AutoHandler: crdExistsChecker{
 				GVR: schema.GroupVersionResource{
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
@@ -341,7 +344,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[gatewayFeature],
+			Enabled: featureGates[gatewayAlphaFeature],
 			AutoHandler: crdExistsChecker{
 				GVR: schema.GroupVersionResource{
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
@@ -357,7 +360,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[gatewayFeature],
+			Enabled: featureGates[gatewayAlphaFeature],
 			AutoHandler: crdExistsChecker{
 				GVR: schema.GroupVersionResource{
 					Group:    gatewayv1alpha2.SchemeGroupVersion.Group,

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -17,6 +17,10 @@ const (
 	// gatewayFeature is the name of the feature-gate for enabling/disabling Gateway APIs.
 	gatewayFeature = "Gateway"
 
+	// gatewayAlphaFeature is the name of the feature-gate for enabling or
+	// disabling the Alpha maturity APIs and relevant features for Gateway API.
+	gatewayAlphaFeature = "GatewayAlpha"
+
 	// combinedRoutesFeature is the name of the feature-gate for the newer object
 	// translation logic that will combine routes for kong services when translating
 	// objects like Ingress instead of creating a route per path.
@@ -56,7 +60,8 @@ func setupFeatureGates(setupLog logr.Logger, c *Config) (map[string]bool, error)
 func getFeatureGatesDefaults() map[string]bool {
 	return map[string]bool{
 		knativeFeature:                false,
-		gatewayFeature:                false,
+		gatewayFeature:                true,
+		gatewayAlphaFeature:           false,
 		combinedRoutesFeature:         false,
 		ingressClassParametersFeature: false,
 	}

--- a/internal/manager/feature_gates_test.go
+++ b/internal/manager/feature_gates_test.go
@@ -24,10 +24,10 @@ func TestFeatureGates(t *testing.T) {
 	assert.Len(t, fgs, len(getFeatureGatesDefaults()))
 
 	t.Log("verifying feature gates setup results when valid feature gates options are present")
-	config.FeatureGates = map[string]bool{knativeFeature: true}
+	config.FeatureGates = map[string]bool{gatewayFeature: true}
 	fgs, err = setupFeatureGates(setupLog, config)
 	assert.NoError(t, err)
-	assert.True(t, fgs[knativeFeature])
+	assert.True(t, fgs[gatewayFeature])
 
 	t.Log("configuring several invalid feature gates options")
 	config.FeatureGates = map[string]bool{"invalidGateway": true}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 		"--dump-config",
 		"--log-level=trace",
 		"--debug-log-reduce-redundancy",
-		"--feature-gates=Gateway=true",
+		"--feature-gates=GatewayAlpha=true",
 		fmt.Sprintf("--kong-admin-url=%s", admin.String()),
 	}
 	exitOnErr(testutils.DeployControllerManagerForCluster(ctx, env.Cluster(), args...))

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -305,7 +305,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	for i, container := range deployment.Spec.Template.Spec.Containers {
 		if container.Name == "ingress-controller" {
 			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "Gateway=true"})
+				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "GatewayAlpha=true"})
 		}
 	}
 

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -100,7 +100,7 @@ const (
 	// provided if none are provided by the user. This generally includes features
 	// that are innocuous, or otherwise don't actually get triggered unless the
 	// user takes further action.
-	defaultFeatureGates = "Gateway=true"
+	defaultFeatureGates = "GatewayAlpha=true"
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch promotes the "Gateway" feature gate to beta and
turns it on by default for future releases.

Due to the fact that some Gateway API resources are still
in an alpha stage, this commit also creates the new feature
gate "GatewayAlpha" to lock alpha stage APIs behind a gate
that's off by default and not mix them with the beta APIs.

**Which issue this PR fixes**:

Partially resolves #2779

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated
