### PR TITLE
chore(validations): remove unnecessary targetPort validation for ExternalName services

### DIFF
--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -703,17 +703,9 @@ func getEndpoints(
 	if s.Spec.Type == corev1.ServiceTypeExternalName {
 		log.Debug("found service of type=ExternalName")
 
-		targetPort := port.TargetPort.IntValue()
-		// check for invalid port value
-		if targetPort <= 0 {
-			err := fmt.Errorf("invalid port: %v", targetPort)
-			log.WithError(err).Error("invalid service")
-			return upsServers
-		}
-
 		return append(upsServers, util.Endpoint{
 			Address: s.Spec.ExternalName,
-			Port:    fmt.Sprintf("%v", targetPort),
+			Port:    fmt.Sprintf("%v", port.TargetPort.IntValue()),
 		})
 	}
 	if annotations.HasServiceUpstreamAnnotation(s.Annotations) {

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -705,7 +705,7 @@ func getEndpoints(
 
 		return append(upsServers, util.Endpoint{
 			Address: s.Spec.ExternalName,
-			Port:    fmt.Sprintf("%v", port.TargetPort.IntValue()),
+			Port:    port.TargetPort.String(),
 		})
 	}
 	if annotations.HasServiceUpstreamAnnotation(s.Annotations) {

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -3876,20 +3876,6 @@ func TestGetEndpoints(t *testing.T) {
 			result: []util.Endpoint{},
 		},
 		{
-			name: "a service type ServiceTypeExternalName service with an invalid port should return 0 endpoints",
-			svc: &corev1.Service{
-				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeExternalName,
-				},
-			},
-			port:  &corev1.ServicePort{Name: "default"},
-			proto: corev1.ProtocolTCP,
-			fn: func(string, string) (*corev1.Endpoints, error) {
-				return &corev1.Endpoints{}, nil
-			},
-			result: []util.Endpoint{},
-		},
-		{
 			name: "a service type ServiceTypeExternalName with a valid port should return one endpoint",
 			svc: &corev1.Service{
 				Spec: corev1.ServiceSpec{

--- a/test/integration/crd_validations_test.go
+++ b/test/integration/crd_validations_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"

--- a/test/integration/crd_validations_test.go
+++ b/test/integration/crd_validations_test.go
@@ -86,27 +86,6 @@ func TestCRDValidations(t *testing.T) {
 				require.ErrorContains(t, err, "spec.rules[0].port")
 			},
 		},
-		{
-			name: "service type=ExternalName with empty target port",
-			scenario: func(t *testing.T, cleaner *clusters.Cleaner, ns string) {
-				service := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "service-name",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeExternalName,
-						Ports: []corev1.ServicePort{
-							{
-								TargetPort: intstr.FromInt(0),
-							},
-						},
-						ExternalName: "example.com",
-					},
-				}
-				_, err := env.Cluster().Client().CoreV1().Services(ns).Create(ctx, service, metav1.CreateOptions{})
-				require.ErrorContains(t, err, "spec.ports[0].targetPort: Invalid value: 0")
-			},
-		},
 	}
 
 	for _, tt := range testCases {

--- a/test/integration/crd_validations_test.go
+++ b/test/integration/crd_validations_test.go
@@ -6,15 +6,13 @@ package integration
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes validation of `targetPort` being `>= 0` for `corev1.Service` of `ExternalName` type. It's not needed as the validation is handled on Kubernetes API level (proved in the added testcase). 

**Which issue this PR fixes**:

Part of #3097. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
