### PR TITLE
chore(tests) refactor E2E kustomize handling

### DIFF
--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -1,0 +1,146 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+)
+
+const (
+	// the Kustomization type uses raw strings for all its patch fields, even though it should be possible to use a
+	// proper struct for JSONPatches. Using multiline strings here causes something screwy in marshalling and converts
+	// these to JSON for god knows what reason. This doesn't actually work and makes kustomize mad, so these are
+	// annoying single-line strings, which don't break. Alternative is to carve out more of the krusty innards and
+	// skip writing to disk, and somehow load the bytes directly into the kustomize builder.
+
+	increaseControllerInitRetriesPatch = "- op: add\n  path: /spec/template/spec/containers/1/env/-\n  value:\n    name: CONTROLLER_KONG_ADMIN_INIT_RETRIES\n    value: \"%d\""
+
+	increaseControllerInitDelayPatch = "- op: add\n  path: /spec/template/spec/containers/1/env/-\n  value:\n    name: CONTROLLER_KONG_ADMIN_INIT_RETRY_DELAY\n    value: \"%s\""
+)
+
+// getKustomizedManifest takes a base manifest Reader and a Kustomization, and returns the manifest after applying the
+// Kustomization. It overwrites the Kustomization's Bases; any existing Bases will be discarded.
+func getKustomizedManifest(baseManifestReader io.Reader, kustomization types.Kustomization) (io.Reader, error) {
+	workDir, err := os.MkdirTemp("", "kictest.")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(workDir)
+	orig, err := io.ReadAll(baseManifestReader)
+	if err != nil {
+		return nil, err
+	}
+	err = os.WriteFile(filepath.Join(workDir, "base.yaml"), orig, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	kustomization.Bases = []string{"base.yaml"}
+	kBytes, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return nil, err
+	}
+	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), kBytes, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	kustomized, err := runKustomize(workDir)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(kustomized), nil
+}
+
+// patchControllerImage replaces the kong/kubernetes-ingress-controller image with the provided image and tag,
+// and returns the modified manifest.
+func patchControllerImage(baseManifestReader io.Reader, image, tag string) (io.Reader, error) {
+	kustomization := types.Kustomization{
+		Bases: []string{"base.yaml"},
+		Images: []types.Image{
+			{
+				Name:    "kong/kubernetes-ingress-controller",
+				NewName: image,
+				NewTag:  tag,
+			},
+		},
+	}
+	return getKustomizedManifest(baseManifestReader, kustomization)
+}
+
+// patchKongImage replaces the kong and kong/kong-gateway images in a manifest with the provide image and tag,
+//and returns the modified manifest.
+func patchKongImage(baseManifestsReader io.Reader, image, tag string) (io.Reader, error) {
+	kustomization := types.Kustomization{
+		Bases: []string{"base.yaml"},
+		Images: []types.Image{
+			{
+				Name:    "kong/kong-gateway",
+				NewName: image,
+				NewTag:  tag,
+			},
+			{
+				Name:    "kong",
+				NewName: image,
+				NewTag:  tag,
+			},
+		},
+	}
+	return getKustomizedManifest(baseManifestsReader, kustomization)
+}
+
+// patchControllerStartTimeout adds or updates the controller container CONTROLLER_KONG_ADMIN_INIT_RETRIES and
+// CONTROLLER_KONG_ADMIN_INIT_RETRY_DELAY environment variables with the provided values, and returns the modified
+// manifest.
+func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay string) (io.Reader, error) {
+	kustomization := types.Kustomization{
+		Bases: []string{"base.yaml"},
+		Patches: []types.Patch{
+			{
+				Patch: fmt.Sprintf(increaseControllerInitRetriesPatch, tries),
+				Target: &types.Selector{
+					ResId: resid.ResId{
+						Gvk: resid.Gvk{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						Name:      "ingress-kong",
+						Namespace: "kong",
+					},
+				},
+			},
+			{
+				Patch: fmt.Sprintf(increaseControllerInitDelayPatch, delay),
+				Target: &types.Selector{
+					ResId: resid.ResId{
+						Gvk: resid.Gvk{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						Name:      "ingress-kong",
+						Namespace: "kong",
+					},
+				},
+			},
+		},
+	}
+	return getKustomizedManifest(baseManifestReader, kustomization)
+}
+
+// runKustomize runs kustomize on a path and returns the YAML output.
+func runKustomize(path string) ([]byte, error) {
+	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	m, err := k.Run(filesys.MakeFsOnDisk(), path)
+	if err != nil {
+		return []byte{}, err
+	}
+	return m.AsYaml()
+}

--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -48,7 +48,7 @@ func patchControllerImage(baseManifestReader io.Reader, image, tag string) (io.R
 	return kubectl.GetKustomizedManifest(kustomization, baseManifestReader)
 }
 
-// patchKongImage replaces the kong and kong/kong-gateway images in a manifest with the provide image and tag,
+// patchKongImage replaces the kong and kong/kong-gateway images in a manifest with the provided image and tag,
 // and returns the modified manifest.
 func patchKongImage(baseManifestReader io.Reader, image, tag string) (io.Reader, error) {
 	kustomization := types.Kustomization{

--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -109,12 +110,12 @@ func patchKongImage(baseManifestsReader io.Reader, image, tag string) (io.Reader
 // patchControllerStartTimeout adds or updates the controller container CONTROLLER_KONG_ADMIN_INIT_RETRIES and
 // CONTROLLER_KONG_ADMIN_INIT_RETRY_DELAY environment variables with the provided values, and returns the modified
 // manifest.
-func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay string) (io.Reader, error) {
+func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay time.Duration) (io.Reader, error) {
 	kustomization := types.Kustomization{
 		Bases: []string{"base.yaml"},
 		Patches: []types.Patch{
 			{
-				Patch: fmt.Sprintf(initRetryPatch, delay, tries),
+				Patch: fmt.Sprintf(initRetryPatch, delay.String(), tries),
 				Target: &types.Selector{
 					ResId: resid.ResId{
 						Gvk: resid.Gvk{
@@ -134,12 +135,12 @@ func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay 
 
 // patchLivenessProbes patches the given container's liveness probe, replacing the initial delay, period, and failure
 // threshold.
-func patchLivenessProbes(baseManifestReader io.Reader, container, initial, period, failure int) (io.Reader, error) {
+func patchLivenessProbes(baseManifestReader io.Reader, container, failure int, initial, period time.Duration) (io.Reader, error) {
 	kustomization := types.Kustomization{
 		Bases: []string{"base.yaml"},
 		Patches: []types.Patch{
 			{
-				Patch: fmt.Sprintf(livenessProbePatch, container, initial, period, failure),
+				Patch: fmt.Sprintf(livenessProbePatch, container, int(initial.Seconds()), int(period.Seconds()), failure),
 				Target: &types.Selector{
 					ResId: resid.ResId{
 						Gvk: resid.Gvk{

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -173,6 +173,18 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 		return manifestsReader, nil
 	}
 
+	manifestsReader, err = patchLivenessProbes(manifestsReader, 0, 15, 3, 10)
+	if err != nil {
+		t.Logf("failed patching kong liveness (%v), using default manifest %v", err, baseManifestPath)
+		return manifestsReader, nil
+	}
+
+	manifestsReader, err = patchLivenessProbes(manifestsReader, 1, 15, 3, 10)
+	if err != nil {
+		t.Logf("failed patching controller liveness (%v), using default manifest %v", err, baseManifestPath)
+		return manifestsReader, nil
+	}
+
 	t.Logf("generated modified manifest at %v", baseManifestPath)
 	return manifestsReader, nil
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -179,7 +179,7 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 		return manifestsReader, nil
 	}
 
-	manifestsReader, err = patchLivenessProbes(manifestsReader, 1, 15, 3, 10)
+	manifestsReader, err = patchLivenessProbes(manifestsReader, 1, 15, time.Second*3, time.Second*10)
 	if err != nil {
 		t.Logf("failed patching controller liveness (%v), using default manifest %v", err, baseManifestPath)
 		return manifestsReader, nil

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -167,13 +167,13 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 		}
 	}
 
-	manifestsReader, err = patchControllerStartTimeout(manifestsReader, 120, "3s")
+	manifestsReader, err = patchControllerStartTimeout(manifestsReader, 120, time.Second*3)
 	if err != nil {
 		t.Logf("failed patching controller timeouts (%v), using default manifest %v", err, baseManifestPath)
 		return manifestsReader, nil
 	}
 
-	manifestsReader, err = patchLivenessProbes(manifestsReader, 0, 15, 3, 10)
+	manifestsReader, err = patchLivenessProbes(manifestsReader, 0, 10, time.Second*15, time.Second*3)
 	if err != nil {
 		t.Logf("failed patching kong liveness (%v), using default manifest %v", err, baseManifestPath)
 		return manifestsReader, nil

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -27,8 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/kustomize/api/krusty"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var (
@@ -170,96 +167,14 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 		}
 	}
 
-	t.Logf("using modified %v manifest", baseManifestPath)
+	manifestsReader, err = patchControllerStartTimeout(manifestsReader, 120, "3s")
+	if err != nil {
+		t.Logf("failed patching controller timeouts (%v), using default manifest %v", err, baseManifestPath)
+		return manifestsReader, nil
+	}
 
-	// patch kong image.
+	t.Logf("generated modified manifest at %v", baseManifestPath)
 	return manifestsReader, nil
-}
-
-const imageKustomizationContents = `resources:
-- base.yaml
-images:
-- name: kong/kubernetes-ingress-controller
-  newName: %v
-  newTag: '%v'
-`
-
-// patchControllerImage takes a manifest, image, and tag and runs kustomize to replace the
-// kong/kubernetes-ingress-controller image with the provided image. It returns the location of kustomize's output.
-func patchControllerImage(baseManifestReader io.Reader, image string, tag string) (io.Reader, error) {
-	workDir, err := os.MkdirTemp("", "kictest.")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(workDir)
-	orig, err := io.ReadAll(baseManifestReader)
-	if err != nil {
-		return nil, err
-	}
-	err = os.WriteFile(filepath.Join(workDir, "base.yaml"), orig, 0o600)
-	if err != nil {
-		return nil, err
-	}
-	kustomization := []byte(fmt.Sprintf(imageKustomizationContents, image, tag))
-	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), kustomization, 0o600)
-	if err != nil {
-		return nil, err
-	}
-
-	kustomized, err := kustomizeManifest(workDir)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewReader(kustomized), nil
-}
-
-const kongImageKustomizationContents = `resources:
-- base.yaml
-images:
-- name: kong
-  newName: %v
-  newTag: '%v'
-- name: kong/kong-gateway
-  newName: %v
-  newTag: '%v'
-`
-
-func patchKongImage(baseManifestsReader io.Reader, image string, tag string) (io.Reader, error) {
-	workDir, err := os.MkdirTemp("", "kictest.")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(workDir)
-	orig, err := io.ReadAll(baseManifestsReader)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.WriteFile(filepath.Join(workDir, "base.yaml"), orig, 0o600)
-	if err != nil {
-		return nil, err
-	}
-
-	kustomization := []byte(fmt.Sprintf(kongImageKustomizationContents, image, tag, image, tag))
-	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), kustomization, 0o600)
-	if err != nil {
-		return nil, err
-	}
-	kustomized, err := kustomizeManifest(workDir)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewReader(kustomized), nil
-}
-
-// kustomizeManifest runs kustomize on a path and returns the YAML output.
-func kustomizeManifest(path string) ([]byte, error) {
-	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
-	m, err := k.Run(filesys.MakeFsOnDisk(), path)
-	if err != nil {
-		return []byte{}, err
-	}
-	return m.AsYaml()
 }
 
 func getCurrentGitTag(path string) (semver.Version, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor E2E kustomize patching to use structs. This allows contsructing kustomizations with patches or other complex features more easily.

Add a patch to increase the controller init retries.

**Special notes for your reviewer**:

This was an attempt to address E2E failures where Kong fails to ever listen (it simply never makes any `bind()` call) by allowing more retries. It didn't quite work; we need at least extended liveness probes also. Extending the kustomize support and DRYing those functions is useful on its own.

Testing other things to try and reduce timeouts other ways but going ahead and submitting this on its own. https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3147412453/attempts/1 is the "didn't fall over entirely" test.