### PR TITLE
chore: bump Gateway API's Gateway from v1alpha2 to v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,10 +78,11 @@
 - Added support for Kong 3.0 upstream `query_arg` and `uri_capture` hash
   configuration to KongIngress.
   [#2822](https://github.com/Kong/kubernetes-ingress-controller/issues/2822)
-- Added support for Gateway API's v1beta1 versions of: GatewayClass, Gateway
-  and HTTPRoute.
+- Added support for Gateway API's `v1beta1` versions of: `GatewayClass`, `Gateway`
+  and `HTTPRoute`.
   [#2889](https://github.com/Kong/kubernetes-ingress-controller/issues/2889)
   [#2894](https://github.com/Kong/kubernetes-ingress-controller/issues/2894)
+  [#2900](https://github.com/Kong/kubernetes-ingress-controller/issues/2900)
 
 #### Fixed
 

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configuration "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -184,13 +183,13 @@ var (
 		Resource: "secrets",
 	}
 	gatewayGVResource = metav1.GroupVersionResource{
-		Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
-		Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
+		Group:    gatewayv1beta1.SchemeGroupVersion.Group,
+		Version:  gatewayv1beta1.SchemeGroupVersion.Version,
 		Resource: "gateways",
 	}
 	httprouteGVResource = metav1.GroupVersionResource{
-		Group:    gatewayv1alpha2.SchemeGroupVersion.Group,
-		Version:  gatewayv1alpha2.SchemeGroupVersion.Version,
+		Group:    gatewayv1beta1.SchemeGroupVersion.Group,
+		Version:  gatewayv1beta1.SchemeGroupVersion.Version,
 		Resource: "httproutes",
 	}
 )
@@ -294,7 +293,7 @@ func (a RequestHandler) handleValidation(ctx context.Context, request admissionv
 			return nil, fmt.Errorf("unknown operation '%v'", string(request.Operation))
 		}
 	case gatewayGVResource:
-		gateway := gatewayv1alpha2.Gateway{}
+		gateway := gatewayv1beta1.Gateway{}
 		deserializer := codecs.UniversalDeserializer()
 		_, _, err = deserializer.Decode(request.Object.Raw, nil, &gateway)
 		if err != nil {

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -15,7 +15,6 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configuration "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -51,7 +50,7 @@ func (v KongFakeValidator) ValidateCredential(ctx context.Context, secret corev1
 	return v.Result, v.Message, v.Error
 }
 
-func (v KongFakeValidator) ValidateGateway(ctx context.Context, gateway gatewayv1alpha2.Gateway) (bool, string, error) {
+func (v KongFakeValidator) ValidateGateway(ctx context.Context, gateway gatewayv1beta1.Gateway) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -17,45 +17,45 @@ import (
 
 func Test_readyConditionExistsForObservedGeneration(t *testing.T) {
 	t.Log("checking ready condition for currently ready gateway")
-	currentlyReadyGateway := &gatewayv1alpha2.Gateway{
+	currentlyReadyGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 1,
 		},
-		Status: gatewayv1alpha2.GatewayStatus{
+		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
-				Type:               string(gatewayv1alpha2.GatewayConditionReady),
+				Type:               string(gatewayv1beta1.GatewayConditionReady),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: 1,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1alpha2.GatewayReasonReady),
+				Reason:             string(gatewayv1beta1.GatewayReasonReady),
 			}},
 		},
 	}
 	assert.True(t, isGatewayReady(currentlyReadyGateway))
 
 	t.Log("checking ready condition for previously ready gateway that has since been updated")
-	previouslyReadyGateway := &gatewayv1alpha2.Gateway{
+	previouslyReadyGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 2,
 		},
-		Status: gatewayv1alpha2.GatewayStatus{
+		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
-				Type:               string(gatewayv1alpha2.GatewayConditionReady),
+				Type:               string(gatewayv1beta1.GatewayConditionReady),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: 1,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1alpha2.GatewayReasonReady),
+				Reason:             string(gatewayv1beta1.GatewayReasonReady),
 			}},
 		},
 	}
 	assert.False(t, isGatewayReady(previouslyReadyGateway))
 
 	t.Log("checking ready condition for a gateway which has never been ready")
-	neverBeenReadyGateway := &gatewayv1alpha2.Gateway{
+	neverBeenReadyGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 10,
 		},
-		Status: gatewayv1alpha2.GatewayStatus{},
+		Status: gatewayv1beta1.GatewayStatus{},
 	}
 	assert.False(t, isGatewayReady(neverBeenReadyGateway))
 }
