### PR TITLE
[WIP] test: update e2e to test KIC works without gateway API CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,8 @@ print-gateway-api-raw-repo-url:
 
 .PHONY: generate.gateway-api-urls
 generate.gateway-api-urls:
-	CRDS_URL=$(shell $(MAKE) print-gateway-api-crds-url) \
+	STANDARD_CRDS_URL=$(shell GATEWAY_API_RELEASE_CHANNEL="" $(MAKE) print-gateway-api-crds-url)\
+		CRDS_URL=$(shell $(MAKE) print-gateway-api-crds-url) \
 		RAW_REPO_URL=$(shell $(MAKE) print-gateway-api-raw-repo-url) \
 		INPUT=$(shell pwd)/test/internal/cmd/generate-gateway-api-urls/gateway_consts.tmpl \
 		OUTPUT=$(shell pwd)/test/consts/zz_generated_gateway.go \

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -3,6 +3,7 @@
 package consts
 
 const (
-	GatewayCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.0"
-	GatewayRawRepoURL       = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.0"
+	GatewayStandardCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v0.5.0"
+	GatewayCRDsKustomizeURL         = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.0"
+	GatewayRawRepoURL               = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.0"
 )

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -6,8 +6,10 @@ package e2e
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -287,30 +290,17 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 		assert.NoError(t, env.Cleanup(ctx))
 	}()
 
-	t.Logf("deploying Gateway APIs CRDs from %s", consts.GatewayCRDsKustomizeURL)
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), consts.GatewayCRDsKustomizeURL))
-
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
 	require.NoError(t, err)
 	deployment := deployKong(ctx, t, env, manifest)
+	deploymentListOptions := metav1.ListOptions{
+		LabelSelector: "app=" + deployment.Name,
+	}
 
 	t.Log("running the admission webhook setup script")
 	cmd := exec.Command("bash", admissionScriptPath)
 	require.NoError(t, cmd.Run())
-
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-	t.Log("updating kong deployment to enable Gateway feature gate and admission controller")
-	for i, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == "ingress-controller" {
-			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "GatewayAlpha=true"})
-		}
-	}
-
-	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
-		deployment, metav1.UpdateOptions{})
 
 	// vov it's easier than tracking the deployment state
 	t.Log("creating a consumer to ensure the admission webhook is online")
@@ -329,6 +319,34 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 		_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
 		return err == nil
 	}, time.Minute*2, time.Second*1)
+
+	t.Log("verifying that KIC disabled controllers for Gateway API and printed proper log")
+	require.Eventually(t, func() bool {
+		pods, err := env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, deploymentListOptions)
+		require.NoError(t, err)
+		for _, pod := range pods.Items {
+			logs, err := getKubernetesLogs(ctx, t, env, pod.Namespace, pod.Name)
+			if err != nil {
+				t.Logf("failed to get logs of pods %s/%s, error %v", pod.Namespace, pod.Name, err)
+				return false
+			}
+			if !strings.Contains(logs, "CRD does not exist, disable gateway feature") {
+				return false
+			}
+		}
+		return true
+	}, time.Minute, 5*time.Second)
+
+	t.Logf("deploying Gateway APIs CRDs in standard channel from %s", consts.GatewayStandardCRDsKustomizeURL)
+	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), consts.GatewayStandardCRDsKustomizeURL))
+
+	t.Logf("deleting KIC pods to restart them after Gateway APIs CRDs installed")
+	pods, err := env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, deploymentListOptions)
+	require.NoError(t, err)
+	for _, pod := range pods.Items {
+		err = env.Cluster().Client().CoreV1().Pods(deployment.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
 
 	t.Log("verifying controller updates associated Gateway resoures")
 	gw := deployGateway(ctx, t, env)
@@ -390,6 +408,43 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 
 	gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 	require.NoError(t, err)
+
+	t.Logf("deploying Gateway APIs CRDs in experimental channel from %s", consts.GatewayCRDsKustomizeURL)
+	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), consts.GatewayCRDsKustomizeURL))
+
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	t.Log("updating kong deployment to enable Gateway feature gate and admission controller")
+	for i, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "ingress-controller" {
+			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
+				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: "GatewayAlpha=true"})
+		}
+		if container.Name == "proxy" {
+			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
+				corev1.EnvVar{Name: "KONG_STREAM_LISTEN", Value: fmt.Sprintf("0.0.0.0:%d", tcpListnerPort)})
+		}
+	}
+	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("updating kong proxy service to enable TCP listener")
+	proxyService, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
+	require.NoError(t, err)
+	proxyService.Spec.Ports = append(proxyService.Spec.Ports, corev1.ServicePort{
+		Name:       "stream-tcp",
+		Protocol:   corev1.ProtocolTCP,
+		Port:       tcpListnerPort,
+		TargetPort: intstr.FromInt(tcpListnerPort),
+	})
+	_, err = env.Cluster().Client().CoreV1().Services(namespace).Update(ctx, proxyService, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	gw = deployGatewayWithTCPListener(ctx, t, env)
+	verifyGateway(ctx, t, env, gw)
+
+	deployTCPRoute(ctx, t, env, gw)
+	verifyTCPRoute(ctx, t, env)
 }
 
 // Unsatisfied LoadBalancers have special handling, see

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -41,6 +43,11 @@ const (
 	ingressClass     = "kong"
 	namespace        = "kong"
 	adminServiceName = "kong-admin"
+)
+
+const (
+	tcpEchoPort    = 1025
+	tcpListnerPort = 8888
 )
 
 func deployKong(ctx context.Context, t *testing.T, env environments.Environment, manifest io.Reader, additionalSecrets ...*corev1.Secret) *appsv1.Deployment {
@@ -89,6 +96,7 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 	require.Eventually(t, func() bool {
 		deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace).Get(ctx, "ingress-kong", metav1.GetOptions{})
 		require.NoError(t, err)
+		t.Logf("%d/%d replicas ready", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}, kongComponentWait, time.Second)
 	return deployment
@@ -226,6 +234,58 @@ func verifyGateway(ctx context.Context, t *testing.T, env environments.Environme
 	}, gatewayUpdateWaitTime, time.Second)
 }
 
