### PR TITLE
test(gateway-api): cover L4 routes in getSupportedGatewayForRoute tests

### DIFF
--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -226,915 +224,311 @@ func addressOf[T any](v T) *T {
 }
 
 func Test_getSupportedGatewayForRoute(t *testing.T) {
-	t.Run("HTTPRoute", func(t *testing.T) {
-		type expected struct {
-			gateway      types.NamespacedName
-			condition    metav1.Condition
-			listenerName string
+	gatewayClass := &GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-gatewayclass",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
+		},
+	}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+		},
+	}
+
+	routeConditionAccepted := func(status metav1.ConditionStatus, reason gatewayv1beta1.RouteConditionReason) metav1.Condition {
+		return metav1.Condition{
+			Type:   string(gatewayv1beta1.RouteConditionAccepted),
+			Status: status,
+			Reason: string(reason),
 		}
+	}
+
+	type expected struct {
+		condition    metav1.Condition
+		listenerName string
+	}
+
+	t.Run("HTTPRoute", func(t *testing.T) {
+		basicHTTPRoute := func() *HTTPRoute {
+			return &HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HTTPRoute",
+					APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: "test-namespace",
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{
+							{
+								Name: "test-gateway",
+							},
+						},
+					},
+					Rules: []gatewayv1beta1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+								builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+							},
+						},
+					},
+				},
+			}
+		}
+		gatewayWithHTTP80Ready := func() *Gateway {
+			return &Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: gatewayv1beta1.GroupVersion.String(),
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "test-namespace",
+					UID:       "ce7f0678-f59a-483c-80d1-243d3738d22c",
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: "test-gatewayclass",
+					Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
+				},
+				Status: gatewayv1beta1.GatewayStatus{
+					Listeners: []gatewayv1beta1.ListenerStatus{
+						{
+							Name: "http",
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Ready",
+									Status: metav1.ConditionTrue,
+								},
+							},
+							SupportedKinds: supportedRouteGroupKinds,
+						},
+					},
+				},
+			}
+		}
+
 		tests := []struct {
 			name     string
 			route    *HTTPRoute
 			expected []expected
 			objects  []client.Object
-			wantErr  bool
 		}{
 			{
-				name: "basic HTTPRoute gets accepted",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic HTTPRoute gets accepted",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					gatewayWithHTTP80Ready(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
-				name: "basic HTTPRoute with TLS configuration gets accepted",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic HTTPRoute with TLS configuration gets accepted",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.
-								NewListener("https").WithPort(443).HTTPS().
-								WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-									Mode: (*gatewayv1beta1.TLSModeType)(pointer.StringPtr(string(gatewayv1beta1.TLSModeTerminate))),
-								}).
-								IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("https"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.
+							NewListener("http").WithPort(443).HTTPS().
+							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
+								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+							}).
+							IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
 				name: "basic HTTPRoute specifying existing section name gets Accepted",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name:        gatewayv1beta1.ObjectName("test-gateway"),
