### PR TITLE
chore(deps): use lo.ToPtr for pointer casting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -84,6 +84,11 @@ linters-settings:
           recommendations:
             - fmt
             - errors
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    packages-with-error-message:
+      - k8s.io/utils/pointer: "Use github.com/samber/lo ToPtr instead"
 issues:
   fix: true
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
 	k8s.io/component-base v0.26.0
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	knative.dev/networking v0.0.0-20220302134042-e8b2eb995165
 	knative.dev/pkg v0.0.0-20220301181942-2fdd5f232e77
 	sigs.k8s.io/controller-runtime v0.14.0
@@ -168,6 +167,7 @@ require (
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/kubectl v0.26.0 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kind v0.17.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 func TestReadyConditionExistsForObservedGeneration(t *testing.T) {
@@ -577,7 +577,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: address.Of(Namespace("otherNamespace")),
+				Namespace: lo.ToPtr(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -596,7 +596,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 							{
 								Group: "",
 								Kind:  "Secret",
-								Name:  address.Of(gatewayv1alpha2.ObjectName("anotherSecret")),
+								Name:  lo.ToPtr(gatewayv1alpha2.ObjectName("anotherSecret")),
 							},
 						},
 					},
@@ -610,7 +610,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: address.Of(Namespace("otherNamespace")),
+				Namespace: lo.ToPtr(Namespace("otherNamespace")),
 			},
 			expectedReason: string(gatewayv1alpha2.ListenerReasonRefNotPermitted),
 		},
@@ -620,7 +620,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: address.Of(Namespace("otherNamespace")),
+				Namespace: lo.ToPtr(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -659,7 +659,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 			certRef: gatewayv1beta1.SecretObjectReference{
 				Kind:      util.StringToGatewayAPIKindPtr("Secret"),
 				Name:      "testSecret",
-				Namespace: address.Of(Namespace("otherNamespace")),
+				Namespace: lo.ToPtr(Namespace("otherNamespace")),
 			},
 			referenceGrants: []gatewayv1alpha2.ReferenceGrant{
 				{
@@ -678,7 +678,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 							{
 								Group: "",
 								Kind:  "Secret",
-								Name:  address.Of(gatewayv1alpha2.ObjectName("testSecret")),
+								Name:  lo.ToPtr(gatewayv1alpha2.ObjectName("testSecret")),
 							},
 						},
 					},

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
 
@@ -61,7 +61,7 @@ func TestGetListenerSupportedRouteKinds(t *testing.T) {
 				Protocol: HTTPProtocolType,
 				AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 					Kinds: []gatewayv1beta1.RouteGroupKind{{
-						Group: address.Of(gatewayv1beta1.Group("unknown.group.com")),
+						Group: lo.ToPtr(gatewayv1beta1.Group("unknown.group.com")),
 						Kind:  Kind("UnknownKind"),
 					}},
 				},

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // -----------------------------------------------------------------------------
@@ -234,8 +234,8 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForGateway(obj client.Object) []reco
 // HTTPRoute Controller - Reconciliation
 // -----------------------------------------------------------------------------
 
-//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
-//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=get;update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=get;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -427,7 +427,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 			}},
 		}
 		if gateway.listenerName != "" {
-			gatewayParentStatus.ParentRef.SectionName = address.Of(SectionName(gateway.listenerName))
+			gatewayParentStatus.ParentRef.SectionName = lo.ToPtr(SectionName(gateway.listenerName))
 		}
 
 		key := fmt.Sprintf("%s/%s/%s", gateway.gateway.Namespace, gateway.gateway.Name, gateway.listenerName)
@@ -640,9 +640,9 @@ func (r *HTTPRouteReconciler) ensureParentsAcceptedCondition(
 			// add a new parent if the parent is not found in status.
 			newParentStatus := &gatewayv1beta1.RouteParentStatus{
 				ParentRef: gatewayv1beta1.ParentReference{
-					Namespace:   address.Of(gatewayv1beta1.Namespace(gateway.Namespace)),
+					Namespace:   lo.ToPtr(gatewayv1beta1.Namespace(gateway.Namespace)),
 					Name:        gatewayv1beta1.ObjectName(gateway.Name),
-					SectionName: address.Of(gatewayv1beta1.SectionName(g.listenerName)),
+					SectionName: lo.ToPtr(gatewayv1beta1.SectionName(g.listenerName)),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
 				Conditions: []metav1.Condition{

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +17,6 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
@@ -339,7 +339,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("http").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
+								Mode: lo.ToPtr(gatewayv1beta1.TLSModeTerminate),
 							}).
 							IntoSlice()
 						return gw
@@ -357,7 +357,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing section name gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.ParentRefs[0].SectionName = address.Of(gatewayv1beta1.SectionName("http"))
+					r.Spec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1beta1.SectionName("http"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -376,7 +376,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying existing port gets Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1beta1.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1beta1.PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -394,7 +394,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
 				route: func() *HTTPRoute {
 					r := basicHTTPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(PortNumber(80))
 					return r
 				}(),
 				objects: []client.Object{
@@ -514,7 +514,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						gw.Spec.Listeners = builder.
 							NewListener("https").WithPort(443).HTTPS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
+								Mode: lo.ToPtr(gatewayv1beta1.TLSModePassthrough),
 							}).
 							IntoSlice()
 						gw.Status.Listeners[0].Name = "https"
@@ -651,7 +651,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying existing port gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(80))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -672,7 +672,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying non existing port does not get Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(8000))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -693,8 +693,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tcp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("tcp"))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -716,8 +716,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TCPRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *TCPRoute {
 					r := basicTCPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(80))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(80))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("unknown-listener"))
 					r.Spec.Rules = []gatewayv1alpha2.TCPRouteRule{
 						{
 							BackendRefs: builder.NewBackendRef("fake-service").WithPort(80).ToSlice(),
@@ -856,7 +856,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying existing port gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(53))
 					return r
 				}(),
 				objects: []client.Object{
@@ -872,7 +872,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying non existing port does not get Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(8000))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(8000))
 					return r
 				}(),
 				objects: []client.Object{
@@ -888,8 +888,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("udp"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("udp"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -906,8 +906,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "UDPRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *UDPRoute {
 					r := basicUDPRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(53))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(53))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("unknown-listener"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -983,7 +983,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 						WithPort(443).
 						TLS().
 						WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-							Mode: address.Of(gatewayv1beta1.TLSModePassthrough),
+							Mode: lo.ToPtr(gatewayv1beta1.TLSModePassthrough),
 						}).IntoSlice(),
 				},
 				Status: gatewayv1beta1.GatewayStatus{
@@ -1038,7 +1038,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 							WithPort(443).
 							TLS().
 							WithTLSConfig(&gatewayv1beta1.GatewayTLSConfig{
-								Mode: address.Of(gatewayv1beta1.TLSModeTerminate),
+								Mode: lo.ToPtr(gatewayv1beta1.TLSModeTerminate),
 							}).IntoSlice()
 						return gw
 					}(),
