### PR TITLE
chore(docs): remove top-level CRD extensive godocs

### DIFF
--- a/config/crd/bases/configuration.konghq.com_ingressclassparameterses.yaml
+++ b/config/crd/bases/configuration.konghq.com_ingressclassparameterses.yaml
@@ -34,6 +34,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec is the IngressClassParameters specification.
             properties:
               enableLegacyRegexDetection:
                 default: false

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -41,10 +41,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the  API. The only differences
-          between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a
-          Kubernetes cluster-level resource instead of a namespaced resource, and
-          can be applied as a global plugin using `global` label.
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -31,12 +31,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: "KongConsumer is the Schema for the kongconsumers API. When this
-          resource is created, a corresponding consumer entity will be created in
-          Kong. \n While KongConsumer exists in a specific Kubernetes namespace, KongConsumers
-          from all namespaces are combined into a single Kong configuration, and no
-          KongConsumers with the same `kubernetes.io/ingress.class` may share the
-          same Username or CustomID value."
+        description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -22,17 +22,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "KongIngress is the Schema for the kongingresses API. It serves
-          as an \"extension\" to Ingress resource. It is not meant as a replacement
-          to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes
-          can define routing policies based on HTTP Host header and paths. While this
-          is sufficient in most cases, sometimes, users may want more control over
-          routing at the Ingress level. \n Once a `KongIngress` resource is created,
-          it needs to be associated with an Ingress or Service resource using the
-          `konghq.com/override` annotation. \n Many fields available on KongIngress
-          are also available as annotations. When an annotation is available, it is
-          the preferred means of configuring that setting, and the annotation value
-          will take precedence over a KongIngress value if both set the same setting."
+        description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -41,9 +41,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongPlugin is the Schema for the kongplugins API. Plugins can
-          be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins`
-          annotation.
+        description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/configuration.konghq.com_tcpingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_tcpingresses.yaml
@@ -29,9 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API. The Ingress
-          resource in Kubernetes is HTTP-only. This custom resource is modeled similar
-          to the Ingress resource but for TCP and TLS SNI based routing purposes.
+        description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -46,7 +44,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TCPIngressSpec defines the desired state of TCPIngress.
+            description: Spec is the TCPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/config/crd/bases/configuration.konghq.com_udpingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_udpingresses.yaml
@@ -29,10 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API. It makes it
-          possible to route traffic to your UDP services using Kong (e.g. DNS, Game
-          Servers, etc.). For each rule provided in the spec the Kong proxy environment
-          must be updated to listen to UDP on that port as well.
+        description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,7 +44,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: UDPIngressSpec defines the desired state of UDPIngress.
+            description: Spec is the UDPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -38,6 +38,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec is the IngressClassParameters specification.
             properties:
               enableLegacyRegexDetection:
                 default: false
@@ -97,10 +98,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the  API. The only differences
-          between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a
-          Kubernetes cluster-level resource instead of a namespaced resource, and
-          can be applied as a global plugin using `global` label.
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -247,12 +245,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: "KongConsumer is the Schema for the kongconsumers API. When this
-          resource is created, a corresponding consumer entity will be created in
-          Kong. \n While KongConsumer exists in a specific Kubernetes namespace, KongConsumers
-          from all namespaces are combined into a single Kong configuration, and no
-          KongConsumers with the same `kubernetes.io/ingress.class` may share the
-          same Username or CustomID value."
+        description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -308,17 +301,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "KongIngress is the Schema for the kongingresses API. It serves
-          as an \"extension\" to Ingress resource. It is not meant as a replacement
-          to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes
-          can define routing policies based on HTTP Host header and paths. While this
-          is sufficient in most cases, sometimes, users may want more control over
-          routing at the Ingress level. \n Once a `KongIngress` resource is created,
-          it needs to be associated with an Ingress or Service resource using the
-          `konghq.com/override` annotation. \n Many fields available on KongIngress
-          are also available as annotations. When an annotation is available, it is
-          the preferred means of configuring that setting, and the annotation value
-          will take precedence over a KongIngress value if both set the same setting."
+        description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -665,9 +648,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongPlugin is the Schema for the kongplugins API. Plugins can
-          be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins`
-          annotation.
+        description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -808,9 +789,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API. The Ingress
-          resource in Kubernetes is HTTP-only. This custom resource is modeled similar
-          to the Ingress resource but for TCP and TLS SNI based routing purposes.
+        description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -825,7 +804,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TCPIngressSpec defines the desired state of TCPIngress.
+            description: Spec is the TCPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.
@@ -997,10 +976,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API. It makes it
-          possible to route traffic to your UDP services using Kong (e.g. DNS, Game
-          Servers, etc.). For each rule provided in the spec the Kong proxy environment
-          must be updated to listen to UDP on that port as well.
+        description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1015,7 +991,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: UDPIngressSpec defines the desired state of UDPIngress.
+            description: Spec is the UDPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -38,6 +38,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec is the IngressClassParameters specification.
             properties:
               enableLegacyRegexDetection:
                 default: false