+func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environments.Environment) *gatewayv1alpha2.Gateway {
+	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
+	t.Log("deploying a supported gatewayclass to the test cluster")
+	supportedGatewayClass := &gatewayv1alpha2.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayv1alpha2.GatewayClassSpec{
+			ControllerName: gateway.ControllerName,
+		},
+	}
+	supportedGatewayClass, err = gc.GatewayV1alpha2().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
+	gw := &gatewayv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kong",
+		},
+		Spec: gatewayv1alpha2.GatewaySpec{
+			GatewayClassName: gatewayv1alpha2.ObjectName(supportedGatewayClass.Name),
+			Listeners: []gatewayv1alpha2.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1alpha2.HTTPProtocolType,
+					Port:     gatewayv1alpha2.PortNumber(80),
+				},
+				{
+					Name:     "tcp",
+					Protocol: gatewayv1alpha2.TCPProtocolType,
+					Port:     gatewayv1alpha2.PortNumber(tcpListnerPort),
+				},
+			},
+		},
+	}
+	_, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+	if err == nil {
+		t.Logf("gateway %s exists, delete and re-create it", gw.Name)
+		err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Delete(ctx, gw.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
+		require.NoError(t, err)
+	} else {
+		require.True(t, errors.IsNotFound(err))
+		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	return gw
+}
+
 func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1alpha2.Gateway) {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	assert.NoError(t, err)
@@ -248,7 +308,7 @@ func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
-				annotations.AnnotationPrefix + annotations.StripPathKey: "true", // trigger the unmanaged gateway mode
+				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 			},
 		},
 		Spec: gatewayv1alpha2.HTTPRouteSpec{
@@ -305,6 +365,82 @@ func verifyHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 		}
 		return false
 	}, ingressWait, time.Second)
