### PR TITLE
tests: deploy knative addon only when necessary

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
@@ -165,12 +164,6 @@ func TestMain(m *testing.M) {
 	exitOnErr(ctx, err)
 	clusterVersion, err = env.Cluster().Version()
 	exitOnErr(ctx, err)
-	if clusterVersion.GE(knativeMinKubernetesVersion) {
-		fmt.Println("INFO: deploying knative addon")
-		knativeBuilder := knative.NewBuilder()
-		knativeAddon := knativeBuilder.Build()
-		exitOnErr(ctx, env.Cluster().DeployAddon(ctx, knativeAddon))
-	}
 
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
 	exitOnErr(ctx, <-env.WaitForReady(ctx))

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
@@ -26,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -436,11 +434,7 @@ func setup(t *testing.T) (*corev1.Namespace, *clusters.Cleaner) {
 	cleaner := clusters.NewCleaner(env.Cluster())
 
 	t.Log("creating a testing namespace")
-	namespace, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-	}, metav1.CreateOptions{})
+	namespace, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
 	require.NoError(t, err)
 	cleaner.AddNamespace(namespace)
 	t.Logf("created namespace %s for test case %s", namespace.Name, t.Name())


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes it so that knative tests that require knative addon to be installed install it themselves, whenever needed. This makes all the other tests to run without knative addon, faster and it also makes the knative addon not install itself when running tests manually with `-run Test....` flag.
