### PR TITLE
ci: add build tag to go generate invocation for gateway API URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,14 @@ generate: generate.controllers generate.clientsets generate.gateway-api-urls
 .PHONY: generate.controllers
 generate.controllers: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="$(CRD_GEN_PATHS)"
-	go generate ./...
+	go generate $(PROJECT_DIR)/internal/cmd
+# TODO: Previously this didn't have build tags assigned so technically nothing really
+# happened upon go generate invocation for fips binary.
+# Unfortunately this requires a bit more code to change the generation code since
+# github.com/kong/kubernetes-ingress-controller/v2/hack/generators/controllers/networking
+# relies on a relative path to boilerplate.go.txt which breaks if accessed from internal/cmd/fips.
+# Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/2853
+# go generate --tags fips $(PROJECT_DIR)/internal/cmd/fips
 
 # this will generate the custom typed clients needed for end-users implementing logic in Go to use our API types.
 # TODO: we're hacking around client-gen for now to enable it for enabled go modules, should probably contribute upstream to improve this.
@@ -376,7 +383,7 @@ generate.gateway-api-urls:
 		RAW_REPO_URL=$(shell $(MAKE) print-gateway-api-raw-repo-url) \
 		INPUT=$(shell pwd)/test/internal/cmd/generate-gateway-api-urls/gateway_consts.tmpl \
 		OUTPUT=$(shell pwd)/test/consts/zz_generated_gateway.go \
-		go generate ./test/internal/cmd/generate-gateway-api-urls
+		go generate -tags=generate_gateway_api_urls ./test/internal/cmd/generate-gateway-api-urls
 
 .PHONY: go-mod-download-gateway-api
 go-mod-download-gateway-api:

--- a/test/internal/cmd/generate-gateway-api-urls/main.go
+++ b/test/internal/cmd/generate-gateway-api-urls/main.go
@@ -1,3 +1,6 @@
+//go:build generate_gateway_api_urls
+// +build generate_gateway_api_urls
+
 package main
 
 import (
@@ -12,7 +15,7 @@ import (
 	"text/template"
 )
 
-//go:generate go run . -crds-standard-url $CRDS_STANDARD_URL -crds-experimental-url $CRDS_EXPERIMENTAL_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
+//go:generate go run --tags generate_gateway_api_urls . -crds-standard-url $CRDS_STANDARD_URL -crds-experimental-url $CRDS_EXPERIMENTAL_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
 
 var (
 	crdsStandardURLFlag     = flag.String("crds-standard-url", "", "The URL of standard Gateway API CRDs to be consumed by kustomize")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses a nuance where `make generate` would trigger generation of Gateway API URLs twice (once incorrectly).

Due to this Makefile target definition:

```
.PHONY: generate
generate: generate.controllers generate.clientsets generate.gateway-api-urls
...
.PHONY: generate.controllers
generate.controllers: controller-gen
...
	go generate ./...
```

`generate.controllers` was invocation all `go:generate`s recursively from the whole repo. This was unnecessary.

This PR makes it so that `make generate.controllers` will now only call the necessary `go:generate`s and the generate code in `test/internal/cmd/generate-gateway-api-urls/` is now behind a build tag `generate_gateway_api_urls` so in the future `go generate ./...` will not trigger it without specifically adding `-tags generate_gateway_api_urls`.

The effect of this PR should be that users calling `make generate` no longer see the following:

```
go generate ./...
2022/08/24 11:02:19 Please provide the 'crds-standard-url' flag
```