### PR TITLE
feat(gateway-api): add destination port matching GEP-957

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ Adding a new version? You'll need three changes:
 - CRDs' validations improvements: `UDPIngressRule.Port`, `IngressRule.Port` and `IngressBackend.ServiceName`
   instead of being validated in the Parser, are validated by the Kubernetes API now.
   [#3136](https://github.com/Kong/kubernetes-ingress-controller/pull/3136)
+- Gateway API: Implement port matching for routes as defined in
+  [GEP-957](https://gateway-api.sigs.k8s.io/geps/gep-957/)
+  [#3129](https://github.com/Kong/kubernetes-ingress-controller/pull/3129)
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
+	github.com/samber/lo v1.33.0
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.8 // indirect
 	github.com/ssgelm/cookiejarparser v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -675,6 +675,8 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.33.0 h1:2aKucr+rQV6gHpY3bpeZu69uYoQOzVhGT3J22Op6Cjk=
+github.com/samber/lo v1.33.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -729,6 +731,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
 github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -417,7 +417,7 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 	// 0.0.0.0 as the address for its listeners internally). In order to get addresses we have to derive them
 	// from the Kubernetes Service which will also give us all the L4 information about the proxy. From there
 	// we can use that L4 information to derive the higher level TLS and HTTP,GRPC, e.t.c. information from
-	// the data-plane's // metadata.
+	// the data-plane's metadata.
 	debug(log, gateway, "determining listener configurations from publish service")
 	kongAddresses, kongListeners, err := r.determineL4ListenersFromService(log, svc)
 	if err != nil {

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -336,6 +336,12 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{Requeue: true}, nil
 			}
 		}
+	} else {
+		// route is not accepted, remove it from kong store
+		if err := r.DataplaneClient.DeleteObject(httproute); err != nil {
+			debug(log, httproute, "failed to delete object in data-plane, requeueing")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// now that the object has been successfully configured for in the dataplane

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -1,13 +1,35 @@
 package gateway
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
+
+func init() {
+	if err := corev1.AddToScheme(scheme.Scheme); err != nil {
+		fmt.Println("error while adding core1 scheme")
+		os.Exit(1)
+	}
+	if err := gatewayv1beta1.Install(scheme.Scheme); err != nil {
+		fmt.Println("error while adding gatewayv1beta1 scheme")
+		os.Exit(1)
+	}
+}
 
 func TestFilterHostnames(t *testing.T) {
 	commonGateway := &gatewayv1beta1.Gateway{
@@ -163,4 +185,407 @@ func TestFilterHostnames(t *testing.T) {
 		filteredHTTPRoute := filterHostnames(tc.gateways, tc.httpRoute)
 		assert.Equal(t, tc.expectedHTTPRoute.Spec, filteredHTTPRoute.Spec, tc.name)
 	}
+}
+
+func addressOf[T any](v T) *T {
+	return &v
+}
+
+func Test_getSupportedGatewayForRoute(t *testing.T) {
+	t.Run("HTTPRoute", func(t *testing.T) {
+		type expected struct {
+			gateway      types.NamespacedName
+			condition    metav1.Condition
+			listenerName string
+		}
+		tests := []struct {
+			name     string
+			route    *HTTPRoute
+			expected []expected
+			objects  []client.Object
+			wantErr  bool
+		}{
+			{
+				name: "basic HTTPRoute gets accepted",
+				route: &HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1beta1.RouteReasonAccepted),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute specifying existing section name gets Accepted",
+				route: &HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name:        gatewayv1beta1.ObjectName("test-gateway"),
+									SectionName: addressOf(gatewayv1beta1.SectionName("http")),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "http",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1beta1.RouteReasonAccepted),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute specifying existing port gets Accepted",
+				route: &HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+									Port: addressOf(gatewayv1beta1.PortNumber(80)),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1beta1.RouteReasonAccepted),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
+				route: &HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+									Port: addressOf(gatewayv1beta1.PortNumber(80)),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(81),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(RouteReasonNoMatchingListenerPort),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				fakeClient := fakeclient.
+					NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(tt.objects...).
+					Build()
+
+				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Len(t, got, len(tt.expected))
+
+					for i := range got {
+						assert.Equalf(t, tt.expected[i].gateway.Namespace, got[i].gateway.Namespace, "gateway namespace #%d", i)
+						assert.Equalf(t, tt.expected[i].gateway.Name, got[i].gateway.Name, "gateway name #%d", i)
+						assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
+						assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
+					}
+				}
+			})
+		}
+	})
 }

