### PR TITLE
fix(gateway): disable referenceGrant when GatewayAlpha feature is off

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -48,8 +48,10 @@ type GatewayReconciler struct { //nolint:revive,golint
 	Scheme          *runtime.Scheme
 	DataplaneClient *dataplane.KongClient
 
-	PublishService       string
-	WatchNamespaces      []string
+	PublishService  string
+	WatchNamespaces []string
+	// If EnableReferenceGrant is true, controller will watch ReferenceGrants
+	// to invalidate or allow cross-namespace TLSConfigs in gateways.
 	EnableReferenceGrant bool
 
 	publishServiceRef types.NamespacedName

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -48,9 +48,9 @@ type GatewayReconciler struct { //nolint:revive,golint
 	Scheme          *runtime.Scheme
 	DataplaneClient *dataplane.KongClient
 
-	PublishService      string
-	WatchNamespaces     []string
-	WatchReferenceGrant bool
+	PublishService       string
+	WatchNamespaces      []string
+	EnableReferenceGrant bool
 
 	publishServiceRef types.NamespacedName
 }
@@ -107,7 +107,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// watch ReferenceGrants, which may invalidate or allow cross-namespace TLSConfigs
-	if r.WatchReferenceGrant {
+	if r.EnableReferenceGrant {
 		if err := c.Watch(
 			&source.Kind{Type: &gatewayv1alpha2.ReferenceGrant{}},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
@@ -403,7 +403,7 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 	// the ReferenceGrants need to be retrieved to ensure that all gateway listeners reference
 	// TLS secrets they are granted for
 	referenceGrantList := &gatewayv1alpha2.ReferenceGrantList{}
-	if r.WatchReferenceGrant {
+	if r.EnableReferenceGrant {
 		if err := r.Client.List(ctx, referenceGrantList); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -38,8 +38,8 @@ type HTTPRouteReconciler struct {
 	Scheme          *runtime.Scheme
 	DataplaneClient *dataplane.KongClient
 	// If EnableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs. If it is false, referecing backend in different namespace
-	// will be directly rejected.
+	// namespace is in backendRefs.
+	// If it is false, referencing backend in different namespace will be rejected.
 	EnableReferenceGrant bool
 }
 

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -37,6 +37,10 @@ type HTTPRouteReconciler struct {
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
 	DataplaneClient *dataplane.KongClient
+	// If EnableReferenceGrant is true, we will check for ReferenceGrant if backend in another
+	// namespace is in backendRefs. If it is false, referecing backend in different namespace
+	// will be directly rejected.
+	EnableReferenceGrant bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -541,6 +545,10 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 			// Check if the object referenced is in another namespace,
 			// and if there is grant for that reference
 			if httpRoute.Namespace != backendNamespace {
+				if !r.EnableReferenceGrant {
+					return gatewayv1alpha2.RouteReasonRefNotPermitted, nil
+				}
+
 				referenceGrantList := &gatewayv1alpha2.ReferenceGrantList{}
 				if err := r.Client.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
 					return "", err

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -157,7 +157,7 @@ func (p *Parser) generateKongServiceFromBackendRef(
 			if backendRef.Kind != nil {
 				kind = string(*backendRef.Kind)
 			}
-			p.logger.Errorf("%s requested backendRef to %s %s/%s, but no ReferencePolicy permits it, skipping...",
+			p.logger.Errorf("%s requested backendRef to %s %s/%s, but no ReferenceGrant permits it, skipping...",
 				objName, kind, namespace, backendRef.Name)
 		}
 	}

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -278,13 +278,14 @@ func setupControllers(
 			Enabled:     featureGates[gatewayFeature],
 			AutoHandler: gatewayCRDExistsChecker.CRDExists,
 			Controller: &gateway.GatewayReconciler{
-				Client:              mgr.GetClient(),
-				Log:                 ctrl.Log.WithName("controllers").WithName(gatewayFeature),
-				Scheme:              mgr.GetScheme(),
-				DataplaneClient:     dataplaneClient,
-				PublishService:      c.PublishService,
-				WatchNamespaces:     c.WatchNamespaces,
-				WatchReferenceGrant: featureGates[gatewayAlphaFeature],
+				Client:          mgr.GetClient(),
+				Log:             ctrl.Log.WithName("controllers").WithName(gatewayFeature),
+				Scheme:          mgr.GetScheme(),
+				DataplaneClient: dataplaneClient,
+				PublishService:  c.PublishService,
+				WatchNamespaces: c.WatchNamespaces,
+				WatchReferenceGrant: featureGates[gatewayAlphaFeature] &&
+					referenceGrantCRDExistsChecker.CRDExists(mgr.GetClient()),
 			},
 		},
 		{
@@ -295,6 +296,8 @@ func setupControllers(
 				Log:             ctrl.Log.WithName("controllers").WithName("HTTPRoute"),
 				Scheme:          mgr.GetScheme(),
 				DataplaneClient: dataplaneClient,
+				EnableReferenceGrant: featureGates[gatewayAlphaFeature] &&
+					referenceGrantCRDExistsChecker.CRDExists(mgr.GetClient()),
 			},
 		},
 		// ---------------------------------------------------------------------------

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -284,7 +284,7 @@ func setupControllers(
 				DataplaneClient: dataplaneClient,
 				PublishService:  c.PublishService,
 				WatchNamespaces: c.WatchNamespaces,
-				WatchReferenceGrant: featureGates[gatewayAlphaFeature] &&
+				EnableReferenceGrant: featureGates[gatewayAlphaFeature] &&
 					referenceGrantCRDExistsChecker.CRDExists(mgr.GetClient()),
 			},
 		},


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Disable listing `ReferenceGrant`s in `HTTPRoute` controller when `GatewayAlpha` feature is not opened. Because  `HTTPRoute` is in v1beta1 resources, it should not depend on `v1alpha2` resource `ReferenceGrant`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2828. 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR 
No need to update `CHANGELOG.md`
