### PR TITLE
chore(ci): fix KONG_CLUSTER_VERSION in test-previous-kubernetes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -267,7 +267,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-          KONG_CLUSTER_VERSION: v1.${{ matrix.minor }}
+          KONG_CLUSTER_VERSION: v1.${{ matrix.minor }}.0
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
   publish-release:


### PR DESCRIPTION
**What this PR does / why we need it**:

`KONG_CLUSTER_VERSION` is expected to be in `vMajor.Minor.Patch` format: https://github.com/Kong/kubernetes-ingress-controller/blob/c6344be0ccf080010c9b422a53f0cf463dd52603/hack/e2e/cluster/deploy/main.go#L32

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3199 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


