### PR TITLE
fix: adapt admission webhook tests to run in colima host

### DIFF
--- a/internal/util/test/webhooks.go
+++ b/internal/util/test/webhooks.go
@@ -109,18 +109,20 @@ ctFsgXhf5+tDgbBZpcuTMpd3KnaDUYg=
 -----END PRIVATE KEY-----`
 )
 
-// XXX (this hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613):
+// This hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613:
 //
 // The test process (`go test github.com/Kong/kubernetes-ingress-controller/test/integration/...`) serves the webhook
 // endpoints to be consumed by the apiserver (so that the tests can apply a ValidatingWebhookConfiguration and test
 // those validations).
+//
 // In order to make that possible, we needed to allow the apiserver (that gets spun up by the test harness) to access
 // the system under test (which runs as a part of the `go test` process).
-// Below, we're making an audacious assumption that the host running the `go test` process is either
-//   - a direct Docker host on the default bridge, and that the apiserver is running within a context
-//     (such as KIND running on that same docker bridge), from which 172.17.0.1 routes to the host OR
-//   - a Colima host, and that the apiserver is running within a docker container hosted by Colima
-//     from which 192.168.5.2 routes to the host (https://github.com/abiosoft/colima/issues/220)
+// Below, we're making an audacious assumption that the host running the `go test` process is either:
+//
+// - a direct Docker host on the default bridge, and that the apiserver is running within a context
+// (such as KIND running on that same docker bridge), from which 172.17.0.1 routes to the host OR
+// - a Colima host, and that the apiserver is running within a docker container hosted by Colima
+// from which 192.168.5.2 routes to the host (https://github.com/abiosoft/colima/issues/220)
 //
 // This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
 var AdmissionWebhookListenHost = admissionWebhookListenHost()

--- a/internal/util/test/webhooks.go
+++ b/internal/util/test/webhooks.go
@@ -1,5 +1,10 @@
 package test
 
+import (
+	"os/exec"
+	"strings"
+)
+
 const (
 	// KongSystemServiceCert is a testing TLS certificate with SAN *.kong-system.svc.
 	//
@@ -104,18 +109,42 @@ ctFsgXhf5+tDgbBZpcuTMpd3KnaDUYg=
 -----END PRIVATE KEY-----`
 )
 
+// XXX (this hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613):
+//
+// The test process (`go test github.com/Kong/kubernetes-ingress-controller/test/integration/...`) serves the webhook
+// endpoints to be consumed by the apiserver (so that the tests can apply a ValidatingWebhookConfiguration and test
+// those validations).
+// In order to make that possible, we needed to allow the apiserver (that gets spun up by the test harness) to access
+// the system under test (which runs as a part of the `go test` process).
+// Below, we're making an audacious assumption that the host running the `go test` process is either
+//   - a direct Docker host on the default bridge, and that the apiserver is running within a context
+//     (such as KIND running on that same docker bridge), from which 172.17.0.1 routes to the host OR
+//   - a Colima host, and that the apiserver is running within a docker container hosted by Colima
+//     from which 192.168.5.2 routes to the host (https://github.com/abiosoft/colima/issues/220)
+//
+// This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
+var AdmissionWebhookListenHost = admissionWebhookListenHost()
+
 const (
-	// XXX (this hack is tracked in https://github.com/Kong/kubernetes-ingress-controller/issues/1613):
-	//
-	// The test process (`go test github.com/Kong/kubernetes-ingress-controller/test/integration/...`) serves the webhook
-	// endpoints to be consumed by the apiserver (so that the tests can apply a ValidatingWebhookConfiguration and test
-	// those validations).
-	// In order to make that possible, we needed to allow the apiserver (that gets spun up by the test harness) to access
-	// the system under test (which runs as a part of the `go test` process).
-	// In the constants below, we're making an audacious assumption that the host running the `go test` process is also
-	// the Docker host on the default bridge (therefore it can listen on 172.17.0.1), and that the apiserver
-	// is running within a context (such as KIND running on that same docker bridge), from which 172.17.0.1 is routable.
-	// This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
-	AdmissionWebhookListenHost = "172.17.0.1"
 	AdmissionWebhookListenPort = 49023
+
+	colimaHostAddress                 = "192.168.5.2"
+	defaultDockerBridgeNetworkGateway = "172.17.0.1"
 )
+
+func admissionWebhookListenHost() string {
+	if isColimaHost() {
+		return colimaHostAddress
+	}
+
+	return defaultDockerBridgeNetworkGateway
+}
+
+func isColimaHost() bool {
+	out, err := exec.Command("docker", "info", "--format", "{{.Name}}").Output()
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(out), "colima")
+}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -208,7 +208,7 @@ func TestMain(m *testing.M) {
 			fmt.Sprintf("--ingress-class=%s", ingressClass),
 			fmt.Sprintf("--admission-webhook-cert=%s", testutils.KongSystemServiceCert),
 			fmt.Sprintf("--admission-webhook-key=%s", testutils.KongSystemServiceKey),
-			fmt.Sprintf("--admission-webhook-listen=%s:%d", testutils.AdmissionWebhookListenHost, testutils.AdmissionWebhookListenPort),
+			fmt.Sprintf("--admission-webhook-listen=0.0.0.0:%d", testutils.AdmissionWebhookListenPort),
 			"--profiling",
 			"--dump-config",
 			"--log-level=trace",


### PR DESCRIPTION
**What this PR does / why we need it**:

* changes binding address of the webhook server to `0.0.0.0` so that it's reachable from any address host is called 
* makes `AdmissionWebhookListenHost` depend on the host environment 
  * for vanilla docker host it will use default docker bridge network gateway - `172.17.0.1` as it already did 
  * for colima docker host it will use a hardcoded host IP address routable from colima VM and colima hosted containers - `192.168.5.2`. 

It allows to run admission webhook integration tests locally on a colima based docker host. 

Drawback is that we're building more hacks on top of the hack which is tracked by this issue: https://github.com/Kong/kubernetes-ingress-controller/issues/1613

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
