### PR TITLE
Include Kong service name in multi-Service Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ Adding a new version? You'll need three changes:
 - Change existing `resolvedRefs` condition in status `HTTPRoute` if there is
   already one to avoid multiple appearance of conditions with same type
   [#3386](https://github.com/Kong/kubernetes-ingress-controller/pull/3386)
+- Event messages for invalid multi-Service backends now indicate their derived
+  Kong resource name.
+  [#3318](https://github.com/Kong/kubernetes-ingress-controller/pull/3318)
 
 ### Deprecated
 

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -477,7 +477,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			},
 			expected: false,
 			expectedLogEntries: []string{
-				"in the backend group of 3 kubernetes services some have the konghq.com/foo annotation while others don't",
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 			},
 		},
 		{
@@ -519,8 +519,8 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			},
 			expected: false,
 			expectedLogEntries: []string{
-				"the value of annotation konghq.com/foo is different between the 3 services which comprise this backend.",
-				"the value of annotation konghq.com/foo is different between the 3 services which comprise this backend.",
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 			},
 		},
 	} {
@@ -528,7 +528,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			logger, loggerHook := test.NewNullLogger()
 			failuresCollector, err := failures.NewResourceFailuresCollector(logger)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, servicesAllUseTheSameKongAnnotations(tt.services, tt.annotations, failuresCollector))
+			assert.Equal(t, tt.expected, servicesAllUseTheSameKongAnnotations(tt.services, tt.annotations, failuresCollector, ""))
 			assert.Len(t, failuresCollector.PopResourceFailures(), len(tt.expectedLogEntries), "expecting as many translation failures as log entries")
 			for i := range tt.expectedLogEntries {
 				assert.Contains(t, loggerHook.AllEntries()[i].Message, tt.expectedLogEntries[i])

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -127,7 +127,8 @@ func TestTranslationFailures(t *testing.T) {
 				return expectedTranslationFailure{
 					// expect event for service2 as it doesn't have annotations that service1 has
 					causingObjects: []client.Object{service2},
-					reasonContains: "when multiple services comprise a backend all kong annotations between them must be set to the same value",
+					reasonContains: "All Services in a multi-Service backend must have matching Kong annotations. " +
+						"Review the associated route resource and align annotations in its multi-Service backends.",
 				}
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Kong Service name to invalid multi-Service backend Events. This name indicates the route resource that requires the Service, and will in turn indicate the other Services that need matching annotations:

```
11:32:06-0800 esenin $ kubectl -n 71dba048-df32-448b-bfb4-d6df2913e4f7 get events | grep multi                                         
74s         Warning   KongConfigurationTranslationFailed   service/httpbin                                  Service has inconsistent konghq.com/host-header annotation and is used in multi-Service backend httproute.71dba048-df32-448b-bfb4-d6df2913e4f7.2ab68c8f-e26c-4a32-86d1-96208bb7c6ef.1.All Services in a multi-Service backend must have matching Kong annotations. Review the associated route resource and align annotations in its multi-Service backends.
```

Cannot think of a non-awkward way to write that sentence though.

**Which issue this PR fixes**:

Fix #2566. Simpler than the original proposal, but satisfies the main goal of it.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
