### PR TITLE
chore(tests) use 3.x release images

### DIFF
--- a/.github/workflows/kong3.0_compatibility.yaml
+++ b/.github/workflows/kong3.0_compatibility.yaml
@@ -44,15 +44,15 @@ jobs:
       id: setup_env_oss
       if: ${{ matrix.kong-edition == 'OSS' }}
       run: |
-        echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
-        echo "TEST_KONG_TAG=3.0.0-alpha.14-alpine" >> $GITHUB_ENV
+        echo "TEST_KONG_IMAGE=kong" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=3.0" >> $GITHUB_ENV
 
     - name: setup test kong image and env for enterprise edition
       id: setup_env_ee
       if: ${{ matrix.kong-edition == 'enterprise' }}
       run: |
-        echo "TEST_KONG_IMAGE=kong/kong-gateway-internal" >> $GITHUB_ENV
-        echo "TEST_KONG_TAG=3.0.x.x-alpine" >> $GITHUB_ENV
+        echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=3.0" >> $GITHUB_ENV
         echo "TEST_KONG_ENTERPRISE=true" >> $GITHUB_ENV
 
     - name: setup database mode for dbless
@@ -141,7 +141,7 @@ jobs:
       env:
         TEST_KONG_CONTROLLER_IMAGE_LOAD: kong/kubernetes-ingress-controller:ci
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: kong/kubernetes-ingress-controller:ci
-        TEST_KONG_IMAGE_OVERRIDE: kong/kong:3.0.0-alpha.14-alpine
+        TEST_KONG_IMAGE_OVERRIDE: kong:3.0
         KONG_CLUSTER_VERSION: "v1.24.2"
         ISTIO_VERSION: "v1.14.1"
         NCPU: 1