@@ -97,10 +98,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the  API. The only differences
-          between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a
-          Kubernetes cluster-level resource instead of a namespaced resource, and
-          can be applied as a global plugin using `global` label.
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -247,12 +245,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: "KongConsumer is the Schema for the kongconsumers API. When this
-          resource is created, a corresponding consumer entity will be created in
-          Kong. \n While KongConsumer exists in a specific Kubernetes namespace, KongConsumers
-          from all namespaces are combined into a single Kong configuration, and no
-          KongConsumers with the same `kubernetes.io/ingress.class` may share the
-          same Username or CustomID value."
+        description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -308,17 +301,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "KongIngress is the Schema for the kongingresses API. It serves
-          as an \"extension\" to Ingress resource. It is not meant as a replacement
-          to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes
-          can define routing policies based on HTTP Host header and paths. While this
-          is sufficient in most cases, sometimes, users may want more control over
-          routing at the Ingress level. \n Once a `KongIngress` resource is created,
-          it needs to be associated with an Ingress or Service resource using the
-          `konghq.com/override` annotation. \n Many fields available on KongIngress
-          are also available as annotations. When an annotation is available, it is
-          the preferred means of configuring that setting, and the annotation value
-          will take precedence over a KongIngress value if both set the same setting."
+        description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -665,9 +648,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongPlugin is the Schema for the kongplugins API. Plugins can
-          be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins`
-          annotation.
+        description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -808,9 +789,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API. The Ingress
-          resource in Kubernetes is HTTP-only. This custom resource is modeled similar
-          to the Ingress resource but for TCP and TLS SNI based routing purposes.
+        description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -825,7 +804,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TCPIngressSpec defines the desired state of TCPIngress.
+            description: Spec is the TCPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.
@@ -997,10 +976,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API. It makes it
-          possible to route traffic to your UDP services using Kong (e.g. DNS, Game
-          Servers, etc.). For each rule provided in the spec the Kong proxy environment
-          must be updated to listen to UDP on that port as well.
+        description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1015,7 +991,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: UDPIngressSpec defines the desired state of UDPIngress.
+            description: Spec is the UDPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -38,6 +38,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec is the IngressClassParameters specification.
             properties:
               enableLegacyRegexDetection:
                 default: false
@@ -97,10 +98,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the  API. The only differences
-          between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a
-          Kubernetes cluster-level resource instead of a namespaced resource, and
-          can be applied as a global plugin using `global` label.
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -247,12 +245,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: "KongConsumer is the Schema for the kongconsumers API. When this
-          resource is created, a corresponding consumer entity will be created in
-          Kong. \n While KongConsumer exists in a specific Kubernetes namespace, KongConsumers
-          from all namespaces are combined into a single Kong configuration, and no
-          KongConsumers with the same `kubernetes.io/ingress.class` may share the
-          same Username or CustomID value."
+        description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -308,17 +301,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "KongIngress is the Schema for the kongingresses API. It serves
-          as an \"extension\" to Ingress resource. It is not meant as a replacement
-          to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes
-          can define routing policies based on HTTP Host header and paths. While this
-          is sufficient in most cases, sometimes, users may want more control over
-          routing at the Ingress level. \n Once a `KongIngress` resource is created,
-          it needs to be associated with an Ingress or Service resource using the
-          `konghq.com/override` annotation. \n Many fields available on KongIngress
-          are also available as annotations. When an annotation is available, it is
-          the preferred means of configuring that setting, and the annotation value
-          will take precedence over a KongIngress value if both set the same setting."
+        description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -665,9 +648,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongPlugin is the Schema for the kongplugins API. Plugins can
-          be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins`
-          annotation.
+        description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -808,9 +789,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API. The Ingress
-          resource in Kubernetes is HTTP-only. This custom resource is modeled similar
-          to the Ingress resource but for TCP and TLS SNI based routing purposes.
+        description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -825,7 +804,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TCPIngressSpec defines the desired state of TCPIngress.
+            description: Spec is the TCPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.
@@ -997,10 +976,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API. It makes it
-          possible to route traffic to your UDP services using Kong (e.g. DNS, Game
-          Servers, etc.). For each rule provided in the spec the Kong proxy environment
-          must be updated to listen to UDP on that port as well.
+        description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1015,7 +991,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: UDPIngressSpec defines the desired state of UDPIngress.
+            description: Spec is the UDPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -38,6 +38,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec is the IngressClassParameters specification.
             properties:
               enableLegacyRegexDetection:
                 default: false