-									SectionName: addressOf(gatewayv1beta1.SectionName("http")),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				route: func() *HTTPRoute {
+					r := basicHTTPRoute()
+					r.Spec.ParentRefs[0].SectionName = addressOf(gatewayv1beta1.SectionName("http"))
+					return r
+				}(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					gatewayWithHTTP80Ready(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
 						listenerName: "http",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition:    routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
 				name: "basic HTTPRoute specifying existing port gets Accepted",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-									Port: addressOf(gatewayv1beta1.PortNumber(80)),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				route: func() *HTTPRoute {
+					r := basicHTTPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1beta1.PortNumber(80))
+					return r
+				}(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					gatewayWithHTTP80Ready(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-									Port: addressOf(gatewayv1beta1.PortNumber(80)),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				route: func() *HTTPRoute {
+					r := basicHTTPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(PortNumber(80))
+					return r
+				}(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(81).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.NewListener("http").WithPort(81).HTTP().IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							Reason: string(RouteReasonNoMatchingParent),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
 					},
 				},
 			},
 			{
-				name: "basic HTTPRoute does not get accepted if it is not in the supported kinds",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic HTTPRoute does not get accepted if it is not in the supported kinds",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Status.Listeners[0].SupportedKinds = nil
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNotAllowedByListeners),
 					},
 				},
 			},
 			{
-				name: "basic HTTPRoute does not get accepted if it is not permitted by allowed routes",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic HTTPRoute does not get accepted if it is not permitted by allowed routes",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.
-								NewListener("http").WithPort(80).HTTP().
-								WithAllowedRoutes(
-									&gatewayv1beta1.AllowedRoutes{
-										Kinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
-									},
-								).
-								IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.NewListener("http").
+							WithPort(80).
+							HTTP().
+							WithAllowedRoutes(
+								&gatewayv1beta1.AllowedRoutes{
+									Kinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
 								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+							).
+							IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							// NOTE: Is this correct? Does ListenerStatus.SupportedKinds have impact on this?
-							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNotAllowedByListeners),
 					},
 				},
 			},
 			{
-				name: "basic HTTPRoute does get accepted if allowed routes only specified Same namespace",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic HTTPRoute does get accepted if allowed routes only specified Same namespace",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: builder.NewRouteGroupKind().HTTPRoute().IntoSlice(),
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.NewListener("http").
+							WithPort(80).
+							HTTP().
+							WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).
+							IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
 				name: "HTTPRoute does not get accepted if Listener hostnames do not match route hostnames",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						Hostnames: []gatewayv1beta1.Hostname{
-							"very.specific.com",
-						},
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-								},
-							},
-						},
-					},
-				},
+				route: func() *HTTPRoute {
+					r := basicHTTPRoute()
+					r.Spec.Hostnames = []gatewayv1beta1.Hostname{"very.specific.com"}
+					return r
+				}(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).WithHostname("hostname.com").IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: builder.NewRouteGroupKind().HTTPRoute().IntoSlice(),
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.NewListener("http").
+							WithPort(80).
+							HTTP().
+							WithAllowedRoutes(builder.NewAllowedRoutesFromSameNamespaces()).
+							WithHostname("hostname.com").
+							IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							Reason: string(gatewayv1beta1.RouteReasonNoMatchingListenerHostname),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingListenerHostname),
 					},
 				},
 			},
 			{
-				name: "HTTPRoute does not get accepted if Listener TLSConfig uses PassThrough",
-				route: &HTTPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
-						APIVersion: gatewayv1beta1.GroupVersion.Group + "/" + gatewayv1beta1.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-httproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayv1beta1.ParentReference{
-								{
-									Name: gatewayv1beta1.ObjectName("test-gateway"),
-								},
-							},
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("fake-service").WithPort(443).Build(),
-								},
-							},
-						},
-					},
-				},
+				name:  "HTTPRoute does not get accepted if Listener TLSConfig uses PassThrough",
+				route: basicHTTPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.
-								NewListener("https").WithPort(443).HTTPS().
-								WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-									Mode: (*gatewayv1beta1.TLSModeType)(pointer.StringPtr(string(gatewayv1beta1.TLSModePassthrough))),
-								}).
-								IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("https"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-									},
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Spec.Listeners = builder.
+							NewListener("https").WithPort(443).HTTPS().
+							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
+								Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+							}).
+							IntoSlice()
+						gw.Status.Listeners[0].Name = "https"
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							Reason: string(RouteReasonNoMatchingParent),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
 					},
 				},
 			},
@@ -1150,200 +544,201 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 					Build()
 
 				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
-				if tt.wantErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-					require.Len(t, got, len(tt.expected))
+				require.NoError(t, err)
+				require.Len(t, got, len(tt.expected))
 
