### PR TITLE
fix: filter hostnames in HTTPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,12 @@ Adding a new version? You'll need three changes:
 - Admin and proxy listens in the deploy manifests now use the same parameters
   as the default upstream kong.conf.
   [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
-- Fix the behavior of filtering hostnames in `HTTPRoutes` when listeners 
-  of parent gateways specified hostname.
+- Fix the behavior of filtering hostnames in `HTTPRoute` when listeners 
+  of parent gateways specified hostname. Now if an `HTTPRoute` does not 
+  specify hostnames, and one of its parent listeners has not specified
+  hostname, the hostnames will not be filtered in `HTTPRoute`. 
+  If an `HTTPRoute` specifies hostnames, and no intersecting hostnames 
+  could be found in its parent listners, it is not accepted.
   [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)
 
 ## [2.7.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,9 +183,9 @@ Adding a new version? You'll need three changes:
   as the default upstream kong.conf.
   [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
 - Fix the behavior of filtering hostnames in `HTTPRoute` when listeners 
-  of parent gateways specified hostname. Now if an `HTTPRoute` does not 
-  specify hostnames, and one of its parent listeners has not specified
-  hostname, the hostnames will not be filtered in `HTTPRoute`. 
+  of parent gateways specified hostname.
+  If an `HTTPRoute` does not specify hostnames, and one of its parent listeners
+  has not specified hostname, the `HTTPRoute` matches any hostname. 
   If an `HTTPRoute` specifies hostnames, and no intersecting hostnames 
   could be found in its parent listners, it is not accepted.
   [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ Adding a new version? You'll need three changes:
 - Admin and proxy listens in the deploy manifests now use the same parameters
   as the default upstream kong.conf.
   [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
+- Fix the behavior of filtering hostnames in `HTTPRoutes` when listeners 
+  of parent gateways specified hostname.
+  [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)
 
 ## [2.7.0]
 

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -153,6 +153,17 @@ func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[types
 	return nsNames
 }
 
+// extractListenerSpecFromGateway returns the spec of the listener with the given name.
+// returns nil if the listener with given name is not found.
+func extractListenerSpecFromGateway(gateway *gatewayv1beta1.Gateway, listenerName gatewayv1beta1.SectionName) *gatewayv1beta1.Listener {
+	for i, l := range gateway.Spec.Listeners {
+		if l.Name == listenerName {
+			return &gateway.Spec.Listeners[i]
+		}
+	}
+	return nil
+}
+
 // ListenerTracker holds Gateway Listeners and their statuses, and provides methods to update statuses upon
 // reconciliation.
 type ListenerTracker struct {

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -150,7 +150,6 @@ func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[types
 			}] = struct{}{}
 		}
 	}
-
 	return nsNames
 }
 

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -150,6 +150,7 @@ func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[types
 			}] = struct{}{}
 		}
 	}
+
 	return nsNames
 }
 

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -328,7 +328,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				ctx,
 				httproute, gateways,
 				metav1.ConditionFalse,
