### PR TITLE
chore: bump Gateway API's GatewayClass from v1alpha2 to v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
 - Added support for Kong 3.0 upstream `query_arg` and `uri_capture` hash
   configuration to KongIngress.
   [#2822](https://github.com/Kong/kubernetes-ingress-controller/issues/2822)
+- Added support for Gateway API's GatewayClass v1beta1.
+  [#2889](https://github.com/Kong/kubernetes-ingress-controller/issues/2889)
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@
 - Added support for Kong 3.0 upstream `query_arg` and `uri_capture` hash
   configuration to KongIngress.
   [#2822](https://github.com/Kong/kubernetes-ingress-controller/issues/2822)
-- Added support for Gateway API's GatewayClass v1beta1.
+- Added support for Gateway API's v1beta1 versions of: GatewayClass, Gateway
+  and HTTPRoute.
   [#2889](https://github.com/Kong/kubernetes-ingress-controller/issues/2889)
 
 #### Fixed

--- a/Makefile
+++ b/Makefile
@@ -400,21 +400,21 @@ go-mod-download-gateway-api:
 	@go mod download $(GATEWAY_API_PACKAGE)
 
 .PHONY: install-gateway-api-crds
-install-gateway-api-crds: go-mod-download-gateway-api
+install-gateway-api-crds: go-mod-download-gateway-api kustomize
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_LOCAL_PATH) | kubectl apply -f -
 
 .PHONY: uninstall-gateway-api-crds
-uninstall-gateway-api-crds: go-mod-download-gateway-api
+uninstall-gateway-api-crds: go-mod-download-gateway-api kustomize
 	$(KUSTOMIZE) build $(GATEWAY_API_CRDS_LOCAL_PATH) | kubectl delete -f -
 
 # Install CRDs into the K8s cluster specified in $KUBECONFIG.
 .PHONY: install
-install: manifests kustomize install-gateway-api-crds
+install: manifests install-gateway-api-crds
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
 # Uninstall CRDs from the K8s cluster specified in $KUBECONFIG.
 .PHONY: uninstall
-uninstall: manifests kustomize uninstall-gateway-api-crds
+uninstall: manifests uninstall-gateway-api-crds
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in $KUBECONFIG.

--- a/PROJECT
+++ b/PROJECT
@@ -75,6 +75,15 @@ resources:
   controller: true
   domain: networking.k8s.io
   group: gateway
+  kind: GatewayClass
+  path: github.com/kubernetes-sigs/gateway-api/apis/v1beta1
+  version: v1beta1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: networking.k8s.io
+  group: gateway
   kind: HTTPRoute
   path: github.com/kubernetes-sigs/gateway-api/apis/v1alpha2
   version: v1alpha2

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
@@ -90,7 +91,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// watch for updates to gatewayclasses, if any gateway classes change, enqueue
 	// reconciliation for all supported gateway objects which reference it.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.GatewayClass{}},
+		&source.Kind{Type: &gatewayv1beta1.GatewayClass{}},
 		handler.EnqueueRequestsFromMapFunc(r.listGatewaysForGatewayClass),
 		predicate.NewPredicateFuncs(r.gatewayClassMatchesController),
 	); err != nil {
@@ -122,7 +123,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// start the required gatewayclass controller as well
 	gwcCTRL := &GatewayClassReconciler{
 		Client: r.Client,
-		Log:    r.Log.WithName("V1Alpha2GatewayClass"),
+		Log:    r.Log.WithName("V1Beta1GatewayClass"),
 		Scheme: r.Scheme,
 	}
 
@@ -141,23 +142,23 @@ func (r *GatewayReconciler) gatewayHasMatchingGatewayClass(obj client.Object) bo
 		r.Log.Error(fmt.Errorf("unexpected object type in gateway watch predicates"), "expected", "*gatewayv1alpha2.Gateway", "found", reflect.TypeOf(obj))
 		return false
 	}
-	gatewayClass := &gatewayv1alpha2.GatewayClass{}
+	gatewayClass := &gatewayv1beta1.GatewayClass{}
 	if err := r.Client.Get(context.Background(), client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
 		r.Log.Error(err, "could not retrieve gatewayclass", "gatewayclass", gateway.Spec.GatewayClassName)
 		return false
 	}
-	return gatewayClass.Spec.ControllerName == ControllerName
+	return gatewayClass.Spec.ControllerName == gatewayv1beta1.GatewayController(ControllerName)
 }
 
 // gatewayClassMatchesController is a watch predicate which filters out events for gatewayclasses which
 // aren't configured with the required ControllerName, e.g. they are not supported by this controller.
 func (r *GatewayReconciler) gatewayClassMatchesController(obj client.Object) bool {
-	gatewayClass, ok := obj.(*gatewayv1alpha2.GatewayClass)
+	gatewayClass, ok := obj.(*gatewayv1beta1.GatewayClass)
 	if !ok {
-		r.Log.Error(fmt.Errorf("unexpected object type in gatewayclass watch predicates"), "expected", "*gatewayv1alpha2.GatewayClass", "found", reflect.TypeOf(obj))
+		r.Log.Error(fmt.Errorf("unexpected object type in gatewayclass watch predicates"), "expected", "*gatewayv1beta1.GatewayClass", "found", reflect.TypeOf(obj))
 		return false
 	}
-	return gatewayClass.Spec.ControllerName == ControllerName
+	return gatewayClass.Spec.ControllerName == gatewayv1beta1.GatewayController(ControllerName)
 }
 
 // listGatewaysForGatewayClass is a watch predicate which finds all the gateway objects reference
@@ -215,7 +216,7 @@ func (r *GatewayReconciler) listGatewaysForService(svc client.Object) (recs []re
 		return
 	}
 	for _, gateway := range gateways.Items {
-		gatewayClass := &gatewayv1alpha2.GatewayClass{}
+		gatewayClass := &gatewayv1beta1.GatewayClass{}
 		if err := r.Client.Get(context.Background(), types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
 			r.Log.Error(err, "failed to retrieve gateway class in watch predicates", "gatewayclass", gateway.Spec.GatewayClassName)
 			return
@@ -280,7 +281,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// the interim while the object has been queued for reconciliation. This double check
 	// reduces reconciliation operations that would occur on old information.
 	debug(log, gateway, "verifying gatewayclass")
-	gwc := &gatewayv1alpha2.GatewayClass{}
+	gwc := &gatewayv1beta1.GatewayClass{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, gwc); err != nil {
 		debug(log, gateway, "could not retrieve gatewayclass for gateway", "gatewayclass", string(gateway.Spec.GatewayClassName))
 		if err := r.DataplaneClient.DeleteObject(gateway); err != nil {
@@ -290,7 +291,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		debug(log, gateway, "ensured object was removed from the data-plane (if ever present)")
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(gateway)
 	}
-	if gwc.Spec.ControllerName != ControllerName {
+	if gwc.Spec.ControllerName != gatewayv1beta1.GatewayController(ControllerName) {
 		debug(log, gateway, "unsupported gatewayclass controllername, ignoring", "gatewayclass", gwc.Name, "controllername", gwc.Spec.ControllerName)
 		if err := r.DataplaneClient.DeleteObject(gateway); err != nil {
 			debug(log, gateway, "failed to delete object from data-plane, requeuing")

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -230,12 +231,12 @@ func Test_pruneStatusConditions(t *testing.T) {
 
 func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 	t.Log("generating a gatewayclass to test reconciliation filters")
-	gatewayClass := &gatewayv1alpha2.GatewayClass{
+	gatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "us",
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(ControllerName),
 		},
 	}
 
@@ -325,21 +326,21 @@ func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 
 func Test_isGatewayControlledAndUnmanagedMode(t *testing.T) {
 	t.Log("generating a gatewayclass controlled by this controller implementation")
-	controlledGatewayClass := &gatewayv1alpha2.GatewayClass{
+	controlledGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "us",
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(ControllerName),
 		},
 	}
 
 	t.Log("generating a gatewayclass not controlled by this implementation")
-	uncontrolledGatewayClass := &gatewayv1alpha2.GatewayClass{
+	uncontrolledGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "eu",
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
+		Spec: gatewayv1beta1.GatewayClassSpec{
 			ControllerName: "acme.io/gateway-controller",
 		},
 	}

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 )
@@ -67,9 +68,9 @@ func isGatewayReady(gateway *gatewayv1alpha2.Gateway) bool {
 
 // isGatewayInClassAndUnmanaged returns boolean if the provided combination of gateway and class
 // is controlled by this controller and the gateway is configured for unmanaged mode.
-func isGatewayInClassAndUnmanaged(gatewayClass *gatewayv1alpha2.GatewayClass, gateway gatewayv1alpha2.Gateway) bool {
+func isGatewayInClassAndUnmanaged(gatewayClass *gatewayv1beta1.GatewayClass, gateway gatewayv1alpha2.Gateway) bool {
 	_, ok := annotations.ExtractUnmanagedGatewayMode(gateway.Annotations)
-	return ok && gatewayClass.Spec.ControllerName == ControllerName
+	return ok && gatewayClass.Spec.ControllerName == gatewayv1beta1.GatewayController(ControllerName)
 }
 
 // getRefFromPublishService splits a publish service string in the format namespace/name into a types.NamespacedName
@@ -547,12 +548,12 @@ func isGatewayClassEventInClass(log logr.Logger, watchEvent interface{}) bool {
 	}
 
 	for _, obj := range objs {
-		gwc, ok := obj.(*gatewayv1alpha2.GatewayClass)
+		gwc, ok := obj.(*gatewayv1beta1.GatewayClass)
 		if !ok {
 			log.Error(fmt.Errorf("invalid type"), "received invalid object type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 			continue
 		}
-		if gwc.Spec.ControllerName == ControllerName {
+		if gwc.Spec.ControllerName == gatewayv1beta1.GatewayController(ControllerName) {
 			return true
 		}
 	}

--- a/internal/controllers/gateway/gatewayclass_controller_test.go
+++ b/internal/controllers/gateway/gatewayclass_controller_test.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func Test_setGatewayClassCondtion(t *testing.T) {
 	testCases := []struct {
 		name            string
-		gwc             *gatewayv1alpha2.GatewayClass
+		gwc             *gatewayv1beta1.GatewayClass
 		condition       metav1.Condition
 		conditionLength int
 	}{
 		{
 			name: "no_such_condition_should_append_one",
-			gwc:  &gatewayv1alpha2.GatewayClass{},
+			gwc:  &gatewayv1beta1.GatewayClass{},
 			condition: metav1.Condition{
 				Type:               "fake1",
 				Status:             metav1.ConditionTrue,
@@ -29,8 +29,8 @@ func Test_setGatewayClassCondtion(t *testing.T) {
 		},
 		{
 			name: "have_condition_with_type_should_replace",
-			gwc: &gatewayv1alpha2.GatewayClass{
-				Status: gatewayv1alpha2.GatewayClassStatus{
+			gwc: &gatewayv1beta1.GatewayClass{
+				Status: gatewayv1beta1.GatewayClassStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               "fake1",
@@ -53,8 +53,8 @@ func Test_setGatewayClassCondtion(t *testing.T) {
 		},
 		{
 			name: "multiple_conditions_with_type_should_preserve_one",
-			gwc: &gatewayv1alpha2.GatewayClass{
-				Status: gatewayv1alpha2.GatewayClassStatus{
+			gwc: &gatewayv1beta1.GatewayClass{
+				Status: gatewayv1beta1.GatewayClassStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               "fake1",

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -60,7 +61,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.GatewayClass{}},
+		&source.Kind{Type: &gatewayv1beta1.GatewayClass{}},
 		handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForGatewayClass),
 		predicate.Funcs{
 			GenericFunc: func(e event.GenericEvent) bool { return false }, // we don't need to enqueue from generic
@@ -106,7 +107,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // the cached manager client to avoid API overhead.
 func (r *HTTPRouteReconciler) listHTTPRoutesForGatewayClass(obj client.Object) []reconcile.Request {
 	// verify that the object is a GatewayClass
-	gwc, ok := obj.(*gatewayv1alpha2.GatewayClass)
+	gwc, ok := obj.(*gatewayv1beta1.GatewayClass)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 		return nil

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
@@ -86,7 +87,7 @@ func getSupportedGatewayForRoute(ctx context.Context, mgrc client.Client, obj cl
 		}
 
 		// pull the GatewayClass for the Gateway object from the cached client
-		gatewayClass := gatewayv1alpha2.GatewayClass{}
+		gatewayClass := gatewayv1beta1.GatewayClass{}
 		if err := mgrc.Get(ctx, client.ObjectKey{
 			Name: string(gateway.Spec.GatewayClassName),
 		}, &gatewayClass); err != nil {
@@ -101,7 +102,7 @@ func getSupportedGatewayForRoute(ctx context.Context, mgrc client.Client, obj cl
 
 		// if the GatewayClass matches this controller we're all set and this controller
 		// should reconcile this object.
-		if gatewayClass.Spec.ControllerName == ControllerName {
+		if gatewayClass.Spec.ControllerName == gatewayv1beta1.GatewayController(ControllerName) {
 			allowedNamespaces := make(map[string]interface{})
 			// set true if we find any AllowedRoutes. there may be none, in which case any namespace is permitted
 			filtered := false

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -54,7 +55,7 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.GatewayClass{}},
+		&source.Kind{Type: &gatewayv1beta1.GatewayClass{}},
 		handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForGatewayClass),
 		predicate.Funcs{
 			GenericFunc: func(e event.GenericEvent) bool { return false }, // we don't need to enqueue from generic
@@ -100,7 +101,7 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // the cached manager client to avoid API overhead.
 func (r *TCPRouteReconciler) listTCPRoutesForGatewayClass(obj client.Object) []reconcile.Request {
 	// verify that the object is a GatewayClass
-	gwc, ok := obj.(*gatewayv1alpha2.GatewayClass)
+	gwc, ok := obj.(*gatewayv1beta1.GatewayClass)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 		return nil

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -54,7 +55,7 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.GatewayClass{}},
+		&source.Kind{Type: &gatewayv1beta1.GatewayClass{}},
 		handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForGatewayClass),
 		predicate.Funcs{
 			GenericFunc: func(e event.GenericEvent) bool { return false }, // we don't need to enqueue from generic
@@ -100,7 +101,7 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // the cached manager client to avoid API overhead.
 func (r *TLSRouteReconciler) listTLSRoutesForGatewayClass(obj client.Object) []reconcile.Request {
 	// verify that the object is a GatewayClass
-	gwc, ok := obj.(*gatewayv1alpha2.GatewayClass)
+	gwc, ok := obj.(*gatewayv1beta1.GatewayClass)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 		return nil

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -54,7 +55,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.GatewayClass{}},
+		&source.Kind{Type: &gatewayv1beta1.GatewayClass{}},
 		handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForGatewayClass),
 		predicate.Funcs{
 			GenericFunc: func(e event.GenericEvent) bool { return false }, // we don't need to enqueue from generic
@@ -100,7 +101,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // the cached manager client to avoid API overhead.
 func (r *UDPRouteReconciler) listUDPRoutesForGatewayClass(obj client.Object) []reconcile.Request {
 	// verify that the object is a GatewayClass
-	gwc, ok := obj.(*gatewayv1alpha2.GatewayClass)
+	gwc, ok := obj.(*gatewayv1beta1.GatewayClass)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 		return nil

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -260,9 +260,10 @@ var (
 // decisions (such as staggering or stifling duplicate log lines).
 //
 // TODO: This is a bit of a hack for now to keep backwards compat,
-//       but in the future we might configure rolling this into
-//       some object/interface which has this functionality as an
-//       inherent behavior.
+//
+//	but in the future we might configure rolling this into
+//	some object/interface which has this functionality as an
+//	inherent behavior.
 func hasSHAUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
 	shaLock.Lock()
 	defer shaLock.Unlock()

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
@@ -370,8 +371,8 @@ var gatewayCRDExistsChecker = crdExistsChecker{
 
 var gatewayClassCRDExistsChecker = crdExistsChecker{
 	GVR: schema.GroupVersionResource{
-		Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
-		Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
+		Group:    gatewayv1beta1.SchemeGroupVersion.Group,
+		Version:  gatewayv1beta1.SchemeGroupVersion.Version,
 		Resource: "gatewayclasses",
 	},
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/metadata"
@@ -47,6 +48,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	utilruntime.Must(configurationv1beta1.AddToScheme(scheme))
 	utilruntime.Must(knativev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gatewayv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
 
 	if c.EnableLeaderElection {
 		setupLog.V(0).Info("the --leader-elect flag is deprecated and no longer has any effect: leader election is set based on the Kong database setting")

--- a/pkg/apis/configuration/v1/configsource.go
+++ b/pkg/apis/configuration/v1/configsource.go
@@ -1,19 +1,19 @@
 package v1
 
 // ConfigSource is a wrapper around SecretValueFromSource
-//+kubebuilder:object:generate=true
+// +kubebuilder:object:generate=true
 type ConfigSource struct {
 	SecretValue SecretValueFromSource `json:"secretKeyRef,omitempty"`
 }
 
 // NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource
-//+kubebuilder:object:generate=true
+// +kubebuilder:object:generate=true
 type NamespacedConfigSource struct {
 	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value
-//+kubebuilder:object:generate=true
+// +kubebuilder:object:generate=true
 type SecretValueFromSource struct {
 	// the secret containing the key
 	//+kubebuilder:validation:Required
@@ -24,7 +24,7 @@ type SecretValueFromSource struct {
 }
 
 // NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace
-//+kubebuilder:object:generate=true
+// +kubebuilder:object:generate=true
 type NamespacedSecretValueFromSource struct {
 	// The namespace containing the secret
 	//+kubebuilder:validation:Required

--- a/pkg/apis/configuration/v1/kongingress_types.go
+++ b/pkg/apis/configuration/v1/kongingress_types.go
@@ -59,7 +59,7 @@ type KongIngressList struct {
 }
 
 // KongIngressService contains KongIngress service configuration.
-//+ It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress
+// + It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress
 type KongIngressService struct {
 	// The protocol used to communicate with the upstream.
 	//+kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
@@ -89,7 +89,7 @@ type KongIngressService struct {
 }
 
 // KongIngressRoute contains KongIngress route configuration
-//+ It contains the subset of go-kong.kong.Route fields supported by kongstate.Route.overrideByKongIngress
+// + It contains the subset of go-kong.kong.Route fields supported by kongstate.Route.overrideByKongIngress
 type KongIngressRoute struct {
 	// Methods is a list of HTTP methods that match this Route.
 	Methods []*string `json:"methods,omitempty" yaml:"methods,omitempty"`
@@ -135,7 +135,7 @@ type KongIngressRoute struct {
 }
 
 // KongIngressUpstream contains KongIngress upstream configuration
-//+ It contains the subset of go-kong.kong.Upstream fields supported by kongstate.Upstream.overrideByKongIngress
+// + It contains the subset of go-kong.kong.Upstream fields supported by kongstate.Upstream.overrideByKongIngress
 type KongIngressUpstream struct {
 	// HostHeader is The hostname to be used as Host header
 	// when proxying requests through Kong.

--- a/pkg/apis/configuration/v1/kongprotocol_types.go
+++ b/pkg/apis/configuration/v1/kongprotocol_types.go
@@ -1,9 +1,9 @@
 package v1
 
-//+ KongProtocol is a valid Kong protocol
-//+ This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
-//+kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
-//+kubebuilder:object:generate=true
+// + KongProtocol is a valid Kong protocol
+// + This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+// +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
+// +kubebuilder:object:generate=true
 type KongProtocol string
 
 // KongProtocolsToStrings converts a slice of KongProtocol to plain strings

--- a/pkg/apis/configuration/v1beta1/groupversion_info.go
+++ b/pkg/apis/configuration/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the configuration.konghq.com v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=configuration.konghq.com
+// +kubebuilder:object:generate=true
+// +groupName=configuration.konghq.com
 package v1beta1
 
 import (

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
@@ -33,14 +34,15 @@ func TestGatewayConformance(t *testing.T) {
 	client, err := client.New(env.Cluster().Config(), client.Options{})
 	require.NoError(t, err)
 	require.NoError(t, gatewayv1alpha2.AddToScheme(client.Scheme()))
+	require.NoError(t, gatewayv1beta1.AddToScheme(client.Scheme()))
 
 	t.Log("creating GatewayClass for gateway conformance tests")
-	gwc := &gatewayv1alpha2.GatewayClass{
+	gwc := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(gateway.ControllerName),
 		},
 	}
 	require.NoError(t, client.Create(ctx, gwc))

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -36,15 +37,15 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 	require.NoError(t, err)
 
 	t.Log("deploying a supported gatewayclass to the test cluster")
-	supportedGatewayClass := &gatewayv1alpha2.GatewayClass{
+	supportedGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(gateway.ControllerName),
 		},
 	}
-	supportedGatewayClass, err = gc.GatewayV1alpha2().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
+	supportedGatewayClass, err = gc.GatewayV1beta1().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
@@ -93,15 +94,15 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 	require.NoError(t, err)
 
 	t.Log("deploying a supported gatewayclass to the test cluster")
-	supportedGatewayClass := &gatewayv1alpha2.GatewayClass{
+	supportedGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(gateway.ControllerName),
 		},
 	}
-	supportedGatewayClass, err = gc.GatewayV1alpha2().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
+	supportedGatewayClass, err = gc.GatewayV1beta1().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -361,8 +362,8 @@ func TestUnmanagedGatewayControllerSupport(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("deploying an unsupported gatewayclass to the test cluster")
-	unsupportedGatewayClass, err := DeployGatewayClass(ctx, gatewayClient, uuid.NewString(), func(gc *gatewayv1alpha2.GatewayClass) {
-		gc.Spec.ControllerName = unmanagedControllerName
+	unsupportedGatewayClass, err := DeployGatewayClass(ctx, gatewayClient, uuid.NewString(), func(gc *gatewayv1beta1.GatewayClass) {
+		gc.Spec.ControllerName = gatewayv1beta1.GatewayController(unmanagedControllerName)
 	})
 	require.NoError(t, err)
 	cleaner.Add(unsupportedGatewayClass)

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
@@ -34,13 +35,13 @@ const (
 
 // DeployGateway creates a default gatewayClass, accepts a variadic set of options,
 // and finally deploys it on the Kubernetes cluster by means of the gateway client given as arg.
-func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, gatewayClassName string, opts ...func(*gatewayv1alpha2.GatewayClass)) (*gatewayv1alpha2.GatewayClass, error) {
-	gwc := &gatewayv1alpha2.GatewayClass{
+func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, gatewayClassName string, opts ...func(*gatewayv1beta1.GatewayClass)) (*gatewayv1beta1.GatewayClass, error) {
+	gwc := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gatewayClassName,
 		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController(gateway.ControllerName),
 		},
 	}
 
@@ -48,13 +49,13 @@ func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, ga
 		opt(gwc)
 	}
 
-	result, err := client.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+	result, err := client.GatewayV1beta1().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
-		err = client.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{})
+		err = client.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{})
 		if err != nil {
 			return result, err
 		}
-		result, err = client.GatewayV1alpha2().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
+		result, err = client.GatewayV1beta1().GatewayClasses().Create(ctx, gwc, metav1.CreateOptions{})
 	}
 	return result, err
 }

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -13,6 +13,7 @@ import (
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
@@ -56,8 +57,8 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 	cleaner.Add(managedGateway)
 
 	t.Log("creating an unmanaged gatewayclass")
-	unmanagedGatewayClass, err := DeployGatewayClass(ctx, gatewayClient, uuid.NewString(), func(gc *gatewayv1alpha2.GatewayClass) {
-		gc.Spec.ControllerName = unmanagedControllerName
+	unmanagedGatewayClass, err := DeployGatewayClass(ctx, gatewayClient, uuid.NewString(), func(gc *gatewayv1beta1.GatewayClass) {
+		gc.Spec.ControllerName = gatewayv1beta1.GatewayController(unmanagedControllerName)
 	})
 	require.NoError(t, err)
 	cleaner.Add(unmanagedGatewayClass)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the handled Gateway API's CRD `GatewayConfiguration` from `v1alpha2` to `v1beta1`

**Which issue this PR fixes**:

Partially addresses #2887
Fixes #2890 

**PR Readiness Checklist**:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
- [x] manually run (via `make run`) against a local kind cluster and applied https://github.com/Kong/kubernetes-ingress-controller/blob/e6cf3cdfc551d78eceebd963a162ee293338f144/examples/gateway-httproute.yaml which contains `GatewayClass` (in API version `v1beta1`) and didn't observe any issues.
