### PR TITLE
test: temp disable kong EE and upload diag

### DIFF
--- a/.github/workflows/kong3.0_compatibility.yaml
+++ b/.github/workflows/kong3.0_compatibility.yaml
@@ -16,7 +16,7 @@ jobs:
           - 'postgres'
         kong-edition:
           - 'OSS'
-          - 'enterprise'
+          # - 'enterprise' ## temporarily disable it for issue https://github.com/Kong/kubernetes-ingress-controller/issues/2891 
     steps:
     - name: setup golang
       id: setup_golang
@@ -81,5 +81,13 @@ jobs:
         TEST_DATABASE_MODE: ${{ env.TEST_DATABASE_MODE }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests-enterprise-postgres
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
 
   # e2e-tests: ## TODO: blocked by loading kong image in manifests: https://github.com/Kong/kubernetes-ingress-controller/issues/2884


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

upload diagnostics of running Kong 3.0 compatibility tests, and temporarily disable tests against Kong EE for #2891.

failures: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/2983305677

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
