### PR TITLE
chore: introduce CheckCondition helper

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -146,7 +146,7 @@ func (r *GatewayReconciler) gatewayHasMatchingGatewayClass(obj client.Object) bo
 		r.Log.Error(err, "could not retrieve gatewayclass", "gatewayclass", gateway.Spec.GatewayClassName)
 		return false
 	}
-	return isGatewayClassControlledAndUmanaged(gatewayClass)
+	return isGatewayClassControlledAndUnmanaged(gatewayClass)
 }
 
 // gatewayClassMatchesController is a watch predicate which filters out events for gatewayclasses which
@@ -157,7 +157,7 @@ func (r *GatewayReconciler) gatewayClassMatchesController(obj client.Object) boo
 		r.Log.Error(fmt.Errorf("unexpected object type in gatewayclass watch predicates"), "expected", "*gatewayv1beta1.GatewayClass", "found", reflect.TypeOf(obj))
 		return false
 	}
-	return isGatewayClassControlledAndUmanaged(gatewayClass)
+	return isGatewayClassControlledAndUnmanaged(gatewayClass)
 }
 
 // listGatewaysForGatewayClass is a watch predicate which finds all the gateway objects reference
@@ -220,7 +220,7 @@ func (r *GatewayReconciler) listGatewaysForService(svc client.Object) (recs []re
 			r.Log.Error(err, "failed to retrieve gateway class in watch predicates", "gatewayclass", gateway.Spec.GatewayClassName)
 			return
 		}
