### PR TITLE
chore(*) translate semver fork to original

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/kong/deck v1.14.0
-	github.com/kong/go-kong v0.31.1
+	github.com/kong/go-kong v0.32.0
 	github.com/kong/kubernetes-testing-framework v0.20.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.50
@@ -110,6 +110,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kong/semver/v4 v4.0.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,10 +512,12 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kong/deck v1.14.0 h1:ZqYgDqOr3KXqBTOMakFUf2EIQjjyXVevQrveUNJMneo=
 github.com/kong/deck v1.14.0/go.mod h1:H26s8ZNZhtouUy9drgLjgsGVIXayVtoClRz46TBrap8=
-github.com/kong/go-kong v0.31.1 h1:bO9jRdw35HQKXd3XS5baJhwTAVl8gZjdY51cvglojUU=
-github.com/kong/go-kong v0.31.1/go.mod h1:76auWSrwSmH1de2oBJ2/6zibVS0eW+sJgAsdA94f1jI=
+github.com/kong/go-kong v0.32.0 h1:XmSWmKl5bNfcQHbmw3GBNiT7pRHbuehmeMft0Hjr63U=
+github.com/kong/go-kong v0.32.0/go.mod h1:GzkYwVXXuAZwxr3K6kgAbSEkh2zBDKtliD0xIqMu/9E=
 github.com/kong/kubernetes-testing-framework v0.20.0 h1:DhRYUhCC0UsMbuOPi5ydcbJAARJaccJzRhZIX2wtuBc=
 github.com/kong/kubernetes-testing-framework v0.20.0/go.mod h1:QF489Va4Ke1QRUCYALcgIF420SDenfayG8+r9JVjBb4=
+github.com/kong/semver/v4 v4.0.1 h1:DIcNR8W3gfx0KabFBADPalxxsp+q/5COwIFkkhrFQ2Y=
+github.com/kong/semver/v4 v4.0.1/go.mod h1:LImQ0oT15pJvSns/hs2laLca2zcYoHu5EsSNY0J6/QA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/prometheus/client_golang/prometheus"
@@ -161,13 +162,13 @@ func NewKongClient(
 	}
 
 	// validate the proxy version
-	proxySemver, err := kong.ParseSemanticVersion(kong.VersionFromInfo(root))
+	proxyVersion, err := kong.ParseSemanticVersion(kong.VersionFromInfo(root))
 	if err != nil {
 		return nil, err
 	}
 
 	// store the gathered configuration options
-	c.kongConfig.Version = proxySemver
+	c.kongConfig.Version = semver.Version{Major: proxyVersion.Major(), Minor: proxyVersion.Minor(), Patch: proxyVersion.Patch()}
 	c.dbmode = dbmode
 
 	return c, nil

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -103,7 +104,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	if err != nil {
 		setupLog.V(util.WarnLevel).Info("could not parse Kong version, version-specific behavior disabled", "error", err)
 	} else {
-		versions.SetKongVersion(kongVersion)
+		versions.SetKongVersion(semver.Version{Major: kongVersion.Major(), Minor: kongVersion.Minor(), Patch: kongVersion.Patch()})
 	}
 	kongRootConfig, ok := kongRoot["configuration"].(map[string]interface{})
 	if !ok {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -186,7 +186,11 @@ const (
 
 func getKongVersion() (semver.Version, error) {
 	if override := os.Getenv("TEST_KONG_VERSION_OVERRIDE"); len(override) > 0 {
-		return kong.ParseSemanticVersion(override)
+		version, err := kong.ParseSemanticVersion(override)
+		if err != nil {
+			return semver.Version{}, err
+		}
+		return semver.Version{Major: version.Major(), Minor: version.Minor(), Patch: version.Patch()}, nil
 	}
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", proxyAdminURL.String(), nil)
@@ -208,7 +212,11 @@ func getKongVersion() (semver.Version, error) {
 	if err != nil {
 		return semver.Version{}, err
 	}
-	return kong.ParseSemanticVersion(kong.VersionFromInfo(jsonResp))
+	version, err := kong.ParseSemanticVersion(kong.VersionFromInfo(jsonResp))
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return semver.Version{Major: version.Major(), Minor: version.Minor(), Patch: version.Patch()}, nil
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller expects the original version of the semver library, not the fork. To avoid a more extensive rework of the controller version code at this time, this converts the forked semver back into a standard semver.

**Special notes for your reviewer**:

A follow-up issue to try and disentangle this mess is forthcoming.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ nothing user-facing
