### PR TITLE
perf: use maps in SecretNameToSNIs

### DIFF
--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -33,13 +33,7 @@ func mergeIngressRules(objs ...ingressRules) ingressRules {
 	result := newIngressRules()
 
 	for _, obj := range objs {
-		for k, v := range obj.SecretNameToSNIs {
-			if _, ok := result.SecretNameToSNIs[k]; !ok {
-				result.SecretNameToSNIs[k] = &SNIs{}
-			}
-			result.SecretNameToSNIs[k].hosts = append(result.SecretNameToSNIs[k].hosts, v.hosts...)
-			result.SecretNameToSNIs[k].parents = append(result.SecretNameToSNIs[k].parents, v.parents...)
-		}
+		result.SecretNameToSNIs.merge(obj.SecretNameToSNIs)
 		for k, v := range obj.ServiceNameToServices {
 			result.ServiceNameToServices[k] = v
 		}
@@ -89,12 +83,7 @@ func (ir *ingressRules) populateServices(log logrus.FieldLogger, s store.Storer,
 				}
 
 				// ensure that the cert is loaded into Kong
-				if _, ok := ir.SecretNameToSNIs[secretKey]; !ok {
-					ir.SecretNameToSNIs[secretKey] = &SNIs{
-						parents: []client.Object{k8sService},
-						hosts:   []string{},
-					}
-				}
+				ir.SecretNameToSNIs.addUniqueParents(secretKey, k8sService)
 				service.ClientCertificate = &kong.Certificate{
 					ID: kong.String(string(secret.UID)),
 				}
@@ -108,15 +97,32 @@ func (ir *ingressRules) populateServices(log logrus.FieldLogger, s store.Storer,
 	return serviceNamesToSkip
 }
 
-type SecretNameToSNIs map[string]*SNIs
+type SecretNameToSNIs struct {
+	m map[string]*SNIs
 
-type SNIs struct {
-	parents []client.Object
-	hosts   []string
+	// hosts keep global hosts registry to make sure only one secret can refer a single host
+	hosts map[string]struct{}
 }
 
 func newSecretNameToSNIs() SecretNameToSNIs {
-	return map[string]*SNIs{}
+	return SecretNameToSNIs{
+		m:     map[string]*SNIs{},
+		hosts: map[string]struct{}{},
+	}
+}
+
+func (m SecretNameToSNIs) Parents(secretKey string) []client.Object {
+	if _, ok := m.m[secretKey]; !ok {
+		return nil
+	}
+	return m.m[secretKey].Parents()
+}
+
+func (m SecretNameToSNIs) Hosts(secretKey string) []string {
+	if _, ok := m.m[secretKey]; !ok {
+		return nil
+	}
+	return m.m[secretKey].Hosts()
 }
 
 func (m SecretNameToSNIs) addFromIngressV1TLS(tlsSections []netv1.IngressTLS, parent client.Object) {
@@ -129,52 +135,71 @@ func (m SecretNameToSNIs) addFromIngressV1TLS(tlsSections []netv1.IngressTLS, pa
 		}
 
 		secretKey := parent.GetNamespace() + "/" + tls.SecretName
-		m.addUniqueHosts(secretKey, tls.Hosts)
-		m.addUniqueParents(secretKey, []client.Object{parent})
+		m.addUniqueHosts(secretKey, tls.Hosts...)
+		m.addUniqueParents(secretKey, parent)
 	}
 }
 
-func (m SecretNameToSNIs) addUniqueHosts(secretKey string, hosts []string) {
-	if _, ok := m[secretKey]; !ok {
-		m[secretKey] = &SNIs{}
-	}
+func (m SecretNameToSNIs) addUniqueHosts(secretKey string, hosts ...string) {
+	m.ensureSNIsEntry(secretKey)
 
-	seenHosts := map[string]bool{}
-	for _, snis := range m {
-		for _, host := range snis.hosts {
-			seenHosts[host] = true
-		}
-	}
-
-	var hostsToAdd []string
 	for _, host := range hosts {
-		if !seenHosts[host] {
-			hostsToAdd = append(hostsToAdd, host)
+		if _, ok := m.hosts[host]; ok {
+			// skip this host, it's already added, possibly for other secret
+			continue
 		}
-	}
 
-	m[secretKey].hosts = append(m[secretKey].hosts, hostsToAdd...)
+		m.m[secretKey].hosts = append(m.m[secretKey].hosts, host)
+		m.hosts[host] = struct{}{}
+	}
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3166
-func (m SecretNameToSNIs) addUniqueParents(secretKey string, parents []client.Object) {
-	if _, ok := m[secretKey]; !ok {
-		m[secretKey] = &SNIs{}
-	}
+func (m SecretNameToSNIs) addUniqueParents(secretKey string, parents ...client.Object) {
+	m.ensureSNIsEntry(secretKey)
 
-	seenParents := map[types.UID]struct{}{}
-	for _, parent := range m[secretKey].parents {
-		seenParents[parent.GetUID()] = struct{}{}
-	}
-
-	var parentsToAdd []client.Object
 	for _, parent := range parents {
-		if _, ok := seenParents[parent.GetUID()]; !ok {
-			parentsToAdd = append(parentsToAdd, parent)
+		m.m[secretKey].parents[parent.GetUID()] = parent
+	}
+}
+
+func (m SecretNameToSNIs) ensureSNIsEntry(secretKey string) {
+	if _, ok := m.m[secretKey]; !ok {
+		m.m[secretKey] = newSNIs()
+	}
+}
+
+func (m SecretNameToSNIs) merge(o SecretNameToSNIs) {
+	for secretKey, snis := range o.m {
+		for _, obj := range snis.parents {
+			m.addUniqueParents(secretKey, obj)
+		}
+		for _, hostKey := range snis.hosts {
+			m.addUniqueHosts(secretKey, hostKey)
 		}
 	}
+}
 
-	m[secretKey].parents = append(m[secretKey].parents, parentsToAdd...)
+type SNIs struct {
+	parents map[types.UID]client.Object
+	hosts   []string
+}
+
+func newSNIs() *SNIs {
+	return &SNIs{
+		parents: map[types.UID]client.Object{},
+	}
+}
+
+func (s SNIs) Parents() []client.Object {
+	parents := make([]client.Object, 0, len(s.parents))
+	for _, p := range s.parents {
+		parents = append(parents, p)
+	}
+	return parents
+}
+
+func (s SNIs) Hosts() []string {
+	return s.hosts
 }
 
 func getK8sServicesForBackends(

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -483,16 +483,16 @@ func (p *Parser) getGatewayCerts() []certWrapper {
 func (p *Parser) getCerts(secretsToSNIs SecretNameToSNIs) []certWrapper {
 	certs := []certWrapper{}
 
-	for secretKey, SNIs := range secretsToSNIs {
+	for secretKey, SNIs := range secretsToSNIs.m {
 		namespaceName := strings.Split(secretKey, "/")
 		secret, err := p.storer.GetSecret(namespaceName[0], namespaceName[1])
 		if err != nil {
-			p.registerTranslationFailure(fmt.Sprintf("failed to fetch the secret (%s)", secretKey), SNIs.parents...)
+			p.registerTranslationFailure(fmt.Sprintf("failed to fetch the secret (%s)", secretKey), SNIs.Parents()...)
 			continue
 		}
 		cert, key, err := getCertFromSecret(secret)
 		if err != nil {
-			causingObjects := append(SNIs.parents, secret)
+			causingObjects := append(SNIs.Parents(), secret)
 			p.registerTranslationFailure("failed to construct certificate from secret", causingObjects...)
 			continue
 		}
@@ -504,7 +504,7 @@ func (p *Parser) getCerts(secretsToSNIs SecretNameToSNIs) []certWrapper {
 				Key:  kong.String(key),
 			},
 			CreationTimestamp: secret.CreationTimestamp,
-			snis:              SNIs.hosts,
+			snis:              SNIs.Hosts(),
 		})
 	}
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -483,7 +483,7 @@ func (p *Parser) getGatewayCerts() []certWrapper {
 func (p *Parser) getCerts(secretsToSNIs SecretNameToSNIs) []certWrapper {
 	certs := []certWrapper{}
 
-	for secretKey, SNIs := range secretsToSNIs.m {
+	for secretKey, SNIs := range secretsToSNIs.secretToSNIs {
 		namespaceName := strings.Split(secretKey, "/")
 		secret, err := p.storer.GetSecret(namespaceName[0], namespaceName[1])
 		if err != nil {

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -4635,7 +4635,7 @@ func TestPickPort(t *testing.T) {
 
 func TestCertificate(t *testing.T) {
 	assert := assert.New(t)
-	t.Run("same host with multiple namespace return the first namespace/secret by asc ", func(t *testing.T) {
+	t.Run("same host with multiple namespace return the first namespace/secret by asc", func(t *testing.T) {
 		ingresses := []*netv1beta1.Ingress{
 			{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -41,7 +41,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			msg: "an empty list of HTTPRoutes should produce no ingress rules",
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIs(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -68,7 +68,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -125,7 +125,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIs(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -154,7 +154,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -204,7 +204,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIs(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -233,7 +233,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs:      SecretNameToSNIs{},
+					SecretNameToSNIs:      newSecretNameToSNIs(),
 					ServiceNameToServices: make(map[string]kongstate.Service),
 				}
 			},
@@ -262,7 +262,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -322,7 +322,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -392,7 +392,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -467,7 +467,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // 1 service per route should be created
@@ -581,7 +581,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -711,7 +711,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created
@@ -828,7 +828,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -981,7 +981,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{
@@ -1235,7 +1235,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 			}},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
-					SecretNameToSNIs: SecretNameToSNIs{},
+					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.basic-httproute.0": {
 							Service: kong.Service{ // only 1 service should be created

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -274,7 +274,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string]*SNIs),
+			SecretNameToSNIs:      newSecretNameToSNIs(),
 		}, parsedInfo)
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
@@ -323,9 +323,9 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["bar-namespace/sooper-secret"].hosts))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["bar-namespace/sooper-secret2"].hosts))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -748,7 +748,7 @@ func TestFromIngressV1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string]*SNIs),
+			SecretNameToSNIs:      newSecretNameToSNIs(),
 		}, parsedInfo)
 	})
 	t.Run("simple ingress rule is parsed", func(t *testing.T) {
@@ -800,9 +800,9 @@ func TestFromIngressV1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["bar-namespace/sooper-secret"].hosts))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["bar-namespace/sooper-secret2"].hosts))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -323,7 +323,6 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 	})
@@ -800,7 +799,6 @@ func TestFromIngressV1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 	})

--- a/internal/dataplane/parser/translate_knative_test.go
+++ b/internal/dataplane/parser/translate_knative_test.go
@@ -294,7 +294,7 @@ func TestFromKnativeIngress(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromKnativeIngress()
-		assert.Equal(SecretNameToSNIs(map[string]*SNIs{
+		assert.Equal(makeSecretToSNIs(map[string]testSNIs{
 			"foo-namespace/bar-secret": {hosts: []string{"bar.example.com", "bar1.example.com"}, parents: []client.Object{ingressList[3]}},
 			"foo-namespace/foo-secret": {hosts: []string{"foo.example.com", "foo1.example.com"}, parents: []client.Object{ingressList[3]}},
 		}), parsedInfo.SecretNameToSNIs)

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -193,7 +193,6 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("default/sooper-secret")))
 		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("default/sooper-secret2")))
 	})

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -108,7 +108,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string]*SNIs),
+			SecretNameToSNIs:      newSecretNameToSNIs(),
 		}, parsedInfo)
 	})
 	t.Run("empty TCPIngress return empty info", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
 		assert.Equal(ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
-			SecretNameToSNIs:      make(map[string]*SNIs),
+			SecretNameToSNIs:      newSecretNameToSNIs(),
 		}, parsedInfo)
 	})
 	t.Run("simple TCPIngress rule is parsed", func(t *testing.T) {
@@ -193,8 +193,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromTCPIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["default/sooper-secret"].hosts))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs["default/sooper-secret2"].hosts))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.m))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("default/sooper-secret")))
+		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("default/sooper-secret2")))
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It makes the `SecretNameToSNIs` use maps internally to store hosts and parents in order to avoid expensive maps building while adding a host/parent.

Global (meaning - in the scope of all secrets stored under a single `SecretNameToSNIs` instance) `seenHosts` map is kept in order to make sure only one secret is assigned to a host. `parents` map is stored on a single `SNIs` entry level to make sure we have no duplicates there as well.

**Which issue this PR fixes**:

Fixes #3166.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