@@ -97,10 +98,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the  API. The only differences
-          between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a
-          Kubernetes cluster-level resource instead of a namespaced resource, and
-          can be applied as a global plugin using `global` label.
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -247,12 +245,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: "KongConsumer is the Schema for the kongconsumers API. When this
-          resource is created, a corresponding consumer entity will be created in
-          Kong. \n While KongConsumer exists in a specific Kubernetes namespace, KongConsumers
-          from all namespaces are combined into a single Kong configuration, and no
-          KongConsumers with the same `kubernetes.io/ingress.class` may share the
-          same Username or CustomID value."
+        description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -308,17 +301,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "KongIngress is the Schema for the kongingresses API. It serves
-          as an \"extension\" to Ingress resource. It is not meant as a replacement
-          to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes
-          can define routing policies based on HTTP Host header and paths. While this
-          is sufficient in most cases, sometimes, users may want more control over
-          routing at the Ingress level. \n Once a `KongIngress` resource is created,
-          it needs to be associated with an Ingress or Service resource using the
-          `konghq.com/override` annotation. \n Many fields available on KongIngress
-          are also available as annotations. When an annotation is available, it is
-          the preferred means of configuring that setting, and the annotation value
-          will take precedence over a KongIngress value if both set the same setting."
+        description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -665,9 +648,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: KongPlugin is the Schema for the kongplugins API. Plugins can
-          be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins`
-          annotation.
+        description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -808,9 +789,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API. The Ingress
-          resource in Kubernetes is HTTP-only. This custom resource is modeled similar
-          to the Ingress resource but for TCP and TLS SNI based routing purposes.
+        description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -825,7 +804,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: TCPIngressSpec defines the desired state of TCPIngress.
+            description: Spec is the TCPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.
@@ -997,10 +976,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API. It makes it
-          possible to route traffic to your UDP services using Kong (e.g. DNS, Game
-          Servers, etc.). For each rule provided in the spec the Kong proxy environment
-          must be updated to listen to UDP on that port as well.
+        description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1015,7 +991,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: UDPIngressSpec defines the desired state of UDPIngress.
+            description: Spec is the UDPIngress specification.
             properties:
               rules:
                 description: A list of rules used to configure the Ingress.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -283,7 +283,7 @@ IngressClassParameters is the Schema for the IngressClassParameters API.
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `IngressClassParameters`
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[IngressClassParametersSpec](#ingressclassparametersspec)_ |  |
+| `spec` _[IngressClassParametersSpec](#ingressclassparametersspec)_ | Spec is the IngressClassParameters specification. |
 
 
 
@@ -326,7 +326,7 @@ TCPIngress is the Schema for the tcpingresses API.
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `TCPIngress`
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[TCPIngressSpec](#tcpingressspec)_ |  |
+| `spec` _[TCPIngressSpec](#tcpingressspec)_ | Spec is the TCPIngress specification. |
 
 
 
@@ -344,7 +344,7 @@ UDPIngress is the Schema for the udpingresses API.
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `UDPIngress`
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[UDPIngressSpec](#udpingressspec)_ |  |
+| `spec` _[UDPIngressSpec](#udpingressspec)_ | Spec is the UDPIngress specification. |
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,7 +19,7 @@ Package v1 contains API Schema definitions for the konghq.com v1 API group.
 
 
 
-KongClusterPlugin is the Schema for the  API. The only differences between KongPlugin and KongClusterPlugin are that KongClusterPlugin is a Kubernetes cluster-level resource instead of a namespaced resource, and can be applied as a global plugin using `global` label.
+KongClusterPlugin is the Schema for the kongclusterplugins API.
 
 <!-- kong_cluster_plugin description placeholder -->
 
@@ -44,8 +44,7 @@ KongClusterPlugin is the Schema for the  API. The only differences between KongP
 
 
 
-KongConsumer is the Schema for the kongconsumers API. When this resource is created, a corresponding consumer entity will be created in Kong. 
- While KongConsumer exists in a specific Kubernetes namespace, KongConsumers from all namespaces are combined into a single Kong configuration, and no KongConsumers with the same `kubernetes.io/ingress.class` may share the same Username or CustomID value.
+KongConsumer is the Schema for the kongconsumers API.
 
 <!-- kong_consumer description placeholder -->
 
@@ -65,9 +64,7 @@ KongConsumer is the Schema for the kongconsumers API. When this resource is crea
 
 
 
-KongIngress is the Schema for the kongingresses API. It serves as an "extension" to Ingress resource. It is not meant as a replacement to the Ingress resource in Kubernetes. Ingress resource spec in Kubernetes can define routing policies based on HTTP Host header and paths. While this is sufficient in most cases, sometimes, users may want more control over routing at the Ingress level. 
- Once a `KongIngress` resource is created, it needs to be associated with an Ingress or Service resource using the `konghq.com/override` annotation. 
- Many fields available on KongIngress are also available as annotations. When an annotation is available, it is the preferred means of configuring that setting, and the annotation value will take precedence over a KongIngress value if both set the same setting.
+KongIngress is the Schema for the kongingresses API.
 
 <!-- kong_ingress description placeholder -->
 
@@ -87,7 +84,7 @@ KongIngress is the Schema for the kongingresses API. It serves as an "extension"
 
 
 
-KongPlugin is the Schema for the kongplugins API. Plugins can be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins` annotation.
+KongPlugin is the Schema for the kongplugins API.
 
 <!-- kong_plugin description placeholder -->
 