-					for i := range got {
-						assert.Equalf(t, tt.expected[i].gateway.Namespace, got[i].gateway.Namespace, "gateway namespace #%d", i)
-						assert.Equalf(t, tt.expected[i].gateway.Name, got[i].gateway.Name, "gateway name #%d", i)
-						assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
-						assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
-					}
+				for i := range got {
+					assert.Equalf(t, "test-namespace", got[i].gateway.Namespace, "gateway namespace #%d", i)
+					assert.Equalf(t, "test-gateway", got[i].gateway.Name, "gateway name #%d", i)
+					assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
+					assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
 				}
 			})
 		}
 	})
 
 	t.Run("TCPRoute", func(t *testing.T) {
+		basicTCPRoute := func() *TCPRoute {
+			return &TCPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TCPRoute",
+					APIVersion: gatewayv1alpha2.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-tcproute",
+					Namespace: "test-namespace",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name: "test-gateway",
+							},
+						},
+					},
+				},
+			}
+		}
+		gatewayWithTCP80Ready := func() *Gateway {
+			return &Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "test-namespace",
+					UID:       "ce7f0678-f59a-483c-80d1-243d3738d22c",
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: "test-gatewayclass",
+					Listeners:        builder.NewListener("tcp").WithPort(80).TCP().IntoSlice(),
+				},
+				Status: gatewayv1beta1.GatewayStatus{
+					Listeners: []gatewayv1beta1.ListenerStatus{
+						{
+							Name: "tcp",
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Ready",
+									Status: metav1.ConditionTrue,
+								},
+							},
+							SupportedKinds: builder.NewRouteGroupKind().TCPRoute().IntoSlice(),
+						},
+					},
+				},
+			}
+		}
+
 		type expected struct {
-			gateway      types.NamespacedName
 			condition    metav1.Condition
 			listenerName string
 		}
 		tests := []struct {
 			name     string
 			route    *TCPRoute
-			expected []expected
+			expected expected
 			objects  []client.Object
 			wantErr  bool
 		}{
 			{
-				name: "basic TCPRoute does get accepted because it is in supported kinds",
-				route: &TCPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "TCPRoute",
-						APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-tcproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1alpha2.TCPRouteSpec{
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{
-								{
-									Name: gatewayv1alpha2.ObjectName("test-gateway"),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic TCPRoute does get accepted because it is in supported kinds",
+				route: basicTCPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("tcp").WithPort(80).TCP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("tcp"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										builder.NewRouteGroupKind().HTTPRoute().Build(),
-										builder.NewRouteGroupKind().TCPRoute().Build(),
-									},
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					gatewayWithTCP80Ready(),
+					gatewayClass,
+					namespace,
 				},
-				expected: []expected{
-					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
-					},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 				},
 			},
 			{
-				name: "basic TCPRoute does not get accepted because it is not in supported kinds",
-				route: &TCPRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "TCPRoute",
-						APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-tcproute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1alpha2.TCPRouteSpec{
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{
-								{
-									Name: gatewayv1alpha2.ObjectName("test-gateway"),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic TCPRoute does not get accepted because it is not in supported kinds",
+				route: basicTCPRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners:        builder.NewListener("http").WithPort(80).HTTP().IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("http"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: supportedRouteGroupKinds,
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithTCP80Ready()
+						gw.Status.Listeners[0].SupportedKinds = nil
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
-				expected: []expected{
-					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							// NOTE: Is this correct? Does ListenerStatus.SupportedKinds have impact on this?
-							Reason: string(gatewayv1beta1.RouteReasonNotAllowedByListeners),
-						},
-					},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNotAllowedByListeners),
 				},
 			},
+			{
+				name: "TCPRoute specifying existing port gets Accepted",
+				route: func() *TCPRoute {
+					r := basicTCPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
+					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
+						{
+							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
+						},
+					}
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTCP80Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+				},
+			},
+			{
+				name: "TCPRoute specifying non existing port does not get Accepted",
+				route: func() *TCPRoute {
+					r := basicTCPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
+						{
+							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
+						},
+					}
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTCP80Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+				},
+			},
+			{
+				name: "TCPRoute specifying in sectionName existing listener gets Accepted",
+				route: func() *TCPRoute {
+					r := basicTCPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tcp"))
+					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
+						{
+							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
+						},
+					}
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTCP80Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					listenerName: "tcp",
+					condition:    routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+				},
+			},
+			// TODO: uncomment when https://github.com/Kong/kubernetes-ingress-controller/issues/3221 is done
+			// {
+			// 	name: "TCPRoute specifying in sectionName non existing listener does not get Accepted",
+			// 	route: func() *TCPRoute {
+			// 		r := basicTCPRoute()
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
+			// 			{
+			// 				BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
+			// 			},
+			// 		}
+			// 		return r
+			// 	}(),
+			// 	objects: []client.Object{
+			// 		gatewayWithTCP80Ready(),
+			// 		gatewayClass,
+			// 		namespace,
+			// 	},
+			// 	expected: expected{
+			// 		listenerName: "tcp",
+			// 		condition:    routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+			// 	},
+			// },
 		}
 
 		for _, tt := range tests {
@@ -1356,26 +751,264 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 					Build()
 
 				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
-				if tt.wantErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-					require.Len(t, got, len(tt.expected))
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				match := got[0]
 
-					for i := range got {
-						assert.Equalf(t, tt.expected[i].gateway.Namespace, got[i].gateway.Namespace, "gateway namespace #%d", i)
-						assert.Equalf(t, tt.expected[i].gateway.Name, got[i].gateway.Name, "gateway name #%d", i)
-						assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
-						assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
-					}
-				}
+				assert.Equal(t, "test-namespace", match.gateway.Namespace)
+				assert.Equal(t, "test-gateway", match.gateway.Name)
+				assert.Equal(t, tt.expected.listenerName, match.listenerName)
+				assert.Equal(t, tt.expected.condition, match.condition)
+			})
+		}
+	})
+
+	t.Run("UDPRoute", func(t *testing.T) {
+		basicUDPRoute := func() *UDPRoute {
+			return &UDPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "UDPRoute",
+					APIVersion: gatewayv1alpha2.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-udproute",
+					Namespace: "test-namespace",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name: "test-gateway",
+							},
+						},
+					},
+				},
+			}
+		}
+		gatewayWithUDP53Ready := func() *Gateway {
+			return &Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "test-namespace",
+					UID:       "ce7f0678-f59a-483c-80d1-243d3738d22c",
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: "test-gatewayclass",
+					Listeners:        builder.NewListener("udp").WithPort(53).UDP().IntoSlice(),
+				},
+				Status: gatewayv1beta1.GatewayStatus{
+					Listeners: []gatewayv1beta1.ListenerStatus{
+						{
+							Name: "udp",
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Ready",
+									Status: metav1.ConditionTrue,
+								},
+							},
+							SupportedKinds: builder.NewRouteGroupKind().UDPRoute().IntoSlice(),
+						},
+					},
+				},
+			}
+		}
+
+		type expected struct {
+			condition    metav1.Condition
+			listenerName string
+		}
+		tests := []struct {
+			name     string
+			route    *UDPRoute
+			expected expected
+			objects  []client.Object
+			wantErr  bool
+		}{
+			{
+				name:  "basic UDPRoute does get accepted because it is in supported kinds",
+				route: basicUDPRoute(),
+				objects: []client.Object{
+					gatewayWithUDP53Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+				},
+			},
+			{
+				name:  "basic UDPRoute does not get accepted because it is not in supported kinds",
+				route: basicUDPRoute(),
+				objects: []client.Object{
+					func() *Gateway {
+						gw := gatewayWithUDP53Ready()
+						gw.Status.Listeners[0].SupportedKinds = nil
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNotAllowedByListeners),
+				},
+			},
+			{
+				name: "UDPRoute specifying existing port gets Accepted",
+				route: func() *UDPRoute {
+					r := basicUDPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithUDP53Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+				},
+			},
+			{
+				name: "UDPRoute specifying non existing port does not get Accepted",
+				route: func() *UDPRoute {
+					r := basicUDPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithUDP53Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+				},
+			},
+			{
+				name: "UDPRoute specifying in sectionName existing listener gets Accepted",
+				route: func() *UDPRoute {
+					r := basicUDPRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("udp"))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithUDP53Ready(),
+					gatewayClass,
+					namespace,
+				},
+				expected: expected{
+					listenerName: "udp",
+					condition:    routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+				},
+			},
+			// TODO: uncomment when https://github.com/Kong/kubernetes-ingress-controller/issues/3221 is done
+			// {
+			// 	name: "UDPRoute specifying in sectionName non existing listener does not get Accepted",
+			// 	route: func() *UDPRoute {
+			// 		r := basicUDPRoute()
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		return r
+			// 	}(),
+			// 	objects: []client.Object{
+			// 		gatewayWithUDP53Ready(),
+			// 		gatewayClass,
+			// 		namespace,
+			// 	},
+			// 	expected: expected{
+			// 		listenerName: "udp",
+			// 		condition:    routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+			// 	},
+			// },
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				fakeClient := fakeclient.
+					NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(tt.objects...).
+					Build()
+
+				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				match := got[0]
+
+				assert.Equal(t, "test-namespace", match.gateway.Namespace)
+				assert.Equal(t, "test-gateway", match.gateway.Name)
+				assert.Equal(t, tt.expected.listenerName, match.listenerName)
+				assert.Equal(t, tt.expected.condition, match.condition)
 			})
 		}
 	})
 
 	t.Run("TLSRoute", func(t *testing.T) {
+		basicTLSRoute := func() *TLSRoute {
+			return &TLSRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TLSRoute",
+					APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-tlsroute",
+					Namespace: "test-namespace",
+				},
+				Spec: gatewayv1alpha2.TLSRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name: "test-gateway",
+							},
+						},
+					},
+				},
+			}
+		}
+		gatewayWithTLS443PassthroughReady := func() *Gateway {
+			return &Gateway{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					Kind:       "Gateway",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "test-namespace",
+					UID:       "ce7f0678-f59a-483c-80d1-243d3738d22c",
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: "test-gatewayclass",
+					Listeners: builder.NewListener("tls").
+						WithPort(443).
+						TLS().
+						WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
+							Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+						}).IntoSlice(),
+				},
+				Status: gatewayv1beta1.GatewayStatus{
+					Listeners: []gatewayv1beta1.ListenerStatus{
+						{
+							Name: "tls",
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Ready",
+									Status: metav1.ConditionTrue,
+								},
+							},
+							SupportedKinds: builder.NewRouteGroupKind().TLSRoute().IntoSlice(),
+						},
+					},
+				},
+			}
+		}
+
 		type expected struct {
-			gateway      types.NamespacedName
 			condition    metav1.Condition
 			listenerName string
 		}
