### PR TITLE
feat(gateway-api): matching routes by `Listener.AllowedRoutes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@ Adding a new version? You'll need three changes:
   [#3150](https://github.com/Kong/kubernetes-ingress-controller/pull/3150)
 - Warning events are recorded when HTTPRoute has no backendRefs specified.
   [#3167](https://github.com/Kong/kubernetes-ingress-controller/pull/3167)
+- Gateway API: Matching routes by `Listener.AllowedRoutes`
+  [#3181](https://github.com/Kong/kubernetes-ingress-controller/pull/3181)
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220512140940-7b36cea86235 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -45,10 +46,10 @@ func parentRefsForRoute[T types.RouteT](route T) ([]ParentReference, error) {
 		ret := make([]ParentReference, len(refsAlpha))
 		for i, v := range refsAlpha {
 			ret[i] = ParentReference{
-				Group:       (*gatewayv1beta1.Group)(v.Group),
+				Group:       (*Group)(v.Group),
 				Kind:        (*Kind)(v.Kind),
-				Namespace:   (*gatewayv1beta1.Namespace)(v.Namespace),
-				Name:        (gatewayv1beta1.ObjectName)(v.Name),
+				Namespace:   (*Namespace)(v.Namespace),
+				Name:        (ObjectName)(v.Name),
 				SectionName: (*SectionName)(v.SectionName),
 				Port:        (*PortNumber)(v.Port),
 			}
@@ -66,15 +67,20 @@ func parentRefsForRoute[T types.RouteT](route T) ([]ParentReference, error) {
 	case *gatewayv1alpha2.TLSRoute:
 		return convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs), nil
 	default:
-		return nil, fmt.Errorf("cant determine parent gateway for unsupported type %s", reflect.TypeOf(route))
+		return nil, fmt.Errorf("cant determine parent gateway for unsupported route type %s", reflect.TypeOf(route))
 	}
 }
 
 const (
-	// This reason is used with the "Accepted" condition when the Gateway has no
-	// compatible Listeners whose Port matches the route
-	// NOTE: This should probably be proposed upstream.
-	RouteReasonNoMatchingListenerPort gatewayv1beta1.RouteConditionReason = "NoMatchingListenerPort"
+	// This reason is used with the "Accepted" condition when there are
+	// no matching Parents. In the case of Gateways, this can occur when
+	// a Route ParentRef specifies a Port and/or SectionName that does not
+	// match any Listeners in the Gateway.
+	//
+	// NOTE: This is already in uptsream, albeit unreleased:
+	// https://github.com/kubernetes-sigs/gateway-api/pull/1516
+	// TODO: swap this out with upstream const when released.
+	RouteReasonNoMatchingParent gatewayv1beta1.RouteConditionReason = "NoMatchingParent"
 )
 
 // getSupportedGatewayForRoute will retrieve the Gateway and GatewayClass object for any
@@ -107,7 +113,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			Namespace: namespace,
 			Name:      name,
 		}, &gateway); err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				// if a configured gateway is not found it's still possible
 				// that there's another gateway, so keep searching through the list.
 				continue
@@ -120,7 +126,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 		if err := mgrc.Get(ctx, client.ObjectKey{
 			Name: string(gateway.Spec.GatewayClassName),
 		}, &gatewayClass); err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				// if a configured gatewayClass is not found it's still possible
 				// that there's another properly configured gateway in the parentRefs,
 				// so keep searching through the list.
@@ -129,123 +135,121 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			return nil, fmt.Errorf("failed to retrieve gatewayclass for gateway: %w", err)
 		}
 
-		// if the GatewayClass matches this controller we're all set and this controller
-		// should reconcile this object.
-		if gatewayClass.Spec.ControllerName == ControllerName {
-			allowedNamespaces := make(map[string]interface{})
-			var (
-				// set true if we find any AllowedRoutes. there may be none, in which case any namespace is permitted
-				filtered         = false
-				matchingHostname = metav1.ConditionFalse
-				// set to true if ParentRef specifies a Port and a listener matches that Port.
-				portMatched = false
-			)
-			for _, listener := range gateway.Spec.Listeners {
-				// TODO check listenerStatus.SupportedKinds
+		// If the GatewayClass does not match this controller then skip it
+		if gatewayClass.Spec.ControllerName != ControllerName {
+			continue
+		}
 
-				// Check if we already have a matching listener in status.
-				if !existsMatchingReadyListenerInStatus(listener, gateway.Status.Listeners) {
-					continue
-				}
+		// Otherwise we're all set and this controller should reconcile this route.
 
-				// Perform the port matching as described in GEP-957.
-				if parentRef.Port != nil && *parentRef.Port != listener.Port {
-					// This ParentRef has a port specified and it's different than current listener's port.
-					continue
-				} else if parentRef.Port != nil && *parentRef.Port == listener.Port {
-					portMatched = true
-				}
+		var (
+			// Set to true if there exists a listener which wasn't filtered by:
+			// - AlowedRoutes
+			// - listener status checks
+			// - listener and route type checks
+			matched = false
+			// Set to true if ParentRef specified a hostname and it matches route's hostnames.
+			matchingHostname *metav1.ConditionStatus
+			// Set to true if ParentRef specifies a Port and a listener matches that Port.
+			portMatched = false
 
-				// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2408
-				// This currently only performs a baseline filter to ensure that routes cannot match based on namespace
-				// criteria on a listener that cannot possibly handle them (e.g. an HTTPRoute should not be included
-				// based on matching a filter for a UDP listener). This needs to be expanded to an allowedRoutes.kind
-				// implementation with default allowed kinds when there's no user-specified filter.
-				var oneHostnameMatch bool
-				switch r := (interface{})(route).(type) {
-				case *gatewayv1beta1.HTTPRoute:
-					hostnames := r.Spec.Hostnames
-					oneHostnameMatch = listenerHostnameIntersectWithRouteHostnames(listener, hostnames)
-					if !(listener.Protocol == HTTPProtocolType || listener.Protocol == HTTPSProtocolType) {
-						continue
-					}
+			allowedByAllowedRoutes  = false
+			allowedBySupportedKinds = false
+		)
 
-				case *gatewayv1alpha2.TCPRoute:
-					if listener.Protocol != (TCPProtocolType) {
-						continue
-					}
-				case *gatewayv1alpha2.UDPRoute:
-					if listener.Protocol != (UDPProtocolType) {
-						continue
-					}
-				case *gatewayv1alpha2.TLSRoute:
-					hostnames := r.Spec.Hostnames
-					oneHostnameMatch = listenerHostnameIntersectWithRouteHostnames(listener, hostnames)
-					if listener.Protocol != (TLSProtocolType) {
-						continue
-					}
-				default:
-					continue
-				}
-				if oneHostnameMatch {
-					matchingHostname = metav1.ConditionTrue
-				}
-				if listener.AllowedRoutes != nil {
-					filtered = true
-					if *listener.AllowedRoutes.Namespaces.From == gatewayv1beta1.NamespacesFromAll {
-						// we allow "all" by just stuffing the namespace we want to find into the map
-						allowedNamespaces[route.GetNamespace()] = nil
-					} else if *listener.AllowedRoutes.Namespaces.From == gatewayv1beta1.NamespacesFromSame {
-						allowedNamespaces[gateway.ObjectMeta.Namespace] = nil
-					} else if *listener.AllowedRoutes.Namespaces.From == gatewayv1beta1.NamespacesFromSelector {
-						namespaces := &corev1.NamespaceList{}
-						selector, err := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
-						if err != nil {
-							return nil, fmt.Errorf("failed to convert LabelSelector to Selector for gateway %s",
-								gateway.ObjectMeta.Name)
-						}
-						err = mgrc.List(ctx, namespaces, &client.ListOptions{LabelSelector: selector})
-						if err != nil {
-							return nil, fmt.Errorf("could not fetch allowed namespaces for gateway %s",
-								gateway.ObjectMeta.Name)
-						}
-						for _, allowed := range namespaces.Items {
-							allowedNamespaces[allowed.ObjectMeta.Name] = nil
-						}
-					}
-				}
+		for _, listener := range gateway.Spec.Listeners {
+			// Check if the route matches listener's AllowedRoutes.
+			if ok, err := routeMatchesListenersAllowedRoutes(ctx, mgrc, route, listener, gateway.Namespace, parentRef.Namespace); err != nil {
+				return nil, fmt.Errorf("failed matching listener %s to a route %s for gateway %s: %w",
+					listener.Name, route.GetName(), gateway.Name, err,
+				)
+			} else if !ok {
+				continue
+			} else {
+				allowedByAllowedRoutes = true
 			}
 
-			_, allowedNamespace := allowedNamespaces[route.GetNamespace()]
-			if ((parentRef.Port != nil) && !portMatched) ||
-				(!filtered || allowedNamespace) {
-
-				reason := gatewayv1beta1.RouteReasonAccepted
-				if (parentRef.Port != nil) && !portMatched {
-					// If ParentRef specified a Port but none of the listeners matched, the gateway Status
-					// Condition Accepted must be set to False with reason NoMatchingListenerPort
-					reason = RouteReasonNoMatchingListenerPort
-				} else if matchingHostname == metav1.ConditionFalse {
-					// If there is no matchingHostname, the gateway Status Condition Accepted must be set to False
-					// with reason NoMatchingListenerHostname
-					reason = gatewayv1beta1.RouteReasonNoMatchingListenerHostname
-				}
-
-				var listenerName string
-				if parentRef.SectionName != nil && *parentRef.SectionName != "" {
-					listenerName = string(*parentRef.SectionName)
-				}
-
-				gateways = append(gateways, supportedGatewayWithCondition{
-					gateway:      &gateway,
-					listenerName: listenerName,
-					condition: metav1.Condition{
-						Type:   string(gatewayv1beta1.RouteConditionAccepted),
-						Status: matchingHostname,
-						Reason: string(reason),
-					},
-				})
+			// Check the listeners statuses:
+			// - Check if a listener status exists with a matching type (via SupportedKinds).
+			// - Check if it matches the requested listener by name (if specified).
+			// - And finally check if that listeners is marked as Ready.
+			if err := existsMatchingReadyListenerInStatus(route, listener, gateway.Status.Listeners); err != nil {
+				continue
+			} else {
+				allowedBySupportedKinds = true
 			}
+
+			// Perform the port matching as described in GEP-957.
+			if parentRef.Port != nil && *parentRef.Port != listener.Port {
+				// This ParentRef has a port specified and it's different than current listener's port.
+				continue
+			} else if parentRef.Port != nil && *parentRef.Port == listener.Port {
+				portMatched = true
+			}
+
+			if !routeTypeMatchesListenerType(route, listener.Protocol) {
+				continue
+			}
+
+			if routeHostnamesIntersectsWithListenerHostname(route, listener) {
+				condTrue := metav1.ConditionTrue
+				matchingHostname = &condTrue
+			} else {
+				condFalse := metav1.ConditionFalse
+				matchingHostname = &condFalse
+				continue
+			}
+
+			matched = true
+		}
+
+		if matched {
+			var listenerName string
+			if parentRef.SectionName != nil && *parentRef.SectionName != "" {
+				listenerName = string(*parentRef.SectionName)
+			}
+
+			gateways = append(gateways, supportedGatewayWithCondition{
+				gateway:      &gateway,
+				listenerName: listenerName,
+				condition: metav1.Condition{
+					Type:   string(gatewayv1beta1.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1beta1.RouteReasonAccepted),
+				},
+			})
+		} else {
+			// We failed to match a listener with this route
+
+			// This will also catch a case of not matching listener/section name.
+			reason := RouteReasonNoMatchingParent
+
+			if matchingHostname != nil && *matchingHostname == metav1.ConditionFalse {
+				// If there is no matchingHostname, the gateway Status Condition Accepted
+				// must be set to False with reason NoMatchingListenerHostname
+				reason = gatewayv1beta1.RouteReasonNoMatchingListenerHostname
+			} else if (parentRef.Port != nil) && !portMatched {
+				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
+				// Condition Accepted must be set to False with reason NoMatchingListenerPort
+				reason = RouteReasonNoMatchingParent
+			} else if !allowedByAllowedRoutes || !allowedBySupportedKinds {
+				reason = gatewayv1beta1.RouteReasonNotAllowedByListeners
+			}
+
+			var listenerName string
+			if parentRef.SectionName != nil && *parentRef.SectionName != "" {
+				listenerName = string(*parentRef.SectionName)
+			}
+
+			gateways = append(gateways, supportedGatewayWithCondition{
+				gateway:      &gateway,
+				listenerName: listenerName,
+				condition: metav1.Condition{
+					Type:   string(gatewayv1beta1.RouteConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(reason),
+				},
+			})
 		}
 	}
 
@@ -258,25 +262,167 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 	return gateways, nil
 }
 
-func existsMatchingReadyListenerInStatus(listener Listener, lss []ListenerStatus) bool {
+func routeHostnamesIntersectsWithListenerHostname[T types.RouteT](route T, listener Listener) bool {
+	switch r := (any)(route).(type) {
+	case *gatewayv1beta1.HTTPRoute:
+		return listenerHostnameIntersectWithRouteHostnames(listener, r.Spec.Hostnames)
+	case *gatewayv1alpha2.TCPRoute:
+		return false
+	case *gatewayv1alpha2.UDPRoute:
+		return false
+	case *gatewayv1alpha2.TLSRoute:
+		return listenerHostnameIntersectWithRouteHostnames(listener, r.Spec.Hostnames)
+	default:
+		return false
+	}
+}
+
+func routeTypeMatchesListenerType[T types.RouteT](route T, listenerProtocol ProtocolType) bool {
+	switch (any)(route).(type) {
+	case *gatewayv1beta1.HTTPRoute:
+		if !(listenerProtocol == HTTPProtocolType || listenerProtocol == HTTPSProtocolType) {
+			return false
+		}
+	case *gatewayv1alpha2.TCPRoute:
+		if listenerProtocol != (TCPProtocolType) {
+			return false
+		}
+	case *gatewayv1alpha2.UDPRoute:
+		if listenerProtocol != (UDPProtocolType) {
+			return false
+		}
+	case *gatewayv1alpha2.TLSRoute:
+		if listenerProtocol != (TLSProtocolType) {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+// routeMatchesListenersAllowedRoutes checks if the provided route matches the
+// criteria defined in listener's AllowedRoutes field.
+func routeMatchesListenersAllowedRoutes[T types.RouteT](
+	ctx context.Context,
+	mgrc client.Client,
+	route T,
+	listener Listener,
+	gatewayNamespace string,
+	parentRefNamespace *Namespace,
+) (bool, error) {
+	if listener.AllowedRoutes == nil {
+		return true, nil
+	}
+
+	if len(listener.AllowedRoutes.Kinds) > 0 {
+		// Find if the route has a type that's within the listener's supported types.
+		_, ok := lo.Find(listener.AllowedRoutes.Kinds, func(rgk gatewayv1beta1.RouteGroupKind) bool {
+			gvk := route.GetObjectKind().GroupVersionKind()
+			return (rgk.Group != nil && string(*rgk.Group) == gvk.Group) && string(rgk.Kind) == gvk.Kind
+		})
+		if !ok {
+			return false, nil
+		}
+	}
+
+	if listener.AllowedRoutes.Namespaces == nil || listener.AllowedRoutes.Namespaces.From == nil {
+		return true, nil
+	}
+
+	switch *listener.AllowedRoutes.Namespaces.From {
+
+	case gatewayv1beta1.NamespacesFromAll:
+		return true, nil
+
+	case gatewayv1beta1.NamespacesFromSame:
+		// If parentRef didn't specify the namespace then we check if
+		// the gateway is from the same namespace as the route
+		if parentRefNamespace == nil {
+			return gatewayNamespace == route.GetNamespace(), nil
+		}
+		// Otherwise compare routes namespace with parentRef's one.
+		return route.GetNamespace() == string(*parentRefNamespace), nil
+
+	case gatewayv1beta1.NamespacesFromSelector:
+		namespaces := corev1.NamespaceList{}
+		selector, err := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to convert AllowedRoutes LabelSelector %s to Selector for listener %s: %w",
+				listener.AllowedRoutes.Namespaces.Selector, listener.Name, err,
+			)
+		}
+		if err = mgrc.List(ctx, &namespaces, &client.ListOptions{LabelSelector: selector}); err != nil {
+			return false, fmt.Errorf(
+				"could not fetch allowed namespaces for listener %s using selector %s: %w",
+				selector, listener.Name, err,
+			)
+		}
+
+		_, ok := lo.Find(namespaces.Items, func(ns corev1.Namespace) bool {
+			return ns.Name == route.GetNamespace()
+		})
+		return ok, nil
+
+	default:
+		return false, fmt.Errorf(
+			"unknown listener.AllowedRoutes.Namespaces.From value: %s for listener %s",
+			*listener.AllowedRoutes.Namespaces.From, listener.Name,
+		)
+	}
+}
+
+var (
+	errUnsupportedRouteKind             = errors.New("unsupported route kind")
+	errUnmatchedListenerName            = errors.New("unmatched listener name")
+	errNoReadyConditionFoundForListener = errors.New("no Ready condition found for listener")
+	errListenerNotReadyYet              = errors.New("listener not ready yet")
+)
+
+// existsMatchingReadyListenerInStatus checks if:
+// - If a listener status exists with a matching type (via SupportedKinds).
+// - If it matches the requested listener by name (if specified).
+// - And finally check if the provided listener is marked as Ready.
+func existsMatchingReadyListenerInStatus[T types.RouteT](route T, listener Listener, lss []ListenerStatus) error {
+	listenerFound := false
+
 	// Find listener's status...
 	listenerStatus, ok := lo.Find(lss, func(ls gatewayv1beta1.ListenerStatus) bool {
-		return ls.Name == listener.Name
+		if ls.Name != listener.Name {
+			return false
+		}
+		listenerFound = true
+
+		// Find if the route has a type that's within the supported types, listed
+		// in listener's status.
+		_, ok := lo.Find(ls.SupportedKinds, func(rgk gatewayv1beta1.RouteGroupKind) bool {
+			gvk := route.GetObjectKind().GroupVersionKind()
+			return (rgk.Group != nil && string(*rgk.Group) == gvk.Group) && string(rgk.Kind) == gvk.Kind
+		})
+		return ok
 	})
-	if !ok {
-		return false // Listener's status not found
+
+	if !ok && !listenerFound {
+		return errUnmatchedListenerName // Matching Listener's not found.
 	}
+
+	if !ok && listenerFound {
+		return errUnsupportedRouteKind // Listener(s) found but none with matching supported kinds.
+	}
+
 	// ... and verify if it's ready.
 	lReadyCond, ok := lo.Find(listenerStatus.Conditions, func(c metav1.Condition) bool {
 		return c.Type == string(gatewayv1beta1.ListenerConditionReady)
 	})
 	if !ok {
-		return false
+		return errNoReadyConditionFoundForListener
 	}
 	if lReadyCond.Status != "True" {
-		return false // Listener is not ready yet.
+		return errListenerNotReadyYet // Listener is not ready yet.
 	}
-	return true
+
+	return nil
 }
 
 func listenerHostnameIntersectWithRouteHostnames[H types.HostnameT, L types.ListenerT](listener L, hostnames []H) bool {
@@ -285,7 +431,7 @@ func listenerHostnameIntersectWithRouteHostnames[H types.HostnameT, L types.List
 	}
 
 	// if the listener has no hostname, all hostnames automatically intersect
-	switch l := (interface{})(listener).(type) {
+	switch l := (any)(listener).(type) {
 	case gatewayv1alpha2.Listener:
 		if l.Hostname == nil || *l.Hostname == "" {
 			return true

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -208,6 +209,10 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			{
 				name: "basic HTTPRoute gets accepted",
 				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic-httproute",
 						Namespace: "test-namespace",
@@ -260,6 +265,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
+									SupportedKinds: supportedRouteGroupKinds,
 								},
 							},
 						},
@@ -296,6 +302,10 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			{
 				name: "basic HTTPRoute specifying existing section name gets Accepted",
 				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic-httproute",
 						Namespace: "test-namespace",
@@ -349,6 +359,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
+									SupportedKinds: supportedRouteGroupKinds,
 								},
 							},
 						},
@@ -385,6 +396,10 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			{
 				name: "basic HTTPRoute specifying existing port gets Accepted",
 				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic-httproute",
 						Namespace: "test-namespace",
@@ -438,6 +453,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
+									SupportedKinds: supportedRouteGroupKinds,
 								},
 							},
 						},
@@ -474,6 +490,10 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			{
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
 				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic-httproute",
 						Namespace: "test-namespace",
@@ -527,6 +547,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
+									SupportedKinds: supportedRouteGroupKinds,
 								},
 							},
 						},
@@ -555,7 +576,551 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						condition: metav1.Condition{
 							Type:   string(gatewayv1beta1.RouteConditionAccepted),
 							Status: metav1.ConditionFalse,
-							Reason: string(RouteReasonNoMatchingListenerPort),
+							Reason: string(RouteReasonNoMatchingParent),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute does not get accepted if it is not in the supported kinds",
+				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
+										{
+											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+											Kind:  gatewayv1beta1.Kind("TCPRoute"),
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute does not get accepted if it is not permitted by allowed routes",
+				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+									AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+										Kinds: []gatewayv1beta1.RouteGroupKind{
+											{
+												Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+												Kind:  gatewayv1beta1.Kind("TCPRoute"),
+											},
+										},
+									},
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
+										{
+											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+											Kind:  gatewayv1beta1.Kind("TCPRoute"),
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							// NOTE: Is this correct? Does ListenerStatus.SupportedKinds have impact on this?
+							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
+						},
+					},
+				},
+			},
+			{
+				name: "basic HTTPRoute does get accepted if allowed routes only specified Same namespace",
+				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+									AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+										Namespaces: &gatewayv1beta1.RouteNamespaces{
+											From: addressOf(gatewayv1beta1.NamespacesFromSame),
+										},
+									},
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
+										{
+											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1beta1.RouteReasonAccepted),
+						},
+					},
+				},
+			},
+			{
+				name: "HTTPRoute does not get accepted if Listener hostnames do not match route hostnames",
+				route: &HTTPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "HTTPRoute",
+						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						Hostnames: []gatewayv1beta1.Hostname{
+							"very.specific.com",
+						},
+						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayv1beta1.ParentReference{
+								{
+									Name: gatewayv1beta1.ObjectName("test-gateway"),
+								},
+							},
+						},
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+									AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+										Namespaces: &gatewayv1beta1.RouteNamespaces{
+											From: addressOf(gatewayv1beta1.NamespacesFromSame),
+										},
+									},
+									Hostname: addressOf(gatewayv1beta1.Hostname("hostname.com")),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
+										{
+											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
+										},
+									},
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1beta1.RouteReasonNoMatchingListenerHostname),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				fakeClient := fakeclient.
+					NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(tt.objects...).
+					Build()
+
+				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Len(t, got, len(tt.expected))
+
+					for i := range got {
+						assert.Equalf(t, tt.expected[i].gateway.Namespace, got[i].gateway.Namespace, "gateway namespace #%d", i)
+						assert.Equalf(t, tt.expected[i].gateway.Name, got[i].gateway.Name, "gateway name #%d", i)
+						assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
+						assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("TCPRoute", func(t *testing.T) {
+		type expected struct {
+			gateway      types.NamespacedName
+			condition    metav1.Condition
+			listenerName string
+		}
+		tests := []struct {
+			name     string
+			route    *TCPRoute
+			expected []expected
+			objects  []client.Object
+			wantErr  bool
+		}{
+			{
+				name: "basic TCPRoute does not get accepted because it is not in supported kinds",
+				route: &TCPRoute{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "TCPRoute",
+						APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-httproute",
+						Namespace: "test-namespace",
+					},
+					Spec: gatewayv1alpha2.TCPRouteSpec{
+						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayv1alpha2.ParentReference{
+								{
+									Name: gatewayv1alpha2.ObjectName("test-gateway"),
+								},
+							},
+						},
+					},
+				},
+				objects: []client.Object{
+					&Gateway{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
+						},
+						Spec: gatewayv1beta1.GatewaySpec{
+							GatewayClassName: "test-gatewayclass",
+							Listeners: []gatewayv1beta1.Listener{
+								{
+									Name:     gatewayv1beta1.SectionName("http"),
+									Protocol: gatewayv1beta1.HTTPProtocolType,
+									Port:     gatewayv1beta1.PortNumber(80),
+								},
+							},
+						},
+						Status: gatewayv1beta1.GatewayStatus{
+							Listeners: []gatewayv1beta1.ListenerStatus{
+								{
+									Name: gatewayv1beta1.SectionName("http"),
+									Conditions: []metav1.Condition{
+										{
+											Type:   "Ready",
+											Status: metav1.ConditionTrue,
+										},
+									},
+									SupportedKinds: supportedRouteGroupKinds,
+								},
+							},
+						},
+					},
+					&GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-gatewayclass",
+						},
+						Spec: gatewayv1beta1.GatewayClassSpec{
+							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+				expected: []expected{
+					{
+						gateway: types.NamespacedName{
+							Name:      "test-gateway",
+							Namespace: "test-namespace",
+						},
+						listenerName: "",
+						condition: metav1.Condition{
+							Type:   string(gatewayv1beta1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							// NOTE: Is this correct? Does ListenerStatus.SupportedKinds have impact on this?
+							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
 						},
 					},
 				},

--- a/internal/controllers/gateway/types.go
+++ b/internal/controllers/gateway/types.go
@@ -2,6 +2,7 @@
 package gateway
 
 import (
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -19,10 +20,12 @@ type (
 	Namespace         = gatewayv1beta1.Namespace
 	ObjectName        = gatewayv1beta1.ObjectName
 	ParentReference   = gatewayv1beta1.ParentReference
-	RouteParentStatus = gatewayv1beta1.RouteParentStatus
 	PortNumber        = gatewayv1beta1.PortNumber
 	ProtocolType      = gatewayv1beta1.ProtocolType
+	RouteParentStatus = gatewayv1beta1.RouteParentStatus
 	SectionName       = gatewayv1beta1.SectionName
+
+	TCPRoute = gatewayv1alpha2.TCPRoute
 )
 
 const (

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -301,7 +301,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'False' when it specified a port not existent in Gateway")
-	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, false, gatewaypkg.RouteReasonNoMatchingListenerPort), statusWait, waitTick)
+	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, false, gatewaypkg.RouteReasonNoMatchingParent), statusWait, waitTick)
 }
 
 func TestHTTPRouteMultipleServices(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements matching listeners by [Listener.AllowedRoutes](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.AllowedRoutes) as well as some refactor in `getSupportedGatewayForRoute`

**Which issue this PR fixes**:

Should fix #2408

**Special notes for your reviewer**:

This PR also adds matching routes against listener's status and most specifically `.SupportedKinds`. I'm not sure if that's the right thing to do given the [comment in the spec](https://github.com/kubernetes-sigs/gateway-api/blob/a8f72f5778d9d769dfda5d4332d23529aeb7f2e1/apis/v1beta1/gateway_types.go#L656-L666) but it surely feels right. For now in such cases we'd add a `gatewayv1beta1.RouteReasonNotAllowedByListeners`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