-				RouteReasonNoMatchingListenerHostname,
+				gatewayv1beta1.RouteReasonNoMatchingListenerHostname,
 				err.Error(),
 			)
 			if err != nil {

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -318,8 +318,23 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// perform operations on the kong store only if the route is in accepted status
 	if isRouteAccepted(gateways) {
-		// remove all the hostnames that don't match with at least one Listener's Hostname
-		filteredHTTPRoute := filterHostnames(gateways, httproute.DeepCopy())
+		// if there is no matched hosts in listners for the httproute, the httproute should not be accepted:
+		// and have an "Accepted" condition with status false.
+		// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
+		filteredHTTPRoute, err := filterHostnames(gateways, httproute.DeepCopy())
+		if err != nil {
+			debug(log, httproute, "no matching hostnames after filtering, should not accept")
+			_, err := r.ensureParentsAcceptedCondition(
+				ctx,
+				httproute, gateways,
+				metav1.ConditionFalse,
+				string(RouteReasonNoMatchingListenerHostname),
+				err.Error(),
+			)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 
 		// if the gateways are ready, and the HTTPRoute is destined for them, ensure that
 		// the object is pushed to the dataplane.
@@ -584,4 +599,98 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 		}
 	}
 	return gatewayv1beta1.RouteReasonResolvedRefs, nil
+}
+
+func (r *HTTPRouteReconciler) ensureParentsAcceptedCondition(
+	ctx context.Context,
+	httproute *gatewayv1beta1.HTTPRoute,
+	gateways []supportedGatewayWithCondition,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason string,
+	conditionMessage string,
+) (bool, error) {
+
+	// map the existing parentStatues to avoid duplications
+	parentStatuses := make(map[string]*gatewayv1beta1.RouteParentStatus)
+	for _, existingParent := range httproute.Status.Parents {
+		namespace := httproute.Namespace
+		if existingParent.ParentRef.Namespace != nil {
+			namespace = string(*existingParent.ParentRef.Namespace)
+		}
+		existingParentCopy := existingParent
+		var sectionName string
+		if existingParent.ParentRef.SectionName != nil {
+			sectionName = string(*existingParent.ParentRef.SectionName)
+		}
+		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
+	}
+
+	statusChanged := false
+	for _, g := range gateways {
+		gateway := g.gateway
+		parentRefKey := fmt.Sprintf("%s/%s/%s", gateway.Namespace, gateway.Name, g.listenerName)
+		parentStatus, ok := parentStatuses[parentRefKey]
+		if ok {
+			changed := updateAcceptedConditionInRouteParentStatus(parentStatus, conditionStatus, conditionReason, conditionMessage, httproute.Generation)
+			statusChanged = statusChanged || changed
+		} else {
+			newParentStatus := &gatewayv1beta1.RouteParentStatus{
+				ParentRef: gatewayv1beta1.ParentReference{
+					Namespace:   (*gatewayv1beta1.Namespace)(pointer.String(gateway.Namespace)),
+					Name:        gatewayv1beta1.ObjectName(gateway.Name),
+					SectionName: (*gatewayv1beta1.SectionName)(pointer.String(g.listenerName)),
+					// TODO: set port.
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(gatewayv1beta1.RouteConditionAccepted),
+						Status:             conditionStatus,
+						ObservedGeneration: httproute.Generation,
+						LastTransitionTime: metav1.Now(),
+						Reason:             conditionReason,
+						Message:            conditionMessage,
+					},
+				},
+			}
+			httproute.Status.Parents = append(httproute.Status.Parents, *newParentStatus)
+			parentStatuses[parentRefKey] = newParentStatus
+			statusChanged = true
+		}
+	}
+
+	// update status if needed.
+	if statusChanged {
+		if err := r.Status().Update(ctx, httproute); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	// no need to update if no status is changed.
+	return false, nil
+}
+
+func updateAcceptedConditionInRouteParentStatus(
+	parentStatus *gatewayv1beta1.RouteParentStatus,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason string,
+	conditionMessage string,
+	generation int64,
+) bool {
+	changed := false
+	for i, condition := range parentStatus.Conditions {
+		if condition.Type == string(gatewayv1beta1.RouteConditionAccepted) {
+			if condition.Status != conditionStatus || condition.Reason != conditionReason || condition.Message != conditionMessage {
+				parentStatus.Conditions[i] = metav1.Condition{
+					Type:               string(gatewayv1beta1.RouteConditionAccepted),
+					Status:             conditionStatus,
+					ObservedGeneration: generation,
+					LastTransitionTime: metav1.Now(),
+					Reason:             conditionReason,
+					Message:            conditionMessage,
+				}
+				changed = true
+			}
+		}
+	}
+	return changed
 }

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -84,10 +84,6 @@ const (
 	// https://github.com/kubernetes-sigs/gateway-api/pull/1516
 	// TODO: swap this out with upstream const when released.
 	RouteReasonNoMatchingParent gatewayv1beta1.RouteConditionReason = "NoMatchingParent"
-	// This reason is used with the "Accepted" condition when the Gateway has no
-	// compatible Listeners whose Port matches the route
-	// NOTE: This should probably be proposed upstream.
-	RouteReasonNoMatchingListenerPort gatewayv1beta1.RouteConditionReason = "NoMatchingListenerPort"
 	// This reason is used with the "Accepted" condition when no hostnames in listeners
 	// could match hostname in the spec of route.
 	RouteReasonNoMatchingListenerHostname gatewayv1beta1.RouteConditionReason = "NoMatchingListenerHostname"
@@ -520,7 +516,7 @@ func getUnionOfGatewayHostnames(gateways []supportedGatewayWithCondition) ([]gat
 				if listener.Hostname == nil {
 					return nil, true
 				}
-				hostnames = append(hostnames, (*listener.Hostname))
+				hostnames = append(hostnames, *listener.Hostname)
 			}
 		} else {
 			for _, listener := range gateway.gateway.Spec.Listeners {
@@ -529,7 +525,7 @@ func getUnionOfGatewayHostnames(gateways []supportedGatewayWithCondition) ([]gat
 					if listener.Hostname == nil {
 						return nil, true
 					}
-					hostnames = append(hostnames, (*listener.Hostname))
+					hostnames = append(hostnames, *listener.Hostname)
 				}
 			}
 		}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -27,9 +27,7 @@ const (
 	unsupportedGW = "no supported Gateway found for route"
 )
 
