### PR TITLE
refactor(parser): extract functions to be used in HTTPRouteMatch consolidation

### DIFF
--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -290,7 +290,7 @@ func generateKongRouteFromHTTPRouteMatches(
 	for _, match := range matches {
 		// configure path matching information about the route if paths matching was defined
 		// Kong automatically infers whether or not a path is a regular expression and uses a prefix match by
-		// default it it is not. For those types, we use the path value as-is and let Kong determine the type.
+		// default if it is not. For those types, we use the path value as-is and let Kong determine the type.
 		// For exact matches, we transform the path into a regular expression that terminates after the value
 		if match.Path != nil {
 			path := generateKongRoutePathFromHTTPRouteMatch(match, addRegexPrefix)

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -71,7 +71,7 @@ func (p *Parser) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewa
 		}
 
 		// create a service and attach the routes to it
-		service, err := generateKongServiceFromBackendRef(p.logger, p.storer, result, tcproute, ruleNumber, "tcp", rule.BackendRefs...)
+		service, err := generateKongServiceFromBackendRefWithRuleNumber(p.logger, p.storer, result, tcproute, ruleNumber, "tcp", rule.BackendRefs...)
 		if err != nil {
 			return err
 		}

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -79,7 +79,7 @@ func (p *Parser) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *gatewa
 		}
 
 		// create a service and attach the routes to it
-		service, err := generateKongServiceFromBackendRef(p.logger, p.storer, result, tlsroute, ruleNumber, "tcp", rule.BackendRefs...)
+		service, err := generateKongServiceFromBackendRefWithRuleNumber(p.logger, p.storer, result, tlsroute, ruleNumber, "tcp", rule.BackendRefs...)
 		if err != nil {
 			return err
 		}

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -71,7 +71,7 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 		}
 
 		// create a service and attach the routes to it
-		service, err := generateKongServiceFromBackendRef(p.logger, p.storer, result, udproute, ruleNumber, "udp", rule.BackendRefs...)
+		service, err := generateKongServiceFromBackendRefWithRuleNumber(p.logger, p.storer, result, udproute, ruleNumber, "udp", rule.BackendRefs...)
 		if err != nil {
 			return err
 		}

--- a/internal/dataplane/parser/translate_utils_test.go
+++ b/internal/dataplane/parser/translate_utils_test.go
@@ -800,7 +800,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
-			result, err := generateKongServiceFromBackendRef(p.logger, p.storer, &rules, tt.route, ruleNumber, protocol, tt.refs...)
+			result, err := generateKongServiceFromBackendRefWithRuleNumber(p.logger, p.storer, &rules, tt.route, ruleNumber, protocol, tt.refs...)
 			assert.Equal(t, tt.result, result)
 			if tt.wantErr {
 				assert.NotNil(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the functions used for route translation, so the PR https://github.com/Kong/kubernetes-ingress-controller/pull/3060/ has less noise.

Changes to kong route generation:
- Added  `generateKongRouteFromHTTPRouteMatches` function, that generates the `kong.Route` from a list of backends. It's being invoked in `generateKongRoutesFromHTTPRouteRule` function on two codepaths, thus reducing amount of copied code. It will be used in one more place when #3060 is merged. 
- `generateKongRoutesFromHTTPRouteRule` was made smaller by extracting code blocks into a descriptive functions.
- The new `kong.Rote` generation logic from #3060 is not able to reuse `generateKongRoutesFromHTTPRouteRule`, but `generateKongRouteFromHTTPRouteMatches` will be used, thus the amount of copied code will be reduced.


Changes to kong service generation:
- `generateKongServiceFromBackendRef` was replaced by two functions: `generateKongServiceFromBackendRefWithRuleNumber` and `generateKongServiceFromBackendRefWithName`.
- Originally `generateKongServiceFromBackendRef` was a function that generated a kong service given a backend refs from `HTTPRouteRule` and rule number in the `HTTPRoute`. In order to name the generated `kong.Service` it used the route rule number from the parent `HTTPRoute` object. Before #3008 it was one service per rule, thus using route rule number made sense. When #3008 introduced consolidation of rules used to generate a services based on same backeds, the naming scheme used was based first rule number that was consolidated. However, I strongly feel that passing a rule number to `generateKongServiceFromBackendRef` was misleading in case consolidated service routes, as it's purpose as an input argument was not clear. 
- New function `generateKongServiceFromBackendRefWithRuleNumber` does the same what `generateKongServiceFromBackendRef` was doing originally. All places that used `generateKongServiceFromBackendRefWithRuleNumber`, except the consolidated service generation, are using now this function.
- New function `generateKongServiceFromBackendRefWithName` does the same what `generateKongServiceFromBackendRef` was doing, but it does not attempt to provide a `kong.Route` name. Instead it must be provided by a caller. This function is used by `generateKongServiceFromBackendRefWithRuleNumber`. It will be used in other code path when #3060 is merge.


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
