### PR TITLE
chore: pin k8s to v1.24.4 in conformance tests

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
@@ -95,6 +96,23 @@ func useExistingClusterIfPresent(builder *environments.Builder) {
 		builder.WithExistingCluster(cluster)
 	} else {
 		fmt.Println("INFO: creating new kind cluster for conformance tests")
+
+		// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
+		// even though that
+		// * our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
+		//   which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+		// * when used with ktf (which at the time of writing this comment was set to v0.19.0) we
+		//   should use kind v0.14 since that what ktf has set as dependency
+		//
+		// With all that said, we still managed to get kind v0.15 on our CI
+		// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
+		// which causes issues down the line (metallb manifests using PSP which is not available
+		// in k8s v1.25+).
+		builder.WithKubernetesVersion(semver.Version{
+			Major: 1,
+			Minor: 24,
+			Patch: 4,
+		})
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
even though that
* our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
  which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
* when used with ktf (which at the time of writing this comment was set to v0.19.0) we
  should use kind v0.14 since that what ktf has set as dependency

With all that said, we still managed to get kind v0.15 on our CI
https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
which causes issues down the line (`metallb` manifests using PSP which is not available
in k8s v1.25+).

**Special notes for your reviewer**:

There is an open issue in ktf to support k8s v1.25 https://github.com/Kong/kubernetes-testing-framework/issues/364 which will render this patch unnecessary but this is a band aid that will keep us going (for now).