### PR TITLE
refactor: make synchronizer accept option parameters

### DIFF
--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -19,13 +19,15 @@ const (
 	// DefaultSyncSeconds indicates the time.Duration (minimum) that will occur between
 	// updates to the DataplaneClient.
 	//
-	// This 1s default was based on local testing wherein it appeared sub-second updates
+	// This default was based on local testing wherein it appeared sub-second updates
 	// to the Admin API could be problematic (or at least operate differently) based on
 	// which storage backend was in use (i.e. "dbless", "postgres"). This is a workaround
 	// for improvements we still need to investigate upstream.
 	//
 	// See Also: https://github.com/Kong/kubernetes-ingress-controller/issues/1398
 	DefaultSyncSeconds float32 = 3.0
+
+	DefaultInitWaitPeriod = 5 * time.Second
 )
 
 // -----------------------------------------------------------------------------
@@ -39,37 +41,50 @@ type Synchronizer struct {
 
 	// dataplane client to send updates to the Kong Admin API
 	dataplaneClient Client
+	dbMode          string
 
 	// server configuration, flow control, channels and utility attributes
 	stagger         time.Duration
 	syncTicker      *time.Ticker
 	configApplied   bool
 	isServerRunning bool
+	initWaitPeriod  time.Duration
 
 	lock sync.RWMutex
 }
 
