### PR TITLE
chore(ci): change the redhat registry backend to quay

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  RH_SCAN_REGISTRY: scan.connect.redhat.com
+  RH_SCAN_REGISTRY: quay.io
   RH_SCAN_REGISTRY_IMAGE_NAME: ${{ secrets.RH_PROJECT_ID }}/nightly-ingress-controller
 
 jobs:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,29 +7,34 @@ on:
 
 env:
   RH_SCAN_REGISTRY: quay.io
-  RH_SCAN_REGISTRY_IMAGE_NAME: ${{ secrets.RH_PROJECT_ID }}/nightly-ingress-controller
+  RH_SCAN_REGISTRY_IMAGE_NAME: redhat-isv-containers/5eab1b8ea165648bd1353266
 
 jobs:
   build-push-images:
     environment: 'Docker Push'
     runs-on: ubuntu-latest
+    outputs:
+      TAGS_REDHAT_STANDARD: ${{ steps.tags-redhat-standard.outputs.TAGS_REDHAT_STANDARD }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Add standard tags
+        id: tags-standard
         run: |
-          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=raw,value=nightly' >> $GITHUB_ENV
-          echo "type=raw,value={{date 'YYYY-MM-DD'}}" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_OUTPUT
+          echo 'type=raw,value=nightly' >> $GITHUB_OUTPUT
+          echo "type=raw,value={{date 'YYYY-MM-DD'}}" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
       - name: Add Red Hat standard tags
+        id: tags-redhat-standard
         run: |
-          echo 'REDHAT_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=raw,value=nightly,suffix=-redhat' >> $GITHUB_ENV
-          echo "type=raw,value={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          echo 'TAGS_REDHAT_STANDARD<<EOF' >> $GITHUB_OUTPUT
+          echo 'type=raw,value=nightly,suffix=-redhat' >> $GITHUB_OUTPUT
+          echo "type=raw,value={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -46,18 +51,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Login to RH Scan Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.RH_SCAN_REGISTRY }}
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
           images: kong/nightly-ingress-controller
-          tags: ${{ env.TAGS_STANDARD }}
+          tags: ${{ steps.tags-standard.outputs.TAGS_STANDARD }}
       - name: Docker meta (redhat)
         id: meta_redhat
         uses: docker/metadata-action@v4.1.1
@@ -65,15 +64,7 @@ jobs:
           images: kong/nightly-ingress-controller
           flavor: |
             latest=false
-          tags: ${{ env.REDHAT_STANDARD }}
-      - name: Docker meta (redhat scan registry)
-        id: meta_redhat_scan_registry
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: ${{ env.REDHAT_STANDARD }}${{ env.REDHAT_SUPPLEMENTAL }}
+          tags: ${{ steps.tags-redhat-standard.outputs.TAGS_REDHAT_STANDARD }}
       - name: Build binary
         id: docker_build_binary
         uses: docker/build-push-action@v3
@@ -88,7 +79,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push
+      - name: Build and push distroless image to DockerHub
         id: docker_build
         uses: docker/build-push-action@v3
         with:
@@ -102,7 +93,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat image
+      - name: Build and push Red Hat image to DockerHub
         id: docker_build_redhat
         env:
           TAG: ${{ steps.meta.outputs.version }}
@@ -118,6 +109,45 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
+
+  redhat-certification-test:
+    environment: 'Docker Push'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: 
+      - build-push-images
+    env:
+      REDHAT_STANDARD_TAG: ${{ needs.build-push-images.outputs.REDHAT_STANDARD_TAG }}
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to RH Scan Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.RH_SCAN_REGISTRY }}
+          username: ${{ secrets.RH_USERNAME }}
+          password: ${{ secrets.RH_TOKEN }}
+      - name: Docker meta (redhat scan registry)
+        id: meta_redhat_scan_registry
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: ${{ env.REDHAT_STANDARD_TAG }}
       - name: Build image for local Preflight scan
         id: docker_build_redhat_scan_registry
         env:
@@ -142,7 +172,6 @@ jobs:
           username: ${{ secrets.RH_USERNAME }}
           password: ${{ secrets.RH_TOKEN }}
           submit: false
-
   
   # run integration test in latest version of kubernetes.
   test-current-kubernetes:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
         required: true
         default: 'false'
 env:
-  RH_SCAN_REGISTRY: scan.connect.redhat.com
+  RH_SCAN_REGISTRY: quay.io
   RH_SCAN_REGISTRY_IMAGE_NAME: ${{ secrets.RH_PROJECT_ID }}/kong-ingress-controller
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
         default: 'false'
 env:
   RH_SCAN_REGISTRY: quay.io
-  RH_SCAN_REGISTRY_IMAGE_NAME: ${{ secrets.RH_PROJECT_ID }}/kong-ingress-controller
+  RH_SCAN_REGISTRY_IMAGE_NAME: redhat-isv-containers/5eab1b8ea165648bd1353266
 
 jobs:
   verify-manifest-tag:
@@ -142,7 +142,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push
+      - name: Build and push distroless image to DockerHub
         id: docker_build
         uses: docker/build-push-action@v3
         with:
@@ -156,7 +156,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat image
+      - name: Build and push Red Hat image to DockerHub
         id: docker_build_redhat
         env:
           TAG: ${{ steps.meta_redhat.outputs.version }}
@@ -172,7 +172,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat Scan Registry image
+      - name: Build and push Red Hat image to Red Hat Scan Registry
         id: docker_build_redhat_scan_registry
         env:
           TAG: ${{ steps.meta_redhat_scan_registry.outputs.version }}


### PR DESCRIPTION


**What this PR does / why we need it**:

- Change the redhat registry backend to quay.
- Makes the redhat certification scan on nightly runs run in parallel with test.
- Makes the redhat certification scan on nightly runs run optional, not failing the workflow.

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/2977

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
