### PR TITLE
test: fix e2e variable for k8s version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,8 +51,8 @@ jobs:
       env:
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes_version }}
-        ISTIO_VERSION: ${{ matrix.istio_version }}
+        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+        ISTIO_VERSION: ${{ matrix.istio-version }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job, so only 1 is allowed at a time.
 

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
@@ -85,12 +84,8 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -144,12 +139,9 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -188,12 +180,8 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -241,12 +229,8 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -278,12 +262,8 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -413,7 +393,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 		}
 		t.Logf("expected exactly one leader, actual %d", leaderCount)
 		return leaderCount == 1
-	}, time.Minute, time.Second)
+	}, 2*time.Minute, time.Second)
 }
 
 const entPostgresPath = "../../deploy/single/all-in-one-postgres-enterprise.yaml"
@@ -433,12 +413,8 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	createKongImagePullSecret(ctx, t, env)

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -143,6 +143,7 @@ func TestWebhookUpdate(t *testing.T) {
 	if clusterVersionStr != "" {
 		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
 		require.NoError(t, err)
+		t.Logf("k8s cluster version is set to %v", clusterVersion)
 		clusterBuilder.WithClusterVersion(clusterVersion)
 	}
 	cluster, err := clusterBuilder.Build(ctx)
@@ -298,12 +299,9 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -482,12 +480,9 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
 		addons = append(addons, b.Build())
 	}
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/loadimage"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
@@ -333,4 +334,16 @@ func createKongImagePullSecret(ctx context.Context, t *testing.T, env environmen
 	)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "command output: "+string(out))
+}
+
+// setBuilderKubernetesVersion configures the kubernetes version of test environment builder
+// and returns the updated builder.
+func setBuilderKubernetesVersion(t *testing.T, b *environments.Builder, clusterVersionStr string) *environments.Builder {
+	if clusterVersionStr == "" {
+		return b
+	}
+	clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
+	require.NoError(t, err)
+	t.Logf("k8s cluster version is set to %v", clusterVersion)
+	return b.WithKubernetesVersion(clusterVersion)
 }

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -78,12 +78,8 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	istioAddon := istioBuilder.Build()
 
 	t.Log("deploying a testing environment and Kubernetes cluster with Istio enabled")
-	envBuilder := environments.NewBuilder().WithAddons(metallbAddon, kongAddon, istioAddon)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		envBuilder.WithKubernetesVersion(clusterVersion)
-	}
+	envBuilder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(metallbAddon, kongAddon, istioAddon), clusterVersionStr)
 	env, err := envBuilder.Build(ctx)
 	require.NoError(t, err)
 

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kuma"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
@@ -33,12 +32,9 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
 	addons = append(addons, kuma.New())
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -116,12 +112,8 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 
 	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
 
-	builder := environments.NewBuilder().WithAddons(addons...)
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		builder.WithKubernetesVersion(clusterVersion)
-	}
+	builder := setBuilderKubernetesVersion(t,
+		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
fix the problem that kubernetes version and istio version was not correctly set in e2e action. This causes e2e always run in latest kubernetes version of `kind`. So when k8s 1.25 released and kind bumped k8s version to 1.25, metallb stopped working and caused e2e tests fail.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2897 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