@@ -320,7 +317,7 @@ Package v1beta1 contains API Schema definitions for the configuration.konghq.com
 
 
 
-TCPIngress is the Schema for the tcpingresses API. The Ingress resource in Kubernetes is HTTP-only. This custom resource is modeled similar to the Ingress resource but for TCP and TLS SNI based routing purposes.
+TCPIngress is the Schema for the tcpingresses API.
 
 <!-- tcp_ingress description placeholder -->
 
@@ -338,7 +335,7 @@ TCPIngress is the Schema for the tcpingresses API. The Ingress resource in Kuber
 
 
 
-UDPIngress is the Schema for the udpingresses API. It makes it possible to route traffic to your UDP services using Kong (e.g. DNS, Game Servers, etc.). For each rule provided in the spec the Kong proxy environment must be updated to listen to UDP on that port as well.
+UDPIngress is the Schema for the udpingresses API.
 
 <!-- udp_ingress description placeholder -->
 

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -35,10 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 
-// KongClusterPlugin is the Schema for the  API.
-// The only differences between KongPlugin and KongClusterPlugin are that KongClusterPlugin
-// is a Kubernetes cluster-level resource instead of a namespaced resource, and can be applied
-// as a global plugin using `global` label.
+// KongClusterPlugin is the Schema for the kongclusterplugins API.
 type KongClusterPlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -31,11 +31,6 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 
 // KongConsumer is the Schema for the kongconsumers API.
-// When this resource is created, a corresponding consumer entity will be created in Kong.
-//
-// While KongConsumer exists in a specific Kubernetes namespace, KongConsumers from all namespaces are combined
-// into a single Kong configuration, and no KongConsumers with the same `kubernetes.io/ingress.class`
-// may share the same Username or CustomID value.
 type KongConsumer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/configuration/v1/kongingress_types.go
