### PR TITLE
fix: change name of ingressclassparameterses into lower case

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -59,7 +59,7 @@ resources:
   group: configuration
   kind: IngressClassParameters
   path: github.com/kong/kubernetes-ingress-controller/pkg/apis/configuration/v1alpha1
-  plural: IngressClassParameterses
+  plural: ingressclassparameterses
   version: v1alpha1
 - api:
     crdVersion: v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,7 +76,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - IngressClassParameterses
+  - ingressclassparameterses
   verbs:
   - get
   - list

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1170,7 +1170,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - IngressClassParameterses
+  - ingressclassparameterses
   verbs:
   - get
   - list

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1170,7 +1170,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - IngressClassParameterses
+  - ingressclassparameterses
   verbs:
   - get
   - list

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1170,7 +1170,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - IngressClassParameterses
+  - ingressclassparameterses
   verbs:
   - get
   - list

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1170,7 +1170,7 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
-  - IngressClassParameterses
+  - ingressclassparameterses
   verbs:
   - get
   - list

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -225,7 +225,7 @@ var inputControllersNeeded = &typesNeeded{
 		PackageImportAlias:                "kongv1alpha1",
 		PackageAlias:                      "KongV1Alpha1",
 		Package:                           kongv1alpha1,
-		Plural:                            "IngressClassParameterses",
+		Plural:                            "ingressclassparameterses",
 		CacheType:                         "IngressClassParameters",
 		NeedsStatusPermissions:            false,
 		CapableOfStatusUpdates:            false,

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -1597,7 +1597,7 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) SetupWithManager(mgr ctrl
 	)
 }
 
-//+kubebuilder:rbac:groups=configuration.konghq.com,resources=IngressClassParameterses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=ingressclassparameterses,verbs=get;list;watch
 
 // Reconcile processes the watched objects
 func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
The name of resource (used in RBAC) are in ALL lower case. So `IngressClassParameterses` in clusterroles should be changed into `ingressclassparameterses`. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes the recent e2e failure.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
