### PR TITLE
chore: bump istio version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,9 +68,10 @@ jobs:
         kubernetes-version:
           - 'v1.24.2'
         istio-version:
-          - 'v1.14.1'
-          - 'v1.13.2'
-          - 'v1.12.5'
+          - 'v1.15.1'
+          - 'v1.14.4'
+          - 'v1.13.8'
+          - 'v1.12.9'
           - 'v1.11.8'
     steps:
     - name: setup golang

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -10,7 +10,7 @@ on:
       istio-version:
         description: 'Istio version to test with'
         required: true
-        default: 'v1.12.2'
+        default: 'v1.15.1'
       controller-image:
         description: 'KIC Docker image to test with. The default "kong/kubernetes-ingress-controller:ci" builds an image from the dispatch branch'
         required: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps istio versions in e2e tests to more recent.