@@ -63,13 +63,13 @@ func Test_readyConditionExistsForObservedGeneration(t *testing.T) {
 func Test_setGatewayCondtion(t *testing.T) {
 	testCases := []struct {
 		name            string
-		gw              *gatewayv1alpha2.Gateway
+		gw              *gatewayv1beta1.Gateway
 		condition       metav1.Condition
 		conditionLength int
 	}{
 		{
 			name: "no_such_condition_should_append_one",
-			gw:   &gatewayv1alpha2.Gateway{},
+			gw:   &gatewayv1beta1.Gateway{},
 			condition: metav1.Condition{
 				Type:               "fake1",
 				Status:             metav1.ConditionTrue,
@@ -81,8 +81,8 @@ func Test_setGatewayCondtion(t *testing.T) {
 		},
 		{
 			name: "have_condition_with_type_should_replace",
-			gw: &gatewayv1alpha2.Gateway{
-				Status: gatewayv1alpha2.GatewayStatus{
+			gw: &gatewayv1beta1.Gateway{
+				Status: gatewayv1beta1.GatewayStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               "fake1",
@@ -105,8 +105,8 @@ func Test_setGatewayCondtion(t *testing.T) {
 		},
 		{
 			name: "multiple_conditions_with_type_should_preserve_one",
-			gw: &gatewayv1alpha2.Gateway{
-				Status: gatewayv1alpha2.GatewayStatus{
+			gw: &gatewayv1beta1.Gateway{
+				Status: gatewayv1beta1.GatewayStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               "fake1",
@@ -166,21 +166,21 @@ func Test_setGatewayCondtion(t *testing.T) {
 
 func Test_isGatewayMarkedAsScheduled(t *testing.T) {
 	t.Log("verifying scheduled check for gateway object which has been scheduled")
-	scheduledGateway := &gatewayv1alpha2.Gateway{
-		Status: gatewayv1alpha2.GatewayStatus{
+	scheduledGateway := &gatewayv1beta1.Gateway{
+		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
-				Type:               string(gatewayv1alpha2.GatewayConditionScheduled),
+				Type:               string(gatewayv1beta1.GatewayConditionScheduled),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: 1,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1alpha2.GatewayReasonScheduled),
+				Reason:             string(gatewayv1beta1.GatewayReasonScheduled),
 			}},
 		},
 	}
 	assert.True(t, isGatewayScheduled(scheduledGateway))
 
 	t.Log("verifying scheduled check for gateway object which has not been scheduled")
-	unscheduledGateway := &gatewayv1alpha2.Gateway{}
+	unscheduledGateway := &gatewayv1beta1.Gateway{}
 	assert.False(t, isGatewayScheduled(unscheduledGateway))
 }
 
@@ -203,7 +203,7 @@ func Test_getRefFromPublishService(t *testing.T) {
 
 func Test_pruneStatusConditions(t *testing.T) {
 	t.Log("verifying that a gateway with minimal status conditions is not pruned")
-	gateway := &gatewayv1alpha2.Gateway{}
+	gateway := &gatewayv1beta1.Gateway{}
 	for i := 0; i < 4; i++ {
 		gateway.Status.Conditions = append(gateway.Status.Conditions, metav1.Condition{Type: "fake", ObservedGeneration: int64(i)})
 	}
@@ -241,14 +241,14 @@ func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 	}
 
 	t.Log("generating a list of matching controllers")
-	matching := []gatewayv1alpha2.Gateway{
+	matching := []gatewayv1beta1.Gateway{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "sanfrancisco",
 				Namespace: "california",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{
-				GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClass.Name),
+			Spec: gatewayv1beta1.GatewaySpec{
+				GatewayClassName: gatewayv1beta1.ObjectName(gatewayClass.Name),
 			},
 		},
 		{
@@ -256,8 +256,8 @@ func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 				Name:      "sandiego",
 				Namespace: "california",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{
-				GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClass.Name),
+			Spec: gatewayv1beta1.GatewaySpec{
+				GatewayClassName: gatewayv1beta1.ObjectName(gatewayClass.Name),
 			},
 		},
 		{
@@ -265,21 +265,21 @@ func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 				Name:      "losangelos",
 				Namespace: "california",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{
-				GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClass.Name),
+			Spec: gatewayv1beta1.GatewaySpec{
+				GatewayClassName: gatewayv1beta1.ObjectName(gatewayClass.Name),
 			},
 		},
 	}
 
 	t.Log("generating a list of non-matching controllers")
-	nonmatching := []gatewayv1alpha2.Gateway{
+	nonmatching := []gatewayv1beta1.Gateway{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hamburg",
 				Namespace: "germany",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{
-				GatewayClassName: gatewayv1alpha2.ObjectName("eu"),
+			Spec: gatewayv1beta1.GatewaySpec{
+				GatewayClassName: gatewayv1beta1.ObjectName("eu"),
 			},
 		},
 		{
@@ -287,8 +287,8 @@ func Test_reconcileGatewaysIfClassMatches(t *testing.T) {
 				Name:      "paris",
 				Namespace: "france",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{
-				GatewayClassName: gatewayv1alpha2.ObjectName("eu"),
+			Spec: gatewayv1beta1.GatewaySpec{
+				GatewayClassName: gatewayv1beta1.ObjectName("eu"),
 			},
 		},
 	}
@@ -346,7 +346,7 @@ func Test_isGatewayControlledAndUnmanagedMode(t *testing.T) {
 	}
 
 	t.Log("creating an unmanaged mode enabled gateway")
-	unmanagedGateway := gatewayv1alpha2.Gateway{
+	unmanagedGateway := gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
@@ -356,8 +356,8 @@ func Test_isGatewayControlledAndUnmanagedMode(t *testing.T) {
 	}
 
 	t.Log("verifying the results for several gateways")
-	assert.False(t, isGatewayInClassAndUnmanaged(controlledGatewayClass, gatewayv1alpha2.Gateway{}))
-	assert.False(t, isGatewayInClassAndUnmanaged(uncontrolledGatewayClass, gatewayv1alpha2.Gateway{}))
+	assert.False(t, isGatewayInClassAndUnmanaged(controlledGatewayClass, gatewayv1beta1.Gateway{}))
+	assert.False(t, isGatewayInClassAndUnmanaged(uncontrolledGatewayClass, gatewayv1beta1.Gateway{}))
 	assert.False(t, isGatewayInClassAndUnmanaged(uncontrolledGatewayClass, unmanagedGateway))
 	assert.True(t, isGatewayInClassAndUnmanaged(controlledGatewayClass, unmanagedGateway))
 }
@@ -517,14 +517,14 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 	testCases := []struct {
 		name             string
 		gatewayNamespace string
-		certRef          gatewayv1alpha2.SecretObjectReference
+		certRef          gatewayv1beta1.SecretObjectReference
 		referenceGrants  []gatewayv1alpha2.ReferenceGrant
 		expectedReason   string
 	}{
 		{
 			name:             "no need for reference",
 			gatewayNamespace: "test",
-			certRef: gatewayv1alpha2.SecretObjectReference{
+			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind: util.StringToGatewayAPIKindPtr("Secret"),
 				Name: "testSecret",
 			},
@@ -533,10 +533,10 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 		{
 			name:             "reference not granted",
 			gatewayNamespace: "test",
-			certRef: gatewayv1alpha2.SecretObjectReference{
+			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*gatewayv1alpha2.Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -546,7 +546,7 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 					Spec: gatewayv1alpha2.ReferenceGrantSpec{
 						From: []gatewayv1alpha2.ReferenceGrantFrom{
 							{
-								Group:     gatewayV1alpha2Group,
+								Group:     (gatewayv1alpha2.Group)(gatewayV1beta1Group),
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -566,10 +566,10 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 		{
 			name:             "reference granted, secret name not specified",
 			gatewayNamespace: "test",
-			certRef: gatewayv1alpha2.SecretObjectReference{
+			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*gatewayv1alpha2.Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -586,7 +586,7 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 							},
 							// good entry
 							{
-								Group:     gatewayV1alpha2Group,
+								Group:     (gatewayv1alpha2.Group)(gatewayV1beta1Group),
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -605,10 +605,10 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 		{
 			name:             "reference granted, secret name specified",
 			gatewayNamespace: "test",
-			certRef: gatewayv1alpha2.SecretObjectReference{
+			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*gatewayv1alpha2.Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -618,7 +618,7 @@ func Test_getReferenceGrantConditionReason(t *testing.T) {
 					Spec: gatewayv1alpha2.ReferenceGrantSpec{
 						From: []gatewayv1alpha2.ReferenceGrantFrom{
 							{
-								Group:     gatewayV1alpha2Group,
+								Group:     (gatewayv1alpha2.Group)(gatewayV1beta1Group),
 								Kind:      "Gateway",
 								Namespace: "test",
 							},

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -4,16 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 func Test_filterHostnames(t *testing.T) {
-	commonGateway := &gatewayv1alpha2.Gateway{
-		Spec: gatewayv1alpha2.GatewaySpec{
-			Listeners: []gatewayv1alpha2.Listener{
+	commonGateway := &gatewayv1beta1.Gateway{
+		Spec: gatewayv1beta1.GatewaySpec{
+			Listeners: []Listener{
 				{
 					Name:     "listener-1",
 					Hostname: util.StringToGatewayAPIHostnamePtr("very.specific.com"),

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -72,7 +72,7 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.Gateway{}},
+		&source.Kind{Type: &gatewayv1beta1.Gateway{}},
 		handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForGateway),
 	); err != nil {
 		return err
@@ -108,7 +108,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGatewayClass(obj client.Object) []r
 	}
 
 	// map all Gateway objects
-	gatewayList := gatewayv1alpha2.GatewayList{}
+	gatewayList := gatewayv1beta1.GatewayList{}
 	if err := r.Client.List(context.Background(), &gatewayList); err != nil {
 		r.Log.Error(err, "failed to list gateway objects from the cached client")
 		return nil
@@ -186,7 +186,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGatewayClass(obj client.Object) []r
 // this kind of problem without having to enqueue extra objects.
 func (r *TLSRouteReconciler) listTLSRoutesForGateway(obj client.Object) []reconcile.Request {
 	// verify that the object is a Gateway
-	gw, ok := obj.(*gatewayv1alpha2.Gateway)
+	gw, ok := obj.(*gatewayv1beta1.Gateway)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "Gateway", "found", reflect.TypeOf(obj))
 		return nil
@@ -373,7 +373,7 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{
 				Group:     (*gatewayv1alpha2.Group)(&gatewayv1alpha2.GroupVersion.Group),
-				Kind:      util.StringToGatewayAPIKindPtr(tlsrouteParentKind),
+				Kind:      (*gatewayv1alpha2.Kind)(util.StringToGatewayAPIKindPtr(tlsrouteParentKind)),
 				Namespace: (*gatewayv1alpha2.Namespace)(&gateway.gateway.Namespace),
 				Name:      gatewayv1alpha2.ObjectName(gateway.gateway.Name),
 			},

--- a/internal/controllers/gateway/types.go
+++ b/internal/controllers/gateway/types.go
@@ -1,0 +1,33 @@
+//nolint:revive
+package gateway
+
+import (
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type (
+	Gateway           = gatewayv1beta1.Gateway
+	GatewayAddress    = gatewayv1beta1.GatewayAddress
+	GatewayClass      = gatewayv1beta1.GatewayClass
+	Group             = gatewayv1beta1.Group
+	Hostname          = gatewayv1beta1.Hostname
+	HTTPRoute         = gatewayv1beta1.HTTPRoute
+	Kind              = gatewayv1beta1.Kind
+	Listener          = gatewayv1beta1.Listener
+	ListenerStatus    = gatewayv1beta1.ListenerStatus
+	Namespace         = gatewayv1beta1.Namespace
+	ObjectName        = gatewayv1beta1.ObjectName
+	ParentReference   = gatewayv1beta1.ParentReference
+	RouteParentStatus = gatewayv1beta1.RouteParentStatus
+	PortNumber        = gatewayv1beta1.PortNumber
+	ProtocolType      = gatewayv1beta1.ProtocolType
+	SectionName       = gatewayv1beta1.SectionName
+)
+
+const (
+	HTTPProtocolType  = gatewayv1beta1.HTTPProtocolType
+	HTTPSProtocolType = gatewayv1beta1.HTTPSProtocolType
+	TLSProtocolType   = gatewayv1beta1.TLSProtocolType
+	TCPProtocolType   = gatewayv1beta1.TCPProtocolType
+	UDPProtocolType   = gatewayv1beta1.UDPProtocolType
+)

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -72,7 +72,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// removed from data-plane configurations, and any routes that are now supported
 	// due to that change get added to data-plane configurations.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1alpha2.Gateway{}},
+		&source.Kind{Type: &gatewayv1beta1.Gateway{}},
 		handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForGateway),
 	); err != nil {
 		return err
@@ -108,7 +108,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGatewayClass(obj client.Object) []r
 	}
 
 	// map all Gateway objects
-	gatewayList := gatewayv1alpha2.GatewayList{}
+	gatewayList := gatewayv1beta1.GatewayList{}
 	if err := r.Client.List(context.Background(), &gatewayList); err != nil {
 		r.Log.Error(err, "failed to list gateway objects from the cached client")
 		return nil
@@ -186,7 +186,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGatewayClass(obj client.Object) []r
 // this kind of problem without having to enqueue extra objects.
 func (r *UDPRouteReconciler) listUDPRoutesForGateway(obj client.Object) []reconcile.Request {
 	// verify that the object is a Gateway
-	gw, ok := obj.(*gatewayv1alpha2.Gateway)
+	gw, ok := obj.(*gatewayv1beta1.Gateway)
 	if !ok {
 		r.Log.Error(fmt.Errorf("invalid type"), "found invalid type in event handlers", "expected", "Gateway", "found", reflect.TypeOf(obj))
 		return nil
@@ -373,7 +373,7 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{
 				Group:     (*gatewayv1alpha2.Group)(&gatewayv1alpha2.GroupVersion.Group),
-				Kind:      util.StringToGatewayAPIKindPtr(udprouteParentKind),
+				Kind:      (*gatewayv1alpha2.Kind)(util.StringToGatewayAPIKindPtr(udprouteParentKind)),
 				Namespace: (*gatewayv1alpha2.Namespace)(&gateway.gateway.Namespace),
 				Name:      gatewayv1alpha2.ObjectName(gateway.gateway.Name),
 			},

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
@@ -411,7 +412,7 @@ func getGatewayCerts(log logrus.FieldLogger, s store.Storer) []certWrapper {
 		return certs
 	}
 	for _, gateway := range gateways {
-		statuses := make(map[gatewayv1alpha2.SectionName]gatewayv1alpha2.ListenerStatus, len(gateway.Status.Listeners))
+		statuses := make(map[gatewayv1beta1.SectionName]gatewayv1beta1.ListenerStatus, len(gateway.Status.Listeners))
 		for _, status := range gateway.Status.Listeners {
 			statuses[status.Name] = status
 		}

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -73,7 +73,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 									Name: gatewayv1beta1.ObjectName("fake-service"),
 									Port: &httpPort,
-									Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+									Kind: util.StringToGatewayAPIKindPtr("Service"),
 								},
 							},
 						}},
@@ -146,7 +146,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 													BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 														Name: gatewayv1beta1.ObjectName("fake-service"),
 														Port: &httpPort,
-														Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+														Kind: util.StringToGatewayAPIKindPtr("Service"),
 													},
 												},
 											},
@@ -227,7 +227,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 									Name: gatewayv1beta1.ObjectName("fake-service"),
 									Port: &httpPort,
-									Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+									Kind: util.StringToGatewayAPIKindPtr("Service"),
 								},
 							},
 						}},
@@ -304,7 +304,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 													BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 														Name: gatewayv1beta1.ObjectName("fake-service"),
 														Port: &httpPort,
-														Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+														Kind: util.StringToGatewayAPIKindPtr("Service"),
 													},
 												},
 											},
@@ -374,7 +374,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 									Name: gatewayv1beta1.ObjectName("fake-service"),
 									Port: &httpPort,
-									Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+									Kind: util.StringToGatewayAPIKindPtr("Service"),
 								},
 							},
 						}},
@@ -414,7 +414,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 									Name: gatewayv1beta1.ObjectName("fake-service"),
 									Port: &httpPort,
-									Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+									Kind: util.StringToGatewayAPIKindPtr("Service"),
 								},
 							},
 						}},
@@ -491,7 +491,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 													BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 														Name: gatewayv1beta1.ObjectName("fake-service"),
 														Port: &httpPort,
-														Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+														Kind: util.StringToGatewayAPIKindPtr("Service"),
 													},
 												},
 											},
@@ -537,7 +537,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 									Name: gatewayv1beta1.ObjectName("fake-service"),
 									Port: &httpPort,
-									Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+									Kind: util.StringToGatewayAPIKindPtr("Service"),
 								},
 							},
 						}},
@@ -614,7 +614,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 													BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 														Name: gatewayv1beta1.ObjectName("fake-service"),
 														Port: &httpPort,
-														Kind: util.StringToGatewayAPIKindV1Beta1Ptr("Service"),
+														Kind: util.StringToGatewayAPIKindPtr("Service"),
 													},
 												},
 											},

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -23,7 +23,7 @@ import (
 // Kubernetes API.
 var httprouteGVK = schema.GroupVersionKind{
 	Group:   "gateway.networking.k8s.io",
-	Version: "v1alpha2",
+	Version: "v1beta1",
 	Kind:    "HTTPRoute",
 }
 
@@ -120,7 +120,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Annotations: make(map[string]string),
 								GroupVersionKind: schema.GroupVersionKind{
 									Group:   "gateway.networking.k8s.io",
-									Version: "v1alpha2",
+									Version: "v1beta1",
 									Kind:    "HTTPRoute",
 								},
 							},
@@ -160,7 +160,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 							},
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "HTTPRoute",
-								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+								APIVersion: "gateway.networking.k8s.io/v1beta1",
 							},
 						},
 					},
@@ -274,7 +274,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Annotations: make(map[string]string),
 								GroupVersionKind: schema.GroupVersionKind{
 									Group:   "gateway.networking.k8s.io",
-									Version: "v1alpha2",
+									Version: "v1beta1",
 									Kind:    "HTTPRoute",
 								},
 							},
@@ -318,7 +318,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 							},
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "HTTPRoute",
-								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+								APIVersion: "gateway.networking.k8s.io/v1beta1",
 							},
 						},
 					},
