### PR TITLE
chore: fix syntax to match sh in wait-for-migration script

### DIFF
--- a/config/variants/postgres/kong-ingress-postgres.yaml
+++ b/config/variants/postgres/kong-ingress-postgres.yaml
@@ -12,7 +12,7 @@ spec:
         command:
         - "/bin/sh"
         - "-c"
-        - "while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;"
+        - "while true; do kong migrations list; if [ 0 -eq $? ]; then exit 0; fi; sleep 2;  done;"
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/config/variants/postgres/wait/kong-ingress-postgres.yaml
+++ b/config/variants/postgres/wait/kong-ingress-postgres.yaml
@@ -12,7 +12,7 @@ spec:
         command:
         - "/bin/sh"
         - "-c"
-        - "while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;"
+        - "while true; do kong migrations list; if [ 0 -eq $? ]; then exit 0; fi; sleep 2;  done;"
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1761,8 +1761,8 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
-          sleep 2;  done;
+        - while true; do kong migrations list; if [ 0 -eq $? ]; then exit 0; fi; sleep
+          2;  done;
         env:
         - name: KONG_LICENSE_DATA
           valueFrom:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1703,8 +1703,8 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
-          sleep 2;  done;
+        - while true; do kong migrations list; if [ 0 -eq $? ]; then exit 0; fi; sleep
+          2;  done;
         env:
         - name: KONG_PG_HOST
           value: postgres


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

fixes the wait-for-migration script that cannot match syntax of `sh`. 


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2918. 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
