### PR TITLE
chore(deploy) bump Kong to 3.1

### DIFF
--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   newTag: '3.1'
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.0'
+  newTag: '3.1'

--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.0'
+  newTag: '3.1'
 - name: kong-placeholder
   newName: kong/kong-gateway
   newTag: '3.0'

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.0'
+  newTag: '3.1'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
   newTag: '2.8.0'

--- a/config/variants/enterprise/kustomization.yaml
+++ b/config/variants/enterprise/kustomization.yaml
@@ -5,4 +5,4 @@ patchesStrategicMerge:
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.0'
+  newTag: '3.1'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1658,7 +1658,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.0
+        image: kong/kong-gateway:3.1
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1653,7 +1653,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.0
+        image: kong:3.1
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1716,7 +1716,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.0
+        image: kong/kong-gateway:3.1
         lifecycle:
           preStop:
             exec:
@@ -1835,7 +1835,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong/kong-gateway:3.0
+        image: kong/kong-gateway:3.1
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -1927,7 +1927,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.0
+        image: kong/kong-gateway:3.1
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
@@ -1942,7 +1942,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.0
+        image: kong/kong-gateway:3.1
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1671,7 +1671,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.0
+        image: kong:3.1
         lifecycle:
           preStop:
             exec:
@@ -1772,7 +1772,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:3.0
+        image: kong:3.1
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -1854,7 +1854,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.0
+        image: kong:3.1
         name: kong-migrations
       initContainers:
       - command:
@@ -1867,7 +1867,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.0
+        image: kong:3.1
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

It's [out](https://hub.docker.com/layers/kong/kong-gateway/3.1.0.0-debian/images/sha256-ad345462fe02a5acec549ad0e6d6f56d1e479ca41f5fcdb5366f971bb8bdfa9f?context=explore). Part of  #3220

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
