### PR TITLE
fix(ci): use correct redhat standard tags in nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -117,7 +117,7 @@ jobs:
     needs: 
       - build-push-images
     env:
-      REDHAT_STANDARD_TAG: ${{ needs.build-push-images.outputs.REDHAT_STANDARD_TAG }}
+      REDHAT_STANDARD_TAG: ${{ needs.build-push-images.outputs.TAGS_REDHAT_STANDARD }}
 
     steps:
       - name: checkout repository


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that we didn't use the proper output name in nightly CI's `redhat-certification-test` workflow.

This PR fixes it and uses `TAGS_REDHAT_STANDARD` which is the actual name of `build-push-images` output.

**Which issue this PR fixes**:

Fixes #3202