### PR TITLE
chore(config) enable combined routes by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -292,7 +292,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
       env:
-        KONG_CONTROLLER_FEATURE_GATES: "GatewayAlpha=true,CombinedRoutes=true"
+        KONG_CONTROLLER_FEATURE_GATES: "GatewayAlpha=true,CombinedRoutes=false"
         GOTESTSUM_JUNITFILE: "integration-tests-feature-gates.xml"
 
     - name: collect test coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ Adding a new version? You'll need three changes:
 
 > Release date: TBD
 
+### Breaking changes
+
+- The `CombinedRoutes` feature flag is enabled by default, and traditional
+  route generation is deprecated. This reduces configuration size without
+  affecting routing, but does change route names and IDs. Metrics
+  monitors or other systems that track data by route name or ID will see a
+  break in continuity. The [feature gates document](https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md#differences-between-traditional-and-combined-routes)
+  covers changes in greater detail. Please [comment on the deprecation
+  issue](https://github.com/Kong/kubernetes-ingress-controller/issues/3131)
+  if you have questions or concerns about the transition.
+  [#3132](https://github.com/Kong/kubernetes-ingress-controller/pull/3132)
+
 ### Added
 
 - Added `HTTPRoute` support for `CombinedRoutes` feature. When enabled,

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -58,6 +58,6 @@ func getFeatureGatesDefaults() map[string]bool {
 		knativeFeature:        false,
 		gatewayFeature:        true,
 		gatewayAlphaFeature:   false,
-		combinedRoutesFeature: false,
+		combinedRoutesFeature: true,
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Flips the CombinedRoutes feature gate default to `true`.

Sets `CombinedRoute=false` in the feature gates integration test. We now have this in place for any tests of the old system so long as it's deprecated.

Adds documentation to FEATURE_GATES.md (do we instead want this somewhere else) to help users understand the change impact.

**Which issue this PR fixes**:

Fix #2881 

**Special notes for your reviewer**:

https://github.com/Kong/kubernetes-ingress-controller/issues/3131 is the follow-up issue to collect community comments and eventually remove traditional in 3.0 barring and showstopper issues.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
