### PR TITLE
Handle HTTPRoutes with invalid header filters

### DIFF
--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -5,5 +5,5 @@ package consts
 const (
 	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v0.5.1"
 	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1"
-	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.1"
+	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/rainest/gateway-api/header-filter-single"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a controller mechanism to scan HTTPRoutes for misconfiguration. If the HTTPRoute is invalid, it is not added to the store (or is removed if it was already present) and is not converted to a Kong route. The controller adds a Condition to the HTTPRoute indicating the cause of the problem.

Adds a controller validation check to confirm that an HTTPRoute does not have a header filter that manipulates the same header twice.

**Which issue this PR fixes**:

Related to discussions in https://github.com/kubernetes-sigs/gateway-api/issues/480. Written in advance of the actual spec change to demonstrate implementation viability.

**Special notes for your reviewer**:

This breaks the status quo for our resource processing. Our existing logic tends to be best-effort, with errors handled in the parser: we will add partial configuration for a resource if invalid sections do not break it entirely. For example, following this pattern for this case would have us create the Kong route for the HTTPRoute still, but we would omit the invalid header transformations.

GWAPI promotes the opposite approach: invalid configuration invalidates the entire resource. Sub-resource partial configuration generally violates the spec. We should move toward this approach, but we don't yet do it across the board and the mixture means we have inconsistent UX.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
