### PR TITLE
fix(translate) use Ingress-specific regex prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## [2.7.0]
+
+> Release date: TBD
+
+### Breaking changes
+
+- Ingress paths that begin with `/~` are now treated as regular expressions,
+  and are translated into a Kong route path that begins with `~` instead of
+  `/~`. To preserve the existing translation, set `konghq.com/regex-prefix` to
+  some value. For example, if you set `konghq.com/regex-prefix: /@`, paths
+  beginning with `/~` will result in route paths beginning in `/~`, whereas
+  paths beginning in `/@` will result in route paths beginning in `~`.
+  [#2956](https://github.com/Kong/kubernetes-ingress-controller/pull/2956)
+
+### Added
+
+- The controller-specific `/~` prefix translates to the Kong `~` prefix, as
+  Ingress does not allow paths that do not begin in `/`. The prefix can be
+  overriden by setting a `konghq.com/regex-prefix` annotation, for routes that
+  need their paths to actually begin with `/~`
+  [#2956](https://github.com/Kong/kubernetes-ingress-controller/pull/2956)
+
+### Fixed
+
+- The legacy regex heuristic toggle on IngressClassParameters now works when
+  the combined routes feature flag is enabled.
+  [#2942](https://github.com/Kong/kubernetes-ingress-controller/pull/2942)
+
 ## [2.6.0]
 
 > Release date: 2022-09-14
@@ -1934,6 +1962,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.2...v2.5.0
 [2.4.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.1...v2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@
 
 > Release date: TBD
 
+2.7 patches several bugs in 2.6.0. One of these required a breaking change. The
+breaking change is not expected to affect most configurations, but does require
+a minor version bump to comply with semver. If you have not already upgraded to
+2.6, you should upgrade directly from 2.5 to 2.7, and follow the 2.6 upgrade
+instructions and the [revised Kong 3.x upgrade instructions](https://docs.konghq.com/kubernetes-ingress-controller/2.7.x/guides/upgrade-kong-3x).
+
 ### Breaking changes
 
 - Ingress paths that begin with `/~` are now treated as regular expressions,
@@ -78,6 +84,14 @@
 - The legacy regex heuristic toggle on IngressClassParameters now works when
   the combined routes feature flag is enabled.
   [#2942](https://github.com/Kong/kubernetes-ingress-controller/pull/2942)
+- Handles Kubernetes versions that do not support namespaced
+  IngressClassParameters without panicking. Although the controller will run on
+  clusters without the `IngressClassNamespacedParams` feature gate enabled
+  (1.21) or without it available (<1.21), these clusters do not support the
+  legacy regular expression heuristic IngressClassParameters option. These
+  versions are EOL, and we advise users to upgrade to Kubernetes 1.22 or later
+  before upgrading to KIC 2.6+ or Kong 3.0+.
+  [#2970](https://github.com/Kong/kubernetes-ingress-controller/pull/2970)
 
 ## [2.6.0]
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -55,6 +55,7 @@ const (
 	RequestBuffering     = "/request-buffering"
 	ResponseBuffering    = "/response-buffering"
 	HostAliasesKey       = "/host-aliases"
+	RegexPrefixKey       = "/regex-prefix"
 
 	// GatewayClassUnmanagedAnnotationSuffix is an annotation used on a Gateway resource to
 	// indicate that the GatewayClass should be reconciled according to unmanaged

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -69,12 +69,7 @@ func (p *Parser) ingressRulesFromIngressV1beta1() ingressRules {
 					log.Errorf("rule skipped: invalid path: '%v'", path)
 					continue
 				}
-				if strings.HasPrefix(path, regexPrefix) {
-					path = strings.Replace(path, regexPrefix,
-						translators.KongPathRegexPrefix, 1)
-				} else if icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix {
-					path = maybePrependRegexPrefix(path)
-				}
+				path = maybePrependRegexPrefix(path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
 				if path == "" {
 					path = "/"
 				}
@@ -230,13 +225,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 			for _, kongStateService := range translators.TranslateIngress(ingress, p.flagEnabledRegexPathPrefix) {
 				for _, route := range kongStateService.Routes {
 					for i, path := range route.Paths {
-						newPath := *path
-						if strings.HasPrefix(*path, regexPrefix) {
-							newPath = strings.Replace(*path, regexPrefix,
-								translators.KongPathRegexPrefix, 1)
-						} else if icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix {
-							newPath = maybePrependRegexPrefix(*path)
-						}
+						newPath := maybePrependRegexPrefix(*path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
 						route.Paths[i] = &newPath
 					}
 				}
@@ -266,13 +255,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 					}
 
 					for i, path := range paths {
-						newPath := *path
-						if strings.HasPrefix(*path, regexPrefix) {
-							newPath = strings.Replace(*path, regexPrefix,
-								translators.KongPathRegexPrefix, 1)
-						} else if icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix {
-							newPath = maybePrependRegexPrefix(*path)
-						}
+						newPath := maybePrependRegexPrefix(*path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
 						paths[i] = &newPath
 					}
 

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/kong/go-kong/kong"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -65,14 +64,9 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 			for j, rule := range rule.HTTP.Paths {
 				path := rule.Path
 
+				path = maybePrependRegexPrefix(path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
 				if path == "" {
 					path = "/"
-				}
-				if strings.HasPrefix(path, regexPrefix) {
-					path = strings.Replace(path, regexPrefix,
-						translators.KongPathRegexPrefix, 1)
-				} else if icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix {
-					path = maybePrependRegexPrefix(path)
 				}
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),

--- a/internal/dataplane/parser/translators/translator_vars.go
+++ b/internal/dataplane/parser/translators/translator_vars.go
@@ -3,4 +3,8 @@ package translators
 const (
 	// KongPathRegexPrefix is the reserved prefix string that instructs Kong 3.0+ to interpret a path as a regex.
 	KongPathRegexPrefix = "~"
+
+	// ControllerPathRegePrefix is the prefix string used to indicate that the controller should treat a path as a
+	// regular expression. The controller replaces this prefix with KongPathRegexPrefix when sending routes to Kong.
+	ControllerPathRegexPrefix = "/~"
 )

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -854,6 +854,18 @@ func TestIngressRegexPrefix(t *testing.T) {
 										},
 									},
 								},
+								{
+									Path:     `/~/test_ingress_regex_prefix_nonstandard_default`,
+									PathType: &pathTypeImplementationSpecific,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: service.Name,
+											Port: netv1.ServiceBackendPort{
+												Number: service.Spec.Ports[0].Port,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -883,6 +895,22 @@ func TestIngressRegexPrefix(t *testing.T) {
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_regex_prefix_nonstandard/999", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			b := new(bytes.Buffer)
+			n, err := b.ReadFrom(resp.Body)
+			require.NoError(t, err)
+			require.True(t, n > 0)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, ingressWait, waitTick)
+	require.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/~/test_ingress_regex_prefix_nonstandard_default", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false


### PR DESCRIPTION
**What this PR does / why we need it**:

Translate between an Ingress-compatible regex prefix and the Kong regex prefix. Allow users to override the default regex prefix using an annotation.

Add tests for regex Ingress paths using the prefix.

By default, Ingress paths beginning with `/~` will translate to Kong route paths beginning with `~`. This functionality _is not_ version-gated, with the expectation that such paths are uncommon in the wild. For users that do need these paths translated verbatim, overriding the prefix with the `konghq.com/regex-prefix` allows you to preserve `/~`-prefixed paths as they are.

**Which issue this PR fixes**:
Fix #2945 

**Special notes for your reviewer**:


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
