### PR TITLE
fix: info instead of warn for no targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,11 @@
 #### Fixed
 
 - When `Endpoints` could not be found for a `Service` to add them as targets of
-  a Kong `Upstream`, this was producing a log message at `error` level which was
-  inaccurate because this condition is often expected when `Pods` are being
-  provisioned. Those log entries now report at `info` level.
+  a Kong `Upstream`, this would produce a log message at `error` and `warning`
+  levels which was inaccurate because this condition is often expected when
+  `Pods` are being provisioned. Those log entries now report at `info` level.
   [#2820](https://github.com/Kong/kubernetes-ingress-controller/issues/2820)
+  [#2825](https://github.com/Kong/kubernetes-ingress-controller/pull/2825)
 - Added `mtls-auth` to the admission webhook supported credential types list.
   [#2739](https://github.com/Kong/kubernetes-ingress-controller/pull/2739)
 - Disabled additional IngressClass lookups in other reconcilers when the

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -351,7 +351,7 @@ func getUpstreams(
 
 			// warn if an upstream was created with 0 targets
 			if len(targets) == 0 {
-				log.WithField("service_name", *service.Name).Warnf("no targets found to create upstream")
+				log.WithField("service_name", *service.Name).Infof("no targets found to create upstream")
 			}
 
 			// define the upstream including all the newly populated targets


### PR DESCRIPTION
**What this PR does / why we need it**:

This turns a previous warning log about targets not being available for an upstream into an info log, as this condition is expected any time there are pods in flight.

**Which issue this PR fixes**:

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2820

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated