### PR TITLE
chore(deps): bump e2e matrix dependencies

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,11 +90,12 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.24.2'
+          - 'v1.26.0'
         istio-version:
-          - 'v1.15.1'
-          - 'v1.14.4'
-          - 'v1.13.8'
+          - 'v1.16.1'
+          - 'v1.15.4'
+          - 'v1.14.6'
+          - 'v1.13.9'
           - 'v1.12.9'
           - 'v1.11.8'
     steps:
@@ -153,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version: # the GKE setup script ignores the patch version here and uses the latest, but we still include it for consistency with the other E2E jobs
-          - 'v1.24.2'
+          - 'v1.24.7'
     steps:
     - name: setup golang
       uses: actions/setup-go@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump all Istio versions to the latest patch
- Add Istio `v1.16.1` 
- Bump GKE Kubernetes version to `v1.24.7`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3199 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

