### PR TITLE
fix: do not create two Detached conditions when no port for the protocol available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Adding a new version? You'll need three changes:
   [#3132](https://github.com/Kong/kubernetes-ingress-controller/pull/3132)
 
 ### Deprecated
+
 - KongIngress' `proxy` and `route` fields are now deprecated in favor of
   Service and Ingress annotations. The annotations will become the only
   means of configuring those settings in 3.0 release.
@@ -200,6 +201,9 @@ Adding a new version? You'll need three changes:
   if a route specifies `sectionName` in parentRefs, and no listener can 
   match the specified name, the route is not accepted.
   [#3230](https://github.com/Kong/kubernetes-ingress-controller/pull/3230)
+- If there's no matching Kong listener for a protocol specified in a Gateway's
+  Listener, only one `Detached` condition is created in the Listener's status.
+  [#3257](https://github.com/Kong/kubernetes-ingress-controller/pull/3257)
 
 ## [2.7.0]
 

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -458,7 +458,7 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 	// a single set of shared listens. We lack knowledge of whether this is compatible with user intent, and it may
 	// be incompatible with the spec, so we should consider evaluating cross-Gateway compatibility and raising error
 	// conditions in the event of a problem
-	listenerStatuses, err := r.getListenerStatus(ctx, gateway, kongListeners, referenceGrantList.Items)
+	listenerStatuses, err := getListenerStatus(ctx, gateway, kongListeners, referenceGrantList.Items, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -361,16 +361,17 @@ func (r *GatewayReconciler) getListenerStatus(
 				Reason:             string(gatewayv1alpha2.ListenerReasonUnsupportedProtocol),
 				Message:            "no Kong listen with the requested protocol is configured",
 			})
-		}
-		if _, ok := kongProtocolsToPort[listener.Protocol][listener.Port]; !ok {
-			status.Conditions = append(status.Conditions, metav1.Condition{
-				Type:               string(gatewayv1alpha2.ListenerConditionDetached),
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: gateway.Generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1alpha2.ListenerReasonPortUnavailable),
-				Message:            "no Kong listen with the requested protocol is configured for the requested port",
-			})
+		} else {
+			if _, ok := kongProtocolsToPort[listener.Protocol][listener.Port]; !ok {
+				status.Conditions = append(status.Conditions, metav1.Condition{
+					Type:               string(gatewayv1alpha2.ListenerConditionDetached),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: gateway.Generation,
+					LastTransitionTime: metav1.Now(),
+					Reason:             string(gatewayv1alpha2.ListenerReasonPortUnavailable),
+					Message:            "no Kong listen with the requested protocol is configured for the requested port",
+				})
+			}
 		}
 
 		// finalize adding any general conditions

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -277,11 +277,12 @@ func canSharePort(requested, existing ProtocolType) bool {
 	}
 }
 
-func (r *GatewayReconciler) getListenerStatus(
+func getListenerStatus(
 	ctx context.Context,
 	gateway *Gateway,
 	kongListens []Listener,
 	referenceGrants []gatewayv1alpha2.ReferenceGrant,
+	client client.Client,
 ) ([]ListenerStatus, error) {
 	statuses := make(map[SectionName]ListenerStatus, len(gateway.Spec.Listeners))
 	portToProtocol, portToHostname, listenerToAttached := initializeListenerMaps(gateway)
@@ -469,7 +470,7 @@ func (r *GatewayReconciler) getListenerStatus(
 				if certRef.Namespace != nil {
 					secretNamespace = string(*certRef.Namespace)
 				}
-				if err := r.Client.Get(ctx, types.NamespacedName{Namespace: secretNamespace, Name: string(certRef.Name)}, secret); err != nil {
+				if err := client.Get(ctx, types.NamespacedName{Namespace: secretNamespace, Name: string(certRef.Name)}, secret); err != nil {
 					if !k8serrors.IsNotFound(err) {
 						return nil, err
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:

This prevents creating two Detached conditions for Listener that has no matching protocol in `kongProtocolsToPort`. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #3256. 

Proven in the following tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3685516223/jobs/6237448308

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
