### PR TITLE
Revert "chore(*) release 2.7.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Table of Contents
 
- - [2.7.0](#270)
  - [2.6.0](#260)
  - [2.5.0](#250)
  - [2.4.2](#242)
@@ -54,7 +53,7 @@
 
 ## [2.7.0]
 
-> Release date: 2022-09-26
+> Release date: TBD
 
 2.7 patches several bugs in 2.6.0. One of these required a breaking change. The
 breaking change is not expected to affect most configurations, but does require

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '3.0'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.7.0'
+  newTag: '2.6.0'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1652,7 +1652,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.7.0
+        image: kong/kubernetes-ingress-controller:2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1647,7 +1647,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.7.0
+        image: kong/kubernetes-ingress-controller:2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1721,7 +1721,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.7.0
+        image: kong/kubernetes-ingress-controller:2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1665,7 +1665,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.7.0
+        image: kong/kubernetes-ingress-controller:2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Reverts Kong/kubernetes-ingress-controller#2974 