### PR TITLE
chore(ci): run buildpulse reporting on all branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,6 +109,7 @@ jobs:
         path: coverage.unit.out
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
@@ -164,6 +165,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
@@ -211,6 +213,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
@@ -258,6 +261,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
@@ -306,6 +310,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
@@ -339,6 +344,7 @@ jobs:
         GOTESTSUM_JUNITFILE: "conformance-tests.xml"
 
     - name: collect test report
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -397,8 +397,8 @@ jobs:
           path: report
 
       - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-        uses: Workshop64/buildpulse-action@main
+        if: ${{ !cancelled() }}
+        uses: Workshop64/buildpulse-action@a0e683af4e5070c379e9801ee9b33792ff414936
         with:
           account: 962416
           repository: 127765544


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to get more data points let's run build pulse reporting on all branches.

Additionally this PR pins the build pulse reporting workflow to a specific commit to avoid problems with malicious code being added in the future.