--- a/internal/controllers/gateway/types.go
+++ b/internal/controllers/gateway/types.go
@@ -6,6 +6,7 @@ import (
 )
 
 type (
+	BackendRef        = gatewayv1beta1.BackendRef
 	Gateway           = gatewayv1beta1.Gateway
 	GatewayAddress    = gatewayv1beta1.GatewayAddress
 	GatewayClass      = gatewayv1beta1.GatewayClass

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -403,6 +403,9 @@ func getGatewayCerts(log logrus.FieldLogger, s store.Storer) []certWrapper {
 		}
 		for _, listener := range gateway.Spec.Listeners {
 			ready := false
+			// TODO: invert the logic to prevent logs about missing listener status
+			// where it's actually in place?
+			// Relevant issue: https://github.com/Kong/kubernetes-ingress-controller/issues/3133
 			if status, ok := statuses[listener.Name]; ok {
 				log.WithFields(logrus.Fields{
 					"gateway":  gateway.Name,

--- a/internal/dataplane/parser/translate_errors.go
+++ b/internal/dataplane/parser/translate_errors.go
@@ -1,0 +1,10 @@
+package parser
+
+import "errors"
+
+var (
+	errRouteValidationNoRules                          = errors.New("no rules provided")
+	errRouteValidationMissingBackendRefs               = errors.New("missing backendRef in rule")
+	errRouteValidationQueryParamMatchesUnsupported     = errors.New("query param matches are not yet supported")
+	errRouteValidationNoMatchRulesOrHostnamesSpecified = errors.New("no match rules or hostnames specified")
+)

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -131,7 +130,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 				}
 			},
 			errs: []error{
-				fmt.Errorf("no match rules or hostnames specified"),
+				errRouteValidationNoMatchRulesOrHostnamesSpecified,
 			},
 		},
 		{
@@ -210,7 +209,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 				}
 			},
 			errs: []error{
-				fmt.Errorf("no rules provided"),
+				errRouteValidationNoRules,
 			},
 		},
 		{
@@ -239,7 +238,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 				}
 			},
 			errs: []error{
-				fmt.Errorf("query param matches are not yet supported"),
+				errRouteValidationQueryParamMatchesUnsupported,
 			},
 		},
 		{
@@ -1104,7 +1103,9 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 			assert.Equal(t, expectedIngressRules, ingressRules)
 
 			// verify that we receive any and all expected errors
-			assert.Equal(t, tt.errs, errs)
+			for i := range tt.errs {
+				assert.ErrorIs(t, errs[i], tt.errs[i])
+			}
 		})
 	}
 }
@@ -1140,7 +1141,9 @@ func TestIngressRulesFromHTTPRoutesWithCombinedServiceRoutes(t *testing.T) {
 			assert.Equal(t, expectedIngressRules, ingressRules)
 
 			// verify that we receive any and all expected errors
-			assert.Equal(t, tt.errs, errs)
+			for i := range tt.errs {
+				assert.ErrorIs(t, errs[i], tt.errs[i])
+			}
 		})
 	}
 }

--- a/internal/dataplane/parser/translate_routes_helpers.go
+++ b/internal/dataplane/parser/translate_routes_helpers.go
@@ -123,16 +123,6 @@ func tcpRouteToKongRoute(
 }
 
 func backendRefsToKongCIDRPorts(backendRefs []gatewayv1alpha2.BackendRef) []*kong.CIDRPort {
-	// For now, Gateway Routes provide no means of specifying a destination port
-	// other than the backend target port
-	//
-	// They will once https://gateway-api.sigs.k8s.io/geps/gep-957/ is stable.
-	// In the interim, this always uses the backend target.
-	//
-	// NOTE: The above is now implemented via:
-	// https://github.com/kubernetes-sigs/gateway-api/pull/1002 and here's the
-	// related issue in KIC:
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/2709
 	destinations := make([]*kong.CIDRPort, 0, len(backendRefs))
 	for _, backendRef := range backendRefs {
 		if backendRef.Port == nil {

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -51,7 +51,7 @@ func (p *Parser) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewa
 	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
 	// at least try to provide a helpful message about the situation in the manager logs.
 	if len(spec.Rules) == 0 {
-		return fmt.Errorf("no rules provided")
+		return errRouteValidationNoRules
 	}
 
 	// each rule may represent a different set of backend services that will be accepting

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -55,7 +55,7 @@ func (p *Parser) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *gatewa
 		return fmt.Errorf("no hostnames provided")
 	}
 	if len(spec.Rules) == 0 {
-		return fmt.Errorf("no rules provided")
+		return errRouteValidationNoRules
 	}
 
 	tlsPassthrough, err := p.isTLSRoutePassthrough(tlsroute)

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -51,7 +51,7 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
 	// at least try to provide a helpful message about the situation in the manager logs.
 	if len(spec.Rules) == 0 {
-		return fmt.Errorf("no rules provided")
+		return errRouteValidationNoRules
 	}
 
 	// each rule may represent a different set of backend services that will be accepting

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -310,7 +310,7 @@ func identifyTestCasesForFile(filePath string) ([]string, error) {
 // Testing Utility Functions - HTTP Requests
 // -----------------------------------------------------------------------------
 
-// eventuallyGETPAth makes a GET request to the Kong proxy multiple times until
+// eventuallyGETPath makes a GET request to the Kong proxy multiple times until
 // either the request starts to respond with the given status code and contents
 // present in the response body, or until timeout occurrs according to
 // ingressWait time limits. This uses only the path of for the request and does


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to implement [GEP-957: Destination Port Matching](https://gateway-api.sigs.k8s.io/geps/gep-957/)

**Which issue this PR fixes**:

Fixes #2709 

**Special notes for your reviewer**:

- Which `Accepted` reason to use:

  ~For now, the routes that will end up not being attached to a Gateway because of unmet port criteria (missing listener in the Gateway with the specified `Port`) will get an `Accepted` condition with `NoMatchingListenerHostname` reason.~
  
  ~This should be addressed also in this PR IMHO and the proposed course of action is:~
  
  ~- use a `const` defined in our codebase~
  ~- submit an issue with the above described proposal to https://github.com/kubernetes-sigs/gateway-api/~
  ~- swap the self defined `const` with the one defined in upstream whenever (if) it gets released there.~
  
  The above has been mitigated for now with `RouteReasonNoMatchingListenerPort` which has been defined in our codebase.

- Open question: since only `HTTPRoute` was graduated in beta would it be fine to add tests just for that route type and leave the other ones without (while tracking that in a separate issue: to add whenever they graduate to beta)?

- I also added a call to `r.DataplaneClient.DeleteObject(httproute)` when the route "is not accepted". This way I was able to get the route to get pruned after changing a parent ref port which wouldn't match the Gateway. I believe that's the way it should be but I can be proven wrong.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
- [x] add integration tests for this change for
  - [x] `HTTPRoute`