### PR TITLE
chore(tests): mark dataplane synchronizer unit test as long

### DIFF
--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestSynchronizer(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	t.Log("setting up a fake dataplane client to test the synchronizer")
 	c := &fakeDataplaneClient{dbmode: "postgres"}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip `TestSynchronizer` when `-short` is specified.

This makes it so that when e.g. `GOTESTFLAGS=-short make test.unit.pretty` is run, this test is skipped to shorten the runtime of tests.