### PR TITLE
fix: handling lagacy regexp detection for paths when combined routes are enabled

### DIFF
--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -216,6 +216,14 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 
 		if p.featureEnabledCombinedServiceRoutes {
 			for _, kongStateService := range translators.TranslateIngress(ingress, p.flagEnabledRegexPathPrefix) {
+				if icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix {
+					for _, route := range kongStateService.Routes {
+						for i, path := range route.Paths {
+							newPath := maybePrependRegexPrefix(*path)
+							route.Paths[i] = &newPath
+						}
+					}
+				}
 				result.ServiceNameToServices[*kongStateService.Service.Name] = *kongStateService
 			}
 			objectSuccessfullyParsed = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the controller does not correctly add the `3.x "~" regular expression path prefix` to ingress paths  when all of the conditions are met:
- Path match the 2.x regex heuristic
- IngressClass has the EnableLegacyRegexDetection flag set.
- The `combined routes` feature is enabled. 

The `combined routes`  feature seems to disable the regexp detection.

As a result test `TestIngressClassRegexToggle` fails when run with `KONG_CONTROLLER_FEATURE_GATES="GatewayAlpha=true,CombinedRoutes=true"`.

This PR aims at fixing that by making the code for ingress rule translation on `featureEnabledCombinedServiceRoutes` path behaves the same as on `!featureEnabledCombinedServiceRoutes` path.

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/2942

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
