### PR TITLE
Support GKE E2E tests and use (actual) E2E tests to gate releases

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -215,7 +215,7 @@ jobs:
         GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
         KUBERNETES_MAJOR_VERSION: 1
-        KUBERNETES_MINOR_VERSION: 25
+        KUBERNETES_MINOR_VERSION: 24
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     - name: upload diagnostics

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -181,7 +181,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   e2e-gke-tests:
-    environment: "Configure ci"
+    environment: "gcloud"
     runs-on: ubuntu-latest
     steps:
     - name: setup golang

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -179,3 +179,49 @@ jobs:
           path: report/*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+  e2e-gke-tests:
+    environment: "Configure ci"
+    runs-on: ubuntu-latest
+    steps:
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        # PULP_PASSWORD secret is set in "Configure ci" environment
+        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: run ${{ matrix.kubernetes-version }}
+      run: make test.e2e.gke
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+        GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+        KUBERNETES_MAJOR_VERSION: 1
+        KUBERNETES_MINOR_VERSION: 25
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-e2e-tests
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -186,6 +186,7 @@ jobs:
         KUBERNETES_MAJOR_VERSION: 1
         KUBERNETES_MINOR_VERSION: 24
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        GOTESTSUM_JUNITFILE: "gke-${{ matrix.kubernetes-version }}-tests.xml"
 
     - name: upload diagnostics
       if: ${{ always() }}
@@ -194,6 +195,12 @@ jobs:
         name: diagnostics-e2e-tests
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
+    
+    - name: collect test report
+      uses: actions/upload-artifact@v3
+      with:
+        name: tests-report
+        path: gke-${{ matrix.kubernetes-version }}-tests.xml
 
   buildpulse-report:
     environment: "Configure ci"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -149,37 +149,6 @@ jobs:
         name: tests-report
         path: istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml
 
-  buildpulse-report:
-    environment: "Configure ci"
-    needs:
-      - "e2e-tests"
-      - "istio-tests"
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: download tests report
-        id: download-coverage
-        uses: actions/download-artifact@v3
-        with:
-          name: tests-report
-          path: report
-
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: Workshop64/buildpulse-action@main
-        with:
-          account: 962416
-          repository: 127765544
-          path: report/*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
   e2e-gke-tests:
     environment: "gcloud"
     runs-on: ubuntu-latest
@@ -225,3 +194,35 @@ jobs:
         name: diagnostics-e2e-tests
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
+
+  buildpulse-report:
+    environment: "Configure ci"
+    needs:
+      - "e2e-tests"
+      - "e2e-gke-tests"
+      - "istio-tests"
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: download tests report
+        id: download-coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: tests-report
+          path: report
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        if: ${{ !cancelled() }}
+        uses: Workshop64/buildpulse-action@main
+        with:
+          account: 962416
+          repository: 127765544
+          path: report/*.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -152,6 +152,11 @@ jobs:
   e2e-gke-tests:
     environment: "gcloud"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: # the GKE setup script ignores the patch version here and uses the latest, but we still include it for consistency with the other E2E jobs
+          - 'v1.24.2'
     steps:
     - name: setup golang
       uses: actions/setup-go@v3
@@ -183,8 +188,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-        KUBERNETES_MAJOR_VERSION: 1
-        KUBERNETES_MINOR_VERSION: 24
+        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         GOTESTSUM_JUNITFILE: "gke-${{ matrix.kubernetes-version }}-tests.xml"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,9 +206,6 @@ jobs:
       matrix:
         kubernetes-version:
           - 'v1.24.3'
-        dbmode:
-          - 'dbless'
-          - 'postgres'
     steps:
       - name: setup golang
         uses: actions/setup-go@v3
@@ -225,7 +222,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests
+      - name: Kubernetes ${{ matrix.kubernetes-version }} E2E Tests
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}
 
   test-previous-kubernetes:
@@ -238,9 +235,6 @@ jobs:
           - '21'
           - '22'
           - '23'
-        dbmode:
-          - 'dbless'
-          - 'postgres'
     steps:
       - name: setup golang
         uses: actions/setup-go@v3
@@ -257,8 +251,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: test ${{ matrix.dbmode }} on GKE v1.${{ matrix.minor }}
-        run: make test.integration.gke
+      - name: E2E on GKE v1.${{ matrix.minor }}
+        run: make test.e2e.gke
         env:
           KUBERNETES_MAJOR_VERSION: 1
           KUBERNETES_MINOR_VERSION: ${{ matrix.minor }}

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ test.e2e.gke:
 	CLUSTER_NAME="e2e-$(uuidgen)" \
 		KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/cluster/deploy/main.go \
 		KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" \
-		GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
+		GOFLAGS="-tags=e2e_tests" $(GOTESTSUM) -- $(GOTESTFLAGS) \
 			-race \
 			-run $(E2E_TEST_RUN) \
 			-parallel $(NCPU) \

--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,20 @@ test.integration.kind:
 	@$(MAKE) _test.integration.cp \
 		CP="kind"
 
+.PHONY: test.e2e.gke
+test.e2e.gke:
+	CLUSTER_NAME="e2e-$(uuidgen)" \
+		KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/cluster/deploy/main.go \
+		KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" \
+		GOFLAGS="-tags=e2e_tests" go test -v $(GOTESTFLAGS) \
+			-race \
+			-run $(E2E_TEST_RUN) \
+			-parallel $(NCPU) \
+			-timeout $(E2E_TEST_TIMEOUT) \
+			./test/e2e/... \
+		go run hack/e2e/cluster/cleanup/main.go ${CLUSTER_NAME} \
+		trap cleanup EXIT SIGINT SIGQUIT
+
 .PHONY: test.e2e
 test.e2e: gotestsum
 	GOFLAGS="-tags=e2e_tests" \

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
-	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -107,13 +105,8 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
@@ -159,13 +152,8 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -215,13 +203,8 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -256,13 +239,8 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -412,13 +390,8 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	createKongImagePullSecret(ctx, t, env)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -46,13 +46,8 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -1,0 +1,19 @@
+package e2e
+
+import "os"
+
+var (
+	// clusterVersionStr indicates the Kubernetes cluster version to use when
+	// generating a testing environment and allows the caller to provide a specific
+	// version. If no version is provided the default version for the cluster
+	// provisioner in the testing framework will be used.
+	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
+
+	imageOverride         = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
+	imageLoad             = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_LOAD")
+	kongImageOverride     = os.Getenv("TEST_KONG_IMAGE_OVERRIDE")
+	kongImageLoad         = os.Getenv("TEST_KONG_IMAGE_LOAD")
+	kongImagePullUsername = os.Getenv("TEST_KONG_PULL_USERNAME")
+	kongImagePullPassword = os.Getenv("TEST_KONG_PULL_PASSWORD")
+	existingCluster       = os.Getenv("KONG_TEST_CLUSTER")
+)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -85,7 +85,7 @@ func getEnvironmentBuilder(ctx context.Context) (*environments.Builder, error) {
 		default:
 			return nil, fmt.Errorf("unrecognized cluster type %s", clusterType)
 		}
-	} 
+	}
 	return createDefaultKINDBuilder(), nil
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -66,8 +66,6 @@ const (
 )
 
 func getEnvironmentBuilder(ctx context.Context) (*environments.Builder, error) {
-	var builder *environments.Builder
-	var err error
 	if existingCluster != "" {
 		if clusterVersionStr != "" {
 			return nil, fmt.Errorf("cannot provide cluster version with existing cluster")
@@ -81,22 +79,14 @@ func getEnvironmentBuilder(ctx context.Context) (*environments.Builder, error) {
 		fmt.Printf("INFO: using existing %s cluster %s\n", clusterType, clusterName)
 		switch clusterType {
 		case string(kind.KindClusterType):
-			builder, err = createExistingKINDBuilder(clusterName)
-			if err != nil {
-				return nil, err
-			}
+			return createExistingKINDBuilder(clusterName)
 		case string(gke.GKEClusterType):
-			builder, err = createExistingGKEBuilder(ctx, clusterName)
-			if err != nil {
-				return nil, err
-			}
+			return createExistingGKEBuilder(ctx, clusterName)
 		default:
 			return nil, fmt.Errorf("unrecognized cluster type %s", clusterType)
 		}
-	} else {
-		builder = createDefaultKINDBuilder()
-	}
-	return builder, err
+	} 
+	return createDefaultKINDBuilder(), nil
 }
 
 func createDefaultKINDBuilder() *environments.Builder {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -126,7 +126,7 @@ func createExistingKINDBuilder(name string) (*environments.Builder, error) {
 
 // existing GKE patterns rely on running hack/e2e/cluster/deploy/main.go (integration too) and then just loading
 // an existing cluster. this could probably avoid the hack script, and may be reasonable to integrate into KTF.
-// there is no default GKE builder as such.
+// there is no default GKE builder as such: https://github.com/Kong/kubernetes-ingress-controller/issues/1613
 
 func createExistingGKEBuilder(ctx context.Context, name string) (*environments.Builder, error) {
 	cluster, err := gke.NewFromExistingWithEnv(ctx, name)

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kuma"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
-	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -26,15 +24,9 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	addons = append(addons, kuma.New())
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
+	builder = builder.WithAddons(kuma.New())
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
@@ -113,14 +105,9 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	addons := []clusters.Addon{}
-	addons = append(addons, metallb.New())
-	addons = append(addons, kuma.New())
-
-	addons = append(addons, buildImageLoadAddons(t, imageLoad, kongImageLoad)...)
-
-	builder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(addons...), clusterVersionStr)
+	builder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
+	builder = builder.WithAddons(kuma.New())
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -30,12 +30,6 @@ import (
 )
 
 var (
-	// clusterVersionStr indicates the Kubernetes cluster version to use when
-	// generating a testing environment and allows the caller to provide a specific
-	// version. If no version is provided the default version for the cluster
-	// provisioner in the testing framework will be used.
-	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
-
 	// httpc is a standard HTTP client for tests to use that has a low default
 	// timeout instead of the longer default provided by the http stdlib.
 	httpc = http.Client{Timeout: time.Second * 10}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -29,11 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var (
-	// httpc is a standard HTTP client for tests to use that has a low default
-	// timeout instead of the longer default provided by the http stdlib.
-	httpc = http.Client{Timeout: time.Second * 10}
-)
+// httpc is a standard HTTP client for tests to use that has a low default
+// timeout instead of the longer default provided by the http stdlib.
+var httpc = http.Client{Timeout: time.Second * 10}
 
 const (
 	// adminPasswordSecretName is the name of the secret which will house the admin


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds GKE and existing cluster support to E2E tests.
- ~Uses the E2E tests as the release job condition for creating the release tag~ not yet, currently just a test variant because I can't easily test with the release workflow.

We need this because we aren't currently running the test suite we want to during releases. It also requires some refactoring of the E2E tests themselves, which is a good opportunity to refactor them and KTF to address some ease of use issues. Tests cannot easily load cluster-specific functionality (loading images, adding a KIND configuration, etc.) without abusing the environment addon functionality (we have addons that fail if loaded on an unsupported cluster, which we don't want). https://github.com/Kong/kubernetes-testing-framework/pull/403 seems an appropriate means of allowing for this.

**Which issue this PR fixes**:
Part of #2790 
Fix #2287 (I think this actually got fixed earlier, but whatever, it's still open and this obsoletes it).
Fix #3041

**Special notes for your reviewer**:

- https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3201260283/jobs/5229046505 uses the temporary E2E addition. ~We may want to make this permanent, but it's not the release job this eventually intends to be part of.~ I left it in for #3041
- ~This draft only adopts the new system for `TestDeployAllInOneDBLESS`. Pausing for any "wait, don't do it this way" comments before doing it for the rest.~
- TestWebhookUpdate requires an odd hack that's not useful anywhere else, and the changes to handle image loading generically don't help its hack. As it's an E2E test only because we can't write an integration test for it, I don't think it's worth supporting other platforms for it at the moment, and just made it KIND-only.
- The image loader still has bits of a bad design from when I originally wrote it. https://github.com/Kong/kubernetes-testing-framework/issues/440 plans to remove this, but there's a functionally identical workaround in place here to avoid releasing a new KTF yet.
