### PR TITLE
test: fix dbmode in 3.0 compat test

### DIFF
--- a/.github/workflows/kong3.0_compatibility.yaml
+++ b/.github/workflows/kong3.0_compatibility.yaml
@@ -75,20 +75,23 @@ jobs:
       id: run_integration_tests
       run: make _test.integration
       continue-on-error: true
+      ## skip enterprise-dbless option.
+      if: ${{ matrix.kong-edition == 'OSS' || matrix.database-mode == 'postgres' }} 
       env:
         TEST_KONG_IMAGE: ${{ env.TEST_KONG_IMAGE }}
         TEST_KONG_TAG: ${{ env.TEST_KONG_TAG }}
         TEST_KONG_ENTERPRISE: ${{ env.TEST_KONG_ENTERPRISE }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_DATABASE_MODE: ${{ env.TEST_DATABASE_MODE }}
+        DBMODE: ${{ env.TEST_DATABASE_MODE }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
+        NCPU: 1
 
     - name: upload diagnostics
       if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
-        name: diagnostics-integration-${{ matrix.database-mode }}-${{ matrix.kong-edtion }}
+        name: diagnostics-integration-${{ matrix.database-mode }}-${{ matrix.kong-edition }}
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
     


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

fix the problem that dbmode is not passed to `make _test.integration` correctly because env `DBMODE` is actually used in makefile. Also skipped enterprise/dbless combination because we do not have such test in makefile yet.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #2891 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
