### PR TITLE
chore(deploy) align listens with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,9 @@ Adding a new version? You'll need three changes:
 - Improve signal handling and cancellation. With this change broken connection to
   Admin API and/or initial data plane sync can be cancelled properly.
   [#3076](https://github.com/Kong/kubernetes-ingress-controller/pull/3076)
+- Admin and proxy listens in the deploy manifests now use the same parameters
+  as the default upstream kong.conf.
+  [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
 
 ## [2.7.0]
 

--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -39,11 +39,11 @@ spec:
         env:
           # servers
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384
         - name: KONG_PORT_MAPS
           value: "80:8000, 443:8443"
         - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
+          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
         - name: KONG_STATUS_LISTEN
           value: 0.0.0.0:8100
           # DB

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1581,11 +1581,12 @@ spec:
               key: license
               name: kong-enterprise-license
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
         - name: KONG_PORT_MAPS
           value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
+          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
         - name: KONG_STATUS_LISTEN
           value: 0.0.0.0:8100
         - name: KONG_DATABASE

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1576,11 +1576,12 @@ spec:
       containers:
       - env:
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
         - name: KONG_PORT_MAPS
           value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
+          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
         - name: KONG_STATUS_LISTEN
           value: 0.0.0.0:8100
         - name: KONG_DATABASE

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1643,7 +1643,8 @@ spec:
         - name: KONG_PG_PASSWORD
           value: kong
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
         - name: KONG_PORT_MAPS
           value: 80:8000, 443:8443
         - name: KONG_STATUS_LISTEN

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1596,11 +1596,12 @@ spec:
         - name: KONG_PG_PASSWORD
           value: kong
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
         - name: KONG_PORT_MAPS
           value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 ssl
+          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
         - name: KONG_STATUS_LISTEN
           value: 0.0.0.0:8100
         - name: KONG_NGINX_WORKER_PROCESSES


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the listen configurations in the deploy manifests to use the same parameters as the upstream default kong.conf listens.

**Which issue this PR fixes**:

Removes discrepancies between configuration here and kong.conf defaults (https://github.com/Kong/kong/blob/ea485a8467259c2f7fee5959d757fee6a7318c99/kong.conf.default#L527 and https://github.com/Kong/kong/blob/ea485a8467259c2f7fee5959d757fee6a7318c99/kong.conf.default#L397).

With https://github.com/Kong/kubernetes-ingress-controller/issues/2435 resolved by 3.0 (as far as we know--there's one report that it's still happening but not one that I can replicate) there's no reason to not use the same config as upstream anymore.

**Special notes for your reviewer**:

E2E test for the modified manifests: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3448701987

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
