### PR TITLE
chore: don't send telemetry from integration and conformance tests

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 		"--log-level=trace",
 		"--debug-log-reduce-redundancy",
 		"--feature-gates=GatewayAlpha=true",
+		"--anonymous-reports=false",
 		fmt.Sprintf("--kong-admin-url=%s", admin.String()),
 	}
 	exitOnErr(testutils.DeployControllerManagerForCluster(ctx, env.Cluster(), args...))

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -217,6 +217,7 @@ func TestMain(m *testing.M) {
 			"--dump-config",
 			"--log-level=trace",
 			"--debug-log-reduce-redundancy",
+			"--anonymous-reports=false",
 			fmt.Sprintf("--feature-gates=%s", controllerFeatureGates),
 			fmt.Sprintf("--election-namespace=%s", kongAddon.Namespace()),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `--anonymous-reports=false` to controller flags when launching it in conformance and integration tests.

E2Es will require a separate kustomization to apply when running the controller as a container which can be done in a separate PR.