### PR TITLE
build: use third_party build tag for dependencies

### DIFF
--- a/third_party/client-gen.go
+++ b/third_party/client-gen.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "k8s.io/code-generator/cmd/client-gen"
+)
+
+//go:generate go install -modfile go.mod k8s.io/code-generator/cmd/client-gen

--- a/third_party/controller-gen.go
+++ b/third_party/controller-gen.go
@@ -1,0 +1,25 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "sigs.k8s.io/controller-tools/pkg/crd"
+	_ "sigs.k8s.io/controller-tools/pkg/rbac"
+	_ "sigs.k8s.io/controller-tools/pkg/version"
+	_ "sigs.k8s.io/controller-tools/pkg/webhook"
+)
+
+// For some reason controller-tools is the only package that complains when
+// imported. Proabably because it's a main package but not sure why other main
+// package modules don't complain like this.
+//
+// Hence we resort to manually importing several of its subpackages to
+// make sigs.k8s.io/controller-tools show up in go.mod with a proper version
+// so that it can be managed via go tools when udating tools' dependencies.
+//
+// go: finding module for package sigs.k8s.io/controller-tools
+// github.com/kong/gateway-operator/third_party imports
+// sigs.k8s.io/controller-tools: module sigs.k8s.io/controller-tools@latest found (v0.9.2), but does not contain package sigs.k8s.io/controller-tools
+
+//go:generate go install -modfile go.mod sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/third_party/golangci-lint.go
+++ b/third_party/golangci-lint.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+)
+
+//go:generate go install -modfile go.mod github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/third_party/gotestfmt.go
+++ b/third_party/gotestfmt.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "github.com/haveyoudebuggedit/gotestfmt/v2"
+)
+
+//go:generate go install -modfile go.mod github.com/haveyoudebuggedit/gotestfmt/v2

--- a/third_party/kustomize.go
+++ b/third_party/kustomize.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "sigs.k8s.io/kustomize/kustomize/v4"
+)
+
+//go:generate go install -modfile go.mod sigs.k8s.io/kustomize/kustomize/v4

--- a/third_party/pkg.go
+++ b/third_party/pkg.go
@@ -1,9 +1,0 @@
-package tools
-
-import (
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/haveyoudebuggedit/gotestfmt/v2"
-	_ "k8s.io/code-generator/cmd/client-gen"
-	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
-	_ "sigs.k8s.io/kustomize/kustomize/v4"
-)


### PR DESCRIPTION
**What this PR does / why we need it**:

This retrofits https://github.com/Kong/gateway-operator/pull/90 into this repo.

The reason why I want to do this now is that after https://github.com/Kong/gateway-operator/pull/252 got merged, `make generate.apis` throws this error:

```
<PATH>/gateway-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
pkg.go:4:2: import "github.com/golangci/golangci-lint/cmd/golangci-lint" is a program, not an importable package
pkg.go:6:2: import "k8s.io/code-generator/cmd/client-gen" is a program, not an importable package
pkg.go:7:2: import "sigs.k8s.io/controller-tools/cmd/controller-gen" is a program, not an importable package
pkg.go:8:2: import "sigs.k8s.io/kustomize/kustomize/v4" is a program, not an importable package
```