### PR TITLE
chore(ci) update and sync action version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
       - name: Parse semver string
         id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.6
         with:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Parse semver string
         id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@e81ad80123156d7ddd4f6c8383e63f497f857deb
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.6
         with:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the parse-semver action to 1.4.6 now that it's on Marketplace. Set the other workflow that uses it to use the same released version instead of a SHA.

Exclude CI-only changes from code tests because why not, they should never perturb code. Doesn't seem to be taking effect though, does that check against the target? https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths and https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore seems like it should work for that :thinking: 

**Which issue this PR fixes**:

Should clear Github deprecation warnings for the release jobs.