### PR TITLE
chore: custom entites known issue note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ Adding a new version? You'll need three changes:
   if you have questions or concerns about the transition.
   [#3132](https://github.com/Kong/kubernetes-ingress-controller/pull/3132)
 
+### Known issues
+
+- Processing of custom entites through `--kong-custom-entities-secret` flag or
+  `CONTROLLER_KONG_CUSTOM_ENTITIES_SECRET` environment variable does not work.
+  [#3278](https://github.com/Kong/kubernetes-ingress-controller/issues/3278)
+
 ### Deprecated
 
 - KongIngress' `proxy` and `route` fields are now deprecated in favor of

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -152,7 +152,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", dataplane.DefaultTimeoutSeconds,
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
-	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `A Secret containing custom entities for DB-less mode, in "namespace/name" format`)
+	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #1304)`)
 
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -152,7 +152,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", dataplane.DefaultTimeoutSeconds,
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
-	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #1304)`)
+	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #3278)`)
 
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -152,7 +152,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", dataplane.DefaultTimeoutSeconds,
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
-	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #3278)`)
+	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `No longer has any effect and will be removed in a later release (see github issue #3278)`)
 
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -152,7 +152,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Float32Var(&c.ProxyTimeoutSeconds, "proxy-timeout-seconds", dataplane.DefaultTimeoutSeconds,
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
-	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `No longer has any effect and will be removed in a later release (see github issue #3278)`)
+	flagSet.StringVar(&c.KongCustomEntitiesSecret, "kong-custom-entities-secret", "", `WARNING: Does not work. It's a known issue tracked in a GitHub issue #3278.`)
 
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR marks the `--kong-custom-entities-secret` flag as deprecated and adds a "known issue" note in v2.8 changelog stating that this does not work currently.

**Related issue(s)**

https://github.com/Kong/kubernetes-ingress-controller/issues/3278