### PR TITLE
fix: don't fail integration tests when ingres class is already present in the cluster

### DIFF
--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -109,7 +110,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 					},
 				},
 				Spec: netv1.IngressSpec{
-					IngressClassName: &ingressClass,
+					IngressClassName: lo.ToPtr(ingressClass),
 					Rules: []netv1.IngressRule{
 						{
 							IngressRuleValue: netv1.IngressRuleValue{
@@ -244,7 +245,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 					},
 				},
 				Spec: netv1.IngressSpec{
-					IngressClassName: &ingressClass,
+					IngressClassName: lo.ToPtr(ingressClass),
 					Rules: []netv1.IngressRule{
 						{
 							IngressRuleValue: netv1.IngressRuleValue{

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -54,6 +54,11 @@ const (
 // Testing Variables
 // -----------------------------------------------------------------------------
 
+const (
+	// ingressClass indicates the ingress class name which the tests will use for supported object reconciliation.
+	ingressClass = "kongtests"
+)
+
 var (
 	// ctx the topical context of the test suite, can be used by test cases if they don't need
 	// any special context as a function of the test.
@@ -65,9 +70,6 @@ var (
 	// redisImage is Redis. Pinned because of
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/2735#issuecomment-1194376496 breakage.
 	redisImage = "bitnami/redis:7.0.4-debian-11-r3"
-
-	// ingressClass indicates the ingress class name which the tests will use for supported object reconciliation.
-	ingressClass = "kongtests"
 
 	// controllerNamespace is the Kubernetes namespace where the controller is deployed.
 	controllerNamespace = "kong-system"


### PR DESCRIPTION
**What this PR does / why we need it**:

When ingress class for tests is already present in the cluster don't fail outright but try to recreate it ( so that it's in the state that we want it to be ) and continue on.

