### PR TITLE
chore(tests) add temp TestTCPRouteEssentials diag

### DIFF
--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -190,6 +190,10 @@ func TestTCPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is no longer responding")
+	defer func() {
+		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		t.Logf("no longer responding check state: responded=%v, eof=%v, err=%v", responded, errors.Is(err, io.EOF), err)
+	}()
 	require.Eventually(t, func() bool {
 		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && errors.Is(err, io.EOF)


### PR DESCRIPTION
**What this PR does / why we need it**:
Runs a check in an eventually in a defer, to try and diagnose that eventually's failure without spamming logs.

**Which issue this PR fixes**:
Related to https://github.com/Kong/kubernetes-ingress-controller/issues/2668#issuecomment-1211219322