### PR TITLE
chore: release template describes red hat catalog process

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -48,7 +48,7 @@ body:
     label: "**For all releases** Publish images to Red Hat Catalog"
     options:
       - label: Verify the image was pushed by a pipeline to the [KIC project in Red Hat partners portal](https://connect.redhat.com/projects/5eab1b8ea165648bd1353266/images) to confirm that E2E tests are succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml).
-      - label: Click publish button for all tags to publish the image to Red Hat Catalog.
+      - label: Click publish button for all tags related to the release that were pushed to the portal. That will publish the image to Red Hat Catalog.
       - label: Make sure the latest tag was added when asked. If forgot, the tag can be added from a dropdown menu.
 - type: checkboxes
   id: release_documents

--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -49,7 +49,7 @@ body:
     options:
       - label: Verify the image was pushed by a pipeline to the [KIC project in Red Hat partners portal](https://connect.redhat.com/projects/5eab1b8ea165648bd1353266/images) to confirm that E2E tests are succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml).
       - label: Click publish button for all tags related to the release that were pushed to the portal. That will publish the image to Red Hat Catalog.
-      - label: Make sure the latest tag was added when asked. If forgot, the tag can be added from a dropdown menu.
+      - label: Make sure the latest tag was added when asked. If forgot, the tag can be added from the dropdown menu.
 - type: checkboxes
   id: release_documents
   attributes:

--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -43,6 +43,14 @@ body:
       - label: Once the PR is merged, [initiate a release job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/release.yaml). Your tag must use `vX.Y.Z` format. Set `latest` to true if this will be the latest release.
       - label: CI will validate the requested version, build and push an image, and run tests against the image before finally creating a tag and publishing a release. If tests fail, CI will push the image but not the tag or release. Investigate the failure, correct it as needed, and start a new release job.
 - type: checkboxes
+  id: release_redhat
+  attributes:
+    label: "**For all releases** Publish images to Red Hat Catalog"
+    options:
+      - label: Verify the image was pushed by a pipeline to the [KIC project in Red Hat partners portal](https://connect.redhat.com/projects/5eab1b8ea165648bd1353266/images) to confirm that E2E tests are succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml).
+      - label: Click publish button for all tags to publish the image to Red Hat Catalog.
+      - label: Make sure the latest tag was added when asked. If forgot, the tag can be added from a dropdown menu.
+- type: checkboxes
   id: release_documents
   attributes:
     label: "**For major/minor releases only** Update Release documents"


### PR DESCRIPTION

**What this PR does / why we need it**:

Release template describes red hat catalog process.
