### PR TITLE
Separate test request paths

### DIFF
--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -537,7 +537,7 @@ func TestGatewayFilters(t *testing.T) {
 					{
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchPrefix,
-							Value: kong.String("/httpbin"),
+							Value: kong.String("/test_gateway_filters"),
 						},
 					},
 				},
@@ -557,7 +557,7 @@ func TestGatewayFilters(t *testing.T) {
 
 	otherRoute, err := gatewayClient.GatewayV1alpha2().HTTPRoutes(other.Name).Create(ctx, httprouteTemplate, metav1.CreateOptions{})
 	require.NoError(t, err)
-	otherRoute.Spec.Rules[0].Matches[0].Path.Value = kong.String("/otherbin")
+	otherRoute.Spec.Rules[0].Matches[0].Path.Value = kong.String("/other_test_gateway_filters")
 	_, err = gatewayClient.GatewayV1alpha2().HTTPRoutes(other.Name).Update(ctx, otherRoute, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -580,9 +580,9 @@ func TestGatewayFilters(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 	t.Log("waiting for routes from HTTPRoute in other namespace to become operational")
-	eventuallyGETPath(t, "otherbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("changing to the same namespace filter")
 	gateway, err = gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
@@ -614,9 +614,9 @@ func TestGatewayFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("confirming other namespace route becomes inaccessible")
-	eventuallyGETPath(t, "otherbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
+	eventuallyGETPath(t, "other_test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet)
 	t.Log("confirming same namespace route still operational")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("changing to a selector filter")
 	gateway, err = gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
@@ -659,7 +659,7 @@ func TestGatewayFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("confirming wrong selector namespace route becomes inaccessible")
-	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "no Route matched", emptyHeaderSet)
+	eventuallyGETPath(t, "test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet)
 	t.Log("confirming right selector namespace route becomes operational")
-	eventuallyGETPath(t, "otherbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 }

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -124,19 +124,19 @@ func TestHTTPRouteEssentials(t *testing.T) {
 					{
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchPrefix,
-							Value: kong.String("/httpbin"),
+							Value: kong.String("/test-http-route-essentials"),
 						},
 					},
 					{
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchRegularExpression,
-							Value: kong.String(`/regex-\d{3}-httpbin`),
+							Value: kong.String(`/regex-\d{3}-test-http-route-essentials`),
 						},
 					},
 					{
 						Path: &gatewayv1alpha2.HTTPPathMatch{
 							Type:  &pathMatchExact,
-							Value: kong.String(`/exact-httpbin`),
+							Value: kong.String(`/exact-test-http-route-essentials`),
 						},
 					},
 				},
@@ -172,22 +172,22 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
 		http.StatusOK, "«yoʻq» dan boshqa bir javobimiz yoʻqdir.", emptyHeaderSet)
-	eventuallyGETPath(t, "regex-123-httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "exact-httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
-	eventuallyGETPath(t, "exact-httpbina", http.StatusNotFound, "no Route matched", emptyHeaderSet)
+	eventuallyGETPath(t, "regex-123-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet)
 
 	require.Eventually(t, func() bool {
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "httpbin"), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "test-http-route-essentials"), nil)
 		if err != nil {
 			t.Logf("WARNING: failed to create HTTP request: %v", err)
 			return false
 		}
 		resp, err := httpc.Do(req)
 		if err != nil {
-			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, "httpbin", err)
+			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, "test-http-route-essentials", err)
 			return false
 		}
 		defer resp.Body.Close()
@@ -243,8 +243,8 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	t.Log("verifying that both backends are ready to receive traffic")
 	httpbinRespContent := "<title>httpbin.org</title>"
 	nginxRespContent := "<title>Welcome to nginx!</title>"
-	eventuallyGETPath(t, "httpbin", http.StatusOK, httpbinRespContent, emptyHeaderSet)
-	eventuallyGETPath(t, "httpbin", http.StatusOK, nginxRespContent, emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, httpbinRespContent, emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, nginxRespContent, emptyHeaderSet)
 
 	t.Log("verifying that both backends receive requests according to weighted distribution")
 	httpbinRespName := "httpbin-resp"
@@ -256,7 +256,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}
 	weightedLoadBalancingTestConfig := countHTTPResponsesConfig{
 		Method:      http.MethodGet,
-		Path:        "httpbin",
+		Path:        "test-http-route-essentials",
 		Headers:     emptyHeaderSet,
 		Duration:    5 * time.Second,
 		RequestTick: 50 * time.Millisecond,
@@ -289,7 +289,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the parentRefs now removed")
-	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the parentRefs back")
 	require.Eventually(t, func() bool {
@@ -305,7 +305,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting the GatewayClass")
 	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
@@ -314,7 +314,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.HTTPProtocolType, ns.Name, httpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the GatewayClass now removed")
-	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the GatewayClass back")
 	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -326,7 +326,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting the Gateway")
 	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
@@ -336,7 +336,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the Gateway now removed")
-	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet)
 
 	t.Log("putting the Gateway back")
 	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
@@ -349,7 +349,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	eventuallyGETPath(t, "httpbin", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -360,5 +360,5 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute does not get orphaned with the GatewayClass and Gateway gone")
-	eventuallyGETPath(t, "httpbin", http.StatusNotFound, "", emptyHeaderSet)
+	eventuallyGETPath(t, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet)
 }

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -163,7 +163,7 @@ func TestHTTPSRedirect(t *testing.T) {
 	t.Logf("exposing Service %s via Ingress", service.Name)
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/test_https_redirect", map[string]string{
 		annotations.IngressClassKey:             ingressClass,
 		"konghq.com/protocols":                  "https",
 		"konghq.com/https-redirect-status-code": "301",
@@ -183,7 +183,7 @@ func TestHTTPSRedirect(t *testing.T) {
 		Timeout: time.Second * 3,
 	}
 	assert.Eventually(t, func() bool {
-		resp, err := client.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := client.Get(fmt.Sprintf("%s/test_https_redirect", proxyURL))
 		if err != nil {
 			return false
 		}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -65,7 +65,7 @@ func TestIngressEssentials(t *testing.T) {
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/test_ingress_essentials", map[string]string{
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
@@ -91,7 +91,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -137,7 +137,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Logf("verifying that removing the ingress.class annotation %q from ingress causes routes to disconnect", ingressClass)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -174,7 +174,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational after reintroducing ingress class annotation")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -195,7 +195,7 @@ func TestIngressEssentials(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -304,7 +304,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{"konghq.com/strip-path": "true"}, service)
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/test_ingressclassname_spec", map[string]string{"konghq.com/strip-path": "true"}, service)
 	switch obj := ingress.(type) {
 	case *netv1.Ingress:
 		obj.Spec.IngressClassName = kong.String(ingressClass)
@@ -324,13 +324,13 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
 		}
 		defer resp.Body.Close()
-		t.Logf("GET %s/httpbin: status code %d", proxyURL, resp.StatusCode)
+		t.Logf("GET %s/test_ingressclassname_spec: status code %d", proxyURL, resp.StatusCode)
 		if resp.StatusCode == http.StatusOK {
 			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
 			// Expected: "<title>httpbin.org</title>"
@@ -349,13 +349,13 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress causes routes to disconnect", ingressClass)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
 		}
 		defer resp.Body.Close()
-		t.Logf("GET %s/httpbin: status code %d", proxyURL, resp.StatusCode)
+		t.Logf("GET %s/test_ingressclassname_spec: status code %d", proxyURL, resp.StatusCode)
 		return expect404WithNoRoute(t, proxyURL.String(), resp)
 	}, ingressWait, waitTick)
 
@@ -365,13 +365,13 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational after reintroducing ingress class annotation")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
 		}
 		defer resp.Body.Close()
-		t.Logf("GET %s/httpbin: status code %d", proxyURL, resp.StatusCode)
+		t.Logf("GET %s/test_ingressclassname_spec: status code %d", proxyURL, resp.StatusCode)
 		if resp.StatusCode == http.StatusOK {
 			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
 			// Expected: "<title>httpbin.org</title>"
@@ -388,7 +388,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -57,7 +57,7 @@ func TestKongIngressEssentials(t *testing.T) {
 	t.Logf("routing to service %s via Ingress", service.Name)
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/test_kongingress_essentials", map[string]string{
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
@@ -96,7 +96,7 @@ func TestKongIngressEssentials(t *testing.T) {
 	t.Log("waiting for routes from Ingress to be operational and that overrides are in place")
 	httpc := http.Client{Timeout: time.Second * 10} // this timeout should never be hit, we expect a 504 from the proxy within 1000ms
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin/delay/5", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_kongingress_essentials/delay/5", proxyURL))
 		if err != nil {
 			return false
 		}
@@ -115,7 +115,7 @@ func TestKongIngressEssentials(t *testing.T) {
 
 	t.Logf("ensuring that Service %s overrides are eventually removed", service.Name)
 	assert.Eventually(t, func() bool {
-		url := fmt.Sprintf("%s/httpbin/delay/5", proxyURL)
+		url := fmt.Sprintf("%s/test_kongingress_essentials/delay/5", proxyURL)
 		resp, err := httpc.Get(url)
 		if err != nil {
 			t.Logf("failed issuing http GET for %q: %v", url, err)

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -219,7 +219,7 @@ func TestPluginOrdering(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
-	ingress := generators.NewIngressForService("/httpbin", map[string]string{
+	ingress := generators.NewIngressForService("/test_plugin_ordering", map[string]string{
 		annotations.IngressClassKey: ingressClass,
 		"konghq.com/strip-path":     "true",
 	}, service)
@@ -228,7 +228,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -286,7 +286,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", termplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -308,7 +308,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", authplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -330,7 +330,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s now takes precedence", termplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -342,7 +342,7 @@ func TestPluginOrdering(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // -----------------------------------------------------------------------------
@@ -495,4 +496,20 @@ func setup(t *testing.T) (*corev1.Namespace, *clusters.Cleaner) {
 	cleaner.AddNamespace(namespace)
 
 	return namespace, cleaner
+}
+
+// -----------------------------------------------------------------------------
+// Ingress Helpers
+// -----------------------------------------------------------------------------
+
+func cleanIngress(cleaner *clusters.Cleaner, ingress runtime.Object) error {
+	if v1, ok := ingress.(*netv1.Ingress); ok {
+		cleaner.Add(v1)
+		return nil
+	}
+	if v1beta1, ok := ingress.(*netv1beta1.Ingress); ok {
+		cleaner.Add(v1beta1)
+		return nil
+	}
+	return fmt.Errorf("%s is not an Ingress", ingress.GetObjectKind().GroupVersionKind().String())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Stops using the same route path across different tests. I'm not sure why this hasn't caused many problems in the past (maybe they were just uncommon and ambiguous enough that we never dug into them), but it makes sense. If nothing else, it confirms what made what when reading diagnostic dumps.

Update the plugin test to use the diagnostics system. Adding this required a small helper to handle the v1/v1beta1 Ingress split.