### PR TITLE
chore: pin k8s to v1.24.4 in integration tests

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -107,7 +107,24 @@ func TestMain(m *testing.M) {
 		}
 	} else {
 		fmt.Println("INFO: no existing cluster found, deploying using Kubernetes In Docker (KIND)")
+
 		builder.WithAddons(metallb.New())
+		// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
+		// even though that
+		// * our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
+		//   which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+		// * when used with ktf (which at the time of writing this comment was set to v0.19.0) we
+		//   should use kind v0.14 since that what ktf has set as dependency
+		//
+		// With all that said, we still managed to get kind v0.15 on our CI
+		// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
+		// which causes issues down the line (metallb manifests using PSP which is not available
+		// in k8s v1.25+).
+		builder.WithKubernetesVersion(semver.Version{
+			Major: 1,
+			Minor: 24,
+			Patch: 4,
+		})
 	}
 	if clusterVersionStr != "" {
 		clusterVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
even though that
* our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
  which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
* when used with ktf (which at the time of writing this comment was set to v0.19.0) we
  should use kind v0.14 since that what ktf has set as dependency

With all that said, we still managed to get kind v0.15 on our CI
https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
which causes issues down the line (`metallb` manifests using PSP which is not available
in k8s v1.25+).

**Special notes for your reviewer**:

There is an open issue in ktf to support k8s v1.25 https://github.com/Kong/kubernetes-testing-framework/issues/364 which will render this patch unnecessary but this is a band aid that will keep us going (for now).