@@ -1073,7 +1073,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying existing port gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(443))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1091,7 +1091,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying non existing port does not get Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(444))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(444))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1109,8 +1109,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying in sectionName existing listener gets Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("tls"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("tls"))
 					return r
 				}(),
 				objects: []client.Object{
@@ -1130,8 +1130,8 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 				name: "TLSRoute specifying in sectionName non existing listener does not get Accepted",
 				route: func() *TLSRoute {
 					r := basicTLSRoute()
-					r.Spec.CommonRouteSpec.ParentRefs[0].Port = address.Of(gatewayv1alpha2.PortNumber(443))
-					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = address.Of(gatewayv1alpha2.SectionName("unknown-listener"))
+					r.Spec.CommonRouteSpec.ParentRefs[0].Port = lo.ToPtr(gatewayv1alpha2.PortNumber(443))
+					r.Spec.CommonRouteSpec.ParentRefs[0].SectionName = lo.ToPtr(gatewayv1alpha2.SectionName("unknown-listener"))
 					return r
 				}(),
 				objects: []client.Object{

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 type testSNIs struct {
@@ -588,7 +588,7 @@ func TestPopulateServices(t *testing.T) {
 			serviceNamesToServices: map[string]kongstate.Service{
 				"service-to-skip": {
 					Service: kong.Service{
-						Name: address.Of("service-to-skip"),
+						Name: lo.ToPtr("service-to-skip"),
 					},
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{
@@ -604,7 +604,7 @@ func TestPopulateServices(t *testing.T) {
 				},
 				"service-to-keep": {
 					Service: kong.Service{
-						Name: address.Of("service-to-skip"),
+						Name: lo.ToPtr("service-to-skip"),
 					},
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -14,7 +15,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
 
@@ -181,7 +181,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -289,7 +289,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -349,7 +349,7 @@ func getIngressRulesFromHTTPRoutesCommonTestCases() []testCaseIngressRulesFromHT
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -422,7 +422,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -494,7 +494,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -526,7 +526,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},
@@ -611,7 +611,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -646,7 +646,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -740,7 +740,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -765,7 +765,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -860,7 +860,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -877,7 +877,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 										Methods:   []*string{kong.String("DELETE")},
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
@@ -895,7 +895,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 										Headers: map[string][]string{
 											"x-header-1": {"x-value-1"},
 											"x-header-2": {"x-value-2"},
@@ -1014,7 +1014,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 								},
@@ -1031,7 +1031,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 										Methods:   []*string{kong.String("DELETE")},
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
@@ -1050,7 +1050,7 @@ func getIngressRulesFromHTTPRoutesCombinedRoutesTestCases() []testCaseIngressRul
 											kong.String("http"),
 											kong.String("https"),
 										},
-										StripPath: address.Of(false),
+										StripPath: lo.ToPtr(false),
 									},
 									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 									Plugins: []kong.Plugin{
@@ -1262,7 +1262,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 										kong.String("http"),
 										kong.String("https"),
 									},
-									StripPath: address.Of(false),
+									StripPath: lo.ToPtr(false),
 								},
 								Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
 							}},

--- a/internal/dataplane/parser/translate_routes_helpers_test.go
+++ b/internal/dataplane/parser/translate_routes_helpers_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 				BackendRefs: []gatewayv1alpha2.BackendRef{
 					{
 						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Port: address.Of(gatewayv1alpha2.PortNumber(1234)),
+							Port: lo.ToPtr(gatewayv1alpha2.PortNumber(1234)),
 						},
 					},
 				},
@@ -46,14 +46,14 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: address.Of("tcproute.mynamespace.mytcproute-name.0.0"),
+						Name: lo.ToPtr("tcproute.mynamespace.mytcproute-name.0.0"),
 						Destinations: []*kong.CIDRPort{
 							{
-								Port: address.Of(1234),
+								Port: lo.ToPtr(1234),
 							},
 						},
 						Protocols: []*string{
-							address.Of("tcp"),
+							lo.ToPtr("tcp"),
 						},
 					},
 				},
@@ -94,7 +94,7 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 				BackendRefs: []gatewayv1alpha2.BackendRef{
 					{
 						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Port: address.Of(gatewayv1alpha2.PortNumber(1234)),
+							Port: lo.ToPtr(gatewayv1alpha2.PortNumber(1234)),
 						},
 					},
 				},
@@ -107,14 +107,14 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: address.Of("udproute.mynamespace.myudproute-name.0.0"),
+						Name: lo.ToPtr("udproute.mynamespace.myudproute-name.0.0"),
 						Destinations: []*kong.CIDRPort{
 							{
-								Port: address.Of(1234),
+								Port: lo.ToPtr(1234),
 							},
 						},
 						Protocols: []*string{
-							address.Of("udp"),
+							lo.ToPtr("udp"),
 						},
 					},
 				},
