### PR TITLE
Add builders for `AllowedRoutes`, `RouteNamespaces` and `RouteGroupKind`

### DIFF
--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -610,12 +610,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("TCPRoute"),
-										},
-									},
+									SupportedKinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
 								},
 							},
 						},
@@ -694,12 +689,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 								NewListener("http").WithPort(80).HTTP().
 								WithAllowedRoutes(
 									&gatewayv1beta1.AllowedRoutes{
-										Kinds: []gatewayv1beta1.RouteGroupKind{
-											{
-												Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-												Kind:  gatewayv1beta1.Kind("TCPRoute"),
-											},
-										},
+										Kinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
 									},
 								).
 								IntoSlice(),
@@ -714,12 +704,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("TCPRoute"),
-										},
-									},
+									SupportedKinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
 								},
 							},
 						},
@@ -795,16 +780,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						},
 						Spec: gatewayv1beta1.GatewaySpec{
 							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.
-								NewListener("http").WithPort(80).HTTP().
-								WithAllowedRoutes(
-									&gatewayv1beta1.AllowedRoutes{
-										Namespaces: &gatewayv1beta1.RouteNamespaces{
-											From: addressOf(gatewayv1beta1.NamespacesFromSame),
-										},
-									},
-								).
-								IntoSlice(),
+							Listeners:        builder.NewListener("http").WithPort(80).HTTP().WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).IntoSlice(),
 						},
 						Status: gatewayv1beta1.GatewayStatus{
 							Listeners: []gatewayv1beta1.ListenerStatus{
@@ -816,12 +792,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-									},
+									SupportedKinds: builder.NewRouteGroupKind().HTTPRoute().IntoSlice(),
 								},
 							},
 						},
@@ -899,17 +870,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						},
 						Spec: gatewayv1beta1.GatewaySpec{
 							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.
-								NewListener("http").WithPort(80).HTTP().
-								WithAllowedRoutes(
-									&gatewayv1beta1.AllowedRoutes{
-										Namespaces: &gatewayv1beta1.RouteNamespaces{
-											From: addressOf(gatewayv1beta1.NamespacesFromSame),
-										},
-									},
-								).
-								WithHostname("hostname.com").
-								IntoSlice(),
+							Listeners:        builder.NewListener("http").WithPort(80).HTTP().WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).WithHostname("hostname.com").IntoSlice(),
 						},
 						Status: gatewayv1beta1.GatewayStatus{
 							Listeners: []gatewayv1beta1.ListenerStatus{
@@ -921,12 +882,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 											Status: metav1.ConditionTrue,
 										},
 									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-									},
+									SupportedKinds: builder.NewRouteGroupKind().HTTPRoute().IntoSlice(),
 								},
 							},
 						},
@@ -1049,14 +1005,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 										},
 									},
 									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("TCPRoute"),
-										},
+										builder.NewRouteGroupKind().HTTPRoute().Build(),
+										builder.NewRouteGroupKind().TCPRoute().Build(),
 									},
 								},
 							},

--- a/internal/util/builder/allowedroutes.go
+++ b/internal/util/builder/allowedroutes.go
@@ -1,0 +1,15 @@
+package builder
+
+import gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+func NewAllowedRoutesFromSameNamespaces() *gatewayv1beta1.AllowedRoutes {
+	return &gatewayv1beta1.AllowedRoutes{
+		Namespaces: NewRouteNamespaces().FromSame().Build(),
+	}
+}
+
+func NewAllowedRoutesFromAllNamespaces() *gatewayv1beta1.AllowedRoutes {
+	return &gatewayv1beta1.AllowedRoutes{
+		Namespaces: NewRouteNamespaces().FromAll().Build(),
+	}
+}

--- a/internal/util/builder/routegroupkind.go
+++ b/internal/util/builder/routegroupkind.go
@@ -1,0 +1,38 @@
+package builder
+
+import gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+// RouteGroupKindBuilder is a builder for gateway api RouteGroupKind.
+// Will set default values, as specified in the gateway API, for fields that are not set.
+// Primarily used for testing.
+type RouteGroupKindBuilder struct {
+	routeGroupKind gatewayv1beta1.RouteGroupKind
+}
+
+func NewRouteGroupKind() *RouteGroupKindBuilder {
+	return &RouteGroupKindBuilder{
+		routeGroupKind: gatewayv1beta1.RouteGroupKind{
+			Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+		},
+	}
+}
+
+// Build returns the configured RouteGroupKind.
+func (b *RouteGroupKindBuilder) Build() gatewayv1beta1.RouteGroupKind {
+	return b.routeGroupKind
+}
+
+// IntoSlice returns the configured RouteGroupKind in a slice.
+func (b *RouteGroupKindBuilder) IntoSlice() []gatewayv1beta1.RouteGroupKind {
+	return []gatewayv1beta1.RouteGroupKind{b.routeGroupKind}
+}
+
+func (b *RouteGroupKindBuilder) TCPRoute() *RouteGroupKindBuilder {
+	b.routeGroupKind.Kind = gatewayv1beta1.Kind("TCPRoute")
+	return b
+}
+
+func (b *RouteGroupKindBuilder) HTTPRoute() *RouteGroupKindBuilder {
+	b.routeGroupKind.Kind = gatewayv1beta1.Kind("HTTPRoute")
+	return b
+}

--- a/internal/util/builder/routenamespaces.go
+++ b/internal/util/builder/routenamespaces.go
@@ -1,0 +1,38 @@
+package builder
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// RouteNamespacesBuilder is a builder for gateway api RouteNamespaces.
+// Will set default values, as specified in the gateway API, for fields that are not set.
+// Primarily used for testing.
+type RouteNamespacesBuilder struct {
+	routeNamespaces gatewayv1beta1.RouteNamespaces
+}
+
+func NewRouteNamespaces() *RouteNamespacesBuilder {
+	return &RouteNamespacesBuilder{}
+}
+
+// Build returns the configured RouteNamespaces.
+func (b *RouteNamespacesBuilder) Build() *gatewayv1beta1.RouteNamespaces {
+	return &b.routeNamespaces
+}
+
+func (b *RouteNamespacesBuilder) FromSame() *RouteNamespacesBuilder {
+	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromSame)
+	return b
+}
+
+func (b *RouteNamespacesBuilder) FromAll() *RouteNamespacesBuilder {
+	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromAll)
+	return b
+}
+
+func (b *RouteNamespacesBuilder) FromSelector(s *metav1.LabelSelector) *RouteNamespacesBuilder {
+	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromSelector)
+	b.routeNamespaces.Selector = s
+	return b
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds builders for `AllowedRoutes`, `RouteNamespaces` and `RouteGroupKind`

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
