### PR TITLE
fix(ci): use correct junit file name in nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -207,7 +207,7 @@ jobs:
       - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests With ${{ matrix.kong-router-flavor }} Kong Router
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}
         env:
-          GOTESTSUM_JUNITFILE: integration-${{ matrix.kong-router-flavor }}-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-tests.xml
+          GOTESTSUM_JUNITFILE: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-${{ matrix.kong-router-flavor }}-tests.xml
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.kong-router-flavor }}
       - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests for Invalid Configurations With ${{ matrix.kong-router-flavor }} Kong Router
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}


### PR DESCRIPTION
**What this PR does / why we need it**:

#3127 changed junit file names ever so slightly thus making the artifact download job not being able to find them.

This PR fixes it by using the same file names in integration tests make target and in artifact upload step.

Exemplar failure: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3593876328/jobs/6052288394
