### PR TITLE
feat(#3097): propagate translation failures for missing service's referred client-cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ Adding a new version? You'll need three changes:
   [#3125](https://github.com/Kong/kubernetes-ingress-controller/pull/3125)
 - Warning events are recorded when annotations in services backing a single route do not match. 
   [#3130](https://github.com/Kong/kubernetes-ingress-controller/pull/3130)
+- Warning events are recorded when a service's referred client-cert does not exist. 
+  [#3137](https://github.com/Kong/kubernetes-ingress-controller/pull/3137)
 
 ### Fixed
 

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -1142,7 +1142,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		assert.Nil(err)
 		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
-		require.Empty(t, translationFailures)
+		require.Len(t, translationFailures, 1)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")
@@ -2856,7 +2856,7 @@ func TestDefaultBackend(t *testing.T) {
 		assert.Nil(err)
 		p := mustNewParser(t, store)
 		state, translationFailures := p.Build()
-		require.Empty(t, translationFailures)
+		require.Len(t, translationFailures, 1)
 		assert.NotNil(state)
 		assert.Equal(0, len(state.Certificates),
 			"expected no certificates to be rendered")

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,6 +114,37 @@ func TestTranslationFailures(t *testing.T) {
 
 				// expect event for service2 as it doesn't have annotations that service1 has
 				return []client.Object{service2}
+			},
+		},
+		{
+			name: "missing client-cert for service",
+			translationFailureTrigger: func(t *testing.T, cleaner *clusters.Cleaner, ns string) []client.Object {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testutils.RandomName(testTranslationFailuresObjectsPrefix),
+						Annotations: map[string]string{
+							"konghq.com/client-cert": "not-existing-secret",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Port: 80,
+							},
+						},
+					},
+				}
+				service, err := env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service, metav1.CreateOptions{})
+				require.NoError(t, err)
+
+				_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns).Create(
+					ctx,
+					ingressWithPathBackedByService(service),
+					metav1.CreateOptions{},
+				)
+				require.NoError(t, err)
+
+				return []client.Object{service}
 			},
 		},
 	}
@@ -260,6 +292,42 @@ func httpRouteWithBackends(gatewayName string, services ...*corev1.Service) *gat
 						},
 					},
 					BackendRefs: backendRefs,
+				},
+			},
+		},
+	}
+}
+
+func ingressWithPathBackedByService(service *corev1.Service) *netv1.Ingress {
+	pathType := netv1.PathTypePrefix
+	return &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testutils.RandomName(testTranslationFailuresObjectsPrefix),
+			Annotations: map[string]string{
+				annotations.IngressClassKey: ingressClass,
+			},
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathType,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: service.Name,
+											Port: netv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

It will propagate translation failures for services for which the referred client-cert cannot be fetched.

**Which issue this PR fixes**:

Part of #3097.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
