### PR TITLE
chore: tag RH images with latest tag in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           images: kong/kubernetes-ingress-controller
           flavor: |
-            latest=false
+            latest=${{ github.event.inputs.latest == 'true' }}
           tags: ${{ env.REDHAT_STANDARD }}${{ env.REDHAT_SUPPLEMENTAL }}
       - name: Docker meta (redhat scan registry)
         id: meta_redhat_scan_registry
@@ -126,7 +126,7 @@ jobs:
         with:
           images: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}
           flavor: |
-            latest=false
+            latest=${{ github.event.inputs.latest == 'true' }}
           tags: ${{ env.REDHAT_STANDARD }}${{ env.REDHAT_SUPPLEMENTAL }}
       - name: Build binary
         id: docker_build_binary


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables tagging RedHat images with the `latest` when the workflow's `latest` input is set to `true`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/team-k8s/issues/267. 
