### PR TITLE
fix: parse ttl to int in key auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Adding a new version? You'll need three changes:
   This is all the way at the bottom. It's the thing we always forget.
 --->
 
+ - [2.8.1](#281)
  - [2.8.0](#280)
  - [2.7.0](#270)
  - [2.6.0](#260)
@@ -61,7 +62,7 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
-## [2.9.0]
+## [2.8.1]
 
 > Release date: TBD
 
@@ -74,6 +75,9 @@ Adding a new version? You'll need three changes:
 - Fix an issue with `CombinedRoutes`, which caused the controller to fail when
   creating config for Ingress when backend services specified only port names
   [#3313](https://github.com/Kong/kubernetes-ingress-controller/pull/3313)
+- Parse `ttl` field of key-auth credentials in secrets to `int` type before filling
+  to kong credentials to fix the invalid type error.
+  [#3319](https://github.com/Kong/kubernetes-ingress-controller/pull/3319)
 
 ## [2.8.0]
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -100,7 +100,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 					}
 					continue
 				}
-				// TODO: ttl is a field that only appears in keyAuth credentials and has int type.
+				// ttl is a field that only appears in keyAuth credentials and has int type.
 				// Same as above, we cannot fix individual keys after translated to credConfig.
 				if k == "ttl" {
 					intVal, err := strconv.Atoi(string(v))

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -100,6 +100,17 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 					}
 					continue
 				}
+				// TODO: ttl is a field that only appears in keyAuth credentials and has int type.
+				// Same as above, we cannot fix individual keys after translated to credConfig.
+				if k == "ttl" {
+					intVal, err := strconv.Atoi(string(v))
+					if err != nil {
+						log.WithError(err).Errorf("failed to parse ttl to int, skip filling the field")
+					} else {
+						credConfig[k] = intVal
+					}
+					continue
+				}
 				credConfig[k] = string(v)
 			}
 			credType, ok := credConfig["kongCredType"].(string)

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -317,6 +317,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			Data: map[string][]byte{
 				"kongCredType": []byte("key-auth"),
 				"key":          []byte("whatever"),
+				"ttl":          []byte("1024"),
 			},
 		},
 		{
@@ -362,7 +363,10 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				Username: kong.String("foo"),
 				CustomID: kong.String("foo"),
 			},
-			KeyAuths: []*KeyAuth{{kong.KeyAuth{Key: kong.String("whatever")}}},
+			KeyAuths: []*KeyAuth{{kong.KeyAuth{
+				Key: kong.String("whatever"),
+				TTL: kong.Int(1024),
+			}}},
 			Oauth2Creds: []*Oauth2Credential{
 				{
 					kong.Oauth2Credential{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

parse `ttl` field of kong key-auth credentials to `int` type to fix error of invalid type when filling the `ttl` in secret to Kong credential.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #2734 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