-var (
-	ErrNoMatchingListenerHostname = fmt.Errorf("no matching hostnames in listener")
-)
+var ErrNoMatchingListenerHostname = fmt.Errorf("no matching hostnames in listener")
 
 // supportedGatewayWithCondition is a struct that wraps a gateway and some further info
 // such as the condition Status condition Accepted of the gateway and the listenerName.

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -469,7 +469,7 @@ func listenerHostnameIntersectWithRouteHostnames[H types.HostnameT, L types.List
 
 // isListenterHostnameEffective if the listener could specify an effective hostname to match hostnames in requests.
 // it will return true when the protocol of listener is HTTP, HTTPS, or TLS.
-func isListenterHostnameEffective(listener gatewayv1beta1.Listener) bool {
+func isListenerHostnameEffective(listener gatewayv1beta1.Listener) bool {
 	return listener.Protocol == gatewayv1beta1.HTTPProtocolType ||
 		listener.Protocol == gatewayv1beta1.HTTPSProtocolType ||
 		listener.Protocol == gatewayv1beta1.TLSProtocolType
@@ -486,8 +486,9 @@ func filterHostnames(gateways []supportedGatewayWithCondition, httpRoute *gatewa
 	if len(httpRoute.Spec.Hostnames) == 0 {
 		for _, gateway := range gateways {
 			for _, listener := range gateway.gateway.Spec.Listeners {
-				if listenerName := gateway.listenerName; listenerName == "" || listenerName == string(listener.Name) &&
-					isListenterHostnameEffective(listener) {
+				listenerName := gateway.listenerName
+				if (listenerName == "" || listenerName == string(listener.Name)) &&
+					isListenerHostnameEffective(listener) {
 					// httpRoute remains an empty hostname if any of the listeners
 					// has not specified hostname to match any host.
 					if listener.Hostname == nil {

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -57,6 +57,8 @@ func TestFilterHostnames(t *testing.T) {
 		gateways          []supportedGatewayWithCondition
 		httpRoute         *gatewayv1beta1.HTTPRoute
 		expectedHTTPRoute *gatewayv1beta1.HTTPRoute
+		hasError          bool
+		errString         string
 	}{
 		{
 			name: "listener 1 - specific",
@@ -179,12 +181,20 @@ func TestFilterHostnames(t *testing.T) {
 					Hostnames: []gatewayv1beta1.Hostname{},
 				},
 			},
+			hasError:  true,
+			errString: "no matching hostnames in listener",
 		},
 	}
 
 	for _, tc := range testCases {
-		filteredHTTPRoute := filterHostnames(tc.gateways, tc.httpRoute)
-		assert.Equal(t, tc.expectedHTTPRoute.Spec, filteredHTTPRoute.Spec, tc.name)
+		filteredHTTPRoute, err := filterHostnames(tc.gateways, tc.httpRoute)
+		if tc.hasError {
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errString)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedHTTPRoute.Spec, filteredHTTPRoute.Spec, tc.name)
+		}
 	}
 }
 

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -48,6 +48,9 @@ func TestFilterHostnames(t *testing.T) {
 					Name:     "listener-3",
 					Hostname: util.StringToGatewayAPIHostnamePtr("*.anotherwildcard.io"),
 				},
+				{
+					Name: "listener-4",
+				},
 			},
 		},
 	}
@@ -162,10 +165,29 @@ func TestFilterHostnames(t *testing.T) {
 			},
 		},
 		{
-			name: "no match",
+			name: "no listner specified - no hostname",
 			gateways: []supportedGatewayWithCondition{
 				{
 					gateway: commonGateway,
+				},
+			},
+			httpRoute: &gatewayv1beta1.HTTPRoute{
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayv1beta1.Hostname{},
+				},
+			},
+			expectedHTTPRoute: &gatewayv1beta1.HTTPRoute{
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayv1beta1.Hostname{},
+				},
+			},
+		},
+		{
+			name: "listener 1 - no match",
+			gateways: []supportedGatewayWithCondition{
+				{
+					gateway:      commonGateway,
+					listenerName: "listner-1",
 				},
 			},
 			httpRoute: &gatewayv1beta1.HTTPRoute{

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	gatewaypkg "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
@@ -541,8 +542,6 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("creating an httproute with a same hostname and another unmatched hostname")
-	httpPort := gatewayv1beta1.PortNumber(80)
-	pathMatchPrefix := gatewayv1beta1.PathMatchPathPrefix
 	httpRoute := &gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
@@ -563,22 +562,11 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 			},
 			Rules: []gatewayv1beta1.HTTPRouteRule{{
 				Matches: []gatewayv1beta1.HTTPRouteMatch{
-					{
-						Path: &gatewayv1beta1.HTTPPathMatch{
-							Type:  &pathMatchPrefix,
-							Value: kong.String("/test-http-route-filter-hosts"),
-						},
-					},
+					builder.NewHTTPRouteMatch().WithPathPrefix("/test-http-route-filter-hosts").Build(),
 				},
-				BackendRefs: []gatewayv1beta1.HTTPBackendRef{{
-					BackendRef: gatewayv1beta1.BackendRef{
-						BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-							Name: gatewayv1beta1.ObjectName(service.Name),
-							Port: &httpPort,
-							Kind: util.StringToGatewayAPIKindPtr("Service"),
-						},
-					},
-				}},
+				BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+					builder.NewHTTPBackendRef(service.Name).WithPort(80).Build(),
+				},
 			}},
 		},
 	}

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -494,3 +494,162 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	t.Log("verifying that misconfigured service rules are _not_ routed")
 	eventuallyGETPath(t, "test-http-route-multiple-services-broken", http.StatusNotFound, "", emptyHeaderSet)
 }
