### PR TITLE
chore(build) make distroless default Docker target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ Adding a new version? You'll need three changes:
   reference, the listener ResolvedRefs condition reason is set to
   RefNotPermitted.
   [#3024](https://github.com/Kong/kubernetes-ingress-controller/pull/3024)
+- The `distroless` target is now the last target in the Dockerfile. This makes
+  it the default target if `docker buildx build` is invoked without a target.
+  While custom image build pipelines _should_ specify a target, this change
+  makes the default the same target released as the standard
+  `kong/kubernetes-ingress-controller:X.Y.Z` tags in the official repo.
+  [#3043](https://github.com/Kong/kubernetes-ingress-controller/pull/3043)
 
 ## [2.7.0]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,29 +84,6 @@ USER 65532:65532
 ENTRYPOINT ["/go/bin/dlv"]
 CMD ["exec", "--continue", "--accept-multiclient",  "--headless", "--api-version=2", "--listen=:2345", "--log", "/workspace/manager-debug"]
 
-### Distroless/default
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot AS distroless
-ARG TAG
-ARG TARGETPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
-
-LABEL name="Kong Ingress Controller" \
-      vendor="Kong" \
-      version="$TAG" \
-      release="1" \
-      url="https://github.com/Kong/kubernetes-ingress-controller" \
-      summary="Kong for Kubernetes Ingress" \
-      description="Use Kong for Kubernetes Ingress. Configure plugins, health checking, load balancing and more in Kong for Kubernetes Services, all using Custom Resource Definitions (CRDs) and Kubernetes-native tooling."
-
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
-
-ENTRYPOINT ["/manager"]
-
 ### RHEL
 # Build UBI image
 FROM registry.access.redhat.com/ubi8/ubi AS redhat
@@ -170,4 +147,27 @@ COPY LICENSE /licenses/
 USER 1000
 
 # Run the compiled binary.
+ENTRYPOINT ["/manager"]
+
+### Distroless/default
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot AS distroless
+ARG TAG
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+LABEL name="Kong Ingress Controller" \
+      vendor="Kong" \
+      version="$TAG" \
+      release="1" \
+      url="https://github.com/Kong/kubernetes-ingress-controller" \
+      summary="Kong for Kubernetes Ingress" \
+      description="Use Kong for Kubernetes Ingress. Configure plugins, health checking, load balancing and more in Kong for Kubernetes Services, all using Custom Resource Definitions (CRDs) and Kubernetes-native tooling."
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the distroless target to the end of the Dockerfile. This makes it the default when Docker buildx builds are run without a target. Although our make targets and release workflow _do_ specify targets, custom CD may not, and this change leads them to produce a better output.

**Which issue this PR fixes**:
Inspired by #3036 

**Special notes for your reviewer**:

https://gist.github.com/rainest/ae3f00050b66429aca052eeb7057b540#file-docker-txt-L324-L347 is the example buildx build without this change.

The `docker build` invocation above just builds everything. There's nothing we can really do for vanilla Docker builds; they always build everything unless you provide a target.

This is listed as a fix since we never intended for the FIPS target to be the default and don't have hard guarantees around the order of the Dockerfile. I expect it's unlikely that anyone was omitting a target in a custom pipeline with the expectation that it would produce the FIPS image, given that those aren't really officially a thing.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