+++ b/pkg/apis/configuration/v1/kongingress_types.go
@@ -30,17 +30,6 @@ import (
 // +kubebuilder:validation:Optional
 
 // KongIngress is the Schema for the kongingresses API.
-// It serves as an "extension" to Ingress resource. It is not meant as a replacement to
-// the Ingress resource in Kubernetes.
-// Ingress resource spec in Kubernetes can define routing policies based on HTTP Host header and paths.
-// While this is sufficient in most cases, sometimes, users may want more control over routing at the Ingress level.
-//
-// Once a `KongIngress` resource is created, it needs to be associated with
-// an Ingress or Service resource using the `konghq.com/override` annotation.
-//
-// Many fields available on KongIngress are also available as annotations.
-// When an annotation is available, it is the preferred means of configuring that setting, and the annotation value
-// will take precedence over a KongIngress value if both set the same setting.
 type KongIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -35,7 +35,6 @@ import (
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 
 // KongPlugin is the Schema for the kongplugins API.
-// Plugins can be associated with Ingress or Service object in Kubernetes using `konghq.com/plugins` annotation.
 type KongPlugin struct {
 	metav1.TypeMeta `json:",inline"`
 	// Setting a `global` label to `true` will apply the plugin to every request proxied by the Kong.

--- a/pkg/apis/configuration/v1alpha1/ingress_class_param_types.go
+++ b/pkg/apis/configuration/v1alpha1/ingress_class_param_types.go
@@ -45,6 +45,7 @@ type IngressClassParameters struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// Spec is the IngressClassParameters specification.
 	Spec IngressClassParametersSpec `json:"spec,omitempty"`
 }
 

--- a/pkg/apis/configuration/v1beta1/tcpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/tcpingress_types.go
@@ -36,6 +36,7 @@ type TCPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// Spec is the TCPIngress specification.
 	Spec   TCPIngressSpec   `json:"spec,omitempty"`
 	Status TCPIngressStatus `json:"status,omitempty"`
 }

--- a/pkg/apis/configuration/v1beta1/tcpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/tcpingress_types.go
@@ -32,8 +32,6 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 
 // TCPIngress is the Schema for the tcpingresses API.
-// The Ingress resource in Kubernetes is HTTP-only. This custom resource is modeled similar to the Ingress resource
-// but for TCP and TLS SNI based routing purposes.
 type TCPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/configuration/v1beta1/udpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/udpingress_types.go
@@ -49,6 +49,7 @@ type UDPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// Spec is the UDPIngress specification.
 	Spec   UDPIngressSpec   `json:"spec,omitempty"`
 	Status UDPIngressStatus `json:"status,omitempty"`
 }

--- a/pkg/apis/configuration/v1beta1/udpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/udpingress_types.go
@@ -45,8 +45,6 @@ type UDPIngressList struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 
 // UDPIngress is the Schema for the udpingresses API.
-// It makes it possible to route traffic to your UDP services using Kong (e.g. DNS, Game Servers, etc.).
-// For each rule provided in the spec the Kong proxy environment must be updated to listen to UDP on that port as well.
 type UDPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/scripts/apidocs-gen/post-process-for-konghq.sh
+++ b/scripts/apidocs-gen/post-process-for-konghq.sh
@@ -27,4 +27,6 @@ cat "${CRD_REF_DOC}" >> "${POST_PROCESSED_DOC}"
 echo "<!-- vale on -->" >> "${POST_PROCESSED_DOC}"
 
 # Replace all description placeholders with proper include directives
-sed -i '' -E 's/<!-- (.*) description placeholder -->/{% include_cached md\/kubernetes-ingress-controller\/\1_description.md %}/' "${POST_PROCESSED_DOC}"
+sed -i '' -E \
+  's/<!-- (.*) description placeholder -->/{% include_cached md\/kubernetes-ingress-controller\/\1_description.md kong_version=page.kong_version %}/' \
+  "${POST_PROCESSED_DOC}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes top-level CRD godocs. They will be included in hand-written markdown files in the docs repository to give wider possibilities of formatting (`{:.warning}` directives etc.). 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3019 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Notes for the reviewers**:

removed godocs are going to be moved to docs.konghq.com in [this PR](https://github.com/Kong/docs.konghq.com/pull/4813).