### PR TITLE
test: fix base.yaml not found in e2e tests

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -244,15 +244,18 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		}
 		if err := json.Unmarshal(body, &adminOutput); err != nil {
 			t.Log("failed to parse version from response body from admin API:", err)
+			t.Logf("response body: %s", string(body))
 			return false
 		}
 		return adminOutput.Version != ""
 	}, adminAPIWait, time.Second)
 	if string(adminOutput.Version[0]) == "3" {
 		// 3.x removed the "-enterprise-edition" string but provided no other indication that something is enterprise
-		require.Len(t, strings.Split(adminOutput.Version, "."), 4)
+		require.Len(t, strings.Split(adminOutput.Version, "."), 4,
+			fmt.Sprintf("actual kong version: %s", adminOutput.Version))
 	} else {
-		require.Contains(t, adminOutput.Version, "enterprise-edition")
+		require.Contains(t, adminOutput.Version, "enterprise-edition",
+			fmt.Sprintf("actual kong version: %s", adminOutput.Version))
 	}
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -229,22 +229,17 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		// before considering this complete.
 		resp, err := httpc.Do(req)
 		if err != nil {
-			t.Log("failed to get response from admin API:", err)
 			return false
 		}
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Log("failed to read response body from admin API:", err)
 			return false
 		}
 		if resp.StatusCode != http.StatusOK {
-			t.Log("received non-OK http code:", resp.StatusCode)
 			return false
 		}
 		if err := json.Unmarshal(body, &adminOutput); err != nil {
-			t.Log("failed to parse version from response body from admin API:", err)
-			t.Logf("response body: %s", string(body))
 			return false
 		}
 		return adminOutput.Version != ""

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -229,17 +229,21 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		// before considering this complete.
 		resp, err := httpc.Do(req)
 		if err != nil {
+			t.Log("failed to get response from admin API:", err)
 			return false
 		}
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
+			t.Log("failed to read response body from admin API:", err)
 			return false
 		}
 		if resp.StatusCode != http.StatusOK {
+			t.Log("received non-OK http code:", resp.StatusCode)
 			return false
 		}
 		if err := json.Unmarshal(body, &adminOutput); err != nil {
+			t.Log("failed to parse version from response body from admin API:", err)
 			return false
 		}
 		return adminOutput.Version != ""

--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -97,7 +97,6 @@ func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay 
 // threshold.
 func patchLivenessProbes(baseManifestReader io.Reader, container, failure int, initial, period time.Duration) (io.Reader, error) {
 	kustomization := types.Kustomization{
-		Bases: []string{"base.yaml"},
 		Patches: []types.Patch{
 			{
 				Patch: fmt.Sprintf(livenessProbePatch, container, int(initial.Seconds()), int(period.Seconds()), failure),

--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -1,3 +1,6 @@
+//go:build e2e_tests
+// +build e2e_tests
+
 package e2e
 
 import (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- remove the `Base` field specification in kustomization to fix the "base.yaml not found" error in e2e tests.
- more: add build tags in `kustomization.go` to avoid "unused" notes from editor plugin/ IDEs
 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

targeted e2e still has failures on case `TestDeployAllInOneEnterpriseDBLESS`: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3213059078/jobs/5252443520 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
