### PR TITLE
chore(tests) separate Istio via build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,11 +324,10 @@ test.e2e:
 .PHONY: test.istio
 test.istio:
 	ISTIO_TEST_ENABLED="true" \
-	GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
+	GOFLAGS="-tags=istio_tests" go test -v $(GOTESTFLAGS) \
 		-race \
 		-parallel $(NCPU) \
 		-timeout $(E2E_TEST_TIMEOUT) \
-		-run "^TestIstio" \
 		./test/e2e/...
 
 # ------------------------------------------------------------------------------

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -25,39 +25,6 @@ import (
 )
 
 // -----------------------------------------------------------------------------
-// All-In-One Manifest Tests - Vars
-// -----------------------------------------------------------------------------
-
-const (
-	// kongComponentWait is the maximum amount of time to wait for components (such as
-	// the ingress controller or the Kong Gateway) to become responsive after
-	// deployment to the cluster has finished.
-	kongComponentWait = time.Minute * 7
-
-	// ingressWait is the maximum amount of time to wait for a basic HTTP service
-	// (e.g. httpbin) to come online and for ingress to have properly configured
-	// proxy traffic to route to it.
-	ingressWait = time.Minute * 5
-
-	// adminAPIWait is the maximum amount of time to wait for the Admin API to become
-	// responsive after updating the KONG_ADMIN_LISTEN and adding a service for it.
-	adminAPIWait = time.Minute * 2
-
-	// gatewayUpdateWaitTime is the amount of time to wait for updates to the Gateway, or to its
-	// parent Service to fully resolve into ready state.
-	gatewayUpdateWaitTime = time.Minute * 3
-)
-
-var (
-	imageOverride         = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
-	imageLoad             = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_LOAD")
-	kongImageOverride     = os.Getenv("TEST_KONG_IMAGE_OVERRIDE")
-	kongImageLoad         = os.Getenv("TEST_KONG_IMAGE_LOAD")
-	kongImagePullUsername = os.Getenv("TEST_KONG_PULL_USERNAME")
-	kongImagePullPassword = os.Getenv("TEST_KONG_PULL_PASSWORD")
-)
-
-// -----------------------------------------------------------------------------
 // All-In-One Manifest Tests - Suite
 //
 // The following tests ensure that the local "all-in-one" style deployment manifests

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,5 +1,5 @@
-//go:build e2e_tests
-// +build e2e_tests
+//go:build e2e_tests || istio_tests
+// +build e2e_tests istio_tests
 
 package e2e
 
@@ -36,14 +36,39 @@ import (
 )
 
 const (
+	// kongComponentWait is the maximum amount of time to wait for components (such as
+	// the ingress controller or the Kong Gateway) to become responsive after
+	// deployment to the cluster has finished.
+	kongComponentWait = time.Minute * 7
+
+	// ingressWait is the maximum amount of time to wait for a basic HTTP service
+	// (e.g. httpbin) to come online and for ingress to have properly configured
+	// proxy traffic to route to it.
+	ingressWait = time.Minute * 5
+
+	// adminAPIWait is the maximum amount of time to wait for the Admin API to become
+	// responsive after updating the KONG_ADMIN_LISTEN and adding a service for it.
+	adminAPIWait = time.Minute * 2
+
+	// gatewayUpdateWaitTime is the amount of time to wait for updates to the Gateway, or to its
+	// parent Service to fully resolve into ready state.
+	gatewayUpdateWaitTime = time.Minute * 3
+
 	ingressClass     = "kong"
 	namespace        = "kong"
 	adminServiceName = "kong-admin"
-)
 
-const (
 	tcpEchoPort    = 1025
 	tcpListnerPort = 8888
+)
+
+var (
+	imageOverride         = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
+	imageLoad             = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_LOAD")
+	kongImageOverride     = os.Getenv("TEST_KONG_IMAGE_OVERRIDE")
+	kongImageLoad         = os.Getenv("TEST_KONG_IMAGE_LOAD")
+	kongImagePullUsername = os.Getenv("TEST_KONG_PULL_USERNAME")
+	kongImagePullPassword = os.Getenv("TEST_KONG_PULL_PASSWORD")
 )
 
 func deployKong(ctx context.Context, t *testing.T, env environments.Environment, manifest io.Reader, additionalSecrets ...*corev1.Secret) *appsv1.Deployment {

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -1,5 +1,5 @@
-//go:build e2e_tests
-// +build e2e_tests
+//go:build istio_tests
+// +build istio_tests
 
 package e2e
 
@@ -58,15 +58,6 @@ var (
 // See: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/#istio
 func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Parallel()
-
-	// Istio's test is unique in that it operates like the integration tests, and runs the controller manager from the
-	// test, whereas most E2E tests deploy it to the cluster normally. The upshot of this is that the Istio test
-	// pollutes E2E logs with a bunch of controller log nonsense and a boatload of goroutines that litter the panic
-	// logs. It uses a different make target that enables this and only runs tests beginning with "TestIstio" as such.
-	if len(enableIstioTest) == 0 {
-		t.Log("Istio test disabled, skipping...")
-		t.Skip()
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1,5 +1,5 @@
-//go:build e2e_tests
-// +build e2e_tests
+//go:build e2e_tests || istio_tests
+// +build e2e_tests istio_tests
 
 package e2e
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors https://github.com/Kong/kubernetes-ingress-controller/pull/2989 to replace the hack with build tags.


**Special notes for your reviewer**:

Thanks @randmonkey and @pmalek for educating me on how to use the build ORs

Sample run at https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3153122011
