### PR TITLE
chore(e2e): test istio according to its support matrix

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,13 +92,16 @@ jobs:
         kubernetes-version:
           # v1.25 is the latest Kubernetes version supported by Istio: https://istio.io/latest/docs/releases/supported-releases/
           - 'v1.25.3'
+          - 'v1.24.7'
         istio-version:
           - 'v1.16.1'
           - 'v1.15.4'
           - 'v1.14.6'
-          - 'v1.13.9'
-          - 'v1.12.9'
-          - 'v1.11.8'
+        exclude:
+          # Istio v1.14 does not support Kubernetes v1.25: https://istio.io/latest/docs/releases/supported-releases/
+          - kubernetes-version: 'v1.25.3'
+            istio-version: 'v1.14.6'
+
     steps:
     - name: setup golang
       uses: actions/setup-go@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

- Do not test against Istio < v1.14. v1.13 had its EOL on Oct 12, 2022
- Test against two versions of Kubernetes as Kubernetes v1.25 is not supported by Istio v1.14.6 (exclude this one case)

Istio support: https://istio.io/latest/docs/releases/supported-releases/

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3199 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


