### PR TITLE
chore(tests): remove hardcoded v1.24 version for tests

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
@@ -70,23 +69,6 @@ func useExistingClusterIfPresent(builder *environments.Builder) {
 		builder.WithExistingCluster(cluster)
 	} else {
 		fmt.Println("INFO: creating new kind cluster for conformance tests")
-
-		// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
-		// even though that
-		// * our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
-		//   which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
-		// * when used with ktf (which at the time of writing this comment was set to v0.19.0) we
-		//   should use kind v0.14 since that what ktf has set as dependency
-		//
-		// With all that said, we still managed to get kind v0.15 on our CI
-		// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
-		// which causes issues down the line (metallb manifests using PSP which is not available
-		// in k8s v1.25+).
-		builder.WithKubernetesVersion(semver.Version{
-			Major: 1,
-			Minor: 24,
-			Patch: 4,
-		})
 	}
 }
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -29,23 +29,6 @@ import (
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 )
 
-// For some reason we've ended up using kind v0.15.0 (which by default deploys k8s v1.25)
-// even though that
-//   - our CI runners use ubuntu-latest (which at the time of writing this comment was ubuntu20.04)
-//     which uses kind v0.14 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
-//   - when used with ktf (which at the time of writing this comment was set to v0.19.0) we
-//     should use kind v0.14 since that what ktf has set as dependency
-//
-// With all that said, we still managed to get kind v0.15 on our CI
-// https://github.com/Kong/kubernetes-ingress-controller/runs/8211490522?check_suite_focus=true#step:5:6
-// which causes issues down the line (metallb manifests using PSP which is not available
-// in k8s v1.25+).
-var defaultKindClusterVesion = semver.Version{
-	Major: 1,
-	Minor: 24,
-	Patch: 4,
-}
-
 var k8sClient *kubernetes.Clientset
 
 // -----------------------------------------------------------------------------
@@ -135,15 +118,14 @@ func TestMain(m *testing.M) {
 
 		builder.WithAddons(metallb.New())
 
-		clusterVersion = defaultKindClusterVesion
 		if clusterVersionStr != "" {
 			var err error
 			clusterVersion, err = semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
 			exitOnErr(err)
 
+			fmt.Printf("INFO: build a new KIND cluster with version %s\n", clusterVersion.String())
+			builder.WithKubernetesVersion(clusterVersion)
 		}
-		fmt.Printf("INFO: build a new KIND cluster with version %s\n", clusterVersion.String())
-		builder.WithKubernetesVersion(clusterVersion)
 	}
 
 	fmt.Println("INFO: building test environment")


### PR DESCRIPTION
**What this PR does / why we need it**:

After [pinning k8s version to v1.24 for some tests](https://github.com/Kong/kubernetes-ingress-controller/pull/2904) it seems that the issue is now resolved and we can get rid of the hardcode.