+
+func TestHTTPRouteFilterHosts(t *testing.T) {
+	ns, cleaner := setup(t)
+	defer func() {
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
+	}()
+
+	listenerHostname := gatewayv1beta1.Hostname("test.specific.io")
+
+	t.Log("getting a gateway client")
+	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
+	t.Log("deploying a new gatewayClass")
+	gatewayClassName := uuid.NewString()
+	gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
+	require.NoError(t, err)
+	cleaner.Add(gwc)
+
+	t.Log("deploying a new gateway with specified hostname")
+	gatewayName := uuid.NewString()
+	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
+		gw.Name = gatewayName
+		for i := range gw.Spec.Listeners {
+			gw.Spec.Listeners[i].Hostname = &listenerHostname
+		}
+	})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("creating an httproute with a same hostname and another unmatched hostname")
+	httpPort := gatewayv1beta1.PortNumber(80)
+	pathMatchPrefix := gatewayv1beta1.PathMatchPathPrefix
+	httpRoute := &gatewayv1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+				annotations.AnnotationPrefix + annotations.PluginsKey:   "correlation",
+			},
+		},
+		Spec: gatewayv1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayv1beta1.ParentReference{{
+					Name: gatewayv1beta1.ObjectName(gateway.Name),
+				}},
+			},
+			Hostnames: []gatewayv1beta1.Hostname{
+				gatewayv1beta1.Hostname("test.specific.io"),
+				gatewayv1beta1.Hostname("another.specific.io"),
+			},
+			Rules: []gatewayv1beta1.HTTPRouteRule{{
+				Matches: []gatewayv1beta1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1beta1.HTTPPathMatch{
+							Type:  &pathMatchPrefix,
+							Value: kong.String("/test-http-route-filter-hosts"),
+						},
+					},
+				},
+				BackendRefs: []gatewayv1beta1.HTTPBackendRef{{
+					BackendRef: gatewayv1beta1.BackendRef{
+						BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+							Name: gatewayv1beta1.ObjectName(service.Name),
+							Port: &httpPort,
+							Kind: util.StringToGatewayAPIKindPtr("Service"),
+						},
+					},
+				}},
+			}},
+		},
+	}
+	_, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Create(ctx, httpRoute, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(httpRoute)
+
+	// testGetByHost tries to get the test path with specified host in request,
+	// and returns true if 200 returned.
+	testGetByHost := func(t *testing.T, host string) bool {
+		req, err := http.NewRequest("GET", proxyURL.String()+"/test-http-route-filter-hosts", nil)
+		require.NoError(t, err)
+		req.Host = host
+		resp, err := httpc.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}
+
+	t.Logf("test host matched hostname in listeners")
+	require.Eventually(t, func() bool {
+		return testGetByHost(t, "test.specific.io")
+	}, ingressWait, waitTick)
+	t.Logf("test host matched in httproute, but not in listeners")
+	require.False(t, testGetByHost(t, "another.specific.io"))
+
+	t.Logf("update hostnames in httproute to wildcard")
+	httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	httpRoute.Spec.Hostnames = []gatewayv1beta1.Hostname{
+		gatewayv1beta1.Hostname("*.specific.io"),
+	}
+	_, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	t.Logf("test host matched hostname in listeners")
+	require.Eventually(t, func() bool {
+		return testGetByHost(t, "test.specific.io")
+	}, ingressWait, waitTick)
+	t.Logf("test host matched in httproute, but not in listeners")
+	require.False(t, testGetByHost(t, "another2.specific.io"))
+
+	t.Logf("update hostname in httproute to an unmatched host")
+	httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	httpRoute.Spec.Hostnames = []gatewayv1beta1.Hostname{
+		gatewayv1beta1.Hostname("another.specific.io"),
+	}
+	_, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	t.Logf("status of httproute should contain an 'Accepted' condition with 'False' status")
+	require.Eventuallyf(t, func() bool {
+		currentHTTPRoute, err := gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		for _, parent := range currentHTTPRoute.Status.Parents {
+			for _, condition := range parent.Conditions {
+				if condition.Type == string(gatewayv1beta1.RouteReasonAccepted) && condition.Status == metav1.ConditionFalse {
+					return true
+				}
+			}
+		}
+		return false
+	}, ingressWait, waitTick,
+		func() string {
+			currentHTTPRoute, err := gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+			if err != nil {
+				return err.Error()
+			}
+			return fmt.Sprintf("current status of HTTPRoute %s/%s:%v", httpRoute.Namespace, httpRoute.Name, currentHTTPRoute.Status)
+		}())
+	t.Logf("test host matched in httproute, but not in listeners")
+	require.False(t, testGetByHost(t, "another.specific.io"))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

- Does not filter hostnames when `HTTPRoute` contains empty `spec.hostnames`, and any of compatible listeners does not specify `hostname`
- When no hostnames in `HTTPRoute` could match hostnames in listners, do not accept this `HTTPRoute`: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3175 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

According to API specification of gateway APIs, what should do when `HTTPRoute` does not contain `hostnames`
 but listeners contains `hostname` is not defined. I think the most reasonable behavior is to match the hostname specified by the listener which the `HTTPRoute` attached to. When an `HTTPRoute` is not attached to a listener (has empty `parentRef.SectionName`), I think the reasonable behavior is to match **UNION** of all (compatible) listeners in the gateway. If any of the `HTTP`,`HTTPS`,`TLS` listeners has an empty hostname to match any hostname, the hostname in `HTTPRoute` should be also empty to match any hostname.

Also, gateway API spec tells that when no hostname in `HTTPRoute` can match hostnames in listeners, the `HTTPRoute` should not be accepted.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
