### PR TITLE
ci: allow running tests that require secrets on PRs from forks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '*'
   push:

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,7 +1,7 @@
 name: tests-nightly
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
   workflow_dispatch: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to allow outside contributions from forks and make tests run (with access to secrets) for those, let's use [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) instead of `pull_request` as an event that would trigger tests workflows.

