### PR TITLE
WIP: perf: change secretNameToSNI to a map

### DIFF
--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -4635,6 +4635,7 @@ func TestPickPort(t *testing.T) {
 
 func TestCertificate(t *testing.T) {
 	assert := assert.New(t)
+	// TODO: do we actually need to keep the order? if so, the method `addHost` of `SNIHostMap` should consider the adding time.
 	t.Run("same host with multiple namespace return the first namespace/secret by asc ", func(t *testing.T) {
 		ingresses := []*netv1beta1.Ingress{
 			{

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -41,7 +41,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			msg: "an empty list of HTTPRoutes should produce no ingress rules",
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIMap(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -68,7 +68,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -125,7 +125,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIMap(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -154,7 +154,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -204,7 +204,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIMap(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -233,7 +233,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIMap(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -262,7 +262,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -322,7 +322,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -392,7 +392,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -467,7 +467,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // 1 service per route should be created
@@ -581,7 +581,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -711,7 +711,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -828,7 +828,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -981,7 +981,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -1235,7 +1235,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIMap(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -274,7 +274,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string][]string),
+			SecretNameToSNIs:      newSecretNameToSNIMap(),
 		}, parsedInfo)
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
@@ -748,7 +748,7 @@ func TestFromIngressV1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string][]string),
+			SecretNameToSNIs:      newSecretNameToSNIMap(),
 		}, parsedInfo)
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -44,7 +44,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 	})
 
 	services := map[string]kongstate.Service{}
-	secretToSNIs := newSecretNameToSNIs()
+	secretToSNIs := newSecretNameToSNIMap()
 
 	for _, ingress := range ingressList {
 		regexPrefix := translators.ControllerPathRegexPrefix
@@ -53,7 +53,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 		}
 		ingressSpec := ingress.Spec
 
-		secretToSNIs.addFromIngressV1beta1TLS(knativeIngressToNetworkingTLS(ingress.Spec.TLS), ingress.Namespace)
+		secretToSNIs.addFromIngressV1TLS(knativeIngressToNetworkingV1TLS(ingress.Spec.TLS), ingress.Namespace)
 
 		var objectSuccessfullyParsed bool
 		for i, rule := range ingressSpec.Rules {

--- a/internal/dataplane/parser/translate_knative_test.go
+++ b/internal/dataplane/parser/translate_knative_test.go
@@ -223,7 +223,7 @@ func TestFromKnativeIngress(t *testing.T) {
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
-		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+		assert.Equal(newSecretNameToSNIMap(), parsedInfo.SecretNameToSNIs)
 	})
 	t.Run("empty ingress returns empty info", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -236,7 +236,7 @@ func TestFromKnativeIngress(t *testing.T) {
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
 		assert.Equal(map[string]kongstate.Service{}, parsedInfo.ServiceNameToServices)
-		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+		assert.Equal(newSecretNameToSNIMap(), parsedInfo.SecretNameToSNIs)
 	})
 	t.Run("basic knative Ingress resource is parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -281,7 +281,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		}, svc.Plugins[0])
 
-		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+		assert.Equal(newSecretNameToSNIMap(), parsedInfo.SecretNameToSNIs)
 	})
 	t.Run("knative TLS section is correctly parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -293,7 +293,7 @@ func TestFromKnativeIngress(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
-		assert.Equal(SecretNameToSNIs(map[string][]string{
+		assert.Equal(makeSecretNameToSNIMap(map[string][]string{
 			"foo-namespace/bar-secret": {"bar.example.com", "bar1.example.com"},
 			"foo-namespace/foo-secret": {"foo.example.com", "foo1.example.com"},
 		}), parsedInfo.SecretNameToSNIs)
@@ -341,7 +341,7 @@ func TestFromKnativeIngress(t *testing.T) {
 			},
 		}, svc.Plugins[0])
 
-		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+		assert.Equal(newSecretNameToSNIMap(), parsedInfo.SecretNameToSNIs)
 	})
 	t.Run("regex prefix translated to Kong form", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -357,6 +357,6 @@ func TestFromKnativeIngress(t *testing.T) {
 		svc := parsedInfo.ServiceNameToServices["foo-ns.foo-svc.42"]
 		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *svc.Routes[0].Route.Paths[0])
 
-		assert.Equal(newSecretNameToSNIs(), parsedInfo.SecretNameToSNIs)
+		assert.Equal(newSecretNameToSNIMap(), parsedInfo.SecretNameToSNIs)
 	})
 }

--- a/internal/dataplane/parser/translate_kong_l4.go
+++ b/internal/dataplane/parser/translate_kong_l4.go
@@ -28,7 +28,7 @@ func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
 	for _, ingress := range ingressList {
 		ingressSpec := ingress.Spec
 
-		result.SecretNameToSNIs.addFromIngressV1beta1TLS(tcpIngressToNetworkingTLS(ingressSpec.TLS), ingress.Namespace)
+		result.SecretNameToSNIs.addFromIngressV1TLS(tcpIngressToNetworkingV1TLS(ingressSpec.TLS), ingress.Namespace)
 
 		var objectSuccessfullyParsed bool
 		for i, rule := range ingressSpec.Rules {

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -108,7 +108,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string][]string),
+			SecretNameToSNIs:      newSecretNameToSNIMap(),
 		}, parsedInfo)
 	})
 	t.Run("empty TCPIngress return empty info", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string][]string),
+			SecretNameToSNIs:      newSecretNameToSNIMap(),
 		}, parsedInfo)
 	})
 	t.Run("simple TCPIngress rule is parsed", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

use a map to store non-dupliacate SNI hosts using the secret as certificates to increase performance of generating and merging ingress rules for TLS.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3166 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

- unit test `TestCertificate` is affected. The order is not guaranteed when using map to store.
- will be largely affected by #3150 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
