### PR TITLE
fix: use GetFullSchema instead of deprecated GetSchema

### DIFF
--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -127,7 +127,7 @@ func FillPluginConfig(schema map[string]interface{},
 		return nil, err
 	}
 	// Get all in the schema
-	value := gjson.ParseBytes((jsonb))
+	value := gjson.ParseBytes((jsonb)).Get("config")
 	return fillRecord(value, config)
 }
 

--- a/internal/util/plugin_schema_helper.go
+++ b/internal/util/plugin_schema_helper.go
@@ -38,7 +38,7 @@ func (p *PluginSchemaStore) Schema(ctx context.Context, pluginName string) (map[
 	}
 
 	// not present in cache, lookup
-	schema, err := p.client.Plugins.GetSchema(ctx, &pluginName) //nolint:staticcheck
+	schema, err := p.client.Plugins.GetFullSchema(ctx, &pluginName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

`GetSchema` and the API called `GET /plugins/schema/<plugin_name>` are deprecated. Use `GetFullSchema` (calling `GET /schemas/plugins/<plugin_name>` instead).

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #3086 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