-		if isGatewayClassControlledAndUmanaged(gatewayClass) {
+		if isGatewayClassControlledAndUnmanaged(gatewayClass) {
 			recs = append(recs, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: gateway.Namespace,
@@ -313,7 +313,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// This check has already been performed by predicates, but we need to ensure this condition
 	// as the reconciliation loop may be triggered by objects in which predicates we
 	// cannot check the ControllerName and the unmanaged mode (e.g., ReferenceGrants).
-	if !isGatewayClassControlledAndUmanaged(gwc) {
+	if !isGatewayClassControlledAndUnmanaged(gwc) {
 		return reconcile.Result{}, nil
 	}
 

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -167,6 +167,7 @@ func Test_setGatewayCondtion(t *testing.T) {
 func Test_isGatewayMarkedAsScheduled(t *testing.T) {
 	t.Log("verifying scheduled check for gateway object which has been scheduled")
 	scheduledGateway := &gatewayv1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
 		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
 				Type:               string(gatewayv1beta1.GatewayConditionScheduled),

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -392,7 +392,7 @@ func Test_isGatewayControlledAndUnmanagedMode(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.expectedResult, isGatewayClassControlledAndUmanaged(tc.GatewayClass))
+			assert.Equal(t, tc.expectedResult, isGatewayClassControlledAndUnmanaged(tc.GatewayClass))
 		})
 	}
 }

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -433,12 +433,14 @@ func getGatewayCerts(log logrus.FieldLogger, s store.Storer) []certWrapper {
 					"gateway":  gateway.Name,
 					"listener": listener.Name,
 				}).Debug("listener missing status information")
-				for _, c := range status.Conditions {
-					if c.Type == string(gatewayv1alpha2.ListenerConditionReady) {
-						if c.Status == metav1.ConditionTrue {
-							ready = true
-						}
-					}
+				if ok := util.CheckCondition(
+					status.Conditions,
+					util.ConditionType(gatewayv1alpha2.ListenerConditionReady),
+					util.ConditionReason(gatewayv1alpha2.ListenerReasonReady),
+					metav1.ConditionTrue,
+					gateway.Generation,
+				); ok {
+					ready = true
 				}
 			}
 			if !ready {

--- a/internal/util/conditions.go
+++ b/internal/util/conditions.go
@@ -1,0 +1,25 @@
+package util
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type ConditionType string
+
+type ConditionReason string
+
+func CheckCondition(
+	conditions []metav1.Condition,
+	typ ConditionType,
+	reason ConditionReason,
+	status metav1.ConditionStatus,
+	resourceGeneration int64,
+) bool {
+	for _, cond := range conditions {
+		if cond.Type == string(typ) &&
+			cond.Reason == string(reason) &&
+			cond.Status == status &&
+			cond.ObservedGeneration >= resourceGeneration {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/conditions.go
+++ b/internal/util/conditions.go
@@ -2,10 +2,14 @@ package util
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// ConditionType can be any condition type, e.g. `gatewayv1beta1.GatewayConditionReady`.
 type ConditionType string
 
+// ConditionReason can be any condition reason, e.g. `gatewayv1beta1.GatewayReasonReady`.
 type ConditionReason string
 
+// CheckCondition tells if there's a condition matching the given type, reason, and status in conditions.
+// It also makes sure that the condition's observed generation is no older than the resource's actual generation.
 func CheckCondition(
 	conditions []metav1.Condition,
 	typ ConditionType,

--- a/internal/util/conditions.go
+++ b/internal/util/conditions.go
@@ -21,7 +21,7 @@ func CheckCondition(
 		if cond.Type == string(typ) &&
 			cond.Reason == string(reason) &&
 			cond.Status == status &&
-			cond.ObservedGeneration >= resourceGeneration {
+			cond.ObservedGeneration == resourceGeneration {
 			return true
 		}
 	}

--- a/internal/util/conditions_test.go
+++ b/internal/util/conditions_test.go
@@ -1,0 +1,127 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+func TestCheckCondition(t *testing.T) {
+	expectedType := util.ConditionType(gatewayv1alpha2.ListenerConditionReady)
+	expectedReason := util.ConditionReason(gatewayv1alpha2.GatewayReasonScheduled)
+	expectedStatus := metav1.ConditionTrue
+	generation := int64(1)
+	givenConditions := []metav1.Condition{
+		{
+			Type:               string(expectedType),
+			Reason:             string(expectedReason),
+			Status:             expectedStatus,
+			ObservedGeneration: generation,
+		},
+	}
+
+	otherType := util.ConditionType(gatewayv1alpha2.ListenerConditionConflicted)
+	otherReason := util.ConditionReason(gatewayv1alpha2.GatewayReasonReady)
+	otherStatus := metav1.ConditionFalse
+
+	testCases := []struct {
+		name           string
+		givenType      util.ConditionType
+		givenReason    util.ConditionReason
+		givenStatus    metav1.ConditionStatus
+		expectedResult bool
+	}{
+		{
+			name:           "all_as_expected_should_give_true",
+			givenType:      expectedType,
+			givenReason:    expectedReason,
+			givenStatus:    expectedStatus,
+			expectedResult: true,
+		},
+		{
+			name:           "all_but_type_as_expected_should_give_false",
+			givenType:      otherType,
+			givenReason:    expectedReason,
+			givenStatus:    expectedStatus,
+			expectedResult: false,
+		},
+		{
+			name:           "all_but_reason_as_expected_should_give_false",
+			givenType:      expectedType,
+			givenReason:    otherReason,
+			givenStatus:    expectedStatus,
+			expectedResult: false,
+		},
+		{
+			name:           "all_but_status_as_expected_should_give_false",
+			givenType:      expectedType,
+			givenReason:    expectedReason,
+			givenStatus:    otherStatus,
+			expectedResult: false,
+		},
+		{
+			name:           "only_type_as_expected_should_give_false",
+			givenType:      expectedType,
+			givenReason:    otherReason,
+			givenStatus:    otherStatus,
+			expectedResult: false,
+		},
+		{
+			name:           "only_reason_as_expected_should_give_false",
+			givenType:      otherType,
+			givenReason:    expectedReason,
+			givenStatus:    otherStatus,
+			expectedResult: false,
+		},
+		{
+			name:           "only_status_as_expected_should_give_false",
+			givenType:      otherType,
+			givenReason:    otherReason,
+			givenStatus:    expectedStatus,
+			expectedResult: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ok := util.CheckCondition(
+				givenConditions,
+				testCase.givenType,
+				testCase.givenReason,
+				testCase.givenStatus,
+				generation,
+			)
+			require.Equal(t, testCase.expectedResult, ok)
+		})
+	}
+}
+
+func TestCheckCondition_observed_generations_lower_than_actual_are_ignored(t *testing.T) {
+	expectedType := util.ConditionType(gatewayv1alpha2.ListenerConditionReady)
+	expectedReason := util.ConditionReason(gatewayv1alpha2.GatewayReasonScheduled)
+	expectedStatus := metav1.ConditionTrue
+	givenConditions := []metav1.Condition{
+		{
+			Type:               string(expectedType),
+			Reason:             string(expectedReason),
+			Status:             expectedStatus,
+			ObservedGeneration: 1,
+		},
+	}
+	generationHigherThanObserved := int64(2)
+
+	ok := util.CheckCondition(
+		givenConditions,
+		expectedType,
+		expectedReason,
+		expectedStatus,
+		generationHigherThanObserved,
+	)
+	require.False(t, ok, "expected to not match any condition due to low observed generation")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* introduces `CheckCondition` helper function to reduce code repetition across the codebase (replaces repeating for loops with nested ifs) 
* makes sure that `Condition.ObservedGeneration == Resource.Generation` while matching conditions 

**Which issue this PR fixes**:

Resolves #2609 

**Special notes for your reviewer**:

As I can see according to the [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) we do populate the `ObservedGeneration` property when updating conditions. That's why I have made it to be verified when matching conditions. Please correct if I'm missing something here.  

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~~
