### PR TITLE
spike: create warning events for parsing errors

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -317,7 +317,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 
 	// parse the Kubernetes objects from the storer into Kong configuration
 	kongstate := p.Build()
-	if errors := p.GetParsingErrors(); errors != nil {
+	if errors := p.PopParsingErrors(); errors != nil {
 		c.createParsingErrorsEvents(errors)
 		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 			metrics.SuccessKey: metrics.SuccessFalse,

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -191,7 +191,8 @@ func (p *Parser) GenerateKubernetesObjectReport() []client.Object {
 	return report
 }
 
-func (p *Parser) GetParsingErrors() []ParsingError {
+// PopParsingErrors pops all the parsing errors collected during the last parsing round.
+func (p *Parser) PopParsingErrors() []ParsingError {
 	errors := p.errorsCollector.errors
 	p.errorsCollector.errors = nil
 	return errors

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -2,22 +2,28 @@ package parser
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 )
 
 // getCACerts translates CA certificates Secrets to kong.CACertificates. It ensures every certificate's structure and
 // validity. In case of violation of any validation rule, a secret gets skipped in a result and error message is logged
 // with affected plugins for context.
-func getCACerts(log logrus.FieldLogger, storer store.Storer, plugins []kongstate.Plugin) []kong.CACertificate {
+func (p *Parser) getCACerts(
+	log logrus.FieldLogger,
+	storer store.Storer,
+) []kong.CACertificate {
 	caCertSecrets, err := storer.ListCACerts()
 	if err != nil {
 		log.WithError(err).Error("failed to list CA certs")
@@ -26,22 +32,18 @@ func getCACerts(log logrus.FieldLogger, storer store.Storer, plugins []kongstate
 
 	var caCerts []kong.CACertificate
 	for _, certSecret := range caCertSecrets {
-		log := log.WithFields(logrus.Fields{
-			"secret_name":      certSecret.Name,
-			"secret_namespace": certSecret.Namespace,
-		})
-
 		idBytes, ok := certSecret.Data["id"]
 		if !ok {
-			log.Error("skipping synchronisation, invalid CA certificate: missing 'id' field in data")
+			p.errorsCollector.ParsingError("invalid CA certificate: missing 'id' field in data", certSecret)
 			continue
 		}
 		secretID := string(idBytes)
 
 		caCert, err := toKongCACertificate(certSecret, secretID)
 		if err != nil {
-			logWithAffectedPlugins(log, plugins, secretID).WithError(err).
-				Error("skipping synchronisation, invalid CA certificate")
+			affectedObjects := getPluginsAssociatedWithCACertSecret(secretID, storer)
+			affectedObjects = append(affectedObjects, certSecret)
+			p.errorsCollector.ParsingError(fmt.Sprintf("invalid CA certificate: %s", err), affectedObjects...)
 			continue
 		}
 
@@ -77,19 +79,17 @@ func toKongCACertificate(certSecret *corev1.Secret, secretID string) (kong.CACer
 	}, nil
 }
 
-func logWithAffectedPlugins(log logrus.FieldLogger, plugins []kongstate.Plugin, secretID string) logrus.FieldLogger {
-	affectedPlugins := getPluginsAssociatedWithCACertSecret(plugins, secretID)
-	return log.WithField("affected_plugins", affectedPlugins)
-}
-
-func getPluginsAssociatedWithCACertSecret(plugins []kongstate.Plugin, secretID string) []string {
-	refersToSecret := func(pluginConfig map[string]interface{}) bool {
-		caCertReferences, ok := pluginConfig["ca_certificates"].([]string)
-		if !ok {
+func getPluginsAssociatedWithCACertSecret(secretID string, storer store.Storer) []client.Object {
+	refersToSecret := func(pluginConfig v1.JSON) bool {
+		cfg := struct {
+			CACertificates []string `json:"ca_certificates,omitempty"`
+		}{}
+		err := json.Unmarshal(pluginConfig.Raw, &cfg)
+		if err != nil {
 			return false
 		}
 
-		for _, reference := range caCertReferences {
+		for _, reference := range cfg.CACertificates {
 			if reference == secretID {
 				return true
 			}
@@ -97,10 +97,15 @@ func getPluginsAssociatedWithCACertSecret(plugins []kongstate.Plugin, secretID s
 		return false
 	}
 
-	var affectedPlugins []string
-	for _, p := range plugins {
-		if refersToSecret(p.Config) && p.Name != nil {
-			affectedPlugins = append(affectedPlugins, *p.Name)
+	var affectedPlugins []client.Object
+	for _, p := range storer.ListKongPlugins() {
+		if refersToSecret(p.Config) {
+			affectedPlugins = append(affectedPlugins, p.DeepCopy())
+		}
+	}
+	for _, p := range storer.ListKongClusterPlugins() {
+		if refersToSecret(p.Config) {
+			affectedPlugins = append(affectedPlugins, p.DeepCopy())
 		}
 	}
 

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 )
 
 func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92" //nolint:gosec
-	plugins := []kongstate.Plugin{
+	// todo: adapt to implementation
+	_ = []kongstate.Plugin{
 		{
 			Plugin: kong.Plugin{
 				Name: kong.String("associated-plugin"),
@@ -35,6 +35,6 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 		},
 	}
 
-	associatedPlugins := getPluginsAssociatedWithCACertSecret(plugins, secretID)
-	require.ElementsMatch(t, []string{"associated-plugin", "another-associated-plugin"}, associatedPlugins)
+	// associatedPlugins := getPluginsAssociatedWithCACertSecret(plugins, secretID)
+	// require.ElementsMatch(t, []string{"associated-plugin", "another-associated-plugin"}, associatedPlugins)
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -139,7 +139,18 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) e
 	if err != nil {
 		return fmt.Errorf("%f is not a valid number of seconds to the timeout config for the kong client: %w", c.ProxyTimeoutSeconds, err)
 	}
-	dataplaneClient, err := dataplane.NewKongClient(deprecatedLogger, timeoutDuration, c.IngressClassName, c.EnableReverseSync, c.SkipCACertificates, diagnostic, kongConfig)
+
+	dataplaneEventRecorder := mgr.GetEventRecorderFor("kubernetes-ingress-controller-data-plane")
+	dataplaneClient, err := dataplane.NewKongClient(
+		deprecatedLogger,
+		timeoutDuration,
+		c.IngressClassName,
+		c.EnableReverseSync,
+		c.SkipCACertificates,
+		diagnostic,
+		kongConfig,
+		dataplaneEventRecorder,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize kong data-plane client: %w", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -96,6 +96,8 @@ type Storer interface {
 	ListTCPIngresses() ([]*kongv1beta1.TCPIngress, error)
 	ListUDPIngresses() ([]*kongv1beta1.UDPIngress, error)
 	ListKnativeIngresses() ([]*knative.Ingress, error)
+	ListKongPlugins() []*kongv1.KongPlugin
+	ListKongClusterPlugins() []*kongv1.KongClusterPlugin
 	ListGlobalKongPlugins() ([]*kongv1.KongPlugin, error)
 	ListGlobalKongClusterPlugins() ([]*kongv1.KongClusterPlugin, error)
 	ListKongConsumers() []*kongv1.KongConsumer
@@ -959,6 +961,28 @@ func (s Store) ListGlobalKongClusterPlugins() ([]*kongv1.KongClusterPlugin, erro
 		return nil, err
 	}
 	return plugins, nil
+}
+
+func (s Store) ListKongClusterPlugins() []*kongv1.KongClusterPlugin {
+	var plugins []*kongv1.KongClusterPlugin
+	for _, item := range s.stores.ClusterPlugin.List() {
+		p, ok := item.(*kongv1.KongClusterPlugin)
+		if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.IngressClassKey, s.getIngressClassHandling()) {
+			plugins = append(plugins, p)
+		}
+	}
+	return plugins
+}
+
+func (s Store) ListKongPlugins() []*kongv1.KongPlugin {
+	var plugins []*kongv1.KongPlugin
+	for _, item := range s.stores.Plugin.List() {
+		p, ok := item.(*kongv1.KongPlugin)
+		if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.IngressClassKey, s.getIngressClassHandling()) {
+			plugins = append(plugins, p)
+		}
+	}
+	return plugins
 }
 
 // ListCACerts returns all Secrets containing the label


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds a way to collect translation errors while running Parser and use them to publish Kubernetes API Event objects with a detailed message describing every failure. Every error can be associated with one or more k8s objects and one event per such object gets created. 

**Special notes for your reviewer**:

This PR serves as a reference prototype and is meant to be thrown away. It's expected that some of the tests won't pass. Please focus on the general idea of introducing Events publishing to Parser. 

Fully-fledged implementation will be done once we create an issue and groom it.

Please take a look at my in-line comments to quicker grasp the main points of the changes.