### PR TITLE
test: set gatewayclass to unmanaged in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ test.integration.enterprise.postgres.pretty:
 
 .PHONY: test.e2e
 test.e2e:
-	GOFLAGS="-tags=e2e_tests" go test -v \
+	GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
 		-race \
 		-parallel $(NCPU) \
 		-timeout $(E2E_TEST_TIMEOUT) \

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -40,6 +40,10 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 	supportedGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				// annotate the gatewayclass to unmanaged.
+				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
 			ControllerName: gateway.ControllerName,
@@ -52,9 +56,6 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 	gw := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kong",
-			Annotations: map[string]string{
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder, // trigger the unmanaged gateway mode
-			},
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
 			GatewayClassName: gatewayv1beta1.ObjectName(supportedGatewayClass.Name),
@@ -84,6 +85,7 @@ func verifyGateway(ctx context.Context, t *testing.T, env environments.Environme
 				return true
 			}
 		}
+		t.Logf("conditions: %v", gw.Status.Conditions)
 		return false
 	}, gatewayUpdateWaitTime, time.Second)
 }
@@ -97,6 +99,10 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 	supportedGatewayClass := &gatewayv1beta1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				// annotate the gatewayclass to unmanaged.
+				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
 			ControllerName: gateway.ControllerName,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Fix e2e test failures after #2917 merged, which requires KIC to reconcile gateway when `gatewayClass` is annotated as unmanaged.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