@@ -1387,193 +1020,137 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			wantErr  bool
 		}{
 			{
-				name: "basic TLSRoute does get accepted because it is in supported kinds and there is a listener with TLS in passthrough mode",
-				route: &TLSRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "TLSRoute",
-						APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-tlsroute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1alpha2.TLSRouteSpec{
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{
-								{
-									Name: gatewayv1alpha2.ObjectName("test-gateway"),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic TLSRoute does get accepted because it is in supported kinds and there is a listener with TLS in passthrough mode",
+				route: basicTLSRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.NewListener("tls").
-								WithPort(443).
-								TLS().
-								WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-									Mode: (*gatewayv1beta1.TLSModeType)(pointer.StringPtr(string(gatewayv1beta1.TLSModePassthrough))),
-								}).IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("tls"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("TLSRoute"),
-										},
-									},
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					gatewayWithTLS443PassthroughReady(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: string(gatewayv1beta1.RouteReasonAccepted),
-						},
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
 					},
 				},
 			},
 			{
-				name: "basic TLSRoute does not get accepted because there is no listener with TLS in passthrough mode",
-				route: &TLSRoute{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "TLSRoute",
-						APIVersion: gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-tlsroute",
-						Namespace: "test-namespace",
-					},
-					Spec: gatewayv1alpha2.TLSRouteSpec{
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{
-								{
-									Name: gatewayv1alpha2.ObjectName("test-gateway"),
-								},
-							},
-						},
-					},
-				},
+				name:  "basic TLSRoute does not get accepted because there is no listener with TLS in passthrough mode",
+				route: basicTLSRoute(),
 				objects: []client.Object{
-					&Gateway{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-							UID:       types.UID("ce7f0678-f59a-483c-80d1-243d3738d22c"),
-						},
-						Spec: gatewayv1beta1.GatewaySpec{
-							GatewayClassName: "test-gatewayclass",
-							Listeners: builder.NewListener("tls").
-								WithPort(443).
-								TLS().
-								WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-									Mode: (*gatewayv1beta1.TLSModeType)(pointer.StringPtr(string(gatewayv1beta1.TLSModeTerminate))),
-								}).IntoSlice(),
-						},
-						Status: gatewayv1beta1.GatewayStatus{
-							Listeners: []gatewayv1beta1.ListenerStatus{
-								{
-									Name: gatewayv1beta1.SectionName("tls"),
-									Conditions: []metav1.Condition{
-										{
-											Type:   "Ready",
-											Status: metav1.ConditionTrue,
-										},
-									},
-									SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("HTTPRoute"),
-										},
-										{
-											Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-											Kind:  gatewayv1beta1.Kind("TLSRoute"),
-										},
-									},
-								},
-							},
-						},
-					},
-					&GatewayClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-gatewayclass",
-						},
-						Spec: gatewayv1beta1.GatewayClassSpec{
-							ControllerName: gatewayv1beta1.GatewayController("konghq.com/kic-gateway-controller"),
-						},
-					},
-					&corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-namespace",
-						},
-					},
+					func() *Gateway {
+						gw := gatewayWithTLS443PassthroughReady()
+						gw.Spec.Listeners = builder.NewListener("tls").
+							WithPort(443).
+							TLS().
+							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
+								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+							}).IntoSlice()
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
 				},
 				expected: []expected{
 					{
-						gateway: types.NamespacedName{
-							Name:      "test-gateway",
-							Namespace: "test-namespace",
-						},
-						listenerName: "",
-						condition: metav1.Condition{
-							Type:   string(gatewayv1beta1.RouteConditionAccepted),
-							Status: metav1.ConditionFalse,
-							Reason: string(RouteReasonNoMatchingParent),
-						},
+						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
 					},
 				},
 			},
