### PR TITLE
fix(gateway) handle NodePort addresses

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -549,6 +549,13 @@ func (r *GatewayReconciler) determineL4ListenersFromService(
 		}
 	}
 
+	// the API server transforms a Gateway with a zero-length address slice into a Gateway with a nil address slice
+	// the value we return here needs to match the transformed Gateway, as otherwise the controller will always see
+	// that the Gateway needs a status update and will never mark it ready
+	if len(addresses) == 0 {
+		addresses = nil
+	}
+
 	return addresses, listeners, nil
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -230,7 +230,7 @@ func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	assert.NoError(t, err)
 	t.Log("deploying an HTTP service to test the ingress controller and proxy")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin-httproute", test.HTTPBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -247,6 +247,9 @@ func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 	httproute := &gatewayv1alpha2.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.StripPathKey: "true", // trigger the unmanaged gateway mode
+			},
 		},
 		Spec: gatewayv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that the controller's desired addresses for Services with no external addresses (such as NodePorts) match the Gateway representation of no addresses. This ensures that the address update check does not attempt to proceed with an unnecessary update every reconcile, which would prevent the Gateway from becoming ready.

Add an E2E test that confirms Gateways work with NodePorts.

**Which issue this PR fixes**:

Fix #2808 
Fix #2823

**Special notes for your reviewer**:

E2E run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/2871403290

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ this was a bug introduced by unreleased code from https://github.com/Kong/kubernetes-ingress-controller/pull/2797