### PR TITLE
fix(tests): add GITHUB_TOKEN to tests so that they can authenticate against Github API

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,6 +160,7 @@ jobs:
       if: env.PULP_PASSWORD != ''
       run: make test.integration.enterprise.postgres
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         GOTESTSUM_JUNITFILE: "integration-tests-enterprise-postgres.xml"
 
@@ -210,6 +211,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOTESTSUM_JUNITFILE: "integration-tests-dbless.xml"
 
     - name: collect test coverage
@@ -258,6 +260,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.postgres
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOTESTSUM_JUNITFILE: "integration-tests-postgres.xml"
 
     - name: collect test coverage
@@ -306,6 +309,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_CONTROLLER_FEATURE_GATES: "GatewayAlpha=true,CombinedRoutes=false"
         GOTESTSUM_JUNITFILE: "integration-tests-feature-gates.xml"
 

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -38,6 +38,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.enterprise.postgres
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         TEST_KONG_IMAGE: "kong/kong-gateway-internal"
         TEST_KONG_TAG: "master-alpine"
@@ -84,6 +85,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.postgres
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEST_KONG_IMAGE: "kong/kong"
         TEST_KONG_TAG: "master-alpine"
 
@@ -127,6 +129,7 @@ jobs:
     - name: run integration tests
       run: make test.integration.dbless
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEST_KONG_IMAGE: "kong/kong"
         TEST_KONG_TAG: "master-alpine"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to improve tests reliability and resilience to github API rate limiting we need to pass the `GITHUB_TOKEN` env into CI steps that run the tests so that they can use it for authentication.

Exemplar CI failure caused by the above: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3714943949/jobs/6299504976#step:6:356

```
Error: tests failed: couldn't fetch latest knative/serving release: GET https://api.github.com/repos/knative/serving/releases/latest: 403 API rate limit exceeded for 172.177.73.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 10m00s]
```