### PR TITLE
chore(tests) separate Istio tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,56 @@ jobs:
           - 'v1.22.9'
           - 'v1.23.6'
           - 'v1.24.2'
+    steps:
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: run e2e tests
+      run: make test.e2e
+      env:
+        TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+        NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
+                # multiple kind clusters within a single job, so only 1 is allowed at a time.
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-e2e-tests
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+
+  istio-tests:
+    environment: "Configure ci"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version:
+          - 'v1.24.2'
         istio-version:
           - 'v1.14.1'
           - 'v1.13.2'
@@ -47,8 +97,8 @@ jobs:
         # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
-    - name: run e2e tests
-      run: make test.e2e
+    - name: run Istio tests
+      run: make test.istio
       env:
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,16 @@ test.e2e:
 		-timeout $(E2E_TEST_TIMEOUT) \
 		./test/e2e/...
 
+.PHONY: test.istio
+test.istio:
+	ISTIO_TEST_ENABLED="true" \
+	GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
+		-race \
+		-parallel $(NCPU) \
+		-timeout $(E2E_TEST_TIMEOUT) \
+		-run "^TestIstio" \
+		./test/e2e/...
+
 # ------------------------------------------------------------------------------
 # Operations - Local Deployment
 # ------------------------------------------------------------------------------

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -39,6 +39,9 @@ var (
 	// If not provided, the latest version of Istio will be tested.
 	istioVersionStr = os.Getenv("ISTIO_VERSION")
 
+	// enableIstioTest skips Istio tests if not set.
+	enableIstioTest = os.Getenv("ISTIO_TEST_ENABLED")
+
 	// kialiAPIPort is the port number that the Kiali API will use.
 	kialiAPIPort = 20001
 
@@ -55,11 +58,15 @@ var (
 // See: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/#istio
 func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Parallel()
+
 	// Istio's test is unique in that it operates like the integration tests, and runs the controller manager from the
 	// test, whereas most E2E tests deploy it to the cluster normally. The upshot of this is that the Istio test
 	// pollutes E2E logs with a bunch of controller log nonsense and a boatload of goroutines that litter the panic
-	// logs. Temporarily skip it because it's not failing and it's making it harder to read the failure results.
-	// Ultimately we should probably move it elsewhere.
+	// logs. It uses a different make target that enables this and only runs tests beginning with "TestIstio" as such.
+	if len(enableIstioTest) == 0 {
+		t.Log("Istio test disabled, skipping...")
+		t.Skip()
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the Istio tests into their own directory and create a separate make target and job for them.

Most E2E tests function by deploying a complete deploy manifest to the test cluster, running both Kong and the controller in a Pod. These tests only log information from the test function itself. The integration tests, by comparison, run Kong in a Pod but start the controller from the test function, and their logs include both the test and controller logs. We should maybe separate these and have the controller log to a file, but that's a different discussion.

The Istio E2E tests are not like most E2E tests, and instead operate similar to the integration tests. They spawn a controller from the test suite and display its logs intermixed with test logs. Unlike the integration tests, however, this controller is not used for all tests: it is entirely unused for any other E2E test. At present, with all E2E tests run in the same task, the Istio controller's logs are mixed with logs from tests that it does not interact with at all. This is both noisy and confusing, as you may read the logs, see that the controller is not interacting with some resource the test creates, and conclude that there's an issue with the reconciler or whatever. This is not the case, as the controller instead just simply isn't looking at that resource's cluster at all.

Separating the Istio test into its own target and job avoids this.

**Special notes for your reviewer**:

I originally tried to separate this into its own package or tag but ran into dependency fun. Given how little we actually update the Istio test (and how little I expect us to going forward), I'm not particularly inclined to reorganize stuff into shared libraries and such unless we're going to further split up the E2E tests. The `-run` filter and the environment variable skip is janky, but simpler than refactoring all of E2E's helpers just for this.

This only runs the Istio tests on a single Kubernetes version. Given that we already test Kubernetes versions separately, it seems unnecessary to test them again for each Istio version. Istio already provides their own Kubernetes compatibility information, and we should get the same information about our compatibility with Istio versions on any compatible Kubernetes version (there may be edge cases, but I don't think we're too concerned about edge cases that only arise for older versions specifically when using Istio). This has something of a hidden downside where, since we run only one test per k8s version per run, we no longer get as immediate indication of flakes (since for 80% of the tests the Istio version was irrelevant and a non-Istio test that only failed on some Istio versions was obviously flaky).

Test run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3139181785