### PR TITLE
chore(tests): use shorter rsa keys for adminapi unit tests

### DIFF
--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -109,6 +109,8 @@ func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
 }
 
 func buildTLS(t *testing.T) (caPEM *bytes.Buffer, certPEM *bytes.Buffer, certPrivateKeyPEM *bytes.Buffer, err error) {
+	const rsaKeySize = 2048
+
 	var ca *x509.Certificate
 	var caPrivateKeyPEM *bytes.Buffer
 
@@ -130,7 +132,7 @@ func buildTLS(t *testing.T) (caPEM *bytes.Buffer, certPEM *bytes.Buffer, certPri
 		BasicConstraintsValid: true,
 	}
 
-	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		t.Errorf("Fail to generate CA key %s", err.Error())
 		return nil, nil, nil, err
@@ -180,7 +182,7 @@ func buildTLS(t *testing.T) (caPEM *bytes.Buffer, certPEM *bytes.Buffer, certPri
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 
-	certPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	certPrivateKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		t.Errorf("Fail to generate ingress key %s", err.Error())
 		return nil, nil, nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to shorten the duration of `./internal/adminapi` TLS unit tests, use smaller RSA keys (`4096` -> `2048`) to decrease the runtime of tests.

Before:

```
go test -count 1 -v ./internal/adminapi/...
=== RUN   TestMakeHTTPClientWithTLSOpts
--- PASS: TestMakeHTTPClientWithTLSOpts (2.15s)
=== RUN   TestMakeHTTPClientWithTLSOptsAndFilePaths
--- PASS: TestMakeHTTPClientWithTLSOptsAndFilePaths (4.30s)
PASS
ok      github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi      6.456s
```

After:

```
go test -count 1 -v ./internal/adminapi/...
=== RUN   TestMakeHTTPClientWithTLSOpts
--- PASS: TestMakeHTTPClientWithTLSOpts (0.12s)
=== RUN   TestMakeHTTPClientWithTLSOptsAndFilePaths
--- PASS: TestMakeHTTPClientWithTLSOptsAndFilePaths (0.35s)
PASS
ok      github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi      0.477s
```

If we wanted we could always speed this up even further by

- decreasing the key size to 1024
- using a predefined, `const` PEM block which would be parsed into a private key each time