### PR TITLE
feat: Skip synchronisation of expired CA certificates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Adding a new version? You'll need three changes:
 - Added `--cache-sync-timeout` flag allowing to change the default controllers' 
   cache synchronisation timeout. 
   [#3013](https://github.com/Kong/kubernetes-ingress-controller/pull/3013)
+- Secrets validation introduced: CA certificates won't be synchronized 
+  to Kong if the certificate is expired.
+  [#3063](https://github.com/Kong/kubernetes-ingress-controller/pull/3063)
 
 ### Fixed
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -311,13 +311,9 @@ func (c *KongClient) Update(ctx context.Context) error {
 	}
 
 	// parse the Kubernetes objects from the storer into Kong configuration
-	kongstate, err := p.Build()
-	if err != nil {
-		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
-			metrics.SuccessKey: metrics.SuccessFalse,
-		}).Inc()
-		return err
-	}
+	kongstate := p.Build()
+	// todo: does it still make sense to report TranslationCount when Build no longer returns an error?
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/1892
 	c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 		metrics.SuccessKey: metrics.SuccessTrue,
 	}).Inc()

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -119,7 +119,7 @@ func (p *Parser) Build() (*kongstate.KongState, error) {
 	result.Certificates = mergeCerts(p.logger, ingressCerts, gatewayCerts)
 
 	// populate CA certificates in Kong
-	result.CACertificates = getCACerts(p.logger, p.storer)
+	result.CACertificates = getCACerts(p.logger, p.storer, result.Plugins)
 
 	return &result, nil
 }

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -3,8 +3,6 @@ package parser
 import (
 	"bytes"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"reflect"
 	"sort"
@@ -121,12 +119,7 @@ func (p *Parser) Build() (*kongstate.KongState, error) {
 	result.Certificates = mergeCerts(p.logger, ingressCerts, gatewayCerts)
 
 	// populate CA certificates in Kong
-	var err error
-	caCertSecrets, err := p.storer.ListCACerts()
-	if err != nil {
-		return nil, err
-	}
-	result.CACertificates = toCACerts(p.logger, caCertSecrets)
+	result.CACertificates = getCACerts(p.logger, p.storer)
 
 	return &result, nil
 }
@@ -185,51 +178,6 @@ func (p *Parser) EnableRegexPathPrefix() {
 // -----------------------------------------------------------------------------
 // Parser - Private Methods
 // -----------------------------------------------------------------------------
-
-func toCACerts(log logrus.FieldLogger, caCertSecrets []*corev1.Secret) []kong.CACertificate {
-	var caCerts []kong.CACertificate
-	for _, certSecret := range caCertSecrets {
-		secretName := certSecret.Namespace + "/" + certSecret.Name
-
-		idbytes, idExists := certSecret.Data["id"]
-		log = log.WithFields(logrus.Fields{
-			"secret_name":      secretName,
-			"secret_namespace": certSecret.Namespace,
-		})
-		if !idExists {
-			log.Errorf("invalid CA certificate: missing 'id' field in data")
-			continue
-		}
-
-		caCertbytes, certExists := certSecret.Data["cert"]
-		if !certExists {
-			log.Errorf("invalid CA certificate: missing 'cert' field in data")
-			continue
-		}
-
-		pemBlock, _ := pem.Decode(caCertbytes)
-		if pemBlock == nil {
-			log.Errorf("invalid CA certificate: invalid PEM block")
-			continue
-		}
-		x509Cert, err := x509.ParseCertificate(pemBlock.Bytes)
-		if err != nil {
-			log.WithError(err).Errorf("invalid CA certificate: failed to parse certificate")
-			continue
-		}
-		if !x509Cert.IsCA {
-			log.WithError(err).Errorf("invalid CA certificate: certificate is missing the 'CA' basic constraint")
-			continue
-		}
-
-		caCerts = append(caCerts, kong.CACertificate{
-			ID:   kong.String(string(idbytes)),
-			Cert: kong.String(string(caCertbytes)),
-		})
-	}
-
-	return caCerts
-}
 
 func knativeIngressToNetworkingTLS(tls []knative.IngressTLS) []netv1beta1.IngressTLS {
 	var result []netv1beta1.IngressTLS

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -71,8 +71,7 @@ func NewParser(
 
 // Build creates a Kong configuration from Ingress and Custom resources
 // defined in Kubernetes.
-// It throws an error if there is an error returned from client-go.
-func (p *Parser) Build() (*kongstate.KongState, error) {
+func (p *Parser) Build() *kongstate.KongState {
 	// parse and merge all rules together from all Kubernetes API sources
 	ingressRules := mergeIngressRules(
 		p.ingressRulesFromIngressV1beta1(),
@@ -121,7 +120,7 @@ func (p *Parser) Build() (*kongstate.KongState, error) {
 	// populate CA certificates in Kong
 	result.CACertificates = getCACerts(p.logger, p.storer, result.Plugins)
 
-	return &result, nil
+	return &result
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -237,6 +237,23 @@ etlxzx2CCoUDXKkYW2gZKEozwBZ+eBgUj8WB5g/8jGDAI0qzYnfAgiahjGwlEUtP
 hJiPG/YFADw0m5b/8OMCZ6AXNhxjdweHniDxY2HE734Nwm9mG/7UbkdvhR05tqFh
 G4KCViLH0cXt/TgW1sYB2o9Z
 -----END CERTIFICATE-----`
+	expiredCACert = `-----BEGIN CERTIFICATE-----
+MIICwTCCAamgAwIBAgIUHGUzUWvHJHrREvIZIcORiFUvze4wDQYJKoZIhvcNAQEL
+BQAwEDEOMAwGA1UEAwwFSGVsbG8wHhcNMjAwNTA4MjExODA1WhcNMjAwNjA3MjEx
+ODA1WjAQMQ4wDAYDVQQDDAVIZWxsbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBANCMMBngjuTvqts8ZXtZhqdr181QH/NmytW1KlyqZd6ppXUer+i0OWhP
+1nAyHsBPJljKAFLd8l1EioPFkN78/wJFDJrHOtfniIQPVLdS2cnNQ72dLyQH6smH
+JQDV8ePBQ2GdRP6s61+Da8eoaW6nSLtmEUhxvyteboqwmi2CtUtAfuiU1m5sOdpS
+z+L4D08CE+SFIT4MGD3gxNdg7lccWCHIfk54VRSdGDKEVwed8OQvxD0TdpHY+ym5
+nJ4JSkhiS9XIodnxR3AZ6rIPRqk+MQ4LGTjX2EbM0/Yg4qvnZ7m4fcpK2goDZIVL
+EF8F+ka1RaAYWTsXI1BAkJbb3kdo/yUCAwEAAaMTMBEwDwYDVR0TBAgwBgEB/wIB
+ADANBgkqhkiG9w0BAQsFAAOCAQEAVvB/PeVZpeQ7q2IQQQpADtTd8+22Ma3jNZQD
+EkWGZEQLkRws4EJNCCIvkApzpx1GqRcLLL9lbV+iCSiIdlR5W9HtK07VZ318gpsG
+aTMNrP9/2XWTBzdHWaeZKmRKB04H4z7V2Dl58D+wxjdqNWsMIHeqqPNKGamk/q8k
+YFNqNwisRxMhU6qPOpOj5Swl2jLTuVMAeGWBWmPGU2MUoaJb8sc2Vix9KXcyDZIr
+eidkzkqSrjNzI0yJ2gdCDRS4/Rw9iV3B3SRMs0mJMLBDrsowhNfLAd8I3NHzLwps
+dZFcvZcT/p717K3hlFVdjGnKIgKcG7aYji/XRR87HKnc+cJMCw==
+-----END CERTIFICATE-----`
 )
 
 func TestGlobalPlugin(t *testing.T) {
@@ -944,6 +961,22 @@ func TestCACertificate(t *testing.T) {
 				Data: map[string][]byte{
 					// id is missing
 					"cert": []byte(caCert2),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "non-default",
+					Labels: map[string]string{
+						"konghq.com/ca-cert": "true",
+					},
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
+					},
+				},
+				Data: map[string][]byte{
+					"id":   []byte("670c28aa-e784-43c1-8ec7-ae7f4ce40189"),
+					"cert": []byte(expiredCACert),
 				},
 			},
 		}

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -281,8 +281,7 @@ func TestGlobalPlugin(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected one plugin to be rendered")
@@ -463,7 +462,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
+			state := p.Build()
 			assert.Nil(err)
 			assert.NotNil(state)
 			assert.Equal(3, len(state.Plugins),
@@ -568,7 +567,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
+			state := p.Build()
 			assert.Nil(err)
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
@@ -670,8 +669,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
 				"expected no plugins to be rendered")
@@ -722,8 +720,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 		store, err := store.NewFakeStore(objects)
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		for _, testcase := range references {
 			config, err := kongstate.SecretToConfiguration(store, *testcase, "default")
@@ -821,8 +818,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
 				"expected no plugins to be rendered")
@@ -856,8 +852,7 @@ func TestCACertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.CACertificates))
@@ -907,8 +902,7 @@ func TestCACertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(2, len(state.CACertificates))
@@ -986,8 +980,7 @@ func TestCACertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.CACertificates))
@@ -1070,8 +1063,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"expected one certificates to be rendered")
@@ -1138,8 +1130,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")
@@ -1199,8 +1190,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -1279,8 +1269,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -1360,8 +1349,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1442,8 +1430,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1523,8 +1510,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1604,8 +1590,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1685,8 +1670,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1766,8 +1750,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1847,8 +1830,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one service to be rendered")
@@ -1926,8 +1908,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one service to be rendered")
@@ -2005,8 +1986,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		kongTrue := kong.Bool(true)
@@ -2066,8 +2046,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2117,8 +2096,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(0, len(state.Services),
@@ -2195,8 +2173,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2274,8 +2251,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2344,8 +2320,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2430,8 +2405,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2541,8 +2515,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2624,8 +2597,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2713,8 +2685,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			})
 			assert.Nil(err)
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.Nil(err)
+			state := p.Build()
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -2783,8 +2754,7 @@ func TestDefaultBackend(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
@@ -2852,8 +2822,7 @@ func TestDefaultBackend(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")
@@ -2918,8 +2887,7 @@ func TestParserSecret(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered with empty secret")
@@ -3000,8 +2968,7 @@ func TestParserSecret(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"certificates are de-duplicated")
@@ -3127,8 +3094,7 @@ func TestParserSecret(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"certificates are de-duplicated")
@@ -3209,8 +3175,7 @@ func TestParserSecret(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"SNIs are de-duplicated")
@@ -3292,8 +3257,7 @@ func TestParserSNI(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3357,8 +3321,7 @@ func TestParserSNI(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3417,8 +3380,7 @@ func TestParserHostAliases(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3470,8 +3432,7 @@ func TestParserHostAliases(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3524,8 +3485,7 @@ func TestParserHostAliases(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3614,8 +3574,7 @@ func TestPluginAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3712,8 +3671,7 @@ func TestPluginAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3783,8 +3741,7 @@ func TestPluginAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3830,8 +3787,7 @@ func TestPluginAnnotations(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -4627,8 +4583,7 @@ func TestPickPort(t *testing.T) {
 			assert.NoError(err)
 
 			p := NewParser(logrus.New(), store)
-			state, err := p.Build()
-			assert.NoError(err)
+			state := p.Build()
 
 			assert.Equal(tt.wantTarget, *state.Upstreams[0].Targets[0].Target.Target)
 		})
@@ -4741,8 +4696,7 @@ func TestCertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(3, len(state.Certificates))
 		// foo.com with cert should be fixed
@@ -4834,8 +4788,7 @@ func TestCertificate(t *testing.T) {
 		})
 		assert.Nil(err)
 		p := NewParser(logrus.New(), store)
-		state, err := p.Build()
-		assert.Nil(err)
+		state := p.Build()
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates))
 		assert.Equal(state.Certificates[0], fooCertificate)

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -25,18 +25,17 @@ func getCACerts(log logrus.FieldLogger, storer store.Storer, plugins []kongstate
 	for _, certSecret := range caCertSecrets {
 		idBytes, ok := certSecret.Data["id"]
 		if !ok {
-			log.Errorf("invalid CA certificate: missing 'id' field in data")
+			log.Errorf("skipping synchronisation, invalid CA certificate: missing 'id' field in data")
 			continue
 		}
 		secretID := string(idBytes)
 
 		caCert, err := toKongCACertificate(certSecret, secretID)
 		if err != nil {
-			secretName := certSecret.Namespace + "/" + certSecret.Name
 			logWithAffectedPlugins(log, plugins, secretID).WithFields(logrus.Fields{
-				"secret_name":      secretName,
+				"secret_name":      certSecret.Name,
 				"secret_namespace": certSecret.Namespace,
-			}).WithError(err).Error("invalid CA certificate")
+			}).WithError(err).Error("skipping synchronisation, invalid CA certificate")
 			continue
 		}
 

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
@@ -45,7 +45,7 @@ func getCACerts(log logrus.FieldLogger, storer store.Storer, plugins []kongstate
 	return caCerts
 }
 
-func toKongCACertificate(certSecret *v1.Secret, secretID string) (kong.CACertificate, error) {
+func toKongCACertificate(certSecret *corev1.Secret, secretID string) (kong.CACertificate, error) {
 	caCertbytes, certExists := certSecret.Data["cert"]
 	if !certExists {
 		return kong.CACertificate{}, errors.New("missing 'cert' field in data")

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -1,0 +1,119 @@
+package parser
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
+	"github.com/sirupsen/logrus"
+)
+
+func getCACerts(log logrus.FieldLogger, storer store.Storer) []kong.CACertificate {
+	caCertSecrets, err := storer.ListCACerts()
+	if err != nil {
+		log.WithError(err).Error("failed to list CA certs")
+		return nil
+	}
+
+	var caCerts []kong.CACertificate
+	for _, certSecret := range caCertSecrets {
+		secretName := certSecret.Namespace + "/" + certSecret.Name
+
+		idbytes, idExists := certSecret.Data["id"]
+		log = log.WithFields(logrus.Fields{
+			"secret_name":      secretName,
+			"secret_namespace": certSecret.Namespace,
+		})
+		if !idExists {
+			log.Errorf("invalid CA certificate: missing 'id' field in data")
+			continue
+		}
+		secretID := string(idbytes)
+		log = logWithAffectedPlugins(log, storer, secretID)
+
+		caCertbytes, certExists := certSecret.Data["cert"]
+		if !certExists {
+			log.Errorf("invalid CA certificate: missing 'cert' field in data")
+			continue
+		}
+
+		pemBlock, _ := pem.Decode(caCertbytes)
+		if pemBlock == nil {
+			log.Errorf("invalid CA certificate: invalid PEM block")
+			continue
+		}
+		x509Cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		if err != nil {
+			log.WithError(err).Errorf("invalid CA certificate: failed to parse certificate")
+			continue
+		}
+		if !x509Cert.IsCA {
+			log.WithError(err).Errorf("invalid CA certificate: certificate is missing the 'CA' basic constraint")
+			continue
+		}
+		if time.Now().After(x509Cert.NotAfter) {
+			log.WithError(err).Errorf("expired CA certificate")
+			continue
+		}
+
+		caCerts = append(caCerts, kong.CACertificate{
+			ID:   kong.String(secretID),
+			Cert: kong.String(string(caCertbytes)),
+		})
+	}
+
+	return caCerts
+}
+
+func logWithAffectedPlugins(log logrus.FieldLogger, storer store.Storer, secretID string) logrus.FieldLogger {
+	affectedPlugins := getPluginsAssociatedWithSecret(storer, secretID)
+	return log.WithField("affected_plugins", affectedPlugins)
+}
+
+func getPluginsAssociatedWithSecret(storer store.Storer, secretID string) []string {
+	var affectedPlugins []string
+
+	clusterPlugins, err := storer.ListGlobalKongClusterPlugins()
+	if err != nil {
+		return nil
+	}
+	for _, p := range clusterPlugins {
+		if pluginConfigRefersToSecret(p.Config, secretID) {
+			affectedPlugins = append(affectedPlugins, p.Name)
+		}
+	}
+
+	plugins, err := storer.ListGlobalKongPlugins()
+	if err != nil {
+		return affectedPlugins
+	}
+	for _, p := range plugins {
+		if pluginConfigRefersToSecret(p.Config, secretID) {
+			affectedPlugins = append(affectedPlugins, fmt.Sprintf("%s/%s", p.Namespace, p.Name))
+		}
+	}
+	return affectedPlugins
+}
+
+func pluginConfigRefersToSecret(cfg apiextensionsv1.JSON, secretID string) bool {
+	pluginConfig := struct {
+		CACertificates []string `json:"ca_certificates,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(cfg.Raw, &pluginConfig); err != nil {
+		return false
+	}
+
+	for _, reference := range pluginConfig.CACertificates {
+		if reference == secretID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -1,0 +1,21 @@
+package parser
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPluginsAssociatedWithSecret(t *testing.T) {
+	s, err := store.NewFakeStore(store.FakeObjects{
+		Secrets: []*corev1.Secret{},
+	})
+	require.NoError(t, err)
+	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92"
+
+	associatedPlugins := getPluginsAssociatedWithSecret(s, secretID)
+	require.Empty(t, associatedPlugins)
+}

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -3,11 +3,10 @@ package parser
 import (
 	"testing"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
-
 	"github.com/kong/go-kong/kong"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 )
 
 func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
-	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92"
+	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92" //nolint:gosec
 	plugins := []kongstate.Plugin{
 		{
 			Plugin: kong.Plugin{


### PR DESCRIPTION
**What this PR does / why we need it**:

CA certificate expiration validation is introduced. Once it fails, synchronization to the data plane is skipped (analogically to the other already existing validations against CA certificate secrets). It also adds logging of affected plugins for better context. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This is the first step to resolving https://github.com/Kong/kubernetes-ingress-controller/issues/1892. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
