### PR TITLE
fix: fill in gateway namespace and name when failed to find it in k8s

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -272,10 +272,12 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	gateway := new(gatewayv1beta1.Gateway)
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if k8serrors.IsNotFound(err) {
-			debug(log, gateway, "reconciliation triggered but gateway does not exist, ignoring")
-			return ctrl.Result{Requeue: false}, nil
+			gateway.Namespace = req.Namespace
+			gateway.Name = req.Name
+			debug(log, gateway, "reconciliation triggered but gateway does not exist, deleting it in dataplane")
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(gateway)
 		}
-		return ctrl.Result{Requeue: true}, r.DataplaneClient.DeleteObject(gateway)
+		return ctrl.Result{Requeue: true}, err
 	}
 	debug(log, gateway, "processing gateway")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

fill in gateway namespace and name when failed to find it in k8s, to print the logs and delete object in dataplane object cache correctly.

It seems that the original implementation operates different from the usual case in other controllers. In common logics of controller, we forget the object it the error is a "not found", and requeue it and report error if other errors happened. Here in the PR I changed the logic to the same as other controllers. Please let me know if there are any considerations for the implementations here.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3069

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