@@ -461,7 +461,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Annotations: make(map[string]string),
 								GroupVersionKind: schema.GroupVersionKind{
 									Group:   "gateway.networking.k8s.io",
-									Version: "v1alpha2",
+									Version: "v1beta1",
 									Kind:    "HTTPRoute",
 								},
 							},
@@ -505,7 +505,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 							},
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "HTTPRoute",
-								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+								APIVersion: "gateway.networking.k8s.io/v1beta1",
 							},
 						},
 					},
@@ -584,7 +584,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 								Annotations: make(map[string]string),
 								GroupVersionKind: schema.GroupVersionKind{
 									Group:   "gateway.networking.k8s.io",
-									Version: "v1alpha2",
+									Version: "v1beta1",
 									Kind:    "HTTPRoute",
 								},
 							},
@@ -628,7 +628,7 @@ func Test_ingressRulesFromHTTPRoutes(t *testing.T) {
 							},
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "HTTPRoute",
-								APIVersion: "gateway.networking.k8s.io/v1alpha2",
+								APIVersion: "gateway.networking.k8s.io/v1beta1",
 							},
 						},
 					},

--- a/internal/dataplane/parser/wrappers_refchecker.go
+++ b/internal/dataplane/parser/wrappers_refchecker.go
@@ -64,6 +64,19 @@ func (rc refChecker[T]) IsRefAllowedByGrant(
 			(string)(*br.Kind),
 			allowedRefs,
 		)
