### PR TITLE
chore(tests): add GITHUB_TOKEN to nightly test runs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -208,11 +208,13 @@ jobs:
       - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests With ${{ matrix.kong-router-flavor }} Kong Router
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOTESTSUM_JUNITFILE: integration-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-${{ matrix.kong-router-flavor }}-tests.xml
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.kong-router-flavor }}
       - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests for Invalid Configurations With ${{ matrix.kong-router-flavor }} Kong Router
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOTESTSUM_JUNITFILE: integration-invalid-config-${{ matrix.kong-router-flavor }}-${{ matrix.kubernetes-version }}-${{ matrix.dbmode }}-tests.xml
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.kong-router-flavor }}
           GOTESTFLAGS: "-run=TestIngressRecoverFromInvalidPath"


### PR DESCRIPTION
**What this PR does / why we need it**:

In the same spirit as #3272, this adds `GITHUB_TOKEN` to integration test runs to prevent Github API rate limiting but in nightly test runs.

Exemplar failed CI pipeline: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3718281847/jobs/6306456862#step:5:378

```
Error: tests failed: couldn't fetch latest knative/serving release: GET https://api.github.com/repos/knative/serving/releases/latest: 403 API rate limit exceeded for 65.52.35.16. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 25m45s]
```
