### PR TITLE
test: fix kustomization patch addControllerEnvPatch in e2e

### DIFF
--- a/test/e2e/kustomizations.go
+++ b/test/e2e/kustomizations.go
@@ -38,10 +38,10 @@ const (
   value: %[4]d`
 
 	addControllerEnvPatch = `- op: add
-	path: "/spec/template/spec/containers/1/env/-"
-	value:
-		name: %s
-		value: "%s"`
+  path: "/spec/template/spec/containers/1/env/-"
+  value:
+    name: %s
+    value: "%s"`
 )
 
 // patchControllerImage replaces the kong/kubernetes-ingress-controller image with the provided image and tag,
@@ -131,7 +131,6 @@ func patchLivenessProbes(baseManifestReader io.Reader, container, failure int, i
 // addControllerEnv adds an environment variable to ingress-controller container.
 func addControllerEnv(t *testing.T, baseManifestReader io.Reader, envName, value string) io.Reader {
 	kustomization := types.Kustomization{
-		Bases: []string{"base.yaml"},
 		Patches: []types.Patch{
 			{
 				Patch: fmt.Sprintf(addControllerEnvPatch, envName, value),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

fix `addControllerEnv` in kustomization of e2e tests that makes test case `TestMissingCRDsDontCrashTheController` fail in e2e run https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3247564012/jobs/5327698068.

Changes:
- replace all `\t`s in `addControllerEnvPatch` string to `  ` (2 spaces) for consistency
- remove `Bases` field in Kustomization to avoid "base.yaml not found" error  

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
