### PR TITLE
feature(parser): consolidation of multiple `HTTPRouteMatch` objects into single `kong.Route`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,11 +68,12 @@ Adding a new version? You'll need three changes:
 ### Added
 
 - Added `HTTPRoute` support for `CombinedRoutes` feature. When enabled,
-  this changes how `HTTPRoute` objects are translated to the Kong configuration.
-  Multiple `HTTPRoute.HTTPRouteRule[]` objects can be consolidated into a single
-  Kong Service. Multiple `HTTPRoute.HTTPRouteRule[].HTTPRouteMatch[]` objects 
-  can consolidated into a single Kong Route. 
-  Following limitations apply:
+  `HTTPRoute.HTTPRouteRule` objects with identical `backendRefs` generate a 
+  single Kong service instead of a service per rule, and 
+  `HTTPRouteRule.HTTPRouteMatche` objects using the same `backendRefs` can be 
+  consolidated into a single Kong route instead of always creating a route per 
+  match, reducing configuration size.
+  The following limitations apply:
   - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
     if they belong to different `HTTPRoute`.
   - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
@@ -87,7 +88,7 @@ Adding a new version? You'll need three changes:
     `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between 
     `HTTPRouteMatch[]` objects does not prevent consolidation.
   This change does not functionally impact routing: requests that went to a given Service
-  using the original method still go to the same Service in the new method.
+  using the original method still go to the same Service when `CombinedRoutes` is enabled.
   [#3008](https://github.com/Kong/kubernetes-ingress-controller/pull/3008)
   [#3060]https://github.com/Kong/kubernetes-ingress-controller/pull/3060)
 - Added `--cache-sync-timeout` flag allowing to change the default controllers' 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,13 +68,30 @@ Adding a new version? You'll need three changes:
 ### Added
 
 - Added `HTTPRoute` support for `CombinedRoutes` feature. When enabled,
-  this changes how `HTTPRoute` resources are translated so that `HTTPRouteRule`
-  resources are combined when they have same backends references. This change
-  does not functionally impact routing: requests that went to a given Service
+  this changes how `HTTPRoute` objects are translated to the Kong configuration.
+  Multiple `HTTPRoute.HTTPRouteRule[]` objects can be consolidated into a single
+  Kong Service. Multiple `HTTPRoute.HTTPRouteRule[].HTTPRouteMatch[]` objects 
+  can consolidated into a single Kong Route. 
+  Following limitations apply:
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
+    if they belong to different `HTTPRoute`.
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
+    if they have different `HTTPRouteRule.HTTPBackendRef[]` objects. The order
+    of the backend references is not important.
+  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
+    if parent `HTTPRouteRule` objects cannot be consolidated into a single Kong Service.
+  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
+    if parent `HTTPRouteRule` objects have different `HTTPRouteRule.HTTPRouteFilter[]` filters.
+  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route 
+    if they have different matching spec (`HTTPHeaderMatch.Headers`, `HTTPHeaderMatch.QueryParams`, 
+    `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between 
+    `HTTPRouteMatch[]` objects does not prevent consolidation.
+  This change does not functionally impact routing: requests that went to a given Service
   using the original method still go to the same Service in the new method.
   [#3008](https://github.com/Kong/kubernetes-ingress-controller/pull/3008)
-- Added `--cache-sync-timeout` flag allowing to change the default controllers'
-  cache synchronisation timeout.
+  [#3060]https://github.com/Kong/kubernetes-ingress-controller/pull/3060)
+- Added `--cache-sync-timeout` flag allowing to change the default controllers' 
+  cache synchronisation timeout. 
   [#3013](https://github.com/Kong/kubernetes-ingress-controller/pull/3013)
 - Secrets validation introduced: CA certificates won't be synchronized
   to Kong if the certificate is expired.

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -365,9 +365,6 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 }
 
 func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRulesFromHTTPRoutes {
-	ingressRulesFromHTTPRoutesCommonCasesHTTPPort1 := gatewayv1beta1.PortNumber(80)
-	ingressRulesFromHTTPRoutesCommonCasesHTTPPort2 := gatewayv1beta1.PortNumber(8080)
-
 	return []testCaseIngressRulesFromHTTPRoutes{
 		{
 			msg: "a single HTTPRoute with multiple rules with equal backendRefs results in a single service",
@@ -414,26 +411,12 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
-								// only 2 routes should be created
+								// only 1 route with two paths should be created
 								{
 									Route: kong.Route{
 										Name: kong.String("httproute.default.basic-httproute.0.0"),
 										Paths: []*string{
 											kong.String("/httpbin-1"),
-										},
-										PreserveHost: kong.Bool(true),
-										Protocols: []*string{
-											kong.String("http"),
-											kong.String("https"),
-										},
-										StripPath: pointer.BoolPtr(false),
-									},
-									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
-								},
-								{
-									Route: kong.Route{
-										Name: kong.String("httproute.default.basic-httproute.1.0"),
-										Paths: []*string{
 											kong.String("/httpbin-2"),
 										},
 										PreserveHost: kong.Bool(true),
@@ -471,7 +454,8 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
 									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
 								},
-							}, {
+							},
+							{
 								Matches: []gatewayv1beta1.HTTPRouteMatch{
 									builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-2").Build(),
 								},
@@ -483,7 +467,6 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 					},
 				},
 			},
-
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: SecretNameToSNIs{},
@@ -517,53 +500,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
-							Parent: &gatewayv1beta1.HTTPRoute{
-								Spec: gatewayv1beta1.HTTPRouteSpec{
-									CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
-									Rules: []gatewayv1beta1.HTTPRouteRule{
-										{
-											Matches: []gatewayv1beta1.HTTPRouteMatch{
-												builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-1").Build(),
-											},
-											BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("fake-service"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort1,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-													},
-												},
-											},
-										},
-										{
-											Matches: []gatewayv1beta1.HTTPRouteMatch{
-												builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-2").Build(),
-											},
-											BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("fake-service"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort2,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      "basic-httproute",
-									Namespace: "default",
-								},
-								TypeMeta: metav1.TypeMeta{
-									Kind:       "HTTPRoute",
-									APIVersion: "gateway.networking.k8s.io/v1beta1",
-								},
-							},
+							Parent: routes[0],
 						},
 
 						"httproute.default.basic-httproute.1": {
@@ -669,20 +606,6 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										Name: kong.String("httproute.default.basic-httproute.0.0"),
 										Paths: []*string{
 											kong.String("/httpbin-1"),
-										},
-										PreserveHost: kong.Bool(true),
-										Protocols: []*string{
-											kong.String("http"),
-											kong.String("https"),
-										},
-										StripPath: pointer.BoolPtr(false),
-									},
-									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
-								},
-								{
-									Route: kong.Route{
-										Name: kong.String("httproute.default.basic-httproute.1.0"),
-										Paths: []*string{
 											kong.String("/httpbin-2"),
 										},
 										PreserveHost: kong.Bool(true),
@@ -695,102 +618,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 							},
-							Parent: &gatewayv1beta1.HTTPRoute{
-								Spec: gatewayv1beta1.HTTPRouteSpec{
-									CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
-									Rules: []gatewayv1beta1.HTTPRouteRule{
-										{
-											Matches: []gatewayv1beta1.HTTPRouteMatch{
-												builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-1").Build(),
-											},
-											BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v1"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort1,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(90),
-													},
-												},
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v2"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort2,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(10),
-													},
-												},
-											},
-										},
-										{
-											Matches: []gatewayv1beta1.HTTPRouteMatch{
-												builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-2").Build(),
-											},
-											BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v1"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort1,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(90),
-													},
-												},
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v2"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort2,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(10),
-													},
-												},
-											},
-										},
-										{
-											Matches: []gatewayv1beta1.HTTPRouteMatch{
-												builder.NewHTTPRouteMatch().WithPathPrefix("/httpbin-2").Build(),
-											},
-											BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v1"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort2,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(90),
-													},
-												},
-												{
-													BackendRef: gatewayv1beta1.BackendRef{
-														BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-															Name: gatewayv1beta1.ObjectName("foo-v3"),
-															Port: &ingressRulesFromHTTPRoutesCommonCasesHTTPPort2,
-															Kind: util.StringToGatewayAPIKindPtr("Service"),
-														},
-														Weight: pointer.Int32(10),
-													},
-												},
-											},
-										},
-									},
-								},
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      "basic-httproute",
-									Namespace: "default",
-								},
-								TypeMeta: metav1.TypeMeta{
-									Kind:       "HTTPRoute",
-									APIVersion: "gateway.networking.k8s.io/v1beta1",
-								},
-							},
+							Parent: routes[0],
 						},
 
 						"httproute.default.basic-httproute.2": {
@@ -823,6 +651,420 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										StripPath: pointer.BoolPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+							},
+							Parent: routes[0],
+						},
+					},
+				}
+			},
+		},
+
+		{
+			msg: "a single HTTPRoute with multiple rules with equal backendRefs and different filters results in a single service",
+			routes: []*gatewayv1beta1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathPrefix("/path-0").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+								Filters: []gatewayv1beta1.HTTPRouteFilter{
+									{
+										Type: gatewayv1beta1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayv1beta1.HTTPRequestHeaderFilter{
+											Add: []gatewayv1beta1.HTTPHeader{
+												{Name: "X-Test-Header-1", Value: "test-value-1"},
+											},
+										},
+									},
+								},
+							},
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+								Filters: []gatewayv1beta1.HTTPRouteFilter{
+									{
+										Type: gatewayv1beta1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayv1beta1.HTTPRequestHeaderFilter{
+											Add: []gatewayv1beta1.HTTPHeader{
+												{Name: "X-Test-Header-2", Value: "test-value-2"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
+				return ingressRules{
+					SecretNameToSNIs: SecretNameToSNIs{},
+					ServiceNameToServices: map[string]kongstate.Service{
+						"httproute.default.basic-httproute.0": {
+							Service: kong.Service{ // only 1 service should be created
+								ConnectTimeout: kong.Int(60000),
+								Host:           kong.String("httproute.default.basic-httproute.0"),
+								Name:           kong.String("httproute.default.basic-httproute.0"),
+								Protocol:       kong.String("http"),
+								ReadTimeout:    kong.Int(60000),
+								Retries:        kong.Int(5),
+								WriteTimeout:   kong.Int(60000),
+							},
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+							},
+							Namespace: "default",
+							Routes: []kongstate.Route{
+								// two route  should be created, as the filters are different
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.0"),
+										Paths: []*string{
+											kong.String("/path-0"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+									Plugins: []kong.Plugin{
+										{
+											Name: kong.String("request-transformer"),
+											Config: kong.Configuration{
+												"append": map[string][]string{
+													"headers": {"X-Test-Header-1:test-value-1"},
+												},
+											},
+										},
+									},
+								},
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.1.0"),
+										Paths: []*string{
+											kong.String("/path-1"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+									Plugins: []kong.Plugin{
+										{
+											Name: kong.String("request-transformer"),
+											Config: kong.Configuration{
+												"append": map[string][]string{
+													"headers": {"X-Test-Header-2:test-value-2"},
+												},
+											},
+										},
+									},
+								},
+							},
+							Parent: routes[0],
+						},
+					},
+				}
+			},
+		},
+
+		{
+			msg: "a single HTTPRoute with single rule and multiple matches generates consolidated kong route paths",
+			routes: []*gatewayv1beta1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
+					Rules: []gatewayv1beta1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								// Two matches eligible for consolidation into a single kong route
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-0").Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+								// Other two matches eligible for consolidation, but not with the above two
+								// as they have different methods
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-2").WithMethod(gatewayv1beta1.HTTPMethodDelete).Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-3").WithMethod(gatewayv1beta1.HTTPMethodDelete).Build(),
+								// Other two matches eligible for consolidation, but not with the above two
+								// as they have different headers
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-4").
+									WithHeader("x-header-1", "x-value-1").
+									WithHeader("x-header-2", "x-value-2").
+									Build(),
+								// Note the different header order
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-5").
+									WithHeader("x-header-2", "x-value-2").
+									WithHeader("x-header-1", "x-value-1").
+									Build(),
+							},
+							BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+								builder.NewHTTPBackendRef("foo-v1").WithPort(80).WithWeight(90).Build(),
+								builder.NewHTTPBackendRef("foo-v2").WithPort(8080).WithWeight(10).Build(),
+							},
+						},
+					},
+				},
+			}},
+			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
+				return ingressRules{
+					SecretNameToSNIs: SecretNameToSNIs{},
+					ServiceNameToServices: map[string]kongstate.Service{
+						"httproute.default.basic-httproute.0": {
+							Service: kong.Service{
+								ConnectTimeout: kong.Int(60000),
+								Host:           kong.String("httproute.default.basic-httproute.0"),
+								Name:           kong.String("httproute.default.basic-httproute.0"),
+								Protocol:       kong.String("http"),
+								ReadTimeout:    kong.Int(60000),
+								Retries:        kong.Int(5),
+								WriteTimeout:   kong.Int(60000),
+							},
+
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).Build(),
+								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).Build(),
+							},
+							Namespace: "default",
+							Routes: []kongstate.Route{
+								// First two matches consolidated into a single route
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.0"),
+										Paths: []*string{
+											kong.String("/path-0"),
+											kong.String("/path-1"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+								// Second two matches consolidated into a single route
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.2"),
+										Paths: []*string{
+											kong.String("/path-2"),
+											kong.String("/path-3"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+										Methods:   []*string{kong.String("DELETE")},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+								// Third two matches consolidated into a single route
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.4"),
+										Paths: []*string{
+											kong.String("/path-4"),
+											kong.String("/path-5"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+										Headers: map[string][]string{
+											"x-header-1": {"x-value-1"},
+											"x-header-2": {"x-value-2"},
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+							},
+							Parent: routes[0],
+						},
+					},
+				}
+			},
+		},
+
+		{
+			msg: "a single HTTPRoute with multiple rules and matches generates consolidated kong route paths",
+			routes: []*gatewayv1beta1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
+					Rules: []gatewayv1beta1.HTTPRouteRule{
+						// Rule one has four matches, that can be consolidated into two kong routes
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								// Two matches eligible for consolidation into a single kong route
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-0").Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+								// Other two matches eligible for consolidation, but not with the above two
+								// as they have different methods
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-2").WithMethod(gatewayv1beta1.HTTPMethodDelete).Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-3").WithMethod(gatewayv1beta1.HTTPMethodDelete).Build(),
+							},
+							BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+								builder.NewHTTPBackendRef("foo-v1").WithPort(80).WithWeight(90).Build(),
+								builder.NewHTTPBackendRef("foo-v2").WithPort(8080).WithWeight(10).Build(),
+							},
+						},
+
+						// Rule two:
+						//	- shares the backend refs with rule one
+						//	- has two matches, that can be consolidated with the first two matches of rule one
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-4").Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-5").Build(),
+							},
+							BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+								builder.NewHTTPBackendRef("foo-v1").WithPort(80).WithWeight(90).Build(),
+								builder.NewHTTPBackendRef("foo-v2").WithPort(8080).WithWeight(10).Build(),
+							},
+						},
+
+						// Rule three:
+						//	- shares the backend refs with rule one
+						//	- has two matches, that potentially could be consolidated with the first match of rule one
+						//	- has a different filter than rule one, thus cannot be consolidated
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-6").Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-7").Build(),
+							},
+							BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+								builder.NewHTTPBackendRef("foo-v1").WithPort(80).WithWeight(90).Build(),
+								builder.NewHTTPBackendRef("foo-v2").WithPort(8080).WithWeight(10).Build(),
+							},
+							Filters: []gatewayv1beta1.HTTPRouteFilter{
+								{
+									Type: gatewayv1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayv1beta1.HTTPRequestHeaderFilter{
+										Add: []gatewayv1beta1.HTTPHeader{
+											{Name: "X-Test-Header-1", Value: "test-value-1"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
+				return ingressRules{
+					SecretNameToSNIs: SecretNameToSNIs{},
+					ServiceNameToServices: map[string]kongstate.Service{
+						"httproute.default.basic-httproute.0": {
+							Service: kong.Service{
+								ConnectTimeout: kong.Int(60000),
+								Host:           kong.String("httproute.default.basic-httproute.0"),
+								Name:           kong.String("httproute.default.basic-httproute.0"),
+								Protocol:       kong.String("http"),
+								ReadTimeout:    kong.Int(60000),
+								Retries:        kong.Int(5),
+								WriteTimeout:   kong.Int(60000),
+							},
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).Build(),
+								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).Build(),
+							},
+							Namespace: "default",
+							Routes: []kongstate.Route{
+								// First two matches from rule one and rule two consolidated into a single route
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.0"),
+										Paths: []*string{
+											kong.String("/path-0"),
+											kong.String("/path-1"),
+											kong.String("/path-4"),
+											kong.String("/path-5"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+								// Second two matches consolidated into a single route
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.0.2"),
+										Paths: []*string{
+											kong.String("/path-2"),
+											kong.String("/path-3"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+										Methods:   []*string{kong.String("DELETE")},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+
+								// Matches from rule 3, that has different filter, are not consolidated
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.basic-httproute.2.0"),
+										Paths: []*string{
+											kong.String("/path-6"),
+											kong.String("/path-7"),
+										},
+										PreserveHost: kong.Bool(true),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: pointer.BoolPtr(false),
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+									Plugins: []kong.Plugin{
+										{
+											Name: kong.String("request-transformer"),
+											Config: kong.Configuration{
+												"append": map[string][]string{
+													"headers": {"X-Test-Header-1:test-value-1"},
+												},
+											},
+										},
+									},
 								},
 							},
 							Parent: routes[0],
@@ -1001,13 +1243,9 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 								Retries:        kong.Int(5),
 								WriteTimeout:   kong.Int(60000),
 							},
-							Backends: kongstate.ServiceBackends{{
-								Name: "fake-service",
-								PortDef: kongstate.PortDef{
-									Mode:   kongstate.PortMode(1),
-									Number: 80,
-								},
-							}},
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
 								Route: kong.Route{
@@ -1061,8 +1299,8 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 	}
 }
 
-func HTTPMethodPointer(method string) *gatewayv1beta1.HTTPMethod {
-	return (*gatewayv1beta1.HTTPMethod)(&method)
+func HTTPMethodPointer(method gatewayv1beta1.HTTPMethod) *gatewayv1beta1.HTTPMethod {
+	return &method
 }
 
 func k8sObjectInfoOfHTTPRoute(route *gatewayv1beta1.HTTPRoute) util.K8sObjectInfo {

--- a/internal/dataplane/parser/translators/httproute.go
+++ b/internal/dataplane/parser/translators/httproute.go
@@ -1,20 +1,29 @@
 package translators
 
 import (
+	"encoding/json"
+	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-// HTTPRouteTranslationMeta is a translation of a single HTTPRoute into metadata
+// KongServiceTranslation is a translation of a single HTTPRoute into metadata
 // that can be used to instantiate Kong routes and services.
-// Rules from this object should route traffic to BackendRefs from this object.
-type HTTPRouteTranslationMeta struct {
-	BackendRefs  []gatewayv1beta1.HTTPBackendRef
-	Rules        []gatewayv1beta1.HTTPRouteRule
-	RulesNumbers []int
+// Routes from this object should route traffic to BackendRefs from this object.
+type KongServiceTranslation struct {
+	Name        string
+	BackendRefs []gatewayv1beta1.HTTPBackendRef
+	KongRoutes  []KongRouteTranslation
+}
+
+// KongRouteTranslation is a translation of a single HTTPRoute rule into metadata
+// that can be used to instantiate Kong routes.
+type KongRouteTranslation struct {
+	Name    string
+	Matches []gatewayv1beta1.HTTPRouteMatch
+	Filters []gatewayv1beta1.HTTPRouteFilter
 }
 
 // TranslateHTTPRoutes translates a list of HTTPRoutes into a list of HTTPRouteTranslationMeta
@@ -22,9 +31,9 @@ type HTTPRouteTranslationMeta struct {
 // The translation is done by grouping the HTTPRoutes by their backendRefs.
 // This means that all the rules of a single HTTPRoute will be grouped together
 // if they share the same backendRefs.
-func TranslateHTTPRoute(route *gatewayv1beta1.HTTPRoute) []*HTTPRouteTranslationMeta {
-	index := newHTTPRouteTranslationIndex()
-	index.addRoute(route)
+func TranslateHTTPRoute(route *gatewayv1beta1.HTTPRoute) []*KongServiceTranslation {
+	index := httpRouteTranslationIndex{}
+	index.setRoute(route)
 	return index.translate()
 }
 
@@ -34,100 +43,304 @@ func TranslateHTTPRoute(route *gatewayv1beta1.HTTPRoute) []*HTTPRouteTranslation
 
 // httpRouteTranslationIndex aggregates all rules routing to the same backends group.
 type httpRouteTranslationIndex struct {
-	backendsRules map[httpBackendRefsKey]*rulesEntry
+	httpRoute *gatewayv1beta1.HTTPRoute
+	rulesMeta []httpRouteRuleMeta
 }
 
-type rulesEntry struct {
-	rules       []gatewayv1beta1.HTTPRouteRule
-	ruleNumbers []int
+func (i *httpRouteTranslationIndex) setRoute(route *gatewayv1beta1.HTTPRoute) {
+	i.httpRoute = route
+	i.extractRulesMeta(route)
 }
 
-// newHTTPRouteTranslationIndex creates a new httpRouteTranslationIndex.
-func newHTTPRouteTranslationIndex() *httpRouteTranslationIndex {
-	return &httpRouteTranslationIndex{
-		backendsRules: make(map[httpBackendRefsKey]*rulesEntry),
-	}
-}
+func (i *httpRouteTranslationIndex) extractRulesMeta(route *gatewayv1beta1.HTTPRoute) {
+	i.rulesMeta = make([]httpRouteRuleMeta, 0, len(route.Spec.Rules))
 
-// addRoute an HTTPRoute to the index, grouping the rules by their backendRefs.
-func (i *httpRouteTranslationIndex) addRoute(route *gatewayv1beta1.HTTPRoute) {
 	for ruleNumber, rule := range route.Spec.Rules {
-		backendRefsKey := getHTTPBackendRefsKey(rule.BackendRefs...)
-		entry, ok := i.backendsRules[backendRefsKey]
-		if !ok {
-			entry = &rulesEntry{
-				rules:       []gatewayv1beta1.HTTPRouteRule{},
-				ruleNumbers: []int{},
-			}
-			i.backendsRules[backendRefsKey] = entry
-		}
-		entry.rules = append(entry.rules, rule)
-		entry.ruleNumbers = append(entry.ruleNumbers, ruleNumber)
+		i.rulesMeta = append(i.rulesMeta, httpRouteRuleMeta{
+			RuleNumber: ruleNumber,
+			Rule:       rule,
+		})
 	}
 }
 
-// translate the index into a list of HTTPRouteTranslationMeta objects.
-func (i *httpRouteTranslationIndex) translate() []*HTTPRouteTranslationMeta {
-	translations := make([]*HTTPRouteTranslationMeta, 0)
-	for _, rulesEntry := range i.backendsRules {
-		// get the backendRefs from any rule, as they are all the same
-		backendRefs := rulesEntry.rules[0].BackendRefs
+func (i *httpRouteTranslationIndex) translate() []*KongServiceTranslation {
+	rulesGroupedByBackendRed := groupRulesByBackendRefs(i.rulesMeta)
+	translations := make([]*KongServiceTranslation, 0, len(rulesGroupedByBackendRed))
 
-		translations = append(translations, &HTTPRouteTranslationMeta{
-			BackendRefs:  backendRefs,
-			Rules:        rulesEntry.rules,
-			RulesNumbers: rulesEntry.ruleNumbers,
-		})
+	for _, rulesByBackends := range rulesGroupedByBackendRed {
+		// each backend refs group is a separate Kong service, not eligible for consolidation
+		kongServiceTranslation := i.translateToKongService(rulesByBackends)
+		i.translateToKongServiceRoutes(kongServiceTranslation, rulesByBackends)
+		translations = append(translations, kongServiceTranslation)
 	}
 
 	return translations
+}
+
+func (i *httpRouteTranslationIndex) translateToKongService(rulesMeta []httpRouteRuleMeta) *KongServiceTranslation {
+	return &KongServiceTranslation{
+		Name:        i.translateToKongServiceName(rulesMeta),
+		BackendRefs: i.translateToKongServiceBackends(rulesMeta),
+		KongRoutes:  nil,
+	}
+}
+
+func (i *httpRouteTranslationIndex) translateToKongServiceName(rulesMeta []httpRouteRuleMeta) string {
+	// this should never happen, as we validate for the number of matches in the parser,
+	// but just in case anything changes in the future to avoid panics
+	firstRuleInGroup := -1
+	if len(rulesMeta) > 0 {
+		// rules are guaranteed to retain their order, so we can use the first one
+		firstRuleInGroup = rulesMeta[0].RuleNumber
+	}
+	return fmt.Sprintf(
+		"httproute.%s.%s.%d",
+		i.httpRoute.Namespace,
+		i.httpRoute.Name,
+		firstRuleInGroup,
+	)
+}
+
+func (i *httpRouteTranslationIndex) translateToKongServiceBackends(rulesMeta []httpRouteRuleMeta) []gatewayv1beta1.HTTPBackendRef {
+	if len(rulesMeta) == 0 {
+		return nil
+	}
+	// get the backendRefs and filters from any rule, as they are all the same
+	return rulesMeta[0].Rule.BackendRefs
+}
+
+func (i *httpRouteTranslationIndex) translateToKongServiceRoutes(s *KongServiceTranslation, rulesMeta []httpRouteRuleMeta) {
+	for _, rulesByFilter := range groupRulesByFilter(rulesMeta) {
+		// each filter group must be a separate Kong route, not eligible for consolidation
+		// thus need to be translated separately
+		routesByFilter := i.translateToKongRoutes(rulesByFilter)
+		s.KongRoutes = append(s.KongRoutes, routesByFilter...)
+	}
+
+	// Sort the routes by name to ensure that the order is deterministic.
+	sort.Slice(s.KongRoutes, func(i, j int) bool {
+		return s.KongRoutes[i].Name < s.KongRoutes[j].Name
+	})
+}
+
+func (i *httpRouteTranslationIndex) translateToKongRoutes(rulesMeta []httpRouteRuleMeta) []KongRouteTranslation {
+	// All the rules in the group have the same backendRefs and filters.
+	var filters []gatewayv1beta1.HTTPRouteFilter
+	if len(rulesMeta) > 0 {
+		filters = rulesMeta[0].Rule.Filters
+	}
+
+	// Group the matches for each rule. Then aggregate the matches eligible for the consolidation
+	// into a single match group.
+	matchGroups := make(map[string]httpRouteMatchMetaList)
+	for _, ruleMeta := range rulesMeta {
+		ruleMatchGroups := groupSliceByKeyFn(ruleMeta.matches(), httpRouteMatchMeta.getKey)
+		for matchGroupKey, matchGroup := range ruleMatchGroups {
+			matchGroups[matchGroupKey] = append(matchGroups[matchGroupKey], matchGroup...)
+		}
+	}
+
+	// Then, for each group, create a KongRoute with the multiple paths.
+	kongRoutes := make([]KongRouteTranslation, 0, len(matchGroups))
+	for _, matchGroup := range matchGroups {
+		kongRouteName := i.translateToKongRouteName(matchGroup)
+
+		kongRoutes = append(kongRoutes, KongRouteTranslation{
+			Name:    kongRouteName,
+			Matches: matchGroup.httpRouteMatches(),
+			Filters: filters,
+		})
+	}
+
+	// No matches means a catch-all route based on the hostname
+	if len(matchGroups) == 0 {
+		kongRouteName := fmt.Sprintf("httproute.%s.%s.0.0", i.httpRoute.Namespace, i.httpRoute.Name)
+		kongRoutes = append(kongRoutes, KongRouteTranslation{
+			Name:    kongRouteName,
+			Filters: filters,
+		})
+	}
+
+	return kongRoutes
+}
+
+func (i *httpRouteTranslationIndex) translateToKongRouteName(matchesMeta httpRouteMatchMetaList) string {
+	// this should never happen, as we validate for the number of matches in the parser,
+	// but just in case anything changes in the future to avoid panics
+	firstRuleNumber := -1
+	firstMatchNumber := -1
+	if len(matchesMeta) > 0 {
+		// matches are guaranteed to retain their order, so we can use the first one
+		firstRuleNumber = matchesMeta[0].RuleNumber
+		firstMatchNumber = matchesMeta[0].MatchNumber
+	}
+
+	return fmt.Sprintf(
+		"httproute.%s.%s.%d.%d",
+		i.httpRoute.Namespace,
+		i.httpRoute.Name,
+		firstRuleNumber,
+		firstMatchNumber,
+	)
+}
+
+// groupRulesByBackendRefs groups the rules by their backendRefs.
+// The backendRefs are grouped by their key function.
+// The elements in the groups have the order of the original slice, but the groups themselves are not ordered.
+func groupRulesByBackendRefs(ruleEntries []httpRouteRuleMeta) map[string][]httpRouteRuleMeta {
+	return groupSliceByKeyFn(ruleEntries, httpRouteRuleMeta.getHTTPBackendRefsKey)
+}
+
+// groupRulesByFilter groups the rules by their filters.
+// The filters are grouped by deep equality, key being the numeric index.
+// The elements in the groups have the order of the original slice, but the groups themselves are not ordered.
+func groupRulesByFilter(ruleEntries []httpRouteRuleMeta) map[string][]httpRouteRuleMeta {
+	return groupSliceByKeyFn(ruleEntries, httpRouteRuleMeta.getFiltersKey)
+}
+
+// groupSliceByKeyFn groups a slice by a key function. The elements in the groups
+// have the order of the original slice, but the groups themselves are not ordered.
+func groupSliceByKeyFn[T any](vals []T, keyFn func(val T) string) map[string][]T {
+	groups := make(map[string][]T, len(vals))
+	for _, val := range vals {
+		key := keyFn(val)
+		groups[key] = append(groups[key], val)
+	}
+
+	return groups
 }
 
 // -----------------------------------------------------------------------------
 // HttpRoute Translation - Private - Metadata
 // -----------------------------------------------------------------------------
 
-// httpBackendRefsKey is a key computed from a list of backendRefs.
-type httpBackendRefsKey string
+type httpRouteRuleMeta struct {
+	Rule       gatewayv1beta1.HTTPRouteRule
+	RuleNumber int
+}
+
+// getFiltersKey computes a key from a list of filters.
+// The order of the filters is not important.
+func (m httpRouteRuleMeta) getFiltersKey() string {
+	return getSortedItemsString(m.Rule.Filters)
+}
 
 // getHTTPBackendRefsKey computes a key from a list of backendRefs.
-func getHTTPBackendRefsKey(backendRefs ...gatewayv1beta1.HTTPBackendRef) httpBackendRefsKey {
-	backendKeys := make([]string, 0, len(backendRefs))
+// The order of backedRefs is not important.
+func (m httpRouteRuleMeta) getHTTPBackendRefsKey() string {
+	return getSortedItemsString(m.Rule.BackendRefs)
+}
 
-	// create a list of backend keys
-	for _, backendRef := range backendRefs {
-		var backendKey strings.Builder
+func (m *httpRouteRuleMeta) matches() httpRouteMatchMetaList {
+	matches := make([]httpRouteMatchMeta, 0, len(m.Rule.Matches))
 
-		if backendRef.Group != nil {
-			backendKey.WriteString(string(*backendRef.Group))
-		}
-		backendKey.WriteString(".")
-
-		if backendRef.Kind != nil {
-			backendKey.WriteString(string(*backendRef.Kind))
-		}
-		backendKey.WriteString(".")
-
-		if backendRef.Namespace != nil {
-			backendKey.WriteString(string(*backendRef.Namespace))
-		}
-		backendKey.WriteString(".")
-
-		backendKey.WriteString(string(backendRef.Name))
-		backendKey.WriteString(".")
-
-		if backendRef.Port != nil {
-			backendKey.WriteString(strconv.Itoa(int(*backendRef.Port)))
-		}
-		backendKey.WriteString(".")
-
-		if backendRef.Weight != nil {
-			backendKey.WriteString(strconv.Itoa(int(*backendRef.Weight)))
-		}
-
-		backendKeys = append(backendKeys, backendKey.String())
+	for matchNumber, match := range m.Rule.Matches {
+		match := match
+		matches = append(matches, httpRouteMatchMeta{
+			Match:       &match,
+			RuleNumber:  m.RuleNumber,
+			MatchNumber: matchNumber,
+		})
 	}
-	sort.Strings(backendKeys)
 
-	return httpBackendRefsKey(strings.Join(backendKeys, ";"))
+	return matches
+}
+
+type httpRouteMatchMeta struct {
+	Match       *gatewayv1beta1.HTTPRouteMatch
+	RuleNumber  int
+	MatchNumber int
+}
+
+// getKey computes a key from a HTTPRouteMatch, to be used to group rules by their match.
+// The key is derived from the match method, headers and query parameters.
+func (m httpRouteMatchMeta) getKey() string {
+	// According to the spec of HTTPRouteMatch:
+	//
+	// Name is the name of the HTTP Header to be matched. Name matching MUST be
+	// case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+	//
+	// If multiple entries specify equivalent header names, only the first
+	// entry with an equivalent name MUST be considered for a match. Subsequent
+	// entries with an equivalent header name MUST be ignored. Due to the
+	// case-insensitivity of header names, "foo" and "Foo" are considered
+	// equivalent.
+	//
+	seenHeaders := make(map[string]struct{})
+	headers := make([]gatewayv1beta1.HTTPHeaderMatch, 0, len(m.Match.Headers))
+	for _, header := range m.Match.Headers {
+		name := strings.ToLower(string(header.Name))
+		header.Name = gatewayv1beta1.HTTPHeaderName(strings.ToLower(string(header.Name)))
+		if _, ok := seenHeaders[name]; ok {
+			continue
+		}
+		seenHeaders[name] = struct{}{}
+		headers = append(headers, header)
+	}
+	sort.Slice(headers, func(i, j int) bool {
+		return headers[i].Name < headers[j].Name
+	})
+
+	// According to the spec of HTTPQueryParamMatch:
+	//
+	// If multiple entries specify equivalent query param names, only the first
+	// entry with an equivalent name MUST be considered for a match. Subsequent
+	// entries with an equivalent query param name MUST be ignored.
+	//
+	seenQueryParams := make(map[string]struct{})
+	queryParams := make([]gatewayv1beta1.HTTPQueryParamMatch, 0, len(m.Match.QueryParams))
+	for _, queryParam := range m.Match.QueryParams {
+		if _, ok := seenQueryParams[queryParam.Name]; ok {
+			continue
+		}
+		seenQueryParams[queryParam.Name] = struct{}{}
+		queryParams = append(queryParams, queryParam)
+	}
+
+	keySource := struct {
+		Method  *gatewayv1beta1.HTTPMethod
+		Headers []gatewayv1beta1.HTTPHeaderMatch
+		Query   []gatewayv1beta1.HTTPQueryParamMatch
+	}{
+		m.Match.Method,
+		headers,
+		queryParams,
+	}
+
+	return mustMarshalJSON(keySource)
+}
+
+type httpRouteMatchMetaList []httpRouteMatchMeta
+
+func (l httpRouteMatchMetaList) httpRouteMatches() []gatewayv1beta1.HTTPRouteMatch {
+	matches := make([]gatewayv1beta1.HTTPRouteMatch, 0, len(l))
+	for _, matchMeta := range l {
+		matches = append(matches, *matchMeta.Match)
+	}
+	return matches
+}
+
+// getSortedItemsString returns a string representation of a list of items,
+// sorted by their string representation. The items are required to be
+// to be JSON marshalable.
+func getSortedItemsString[T any](items []T) string {
+	keys := make([]string, 0, len(items))
+
+	for _, item := range items {
+		keys = append(keys, mustMarshalJSON(item))
+	}
+	sort.Strings(keys)
+
+	return strings.Join(keys, ";")
+}
+
+// mustMarshalJSON marshals the given object to JSON or returns an empty string if it fails.
+// It's a developer error if the object cannot be marshaled to JSON.
+// The functions using this, should be calling it with a struct that is known to be marshalable.
+func mustMarshalJSON[T any](val T) string {
+	key, err := json.Marshal(val)
+	if err != nil {
+		return ""
+	}
+	return string(key)
 }

--- a/internal/dataplane/parser/translators/httproute.go
+++ b/internal/dataplane/parser/translators/httproute.go
@@ -105,7 +105,8 @@ func (i *httpRouteTranslationIndex) translateToKongServiceBackends(rulesMeta []h
 	if len(rulesMeta) == 0 {
 		return nil
 	}
-	// get the backendRefs and filters from any rule, as they are all the same
+	// get the backendRefs and filters from any rule, as they are all the same,
+	// because the the rules are processed in groups wit the same backendRefs and filters.
 	return rulesMeta[0].Rule.BackendRefs
 }
 
@@ -252,10 +253,11 @@ type httpRouteMatchMeta struct {
 	MatchNumber int
 }
 
-// getKey computes a key from a HTTPRouteMatch, to be used to group rules by their match.
-// The key is derived from the match method, headers and query parameters.
+// getKey computes a key from an HTTPRouteMatch. Two HTTPRouteMatches will generate the same key if their
+// methods, headers, and query parameters are identical. HTTPRouteMatches with the same key can be
+// combined into a single Kong route.
 func (m httpRouteMatchMeta) getKey() string {
-	// According to the spec of HTTPRouteMatch:
+	// Per the HTTPHeader definition at https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeader
 	//
 	// Name is the name of the HTTP Header to be matched. Name matching MUST be
 	// case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).

--- a/internal/util/builder/httproutematch.go
+++ b/internal/util/builder/httproutematch.go
@@ -53,3 +53,16 @@ func (b *HTTPRouteMatchBuilder) WithQueryParam(name, value string) *HTTPRouteMat
 	})
 	return b
 }
+
+func (b *HTTPRouteMatchBuilder) WithMethod(method gatewayv1beta1.HTTPMethod) *HTTPRouteMatchBuilder {
+	b.httpRouteMatch.Method = &method
+	return b
+}
+
+func (b *HTTPRouteMatchBuilder) WithHeader(name, value string) *HTTPRouteMatchBuilder {
+	b.httpRouteMatch.Headers = append(b.httpRouteMatch.Headers, gatewayv1beta1.HTTPHeaderMatch{
+		Name:  gatewayv1beta1.HTTPHeaderName(name),
+		Value: value,
+	})
+	return b
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR consolidates `HTTPRouteMatch` objects into paths in `kong.Route` if they share the route, filters and matching data.

The behaviour depending on `CombinedRoutes` being enabled or not:
- When the `CombinedRoutes` feature is disabled, the parser generates one `kong.Service` per `HTTPRouteRule` and one `kong.Route` per `HTTPRouteMatch` pointing to that service. 
- When the`CombinedRoutes` feature is enabled, prior to this PR, multiple `HTTPRouteRule` objects can be consolidated into a single `kong.Service` if they share the backend refs. However, single `HTTPRouteMatch` generates a single rule pointing to the generated service.
- With this PR and the `CombinedRoutes` enabled, the multiple `HTTPRouteMatch` objects are further consolidated into a single `kong.Route` with multiple paths.


The following limitations apply to the consolidation logic:
- `HTTPRouteMatch` objects cannot be consolidated if they belong to different `HTTPRoute` objects.
-  `HTTPRouteMatch` objects cannot be consolidated if `HTTPRouteRule` objects they belong to have different backend refs.
- `HTTPRouteMatch` objects cannot be consolidated if `HTTPRouteRule` objects they belong to have different filters.
- `HTTPRouteMatch` objects cannot be consolidated if they have different `spec` (headers, query params, method). 
- The different paths does not prevent consolidation of `HTTPRouteMatch` objects.

This PR changes the code path used for generating `kong.Route` and `kong.Service` objects when service based consolidation is enabled, added previously by https://github.com/Kong/kubernetes-ingress-controller/pull/3008. It does not change the behaviour of soon to be deprecated  `kong.Route` and `kong.Service` generation used when service based consolidation is disabled.  The PR extracts common functions from this code path.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/2881


**Special notes for your reviewer**:

This feature does not yet provide a benchmark, to measure performance hit, but it's intended to provide benchamarks too.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