@@ -166,13 +166,13 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: address.Of("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						Name: lo.ToPtr("tlsroute.mynamespace.mytlsroute-name.0.0"),
 						SNIs: []*string{
-							address.Of("hostname.com"),
-							address.Of("hostname2.com"),
+							lo.ToPtr("hostname.com"),
+							lo.ToPtr("hostname2.com"),
 						},
 						Protocols: []*string{
-							address.Of("tls"),
+							lo.ToPtr("tls"),
 						},
 					},
 				},
@@ -196,10 +196,10 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 					Route: kong.Route{
-						Name: address.Of("tlsroute.mynamespace.mytlsroute-name.0.0"),
+						Name: lo.ToPtr("tlsroute.mynamespace.mytlsroute-name.0.0"),
 						SNIs: []*string{},
 						Protocols: []*string{
-							address.Of("tls"),
+							lo.ToPtr("tls"),
 						},
 					},
 				},

--- a/internal/util/address/of.go
+++ b/internal/util/address/of.go
@@ -1,6 +1,0 @@
-package address
-
-// Of returns an address of provided argument.
-func Of[T any](v T) *T {
-	return &v
-}

--- a/internal/util/builder/backendref.go
+++ b/internal/util/builder/backendref.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	"k8s.io/utils/pointer"
+	"github.com/samber/lo"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
@@ -40,7 +40,7 @@ func (b *BackendRefBuilder) WithPort(port int) *BackendRefBuilder {
 }
 
 func (b *BackendRefBuilder) WithWeight(weight int) *BackendRefBuilder {
-	b.backendRef.Weight = pointer.Int32(int32(weight))
+	b.backendRef.Weight = lo.ToPtr(int32(weight))
 	return b
 }
 

--- a/internal/util/builder/httpbackendref.go
+++ b/internal/util/builder/httpbackendref.go
@@ -1,10 +1,10 @@
 package builder
 
 import (
+	"github.com/samber/lo"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // HTTPBackendRefBuilder is a builder for gateway api HTTPBackendRef.
@@ -38,7 +38,7 @@ func (b *HTTPBackendRefBuilder) WithPort(port int) *HTTPBackendRefBuilder {
 }
 
 func (b *HTTPBackendRefBuilder) WithWeight(weight int) *HTTPBackendRefBuilder {
-	b.httpBackendRef.Weight = address.Of(int32(weight))
+	b.httpBackendRef.Weight = lo.ToPtr(int32(weight))
 	return b
 }
 

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -1,8 +1,9 @@
 package builder
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // KongstateServiceBackendBuilder is a builder for KongstateServiceBackend.
@@ -25,7 +26,7 @@ func (b *KongstateServiceBackendBuilder) WithNamespace(namespace string) *Kongst
 }
 
 func (b *KongstateServiceBackendBuilder) WithWeight(weight int) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.Weight = address.Of(int32(weight))
+	b.kongstateServiceBackend.Weight = lo.ToPtr(int32(weight))
 	return b
 }
 