+			{
+				name:  "TLSRoute does not get accepted because it is not in supported kinds",
+				route: basicTLSRoute(),
+				objects: []client.Object{
+					func() *Gateway {
+						gw := gatewayWithTLS443PassthroughReady()
+						gw.Status.Listeners[0].SupportedKinds = nil
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNotAllowedByListeners),
+					},
+				},
+			},
+			{
+				name: "TLSRoute specifying existing port gets Accepted",
+				route: func() *TLSRoute {
+					r := basicTLSRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTLS443PassthroughReady(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						condition: routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+					},
+				},
+			},
+			{
+				name: "TLSRoute specifying non existing port does not get Accepted",
+				route: func() *TLSRoute {
+					r := basicTLSRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(444))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTLS443PassthroughReady(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+					},
+				},
+			},
+			{
+				name: "TLSRoute specifying in sectionName existing listener gets Accepted",
+				route: func() *TLSRoute {
+					r := basicTLSRoute()
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tls"))
+					return r
+				}(),
+				objects: []client.Object{
+					gatewayWithTLS443PassthroughReady(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						listenerName: "tls",
+						condition:    routeConditionAccepted(metav1.ConditionTrue, gatewayv1beta1.RouteReasonAccepted),
+					},
+				},
+			},
+			// TODO: uncomment when https://github.com/Kong/kubernetes-ingress-controller/issues/3221 is done
+			// {
+			// 	name: "TLSRoute specifying in sectionName non existing listener does not get Accepted",
+			// 	route: func() *TLSRoute {
+			// 		r := basicTLSRoute()
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		return r
+			// 	}(),
+			// 	objects: []client.Object{
+			// 		gatewayWithTLS443PassthroughReady(),
+			// 		gatewayClass,
+			// 		namespace,
+			// 	},
+			// 	expected: []expected{
+			// 		{
+			// 			listenerName: "tls",
+			//			condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+			// 		},
+			// 	},
+			// },
 		}
 
 		for _, tt := range tests {
@@ -1586,18 +1163,14 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 					Build()
 
 				got, err := getSupportedGatewayForRoute(context.Background(), fakeClient, tt.route)
-				if tt.wantErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-					require.Len(t, got, len(tt.expected))
+				require.NoError(t, err)
+				require.Len(t, got, len(tt.expected))
 
-					for i := range got {
-						assert.Equalf(t, tt.expected[i].gateway.Namespace, got[i].gateway.Namespace, "gateway namespace #%d", i)
-						assert.Equalf(t, tt.expected[i].gateway.Name, got[i].gateway.Name, "gateway name #%d", i)
-						assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
-						assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
-					}
+				for i := range got {
+					assert.Equalf(t, "test-namespace", got[i].gateway.Namespace, "gateway namespace #%d", i)
+					assert.Equalf(t, "test-gateway", got[i].gateway.Name, "gateway name #%d", i)
+					assert.Equalf(t, tt.expected[i].listenerName, got[i].listenerName, "listenerName #%d", i)
+					assert.Equalf(t, tt.expected[i].condition, got[i].condition, "condition #%d", i)
 				}
 			})
 		}

