### PR TITLE
feat(#3097): propagate translation failures for http routes not having backend refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@ Adding a new version? You'll need three changes:
 - Warning events are recorded when a Gateway Listener has more than one CertificateRef specified
   or refers to a Secret that has no valid TLS key-pair.
   [#3147](https://github.com/Kong/kubernetes-ingress-controller/pull/3147)
+- Warning events are recorded when HTTPRoute has no backendRefs specified. 
+  [#3167](https://github.com/Kong/kubernetes-ingress-controller/pull/3167)
 
 ### Fixed
 

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -26,22 +26,13 @@ func (p *Parser) ingressRulesFromHTTPRoutes() ingressRules {
 		return result
 	}
 
-	var errs []error
 	for _, httproute := range httpRouteList {
 		if err := p.ingressRulesFromHTTPRoute(&result, httproute); err != nil {
-			errs = append(errs, fmt.Errorf("HTTPRoute %s/%s can't be routed: %w",
-				httproute.Namespace, httproute.Name, err),
-			)
+			p.registerTranslationFailure(fmt.Sprintf("HTTPRoute can't be routed: %s", err), httproute)
 		} else {
 			// at this point the object has been configured and can be
 			// reported as successfully parsed.
 			p.ReportKubernetesObjectUpdate(httproute)
-		}
-	}
-
-	if len(errs) > 0 {
-		for _, err := range errs {
-			p.logger.Errorf(err.Error())
 		}
 	}
 

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -230,6 +230,35 @@ func TestTranslationFailures(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "httproute rule has no backendRefs defined",
+			translationFailureTrigger: func(t *testing.T, cleaner *clusters.Cleaner, ns string) expectedTranslationFailure {
+				gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
+				require.NoError(t, err)
+
+				gatewayClassName := testutils.RandomName(testTranslationFailuresObjectsPrefix)
+				gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
+				require.NoError(t, err)
+				cleaner.Add(gwc)
+
+				gatewayName := testutils.RandomName(testTranslationFailuresObjectsPrefix)
+				gateway, err := DeployGateway(ctx, gatewayClient, ns, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
+					gw.Name = gatewayName
+				})
+				require.NoError(t, err)
+				cleaner.Add(gateway)
+
+				httpRoute := httpRouteWithBackends(gatewayName)
+				httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
+				require.NoError(t, err)
+				cleaner.Add(httpRoute)
+
+				return expectedTranslationFailure{
+					causingObjects: []client.Object{httpRoute},
+					reasonContains: "missing backendRef in rule",
+				}
+			},
+		},
 	}
 
 	for _, tt := range testCases {
@@ -339,25 +368,28 @@ func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
 }
 
 func httpRouteWithBackends(gatewayName string, services ...*corev1.Service) *gatewayv1beta1.HTTPRoute {
-	httpPort := gatewayv1beta1.PortNumber(80)
-	weight := int32(100 / len(services))
-	pathMatchPrefix := gatewayv1beta1.PathMatchPathPrefix
-
 	backendRefs := make([]gatewayv1beta1.HTTPBackendRef, 0, len(services))
-	for _, service := range services {
-		backendRefs = append(backendRefs,
-			gatewayv1beta1.HTTPBackendRef{
-				BackendRef: gatewayv1beta1.BackendRef{
-					BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-						Name: gatewayv1beta1.ObjectName(service.Name),
-						Port: &httpPort,
-						Kind: util.StringToGatewayAPIKindPtr("Service"),
+
+	if len(services) > 0 {
+		httpPort := gatewayv1beta1.PortNumber(80)
+		weight := int32(100 / len(services))
+
+		for _, service := range services {
+			backendRefs = append(backendRefs,
+				gatewayv1beta1.HTTPBackendRef{
+					BackendRef: gatewayv1beta1.BackendRef{
+						BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+							Name: gatewayv1beta1.ObjectName(service.Name),
+							Port: &httpPort,
+							Kind: util.StringToGatewayAPIKindPtr("Service"),
+						},
+						Weight: &weight,
 					},
-					Weight: &weight,
-				},
-			})
+				})
+		}
 	}
 
+	pathMatchPrefix := gatewayv1beta1.PathMatchPathPrefix
 	return &gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testutils.RandomName(testTranslationFailuresObjectsPrefix),


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds propagation of translation failures for HTTPRoute not having any backendRef specified. 

**Which issue this PR fixes**:

Part of #3097. 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
