### PR TITLE
Remove old comment

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -37,9 +37,6 @@ type HTTPClientOpts struct {
 }
 
 // MakeHTTPClient returns an HTTP client with the specified mTLS/headers configuration.
-// BUG: This function overwrites the default transport and client in package http!
-// This problem is being left as-is during refactoring to avoid regression of untested code.
-// https://github.com/Kong/kubernetes-ingress-controller/issues/1233
 func MakeHTTPClient(opts *HTTPClientOpts) (*http.Client, error) {
 	var tlsConfig tls.Config
 


### PR DESCRIPTION
This PR removes a seemingly outdated docblock comment. As I was reading through the source code, I stumbled upon this comment that looks like it was resolved by #2332 and left in by mistake.
