### PR TITLE
chore: remove test-previous-kubernetes-gke in nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -181,52 +181,6 @@ jobs:
         with:
           name: tests-report
           path: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-tests.xml
-  # run integration tests in previous versions of kubernetes
-  test-previous-kubernetes-gke:
-    name: Run integration tests on GKE
-    environment: gcloud
-    runs-on: ubuntu-latest
-    needs: build-push-images
-    strategy:
-      matrix:
-        minor:
-          - '21'
-          - '22'
-          - '23'
-          - '24'
-        dbmode:
-          - 'dbless'
-          - 'postgres'
-    steps:
-      - name: setup golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.19'
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: test ${{ matrix.dbmode }} on GKE v1.${{ matrix.minor }}
-        run: ./hack/e2e/run-tests.sh
-        env:
-          KUBERNETES_MAJOR_VERSION: 1
-          KUBERNETES_MINOR_VERSION: ${{ matrix.minor }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-          GOTESTSUM_JUNITFILE: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-tests.xml
-      - name: collect test report
-        uses: actions/upload-artifact@v3
-        with:
-          name: tests-report
-          path: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-tests.xml
 
   buildpulse-report:
     environment: "Configure ci"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
remove the `test-previous-kubernetes-gke` job in nightly action because `hack/e2e/run-tests.sh` script is removed to fix constant failure of nightly action.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3037 .

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

This PR removes the integration tests on different k8s versions in nightly action. If we still need to run the tests, we should modify the action specifications to run them, or restore the original `hack/e2e/run-tests.sh` script (also needs a more appropriate name).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR No need to update CHANGELOG 
