### PR TITLE
fix(release) align test inputs with regular E2E

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,7 +205,6 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - 'v1.25.3'
           - 'v1.26.0'
     steps:
       - name: setup golang
@@ -231,12 +230,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-push-images
     strategy:
+      fail-fast: true
       matrix:
-        minor:
-          - '21'
-          - '22'
-          - '23'
-          - '24'
+        kubernetes-version:
+          - 'v1.21.12'
+          - 'v1.22.9'
+          - 'v1.23.6'
+          - 'v1.24.2'
+          - 'v1.25.3'
     steps:
       - name: setup golang
         uses: actions/setup-go@v3
@@ -267,7 +268,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-          KONG_CLUSTER_VERSION: v1.${{ matrix.minor }}
+          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
   publish-release:


### PR DESCRIPTION
**What this PR does / why we need it**:

Use full versions for E2E release check. Basically copies what's in https://github.com/Kong/kubernetes-ingress-controller/blob/2da95cf0036e7fbe82fe2095e74f5cd1231ff4fb/.github/workflows/e2e.yaml#L28-L36

Move 1.25 to previous Kubernetes.

**Which issue this PR fixes**:

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3733633765/jobs/6335083552
