### PR TITLE
tests: fix the missing controller logs

### DIFF
--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -3,9 +3,12 @@ package rootcmd
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 )
 
+// Run starts the controller manager.
 func Run(c *manager.Config) error {
 	ctx, err := SetupSignalHandler(c)
 	if err != nil {
@@ -17,4 +20,19 @@ func Run(c *manager.Config) error {
 		return fmt.Errorf("failed to start diagnostics server: %w", err)
 	}
 	return manager.Run(ctx, c, diag.ConfigDumps)
+}
+
+// RunWithLogger starts the controller manager.
+// This function is intended for use in tests, where the logger can be injected.
+func RunWithLogger(c *manager.Config, l logrus.FieldLogger) error {
+	ctx, err := SetupSignalHandler(c)
+	if err != nil {
+		return fmt.Errorf("failed to setup signal handler: %w", err)
+	}
+
+	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c)
+	if err != nil {
+		return fmt.Errorf("failed to start diagnostics server: %w", err)
+	}
+	return manager.RunWithLogger(ctx, c, diag.ConfigDumps, l)
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -39,10 +40,16 @@ import (
 
 // Run starts the controller manager and blocks until it exits.
 func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) error {
-	deprecatedLogger, _, err := setupLoggers(c)
+	deprecatedLogger, _, err := SetupLoggers(c)
 	if err != nil {
 		return err
 	}
+	return RunWithLogger(ctx, c, diagnostic, deprecatedLogger)
+}
+
+// RunWithLogger starts the controller manager and blocks until it exits.
+// This function is intended for use in tests, where the logger can be injected.
+func RunWithLogger(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, deprecatedLogger logrus.FieldLogger) error {
 	setupLog := ctrl.Log.WithName("setup")
 	setupLog.Info("starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.V(util.DebugLevel).Info("the ingress class name has been set", "value", c.IngressClassName)

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -30,7 +30,8 @@ import (
 // Controller Manager - Setup Utility Functions
 // -----------------------------------------------------------------------------
 
-func setupLoggers(c *Config) (logrus.FieldLogger, logr.Logger, error) {
+// SetupLoggers sets up the loggers for the controller manager.
+func SetupLoggers(c *Config) (logrus.FieldLogger, logr.Logger, error) {
 	deprecatedLogger, err := util.MakeLogger(c.LogLevel, c.LogFormat)
 	if err != nil {
 		return nil, logr.Logger{}, fmt.Errorf("failed to make logger: %w", err)

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -50,7 +50,8 @@ func TestGatewayConformance(t *testing.T) {
 		"--feature-gates=GatewayAlpha=true",
 		"--anonymous-reports=false",
 	}
-	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, env.Cluster(), args...))
+
+	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalLogger, env.Cluster(), args...))
 
 	t.Log("creating GatewayClass for gateway conformance tests")
 	gwc := &gatewayv1beta1.GatewayClass{

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -14,14 +14,18 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/sirupsen/logrus"
+
+	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 )
 
 var (
 	existingCluster = os.Getenv("KONG_TEST_CLUSTER")
 	ingressClass    = "kong-conformance-tests"
 
-	env environments.Environment
-	ctx context.Context
+	env          environments.Environment
+	ctx          context.Context
+	globalLogger logrus.FieldLogger
 )
 
 func TestMain(m *testing.M) {
@@ -29,11 +33,22 @@ func TestMain(m *testing.M) {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
+	// Logger needs to be configured before anything else happens.
+	// This is because the controller manager has a timeout for
+	// logger initialization, and if the logger isn't configured
+	// after 30s from the start of controller manager package init function,
+	// the controller manager will set up a no op logger and continue.
+	// The logger cannot be configured after that point.
+	logger, _, err := testutils.SetupLoggers("trace", "text", false)
+	if err != nil {
+		exitOnErr(fmt.Errorf("failed to setup loggers: %w", err))
+	}
+	globalLogger = logger
+
 	kongAddon := kong.NewBuilder().WithControllerDisabled().WithProxyAdminServiceTypeLoadBalancer().Build()
 	builder := environments.NewBuilder().WithAddons(metallb.New(), kongAddon)
 	useExistingClusterIfPresent(builder)
 
-	var err error
 	env, err = builder.Build(ctx)
 	exitOnErr(err)
 	defer func() {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -175,6 +175,10 @@ const (
 	// problems setting up the testing environment and/or cluster.
 	ExitCodeEnvSetupFailed = 104
 
+	// ExitCodeCentCreateLogger is a POSIX compliant exit code for the test suite to indicate
+	// that a failure occurred when trying to create a logger for the test suite.
+	ExitCodeCantCreateLogger = 105
+
 	// kongTestPassword is used as a password only within the context of transient integration test runs
 	// and is left static to help developers debug failures in those testing environments.
 	kongTestPassword = "password"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes missing controller logs in integrations tests.

Logger needs to be configured before anything else happens.This is because the controller manager has a timeout for logger initialization, and if the logger isn't configured after 30s from the start of controller manager package init function, the controller manager will set up a no op logger and continue. The logger cannot be configured after that point.


**Which issue this PR fixes**:

Fixes #2882

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