+
+	case gatewayv1beta1.SecretObjectReference:
+		if br.Namespace == nil {
+			return true
+		}
+
+		return isRefAllowedByGrant(
+			(*string)(br.Namespace),
+			(string)(br.Name),
+			(string)(*br.Group),
+			(string)(*br.Kind),
+			allowedRefs,
+		)
 	}
 
 	return false

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -40,7 +40,7 @@ type FakeObjects struct {
 	TCPRoutes                      []*gatewayv1alpha2.TCPRoute
 	TLSRoutes                      []*gatewayv1alpha2.TLSRoute
 	ReferenceGrants                []*gatewayv1alpha2.ReferenceGrant
-	Gateways                       []*gatewayv1alpha2.Gateway
+	Gateways                       []*gatewayv1beta1.Gateway
 	TCPIngresses                   []*configurationv1beta1.TCPIngress
 	UDPIngresses                   []*configurationv1beta1.UDPIngress
 	IngressClassParametersV1alpha1 []*configurationv1alpha1.IngressClassParameters

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -863,18 +863,18 @@ func TestFakeStoreGateway(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	grants := []*gatewayv1alpha2.Gateway{
+	grants := []*gatewayv1beta1.Gateway{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{},
+			Spec: gatewayv1beta1.GatewaySpec{},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "bar",
 			},
-			Spec: gatewayv1alpha2.GatewaySpec{},
+			Spec: gatewayv1beta1.GatewaySpec{},
 		},
 	}
 	store, err := NewFakeStore(FakeObjects{Gateways: grants})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1048,7 +1048,7 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	// ----------------------------------------------------------------------------
 	// Kubernetes Gateway APIs
 	// ----------------------------------------------------------------------------
-	case gatewayv1alpha2.SchemeGroupVersion.WithKind("HTTPRoutes"):
+	case gatewayv1beta1.SchemeGroupVersion.WithKind("HTTPRoutes"):
 		return &gatewayv1beta1.HTTPRoute{}, nil
 	// ----------------------------------------------------------------------------
 	// Kong APIs

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -91,7 +91,7 @@ type Storer interface {
 	ListTCPRoutes() ([]*gatewayv1alpha2.TCPRoute, error)
 	ListTLSRoutes() ([]*gatewayv1alpha2.TLSRoute, error)
 	ListReferenceGrants() ([]*gatewayv1alpha2.ReferenceGrant, error)
-	ListGateways() ([]*gatewayv1alpha2.Gateway, error)
+	ListGateways() ([]*gatewayv1beta1.Gateway, error)
 	ListTCPIngresses() ([]*kongv1beta1.TCPIngress, error)
 	ListUDPIngresses() ([]*kongv1beta1.UDPIngress, error)
 	ListKnativeIngresses() ([]*knative.Ingress, error)
@@ -264,7 +264,7 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.TLSRoute.Get(obj)
 	case *gatewayv1alpha2.ReferenceGrant:
 		return c.ReferenceGrant.Get(obj)
-	case *gatewayv1alpha2.Gateway:
+	case *gatewayv1beta1.Gateway:
 		return c.Gateway.Get(obj)
 	// ----------------------------------------------------------------------------
 	// Kong API Support
@@ -329,7 +329,7 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.TLSRoute.Add(obj)
 	case *gatewayv1alpha2.ReferenceGrant:
 		return c.ReferenceGrant.Add(obj)
-	case *gatewayv1alpha2.Gateway:
+	case *gatewayv1beta1.Gateway:
 		return c.Gateway.Add(obj)
 	// ----------------------------------------------------------------------------
 	// Kong API Support
@@ -395,7 +395,7 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.TLSRoute.Delete(obj)
 	case *gatewayv1alpha2.ReferenceGrant:
 		return c.ReferenceGrant.Delete(obj)
-	case *gatewayv1alpha2.Gateway:
+	case *gatewayv1beta1.Gateway:
 		return c.Gateway.Delete(obj)
 	// ----------------------------------------------------------------------------
 	// Kong API Support
@@ -667,11 +667,11 @@ func (s Store) ListReferenceGrants() ([]*gatewayv1alpha2.ReferenceGrant, error) 
 }
 
 // ListGateways returns the list of Gateways in the Gateway cache store.
-func (s Store) ListGateways() ([]*gatewayv1alpha2.Gateway, error) {
-	var gateways []*gatewayv1alpha2.Gateway
+func (s Store) ListGateways() ([]*gatewayv1beta1.Gateway, error) {
+	var gateways []*gatewayv1beta1.Gateway
 	if err := cache.ListAll(s.stores.Gateway, labels.NewSelector(),
 		func(ob interface{}) {
-			gw, ok := ob.(*gatewayv1alpha2.Gateway)
+			gw, ok := ob.(*gatewayv1beta1.Gateway)
 			if ok {
 				gateways = append(gateways, gw)
 			}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -28,5 +28,8 @@ type ParentReferenceT interface {
 }
 
 type BackendRefT interface {
-	gatewayv1beta1.BackendRef | gatewayv1alpha2.BackendRef | gatewayv1alpha2.SecretObjectReference
+	gatewayv1alpha2.BackendRef |
+		gatewayv1beta1.BackendRef |
+		gatewayv1alpha2.SecretObjectReference |
+		gatewayv1beta1.SecretObjectReference
 }

--- a/internal/util/conversions.go
+++ b/internal/util/conversions.go
@@ -20,9 +20,9 @@ func StringToGatewayAPIHostnameV1Beta1(hostname string) gatewayv1beta1.Hostname 
 	return (gatewayv1beta1.Hostname)(hostname)
 }
 
-// StringToGatewayAPIHostnamePtr converts a string to a *gatewayv1alpha2.Hostname.
-func StringToGatewayAPIHostnamePtr(hostname string) *gatewayv1alpha2.Hostname {
-	return (*gatewayv1alpha2.Hostname)(pointer.StringPtr(hostname))
+// StringToGatewayAPIHostnamePtr converts a string to a *gatewayv1beta1.Hostname.
+func StringToGatewayAPIHostnamePtr(hostname string) *gatewayv1beta1.Hostname {
+	return (*gatewayv1beta1.Hostname)(pointer.StringPtr(hostname))
 }
 
 // StringToGatewayAPIHostnameV1Beta1Ptr converts a string to a *gatewayv1beta1.Hostname.
@@ -35,12 +35,7 @@ func StringToGatewayAPIKind(kind string) gatewayv1alpha2.Kind {
 	return (gatewayv1alpha2.Kind)(kind)
 }
 
-// StringToGatewayAPIKindPtr converts a string to a *gatewayv1alpha2.Kind.
-func StringToGatewayAPIKindPtr(kind string) *gatewayv1alpha2.Kind {
-	return (*gatewayv1alpha2.Kind)(pointer.StringPtr(kind))
-}
-
-// StringToGatewayAPIKindV1Beta1Ptr converts a string to a *gatewayv1beta1.Kind.
-func StringToGatewayAPIKindV1Beta1Ptr(kind string) *gatewayv1beta1.Kind {
+// StringToGatewayAPIKindPtr converts a string to a *gatewayv1beta1.Kind.
+func StringToGatewayAPIKindPtr(kind string) *gatewayv1beta1.Kind {
 	return (*gatewayv1beta1.Kind)(pointer.StringPtr(kind))
 }

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -3,7 +3,6 @@ package gateway
 import (
 	"fmt"
 
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -14,7 +13,7 @@ import (
 // ValidateHTTPRoute provides a suite of validation for a given HTTPRoute and
 // any number of Gateway resources it's attached to that the caller wants to
 // have it validated against.
-func ValidateHTTPRoute(httproute *gatewayv1beta1.HTTPRoute, attachedGateways ...*gatewayv1alpha2.Gateway) (bool, string, error) {
+func ValidateHTTPRoute(httproute *gatewayv1beta1.HTTPRoute, attachedGateways ...*gatewayv1beta1.Gateway) (bool, string, error) {
 	// perform Gateway validations for the HTTPRoute (e.g. listener validation, namespace validation, e.t.c.)
 	for _, gateway := range attachedGateways {
 		// TODO: validate that the namespace is supported by the linked Gateway objects
@@ -54,7 +53,7 @@ func ValidateHTTPRoute(httproute *gatewayv1beta1.HTTPRoute, attachedGateways ...
 
 // validateHTTPRouteListener verifies that a given HTTPRoute is configured properly
 // for a given gateway listener which it is linked to.
-func validateHTTPRouteListener(listener *gatewayv1alpha2.Listener) error {
+func validateHTTPRouteListener(listener *gatewayv1beta1.Listener) error {
 	// verify that the listener supports HTTPRoute objects
 	if listener.AllowedRoutes != nil && // if there are no allowed routes, assume all are allowed
 		len(listener.AllowedRoutes.Kinds) > 0 { // if there are no allowed kinds, assume all are allowed
@@ -123,7 +122,7 @@ func validateHTTPRouteFeatures(httproute *gatewayv1beta1.HTTPRoute) error {
 // which links to the provided Gateway if available. If the provided Gateway is not
 // actually referenced by parentRef in the provided HTTPRoute this is considered
 // invalid input and will produce an error.
-func getParentRefForHTTPRouteGateway(httproute *gatewayv1beta1.HTTPRoute, gateway *gatewayv1alpha2.Gateway) (*gatewayv1beta1.ParentReference, error) {
+func getParentRefForHTTPRouteGateway(httproute *gatewayv1beta1.HTTPRoute, gateway *gatewayv1beta1.Gateway) (*gatewayv1beta1.ParentReference, error) {
 	// search all the parentRefs on the HTTPRoute to find one that matches the Gateway
 	for _, ref := range httproute.Spec.ParentRefs {
 		// determine the namespace for the gateway reference
@@ -145,8 +144,8 @@ func getParentRefForHTTPRouteGateway(httproute *gatewayv1beta1.HTTPRoute, gatewa
 
 // getListenersForHTTPRouteValidation determines if ALL http listeners should be used for validation
 // or if only a select listener should be considered.
-func getListenersForHTTPRouteValidation(sectionName *gatewayv1beta1.SectionName, gateway *gatewayv1alpha2.Gateway) ([]*gatewayv1alpha2.Listener, error) {
-	var listenersForValidation []*gatewayv1alpha2.Listener
+func getListenersForHTTPRouteValidation(sectionName *gatewayv1beta1.SectionName, gateway *gatewayv1beta1.Gateway) ([]*gatewayv1beta1.Listener, error) {
+	var listenersForValidation []*gatewayv1beta1.Listener
 	if sectionName != nil {
 		// only one specified listener is in use, only need to validate the
 		// route against that listener.
@@ -166,8 +165,8 @@ func getListenersForHTTPRouteValidation(sectionName *gatewayv1beta1.SectionName,
 		// no specific listener was chosen, so we'll simply validate against
 		// all HTTP listeners on the Gateway.
 		for _, listener := range gateway.Spec.Listeners {
-			if (gatewayv1beta1.ProtocolType)(listener.Protocol) == gatewayv1beta1.HTTPProtocolType ||
-				(gatewayv1beta1.ProtocolType)(listener.Protocol) == gatewayv1beta1.HTTPSProtocolType {
+			if (listener.Protocol) == gatewayv1beta1.HTTPProtocolType ||
+				(listener.Protocol) == gatewayv1beta1.HTTPSProtocolType {
 				listenerCopy := listener
 				listenersForValidation = append(listenersForValidation, &listenerCopy)
 			}

--- a/internal/validation/gateway/httproute_test.go
+++ b/internal/validation/gateway/httproute_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestValidateHTTPRoute(t *testing.T) {
 	var (
 		nonexistentListener = gatewayv1beta1.SectionName("listener-that-doesnt-exist")
-		group               = gatewayv1alpha2.Group("gateway.networking.k8s.io")
+		group               = gatewayv1beta1.Group("gateway.networking.k8s.io")
 		defaultGWNamespace  = gatewayv1beta1.Namespace(corev1.NamespaceDefault)
 		pathMatchRegex      = gatewayv1beta1.PathMatchRegularExpression
 		headerMatchRegex    = gatewayv1beta1.HeaderMatchRegularExpression
@@ -26,7 +25,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 	for _, tt := range []struct {
 		msg           string
 		route         *gatewayv1beta1.HTTPRoute
-		gateways      []*gatewayv1alpha2.Gateway
+		gateways      []*gatewayv1beta1.Gateway
 		valid         bool
 		validationMsg string
 		err           error
@@ -39,18 +38,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					Name:      "testing-httproute",
 				},
 			}, // no parentRefs
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -78,18 +77,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "not-the-right-listener",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -116,13 +115,13 @@ func TestValidateHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{},
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{},
 				},
 			}},
 			valid:         false,
@@ -144,18 +143,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -180,18 +179,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http-alternate",
 						Port:     8000,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "TCPRoute",
 							}},
@@ -233,18 +232,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -286,18 +285,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -340,18 +339,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -398,18 +397,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},
@@ -455,18 +454,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 				},
 			},
-			gateways: []*gatewayv1alpha2.Gateway{{
+			gateways: []*gatewayv1beta1.Gateway{{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
 					Name:      "testing-gateway",
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
 						Port:     80,
-						Protocol: (gatewayv1alpha2.ProtocolType)(gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1alpha2.AllowedRoutes{
-							Kinds: []gatewayv1alpha2.RouteGroupKind{{
+						Protocol: (gatewayv1beta1.HTTPProtocolType),
+						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+							Kinds: []gatewayv1beta1.RouteGroupKind{{
 								Group: &group,
 								Kind:  "HTTPRoute",
 							}},

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -377,26 +378,26 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
-	gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+	gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	gw.Spec.Listeners = append(gw.Spec.Listeners,
-		gatewayv1alpha2.Listener{
+		gatewayv1beta1.Listener{
 			Name:     "badhttp",
-			Protocol: gatewayv1alpha2.HTTPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(9999),
+			Protocol: gatewayv1beta1.HTTPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(9999),
 		},
-		gatewayv1alpha2.Listener{
+		gatewayv1beta1.Listener{
 			Name:     "badudp",
-			Protocol: gatewayv1alpha2.UDPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(80),
+			Protocol: gatewayv1beta1.UDPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(80),
 		},
 	)
 
 	t.Log("verifying that unsupported listeners indicate correct status")
-	gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Update(ctx, gw, metav1.UpdateOptions{})
+	gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Update(ctx, gw, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+		gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 		var http, udp bool
 		for _, lstatus := range gw.Status.Listeners {
 			if lstatus.Name == "badhttp" {
@@ -427,7 +428,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 		return http == udp == true
 	}, time.Minute*2, time.Second*5)
 
-	gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+	gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	t.Logf("deploying Gateway APIs CRDs in experimental channel from %s", consts.GatewayExperimentalCRDsKustomizeURL)

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // deployGateway deploys a gateway with a new created gateway class and a fixed name `kong`.
-func deployGateway(ctx context.Context, t *testing.T, env environments.Environment) *gatewayv1alpha2.Gateway {
+func deployGateway(ctx context.Context, t *testing.T, env environments.Environment) *gatewayv1beta1.Gateway {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
@@ -49,38 +49,38 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 	require.NoError(t, err)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gw := &gatewayv1alpha2.Gateway{
+	gw := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kong",
 			Annotations: map[string]string{
 				annotations.AnnotationPrefix + annotations.GatewayUnmanagedAnnotation: "true", // trigger the unmanaged gateway mode
 			},
 		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(supportedGatewayClass.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
+		Spec: gatewayv1beta1.GatewaySpec{
+			GatewayClassName: gatewayv1beta1.ObjectName(supportedGatewayClass.Name),
+			Listeners: []gatewayv1beta1.Listener{{
 				Name:     "http",
-				Protocol: gatewayv1alpha2.HTTPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(80),
+				Protocol: gatewayv1beta1.HTTPProtocolType,
+				Port:     gatewayv1beta1.PortNumber(80),
 			}},
 		},
 	}
-	gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
+	gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err)
 	return gw
 }
 
 // verifyGateway verifies that the gateway `gw` is ready.
-func verifyGateway(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1alpha2.Gateway) {
+func verifyGateway(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1beta1.Gateway) {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
 	t.Log("verifying that the gateway receives a final ready condition once reconciliation completes")
 	require.Eventually(t, func() bool {
-		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+		gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, cond := range gw.Status.Conditions {
-			if cond.Reason == string(gatewayv1alpha2.GatewayReasonReady) {
+			if cond.Reason == string(gatewayv1beta1.GatewayReasonReady) {
 				return true
 			}
 		}
@@ -89,7 +89,7 @@ func verifyGateway(ctx context.Context, t *testing.T, env environments.Environme
 }
 
 // deployGatewayWithTCPListener deploys a gateway `kong` with a tcp listener to test TCPRoute.
-func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environments.Environment) *gatewayv1alpha2.Gateway {
+func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environments.Environment) *gatewayv1beta1.Gateway {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
@@ -106,36 +106,36 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 	require.NoError(t, err)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gw := &gatewayv1alpha2.Gateway{
+	gw := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kong",
 		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(supportedGatewayClass.Name),
-			Listeners: []gatewayv1alpha2.Listener{
+		Spec: gatewayv1beta1.GatewaySpec{
+			GatewayClassName: gatewayv1beta1.ObjectName(supportedGatewayClass.Name),
+			Listeners: []gatewayv1beta1.Listener{
 				{
 					Name:     "http",
-					Protocol: gatewayv1alpha2.HTTPProtocolType,
-					Port:     gatewayv1alpha2.PortNumber(80),
+					Protocol: gatewayv1beta1.HTTPProtocolType,
+					Port:     gatewayv1beta1.PortNumber(80),
 				},
 				{
 					Name:     "tcp",
-					Protocol: gatewayv1alpha2.TCPProtocolType,
-					Port:     gatewayv1alpha2.PortNumber(tcpListnerPort),
+					Protocol: gatewayv1beta1.TCPProtocolType,
+					Port:     gatewayv1beta1.PortNumber(tcpListnerPort),
 				},
 			},
 		},
 	}
-	_, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
+	_, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 	if err == nil {
 		t.Logf("gateway %s exists, delete and re-create it", gw.Name)
-		err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Delete(ctx, gw.Name, metav1.DeleteOptions{})
+		err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Delete(ctx, gw.Name, metav1.DeleteOptions{})
 		require.NoError(t, err)
-		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
+		gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
 		require.NoError(t, err)
 	} else {
 		require.True(t, kerrors.IsNotFound(err))
-		gw, err = gc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
+		gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Create(ctx, gw, metav1.CreateOptions{})
 		require.NoError(t, err)
 	}
 	return gw
@@ -143,7 +143,7 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 
 // deployHTTPRoute creates an `HTTPRoute` and related backend deployment/service.
 // it matches the specified path `/httpbin` by prefix, so we can access the backend service by `http://$PROXY_IP/httpbin`.
-func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1alpha2.Gateway) {
+func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1beta1.Gateway) {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 	t.Log("deploying an HTTP service to test the ingress controller and proxy")
@@ -225,7 +225,7 @@ func verifyHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 }
 
 // deployTCPRoute creates a `TCPRoute` and related backend deployment/service.
-func deployTCPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1alpha2.Gateway) {
+func deployTCPRoute(ctx context.Context, t *testing.T, env environments.Environment, gw *gatewayv1beta1.Gateway) {
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 	t.Log("deploying a TCP service to test the ingress controller and proxy")

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -55,13 +55,13 @@ func TestHTTPRouteExample(t *testing.T) {
 	t.Logf("verifying that the Gateway receives listen addresses")
 	var gatewayAddr string
 	require.Eventually(t, func() bool {
-		obj, err := gwc.GatewayV1alpha2().Gateways(corev1.NamespaceDefault).Get(ctx, "kong", metav1.GetOptions{})
+		obj, err := gwc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, "kong", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 
 		for _, addr := range obj.Status.Addresses {
-			if addr.Type != nil && *addr.Type == gatewayv1alpha2.IPAddressType {
+			if addr.Type != nil && *addr.Type == gatewayv1beta1.IPAddressType {
 				gatewayAddr = addr.Value
 				return true
 			}

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -34,7 +34,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 			{
 				Rule: admregv1.Rule{
 					APIGroups:   []string{"gateway.networking.k8s.io"},
-					APIVersions: []string{"v1alpha2"},
+					APIVersions: []string{"v1beta1"},
 					Resources:   []string{"gateways"},
 				},
 				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
@@ -55,7 +55,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 
 	for _, tt := range []struct {
 		name      string
-		createdGW gatewayv1alpha2.Gateway
+		createdGW gatewayv1beta1.Gateway
 		patch     []byte // optional
 
 		wantCreateErr          bool
@@ -66,19 +66,19 @@ func TestGatewayValidationWebhook(t *testing.T) {
 	}{
 		{
 			name: "valid gateway",
-			createdGW: gatewayv1alpha2.Gateway{
+			createdGW: gatewayv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: uuid.NewString(),
 					Annotations: map[string]string{
 						annotations.AnnotationPrefix + annotations.GatewayUnmanagedAnnotation: "true",
 					},
 				},
-				Spec: gatewayv1alpha2.GatewaySpec{
-					GatewayClassName: gatewayv1alpha2.ObjectName(managedGatewayClassName),
-					Listeners: []gatewayv1alpha2.Listener{{
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1beta1.ObjectName(managedGatewayClassName),
+					Listeners: []gatewayv1beta1.Listener{{
 						Name:     "http",
-						Protocol: gatewayv1alpha2.HTTPProtocolType,
-						Port:     gatewayv1alpha2.PortNumber(80),
+						Protocol: gatewayv1beta1.HTTPProtocolType,
+						Port:     gatewayv1beta1.PortNumber(80),
 					}},
 				},
 			},
@@ -86,7 +86,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, gotCreateErr := gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Create(ctx, &tt.createdGW, metav1.CreateOptions{})
+			_, gotCreateErr := gatewayClient.GatewayV1beta1().Gateways(ns.Name).Create(ctx, &tt.createdGW, metav1.CreateOptions{})
 			if tt.wantCreateErr {
 				require.Error(t, gotCreateErr)
 				require.Contains(t, gotCreateErr.Error(), tt.wantCreateErrSubstring)
@@ -95,7 +95,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 			}
 
 			if len(tt.patch) > 0 {
-				_, gotUpdateErr := gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Patch(ctx, tt.createdGW.Name, types.MergePatchType, tt.patch, metav1.PatchOptions{})
+				_, gotUpdateErr := gatewayClient.GatewayV1beta1().Gateways(ns.Name).Patch(ctx, tt.createdGW.Name, types.MergePatchType, tt.patch, metav1.PatchOptions{})
 				if tt.wantPatchErr {
 					require.Error(t, gotUpdateErr)
 					require.Contains(t, gotUpdateErr.Error(), tt.wantPatchErrSubstring)
@@ -104,7 +104,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 				}
 			}
 
-			if err := gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, tt.createdGW.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			if err := gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, tt.createdGW.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				require.NoError(t, err)
 			}
 		})

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
@@ -33,7 +32,7 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 			{
 				Rule: admregv1.Rule{
 					APIGroups:   []string{"gateway.networking.k8s.io"},
-					APIVersions: []string{"v1alpha2"},
+					APIVersions: []string{"v1beta1"},
 					Resources:   []string{"httproutes"},
 				},
 				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
@@ -50,7 +49,7 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("creating a managed gateway")
-	managedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, managedGatewayClassName, func(g *gatewayv1alpha2.Gateway) {
+	managedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, managedGatewayClassName, func(g *gatewayv1beta1.Gateway) {
 		g.Name = uuid.NewString()
 	})
 	require.NoError(t, err)
@@ -58,13 +57,13 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 
 	t.Log("creating an unmanaged gatewayclass")
 	unmanagedGatewayClass, err := DeployGatewayClass(ctx, gatewayClient, uuid.NewString(), func(gc *gatewayv1beta1.GatewayClass) {
-		gc.Spec.ControllerName = gatewayv1beta1.GatewayController(unmanagedControllerName)
+		gc.Spec.ControllerName = unmanagedControllerName
 	})
 	require.NoError(t, err)
 	cleaner.Add(unmanagedGatewayClass)
 
 	t.Log("creating an unmanaged gateway")
-	unmanagedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClass.Name, func(g *gatewayv1alpha2.Gateway) {
+	unmanagedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClass.Name, func(g *gatewayv1beta1.Gateway) {
 		g.Name = uuid.NewString()
 	})
 	require.NoError(t, err)

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -62,12 +63,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode and port 8888")
 	gatewayName := uuid.NewString()
-	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tcp",
-			Protocol: gatewayv1alpha2.TCPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+			Protocol: gatewayv1beta1.TCPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
 	})
 	require.NoError(t, err)
@@ -165,7 +166,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	cleaner.Add(tcpRoute)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is responding properly")
@@ -185,7 +186,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is no longer responding")
@@ -211,7 +212,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
@@ -221,10 +222,10 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the GatewayClass now removed")
@@ -238,7 +239,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TCPRoutes and the route becomes available again")
@@ -248,10 +249,10 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the Gateway now removed")
@@ -261,18 +262,18 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
-	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tcp",
-			Protocol: gatewayv1alpha2.TCPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+			Protocol: gatewayv1beta1.TCPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
 	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
@@ -282,11 +283,11 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
@@ -300,18 +301,18 @@ func TestTCPRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("putting the Gateway back")
-	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tcp",
-			Protocol: gatewayv1alpha2.TCPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+			Protocol: gatewayv1beta1.TCPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
 	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
@@ -363,11 +364,11 @@ func TestTCPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TCPProtocolType, ns.Name, tcpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
@@ -409,12 +410,12 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
 	gatewayName := uuid.NewString()
-	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tcp",
-			Protocol: gatewayv1alpha2.TCPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort),
+			Protocol: gatewayv1beta1.TCPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
 	})
 	require.NoError(t, err)

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -135,18 +136,18 @@ func TestTLSRouteEssentials(t *testing.T) {
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode and port 8899")
 	gatewayName := uuid.NewString()
-	hostname := gatewayv1alpha2.Hostname(tlsRouteHostname)
-	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	hostname := gatewayv1beta1.Hostname(tlsRouteHostname)
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tls",
-			Protocol: gatewayv1alpha2.TLSProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTLSServicePort),
+			Protocol: gatewayv1beta1.TLSProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTLSServicePort),
 			Hostname: &hostname,
-			TLS: &gatewayv1alpha2.GatewayTLSConfig{
-				CertificateRefs: []gatewayv1alpha2.SecretObjectReference{
+			TLS: &gatewayv1beta1.GatewayTLSConfig{
+				CertificateRefs: []gatewayv1beta1.SecretObjectReference{
 					{
-						Name: gatewayv1alpha2.ObjectName(tlsSecretName),
+						Name: gatewayv1beta1.ObjectName(tlsSecretName),
 					},
 				},
 			},
@@ -226,7 +227,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	cleaner.Add(tlsRoute)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is responding properly over TLS")
@@ -247,7 +248,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho is no longer responding")
@@ -267,7 +268,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
@@ -278,10 +279,10 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute gets dropped with the GatewayClass now removed")
@@ -296,7 +297,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TLSRoutes and the route becomes available again")
@@ -307,10 +308,10 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute gets dropped with the Gateway now removed")
@@ -321,17 +322,17 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
-	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "tls",
-			Protocol: gatewayv1alpha2.TLSProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTLSServicePort),
+			Protocol: gatewayv1beta1.TLSProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTLSServicePort),
 			Hostname: &hostname,
-			TLS: &gatewayv1alpha2.GatewayTLSConfig{
-				CertificateRefs: []gatewayv1alpha2.SecretObjectReference{
+			TLS: &gatewayv1beta1.GatewayTLSConfig{
+				CertificateRefs: []gatewayv1beta1.SecretObjectReference{
 					{
-						Name: gatewayv1alpha2.ObjectName(tlsSecretName),
+						Name: gatewayv1beta1.ObjectName(tlsSecretName),
 					},
 				},
 			},
@@ -340,7 +341,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TLSRoutes and the route becomes available again")
@@ -387,11 +388,11 @@ func TestTLSRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.TLSProtocolType, ns.Name, tlsRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute does not get orphaned with the GatewayClass and Gateway gone")
@@ -458,33 +459,33 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(secret2)
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode")
-	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, managedGatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
-		hostname := gatewayv1alpha2.Hostname(tlsRouteHostname)
-		otherHostname := gatewayv1alpha2.Hostname(tlsRouteExtraHostname)
-		otherNamespace := gatewayv1alpha2.Namespace(otherNs.Name)
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, managedGatewayClassName, func(gw *gatewayv1beta1.Gateway) {
+		hostname := gatewayv1beta1.Hostname(tlsRouteHostname)
+		otherHostname := gatewayv1beta1.Hostname(tlsRouteExtraHostname)
+		otherNamespace := gatewayv1beta1.Namespace(otherNs.Name)
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{
 			{
 				Name:     "tls",
-				Protocol: gatewayv1alpha2.TLSProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTLSServicePort),
+				Protocol: gatewayv1beta1.TLSProtocolType,
+				Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTLSServicePort),
 				Hostname: &hostname,
-				TLS: &gatewayv1alpha2.GatewayTLSConfig{
-					CertificateRefs: []gatewayv1alpha2.SecretObjectReference{
+				TLS: &gatewayv1beta1.GatewayTLSConfig{
+					CertificateRefs: []gatewayv1beta1.SecretObjectReference{
 						{
-							Name: gatewayv1alpha2.ObjectName(secrets[0].Name),
+							Name: gatewayv1beta1.ObjectName(secrets[0].Name),
 						},
 					},
 				},
 			},
 			{
 				Name:     "tlsother",
-				Protocol: gatewayv1alpha2.TLSProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultTLSServicePort),
+				Protocol: gatewayv1beta1.TLSProtocolType,
+				Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTLSServicePort),
 				Hostname: &otherHostname,
-				TLS: &gatewayv1alpha2.GatewayTLSConfig{
-					CertificateRefs: []gatewayv1alpha2.SecretObjectReference{
+				TLS: &gatewayv1beta1.GatewayTLSConfig{
+					CertificateRefs: []gatewayv1beta1.SecretObjectReference{
 						{
-							Name:      gatewayv1alpha2.ObjectName(secrets[1].Name),
+							Name:      gatewayv1beta1.ObjectName(secrets[1].Name),
 							Namespace: &otherNamespace,
 						},
 					},
@@ -573,17 +574,24 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(tlsroute)
 
+	proxyAddress := fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort)
 	t.Log("verifying that the tcpecho is responding properly over TLS")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
-			testUUID, tlsRouteHostname, tlsRouteHostname)
+		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname)
+		if err != nil {
+			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
+			return false
+		}
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho route can also serve certificates permitted by a ReferenceGrant with a named To")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
-			testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
+		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
+		if err != nil {
+			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
+			return false
+		}
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 
@@ -594,13 +602,12 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
-			testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
+		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
 		return err != nil && responded == false
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that a Listener has the invalid ref status condition")
-	gateway, err = gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
+	gateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	invalid := false
 	for _, status := range gateway.Status.Listeners {
@@ -620,8 +627,11 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
-			testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
+		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteExtraHostname, tlsRouteExtraHostname)
+		if err != nil {
+			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
+			return false
+		}
 		return err == nil && responded == true
 	}, ingressWait, waitTick)
 }

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
@@ -49,12 +50,12 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode and port 9999")
 	gatewayName := uuid.NewString()
-	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "udp",
-			Protocol: gatewayv1alpha2.UDPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultUDPServicePort),
+			Protocol: gatewayv1beta1.UDPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultUDPServicePort),
 		}}
 	})
 	require.NoError(t, err)
@@ -190,7 +191,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}()
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udpRoute.Name)
@@ -210,7 +211,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the parentRefs now removed")
@@ -232,7 +233,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
@@ -243,10 +244,10 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the GatewayClass now removed")
@@ -260,7 +261,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of UDPRoutes and the route becomes available again")
@@ -271,10 +272,10 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the Gateway now removed")
@@ -284,18 +285,18 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
-	_, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1alpha2.Gateway) {
+	_, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
-		gw.Spec.Listeners = []gatewayv1alpha2.Listener{{
+		gw.Spec.Listeners = []gatewayv1beta1.Listener{{
 			Name:     "udp",
-			Protocol: gatewayv1alpha2.UDPProtocolType,
-			Port:     gatewayv1alpha2.PortNumber(ktfkong.DefaultUDPServicePort),
+			Protocol: gatewayv1beta1.UDPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultUDPServicePort),
 		}}
 	})
 	require.NoError(t, err)
 
 	t.Log("verifying that the Gateway gets linked to the route via status")
-	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of UDPRoutes and the route becomes available again")
@@ -335,11 +336,11 @@ func TestUDPRouteEssentials(t *testing.T) {
 	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
-	require.NoError(t, gatewayClient.GatewayV1alpha2().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
-	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
+	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
 
 	t.Log("verifying that the Gateway gets unlinked from the route via status")
-	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1alpha2.UDPProtocolType, ns.Name, udpRoute.Name)
+	callback = GetGatewayIsUnlinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the UDPRoute does not get orphaned with the GatewayClass and Gateway gone")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bump Gateway API Gateway resource from `v1alpha2` to `v1beta1`.

**Which issue this PR fixes**:

Fixes #2899 
Partially addresses #2887

**Special notes for your reviewer**:

This PR additionally introduces some type aliases in `internal/controllers/gateway/types.go`.

I was thinking to put that somewhere else where it could be reused by tests as well (at this moment it cannot due to it being in `internal/` package next to test package) but I left it as is in current state.

I'm open for feedback w.r.t 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
