### PR TITLE
refactor: delete custom entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ Adding a new version? You'll need three changes:
 - Disabled non-functioning mesh reporting when `--watch-namespaces` flag set.
   [#3336](https://github.com/Kong/kubernetes-ingress-controller/pull/3336)
 
+### Deprecated
+
+- `kong-custom-entities-secret` flag has been marked as deprecated and will be
+  removed in 3.0.
+  [#3262](https://github.com/Kong/kubernetes-ingress-controller/pull/3262)
+
 ## [2.8.1]
 
 > Release date: 2022-01-04
@@ -79,7 +85,7 @@ Adding a new version? You'll need three changes:
 ### Fixed
 
 - When `CombinedRoutes` is turned on, translator will replace each occurrence of
- `*` in `Ingress`'s host to `_` in kong route names because `*` is not
+  `*` in `Ingress`'s host to `_` in kong route names because `*` is not
   allowed in kong route names.
   [#3312](https://github.com/Kong/kubernetes-ingress-controller/pull/3312)
 - Fix an issue with `CombinedRoutes`, which caused the controller to fail when
@@ -2161,7 +2167,7 @@ Please read the changelog and test in your environment.
    [#92](https://github.com/Kong/kubernetes-ingress-controller/pull/92)
 
 
-## [v0.0.5]
+## [0.0.5]
 
 > Release date: 2018/06/02
 
@@ -2169,7 +2175,7 @@ Please read the changelog and test in your environment.
 
  - Add support for Kong Enterprise Edition 0.32 and above
 
-## [v0.0.4] and prior
+## [0.0.4] and prior
 
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -1,7 +1,6 @@
 package deckgen
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -10,24 +9,15 @@ import (
 	"github.com/kong/go-kong/kong"
 )
 
-// GenerateSHA generates a SHA256 checksum of the (targetContent, customEntities) tuple, with the purpose of change
-// detection.
-func GenerateSHA(targetContent *file.Content,
-	customEntities []byte,
-) ([]byte, error) {
-	var buffer bytes.Buffer
-
+// GenerateSHA generates a SHA256 checksum of targetContent, with the purpose
+// of change detection.
+func GenerateSHA(targetContent *file.Content) ([]byte, error) {
 	jsonConfig, err := json.Marshal(targetContent)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling Kong declarative configuration to JSON: %w", err)
 	}
-	buffer.Write(jsonConfig)
 
-	if customEntities != nil {
-		buffer.Write(customEntities)
-	}
-
-	shaSum := sha256.Sum256(buffer.Bytes())
+	shaSum := sha256.Sum256(jsonConfig)
 	return shaSum[:], nil
 }
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -384,7 +384,6 @@ func (c *KongClient) Update(ctx context.Context) error {
 		c.skipCACertificates,
 		targetConfig,
 		c.kongConfig.FilterTags,
-		nil,
 		c.lastConfigSHA,
 		c.prometheusMetrics,
 	)

--- a/internal/dataplane/sendconfig/sendconfig_test.go
+++ b/internal/dataplane/sendconfig/sendconfig_test.go
@@ -5,126 +5,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
 	"testing"
 
-	"github.com/kong/deck/file"
 	deckutils "github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 )
-
-func TestRenderConfigWithCustomEntities(t *testing.T) {
-	type args struct {
-		state                   *file.Content
-		customEntitiesJSONBytes []byte
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{
-			name: "basic sanity test for fast-path",
-			args: args{
-				state: &file.Content{
-					FormatVersion: "1.1",
-					Services: []file.FService{
-						{
-							Service: kong.Service{
-								Name: kong.String("foo"),
-								Host: kong.String("example.com"),
-							},
-						},
-					},
-				},
-				customEntitiesJSONBytes: nil,
-			},
-			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
-			wantErr: false,
-		},
-		{
-			name: "does not break with random bytes in the custom entities",
-			args: args{
-				state: &file.Content{
-					FormatVersion: "1.1",
-					Services: []file.FService{
-						{
-							Service: kong.Service{
-								Name: kong.String("foo"),
-								Host: kong.String("example.com"),
-							},
-						},
-					},
-				},
-				customEntitiesJSONBytes: []byte("random-bytes"),
-			},
-			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
-			wantErr: false,
-		},
-		{
-			name: "custom entities cannot hijack core entities",
-			args: args{
-				state: &file.Content{
-					FormatVersion: "1.1",
-					Services: []file.FService{
-						{
-							Service: kong.Service{
-								Name: kong.String("foo"),
-								Host: kong.String("example.com"),
-							},
-						},
-					},
-				},
-				customEntitiesJSONBytes: []byte(`{"services":[{"host":"rogue.example.com","name":"rogue"}]}`),
-			},
-			want:    []byte(`{"_format_version":"1.1","services":[{"host":"example.com","name":"foo"}]}`),
-			wantErr: false,
-		},
-		{
-			name: "custom entities can be populated",
-			args: args{
-				state: &file.Content{
-					FormatVersion: "1.1",
-					Services: []file.FService{
-						{
-							Service: kong.Service{
-								Name: kong.String("foo"),
-								Host: kong.String("example.com"),
-							},
-						},
-					},
-				},
-				customEntitiesJSONBytes: []byte(`{"my-custom-dao-name":` +
-					`[{"name":"custom1","key1":"value1"},` +
-					`{"name":"custom2","dumb":"test-value","boring-test-value-name":"really?"}]}`),
-			},
-			want: []byte(`{"_format_version":"1.1",` +
-				`"my-custom-dao-name":[{"key1":"value1","name":"custom1"},` +
-				`{"boring-test-value-name":"really?","dumb":"test-value","name":"custom2"}]` +
-				`,"services":[{"host":"example.com","name":"foo"}]}`),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderConfigWithCustomEntities(logrus.New(), tt.args.state, tt.args.customEntitiesJSONBytes)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("renderConfigWithCustomEntities() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("renderConfigWithCustomEntities() = %v, want %v",
-					string(got), string(tt.want))
-			}
-		})
-	}
-}
 
 func TestUpdateReportingUtilities(t *testing.T) {
 	assert.False(t, hasSHAUpdateAlreadyBeenReported([]byte("fake-sha")))

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -45,15 +45,14 @@ type Config struct {
 	CacheSyncTimeout                  time.Duration
 
 	// Kong Proxy configurations
-	APIServerHost            string
-	APIServerQPS             int
-	APIServerBurst           int
-	MetricsAddr              string
-	ProbeAddr                string
-	KongAdminURL             string
-	ProxySyncSeconds         float32
-	ProxyTimeoutSeconds      float32
-	KongCustomEntitiesSecret string
+	APIServerHost       string
+	APIServerQPS        int
+	APIServerBurst      int
+	MetricsAddr         string
+	ProbeAddr           string
+	KongAdminURL        string
+	ProxySyncSeconds    float32
+	ProxyTimeoutSeconds float32
 
 	// Kubernetes configurations
 	KubeconfigPath           string
@@ -152,7 +151,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", dataplane.DefaultTimeoutSeconds,
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
-	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `WARNING: Does not work. It's a known issue tracked in a GitHub issue #3278.`)
+
+	_ = flagSet.String("kong-custom-entities-secret", "", "Will be removed in next major release.")
+	flagSet.MarkDeprecated("kong-custom-entities-secret", "Will be removed in next major release.") //nolint:errcheck
 
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that custom entities where never used (at least in a handful of recent versions).

The notion of them was "somehow" introduced in #1339 and #2296 made `sendconfig.PerformUpdate()` always pass `nil` in place for "custom entities".

Since it's always `nil` we may as well just delete it altogether.

**Special notes for your reviewer**:

There is still the [CLI flag](https://github.com/Kong/kubernetes-ingress-controller/blob/eb47a6906e583a5b39cbb15038671d7fef472062/internal/manager/config.go#L155)

```
	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `A Secret containing custom entities for DB-less mode, in "namespace/name" format`)
```

~I'd argue that we can add a deprecation notice and state that it doesn't do anything now and that it will be removed in next major release. WDYT?~

This PR marked the flag as deprecated with `flagSet.MarkDeprecated`.


