### PR TITLE
fix: routes with conflicting services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,8 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- When the KongState is built, if there are Kubernetes service that have
-  inconsistent annotations, the an error message is logged and the service
+- When the KongState is built, if there are Kubernetes services that have
+  inconsistent annotations, an error message is logged and the service
   is skipped, instead of breaking the whole configuration.
   [#2942](https://github.com/Kong/kubernetes-ingress-controller/pull/2988)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 <!---
 Adding a new version? You'll need three changes:
-* Add the ToC link, like "[1.2.3](#123]".
+* Add the ToC link, like "[1.2.3](#123)".
 * Add the section header, like "## [1.2.3]".
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
 
+ - [2.8.0](#280)
  - [2.7.0](#270)
  - [2.6.0](#260)
  - [2.5.0](#250)
@@ -59,6 +60,17 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.8.0]
+
+> Release date: TBD
+
+### Fixed
+
+- When the KongState is built, if there are Kubernetes service that have
+  inconsistent annotations, the an error message is logged and the service
+  is skipped, instead of breaking the whole configuration.
+  [#2942](https://github.com/Kong/kubernetes-ingress-controller/pull/2988)
 
 ## [2.7.0]
 
@@ -1991,6 +2003,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.8.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.2...v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,10 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- When the KongState is built, if there are Kubernetes services that have
-  inconsistent annotations, an error message is logged and the service
-  is skipped, instead of breaking the whole configuration.
-  [#2942](https://github.com/Kong/kubernetes-ingress-controller/pull/2988)
+- The controller now logs an error for and skips multi-Service rules that have
+  inconsistent Service annotations. Previously this issue prevented the
+  controller from applying configuration until corrected.
+  [#2988](https://github.com/Kong/kubernetes-ingress-controller/pull/2988)
 
 ## [2.7.0]
 

--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -40,8 +40,8 @@ func mergeIngressRules(objs ...ingressRules) ingressRules {
 	return result
 }
 
-// populateServices populate the ServiceNameToServices map with additional information
-// and return a map of services to be skipped.
+// populateServices populates the ServiceNameToServices map with additional information
+// and returns a map of services to be skipped.
 func (ir *ingressRules) populateServices(log logrus.FieldLogger, s store.Storer) map[string]interface{} {
 	serviceNamesToSkip := make(map[string]interface{})
 

--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -58,9 +58,6 @@ func (ir *ingressRules) populateServices(log logrus.FieldLogger, s store.Storer)
 		// if the Kubernetes services have been deemed invalid, log an error message
 		// and skip the current service.
 		if !servicesAllUseTheSameKongAnnotations(log, k8sServices, seenAnnotations) {
-			log.Errorf("the Kubernetes Services %v cannot have different sets of konghq.com annotations. "+
-				"These Services are used in the same Gateway Route BackendRef together to create the Kong Service %s"+
-				"and must use the same Kong annotations", k8sServices, *service.Name)
 			// The Kong services not having all the k8s services correctly annotated must be marked
 			// as to be skipped.
 			serviceNamesToSkip[key] = nil

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -80,15 +80,18 @@ func (p *Parser) Build() (*kongstate.KongState, error) {
 		p.ingressRulesFromTLSRoutes(),
 	)
 
-	// populate any Kubernetes Service objects relevant objects
-	if err := ingressRules.populateServices(p.logger, p.storer); err != nil {
-		return nil, err
-	}
+	// populate any Kubernetes Service objects relevant objects and get the
+	// services to be skipped because of annotations inconsistency
+	servicesToBeSkipped := ingressRules.populateServices(p.logger, p.storer)
 
 	// add the routes and services to the state
 	var result kongstate.KongState
-	for _, service := range ingressRules.ServiceNameToServices {
-		result.Services = append(result.Services, service)
+	for key, service := range ingressRules.ServiceNameToServices {
+		// if the service doesn't need to be skipped, then add it to the
+		// list of services.
+		if _, ok := servicesToBeSkipped[key]; !ok {
+			result.Services = append(result.Services, service)
+		}
 	}
 
 	// generate Upstreams and Targets from service defs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
Gateway routes with conflicting services in their backend don't break config build.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:
Fixes #2565 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