+}
+
+func deployTCPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1alpha2.Gateway) {
+	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	assert.NoError(t, err)
+	t.Log("deploying a TCP service to test the ingress controller and proxy")
+	container := generators.NewContainer("tcpecho-tcproute", test.TCPEchoImage, tcpEchoPort)
+	container.Env = []corev1.EnvVar{
+		{
+			Name:  "POD_NAME",
+			Value: "tcpecho-tcproute",
+		},
+	}
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:       "echo",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       tcpListnerPort,
+			TargetPort: intstr.FromInt(tcpEchoPort),
+		},
+	}
+	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("creating a TCPRoute for service %s with Gateway %s", service.Name, gw.Name)
+	portNumber := gatewayv1alpha2.PortNumber(tcpListnerPort)
+	tcpRoute := &gatewayv1alpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayv1alpha2.TCPRouteSpec{
+			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+				ParentRefs: []gatewayv1alpha2.ParentReference{{
+					Name: gatewayv1alpha2.ObjectName(gw.Name),
+				}},
+			},
+			Rules: []gatewayv1alpha2.TCPRouteRule{
+				{
+					BackendRefs: []gatewayv1alpha2.BackendRef{
+						{
+							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+								Name: gatewayv1alpha2.ObjectName(service.Name),
+								Port: &portNumber,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = gc.GatewayV1alpha2().TCPRoutes(corev1.NamespaceDefault).Create(ctx, tcpRoute, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func verifyTCPRoute(ctx context.Context, t *testing.T, env environments.Environment) {
+	t.Log("finding the kong proxy service ip")
+	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
+	require.NoError(t, err)
+	proxyIP := getKongProxyIP(ctx, t, env, svc)
+
+	t.Logf("waiting for route from TCPRoute to be operational at %s:%d", proxyIP, tcpListnerPort)
+	require.Eventually(t, func() bool {
+		ok, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyIP, tcpListnerPort), "tcpecho-tcproute")
+		if err != nil {
+			t.Logf("failed to connect to %s:%d, error %v", proxyIP, tcpListnerPort, err)
+			return false
+		}
+		return ok
+	}, ingressWait, 5*time.Second,
+	)
 }
 
 // verifyEnterprise performs some basic tests of the Kong Admin API in the provided

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -23,6 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 )
 
 const examplesDIR = "../../examples"
@@ -174,7 +176,7 @@ func TestTCPRouteExample(t *testing.T) {
 
 	t.Log("verifying that TCPRoute becomes routable")
 	require.Eventually(t, func() bool {
-		responds, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest")
+		responds, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest")
 		return err == nil && responds
 	}, ingressWait, waitTick)
 }

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -4,11 +4,9 @@
 package integration
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"syscall"
 	"testing"
 	"time"
@@ -172,7 +170,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the tcpecho is responding properly")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -193,13 +191,13 @@ func TestTCPRouteEssentials(t *testing.T) {
 	t.Log("verifying that the tcpecho is no longer responding")
 	defer func() {
 		if t.Failed() {
-			responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+			responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 			t.Logf("no longer responding check failure state: responded=%v, eof=%v, reset=%v, err=%v", responded,
 				errors.Is(err, io.EOF), errors.Is(err, syscall.ECONNRESET), err)
 		}
 	}()
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
 	}, ingressWait, waitTick)
 
@@ -218,7 +216,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -231,7 +229,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the GatewayClass now removed")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
 	}, ingressWait, waitTick)
 
@@ -245,7 +243,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -258,7 +256,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the Gateway now removed")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
 	}, ingressWait, waitTick)
 
@@ -279,7 +277,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -293,7 +291,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
 	}, ingressWait, waitTick)
 
@@ -318,7 +316,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -348,19 +346,19 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the TCPRoute is now load-balanced between two services")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -374,7 +372,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
 	}, ingressWait, waitTick)
 }
@@ -536,11 +534,11 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that only the local tcpecho is responding without a ReferenceGrant")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait*2, waitTick)
 	require.Never(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, time.Second*10, time.Second)
 
@@ -583,11 +581,11 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that requests reach both the local and remote namespace echo instances")
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -603,7 +601,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err == nil && responded == true
 	}, ingressWait*2, waitTick)
 
@@ -614,65 +612,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tcpEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
+		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
 		return err != nil && responded == false
 	}, ingressWait, waitTick)
-}
-
-// tcpEchoResponds takes a TCP address URL and a Pod name and checks if a
-// go-echo instance is running on that Pod at that address. It compares an
-// expected message and its length against an expected message, returning true
-// if it is and false and an error explanation if it is not.
-func tcpEchoResponds(url string, podName string) (bool, error) {
-	dialer := net.Dialer{Timeout: time.Second * 10}
-	conn, err := dialer.Dial("tcp", url)
-	if err != nil {
-		return false, err
-	}
-
-	header := []byte(fmt.Sprintf("Running on Pod %s.", podName))
-	message := []byte("testing tcproute")
-
-	wrote, err := conn.Write(message)
-	if err != nil {
-		return false, err
-	}
-
-	if wrote != len(message) {
-		return false, fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
-	}
-
-	if err := conn.SetDeadline(time.Now().Add(time.Second * 5)); err != nil {
-		return false, err
-	}
-
-	headerResponse := make([]byte, len(header)+1)
-	read, err := conn.Read(headerResponse)
-	if err != nil {
-		return false, err
-	}
-
-	if read != len(header)+1 { // add 1 for newline
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
-	}
-
-	if !bytes.Contains(headerResponse, header) {
-		return false, fmt.Errorf(`expected header response "%s", received: "%s"`, string(header), string(headerResponse))
-	}
-
-	messageResponse := make([]byte, wrote+1)
-	read, err = conn.Read(messageResponse)
-	if err != nil {
-		return false, err
-	}
-
-	if read != len(message) {
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(message))
-	}
-
-	if !bytes.Contains(messageResponse, message) {
-		return false, fmt.Errorf(`expected message response "%s", received: "%s"`, string(message), string(messageResponse))
-	}
-
-	return true, nil
 }

