### PR TITLE
chore: remove unsupported golint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ linters:
   - gofmt
   - gofumpt
   - goimports
-  - golint
   - gosec
   - gosimple
   - govet


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` has been deprecated and having it enabled in `.golangci.yaml` causes the following warning:

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```

This PR removes it from the config. The replacement - `revive` - is already in place in the config.