@@ -206,7 +206,7 @@ jobs:
       env:
         TEST_KONG_CONTROLLER_IMAGE_LOAD: kong/kubernetes-ingress-controller:ci
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: kong/kubernetes-ingress-controller:ci
-        TEST_KONG_IMAGE_OVERRIDE: kong/kong-gateway-internal:3.0.x.x-alpine
+        TEST_KONG_IMAGE_OVERRIDE: kong/kong-gateway:3.0
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@
   [#2889](https://github.com/Kong/kubernetes-ingress-controller/issues/2889)
   [#2894](https://github.com/Kong/kubernetes-ingress-controller/issues/2894)
   [#2900](https://github.com/Kong/kubernetes-ingress-controller/issues/2900)
+- Manifests now use `/bin/bash` instead of `/bin/sh` and use bash-based
+  connectivity checks for compatibility with the new Debian Kong images.
+  [#2923](https://github.com/Kong/kubernetes-ingress-controller/issues/2923)
 
 #### Fixed
 

--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -69,7 +69,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: [ "/bin/sh", "-c", "kong quit" ]
+              command: [ "/bin/bash", "-c", "kong quit" ]
         ports:
         - name: proxy
           containerPort: 8000

--- a/config/variants/postgres/kong-ingress-postgres.yaml
+++ b/config/variants/postgres/kong-ingress-postgres.yaml
@@ -10,7 +10,7 @@ spec:
       - name: wait-for-migrations
         image: kong-placeholder:placeholder
         command:
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
         - "while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;"
         env:

--- a/config/variants/postgres/migration.yaml
+++ b/config/variants/postgres/migration.yaml
@@ -17,7 +17,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+        command: [ "/bin/bash", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
         image: kong-placeholder:placeholder
@@ -28,5 +28,5 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
+        command: [ "/bin/bash", "-c", "kong migrations bootstrap" ]
       restartPolicy: OnFailure

--- a/config/variants/postgres/migration.yaml
+++ b/config/variants/postgres/migration.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-postgres
-        image: busybox
+        image: kong-placeholder:placeholder
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/config/variants/postgres/migration.yaml
+++ b/config/variants/postgres/migration.yaml
@@ -17,7 +17,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        command: [ "/bin/bash", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+        command: [ "/bin/bash", "-c", "until timeout 1 bash 9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-migrations
         image: kong-placeholder:placeholder

--- a/config/variants/postgres/wait/kong-ingress-postgres.yaml
+++ b/config/variants/postgres/wait/kong-ingress-postgres.yaml
@@ -10,7 +10,7 @@ spec:
       - name: wait-for-migrations
         image: kong-placeholder:placeholder
         command:
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
         - "while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi; sleep 2;  done;"
         env:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1601,7 +1601,7 @@ spec:
           preStop:
             exec:
               command:
-              - /bin/sh
+              - /bin/bash
               - -c
               - kong quit
         livenessProbe:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1596,7 +1596,7 @@ spec:
           preStop:
             exec:
               command:
-              - /bin/sh
+              - /bin/bash
               - -c
               - kong quit
         livenessProbe:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1873,8 +1873,8 @@ spec:
       - command:
         - /bin/bash
         - -c
-        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
-          sleep 1; done
+        - until timeout 1 bash 9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}; do echo
+          'waiting for db'; sleep 1; done
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1880,7 +1880,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: busybox
+        image: kong/kong-gateway:2.8
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1659,7 +1659,7 @@ spec:
           preStop:
             exec:
               command:
-              - /bin/sh
+              - /bin/bash
               - -c
               - kong quit
         livenessProbe:
@@ -1759,7 +1759,7 @@ spec:
       - name: kong-enterprise-edition-docker
       initContainers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
           sleep 2;  done;
@@ -1845,7 +1845,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - kong migrations bootstrap
         env:
@@ -1871,7 +1871,7 @@ spec:
       - name: kong-enterprise-edition-docker
       initContainers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
           sleep 1; done

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1614,7 +1614,7 @@ spec:
           preStop:
             exec:
               command:
-              - /bin/sh
+              - /bin/bash
               - -c
               - kong quit
         livenessProbe:
@@ -1701,7 +1701,7 @@ spec:
           readOnly: true
       initContainers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - while true; do kong migrations list; if [[ 0 -eq $? ]]; then exit 0; fi;
           sleep 2;  done;
@@ -1782,7 +1782,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - kong migrations bootstrap
         env:
@@ -1796,7 +1796,7 @@ spec:
         name: kong-migrations
       initContainers:
       - command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
           sleep 1; done

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1798,8 +1798,8 @@ spec:
       - command:
         - /bin/bash
         - -c
-        - until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db';
-          sleep 1; done
+        - until timeout 1 bash 9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}; do echo
+          'waiting for db'; sleep 1; done
         env:
         - name: KONG_PG_HOST
           value: postgres

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1805,7 +1805,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: busybox
+        image: kong:2.8
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -22,7 +22,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 	// well use the stock Kubernetes resource.
 	icp, err := getIngressClassParametersOrDefault(p.storer)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound{}) {
+		if errors.As(err, &store.ErrNotFound{}) {
 			// not found is expected if no IngressClass exists or IngressClassParameters isn't configured
 			p.logger.Debugf("could not find IngressClassParameters, using defaults: %s", err)
 		} else {

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -92,6 +92,17 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 		assert.NoError(t, env.Cleanup(ctx))
 	}()
 
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
+	defer func() {
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
+	}()
+
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
 	require.NoError(t, err)
@@ -148,6 +159,17 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 		assert.NoError(t, env.Cleanup(ctx))
 	}()
 
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
+	defer func() {
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
+	}()
+
 	t.Logf("deploying previous version %s kong manifest", preTag)
 	deployKong(ctx, t, env, oldManifest.Body)
 
@@ -187,8 +209,15 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 
 	createKongImagePullSecret(ctx, t, env)
 
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("generating a superuser password")
@@ -233,8 +262,16 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
+
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")
@@ -270,7 +307,12 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	t.Logf("build a cleaner to dump diagnostics...")
 	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")
@@ -419,8 +461,15 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	require.NoError(t, err)
 	createKongImagePullSecret(ctx, t, env)
 
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("generating a superuser password")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -161,14 +161,16 @@ func TestWebhookUpdate(t *testing.T) {
 	builder := environments.NewBuilder().WithExistingCluster(cluster).WithAddons(addons...)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
-	}()
 
 	t.Logf("build a cleaner to dump diagnostics...")
 	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")
@@ -310,9 +312,15 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
+	t.Logf("build a cleaner to dump diagnostics...")
+	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		t.Logf("cleaning up environment for cluster %s", env.Cluster().Name())
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")
@@ -490,8 +498,14 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
+	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")
@@ -570,9 +584,6 @@ func TestDefaultIngressClass(t *testing.T) {
 	builder := environments.NewBuilder().WithExistingCluster(cluster).WithAddons(addons...)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
-	}()
 
 	t.Logf("build a cleaner to dump diagnostics...")
 	cleaner := clusters.NewCleaner(env.Cluster())

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -218,7 +218,12 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		}
 		return adminOutput.Version != ""
 	}, adminAPIWait, time.Second)
-	require.Contains(t, adminOutput.Version, "enterprise-edition")
+	if string(adminOutput.Version[0]) == "3" {
+		// 3.x removed the "-enterprise-edition" string but provided no other indication that something is enterprise
+		require.Len(t, strings.Split(adminOutput.Version, "."), 4)
+	} else {
+		require.Contains(t, adminOutput.Version, "enterprise-edition")
+	}
 }
 
 func verifyEnterpriseWithPostgres(ctx context.Context, t *testing.T, env environments.Environment, adminPassword string) {

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -60,7 +60,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	// pollutes E2E logs with a bunch of controller log nonsense and a boatload of goroutines that litter the panic
 	// logs. Temporarily skip it because it's not failing and it's making it harder to read the failure results.
 	// Ultimately we should probably move it elsewhere.
-	t.Skip("quiet Istio")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -55,6 +55,12 @@ var (
 // See: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/#istio
 func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Parallel()
+	// Istio's test is unique in that it operates like the integration tests, and runs the controller manager from the
+	// test, whereas most E2E tests deploy it to the cluster normally. The upshot of this is that the Istio test
+	// pollutes E2E logs with a bunch of controller log nonsense and a boatload of goroutines that litter the panic
+	// logs. Temporarily skip it because it's not failing and it's making it harder to read the failure results.
+	// Ultimately we should probably move it elsewhere.
+	t.Skip("quiet Istio")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the 3.x compatibility test to use release images. Awaiting https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3039067881 as a test run against this branch.

Changes the the various `/bin/sh -c` invocations in container commands to `/bin/bash -c` as all images provide a bash and the default's `/bin/sh` is not compatible with our scripts.

Fixes the error type check for Knative's IngressClass scan; I forgot it earlier when I fixed the not-Knative version.

**Which issue this PR fixes**:
The Enterprise image pull credentials were not properly configured; this fixes those by virtue of no longer requiring them. We want to start using the release images anyway since they're now the newest versions.

However, it breaks the OSS runs because that image isn't actually available. I'm okay with this; they were passing before, and they will need to pass with that image eventually. This version turns the existing compatibility test into a trial run for the release E2E tests, which will require the released image.