### PR TITLE
fix(sendconfig) vary the format version

### DIFF
--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -21,9 +21,10 @@ func ToDeckContent(
 	k8sState *kongstate.KongState,
 	schemas *util.PluginSchemaStore,
 	selectorTags []string,
+	formatVersion string,
 ) *file.Content {
 	var content file.Content
-	content.FormatVersion = "1.1"
+	content.FormatVersion = formatVersion
 	var err error
 
 	for _, s := range k8sState.Services {

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -297,6 +297,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 	// initialize a parser
 	c.logger.Debug("parsing kubernetes objects into data-plane configuration")
 	p := parser.NewParser(c.logger, storer)
+	formatVersion := "1.1"
 	if c.AreKubernetesObjectReportsEnabled() {
 		p.EnableKubernetesObjectReports()
 	}
@@ -305,6 +306,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 	}
 	if versions.GetKongVersion().MajorMinorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
 		p.EnableRegexPathPrefix()
+		formatVersion = "3.0"
 	}
 
 	// parse the Kubernetes objects from the storer into Kong configuration
@@ -326,6 +328,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 		c.logger, kongstate,
 		c.kongConfig.PluginSchemaStore,
 		c.kongConfig.FilterTags,
+		formatVersion,
 	)
 
 	// generate diagnostic configuration if enabled
@@ -338,6 +341,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 				kongstate.SanitizedCopy(),
 				c.kongConfig.PluginSchemaStore,
 				c.kongConfig.FilterTags,
+				formatVersion,
 			)
 			diagnosticConfig = redactedConfig
 		} else {

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -1,0 +1,184 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
+)
+
+func TestConsumerCredential(t *testing.T) {
+	t.Parallel()
+	ns, cleaner := setup(t)
+	defer func() {
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
+	}()
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(deployment)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(service)
+
+	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
+	kubernetesVersion, err := env.Cluster().Version()
+	require.NoError(t, err)
+	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/test_consumer_credential", map[string]string{
+		annotations.IngressClassKey: ingressClass,
+		"konghq.com/strip-path":     "true",
+	}, service)
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
+	addIngressToCleaner(cleaner, ingress)
+
+	t.Log("waiting for routes from Ingress to be operational")
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			b := new(bytes.Buffer)
+			n, err := b.ReadFrom(resp.Body)
+			require.NoError(t, err)
+			require.True(t, n > 0)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	kongplugin := &kongv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "basicbasic",
+		},
+		PluginName: "basic-auth",
+	}
+	c, err := clientset.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+	kongplugin, err = c.ConfigurationV1().KongPlugins(ns.Name).Create(ctx, kongplugin, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(kongplugin)
+
+	t.Logf("updating Ingress to use plugin %s", kongplugin.Name)
+	require.Eventually(t, func() bool {
+		switch obj := ingress.(type) {
+		case *netv1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
+		case *netv1beta1.Ingress:
+			ingress, err := env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Get(ctx, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = kongplugin.Name
+			_, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(ns.Name).Update(ctx, ingress, metav1.UpdateOptions{})
+			return err == nil
+		}
+		return false
+	}, ingressWait, waitTick)
+
+	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusUnauthorized
+	}, ingressWait, waitTick)
+
+	// we test basic-auth in particular because it's one of the plugins where the credentials are transformed and
+	// stored with values different from the configuration provided (the password gets converted to its HTTP Basic Auth
+	// form)
+	credential := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		StringData: map[string]string{
+			"kongCredType": "basic-auth",
+			"username":     "test_consumer_credential",
+			"password":     "test_consumer_credential",
+		},
+	}
+	_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, credential, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(credential)
+
+	consumer := &kongv1.KongConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Username:    uuid.NewString(),
+		Credentials: []string{credential.Name},
+	}
+	_, err = c.ConfigurationV1().KongConsumers(ns.Name).Create(ctx, consumer, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(consumer)
+
+	t.Logf("validating that consumer has access")
+	assert.Eventually(t, func() bool {
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "test_consumer_credential"), nil)
+		require.NoError(t, err)
+		req.SetBasicAuth("test_consumer_credential", "test_consumer_credential")
+		resp, err := httpc.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, ingressWait, waitTick)
+
+	t.Log("deleting Ingress and waiting for routes to be torn down")
+	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
+	assert.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		return expect404WithNoRoute(t, proxyURL.String(), resp)
+	}, ingressWait, waitTick)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets format version 3.0 if the Kong version is 3.0.x or higher.

Adds a consumer and credential integration test, which surprisingly we apparently never had before.

**Which issue this PR fixes**:

After #2833 tested successfully, [another manual run today](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3023799669) resulted in failures on DB-less. Review of diagnostics indicates this is likely due to paths including the prefix twice:

```
routes:                 
  - regex_priority: 200 
    service: 3d13ec4a-1c07-52f5-a3a1-ced6cae4cfd4
    protocols:             
    - http                  
    - https                                      
    https_redirect_status_code: 426                          
    paths:                
    - /test_ingress_essentials/    
    - ~~/test_ingress_essentials$
```

Per discussion with the gateway team, 3.x was always supposed to automatically add the prefix to anything matching the 2.x heuristic to anything DB-less config with a `format_version` lower than `3.0`, and we use `1.1`. This was not occurring at the time we tested #2833, but is occurring now. It's not immediately clear what Kong-side change fixed this, though there are maybe some other reports of the conversion not working (based on a brief search of chat logs).

**Special notes for your reviewer**:

Initial run against this branch with the latest image: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3024326711

This does jump past another version, introduced in https://github.com/Kong/kong/pull/5835. AFAIK the distinction between transform and don't is the only important change there, and we should continue using the default, which matches the behavior in 1.1 (transform). That is based on a cursory read only, so more relying on tests to vet this than a deep understanding of the formats.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ fix to a previous change for this version.
