### PR TITLE
chore(manifests) add KONG_ROUTER_FLAVOR env var to set kong router mode to traditional

### DIFF
--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -63,6 +63,9 @@ spec:
         # - value: /dev/stdout
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        # router mode in 3.0.0. use `traditional` here for full compatibility.
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1578,6 +1578,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
         image: kong/kong-gateway:2.8
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1573,6 +1573,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
         image: kong:2.8
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1636,6 +1636,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
         image: kong/kong-gateway:2.8
         lifecycle:
           preStop:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1591,6 +1591,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
         image: kong:2.8
         lifecycle:
           preStop:


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Kong gateway 3.0 added a new router, and 3 router modes configured by `KONG_ROUTER_FLAVOR`:

- `traditional` to use the old router
- `traditional_compatible` (default) to use the new router, while the old router APIs are still available. But have incompatibilities.
- `expression` to use the new router, and remove the support of old router APIs.

KIC 2.6 should use `traditional` for compatibility, while the default mode is `traditional_compatible`. So we need to configure the env var `KONG_ROUTER_FLAVOR` here. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2852 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
