### PR TITLE
fix: match listener names for routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,10 @@ Adding a new version? You'll need three changes:
   If an `HTTPRoute` specifies hostnames, and no intersecting hostnames 
   could be found in its parent listners, it is not accepted.
   [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)
+- Matches `sectionName` in parentRefs of route objects in gateway API. Now 
+  if a route specifies `sectionName` in parentRefs, and no listener can 
+  match the specified name, the route is not accepted.
+  [#3230](https://github.com/Kong/kubernetes-ingress-controller/pull/3230)
 
 ## [2.7.0]
 

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -177,7 +177,6 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			// Check the listeners statuses:
 			// - Check if a listener status exists with a matching type (via SupportedKinds).
 			// - Check if it matches the requested listener by name (if specified).
-			// - Check if it matches the requested listener by port (if specified).
 			// - And finally check if that listeners is marked as Ready.
 			if err := existsMatchingReadyListenerInStatus(route, listener, gateway.Status.Listeners); err != nil {
 				continue
@@ -247,7 +246,6 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			} else if (parentRef.SectionName) != nil && !allowedByListenerName {
 				// If ParentRef specified listener names but none of the listeners matches the name,
 				// the gateway Status Condition Accepted must be set to False with reason RouteReasonNoMatchingParent.
-				// TODO: which listenerName to fill in for such case?
 				reason = RouteReasonNoMatchingParent
 			} else if (parentRef.Port != nil) && !portMatched {
 				// If ParentRef specified a Port but none of the listeners matched, the gateway Status

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -148,6 +148,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 		var (
 			// Set to true if there exists a listener which wasn't filtered by:
 			// - AlowedRoutes
+			// - listener name matching
 			// - listener status checks
 			// - listener and route type checks
 			matched = false
@@ -158,6 +159,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 
 			allowedByAllowedRoutes  = false
 			allowedBySupportedKinds = false
+			allowedByListenerName   = false
 		)
 
 		for _, listener := range gateway.Spec.Listeners {
@@ -175,11 +177,20 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			// Check the listeners statuses:
 			// - Check if a listener status exists with a matching type (via SupportedKinds).
 			// - Check if it matches the requested listener by name (if specified).
+			// - Check if it matches the requested listener by port (if specified).
 			// - And finally check if that listeners is marked as Ready.
 			if err := existsMatchingReadyListenerInStatus(route, listener, gateway.Status.Listeners); err != nil {
 				continue
 			} else {
 				allowedBySupportedKinds = true
+			}
+
+			// Check if listener name matches.
+			if parentRef.SectionName != nil {
+				if *parentRef.SectionName != "" && *parentRef.SectionName != listener.Name {
+					continue
+				}
+				allowedByListenerName = true
 			}
 
 			// Perform the port matching as described in GEP-957.
@@ -233,6 +244,11 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 				// If there is no matchingHostname, the gateway Status Condition Accepted
 				// must be set to False with reason NoMatchingListenerHostname
 				reason = gatewayv1beta1.RouteReasonNoMatchingListenerHostname
+			} else if (parentRef.SectionName) != nil && !allowedByListenerName {
+				// If ParentRef specified listener names but none of the listeners matches the name,
+				// the gateway Status Condition Accepted must be set to False with reason RouteReasonNoMatchingParent.
+				// TODO: which listenerName to fill in for such case?
+				reason = RouteReasonNoMatchingParent
 			} else if (parentRef.Port != nil) && !portMatched {
 				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
 				// Condition Accepted must be set to False with reason NoMatchingListenerPort

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
@@ -219,10 +220,6 @@ func TestFilterHostnames(t *testing.T) {
 	}
 }
 
-func addressOf[T any](v T) *T {
-	return &v
-}
-
 func Test_getSupportedGatewayForRoute(t *testing.T) {
 	gatewayClass := &GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -342,7 +339,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("http").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
 							}).
 							IntoSlice()
 						return gw
@@ -360,7 +357,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing section name gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.ParentRefs[0].SectionName = addressOf(gatewayv1beta1.SectionName("http"))
+					r.Spec.ParentRefs[0].SectionName = address.Of(gatewayv1beta1.SectionName("http"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -379,7 +376,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing port gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1beta1.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1beta1.PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -397,7 +394,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -517,7 +514,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("https").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+								Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
 							}).
 							IntoSlice()
 						gw.Status.Listeners[0].Name = "https"
@@ -654,7 +651,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying existing port gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -675,7 +672,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying non existing port does not get Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -696,8 +693,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tcp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tcp"))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -719,8 +716,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -859,7 +856,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying existing port gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
 					return r
 				}(),
 				objects: []client.Object{
@@ -875,7 +872,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying non existing port does not get Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
 					return r
 				}(),
 				objects: []client.Object{
@@ -891,8 +888,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("udp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("udp"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -909,8 +906,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -986,7 +983,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						WithPort(443).
 						TLS().
 						WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-							Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+							Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
 						}).IntoSlice(),
 				},
 				Status: gatewayv1beta1.GatewayStatus{
@@ -1041,7 +1038,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 							WithPort(443).
 							TLS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
 							}).IntoSlice()
 						return gw
 					}(),
@@ -1076,7 +1073,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying existing port gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1094,7 +1091,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying non existing port does not get Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(444))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(444))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1112,8 +1109,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tls"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tls"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1133,8 +1130,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 					return r
 				}(),
 				objects: []client.Object{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Match listener names if routes specified `sectionName` in their parentRefs. If a route specifies `sectionName` in its parentRef, and no listeners can match the name, the route is not accepted.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #3221

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
