### PR TITLE
chore(build): fix gotestfmt install path

### DIFF
--- a/third_party/gotestfmt.go
+++ b/third_party/gotestfmt.go
@@ -7,4 +7,4 @@ import (
 	_ "github.com/haveyoudebuggedit/gotestfmt/v2"
 )
 
-//go:generate go install -modfile go.mod github.com/haveyoudebuggedit/gotestfmt/v2
+//go:generate go install -modfile go.mod github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes `make gotestfmt` target (which installs `gotestfmt` utility).

It seems that the install path was incorrect and it didn't install the binary.