### PR TITLE
test: run cronjob to test against kong nightly

### DIFF
--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,14 +1,12 @@
 name: tests-nightly
 
 on:
-  pull_request:
-    types:
-      - labeled
+  schedule:
+    - cron: '30 6 * * *'
   workflow_dispatch: {}
 
 jobs:
   integration-tests-enterprise-postgres-nightly:
-    if: ${{ github.event.label.name == 'ci/run-nightly' }}
     environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
run `test-nightly` agianst kong nightly build to test the compatibility with kong 3.0.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2850 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
I changed the trigger from run for each PR to run daily. WDYT is the proper way to run these tests?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
