### PR TITLE
chore(tests): add k8s obj info  utility to reduce parser tests lengths

### DIFF
--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -121,16 +121,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("www.konghq.com"),
 									},
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -242,16 +233,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -394,16 +376,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -478,16 +451,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -588,16 +552,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										},
 										StripPath: pointer.BoolPtr(false),
 									},
-									Ingress: util.K8sObjectInfo{
-										Name:        "basic-httproute",
-										Namespace:   corev1.NamespaceDefault,
-										Annotations: make(map[string]string),
-										GroupVersionKind: schema.GroupVersionKind{
-											Group:   "gateway.networking.k8s.io",
-											Version: "v1beta1",
-											Kind:    "HTTPRoute",
-										},
-									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 								{
 									Route: kong.Route{
@@ -612,16 +567,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										},
 										StripPath: pointer.BoolPtr(false),
 									},
-									Ingress: util.K8sObjectInfo{
-										Name:        "basic-httproute",
-										Namespace:   corev1.NamespaceDefault,
-										Annotations: make(map[string]string),
-										GroupVersionKind: schema.GroupVersionKind{
-											Group:   "gateway.networking.k8s.io",
-											Version: "v1beta1",
-											Kind:    "HTTPRoute",
-										},
-									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 							},
 							Parent: routes[0],
@@ -729,16 +675,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: &gatewayv1beta1.HTTPRoute{
 								Spec: gatewayv1beta1.HTTPRouteSpec{
@@ -836,16 +773,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -1016,16 +944,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										},
 										StripPath: pointer.BoolPtr(false),
 									},
-									Ingress: util.K8sObjectInfo{
-										Name:        "basic-httproute",
-										Namespace:   corev1.NamespaceDefault,
-										Annotations: make(map[string]string),
-										GroupVersionKind: schema.GroupVersionKind{
-											Group:   "gateway.networking.k8s.io",
-											Version: "v1beta1",
-											Kind:    "HTTPRoute",
-										},
-									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 								{
 									Route: kong.Route{
@@ -1040,16 +959,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										},
 										StripPath: pointer.BoolPtr(false),
 									},
-									Ingress: util.K8sObjectInfo{
-										Name:        "basic-httproute",
-										Namespace:   corev1.NamespaceDefault,
-										Annotations: make(map[string]string),
-										GroupVersionKind: schema.GroupVersionKind{
-											Group:   "gateway.networking.k8s.io",
-											Version: "v1beta1",
-											Kind:    "HTTPRoute",
-										},
-									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 							},
 							Parent: &gatewayv1beta1.HTTPRoute{
@@ -1212,16 +1122,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										},
 										StripPath: pointer.BoolPtr(false),
 									},
-									Ingress: util.K8sObjectInfo{
-										Name:        "basic-httproute",
-										Namespace:   corev1.NamespaceDefault,
-										Annotations: make(map[string]string),
-										GroupVersionKind: schema.GroupVersionKind{
-											Group:   "gateway.networking.k8s.io",
-											Version: "v1beta1",
-											Kind:    "HTTPRoute",
-										},
-									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
 							},
 							Parent: routes[0],
@@ -1428,16 +1329,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 									},
 									StripPath: pointer.BoolPtr(false),
 								},
-								Ingress: util.K8sObjectInfo{
-									Name:        "basic-httproute",
-									Namespace:   corev1.NamespaceDefault,
-									Annotations: make(map[string]string),
-									GroupVersionKind: schema.GroupVersionKind{
-										Group:   "gateway.networking.k8s.io",
-										Version: "v1beta1",
-										Kind:    "HTTPRoute",
-									},
-								},
+								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
 							Parent: routes[0],
 						},
@@ -1478,4 +1370,23 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 
 func HTTPMethodPointer(method string) *gatewayv1beta1.HTTPMethod {
 	return (*gatewayv1beta1.HTTPMethod)(&method)
+}
+
+func k8sObjectInfoOfHTTPRoute(route *gatewayv1beta1.HTTPRoute) util.K8sObjectInfo {
+	// parsers always provide the annotations map, even if route didn't have any
+	anotations := route.Annotations
+	if anotations == nil {
+		anotations = make(map[string]string)
+	}
+
+	return util.K8sObjectInfo{
+		Name:        route.Name,
+		Namespace:   route.Namespace,
+		Annotations: anotations,
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "gateway.networking.k8s.io",
+			Version: "v1beta1",
+			Kind:    "HTTPRoute",
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a k8s obj info  utility function to reduce parser tests lengths.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
