### PR TITLE
feat(#3097): create warning translation failure events for CA secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ Adding a new version? You'll need three changes:
   irrelevant secrets (e.g: service account tokens) are not stored. This change
   is made to reduce memory usage of the cache.
   [#3047](https://github.com/Kong/kubernetes-ingress-controller/pull/3047)
+- Warning events are recorded when CA secrets cannot be properly translated into Kong configuration.  
+  [#3125](https://github.com/Kong/kubernetes-ingress-controller/pull/3125)
 
 ### Fixed
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -6,14 +6,13 @@ import (
 	"sync"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
-
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
@@ -128,6 +127,7 @@ func NewKongClient(
 	skipCACertificates bool,
 	diagnostic util.ConfigDumpDiagnostic,
 	kongConfig sendconfig.Kong,
+	eventRecorder record.EventRecorder,
 ) (*KongClient, error) {
 	// build the client object
 	cache := store.NewCacheStores()
@@ -141,6 +141,7 @@ func NewKongClient(
 		prometheusMetrics:  metrics.NewCtrlFuncMetrics(),
 		cache:              &cache,
 		kongConfig:         kongConfig,
+		eventRecorder:      eventRecorder,
 	}
 
 	// download the kong root configuration (and validate connectivity to the proxy API)

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -26,9 +26,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
-const (
-	KongConfigurationTranslationFailedEventReason = "KongConfigurationTranslationFailed"
-)
+// KongConfigurationTranslationFailedEventReason defines an event reason used for creating all translation failure events.
+const KongConfigurationTranslationFailedEventReason = "KongConfigurationTranslationFailed"
 
 // -----------------------------------------------------------------------------
 // Dataplane Client - Kong - Public Types
@@ -460,6 +459,8 @@ func (c *KongClient) updateKubernetesObjectReportFilter(set k8sobj.Set) {
 	c.kubernetesObjectReportsFilter = set
 }
 
+// recordTranslationFailureWarningEvents records a warning KongConfigurationTranslationFailedEventReason events,
+// one per a translation failure causing object.
 func (c *KongClient) recordTranslationFailureWarningEvents(translationFailures []parser.TranslationFailure) {
 	for _, failure := range translationFailures {
 		for _, obj := range failure.CausingObjects() {

--- a/internal/manager/consts.go
+++ b/internal/manager/consts.go
@@ -19,3 +19,6 @@ const MetricsPort = 10255
 
 // DiagnosticsPort is the default port of the manager's diagnostics service listens on.
 const DiagnosticsPort = 10256
+
+// KongClientEventRecorderComponentName is a KongClient component name used to identify an events recording component.
+const KongClientEventRecorderComponentName = "kong-client"

--- a/internal/manager/consts.go
+++ b/internal/manager/consts.go
@@ -20,5 +20,5 @@ const MetricsPort = 10255
 // DiagnosticsPort is the default port of the manager's diagnostics service listens on.
 const DiagnosticsPort = 10256
 
-// KongClientEventRecorderComponentName is a KongClient component name used to identify an events recording component.
+// KongClientEventRecorderComponentName is a KongClient component name used to identify the events recording component.
 const KongClientEventRecorderComponentName = "kong-client"

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -34,8 +34,6 @@ import (
 	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
-const KongClientEventRecorderComponentName = "kong-client"
-
 // -----------------------------------------------------------------------------
 // Controller Manager - Setup & Run
 // -----------------------------------------------------------------------------

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -60,12 +60,8 @@ func TestTranslationFailures(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			start := time.Now()
 			ns, cleaner := setup(t)
-			defer func() {
-				assert.NoError(t, cleaner.Cleanup(ctx))
-				t.Logf("test case took: %dms", time.Since(start).Milliseconds())
-			}()
+			defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
 
 			expectedCausingObjects := tt.translationFailureTrigger(t, ns.GetName())
 

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 )
 
-const InvalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae"
+const InvalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae" //nolint:gosec
 
 func invalidCASecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
@@ -83,6 +83,7 @@ func TestTranslationFailures(t *testing.T) {
 				c, err := clientset.NewForConfig(env.Cluster().Config())
 				require.NoError(t, err)
 				createdPlugin, err := c.ConfigurationV1().KongPlugins(ns).Create(ctx, pluginUsingInvalidCACert(ns), metav1.CreateOptions{})
+				require.NoError(t, err)
 
 				// expect events for both: a faulty secret and a plugin referring it
 				return []client.Object{createdSecret, createdPlugin}

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -8,36 +8,108 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 )
+
+const InvalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae"
+
+func invalidCASecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ca-secret-",
+			Namespace:    ns,
+			Labels: map[string]string{
+				"konghq.com/ca-cert": "true",
+			},
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Data: map[string][]byte{
+			"id": []byte(InvalidCASecretID),
+			// missing cert key
+		},
+	}
+}
+
+func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
+	return &kongv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kong-plugin-",
+			Namespace:    ns,
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Config:     v1.JSON{Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, InvalidCASecretID))},
+		PluginName: "mtls-auth",
+	}
+}
 
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
-	ns, cleaner := setup(t)
-	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
-
 	testCases := []struct {
-		name                      string
-		translationFailureTrigger func()
-		expectEventsForObjects    []string
-	}{}
+		name string
+		// translationFailureTrigger should create objects that trigger translation failure and return the objects
+		// that we expect translation failure warning events to be created for.
+		translationFailureTrigger func(ns string) []client.Object
+	}{
+		{
+			name: "invalid CA secret",
+			translationFailureTrigger: func(ns string) []client.Object {
+				createdSecret, err := env.Cluster().Client().CoreV1().Secrets(ns).Create(ctx, invalidCASecret(ns), metav1.CreateOptions{})
+				require.NoError(t, err)
+
+				return []client.Object{createdSecret}
+			},
+		},
+		{
+			name: "invalid CA secret referred by a plugin",
+			translationFailureTrigger: func(ns string) []client.Object {
+				createdSecret, err := env.Cluster().Client().CoreV1().Secrets(ns).Create(ctx, invalidCASecret(ns), metav1.CreateOptions{})
+				require.NoError(t, err)
+
+				c, err := clientset.NewForConfig(env.Cluster().Config())
+				require.NoError(t, err)
+				createdPlugin, err := c.ConfigurationV1().KongPlugins(ns).Create(ctx, pluginUsingInvalidCACert(ns), metav1.CreateOptions{})
+
+				// expect events for both: a faulty secret and a plugin referring it
+				return []client.Object{createdSecret, createdPlugin}
+			},
+		},
+	}
 
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tt.translationFailureTrigger()
+			ns, cleaner := setup(t)
+			defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
+			expectedCausingObjects := tt.translationFailureTrigger(ns.GetName())
 
 			require.Eventually(t, func() bool {
 				eventsForAllObjectsFound := true
-				for _, objectName := range tt.expectEventsForObjects {
+
+				for _, expectedCausingObject := range expectedCausingObjects {
 					events, err := env.Cluster().Client().CoreV1().Events(ns.GetName()).List(ctx, metav1.ListOptions{
-						FieldSelector: fmt.Sprintf("reason=%s", dataplane.KongConfigurationTranslationFailedEventReason),
+						FieldSelector: fmt.Sprintf(
+							"reason=%s,type=%s,involvedObject.name=%s",
+							dataplane.KongConfigurationTranslationFailedEventReason,
+							corev1.EventTypeWarning,
+							expectedCausingObject.GetName(),
+						),
 					})
 					if err != nil {
 						t.Logf("failed to list events: %s", err)
@@ -45,12 +117,13 @@ func TestTranslationFailures(t *testing.T) {
 					}
 
 					if len(events.Items) == 0 {
-						t.Logf("waiting for events related to %s to be created", objectName)
+						t.Logf("waiting for events related to '%s' to be created", expectedCausingObject.GetName())
 						eventsForAllObjectsFound = false
 					}
 				}
+
 				return eventsForAllObjectsFound
-			}, time.Minute, time.Second)
+			}, time.Minute*5, time.Second)
 		})
 	}
 }

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -21,41 +21,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 )
 
