### PR TITLE
test: fix specifying kind cluster version

### DIFF
--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -632,6 +632,14 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
 		t.Skip("legacy regex detection is only relevant for Kong 3.0+")
 	}
+
+	// skip the test if the cluster does not support namespaced ingress class parameter (<=1.21).
+	// since 1.21 is End of Life now.
+	namespacedIngressClassParameterMinKubernetesVersion := semver.MustParse("1.22.0")
+	if clusterVersion.LT(namespacedIngressClassParameterMinKubernetesVersion) {
+		t.Skipf("kubernetes cluster version %s does not support namespaced ingress class parameters", clusterVersion.String())
+	}
+
 	t.Log("locking IngressClass management")
 	ingressClassMutex.Lock()
 	defer func() {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -29,7 +29,17 @@ import (
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 )
 
-// set default k8s version for building kind clusters to v1.24.4.
+// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
+// even though that
+//   - our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
+//     which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+//   - when used with ktf (which at the time of writing this comment was set to v0.19.0) we
+//     should use kind v0.14 since that what ktf has set as dependency
+//
+// With all that said, we still managed to get kind v0.15 on our CI
+// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
+// which causes issues down the line (metallb manifests using PSP which is not available
+// in k8s v1.25+).
 var defaultKindClusterVesion = semver.Version{
 	Major: 1,
 	Minor: 24,

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -29,6 +29,13 @@ import (
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 )
 
+// set default k8s version for building kind clusters to v1.24.4.
+var defaultKindClusterVesion = semver.Version{
+	Major: 1,
+	Minor: 24,
+	Patch: 4,
+}
+
 var k8sClient *kubernetes.Clientset
 
 // -----------------------------------------------------------------------------
@@ -117,29 +124,16 @@ func TestMain(m *testing.M) {
 		fmt.Println("INFO: no existing cluster found, deploying using Kubernetes In Docker (KIND)")
 
 		builder.WithAddons(metallb.New())
-		// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
-		// even though that
-		// * our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
-		//   which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
-		// * when used with ktf (which at the time of writing this comment was set to v0.19.0) we
-		//   should use kind v0.14 since that what ktf has set as dependency
-		//
-		// With all that said, we still managed to get kind v0.15 on our CI
-		// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
-		// which causes issues down the line (metallb manifests using PSP which is not available
-		// in k8s v1.25+).
-		builder.WithKubernetesVersion(semver.Version{
-			Major: 1,
-			Minor: 24,
-			Patch: 4,
-		})
-	}
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
-		exitOnErr(err)
-		cluster, err := kind.NewBuilder().WithClusterVersion(clusterVersion).Build(ctx)
-		exitOnErr(err)
-		builder.WithExistingCluster(cluster)
+
+		clusterVersion = defaultKindClusterVesion
+		if clusterVersionStr != "" {
+			var err error
+			clusterVersion, err = semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
+			exitOnErr(err)
+
+		}
+		fmt.Printf("INFO: build a new KIND cluster with version %s\n", clusterVersion.String())
+		builder.WithKubernetesVersion(clusterVersion)
 	}
 
 	fmt.Println("INFO: building test environment")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

- fixes the failure when creating a cluster in KIND with specified version
- skip `TestIngressClassRegexToggle` in k8s versions <= 1.21 (EOL now) which does not support namespaced ingress class parameters by default.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #2957 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
