### PR TITLE
feat(#3097): propagate translation failures of CA certificate secrets

### DIFF
--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -192,19 +192,16 @@ func (p *Parser) registerTranslationFailure(reason string, causingObjects ...cli
 	p.logTranslationFailure(reason, causingObjects...)
 }
 
-// logTranslationFailure logs an error message signaling that a translation error has occurred along with its reason.
-// `causing_objects` log field is populated with a slice of "GVK, ns/name" strings of translation failure causing objects.
+// logTranslationFailure logs an error message signaling that a translation error has occurred along with its reason
+// for every causing object.
 func (p *Parser) logTranslationFailure(reason string, causingObjects ...client.Object) {
-	objString := func(o client.Object) string {
-		return o.GetObjectKind().GroupVersionKind().String() + ", " + o.GetNamespace() + "/" + o.GetName()
+	for _, obj := range causingObjects {
+		p.logger.WithFields(logrus.Fields{
+			"name":      obj.GetName(),
+			"namespace": obj.GetNamespace(),
+			"GVK":       obj.GetObjectKind().GroupVersionKind().String(),
+		}).Errorf("translation failed: %s", reason)
 	}
-
-	objectsStrings := make([]string, 0, len(causingObjects))
-	for _, o := range causingObjects {
-		objectsStrings = append(objectsStrings, objString(o))
-	}
-
-	p.logger.WithField("causing_objects", objectsStrings).Errorf("translation failure has occurred: %s", reason)
 }
 
 func (p *Parser) popTranslationFailures() []TranslationFailure {

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -920,7 +920,7 @@ func TestCACertificate(t *testing.T) {
 		secrets := []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
+					Name:      "valid-cert",
 					Namespace: "default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
@@ -936,7 +936,7 @@ func TestCACertificate(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bar",
+					Name:      "missing-cert-key",
 					Namespace: "non-default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
@@ -952,7 +952,7 @@ func TestCACertificate(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "baz",
+					Name:      "missing-id-key",
 					Namespace: "non-default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
@@ -968,7 +968,7 @@ func TestCACertificate(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "baz",
+					Name:      "expired-cert",
 					Namespace: "non-default",
 					Labels: map[string]string{
 						"konghq.com/ca-cert": "true",
@@ -990,7 +990,7 @@ func TestCACertificate(t *testing.T) {
 		assert.Nil(err)
 		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
-		require.Empty(t, translationFailures)
+		assert.Len(translationFailures, 3)
 		assert.NotNil(state)
 
 		assert.Equal(1, len(state.CACertificates))

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -17,8 +17,7 @@ import (
 )
 
 // getCACerts translates CA certificates Secrets to kong.CACertificates. It ensures every certificate's structure and
-// validity. In case of violation of any validation rule, a secret gets skipped in a result, and a translation failure
-// is reported.
+// validity. It skips Secrets that do not contain a valid certificate and reports translation failures for them.
 func (p *Parser) getCACerts() []kong.CACertificate {
 	caCertSecrets, err := p.storer.ListCACerts()
 	if err != nil {

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -2,46 +2,44 @@ package parser
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 )
 
 // getCACerts translates CA certificates Secrets to kong.CACertificates. It ensures every certificate's structure and
-// validity. In case of violation of any validation rule, a secret gets skipped in a result and error message is logged
-// with affected plugins for context.
-func getCACerts(log logrus.FieldLogger, storer store.Storer, plugins []kongstate.Plugin) []kong.CACertificate {
-	caCertSecrets, err := storer.ListCACerts()
+// validity. In case of violation of any validation rule, a secret gets skipped in a result, and a translation failure
+// is reported.
+func (p *Parser) getCACerts() []kong.CACertificate {
+	caCertSecrets, err := p.storer.ListCACerts()
 	if err != nil {
-		log.WithError(err).Error("failed to list CA certs")
+		p.logger.WithError(err).Error("failed to list CA certs")
 		return nil
 	}
 
 	var caCerts []kong.CACertificate
 	for _, certSecret := range caCertSecrets {
-		log := log.WithFields(logrus.Fields{
-			"secret_name":      certSecret.Name,
-			"secret_namespace": certSecret.Namespace,
-		})
-
 		idBytes, ok := certSecret.Data["id"]
 		if !ok {
-			log.Error("skipping synchronisation, invalid CA certificate: missing 'id' field in data")
+			p.registerTranslationFailure("invalid CA certificate: missing 'id' field in data", certSecret)
 			continue
 		}
 		secretID := string(idBytes)
 
 		caCert, err := toKongCACertificate(certSecret, secretID)
 		if err != nil {
-			logWithAffectedPlugins(log, plugins, secretID).WithError(err).
-				Error("skipping synchronisation, invalid CA certificate")
+			relatedObjects := getPluginsAssociatedWithCACertSecret(secretID, p.storer)
+			relatedObjects = append(relatedObjects, certSecret.DeepCopy())
+			p.registerTranslationFailure(fmt.Sprintf("invalid CA certificate: %s", err), relatedObjects...)
 			continue
 		}
 
@@ -77,19 +75,17 @@ func toKongCACertificate(certSecret *corev1.Secret, secretID string) (kong.CACer
 	}, nil
 }
 
-func logWithAffectedPlugins(log logrus.FieldLogger, plugins []kongstate.Plugin, secretID string) logrus.FieldLogger {
-	affectedPlugins := getPluginsAssociatedWithCACertSecret(plugins, secretID)
-	return log.WithField("affected_plugins", affectedPlugins)
-}
-
-func getPluginsAssociatedWithCACertSecret(plugins []kongstate.Plugin, secretID string) []string {
-	refersToSecret := func(pluginConfig map[string]interface{}) bool {
-		caCertReferences, ok := pluginConfig["ca_certificates"].([]string)
-		if !ok {
+func getPluginsAssociatedWithCACertSecret(secretID string, storer store.Storer) []client.Object {
+	refersToSecret := func(pluginConfig v1.JSON) bool {
+		cfg := struct {
+			CACertificates []string `json:"ca_certificates,omitempty"`
+		}{}
+		err := json.Unmarshal(pluginConfig.Raw, &cfg)
+		if err != nil {
 			return false
 		}
 
-		for _, reference := range caCertReferences {
+		for _, reference := range cfg.CACertificates {
 			if reference == secretID {
 				return true
 			}
@@ -97,10 +93,15 @@ func getPluginsAssociatedWithCACertSecret(plugins []kongstate.Plugin, secretID s
 		return false
 	}
 
-	var affectedPlugins []string
-	for _, p := range plugins {
-		if refersToSecret(p.Config) && p.Name != nil {
-			affectedPlugins = append(affectedPlugins, *p.Name)
+	var affectedPlugins []client.Object
+	for _, p := range storer.ListKongPlugins() {
+		if refersToSecret(p.Config) {
+			affectedPlugins = append(affectedPlugins, p.DeepCopy())
+		}
+	}
+	for _, p := range storer.ListKongClusterPlugins() {
+		if refersToSecret(p.Config) {
+			affectedPlugins = append(affectedPlugins, p.DeepCopy())
 		}
 	}
 

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -37,18 +37,24 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 		}
 	}
 
-	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92"        //nolint:gosec
-	anotherSecretID := "99fa09c7-f849-4449-891e-19b9a0015763" //nolint:gosec
-	associatedPlugin := kongPluginWithSecret("associated_plugin", secretID)
-	nonAssociatedPlugin := kongPluginWithSecret("non_associated_plugin", anotherSecretID)
-	associatedClusterPlugin := kongClusterPluginWithSecret("associated_cluster_plugin", secretID)
-	nonAssociatedClusterPlugin := kongClusterPluginWithSecret("non_associated_cluster_plugin", anotherSecretID)
+	//nolint:gosec
+	const (
+		secretID        = "8a3753e0-093b-43d9-9d39-27985c987d92"
+		anotherSecretID = "99fa09c7-f849-4449-891e-19b9a0015763"
+	)
+	var (
+		associatedPlugin           = kongPluginWithSecret("associated_plugin", secretID)
+		nonAssociatedPlugin        = kongPluginWithSecret("non_associated_plugin", anotherSecretID)
+		associatedClusterPlugin    = kongClusterPluginWithSecret("associated_cluster_plugin", secretID)
+		nonAssociatedClusterPlugin = kongClusterPluginWithSecret("non_associated_cluster_plugin", anotherSecretID)
+	)
 	storer, err := store.NewFakeStore(store.FakeObjects{
 		KongPlugins:        []*kongv1.KongPlugin{associatedPlugin, nonAssociatedPlugin},
 		KongClusterPlugins: []*kongv1.KongClusterPlugin{associatedClusterPlugin, nonAssociatedClusterPlugin},
 	})
 	require.NoError(t, err)
 
-	associatedPlugins := getPluginsAssociatedWithCACertSecret(secretID, storer)
-	require.ElementsMatch(t, []client.Object{associatedPlugin, associatedClusterPlugin}, associatedPlugins)
+	gotPlugins := getPluginsAssociatedWithCACertSecret(secretID, storer)
+	expectedPlugins := []client.Object{associatedPlugin, associatedClusterPlugin}
+	require.ElementsMatch(t, expectedPlugins, gotPlugins, "expected plugins do not match actual ones")
 }

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -37,8 +37,8 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 		}
 	}
 
-	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92"        // nolint:gosec
-	anotherSecretID := "99fa09c7-f849-4449-891e-19b9a0015763" // nolint:gosec
+	secretID := "8a3753e0-093b-43d9-9d39-27985c987d92"        //nolint:gosec
+	anotherSecretID := "99fa09c7-f849-4449-891e-19b9a0015763" //nolint:gosec
 	associatedPlugin := kongPluginWithSecret("associated_plugin", secretID)
 	nonAssociatedPlugin := kongPluginWithSecret("non_associated_plugin", anotherSecretID)
 	associatedClusterPlugin := kongClusterPluginWithSecret("associated_cluster_plugin", secretID)


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds helper methods to the Parser that allow reporting translation failures and uses them to propagate CA certificate secrets' issues. 

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3097.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
