### PR TITLE
refactor: use one version of getting address to a variable

### DIFF
--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 func TestReadyConditionExistsForObservedGeneration(t *testing.T) {
@@ -577,7 +577,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: address.Of(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -596,7 +596,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 							{
 								Group: "",
 								Kind:  "Secret",
-								Name:  (*gatewayv1alpha2.ObjectName)(pointer.StringPtr("anotherSecret")),
+								Name:  address.Of(gatewayv1alpha2.ObjectName("anotherSecret")),
 							},
 						},
 					},
@@ -610,7 +610,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: address.Of(Namespace("otherNamespace")),
 			},
 			expectedReason: string(gatewayv1alpha2.ListenerReasonRefNotPermitted),
 		},
@@ -620,7 +620,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: address.Of(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -659,7 +659,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: (*Namespace)(pointer.StringPtr("otherNamespace")),
+				Namespace: address.Of(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -678,7 +678,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 							{
 								Group: "",
 								Kind:  "Secret",
-								Name:  (*gatewayv1alpha2.ObjectName)(pointer.StringPtr("testSecret")),
+								Name:  address.Of(gatewayv1alpha2.ObjectName("testSecret")),
 							},
 						},
 					},

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
 
@@ -56,7 +57,7 @@ func TestGetListenerSupportedRouteKinds(t *testing.T) {
 				Protocol: HTTPProtocolType,
 				AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 					Kinds: []gatewayv1beta1.RouteGroupKind{{
-						Group: addressOf(gatewayv1beta1.Group("unknown.group.com")),
+						Group: address.Of(gatewayv1beta1.Group("unknown.group.com")),
 						Kind:  Kind("UnknownKind"),
 					}},
 				},

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // -----------------------------------------------------------------------------
@@ -427,7 +427,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 			}},
 		}
 		if gateway.listenerName != "" {
-			gatewayParentStatus.ParentRef.SectionName = (*SectionName)(pointer.StringPtr(gateway.listenerName))
+			gatewayParentStatus.ParentRef.SectionName = address.Of(SectionName(gateway.listenerName))
 		}
 
 		key := fmt.Sprintf("%s/%s/%s", gateway.gateway.Namespace, gateway.gateway.Name, gateway.listenerName)
@@ -640,9 +640,9 @@ func (r *HTTPRouteReconciler) ensureParentsAcceptedCondition(
 			// add a new parent if the parent is not found in status.
 			newParentStatus := &gatewayv1beta1.RouteParentStatus{
 				ParentRef: gatewayv1beta1.ParentReference{
-					Namespace:   (*gatewayv1beta1.Namespace)(pointer.String(gateway.Namespace)),
+					Namespace:   address.Of(gatewayv1beta1.Namespace(gateway.Namespace)),
 					Name:        gatewayv1beta1.ObjectName(gateway.Name),
-					SectionName: (*gatewayv1beta1.SectionName)(pointer.String(g.listenerName)),
+					SectionName: address.Of(gatewayv1beta1.SectionName(g.listenerName)),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
 				Conditions: []metav1.Condition{

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
@@ -219,10 +220,6 @@ func TestFilterHostnames(t *testing.T) {
 	}
 }
 
-func addressOf[T any](v T) *T {
-	return &v
-}
-
 func Test_getSupportedGatewayForRoute(t *testing.T) {
 	gatewayClass := &GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -342,7 +339,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("http").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
 							}).
 							IntoSlice()
 						return gw
@@ -360,7 +357,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing section name gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.ParentRefs[0].SectionName = addressOf(gatewayv1beta1.SectionName("http"))
+					r.Spec.ParentRefs[0].SectionName = address.Of(gatewayv1beta1.SectionName("http"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -379,7 +376,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing port gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1beta1.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1beta1.PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -397,7 +394,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -517,7 +514,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("https").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+								Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
 							}).
 							IntoSlice()
 						gw.Status.Listeners[0].Name = "https"
@@ -654,7 +651,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying existing port gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -675,7 +672,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying non existing port does not get Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -696,8 +693,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tcp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tcp"))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -720,8 +717,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			// 	name: "TCPRoute specifying in sectionName non existing listener does not get Accepted",
 			// 	route: func() *TCPRoute {
 			// 		r := basicTCPRoute()
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(80))
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 			// 		r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 			// 			{
 			// 				BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -860,7 +857,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying existing port gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
 					return r
 				}(),
 				objects: []client.Object{
@@ -876,7 +873,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying non existing port does not get Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
 					return r
 				}(),
 				objects: []client.Object{
@@ -892,8 +889,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("udp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("udp"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -911,8 +908,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			// 	name: "UDPRoute specifying in sectionName non existing listener does not get Accepted",
 			// 	route: func() *UDPRoute {
 			// 		r := basicUDPRoute()
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(53))
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 			// 		return r
 			// 	}(),
 			// 	objects: []client.Object{
@@ -988,7 +985,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						WithPort(443).
 						TLS().
 						WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-							Mode: addressOf(gatewayv1beta1.TLSModePassthrough),
+							Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
 						}).IntoSlice(),
 				},
 				Status: gatewayv1beta1.GatewayStatus{
@@ -1043,7 +1040,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 							WithPort(443).
 							TLS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: addressOf(gatewayv1beta1.TLSModeTerminate),
+								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
 							}).IntoSlice()
 						return gw
 					}(),
