### PR TITLE
chore(ci) disable E2E fail fast

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,7 @@ jobs:
     environment: "Configure ci"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         kubernetes-version:
           - 'v1.21.12'


### PR DESCRIPTION
Disables E2E job fail fast. The job iterations are independent and there's no reason one failure should abort the rest. We want all of them to run to always get coverage across all matrix versions.