### PR TITLE
chore(ci): exclude generated files from pr size calculations using globbing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 **/zz_generated*.go linguist-generated=true
-pkg/apis/** linguist-generated=true
 pkg/clientset/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-zz_generated_*.go linguist-generated=true
+**/zz_generated*.go linguist-generated=true
+pkg/apis/** linguist-generated=true
+pkg/clientset/** linguist-generated=true


### PR DESCRIPTION
**What this PR does / why we need it**:

Excludes generated files from [pull-request-size](https://github.com/noqcks/pull-request-size) calculation. 

As it was discovered, the tool does not use `.gitattributes` globbing the way we would expect it to do (the same way as git does). Instead, it uses its own library for that purpose ([`minimatch`](https://github.com/noqcks/pull-request-size/blob/f839be1b2b91687584602f24e753325eeb0166c3/index.js#L99)). This change uses this intel to match all generated files in the repository using patterns that `minimatch` library will accept fine. 

It was tested against all generated files in the repository: https://codesandbox.io/s/js-playground-forked-fvx49r?file=/src/index.js

As I understand the tool code it uses [`.gitattributes` from main](https://github.com/noqcks/pull-request-size/blob/f839be1b2b91687584602f24e753325eeb0166c3/index.js#L68), so I expect this to take effect after merging. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~