### PR TITLE
feat(#3097): propagate translation failures for annotations not matching in grouped services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ Adding a new version? You'll need three changes:
   [#3121](https://github.com/Kong/kubernetes-ingress-controller/pull/3121)
 - Warning events are recorded when CA secrets cannot be properly translated into Kong configuration.  
   [#3125](https://github.com/Kong/kubernetes-ingress-controller/pull/3125)
+- Warning events are recorded when annotations in services backing a single route do not match. 
+  [#3130](https://github.com/Kong/kubernetes-ingress-controller/pull/3130)
 
 ### Fixed
 

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
-
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -461,15 +461,13 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout := new(bytes.Buffer)
-			logger := logrus.New()
-			logger.SetOutput(stdout)
+			logger, loggerHook := test.NewNullLogger()
 			failuresCollector, err := NewTranslationFailuresCollector(logger)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, servicesAllUseTheSameKongAnnotations(tt.services, tt.annotations, failuresCollector))
-			assert.Len(t, failuresCollector.PopTranslationFailures(), len(tt.expectedLogEntries))
-			for _, expectedLogEntry := range tt.expectedLogEntries {
-				assert.Contains(t, stdout.String(), expectedLogEntry)
+			assert.Len(t, failuresCollector.PopTranslationFailures(), len(tt.expectedLogEntries), "expecting as many translation failures as log entries")
+			for i := range tt.expectedLogEntries {
+				assert.Contains(t, loggerHook.AllEntries()[i].Message, tt.expectedLogEntries[i])
 			}
 		})
 	}
@@ -574,7 +572,7 @@ func TestPopulateServices(t *testing.T) {
 			require.NoError(t, err)
 			servicesToBeSkipped := ingressRules.populateServices(logrus.New(), fakeStore, failuresCollector)
 			require.Equal(t, tc.serviceNamesToSkip, servicesToBeSkipped)
-			require.Len(t, failuresCollector.PopTranslationFailures(), len(servicesToBeSkipped))
+			require.Len(t, failuresCollector.PopTranslationFailures(), len(servicesToBeSkipped), "expecting as many translation failures as services to skip")
 		})
 	}
 }

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -456,6 +456,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			expected: false,
 			expectedLogEntries: []string{
 				"the value of annotation konghq.com/foo is different between the 3 services which comprise this backend.",
+				"the value of annotation konghq.com/foo is different between the 3 services which comprise this backend.",
 			},
 		},
 	} {
@@ -466,6 +467,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			failuresCollector, err := NewTranslationFailuresCollector(logger)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, servicesAllUseTheSameKongAnnotations(tt.services, tt.annotations, failuresCollector))
+			assert.Len(t, failuresCollector.PopTranslationFailures(), len(tt.expectedLogEntries))
 			for _, expectedLogEntry := range tt.expectedLogEntries {
 				assert.Contains(t, stdout.String(), expectedLogEntry)
 			}

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -95,7 +95,7 @@ func (p *Parser) Build() (*kongstate.KongState, []TranslationFailure) {
 
 	// populate any Kubernetes Service objects relevant objects and get the
 	// services to be skipped because of annotations inconsistency
-	servicesToBeSkipped := ingressRules.populateServices(p.logger, p.storer)
+	servicesToBeSkipped := ingressRules.populateServices(p.logger, p.storer, p.failuresCollector)
 
 	// add the routes and services to the state
 	var result kongstate.KongState
@@ -189,19 +189,6 @@ func (p *Parser) EnableRegexPathPrefix() {
 // registerTranslationFailure should be called when any Kubernetes object translation failure is encountered.
 func (p *Parser) registerTranslationFailure(reason string, causingObjects ...client.Object) {
 	p.failuresCollector.PushTranslationFailure(reason, causingObjects...)
-	p.logTranslationFailure(reason, causingObjects...)
-}
-
-// logTranslationFailure logs an error message signaling that a translation error has occurred along with its reason
-// for every causing object.
-func (p *Parser) logTranslationFailure(reason string, causingObjects ...client.Object) {
-	for _, obj := range causingObjects {
-		p.logger.WithFields(logrus.Fields{
-			"name":      obj.GetName(),
-			"namespace": obj.GetNamespace(),
-			"GVK":       obj.GetObjectKind().GroupVersionKind().String(),
-		}).Errorf("translation failed: %s", reason)
-	}
 }
 
 func (p *Parser) popTranslationFailures() []TranslationFailure {

--- a/internal/util/test/name.go
+++ b/internal/util/test/name.go
@@ -1,0 +1,9 @@
+package test
+
+import "github.com/google/uuid"
+
+// RandomName creates a unique name prepended with a predefined prefix.
+// It can be used to populate .Name field of Kubernetes objects.
+func RandomName(prefix string) string {
+	return prefix + uuid.NewString()
+}

--- a/test/consts.go
+++ b/test/consts.go
@@ -1,12 +1,12 @@
 package test
 
 const (
-	// httpBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
+	// HTTPBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
 	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/kong/httpbin
 	HTTPBinImage = "kong/httpbin:0.1.0"
 
-	// tcpEchoImage echoes TCP text sent to it after printing out basic information about its environment, e.g.
+	// TCPEchoImage echoes TCP text sent to it after printing out basic information about its environment, e.g.
 	// Welcome, you are connected to node kind-control-plane.
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.
 	// In namespace foo.

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -35,7 +35,6 @@ const testTranslationFailuresObjectsPrefix = "translation-failures-"
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
-
 	testCases := []struct {
 		name string
 		// translationFailureTrigger should create objects that trigger translation failure and return the objects

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -91,8 +91,7 @@ func TestTranslationFailures(t *testing.T) {
 				cleaner.Add(deployment)
 
 				service1 := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-				service1.Name = ""
-				service1.GenerateName = "service-"
+				service1.Name = uuid.NewString()
 				// adding the annotation to trigger conflict
 				service1.Annotations = map[string]string{annotations.AnnotationPrefix + annotations.HostHeaderKey: "example.com"}
 				service1, err = env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service1, metav1.CreateOptions{})
@@ -100,8 +99,7 @@ func TestTranslationFailures(t *testing.T) {
 				cleaner.Add(service1)
 
 				service2 := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-				service2.Name = ""
-				service2.GenerateName = "service-"
+				service2.Name = uuid.NewString()
 				service2, err = env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service2, metav1.CreateOptions{})
 				require.NoError(t, err)
 				cleaner.Add(service2)
@@ -205,8 +203,8 @@ func invalidCASecret(ns string) *corev1.Secret {
 func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
 	return &kongv1.KongPlugin{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "kong-plugin-",
-			Namespace:    ns,
+			Name:      uuid.NewString(),
+			Namespace: ns,
 			Annotations: map[string]string{
 				annotations.IngressClassKey: ingressClass,
 			},

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -99,7 +99,7 @@ func TestTranslationFailures(t *testing.T) {
 				cleaner.Add(service1)
 
 				service2 := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-				service2.Name = uuid.NewString()
+				service2.Name = randomName()
 				service2, err = env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service2, metav1.CreateOptions{})
 				require.NoError(t, err)
 				cleaner.Add(service2)

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -72,12 +72,12 @@ func TestTranslationFailures(t *testing.T) {
 				gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 				require.NoError(t, err)
 
-				gatewayClassName := uuid.NewString()
+				gatewayClassName := randomName()
 				gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 				require.NoError(t, err)
 				cleaner.Add(gwc)
 
-				gatewayName := uuid.NewString()
+				gatewayName := randomName()
 				gateway, err := DeployGateway(ctx, gatewayClient, ns, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 					gw.Name = gatewayName
 				})
@@ -91,7 +91,7 @@ func TestTranslationFailures(t *testing.T) {
 				cleaner.Add(deployment)
 
 				service1 := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
-				service1.Name = uuid.NewString()
+				service1.Name = randomName()
 				// adding the annotation to trigger conflict
 				service1.Annotations = map[string]string{annotations.AnnotationPrefix + annotations.HostHeaderKey: "example.com"}
 				service1, err = env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service1, metav1.CreateOptions{})
@@ -184,8 +184,8 @@ const invalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae" //nolint:gosec
 func invalidCASecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "ca-secret-",
-			Namespace:    ns,
+			Name:      randomName(),
+			Namespace: ns,
 			Labels: map[string]string{
 				"konghq.com/ca-cert": "true",
 			},
@@ -203,7 +203,7 @@ func invalidCASecret(ns string) *corev1.Secret {
 func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
 	return &kongv1.KongPlugin{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      uuid.NewString(),
+			Name:      randomName(),
 			Namespace: ns,
 			Annotations: map[string]string{
 				annotations.IngressClassKey: ingressClass,
@@ -236,7 +236,7 @@ func httpRouteWithBackends(gatewayName string, services ...*corev1.Service) *gat
 
 	return &gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			Name: randomName(),
 			Annotations: map[string]string{
 				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 			},
@@ -262,4 +262,8 @@ func httpRouteWithBackends(gatewayName string, services ...*corev1.Service) *gat
 			},
 		},
 	}
+}
+
+func randomName() string {
+	return "translation-failures-" + uuid.NewString()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds propagation of translation failure: annotations not matching in services backing a single route.

**Which issue this PR fixes**:

Part of #3097.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