@@ -1078,7 +1075,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying existing port gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1096,7 +1093,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying non existing port does not get Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(444))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(444))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1114,8 +1111,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("tls"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tls"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1135,8 +1132,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 			// 	name: "TLSRoute specifying in sectionName non existing listener does not get Accepted",
 			// 	route: func() *TLSRoute {
 			// 		r := basicTLSRoute()
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = addressOf(gatewayv1alpha2.PortNumber(443))
-			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = addressOf(gatewayv1alpha2.SectionName("unknown-listener"))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
+			// 		r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
 			// 		return r
 			// 	}(),
 			// 	objects: []client.Object{

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -14,11 +14,11 @@ import (
 	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 type testSNIs struct {
@@ -587,7 +587,7 @@ func TestPopulateServices(t *testing.T) {
 			serviceNamesToServices: map[string]kongstate.Service{
 				"service-to-skip": {
 					Service: kong.Service{
-						Name: pointer.StringPtr("service-to-skip"),
+						Name: address.Of("service-to-skip"),
 					},
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{
@@ -603,7 +603,7 @@ func TestPopulateServices(t *testing.T) {
 				},
 				"service-to-keep": {
 					Service: kong.Service{
-						Name: pointer.StringPtr("service-to-skip"),
+						Name: address.Of("service-to-skip"),
 					},
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -9,12 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
 
@@ -181,7 +181,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -289,7 +289,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -349,7 +349,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -422,7 +422,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -494,7 +494,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -526,7 +526,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -611,7 +611,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -646,7 +646,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -740,7 +740,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -765,7 +765,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -860,7 +860,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -877,7 +877,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 										Methods:   []*string{kong.String("DELETE")},
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
@@ -895,7 +895,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 										Headers: map[string][]string{
 											"x-header-1": {"x-value-1"},
 											"x-header-2": {"x-value-2"},
@@ -1014,7 +1014,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -1031,7 +1031,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 										Methods:   []*string{kong.String("DELETE")},
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
@@ -1050,7 +1050,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: pointer.BoolPtr(false),
+										StripPath: address.Of(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -1262,7 +1262,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: pointer.BoolPtr(false),
+									StripPath: address.Of(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},

--- a/internal/dataplane/parser/translate_routes_helpers_test.go
+++ b/internal/dataplane/parser/translate_routes_helpers_test.go
@@ -11,11 +11,8 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
-
-func addressOf[T any](t T) *T {
-	return &t
-}
 
 func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 	testcases := []struct {
@@ -36,7 +33,7 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 				BackendRefs: []gatewayv1alpha2.BackendRef{
 					{
 						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Port: addressOf(gatewayv1alpha2.PortNumber(1234)),
+							Port: address.Of(gatewayv1alpha2.PortNumber(1234)),
 						},
 					},
 				},
@@ -49,14 +46,14 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: addressOf("tcproute.mynamespace.mytcproute-name.0.0"),
+						Name: address.Of("tcproute.mynamespace.mytcproute-name.0.0"),
 						Destinations: []*kong.CIDRPort{
 							{
-								Port: addressOf(1234),
+								Port: address.Of(1234),
 							},
 						},
 						Protocols: []*string{
-							addressOf("tcp"),
+							address.Of("tcp"),
 						},
 					},
 				},
@@ -97,7 +94,7 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 				BackendRefs: []gatewayv1alpha2.BackendRef{
 					{
 						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Port: addressOf(gatewayv1alpha2.PortNumber(1234)),
+							Port: address.Of(gatewayv1alpha2.PortNumber(1234)),
 						},
 					},
 				},
@@ -110,14 +107,14 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: addressOf("udproute.mynamespace.myudproute-name.0.0"),
+						Name: address.Of("udproute.mynamespace.myudproute-name.0.0"),
 						Destinations: []*kong.CIDRPort{
 							{
-								Port: addressOf(1234),
+								Port: address.Of(1234),
 							},
 						},
 						Protocols: []*string{
-							addressOf("udp"),
+							address.Of("udp"),
 						},
 					},
 				},
@@ -169,13 +166,13 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: addressOf("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						Name: address.Of("tlsroute.mynamespace.mytlsroute-name.0.0"),
 						SNIs: []*string{
-							addressOf("hostname.com"),
-							addressOf("hostname2.com"),
+							address.Of("hostname.com"),
+							address.Of("hostname2.com"),
 						},
 						Protocols: []*string{
-							addressOf("tls"),
+							address.Of("tls"),
 						},
 					},
 				},
@@ -199,10 +196,10 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: addressOf("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						Name: address.Of("tlsroute.mynamespace.mytlsroute-name.0.0"),
 						SNIs: []*string{},
 						Protocols: []*string{
-							addressOf("tls"),
+							address.Of("tls"),
 						},
 					},
 				},

--- a/internal/util/address/of.go
+++ b/internal/util/address/of.go
@@ -1,0 +1,6 @@
+package address
+
+// Of returns an address of provided argument.
+func Of[T any](v T) *T {
+	return &v
+}

--- a/internal/util/builder/address.go
+++ b/internal/util/builder/address.go
@@ -1,5 +1,0 @@
-package builder
-
-func addressOf[T any](v T) *T {
-	return &v
-}

--- a/internal/util/builder/httpbackendref.go
+++ b/internal/util/builder/httpbackendref.go
@@ -1,10 +1,10 @@
 package builder
 
 import (
-	"k8s.io/utils/pointer"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // HTTPBackendRefBuilder is a builder for gateway api HTTPBackendRef.
@@ -38,7 +38,7 @@ func (b *HTTPBackendRefBuilder) WithPort(port int) *HTTPBackendRefBuilder {
 }
 
 func (b *HTTPBackendRefBuilder) WithWeight(weight int) *HTTPBackendRefBuilder {
-	b.httpBackendRef.Weight = pointer.Int32(int32(weight))
+	b.httpBackendRef.Weight = address.Of(int32(weight))
 	return b
 }
 

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -1,9 +1,8 @@
 package builder
 
 import (
-	"k8s.io/utils/pointer"
-
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // KongstateServiceBackendBuilder is a builder for KongstateServiceBackend.
@@ -26,7 +25,7 @@ func (b *KongstateServiceBackendBuilder) WithNamespace(namespace string) *Kongst
 }
 
 func (b *KongstateServiceBackendBuilder) WithWeight(weight int) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.Weight = pointer.Int32(int32(weight))
+	b.kongstateServiceBackend.Weight = address.Of(int32(weight))
 	return b
 }
 

--- a/internal/util/builder/listener.go
+++ b/internal/util/builder/listener.go
@@ -1,6 +1,10 @@
 package builder
 
-import gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+import (
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
+)
 
 // ListenerBuilder is a builder for gateway api Listener.
 // Will set default values, as specified in the gateway API, for fields that are not set.
@@ -58,7 +62,7 @@ func (b *ListenerBuilder) UDP() *ListenerBuilder {
 }
 
 func (b *ListenerBuilder) WithHostname(hostname string) *ListenerBuilder {
-	b.listener.Hostname = addressOf(gatewayv1beta1.Hostname(hostname))
+	b.listener.Hostname = address.Of(gatewayv1beta1.Hostname(hostname))
 	return b
 }
 

--- a/internal/util/builder/routegroupkind.go
+++ b/internal/util/builder/routegroupkind.go
@@ -1,6 +1,10 @@
 package builder
 
-import gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+import (
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
+)
 
 // RouteGroupKindBuilder is a builder for gateway api RouteGroupKind.
 // Will set default values, as specified in the gateway API, for fields that are not set.
@@ -12,7 +16,7 @@ type RouteGroupKindBuilder struct {
 func NewRouteGroupKind() *RouteGroupKindBuilder {
 	return &RouteGroupKindBuilder{
 		routeGroupKind: gatewayv1beta1.RouteGroupKind{
-			Group: addressOf(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+			Group: address.Of(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
 		},
 	}
 }

--- a/internal/util/builder/routenamespaces.go
+++ b/internal/util/builder/routenamespaces.go
@@ -3,6 +3,8 @@ package builder
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // RouteNamespacesBuilder is a builder for gateway api RouteNamespaces.
@@ -22,17 +24,17 @@ func (b *RouteNamespacesBuilder) Build() *gatewayv1beta1.RouteNamespaces {
 }
 
 func (b *RouteNamespacesBuilder) FromSame() *RouteNamespacesBuilder {
-	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromSame)
+	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromSame)
 	return b
 }
 
 func (b *RouteNamespacesBuilder) FromAll() *RouteNamespacesBuilder {
-	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromAll)
+	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromAll)
 	return b
 }
 
 func (b *RouteNamespacesBuilder) FromSelector(s *metav1.LabelSelector) *RouteNamespacesBuilder {
-	b.routeNamespaces.From = addressOf(gatewayv1beta1.NamespacesFromSelector)
+	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromSelector)
 	b.routeNamespaces.Selector = s
 	return b
 }

--- a/internal/util/conversions.go
+++ b/internal/util/conversions.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	"k8s.io/utils/pointer"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // -----------------------------------------------------------------------------
@@ -22,20 +23,20 @@ func StringToGatewayAPIHostnameV1Beta1(hostname string) gatewayv1beta1.Hostname 
 
 // StringToGatewayAPIHostnamePtr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnamePtr(hostname string) *gatewayv1beta1.Hostname {
-	return (*gatewayv1beta1.Hostname)(pointer.String(hostname))
+	return address.Of(gatewayv1beta1.Hostname(hostname))
 }
 
 // StringToGatewayAPIHostnameV1Beta1Ptr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnameV1Beta1Ptr(hostname string) *gatewayv1beta1.Hostname {
-	return (*gatewayv1beta1.Hostname)(pointer.String(hostname))
+	return address.Of(gatewayv1beta1.Hostname(hostname))
 }
 
 // StringToGatewayAPIKindV1Alpha2Ptr converts a string to a *gatewayv1alpha2.Kind.
 func StringToGatewayAPIKindV1Alpha2Ptr(kind string) *gatewayv1alpha2.Kind {
-	return (*gatewayv1alpha2.Kind)(pointer.String(kind))
+	return address.Of(gatewayv1alpha2.Kind(kind))
 }
 
 // StringToGatewayAPIKindPtr converts a string to a *gatewayv1beta1.Kind.
 func StringToGatewayAPIKindPtr(kind string) *gatewayv1beta1.Kind {
-	return (*gatewayv1beta1.Kind)(pointer.String(kind))
+	return address.Of(gatewayv1beta1.Kind(kind))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To minimize the spread of `addressOf` implementations across the codebase let's introduce one that's exported (nested under `internal/` directory tree) and use that throughout the codebase.