### PR TITLE
fix: use . instead of / to make header annotations valid

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -298,7 +298,7 @@ func ExtractRetries(anns map[string]string) (string, bool) {
 // ExtractHeaders extracts the parsed headers annotations values. It returns a map of header names to slices of values.
 func ExtractHeaders(anns map[string]string) (map[string][]string, bool) {
 	headers := make(map[string][]string)
-	prefix := AnnotationPrefix + HeadersKey + "/"
+	prefix := AnnotationPrefix + HeadersKey + "."
 	for key, val := range anns {
 		if strings.HasPrefix(key, prefix) {
 			header := strings.TrimPrefix(key, prefix)

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -849,7 +849,7 @@ func TestExtractHeaders(t *testing.T) {
 			name: "non-empty",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/foo": "foo",
+					"konghq.com/headers.foo": "foo",
 				},
 			},
 			want: map[string][]string{"foo": {"foo"}},
@@ -867,7 +867,7 @@ func TestExtractHeaders(t *testing.T) {
 			name: "no header name",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/": "foo",
+					"konghq.com/headers.": "foo",
 				},
 			},
 			want: map[string][]string{},

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -1073,7 +1073,7 @@ func TestOverrideHeaders(t *testing.T) {
 			name: "single header single value",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/x-example": "example",
+					"konghq.com/headers.x-example": "example",
 				},
 			},
 			want: Route{
@@ -1086,7 +1086,7 @@ func TestOverrideHeaders(t *testing.T) {
 			name: "single header multi value",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/x-example": "foo,bar",
+					"konghq.com/headers.x-example": "foo,bar",
 				},
 			},
 			want: Route{
@@ -1099,8 +1099,8 @@ func TestOverrideHeaders(t *testing.T) {
 			name: "multi header single value",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/x-foo": "example",
-					"konghq.com/headers/x-bar": "example",
+					"konghq.com/headers.x-foo": "example",
+					"konghq.com/headers.x-bar": "example",
 				},
 			},
 			want: Route{
@@ -1116,8 +1116,8 @@ func TestOverrideHeaders(t *testing.T) {
 			name: "multi header multi value",
 			args: args{
 				anns: map[string]string{
-					"konghq.com/headers/x-foo": "foo,bar",
-					"konghq.com/headers/x-bar": "bar,baz",
+					"konghq.com/headers.x-foo": "foo,bar",
+					"konghq.com/headers.x-bar": "bar,baz",
 				},
 			},
 			want: Route{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

use `konghq.com/headers.*` as the pattern for configuring header match in Kong routes since annotation key `konghq.com/headers/*` is not valid. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3153

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No need to update CHANGELOG because the buggy version is not released
