### PR TITLE
chore(ci): replace abandonded linters with unused (as suggested by golangci-lint)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - deadcode
   - depguard
   - dogsled
   - durationcheck
@@ -38,11 +37,10 @@ linters:
   - predeclared
   - revive
   - staticcheck
-  - structcheck
   - typecheck
   - unconvert
   - unparam
-  - varcheck
+  - unused
   - wastedassign
 linters-settings:
   gci:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims at silencing these errors in `golangci-lint`

```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```