### PR TITLE
chore(ci) split E2E into a job per test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,25 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  setup-e2e-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_names: ${{ steps.set_test_names.outputs.test_names }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set_test_names
+        name: Set test names
+        working-directory: test/e2e/
+        # grep magic described in https://unix.stackexchange.com/a/13472
+        # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
+        run: |
+          echo "::set-output name=test_names::$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)"
+      - name: Print test names
+        run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
   e2e-tests:
     environment: "Configure ci"
     runs-on: ubuntu-latest
+    needs: setup-e2e-tests
     strategy:
       fail-fast: false
       matrix:
@@ -17,6 +33,8 @@ jobs:
           - 'v1.22.9'
           - 'v1.23.6'
           - 'v1.24.2'
+          - 'v1.25.2'
+        test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
     - name: setup golang
       uses: actions/setup-go@v3
@@ -42,12 +60,13 @@ jobs:
         # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
-    - name: run e2e tests
+    - name: run ${{ matrix.test }} - ${{ matrix.kubernetes-version }}
       run: make test.e2e
       env:
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+        E2E_TEST_RUN: ${{ matrix.test }}
         NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job, so only 1 is allowed at a time.
 

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ PKG_LIST = ./pkg/...,./internal/...
 KIND_CLUSTER_NAME ?= "integration-tests"
 INTEGRATION_TEST_TIMEOUT ?= "45m"
 E2E_TEST_TIMEOUT ?= "45m"
+E2E_TEST_RUN ?= ""
 KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 GOTESTFMT_CMD ?= $(GOTESTFMT) -hide successful-downloads,empty-packages -showteststatus
 
@@ -338,6 +339,7 @@ test.integration.kind:
 test.e2e:
 	GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
 		-race \
+		-run $(E2E_TEST_RUN) \
 		-parallel $(NCPU) \
 		-timeout $(E2E_TEST_TIMEOUT) \
 		./test/e2e/...


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `E2E_TEST_RUN` variable for the E2E make target. It populates the `-run` argument value. By default, it is blank and will run all tests

Dynamically generates a matrix of all tests in the E2E directory and runs with that matrix populating E2E_TEST_RUN. Each test+Kubernetes version combination runs as a separate job.

The separate jobs indicate more clearly what failed (they're only running a single test) and complete in about 25% of the original time (E2E tests were parallelizable but run in sequence, this runs them all in parallel).

**Which issue this PR fixes**:

General issues with E2E test stability (KIND failing to come online) appear to be resolved with this approach. E2E was apparently leaving clusters behind after completing a test (it shouldn't, though not clear if it always was doing this or we broke something), which this avoids by isolating tests onto a dedicated runner.

**Special notes for your reviewer**:

Example run at https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3184645510/jobs/5193290966

This creates extra jobs for the Istio tests that don't actually run (they always complete successfully). This would partially allow us to move them back into e2e_tests (the separate job means they wouldn't pollute logs), but we can't merge their matrices (the extra Istio version parameter would create duplicates of any job that doesn't use Istio).

To filter them out completely (and avoid wasting ~2m of runner time) we'd need to rely on grep rather than Go tags. I'm on the fence as to whether we should--it's unlikely that a `grep -v Istio` would actually filter out anything not intended or miss anything it should catch, but it's not how we actually split out those tests.