--- a/internal/controllers/gateway/types.go
+++ b/internal/controllers/gateway/types.go
@@ -26,6 +26,7 @@ type (
 	SectionName       = gatewayv1beta1.SectionName
 
 	TCPRoute = gatewayv1alpha2.TCPRoute
+	UDPRoute = gatewayv1alpha2.UDPRoute
 	TLSRoute = gatewayv1alpha2.TLSRoute
 )
 

--- a/internal/util/builder/backendref.go
+++ b/internal/util/builder/backendref.go
@@ -1,0 +1,63 @@
+package builder
+
+import (
+	"k8s.io/utils/pointer"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// BackendRefBuilder is a builder for gateway api BackendRef.
+// Will set default values, as specified in the gateway API, for fields that are not set.
+// Primarily used for testing.
+type BackendRefBuilder struct {
+	backendRef gatewayv1alpha2.BackendRef
+}
+
+func NewBackendRef(name string) *BackendRefBuilder {
+	return &BackendRefBuilder{
+		backendRef: gatewayv1alpha2.BackendRef{
+			BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				Name: gatewayv1alpha2.ObjectName(name),
+				Kind: util.StringToGatewayAPIKindV1Alpha2Ptr("Service"), // default value
+			},
+		},
+	}
+}
+
+func (b *BackendRefBuilder) Build() gatewayv1alpha2.BackendRef {
+	return b.backendRef
+}
+
+func (b *BackendRefBuilder) ToSlice() []gatewayv1alpha2.BackendRef {
+	return []gatewayv1alpha2.BackendRef{b.backendRef}
+}
+
+func (b *BackendRefBuilder) WithPort(port int) *BackendRefBuilder {
+	val := gatewayv1alpha2.PortNumber(port)
+	b.backendRef.Port = &val
+	return b
+}
+
+func (b *BackendRefBuilder) WithWeight(weight int) *BackendRefBuilder {
+	b.backendRef.Weight = pointer.Int32(int32(weight))
+	return b
+}
+
+func (b *BackendRefBuilder) WithKind(kind string) *BackendRefBuilder {
+	val := gatewayv1alpha2.Kind(kind)
+	b.backendRef.Kind = &val
+	return b
+}
+
+func (b *BackendRefBuilder) WithGroup(group string) *BackendRefBuilder {
+	val := gatewayv1alpha2.Group(group)
+	b.backendRef.Group = &val
+	return b
+}
+
+func (b *BackendRefBuilder) WithNamespace(namespace string) *BackendRefBuilder {
+	val := gatewayv1alpha2.Namespace(namespace)
+	b.backendRef.Namespace = &val
+	return b
+}

