### PR TITLE
chore(ci): don't verify manifests for prerelease

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'
       - name: Verify manifests have requested KIC tag
+        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
         env:
           TAG: ${{ steps.semver_parser.outputs.fullversion }}
         run: make verify.versions

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'
       - name: Verify manifests have requested KIC tag
+        # For prereleases we don't expect the manifests on main to point to the prerelease image tag,
+        # so we're skipping this check.
         if: ${{ steps.semver_parser.outputs.prerelease == '' }}
         env:
           TAG: ${{ steps.semver_parser.outputs.fullversion }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When running a prerelease we don't want to have manifests bumped so the check is not needed. 

Sample run that failed due to that: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3837516608/jobs/6532907634


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:
Part of https://github.com/Kong/team-k8s/issues/267.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