-// NewSynchronizer will provide a new Synchronizer object. Note that this
-// starts some background goroutines and the caller is resonsible for marking
-// the provided context.Context as "Done()" to shut down the background routines.
-func NewSynchronizer(logger logrus.FieldLogger, dataplaneClient Client) (*Synchronizer, error) {
-	stagger, err := time.ParseDuration(fmt.Sprintf("%gs", DefaultSyncSeconds))
-	if err != nil {
-		return nil, err
+type SynchronizerOption func(*Synchronizer)
+
+// WithStagger returns a SynchronizerOption which sets the stagger period.
+func WithStagger(period time.Duration) SynchronizerOption {
+	return func(s *Synchronizer) {
+		s.stagger = period
 	}
-	return NewSynchronizerWithStagger(logger, dataplaneClient, stagger)
+}
+
+// WithInitWaitPeriod returns a SynchronizerOption which sets the initial wait period.
+func WithInitWaitPeriod(period time.Duration) SynchronizerOption {
+	return func(s *Synchronizer) {
+		s.initWaitPeriod = period
+	}
 }
 
 // NewSynchronizer will provide a new Synchronizer object with a specified
 // stagger time for data-plane updates to occur. Note that this starts some
 // background goroutines and the caller is resonsible for marking the provided
 // context.Context as "Done()" to shut down the background routines.
-func NewSynchronizerWithStagger(logger logrus.FieldLogger, dataplaneClient Client, stagger time.Duration) (*Synchronizer, error) {
+func NewSynchronizer(logger logrus.FieldLogger, client Client, opts ...SynchronizerOption) (*Synchronizer, error) {
 	synchronizer := &Synchronizer{
 		logger:          logrusr.New(logger),
-		dataplaneClient: dataplaneClient,
-		stagger:         stagger,
+		stagger:         time.Duration(DefaultSyncSeconds),
+		initWaitPeriod:  DefaultInitWaitPeriod,
+		dataplaneClient: client,
 		configApplied:   false,
+		dbMode:          client.DBMode(),
+	}
+
+	for _, opt := range opts {
+		opt(synchronizer)
 	}
 
 	return synchronizer, nil
@@ -89,14 +104,13 @@ func (p *Synchronizer) Start(ctx context.Context) error {
 	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2249
 	// This is a temporary mitigation to allow some time for controllers to
 	// populate their dataplaneClient cache.
-	case <-time.After(time.Second * 5):
+	case <-time.After(p.initWaitPeriod):
 	case <-ctx.Done():
 		return fmt.Errorf("Synchronizer Start() interrupted: %w", ctx.Err())
 	}
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
-
 	if p.isServerRunning {
 		return fmt.Errorf("server is already running")
 	}
@@ -121,11 +135,11 @@ func (p *Synchronizer) IsRunning() bool {
 // of a controller-runtime Runnable interface to wait for readiness before
 // starting controllers.
 func (p *Synchronizer) IsReady() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
 	// If the proxy is has no database, it is only ready after a successful sync
 	// Otherwise, it has no configuration loaded
-	if p.dataplaneClient.DBMode() == "off" {
-		p.lock.RLock()
-		defer p.lock.RUnlock()
+	if p.dbMode == "off" {
 		return p.configApplied
 	}
 	// If the proxy has a database, it is ready immediately
@@ -163,6 +177,7 @@ func (p *Synchronizer) startUpdateServer(ctx context.Context) {
 			p.configApplied = false
 
 			return
+
 		case <-p.syncTicker.C:
 			if err := p.dataplaneClient.Update(ctx); err != nil {
 				p.logger.Error(err, "could not update kong admin")

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -14,6 +15,8 @@ func TestSynchronizer(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+
+	tick := time.Millisecond * 10
 
 	t.Log("setting up a fake dataplane client to test the synchronizer")
 	c := &fakeDataplaneClient{dbmode: "postgres"}
@@ -23,25 +26,24 @@ func TestSynchronizer(t *testing.T) {
 	defer cancel()
 
 	t.Log("initializing the dataplane synchronizer")
-	stagger := time.Millisecond * 200
-	sync, err := NewSynchronizerWithStagger(logrus.New(), c, stagger)
-	assert.NoError(t, err)
+	sync, err := NewSynchronizer(logrus.New(), c, WithStagger(tick), WithInitWaitPeriod(tick))
+	require.NoError(t, err)
 	assert.NotNil(t, sync)
 
 	t.Log("verifying that a non-started dataplane synchronizer reports as not running")
 	assert.False(t, sync.IsRunning())
 
 	t.Log("verifying that postgres dp makes the synchronizer immediately ready")
-	c.dbmode = "postgres"
+	sync.dbMode = "postgres"
 	assert.True(t, sync.IsReady())
 
 	t.Log("verifying dbless mode means the synchronizer wont be ready until a config has been applied")
-	c.dbmode = "off"
+	sync.dbMode = "off"
 	assert.False(t, sync.IsReady())
 
 	t.Log("starting the dataplane synchronizer server")
 	assert.NoError(t, sync.Start(ctx))
-	assert.Eventually(t, func() bool { return sync.IsRunning() }, time.Second, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return sync.IsRunning() }, time.Second, tick)
 	assert.True(t, sync.NeedLeaderElection())
 
 	t.Log("verifying that trying to start the dataplane synchronizer while it's already started fails")
@@ -50,33 +52,33 @@ func TestSynchronizer(t *testing.T) {
 	assert.Equal(t, err.Error(), "server is already running")
 
 	t.Log("verifying that eventually the synchronizer reports as ready for a dbless dataplane")
-	assert.Eventually(t, func() bool { return sync.IsReady() }, stagger*2, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return sync.IsReady() }, tick*2, tick)
 
 	t.Log("verifying that the dataplane eventually receieves several successful updates from the synchronizer")
 	assert.Eventually(t, func() bool {
 		return c.totalUpdates() >= 5
-	}, stagger*2, time.Millisecond*200)
+	}, 10*tick, tick, "got %d updates, expected 5 or more", c.totalUpdates())
 
 	t.Log("verifying that the server shuts down when the context is cancelled")
 	cancel()
-	assert.Eventually(t, func() bool { return !sync.IsRunning() }, time.Second, time.Millisecond*200)
-	assert.Eventually(t, func() bool { return !sync.IsReady() }, time.Second, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return !sync.IsRunning() }, time.Second, tick)
+	assert.Eventually(t, func() bool { return !sync.IsReady() }, time.Second, tick)
 	totalUpdatesSeenSoFar := c.totalUpdates()
 
 	t.Log("verifying that the server can be started back up with a new context")
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 	assert.NoError(t, sync.Start(ctx))
-	assert.Eventually(t, func() bool { return sync.IsRunning() }, time.Second, time.Millisecond*200)
-	assert.Eventually(t, func() bool { return sync.IsReady() }, time.Second, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return sync.IsRunning() }, time.Second, tick)
+	assert.Eventually(t, func() bool { return sync.IsReady() }, time.Second, tick)
 
 	t.Log("verifying that a server that was restarted continues to send successful updates to the dataplane")
-	assert.Eventually(t, func() bool { return c.totalUpdates() >= totalUpdatesSeenSoFar+3 }, time.Second, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return c.totalUpdates() >= totalUpdatesSeenSoFar+3 }, time.Second, tick)
 
 	t.Log("verifying that the server can be shut down a second time")
 	cancel()
-	assert.Eventually(t, func() bool { return !sync.IsRunning() }, time.Second, time.Millisecond*200)
-	assert.Eventually(t, func() bool { return !sync.IsReady() }, time.Second, time.Millisecond*200)
+	assert.Eventually(t, func() bool { return !sync.IsRunning() }, time.Second, tick)
+	assert.Eventually(t, func() bool { return !sync.IsReady() }, time.Second, tick)
 }
 
 // fakeDataplaneClient fakes the dataplane.Client interface so that we can

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -146,16 +146,10 @@ func setupDataplaneSynchronizer(
 		))
 	}
 
-	syncTickDuration, err := time.ParseDuration(fmt.Sprintf("%gs", c.ProxySyncSeconds))
-	if err != nil {
-		logger.Error(err, "%s is not a valid number of seconds to stagger the proxy server synchronization")
-		return nil, err
-	}
-
-	dataplaneSynchronizer, err := dataplane.NewSynchronizerWithStagger(
+	dataplaneSynchronizer, err := dataplane.NewSynchronizer(
 		fieldLogger.WithField("subsystem", "dataplane-synchronizer"),
 		dataplaneClient,
-		syncTickDuration,
+		dataplane.WithStagger(time.Second*time.Duration(c.ProxySyncSeconds)),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the dataplane synchronizer accept options as parameter and refactors its tests so that instead of running for 17s they complete in 0.16s.