--- a/internal/util/builder/listener.go
+++ b/internal/util/builder/listener.go
@@ -52,6 +52,11 @@ func (b *ListenerBuilder) TCP() *ListenerBuilder {
 	return b
 }
 
+func (b *ListenerBuilder) UDP() *ListenerBuilder {
+	b.listener.Protocol = gatewayv1beta1.UDPProtocolType
+	return b
+}
+
 func (b *ListenerBuilder) WithHostname(hostname string) *ListenerBuilder {
 	b.listener.Hostname = addressOf(gatewayv1beta1.Hostname(hostname))
 	return b

--- a/internal/util/builder/routegroupkind.go
+++ b/internal/util/builder/routegroupkind.go
@@ -28,11 +28,21 @@ func (b *RouteGroupKindBuilder) IntoSlice() []gatewayv1beta1.RouteGroupKind {
 }
 
 func (b *RouteGroupKindBuilder) TCPRoute() *RouteGroupKindBuilder {
-	b.routeGroupKind.Kind = gatewayv1beta1.Kind("TCPRoute")
+	b.routeGroupKind.Kind = "TCPRoute"
 	return b
 }
 
 func (b *RouteGroupKindBuilder) HTTPRoute() *RouteGroupKindBuilder {
-	b.routeGroupKind.Kind = gatewayv1beta1.Kind("HTTPRoute")
+	b.routeGroupKind.Kind = "HTTPRoute"
+	return b
+}
+
+func (b *RouteGroupKindBuilder) UDPRoute() *RouteGroupKindBuilder {
+	b.routeGroupKind.Kind = "UDPRoute"
+	return b
+}
+
+func (b *RouteGroupKindBuilder) TLSRoute() *RouteGroupKindBuilder {
+	b.routeGroupKind.Kind = "TLSRoute"
 	return b
 }

--- a/internal/util/conversions.go
+++ b/internal/util/conversions.go
@@ -22,20 +22,20 @@ func StringToGatewayAPIHostnameV1Beta1(hostname string) gatewayv1beta1.Hostname 
 
 // StringToGatewayAPIHostnamePtr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnamePtr(hostname string) *gatewayv1beta1.Hostname {
-	return (*gatewayv1beta1.Hostname)(pointer.StringPtr(hostname))
+	return (*gatewayv1beta1.Hostname)(pointer.String(hostname))
 }
 
 // StringToGatewayAPIHostnameV1Beta1Ptr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnameV1Beta1Ptr(hostname string) *gatewayv1beta1.Hostname {