-const InvalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae" //nolint:gosec
-
-func invalidCASecret(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "ca-secret-",
-			Namespace:    ns,
-			Labels: map[string]string{
-				"konghq.com/ca-cert": "true",
-			},
-			Annotations: map[string]string{
-				annotations.IngressClassKey: ingressClass,
-			},
-		},
-		Data: map[string][]byte{
-			"id": []byte(InvalidCASecretID),
-			// missing cert key
-		},
-	}
-}
-
-func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
-	return &kongv1.KongPlugin{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "kong-plugin-",
-			Namespace:    ns,
-			Annotations: map[string]string{
-				annotations.IngressClassKey: ingressClass,
-			},
-		},
-		Config:     v1.JSON{Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, InvalidCASecretID))},
-		PluginName: "mtls-auth",
-	}
-}
-
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
@@ -126,5 +91,40 @@ func TestTranslationFailures(t *testing.T) {
 				return eventsForAllObjectsFound
 			}, time.Minute*5, time.Second)
 		})
+	}
+}
+
+const invalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae" //nolint:gosec
+
+func invalidCASecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ca-secret-",
+			Namespace:    ns,
+			Labels: map[string]string{
+				"konghq.com/ca-cert": "true",
+			},
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Data: map[string][]byte{
+			"id": []byte(invalidCASecretID),
+			// missing cert key
+		},
+	}
+}
+
+func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
+	return &kongv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kong-plugin-",
+			Namespace:    ns,
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Config:     v1.JSON{Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, invalidCASecretID))},
+		PluginName: "mtls-auth",
 	}
 }

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -1,0 +1,56 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
+// encountered.
+func TestTranslationFailures(t *testing.T) {
+	ns, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
+	testCases := []struct {
+		name                      string
+		translationFailureTrigger func()
+		expectEventsForObjects    []string
+	}{}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.translationFailureTrigger()
+
+			require.Eventually(t, func() bool {
+				eventsForAllObjectsFound := true
+				for _, objectName := range tt.expectEventsForObjects {
+					events, err := env.Cluster().Client().CoreV1().Events(ns.GetName()).List(ctx, metav1.ListOptions{
+						FieldSelector: fmt.Sprintf("reason=%s", dataplane.KongConfigurationTranslationFailedEventReason),
+					})
+					if err != nil {
+						t.Logf("failed to list events: %s", err)
+						eventsForAllObjectsFound = false
+					}
+
+					if len(events.Items) == 0 {
+						t.Logf("waiting for events related to %s to be created", objectName)
+						eventsForAllObjectsFound = false
+					}
+				}
+				return eventsForAllObjectsFound
+			}, time.Minute, time.Second)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It starts creating Kubernetes Events for all TranslationFailures detected during the translation phase. It will create one event per causing object. An integration test suite is also added in order to track all translation failure cases - that should make eventual future refactors safer (e.g. moving validation rules from the parser to the controllers). 

**Which issue this PR fixes**:

Part of #3097. 

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
