### PR TITLE
fix(tests): generate test namespaces in tests

### DIFF
--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestGatewayValidationWebhook(t *testing.T) {
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -208,8 +208,7 @@ func TestIngressEssentials(t *testing.T) {
 
 func TestGRPCIngressEssentials(t *testing.T) {
 	t.Parallel()
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("grpcbin", "moul/grpcbin", 9001)
@@ -479,8 +478,7 @@ func TestIngressNamespaces(t *testing.T) {
 
 func TestIngressStatusUpdatesExtended(t *testing.T) {
 	t.Parallel()
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	if clusterVersion.Major == uint64(1) && clusterVersion.Minor < uint64(19) {
 		t.Skip("status test disabled for old cluster versions")

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -43,8 +43,7 @@ func TestKnativeIngress(t *testing.T) {
 	}
 
 	t.Parallel()
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	t.Log("generating a knative clientset")
 	dynamicClient, err := dynamic.NewForConfig(env.Cluster().Config())

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -27,8 +27,7 @@ import (
 
 func TestKongIngressEssentials(t *testing.T) {
 	t.Parallel()
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	testName := "minking"

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -183,17 +183,6 @@ func TestMain(m *testing.M) {
 	proxyUDPURL, err = kongAddon.ProxyUDPURL(ctx, env.Cluster())
 	exitOnErr(err)
 
-	fmt.Println("INFO: generating unique namespaces for each test case")
-	testCases, err := identifyTestCasesForDir("./")
-	exitOnErr(err)
-	for _, testCase := range testCases {
-		namespaceForTestCase, err := clusters.GenerateNamespace(ctx, env.Cluster(), testCase)
-
-		exitOnErr(err)
-		namespaces[testCase] = namespaceForTestCase
-		watchNamespaces = fmt.Sprintf("%s,%s", watchNamespaces, namespaceForTestCase.Name)
-	}
-
 	if v := os.Getenv("KONG_BRING_MY_OWN_KIC"); v == "true" {
 		fmt.Println("WARNING: caller indicated that they will manage their own controller")
 	} else {

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -43,8 +43,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 		udpMutex.Unlock()
 	}()
 
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	t.Log("configuring coredns corefile")
 	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}
@@ -180,8 +179,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	defer udpMutex.Unlock()
 	defer tcpMutex.Unlock()
 
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	t.Log("configuring coredns corefile")
 	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -40,8 +40,7 @@ const highEndConsumerUsageCount = 50
 
 func TestValidationWebhook(t *testing.T) {
 	t.Parallel()
-	ns, cleanup := namespace(t)
-	defer cleanup()
+	ns := namespace(t)
 
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")


### PR DESCRIPTION
**What this PR does / why we need it**:

Generate test namespaces in tests so that when tests are run separately only necessary namespaces are created in the cluster.

Additionally this makes it so that each test is responsible for each own namespace that it needs.