### PR TITLE
fix(tests) remove require inside eventually

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -153,9 +153,10 @@ func verifyIngress(ctx context.Context, t *testing.T, env environments.Environme
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
 			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
+			_, err := b.ReadFrom(resp.Body)
+			if err != nil {
+				return false
+			}
 			if !strings.Contains(b.String(), "<title>httpbin.org</title>") {
 				return false
 			}


### PR DESCRIPTION
This resulted in several E2E failures and just shouldn't be written this way. I don't care about the case where the output is zero bytes but still passes the string contains check.