### PR TITLE
ci: store gateway API version only in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,9 +352,9 @@ run: install
 # unsupported ref and downloads the manifests from the main branch.
 #
 # [1]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md#remote-directories
-GATEWAY_API_VERSION ?= v0.5.0
-GATEWAY_API_RELEASE_CHANNEL ?= experimental
 GATEWAY_API_PACKAGE ?= sigs.k8s.io/gateway-api
+GATEWAY_API_RELEASE_CHANNEL ?= experimental
+GATEWAY_API_VERSION ?= $(shell go list -m -f '{{ .Version }}' $(GATEWAY_API_PACKAGE))
 GATEWAY_API_CRDS_LOCAL_PATH = $(shell go env GOPATH)/pkg/mod/$(GATEWAY_API_PACKAGE)@$(GATEWAY_API_VERSION)/config/crd
 GATEWAY_API_REPO ?= github.com/kubernetes-sigs/gateway-api
 GATEWAY_API_CRDS_URL = $(GATEWAY_API_REPO)/config/crd/$(GATEWAY_API_RELEASE_CHANNEL)?ref=$(GATEWAY_API_VERSION)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the version of used gateway API from `Makefile` and makes it so we store it only in go.mod.