-	return (*gatewayv1beta1.Hostname)(pointer.StringPtr(hostname))
+	return (*gatewayv1beta1.Hostname)(pointer.String(hostname))
 }
 
-// StringToGatewayAPIKind converts a string to a gatewayv1alpha2.Kind.
-func StringToGatewayAPIKind(kind string) gatewayv1alpha2.Kind {
-	return (gatewayv1alpha2.Kind)(kind)
+// StringToGatewayAPIKindV1Alpha2Ptr converts a string to a *gatewayv1alpha2.Kind.
+func StringToGatewayAPIKindV1Alpha2Ptr(kind string) *gatewayv1alpha2.Kind {
+	return (*gatewayv1alpha2.Kind)(pointer.String(kind))
 }
 
 // StringToGatewayAPIKindPtr converts a string to a *gatewayv1beta1.Kind.
 func StringToGatewayAPIKindPtr(kind string) *gatewayv1beta1.Kind {
-	return (*gatewayv1beta1.Kind)(pointer.StringPtr(kind))
+	return (*gatewayv1beta1.Kind)(pointer.String(kind))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds `getSupportedGatewayForRoute` unit tests for TCP/UDP/TLSRoute 
- Reduces tests volume by extracting common parts and reusing them

**Which issue this PR fixes**:

Part of #2709.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


<!-- Here you can add any open questions or notes that you might have for reviewers -->


