### PR TITLE
fix: use port name when port number is not provided in combined routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,12 @@ Adding a new version? You'll need three changes:
 ### Fixed
 
 - When `CombinedRoutes` is turned on, translator will replace each occurrence of
- `*` in `Ingress`'s host to `_` in kong route names because `*` is not 
+ `*` in `Ingress`'s host to `_` in kong route names because `*` is not
   allowed in kong route names.
   [#3312](https://github.com/Kong/kubernetes-ingress-controller/pull/3312)
+- Fix an issue with `CombinedRoutes`, which caused the controller to fail when
+  creating config for Ingress when backend services specified only port names
+  [#3313](https://github.com/Kong/kubernetes-ingress-controller/pull/3313)
 
 ## [2.8.0]
 

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -113,7 +113,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 						Namespace: ingress.Namespace,
 						Backends: []kongstate.ServiceBackend{{
 							Name:    knativeBackend.ServiceName,
-							PortDef: PortDefFromIntStr(knativeBackend.ServicePort),
+							PortDef: translators.PortDefFromIntStr(knativeBackend.ServicePort),
 						}},
 						Parent: ingress,
 					}

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -1078,11 +1078,80 @@ func TestTranslateIngress(t *testing.T) {
 				Parent: expectedParentIngress(),
 			}},
 		},
+		{
+			name: "use port name when service port number is not provided",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
+									Path: "/api/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: netv1.ServiceBackendPort{
+												Name: "http",
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.http"),
+					Host:           kong.String("test-service.default.http.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.http"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/api/"), // default ImplementationSpecific
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode: kongstate.PortModeByName,
+						Name: "http",
+					},
+				}},
+				Parent: expectedParentIngress(),
+			}},
+		},
 	}
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, TranslateIngress(tt.ingress, false), tt.expected)
+			assert.Equal(t, tt.expected, TranslateIngress(tt.ingress, false))
 		})
 	}
 }

--- a/internal/dataplane/parser/translators/portdef.go
+++ b/internal/dataplane/parser/translators/portdef.go
@@ -1,33 +1,18 @@
-package parser
+package translators
 
 import (
-	"fmt"
-
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 )
 
-func serviceBackendPortToStr(port netv1.ServiceBackendPort) string {
-	if port.Name != "" {
-		return fmt.Sprintf("pname-%s", port.Name)
-	}
-	return fmt.Sprintf("pnum-%d", port.Number)
-}
-
-var priorityForPath = map[netv1.PathType]int{
-	netv1.PathTypeExact:                  300,
-	netv1.PathTypePrefix:                 200,
-	netv1.PathTypeImplementationSpecific: 100,
-}
-
 func PortDefFromServiceBackendPort(sbp *netv1.ServiceBackendPort) kongstate.PortDef {
 	switch {
-	case sbp.Name != "":
-		return kongstate.PortDef{Mode: kongstate.PortModeByName, Name: sbp.Name}
 	case sbp.Number != 0:
 		return kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: sbp.Number}
+	case sbp.Name != "":
+		return kongstate.PortDef{Mode: kongstate.PortModeByName, Name: sbp.Name}
 	default:
 		return kongstate.PortDef{Mode: kongstate.PortModeImplicit}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of #3296 

When user provides only service port name and not the number e.g.

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    konghq.com/strip-path: "true"
    kubernetes.io/ingress.class: kong
  name: nginx-ingress
spec:
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: nginx
            port:
              name: http
```

and [`CombinedRoutes`](https://github.com/Kong/kubernetes-ingress-controller/blob/255296c9d71f84400cc33e6c9f556127edd35bab/internal/manager/feature_gates.go#L24-L27) feature flag is used the translation logic incorrectly used port number which wasn't specified. This PR fixes it.

**Which issue this PR fixes**:


**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
