### PR TITLE
Add TranslationError and TranslationErrorsCollector with unit tests

### DIFF
--- a/internal/dataplane/parser/errors.go
+++ b/internal/dataplane/parser/errors.go
@@ -1,0 +1,75 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TranslationError represents an error occurring during translating Kubernetes objects into Kong ones.
+// It can be associated with one or more Kubernetes objects.
+type TranslationError struct {
+	causingObjects []client.Object
+	reason         string
+}
+
+// NewTranslationError creates a TranslationError with a reason that should be a human-readable explanation
+// of the error reason, and an causingObjects slice that specifies what objects have caused the error.
+func NewTranslationError(reason string, causingObjects ...client.Object) (TranslationError, error) {
+	if reason == "" {
+		reason = "unknown"
+	}
+	if len(causingObjects) < 1 {
+		return TranslationError{}, fmt.Errorf("no causing objects specified, reason: %s", reason)
+	}
+
+	return TranslationError{
+		causingObjects: causingObjects,
+		reason:         reason,
+	}, nil
+}
+
+// CausingObjects returns a slice of objects that have caused the translation error.
+func (p TranslationError) CausingObjects() []client.Object {
+	return p.causingObjects
+}
+
+// Reason returns a human-readable reason of the error.
+func (p TranslationError) Reason() string {
+	return p.reason
+}
+
+// TranslationErrorsCollector should be used to collect all translation errors that happen during the translation process.
+type TranslationErrorsCollector struct {
+	errors []TranslationError
+	logger logrus.FieldLogger
+}
+
+func NewTranslationErrorsCollector(logger logrus.FieldLogger) (*TranslationErrorsCollector, error) {
+	if logger == nil {
+		return nil, errors.New("missing logger")
+	}
+	return &TranslationErrorsCollector{logger: logger}, nil
+}
+
+// PushTranslationError registers a translation error.
+func (c *TranslationErrorsCollector) PushTranslationError(reason string, causingObjects ...client.Object) {
+	translationErr, err := NewTranslationError(reason, causingObjects...)
+	if err != nil {
+		c.logger.Warningf("failed to create translation error: %w", err)
+		return
+	}
+
+	c.errors = append(c.errors, translationErr)
+}
+
+// PopTranslationErrors returns all translation errors that occurred during the translation process and erases them
+// in the collector. It makes the collector reusable during next translation runs.
+func (c *TranslationErrorsCollector) PopTranslationErrors() []TranslationError {
+	errs := c.errors
+	c.errors = nil
+
+	return errs
+}

--- a/internal/dataplane/parser/errors_test.go
+++ b/internal/dataplane/parser/errors_test.go
@@ -1,0 +1,83 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+)
+
+const someValidTranslationErrorReason = "some valid reason"
+
+var someValidTranslationErrorCausingObjects = []client.Object{&kongv1.KongIngress{}, &kongv1.KongPlugin{}}
+
+func TestTranslationError(t *testing.T) {
+
+	t.Run("is_created_and_returns_reason_and_causing_objects", func(t *testing.T) {
+		transErr, err := parser.NewTranslationError(someValidTranslationErrorReason, someValidTranslationErrorCausingObjects...)
+		require.NoError(t, err)
+
+		assert.Equal(t, someValidTranslationErrorReason, transErr.Reason())
+		assert.ElementsMatch(t, someValidTranslationErrorCausingObjects, transErr.CausingObjects())
+	})
+
+	t.Run("fallbacks_to_unknown_reason_when_empty", func(t *testing.T) {
+		transErr, err := parser.NewTranslationError("", someValidTranslationErrorCausingObjects...)
+		require.NoError(t, err)
+		require.Equal(t, "unknown", transErr.Reason())
+	})
+
+	t.Run("requires_at_least_one_causing_object", func(t *testing.T) {
+		_, err := parser.NewTranslationError(someValidTranslationErrorReason, someValidTranslationErrorCausingObjects[0])
+		require.NoError(t, err)
+
+		_, err = parser.NewTranslationError(someValidTranslationErrorReason)
+		require.Error(t, err)
+	})
+}
+
+func TestTranslationErrorsCollector(t *testing.T) {
+	testLogger, _ := test.NewNullLogger()
+
+	t.Run("is_created_when_logger_valid", func(t *testing.T) {
+		collector, err := parser.NewTranslationErrorsCollector(testLogger)
+		require.NoError(t, err)
+		require.NotNil(t, collector)
+	})
+
+	t.Run("requires_non_nil_logger", func(t *testing.T) {
+		_, err := parser.NewTranslationErrorsCollector(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("pushes_and_pops_translation_errors", func(t *testing.T) {
+		collector, err := parser.NewTranslationErrorsCollector(testLogger)
+		require.NoError(t, err)
+
+		collector.PushTranslationError(someValidTranslationErrorReason, someValidTranslationErrorCausingObjects...)
+		collector.PushTranslationError(someValidTranslationErrorReason, someValidTranslationErrorCausingObjects...)
+
+		collectedErrors := collector.PopTranslationErrors()
+		require.Len(t, collectedErrors, 2)
+		require.Empty(t, collector.PopTranslationErrors(), "second call should not return any error")
+	})
+
+	t.Run("does_not_crash_but_logs_warning_when_no_causing_objects_passed", func(t *testing.T) {
+		logger, loggerHook := test.NewNullLogger()
+		collector, err := parser.NewTranslationErrorsCollector(logger)
+		require.NoError(t, err)
+
+		collector.PushTranslationError(someValidTranslationErrorReason)
+
+		lastLog := loggerHook.LastEntry()
+		require.NotNil(t, lastLog)
+		require.Equal(t, logrus.WarnLevel, lastLog.Level)
+		require.Len(t, collector.PopTranslationErrors(), 0, "no errors expected - causing objects missing")
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces utility types that are going to be used for collecting errors that happen during the translation process. 

**Which issue this PR fixes**:
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3097. 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
