### PR TITLE
chore: extend fossa instructions in release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -39,6 +39,8 @@ body:
       - label: "ensure that you have up to date copy of `main`: git checkout main; git pull"
       - label: "create the release branch for the version (e.g. `release/1.3.1`): `git branch -m release/x.y.z`"
       - label: Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
+      - label: Resolve all licensing issues that FOSSA has detected. Go to Issues tab in FOSSA's KIC project and resolve every issue, inspecting if it's a false positive or not. [resolved.json](https://github.com/Kong/team-k8s/blob/main/fossa/kubernetes-ingress-controller/resolved.json) should be useful to look for issues that have been already resolved and reappeared due to version changes (do ctrl+f and look for a library name).
+      - label: Update [resolved.json](https://github.com/Kong/team-k8s/blob/main/fossa/kubernetes-ingress-controller/resolved.json) following instructions in [README](https://github.com/Kong/team-k8s/blob/main/fossa/README.md).
       - label: Retrieve the latest license report from FOSSA and save it to LICENSES (go to Reports tab in FOSSA's KIC project, select 'plain text' format, tick 'direct dependencies' and download it).
       - label: "ensure base manifest versions use the new version (`config/image/enterprise/kustomization.yaml` and `config/image/oss/kustomization.yaml`) and update manifest files: `make manifests`"
       - label: "push the branch up to the remote: `git push --set-upstream origin release/x.y.z`"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a step requiring cleaning up all the existing issues in FOSSA before making a release.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/team-k8s/issues/267.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
