### PR TITLE
fix: info log missing service endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@
 
 #### Fixed
 
+- When `Endpoints` could not be found for a `Service` to add them as targets of
+  a Kong `Upstream`, this was producing a log message at `error` level which was
+  inaccurate because this condition is often expected when `Pods` are being
+  provisioned. Those log entries now report at `info` level.
+  [#2820](https://github.com/Kong/kubernetes-ingress-controller/issues/2820)
 - Added `mtls-auth` to the admission webhook supported credential types list.
   [#2739](https://github.com/Kong/kubernetes-ingress-controller/pull/2739)
 - Disabled additional IngressClass lookups in other reconcilers when the

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -316,7 +316,7 @@ func getUpstreams(
 				newTargets := getServiceEndpoints(log, s, k8sService, port)
 
 				if len(newTargets) == 0 {
-					log.WithField("service_name", *service.Name).Errorf("no targets could be found for kubernetes service %s/%s", k8sService.Namespace, k8sService.Name)
+					log.WithField("service_name", *service.Name).Infof("no targets could be found for kubernetes service %s/%s", k8sService.Namespace, k8sService.Name)
 				}
 
 				// if weights were set for the backend then that weight needs to be


### PR DESCRIPTION
**What this PR does / why we need it**:

Missing service endpoints were being logging at error level, but this is unnecessary noise: there are plenty of normal operational reasons why these could be missing for a time, such as waiting on pods to provision. This patch switches this from error to info level to avoid undue noise and alarm.

**Which issue this PR fixes**:

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2820

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated