### PR TITLE
fix(tests): fix istio tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ run:
   - integration_tests
   - e2e_tests
   - conformance_tests
+  - istio_tests
 linters:
   enable:
   - asciicheck

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -39,9 +39,6 @@ var (
 	// If not provided, the latest version of Istio will be tested.
 	istioVersionStr = os.Getenv("ISTIO_VERSION")
 
-	// enableIstioTest skips Istio tests if not set.
-	enableIstioTest = os.Getenv("ISTIO_TEST_ENABLED")
-
 	// kialiAPIPort is the port number that the Kiali API will use.
 	kialiAPIPort = 20001
 

--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -1,5 +1,5 @@
-//go:build e2e_tests
-// +build e2e_tests
+//go:build e2e_tests || istio_tests
+// +build e2e_tests istio_tests
 
 package e2e
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that istio e2e tests were failing because the build tags were not set right and the compilation would fail with the following error:

```
# github.com/kong/kubernetes-ingress-controller/v2/test/e2e [github.com/kong/kubernetes-ingress-controller/v2/test/e2e.test]
Error: test/e2e/utils_test.go:141:26: undefined: patchControllerImage
Error: test/e2e/utils_test.go:163:26: undefined: patchKongImage
Error: test/e2e/utils_test.go:170:25: undefined: patchControllerStartTimeout
Error: test/e2e/utils_test.go:176:25: undefined: patchLivenessProbes
Error: test/e2e/utils_test.go:182:25: undefined: patchLivenessProbes
WARN invalid TestEvent: FAIL	github.com/kong/kubernetes-ingress-controller/v2/test/e2e [build failed]
bad output from test2json: FAIL	github.com/kong/kubernetes-ingress-controller/v2/test/e2e [build failed]

=== Errors
Error: test/e2e/utils_test.go:141:26: undefined: patchControllerImage
Error: test/e2e/utils_test.go:163:26: undefined: patchKongImage
Error: test/e2e/utils_test.go:170:25: undefined: patchControllerStartTimeout
Error: test/e2e/utils_test.go:176:25: undefined: patchLivenessProbes
Error: test/e2e/utils_test.go:182:25: undefined: patchLivenessProbes

DONE 0 tests, 5 errors in 122.671s
```

Related failed CI run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3239795474/jobs/5309619111

This PR fixes that. It also adds `istio_tests` to golangci-lint config so that those tests are checked with our linter setup as well.

The `enableIstioTest` flag (which this PR removes) can be a subject for another PR to make the test configurable but since the build tags were already introduced I believe the e2e tests are already separated from istio tests at that level so it's not necessary.