### PR TITLE
add additional step in release cycle

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -61,6 +61,7 @@ body:
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.
       - label: Add a section to `app/_data/kong_versions.yml` for your version.
       - label: Open a PR from your branch.
+      - label: Inform and ping the @team-k8s via slack of impending release with a link to the release PR.
 - type: textarea
   id: release_trouble_shooting_link
   attributes:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an additional step in releasing KIC to notify team.


- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
