### PR TITLE
chore: correct PROJECT file with `Gateway` and `HTTPRoute` `v1beta1` CRD versions

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -67,8 +67,8 @@ resources:
   domain: networking.k8s.io
   group: gateway
   kind: Gateway
-  path: github.com/kubernetes-sigs/gateway-api/apis/v1alpha2
-  version: v1alpha2
+  path: github.com/kubernetes-sigs/gateway-api/apis/v1beta1
+  version: v1beta1
 - api:
     crdVersion: v1
     namespaced: true
@@ -85,8 +85,8 @@ resources:
   domain: networking.k8s.io
   group: gateway
   kind: HTTPRoute
-  path: github.com/kubernetes-sigs/gateway-api/apis/v1alpha2
-  version: v1alpha2
+  path: github.com/kubernetes-sigs/gateway-api/apis/v1beta1
+  version: v1beta1
 - api:
     crdVersion: v1
     namespaced: true


### PR DESCRIPTION
**What this PR does / why we need it**:

After merging #2900 and #2984 we forgot to update `PROJECT` file which is what this PR is doing to account for new version of `Gateway` and `HTTPRoute` CRDs that we handle.
