### PR TITLE
chore: bump to go1.19 where we're still using 1.18

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
 
       - name: cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -100,7 +100,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: cache go modules
         uses: actions/cache@v3
         with:
@@ -144,7 +144,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: cache go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,7 +166,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: cache go modules
         uses: actions/cache@v3
         with:
@@ -199,7 +199,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: cache go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -82,7 +82,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -120,7 +120,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -161,7 +161,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -200,7 +200,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -239,7 +239,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3
@@ -280,7 +280,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: setup golang
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
 
     - name: cache go modules
       uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@
   which was working properly).
   [#2781](https://github.com/Kong/kubernetes-ingress-controller/pull/2781)
 
+#### Under the hood
+
+- Updated the compiler to [Go v1.19](https://golang.org/doc/go1.19)
+  [#2794](https://github.com/Kong/kubernetes-ingress-controller/issues/2794)
+
 ## [2.5.0]
 
 > Release date: 2022-07-11

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v2
 
-go 1.18
+go 1.19
 
 replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
 

--- a/pkg/clientset/fake/register.go
+++ b/pkg/clientset/fake/register.go
@@ -41,14 +41,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientset/scheme/register.go
+++ b/pkg/clientset/scheme/register.go
@@ -41,14 +41,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golangci/golangci-lint v1.48.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump to go1.19 since the upgrade has already been started by dependabot in #2770 and it causes issues when e.g. 1.19 is being used in CI to generate and verify no diff in generated files https://github.com/Kong/kubernetes-ingress-controller/runs/7744303539?check_suite_focus=true#step:8:34 but the author of PR uses 1.18 which ( as a result of changes between 1.18 in 1.19 in comments formatting ) does not produce a diff when generating files. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
