### PR TITLE
chore: update HTTPRoute controller version in logs

### DIFF
--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -240,7 +240,7 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForGateway(obj client.Object) []reco
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("NetV1Alpha2HTTPRoute", req.NamespacedName)
+	log := r.Log.WithValues("NetV1Beta1HTTPRoute", req.NamespacedName)
 
 	httproute := new(gatewayv1beta1.HTTPRoute)
 	if err := r.Get(ctx, req.NamespacedName, httproute); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

After HTTPRoute has been bumped to v1beta1 in 2.6/2.7 it seems we forgot to update the HTTPRoute controller logger with that information.
