### PR TITLE
chore(ci): replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,7 +18,7 @@ jobs:
         # grep magic described in https://unix.stackexchange.com/a/13472
         # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
         run: |
-          echo "::set-output name=test_names::$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)"
+          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
   e2e-tests:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,7 +217,7 @@ jobs:
         # grep magic described in https://unix.stackexchange.com/a/13472
         # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
         run: |
-          echo "::set-output name=test_names::$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)"
+          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ replace `set-output` with `GITHUB_OUTPUT`
