### PR TITLE
chore: add yum update in redhat's image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,10 @@ COPY --from=builder /workspace/manager .
 COPY LICENSE /licenses/
 COPY LICENSES /licenses/
 
+# Run yum update to prevent vulnerable packages getting into the final image
+# and preventing publishing on Redhat connect registry.
+RUN yum update -y
+
 # Perform any further action as an unprivileged user.
 USER 1000
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When Redhat connect detect a vulnerability it blocks publishing of an image version with the following prompt 

```
Health index must be A to publish
```

<img width="2179" alt="image" src="https://user-images.githubusercontent.com/739996/204833270-ad442b64-efaf-4e1f-aa28-1444fb788a8b.png">

In order to prevent that, run `yum update -y` on release builds.