### PR TITLE
chore(ci) remove 1.20 from previous Kubernetes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -235,7 +235,6 @@ jobs:
     strategy:
       matrix:
         minor:
-          - '20'
           - '21'
           - '22'
           - '23'


### PR DESCRIPTION
**What this PR does / why we need it**:
I forgot to look at the older versions still supported. See https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3056146579/jobs/4930247339

**Which issue this PR fixes**:
Does not abort release tests due to unsupported versions.

**Special notes for your reviewer**:
Force-merging for expediency.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ CI change only.
