### PR TITLE
fix: do not publish RedHat nightly images

### DIFF
--- a/.github/actions/redhat-opdev-preflight-action/action.yaml
+++ b/.github/actions/redhat-opdev-preflight-action/action.yaml
@@ -4,6 +4,10 @@ inputs:
   image:
     description: 'Image to scan'
     required: true
+  submit:
+    description: 'If false, the result will not be submitted to connect portal'
+    required: true
+    default: 'false'
   username:
     description: 'Docker Username'
     required: true
@@ -11,11 +15,11 @@ inputs:
     description: 'Docker Password'
     required: true
   apitoken:
-    description: 'API token for Pyxis authentication'
-    required: true
+    description: 'API token for Pyxis authentication. Required if submit is not false.'
+    required: false
   certificationid:
-    description: 'Certification Project ID from connect.redhat.com/projects/{certification-project-id}/overview'
-    required: true
+    description: 'Certification Project ID from connect.redhat.com/projects/{certification-project-id}/overview. Required if submit is not false.'
+    required: false
 
 runs:
   using: 'docker'

--- a/.github/actions/redhat-opdev-preflight-action/entrypoint.sh
+++ b/.github/actions/redhat-opdev-preflight-action/entrypoint.sh
@@ -20,13 +20,29 @@ require_env() {
         exit 1
     fi
 }
-require_env INPUT_PASSWORD INPUT_USERNAME INPUT_CERTIFICATIONID INPUT_IMAGE
+require_env INPUT_PASSWORD INPUT_USERNAME INPUT_IMAGE INPUT_SUBMIT
 
 
 # Login.
 echo "$INPUT_PASSWORD"  | docker login scan.connect.redhat.com -u "${INPUT_USERNAME}" --password-stdin
 
-# Run checks.
+
+# Run checks, do not submit the results.
+if [[ "${INPUT_SUBMIT}" == "false" ]]; then
+    printf "Skipping submission to connect portal"
+    docker run                                                          \
+        -v "/var/run/docker.sock":"/var/run/docker.sock"                \
+        -v "/home/runner/.docker/":"/docker"                            \
+        quay.io/opdev/preflight:stable                                  \
+        check container "${INPUT_IMAGE}"                                \
+        --docker-config=/docker/config.json
+    exit 0
+fi
+
+
+# Run checks and submit the results.
+printf "Submitting to connect portal"
+require_env INPUT_APITOKEN INPUT_CERTIFICATIONID
 docker run                                                          \
     -v "/var/run/docker.sock":"/var/run/docker.sock"                \
     -v "/home/runner/.docker/":"/docker"                            \

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -118,13 +118,13 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat Scan Registry image
+      - name: Build image for local Preflight scan
         id: docker_build_redhat_scan_registry
         env:
           TAG: ${{ steps.meta_redhat_scan_registry.outputs.version }}
         uses: docker/build-push-action@v3.1.1
         with:
-          push: true
+          push: false
           file: Dockerfile
           tags: ${{ steps.meta_redhat_scan_registry.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -135,14 +135,13 @@ jobs:
             TAG=${{ steps.meta_redhat_scan_registry.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Run Red Hat Certification Preflight scan
+      - name: Run local Red Hat Certification Preflight scan
         uses: ./.github/actions/redhat-opdev-preflight-action
         with:
           image: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}:${{ steps.meta_redhat_scan_registry.outputs.version }}
           username: ${{ secrets.RH_USERNAME }}
           password: ${{ secrets.RH_TOKEN }}
-          apitoken: ${{ secrets.RH_PYXIS_TOKEN }}
-          certificationid: ${{ secrets.RH_CERTIFICATION_ID }}
+          submit: false
 
   
   # run integration test in latest version of kubernetes.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,6 +195,7 @@ jobs:
           image: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}:${{ steps.meta_redhat_scan_registry.outputs.version }}
           username: ${{ secrets.RH_USERNAME }}
           password: ${{ secrets.RH_TOKEN }}
+          submit: true
           apitoken: ${{ secrets.RH_PYXIS_TOKEN }}
           certificationid: ${{ secrets.RH_CERTIFICATION_ID }}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Nightly builds do not submit images to scan registry, not results to connect portal

**Which issue this PR fixes**:

Fixes #2811



**PR Readiness Checklist**:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
