### PR TITLE
chore(ci): don't test istio against k8s v1.26

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,6 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
+          # v1.25 is the latest Kubernetes version supported by Istio: https://istio.io/latest/docs/releases/supported-releases/
           - 'v1.25.3'
         istio-version:
           - 'v1.16.1'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.26.0'
+          - 'v1.25.3'
         istio-version:
           - 'v1.16.1'
           - 'v1.15.4'


### PR DESCRIPTION
**What this PR does / why we need it**:

According to [Istio's support status](https://istio.io/latest/docs/releases/supported-releases/), Kubernetes v1.26 isn't supported by any Istio version.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3199 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

