### PR TITLE
feat(tests) support manager logs to file

### DIFF
--- a/internal/cmd/rootcmd/servers.go
+++ b/internal/cmd/rootcmd/servers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/bombsimon/logrusr/v2"
+	"github.com/go-logr/logr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
@@ -20,17 +20,18 @@ const (
 	DiagnosticConfigBufferDepth = 3
 )
 
-func StartDiagnosticsServer(ctx context.Context, port int, c *manager.Config) (diagnostics.Server, error) {
-	deprecatedLogger, err := util.MakeLogger(c.LogLevel, c.LogFormat)
-	if err != nil {
-		return diagnostics.Server{}, err
-	}
-	logger := logrusr.New(deprecatedLogger)
-
+// StartDiagnosticsServer starts a goroutine that handles requests for the diagnostics server.
+func StartDiagnosticsServer(
+	ctx context.Context,
+	port int,
+	c *manager.Config,
+	logger logr.Logger,
+) (diagnostics.Server, error) {
 	if !c.EnableProfiling && !c.EnableConfigDumps {
 		logger.Info("diagnostics server disabled")
 		return diagnostics.Server{}, nil
 	}
+	logger.Info("starting diagnostics server")
 
 	s := diagnostics.Server{
 		Logger:           logger,

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -9,10 +9,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bombsimon/logrusr/v2"
+	"github.com/go-logr/logr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 var (
@@ -24,17 +23,11 @@ var (
 // which is canceled on one of these signals. If a second signal is not caught, the program
 // will delay for the configured period of time before terminating. If a second signal is caught,
 // the program is terminated with exit code 1.
-func SetupSignalHandler(cfg *manager.Config) (context.Context, error) {
+func SetupSignalHandler(cfg *manager.Config, logger logr.Logger) (context.Context, error) {
 	// This will prevent multiple signal handlers from being created
 	if ok := mutex.TryLock(); !ok {
 		return nil, errors.New("signal handler can only be setup once")
 	}
-
-	deprecatedLogger, err := util.MakeLogger(cfg.LogLevel, cfg.LogFormat)
-	if err != nil {
-		return nil, err
-	}
-	logger := logrusr.New(deprecatedLogger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -39,17 +39,7 @@ import (
 // -----------------------------------------------------------------------------
 
 // Run starts the controller manager and blocks until it exits.
-func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic) error {
-	deprecatedLogger, _, err := SetupLoggers(c)
-	if err != nil {
-		return err
-	}
-	return RunWithLogger(ctx, c, diagnostic, deprecatedLogger)
-}
-
-// RunWithLogger starts the controller manager and blocks until it exits.
-// This function is intended for use in tests, where the logger can be injected.
-func RunWithLogger(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, deprecatedLogger logrus.FieldLogger) error {
+func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, deprecatedLogger logrus.FieldLogger) error {
 	setupLog := ctrl.Log.WithName("setup")
 	setupLog.Info("starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.V(util.DebugLevel).Info("the ingress class name has been set", "value", c.IngressClassName)
@@ -142,7 +132,7 @@ func RunWithLogger(ctx context.Context, c *Config, diagnostic util.ConfigDumpDia
 	}
 
 	setupLog.Info("Starting Admission Server")
-	if err := setupAdmissionServer(ctx, c, mgr.GetClient()); err != nil {
+	if err := setupAdmissionServer(ctx, c, mgr.GetClient(), deprecatedLogger); err != nil {
 		return err
 	}
 

--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -41,7 +42,7 @@ var logrusLevels = map[string]logrus.Level{
 	"trace": logrus.TraceLevel,
 }
 
-func MakeLogger(level string, formatter string) (logrus.FieldLogger, error) {
+func MakeLogger(level string, formatter string, output io.Writer) (logrus.FieldLogger, error) {
 	log := logrus.New()
 	var err error
 
@@ -54,6 +55,7 @@ func MakeLogger(level string, formatter string) (logrus.FieldLogger, error) {
 	}
 
 	log.SetLevel(logLevel)
+	log.Out = output
 	return log, nil
 }
 

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -51,7 +51,7 @@ func TestGatewayConformance(t *testing.T) {
 		"--anonymous-reports=false",
 	}
 
-	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalLogger, env.Cluster(), args...))
+	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalDeprecatedLogger, globalLogger, env.Cluster(), args...))
 
 	t.Log("creating GatewayClass for gateway conformance tests")
 	gwc := &gatewayv1beta1.GatewayClass{

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -65,8 +65,11 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	// after 30s from the start of controller manager package init function,
 	// the controller manager will set up a no op logger and continue.
 	// The logger cannot be configured after that point.
-	logger, _, err := testutils.SetupLoggers("trace", "text", false)
+	deprecatedLogger, logger, logOutput, err := testutils.SetupLoggers("trace", "text", false)
 	require.NoError(t, err, "failed to configure logger")
+	if logOutput != "" {
+		t.Logf("INFO: writing manager logs to %s", logOutput)
+	}
 
 	t.Log("configuring cluster addons for the testing environment")
 	metallbAddon := metallb.New()
@@ -120,7 +123,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("starting the controller manager")
-	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), "--log-level=debug"))
+	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, deprecatedLogger, logger, env.Cluster(), "--log-level=debug"))
 
 	t.Log("creating a new mesh-enabled namespace for testing http traffic")
 	namespace := &corev1.Namespace{

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -89,9 +89,12 @@ func TestMain(m *testing.M) {
 	// after 30s from the start of controller manager package init function,
 	// the controller manager will set up a no op logger and continue.
 	// The logger cannot be configured after that point.
-	logger, _, err := testutils.SetupLoggers("trace", "text", false)
+	deprecatedLogger, logger, logOutput, err := testutils.SetupLoggers("trace", "text", false)
 	if err != nil {
 		exitOnErrWithCode(fmt.Errorf("failed to setup loggers: %w", err), ExitCodeCantCreateLogger)
+	}
+	if logOutput != "" {
+		fmt.Printf("INFO: writing manager logs to %s\n", logOutput)
 	}
 
 	fmt.Println("INFO: setting up test environment")
@@ -217,7 +220,7 @@ func TestMain(m *testing.M) {
 			fmt.Sprintf("--election-namespace=%s", kongAddon.Namespace()),
 		}
 		allControllerArgs := append(standardControllerArgs, extraControllerArgs...)
-		exitOnErr(testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), allControllerArgs...))
+		exitOnErr(testutils.DeployControllerManagerForCluster(ctx, deprecatedLogger, logger, env.Cluster(), allControllerArgs...))
 	}
 
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor logger setup. Create only a single instance each of the modern and deprecated logger, and share it across each of the manager, diagnostics server, signal handler, and admission server.

Add a new `TEST_KONG_KIC_MANAGER_LOG_OUTPUT` integration test envvar. When set, manager logs output to this file instead of stderr along with test logs.

Fix a race condition in test setup where Gateway API CRDs were deployed successfully but not immmediately available, disabling related controllers at startup.

**Which issue this PR fixes**:

Inspired by discussion on some PR. Because a lot of the controller logs are just the same task, with unchanging results, in an infinite loop, they're often just noise. This lets you shunt the noise elsewhere.

The CRD deploy issue was something unrelated that I encountered during testing and have often (probably) encountered in the past.

**Special notes for your reviewer**:

Would we want to make CI use a separate manager log (uploaded as an artifact) by default? I'd prefer it, but don't know if others would prefer to keep them intermingled. This PR doesn't change the default as such.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ tests only