### PR TITLE
chore(tests): add v1.26 to k8s versions of nightly and e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,11 +29,12 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.21.12'
-          - 'v1.22.9'
-          - 'v1.23.6'
-          - 'v1.24.2'
-          - 'v1.25.2'
+          - 'v1.21.14'
+          - 'v1.22.15'
+          - 'v1.23.13'
+          - 'v1.24.7'
+          - 'v1.25.3'
+          - 'v1.26.0'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
     - name: setup golang

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
   e2e-tests:
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:
@@ -58,7 +57,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: run ${{ matrix.test }} - ${{ matrix.kubernetes-version }}
@@ -87,7 +85,6 @@ jobs:
         path: e2e-${{ matrix.kubernetes-version }}-tests.xml
 
   istio-tests:
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -122,7 +119,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: run Istio tests
@@ -180,7 +176,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: run ${{ matrix.kubernetes-version }}
@@ -208,7 +203,6 @@ jobs:
         path: gke-${{ matrix.kubernetes-version }}-tests.xml
 
   buildpulse-report:
-    environment: "Configure ci"
     needs:
       - "e2e-tests"
       - "e2e-gke-tests"

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   e2e-tests:
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
     - name: setup golang
@@ -67,7 +66,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: run e2e tests
@@ -102,7 +100,6 @@ jobs:
 
   integration-tests:
     if: ${{ github.event.inputs.include-integration == 'true' }}
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
     - name: setup golang
@@ -126,7 +123,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: run integration tests

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -181,7 +181,8 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - 'v1.25.0'
+          - 'v1.26.0'
+          - 'v1.25.3'
         dbmode:
           - 'dbless'
           - 'postgres'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -224,7 +224,6 @@ jobs:
           path: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-${{ matrix.kong-router-flavor }}-tests.xml
 
   buildpulse-report:
-    environment: "Configure ci"
     needs:
       - "test-current-kubernetes"
     if: ${{ always() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,10 +116,8 @@ jobs:
         path: unit-tests.xml
 
   integration-tests-enterprise-postgres:
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     env:
-      # PULP_PASSWORD secret is set in "Configure ci" environment
       PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
     # We don't want to run enterprise tests for contributors whose workflow runs
     # do not have access to enterprise license (here, through the means of
@@ -367,7 +365,6 @@ jobs:
         path: conformance-tests.xml
 
   coverage:
-    environment: "Configure ci"
     needs:
       - "unit-tests"
       - "integration-tests-dbless"
@@ -394,7 +391,6 @@ jobs:
         verbose: true
 
   buildpulse-report:
-    environment: "Configure ci"
     needs:
       - "unit-tests"
       - "integration-tests-dbless"

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -9,14 +9,12 @@ on:
 jobs:
   integration-tests-enterprise-postgres-nightly:
     if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
 
     - uses: Kong/kong-license@master
       id: license
       with:
-        # PULP_PASSWORD secret is set in "Configure ci" environment
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: setup golang
@@ -62,7 +60,6 @@ jobs:
 
   integration-tests-postgres-nightly:
     if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
 
@@ -106,7 +103,6 @@ jobs:
 
   integration-tests-dbless-nightly:
     if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
-    environment: "Configure ci"
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

k8s v1.26 is released, include the latest version in nightly(integration) tests and e2e tests. 
Also bump other k8s versions to the latest patch release of its minor release.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3240 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
