### PR TITLE
feat(#3097): use TranslationFailureCollector in Parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.50
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
 	github.com/sethvargo/go-password v0.2.0
@@ -131,7 +132,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220512140940-7b36cea86235 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.50
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
 	github.com/sethvargo/go-password v0.2.0
@@ -132,6 +131,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220512140940-7b36cea86235 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -320,7 +320,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 			metrics.SuccessKey: metrics.SuccessFalse,
 		}).Inc()
-		c.logger.Debugf("%d translation failures has occurred when building data-plane configuration")
+		c.logger.Debugf("%d translation failures have occurred when building data-plane configuration")
 	} else {
 		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 			metrics.SuccessKey: metrics.SuccessTrue,

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -301,7 +300,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 
 	p, err := parser.NewParser(c.logger, storer)
 	if err != nil {
-		return errors.Wrap(err, "failed to create parser")
+		return fmt.Errorf("failed to create parser: %w", err)
 	}
 	formatVersion := "1.1"
 	if c.AreKubernetesObjectReportsEnabled() {

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -316,11 +316,11 @@ func (c *KongClient) Update(ctx context.Context) error {
 
 	// parse the Kubernetes objects from the storer into Kong configuration
 	kongstate, translationFailures := p.Build()
-	if len(translationFailures) > 0 {
+	if failuresCount := len(translationFailures); failuresCount > 0 {
 		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 			metrics.SuccessKey: metrics.SuccessFalse,
 		}).Inc()
-		c.logger.Debugf("%d translation failures have occurred when building data-plane configuration")
+		c.logger.Debugf("%d translation failures have occurred when building data-plane configuration", failuresCount)
 	} else {
 		c.prometheusMetrics.TranslationCount.With(prometheus.Labels{
 			metrics.SuccessKey: metrics.SuccessTrue,

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -77,7 +77,8 @@ func NewParser(
 // -----------------------------------------------------------------------------
 
 // Build creates a Kong configuration from Ingress and Custom resources
-// defined in Kubernetes.
+// defined in Kubernetes. It returns a slice of TranslationFailures which should
+// be used to provide users with feedback on Kubernetes objects validity.
 func (p *Parser) Build() (*kongstate.KongState, []TranslationFailure) {
 	// parse and merge all rules together from all Kubernetes API sources
 	ingressRules := mergeIngressRules(

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -51,7 +51,7 @@ type Parser struct {
 	featureEnabledCombinedServiceRoutes             bool
 
 	flagEnabledRegexPathPrefix bool
-	errorsCollector            *TranslationFailuresCollector
+	failuresCollector          *TranslationFailuresCollector
 }
 
 // NewParser produces a new Parser object provided a logging mechanism
@@ -60,15 +60,15 @@ func NewParser(
 	logger logrus.FieldLogger,
 	storer store.Storer,
 ) (*Parser, error) {
-	errorsCollector, err := NewTranslationFailuresCollector(logger)
+	failuresCollector, err := NewTranslationFailuresCollector(logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create translation errors collector: %w", err)
 	}
 
 	return &Parser{
-		logger:          logger,
-		storer:          storer,
-		errorsCollector: errorsCollector,
+		logger:            logger,
+		storer:            storer,
+		failuresCollector: failuresCollector,
 	}, nil
 }
 
@@ -183,7 +183,7 @@ func (p *Parser) EnableRegexPathPrefix() {
 }
 
 func (p *Parser) popTranslationFailures() []TranslationFailure {
-	return p.errorsCollector.PopTranslationFailures()
+	return p.failuresCollector.PopTranslationFailures()
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
@@ -63,7 +62,7 @@ func NewParser(
 ) (*Parser, error) {
 	errorsCollector, err := NewTranslationFailuresCollector(logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create translation errors collector")
+		return nil, fmt.Errorf("failed to create translation errors collector: %w", err)
 	}
 
 	return &Parser{

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
@@ -280,8 +281,10 @@ func TestGlobalPlugin(t *testing.T) {
 			},
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected one plugin to be rendered")
@@ -461,8 +464,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.Nil(err)
 			assert.NotNil(state)
 			assert.Equal(3, len(state.Plugins),
@@ -566,8 +571,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.Nil(err)
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
@@ -668,8 +675,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
 				"expected no plugins to be rendered")
@@ -719,8 +728,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 		}
 		store, err := store.NewFakeStore(objects)
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		for _, testcase := range references {
 			config, err := kongstate.SecretToConfiguration(store, *testcase, "default")
@@ -817,8 +828,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 			assert.Equal(0, len(state.Plugins),
 				"expected no plugins to be rendered")
@@ -851,8 +864,10 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.CACertificates))
@@ -901,8 +916,10 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(2, len(state.CACertificates))
@@ -979,8 +996,10 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.CACertificates))
@@ -1062,8 +1081,10 @@ func TestServiceClientCertificate(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"expected one certificates to be rendered")
@@ -1129,8 +1150,10 @@ func TestServiceClientCertificate(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")
@@ -1189,8 +1212,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -1268,8 +1293,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -1348,8 +1375,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1429,8 +1458,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1509,8 +1540,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1589,8 +1622,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1669,8 +1704,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1749,8 +1786,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -1829,8 +1868,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one service to be rendered")
@@ -1907,8 +1948,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one service to be rendered")
@@ -1985,8 +2028,10 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		kongTrue := kong.Bool(true)
@@ -2045,8 +2090,10 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2095,8 +2142,10 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(0, len(state.Services),
@@ -2172,8 +2221,10 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2250,8 +2301,10 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2319,8 +2372,10 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services), "expected one knative service")
@@ -2404,8 +2459,10 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			KongPlugins:      plugins,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2514,8 +2571,10 @@ func TestKongServiceAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2596,8 +2655,10 @@ func TestKongServiceAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.Services),
@@ -2684,8 +2745,10 @@ func TestKongServiceAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 			assert.NotNil(state)
 
 			assert.Equal(1, len(state.Services),
@@ -2753,8 +2816,10 @@ func TestDefaultBackend(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Services),
 			"expected one service to be rendered")
@@ -2821,8 +2886,10 @@ func TestDefaultBackend(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")
@@ -2886,8 +2953,10 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered with empty secret")
@@ -2967,8 +3036,10 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"certificates are de-duplicated")
@@ -3093,8 +3164,10 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"certificates are de-duplicated")
@@ -3174,8 +3247,10 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates),
 			"SNIs are de-duplicated")
@@ -3256,8 +3331,10 @@ func TestParserSNI(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3320,8 +3397,10 @@ func TestParserSNI(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3379,8 +3458,10 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3431,8 +3512,10 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3484,8 +3567,10 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.00"),
@@ -3573,8 +3658,10 @@ func TestPluginAnnotations(t *testing.T) {
 			KongPlugins:      plugins,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3670,8 +3757,10 @@ func TestPluginAnnotations(t *testing.T) {
 			KongClusterPlugins: clusterPlugins,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3740,8 +3829,10 @@ func TestPluginAnnotations(t *testing.T) {
 			KongClusterPlugins: clusterPlugins,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -3786,8 +3877,10 @@ func TestPluginAnnotations(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Plugins),
 			"expected no plugins to be rendered with missing plugin")
@@ -4582,8 +4675,10 @@ func TestPickPort(t *testing.T) {
 			store, err := store.NewFakeStore(tt.objs)
 			assert.NoError(err)
 
-			p := NewParser(logrus.New(), store)
-			state := p.Build()
+			p, err := NewParser(logrus.New(), store)
+			require.NoError(t, err)
+			state, translationFailures := p.Build()
+			require.Empty(t, translationFailures)
 
 			assert.Equal(tt.wantTarget, *state.Upstreams[0].Targets[0].Target.Target)
 		})
@@ -4695,8 +4790,10 @@ func TestCertificate(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(3, len(state.Certificates))
 		// foo.com with cert should be fixed
@@ -4787,8 +4884,10 @@ func TestCertificate(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p := NewParser(logrus.New(), store)
-		state := p.Build()
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+		state, translationFailures := p.Build()
+		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates))
 		assert.Equal(state.Certificates[0], fooCertificate)

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -281,8 +281,7 @@ func TestGlobalPlugin(t *testing.T) {
 			},
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -464,8 +463,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.Nil(err)
@@ -571,8 +569,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.Nil(err)
@@ -675,8 +672,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -728,8 +724,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 		}
 		store, err := store.NewFakeStore(objects)
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -828,8 +823,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			}
 			store, err := store.NewFakeStore(objects)
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -864,8 +858,7 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -916,8 +909,7 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -996,8 +988,7 @@ func TestCACertificate(t *testing.T) {
 			Secrets: secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1081,8 +1072,7 @@ func TestServiceClientCertificate(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1150,8 +1140,7 @@ func TestServiceClientCertificate(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1212,8 +1201,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1293,8 +1281,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1375,8 +1362,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1458,8 +1444,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1540,8 +1525,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1622,8 +1606,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1704,8 +1687,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1786,8 +1768,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -1868,8 +1849,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -1948,8 +1928,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2028,8 +2007,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2090,8 +2068,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2142,8 +2119,7 @@ func TestKongProcessClasslessIngress(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2221,8 +2197,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2301,8 +2276,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2372,8 +2346,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2459,8 +2432,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			KongPlugins:      plugins,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2571,8 +2543,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2655,8 +2626,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2745,8 +2715,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 				Services:         services,
 			})
 			assert.Nil(err)
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 			assert.NotNil(state)
@@ -2816,8 +2785,7 @@ func TestDefaultBackend(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2886,8 +2854,7 @@ func TestDefaultBackend(t *testing.T) {
 			Services:         services,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -2953,8 +2920,7 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3036,8 +3002,7 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3164,8 +3129,7 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3247,8 +3211,7 @@ func TestParserSecret(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3331,8 +3294,7 @@ func TestParserSNI(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3397,8 +3359,7 @@ func TestParserSNI(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3458,8 +3419,7 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3512,8 +3472,7 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3567,8 +3526,7 @@ func TestParserHostAliases(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3658,8 +3616,7 @@ func TestPluginAnnotations(t *testing.T) {
 			KongPlugins:      plugins,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3757,8 +3714,7 @@ func TestPluginAnnotations(t *testing.T) {
 			KongClusterPlugins: clusterPlugins,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3829,8 +3785,7 @@ func TestPluginAnnotations(t *testing.T) {
 			KongClusterPlugins: clusterPlugins,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -3877,8 +3832,7 @@ func TestPluginAnnotations(t *testing.T) {
 			IngressesV1beta1: ingresses,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -4675,8 +4629,7 @@ func TestPickPort(t *testing.T) {
 			store, err := store.NewFakeStore(tt.objs)
 			assert.NoError(err)
 
-			p, err := NewParser(logrus.New(), store)
-			require.NoError(t, err)
+			p := mustNewParser(t, store)
 			state, translationFailures := p.Build()
 			require.Empty(t, translationFailures)
 
@@ -4790,8 +4743,7 @@ func TestCertificate(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
@@ -4884,12 +4836,17 @@ func TestCertificate(t *testing.T) {
 			Secrets:          secrets,
 		})
 		assert.Nil(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
 		require.Empty(t, translationFailures)
 		assert.NotNil(state)
 		assert.Equal(1, len(state.Certificates))
 		assert.Equal(state.Certificates[0], fooCertificate)
 	})
+}
+
+func mustNewParser(t *testing.T, storer store.Storer) *Parser {
+	p, err := NewParser(logrus.New(), storer)
+	require.NoError(t, err)
+	return p
 }

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -968,7 +968,9 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.msg, func(t *testing.T) {
-			p := NewParser(logrus.New(), fakestore)
+			p, err := NewParser(logrus.New(), fakestore)
+			require.NoError(t, err)
+
 			ingressRules := newIngressRules()
 
 			var errs []error
@@ -1002,7 +1004,8 @@ func TestIngressRulesFromHTTPRoutesWithCombinedServiceRoutes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.msg, func(t *testing.T) {
-			p := NewParser(logrus.New(), fakestore)
+			p, err := NewParser(logrus.New(), fakestore)
+			require.NoError(t, err)
 			p.EnableCombinedServiceRoutes()
 
 			ingressRules := newIngressRules()
@@ -1080,9 +1083,11 @@ func TestGetHTTPRouteHostnamesAsSliceOfStringPointers(t *testing.T) {
 func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 	fakestore, err := store.NewFakeStore(store.FakeObjects{})
 	require.NoError(t, err)
-	parser := NewParser(logrus.New(), fakestore)
+	parser, err := NewParser(logrus.New(), fakestore)
+	require.NoError(t, err)
 	parser.EnableRegexPathPrefix()
-	parserWithCombinedServiceRoutes := NewParser(logrus.New(), fakestore)
+	parserWithCombinedServiceRoutes, err := NewParser(logrus.New(), fakestore)
+	require.NoError(t, err)
 	parserWithCombinedServiceRoutes.EnableRegexPathPrefix()
 	parserWithCombinedServiceRoutes.EnableCombinedServiceRoutes()
 	httpPort := gatewayv1beta1.PortNumber(80)

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -968,8 +967,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.msg, func(t *testing.T) {
-			p, err := NewParser(logrus.New(), fakestore)
-			require.NoError(t, err)
+			p := mustNewParser(t, fakestore)
 
 			ingressRules := newIngressRules()
 
@@ -1004,8 +1002,7 @@ func TestIngressRulesFromHTTPRoutesWithCombinedServiceRoutes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.msg, func(t *testing.T) {
-			p, err := NewParser(logrus.New(), fakestore)
-			require.NoError(t, err)
+			p := mustNewParser(t, fakestore)
 			p.EnableCombinedServiceRoutes()
 
 			ingressRules := newIngressRules()
@@ -1083,11 +1080,10 @@ func TestGetHTTPRouteHostnamesAsSliceOfStringPointers(t *testing.T) {
 func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 	fakestore, err := store.NewFakeStore(store.FakeObjects{})
 	require.NoError(t, err)
-	parser, err := NewParser(logrus.New(), fakestore)
+	parser := mustNewParser(t, fakestore)
 	require.NoError(t, err)
 	parser.EnableRegexPathPrefix()
-	parserWithCombinedServiceRoutes, err := NewParser(logrus.New(), fakestore)
-	require.NoError(t, err)
+	parserWithCombinedServiceRoutes := mustNewParser(t, fakestore)
 	parserWithCombinedServiceRoutes.EnableRegexPathPrefix()
 	parserWithCombinedServiceRoutes.EnableCombinedServiceRoutes()
 	httpPort := gatewayv1beta1.PortNumber(80)

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -300,7 +300,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			IngressesV1beta1: []*netv1beta1.Ingress{},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -315,7 +316,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -330,7 +332,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			IngressesV1beta1: []*netv1beta1.Ingress{ingressList[0], ingressList[2]},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
@@ -351,7 +354,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -365,7 +369,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -386,7 +391,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
@@ -399,7 +405,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		assert.NotPanics(func() {
 			p.ingressRulesFromIngressV1beta1()
@@ -412,7 +419,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
@@ -425,7 +433,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Empty(parsedInfo.ServiceNameToServices)
@@ -437,7 +446,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
@@ -786,7 +796,8 @@ func TestFromIngressV1(t *testing.T) {
 			IngressesV1: []*netv1.Ingress{},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(ingressRules{
@@ -801,7 +812,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -819,7 +831,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
@@ -840,7 +853,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -854,7 +868,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -875,7 +890,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
@@ -888,7 +904,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		assert.NotPanics(func() {
 			p.ingressRulesFromIngressV1()
@@ -901,7 +918,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal("foo-svc.foo-namespace.80.svc",
@@ -916,7 +934,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Empty(parsedInfo.ServiceNameToServices)
@@ -928,7 +947,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"]
@@ -941,7 +961,8 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
@@ -993,7 +1014,9 @@ func TestFromIngressV1_RegexPrefix(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
+
 		p.EnableRegexPathPrefix()
 
 		parsedInfo := p.ingressRulesFromIngressV1()

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
@@ -300,8 +299,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			IngressesV1beta1: []*netv1beta1.Ingress{},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -316,8 +314,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -332,8 +329,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			IngressesV1beta1: []*netv1beta1.Ingress{ingressList[0], ingressList[2]},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
@@ -354,8 +350,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -369,8 +364,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -391,8 +385,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
@@ -405,8 +398,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		assert.NotPanics(func() {
 			p.ingressRulesFromIngressV1beta1()
@@ -419,8 +411,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
@@ -433,8 +424,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Empty(parsedInfo.ServiceNameToServices)
@@ -446,8 +436,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
@@ -796,8 +785,7 @@ func TestFromIngressV1(t *testing.T) {
 			IngressesV1: []*netv1.Ingress{},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(ingressRules{
@@ -812,8 +800,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -831,8 +818,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
@@ -853,8 +839,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -868,8 +853,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -890,8 +874,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
@@ -904,8 +887,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		assert.NotPanics(func() {
 			p.ingressRulesFromIngressV1()
@@ -918,8 +900,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal("foo-svc.foo-namespace.80.svc",
@@ -934,8 +915,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Empty(parsedInfo.ServiceNameToServices)
@@ -947,8 +927,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"]
@@ -961,8 +940,7 @@ func TestFromIngressV1(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
@@ -1014,8 +992,7 @@ func TestFromIngressV1_RegexPrefix(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		p.EnableRegexPathPrefix()
 

--- a/internal/dataplane/parser/translate_knative_test.go
+++ b/internal/dataplane/parser/translate_knative_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -220,7 +221,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			KnativeIngresses: []*knative.Ingress{},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
@@ -233,7 +235,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
@@ -246,7 +249,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -291,7 +295,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(SecretNameToSNIs(map[string][]string{
@@ -306,7 +311,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -351,7 +357,8 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))

--- a/internal/dataplane/parser/translate_knative_test.go
+++ b/internal/dataplane/parser/translate_knative_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -221,8 +219,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			KnativeIngresses: []*knative.Ingress{},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
@@ -235,8 +232,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
@@ -249,8 +245,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -295,8 +290,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(SecretNameToSNIs(map[string][]string{
@@ -311,8 +305,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -357,8 +350,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -167,7 +168,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			TCPIngresses: []*configurationv1beta1.TCPIngress{},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -182,7 +184,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -197,7 +200,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -225,7 +229,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -254,7 +259,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -268,7 +274,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -283,7 +290,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -298,7 +306,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p := NewParser(logrus.New(), store)
+		p, err := NewParser(logrus.New(), store)
+		require.NoError(t, err)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -168,8 +166,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			TCPIngresses: []*configurationv1beta1.TCPIngress{},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -184,8 +181,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -200,8 +196,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -229,8 +224,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
@@ -259,8 +253,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
@@ -274,8 +267,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -290,8 +282,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
@@ -306,8 +297,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 			},
 		})
 		assert.NoError(err)
-		p, err := NewParser(logrus.New(), store)
-		require.NoError(t, err)
+		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{

--- a/internal/dataplane/parser/translate_utils_test.go
+++ b/internal/dataplane/parser/translate_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -507,7 +508,8 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 	}
 	fakestore, err := store.NewFakeStore(store.FakeObjects{ReferenceGrants: grants})
 	assert.Nil(t, err)
-	p := NewParser(logrus.New(), fakestore)
+	p, err := NewParser(logrus.New(), fakestore)
+	require.NoError(t, err)
 	// empty since we always want to actually generate a service for tests
 	// static values for the basic string format inputs since nothing interesting happens with them
 	rules := ingressRules{ServiceNameToServices: map[string]kongstate.Service{}}

--- a/internal/dataplane/parser/translate_utils_test.go
+++ b/internal/dataplane/parser/translate_utils_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -508,8 +506,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 	}
 	fakestore, err := store.NewFakeStore(store.FakeObjects{ReferenceGrants: grants})
 	assert.Nil(t, err)
-	p, err := NewParser(logrus.New(), fakestore)
-	require.NoError(t, err)
+	p := mustNewParser(t, fakestore)
 	// empty since we always want to actually generate a service for tests
 	// static values for the basic string format inputs since nothing interesting happens with them
 	rules := ingressRules{ServiceNameToServices: map[string]kongstate.Service{}}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -82,7 +82,8 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 			Name: MetricNameTranslationCount,
 			Help: fmt.Sprintf(
 				"Count of translations from Kubernetes state to Kong state. "+
-					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`).",
+					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`). "+
+					"Unrecoverable error in this case means KIC wasn't able to translate a Kubernetes object to Kong model.",
 				SuccessKey, SuccessFalse, SuccessTrue,
 			),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds `TranslationFailureCollector` to the `Parser`. `Build` method is modified so that translation failures are returned from it. `KongClient` inspects the failures and in case any occurred, reports `TranslationCount` metric with `SuccessKey=SuccessFalse`. 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3097.

**Special notes for your reviewer**:

Number of the line changes in this PR is mostly affected by the alignments after making `Build` method propagate `[]TranslationFailure` and `Parser` constructors returning an error. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