--- a/internal/util/builder/listener.go
+++ b/internal/util/builder/listener.go
@@ -1,9 +1,8 @@
 package builder
 
 import (
+	"github.com/samber/lo"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // ListenerBuilder is a builder for gateway api Listener.
@@ -62,7 +61,7 @@ func (b *ListenerBuilder) UDP() *ListenerBuilder {
 }
 
 func (b *ListenerBuilder) WithHostname(hostname string) *ListenerBuilder {
-	b.listener.Hostname = address.Of(gatewayv1beta1.Hostname(hostname))
+	b.listener.Hostname = lo.ToPtr(gatewayv1beta1.Hostname(hostname))
 	return b
 }
 

--- a/internal/util/builder/routegroupkind.go
+++ b/internal/util/builder/routegroupkind.go
@@ -1,9 +1,8 @@
 package builder
 
 import (
+	"github.com/samber/lo"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // RouteGroupKindBuilder is a builder for gateway api RouteGroupKind.
@@ -16,7 +15,7 @@ type RouteGroupKindBuilder struct {
 func NewRouteGroupKind() *RouteGroupKindBuilder {
 	return &RouteGroupKindBuilder{
 		routeGroupKind: gatewayv1beta1.RouteGroupKind{
-			Group: address.Of(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+			Group: lo.ToPtr(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
 		},
 	}
 }

--- a/internal/util/builder/routenamespaces.go
+++ b/internal/util/builder/routenamespaces.go
@@ -1,10 +1,9 @@
 package builder
 
 import (
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // RouteNamespacesBuilder is a builder for gateway api RouteNamespaces.
@@ -24,17 +23,17 @@ func (b *RouteNamespacesBuilder) Build() *gatewayv1beta1.RouteNamespaces {
 }
 
 func (b *RouteNamespacesBuilder) FromSame() *RouteNamespacesBuilder {
-	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromSame)
+	b.routeNamespaces.From = lo.ToPtr(gatewayv1beta1.NamespacesFromSame)
 	return b
 }
 
 func (b *RouteNamespacesBuilder) FromAll() *RouteNamespacesBuilder {
-	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromAll)
+	b.routeNamespaces.From = lo.ToPtr(gatewayv1beta1.NamespacesFromAll)
 	return b
 }
 
 func (b *RouteNamespacesBuilder) FromSelector(s *metav1.LabelSelector) *RouteNamespacesBuilder {
-	b.routeNamespaces.From = address.Of(gatewayv1beta1.NamespacesFromSelector)
+	b.routeNamespaces.From = lo.ToPtr(gatewayv1beta1.NamespacesFromSelector)
 	b.routeNamespaces.Selector = s
 	return b
 }

--- a/internal/util/conversions.go
+++ b/internal/util/conversions.go
@@ -1,10 +1,9 @@
 package util
 
 import (
+	"github.com/samber/lo"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 )
 
 // -----------------------------------------------------------------------------
@@ -23,20 +22,20 @@ func StringToGatewayAPIHostnameV1Beta1(hostname string) gatewayv1beta1.Hostname 
 
 // StringToGatewayAPIHostnamePtr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnamePtr(hostname string) *gatewayv1beta1.Hostname {
-	return address.Of(gatewayv1beta1.Hostname(hostname))
+	return lo.ToPtr(gatewayv1beta1.Hostname(hostname))
 }
 
 // StringToGatewayAPIHostnameV1Beta1Ptr converts a string to a *gatewayv1beta1.Hostname.
 func StringToGatewayAPIHostnameV1Beta1Ptr(hostname string) *gatewayv1beta1.Hostname {
-	return address.Of(gatewayv1beta1.Hostname(hostname))
+	return lo.ToPtr(gatewayv1beta1.Hostname(hostname))
 }
 
 // StringToGatewayAPIKindV1Alpha2Ptr converts a string to a *gatewayv1alpha2.Kind.
 func StringToGatewayAPIKindV1Alpha2Ptr(kind string) *gatewayv1alpha2.Kind {
-	return address.Of(gatewayv1alpha2.Kind(kind))
+	return lo.ToPtr(gatewayv1alpha2.Kind(kind))
 }
 
 // StringToGatewayAPIKindPtr converts a string to a *gatewayv1beta1.Kind.
 func StringToGatewayAPIKindPtr(kind string) *gatewayv1beta1.Kind {
-	return address.Of(gatewayv1beta1.Kind(kind))
+	return lo.ToPtr(gatewayv1beta1.Kind(kind))
 }

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/address"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
@@ -60,11 +59,11 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 			},
 			// Proxy field is deprecated, expecting warning for it.
 			Proxy: &configurationv1.KongIngressService{
-				Protocol: address.Of("tcp"),
+				Protocol: lo.ToPtr("tcp"),
 			},
 			// Route field is deprecated, expecting warning for it.
 			Route: &configurationv1.KongIngressRoute{
-				Methods: []*string{address.Of("POST")},
+				Methods: []*string{lo.ToPtr("POST")},
 			},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the local implementation of `address.Of`, replaces it with `lo.ToPtr`, and disallows usage of `k8s.io/utils/pointer`. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up of #3261. 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