--- a/test/internal/cmd/generate-gateway-api-urls/gateway_consts.tmpl
+++ b/test/internal/cmd/generate-gateway-api-urls/gateway_consts.tmpl
@@ -3,6 +3,7 @@
 package consts
 
 const (
+	GatewayStandardCRDsKustomizeURL =  "{{.StandardCRDsKustomizeURL}}"
 	GatewayCRDsKustomizeURL = "{{.CRDsKustomizeURL}}"
 	GatewayRawRepoURL = "{{.RawRepoURL}}"
 )

--- a/test/internal/cmd/generate-gateway-api-urls/main.go
+++ b/test/internal/cmd/generate-gateway-api-urls/main.go
@@ -12,26 +12,29 @@ import (
 	"text/template"
 )
 
-//go:generate go run . -crds-url $CRDS_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
+//go:generate go run . -standard-crds-url $STANDARD_CRDS_URL -crds-url $CRDS_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
 
 var (
-	crdsURLFlag    = flag.String("crds-url", "", "The URL of Gateway API CRDs to be consumed by kustomize")
-	rawRepoURLFlag = flag.String("raw-repo-url", "", "The raw URL of Gateway API repository")
-	inFlag         = flag.String("in", "", "Template file path")
-	outFlag        = flag.String("out", "", "Output file path where the generate file will be placed")
+	standardCrdsURLFlag = flag.String("standard-crds-url", "", "The URL of standard Gateway API CRDs to be consumed by kustomize")
+	crdsURLFlag         = flag.String("crds-url", "", "The URL of Gateway API CRDs to be consumed by kustomize")
+	rawRepoURLFlag      = flag.String("raw-repo-url", "", "The raw URL of Gateway API repository")
+	inFlag              = flag.String("in", "", "Template file path")
+	outFlag             = flag.String("out", "", "Output file path where the generate file will be placed")
 )
 
 type Data struct {
-	CRDsKustomizeURL string
-	RawRepoURL       string
+	StandardCRDsKustomizeURL string
+	CRDsKustomizeURL         string
+	RawRepoURL               string
 }
 
 func main() {
 	flagParse()
 
 	data := Data{
-		CRDsKustomizeURL: *crdsURLFlag,
-		RawRepoURL:       *rawRepoURLFlag,
+		StandardCRDsKustomizeURL: *standardCrdsURLFlag,
+		CRDsKustomizeURL:         *crdsURLFlag,
+		RawRepoURL:               *rawRepoURLFlag,
 	}
 	processTemplate(*inFlag, *outFlag, data)
 }
@@ -44,6 +47,10 @@ func must(err error, errMsg string) {
 
 func flagParse() {
 	flag.Parse()
+	if *standardCrdsURLFlag == "" {
+		log.Print("Please provide the 'standard-crds-url' flag")
+		os.Exit(0)
+	}
 	if *crdsURLFlag == "" {
 		log.Print("Please provide the 'crds-url' flag")
 		os.Exit(0)

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+)
+
+// TCPEchoResponds takes a TCP address URL and a Pod name and checks if a
+// go-echo instance is running on that Pod at that address. It compares an
+// expected message and its length against an expected message, returning true
+// if it is and false and an error explanation if it is not.
+func TCPEchoResponds(url string, podName string) (bool, error) {
+	dialer := net.Dialer{Timeout: time.Second * 10}
+	conn, err := dialer.Dial("tcp", url)
+	if err != nil {
+		return false, err
+	}
+
+	header := []byte(fmt.Sprintf("Running on Pod %s.", podName))
+	message := []byte("testing tcproute")
+
+	wrote, err := conn.Write(message)
+	if err != nil {
+		return false, err
+	}
+
+	if wrote != len(message) {
+		return false, fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
+	}
+
+	if err := conn.SetDeadline(time.Now().Add(time.Second * 5)); err != nil {
+		return false, err
+	}
+
+	headerResponse := make([]byte, len(header)+1)
+	read, err := conn.Read(headerResponse)
+	if err != nil {
+		return false, err
+	}
+
+	if read != len(header)+1 { // add 1 for newline
+		return false, fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
+	}
+
+	if !bytes.Contains(headerResponse, header) {
+		return false, fmt.Errorf(`expected header response "%s", received: "%s"`, string(header), string(headerResponse))
+	}
+
+	messageResponse := make([]byte, wrote+1)
+	read, err = conn.Read(messageResponse)
+	if err != nil {
+		return false, err
+	}
+
+	if read != len(message) {
+		return false, fmt.Errorf("read %d bytes but expected %d", read, len(message))
+	}
+
+	if !bytes.Contains(messageResponse, message) {
+		return false, fmt.Errorf(`expected message response "%s", received: "%s"`, string(message), string(messageResponse))
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Update e2e test case `TestDeployAllInOneDBLESSGateway` to verify KIC works wit gateway API when:
 - Gateway API CRDs not installed
 - only `v1beta1` CRDs installed
 - `v1beta1` and `v1alpha2` CRDs installed


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #2835 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
