### PR TITLE
fix(parser): combining overlapping host and service ingress rules

### DIFF
--- a/internal/dataplane/parser/translators/ingress.go
+++ b/internal/dataplane/parser/translators/ingress.go
@@ -98,7 +98,7 @@ func (i *ingressTranslationIndex) add(ingress *netv1.Ingress) {
 			serviceName := httpIngressPath.Backend.Service.Name
 			servicePort := httpIngressPath.Backend.Service.Port.Number
 
-			cacheKey := fmt.Sprintf("%s%s%s%s%d", ingress.Namespace, ingress.Name, ingressRule.Host, serviceName, servicePort)
+			cacheKey := fmt.Sprintf("%s.%s.%s.%s.%d", ingress.Namespace, ingress.Name, ingressRule.Host, serviceName, servicePort)
 			meta, ok := i.cache[cacheKey]
 			if !ok {
 				meta = &ingressTranslationMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

The translator used to combine the ingress rules into services on rare occasions could combine routes that should not be combined when host and service name in the ingress overlapped.

This commit changes how the ingress translation index computes the key for the entries, preventing overlapping host,serviceName,port combinations from being combined.

**Which issue this PR fixes:**

Fixes #3004 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
