### PR TITLE
fix(reports) skip mesh when namespace-limited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Adding a new version? You'll need three changes:
   This is all the way at the bottom. It's the thing we always forget.
 --->
 
+ - [2.9.0](#290)
  - [2.8.1](#281)
  - [2.8.0](#280)
  - [2.7.0](#270)
@@ -61,6 +62,15 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.9.0]
+
+> Release date: TBD
+
+### Fixed
+
+- Disabled non-functioning mesh reporting when `--watch-namespaces` flag set.
+  [#3336](https://github.com/Kong/kubernetes-ingress-controller/pull/3336)
 
 ## [2.8.1]
 
@@ -2164,6 +2174,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.9.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.6.0...v2.7.0

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -219,7 +219,11 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	if c.AnonymousReports {
 		setupLog.Info("Starting anonymous reports")
-		if err := mgrutils.RunReport(ctx, kubeconfig, kongConfig, c.PublishService, metadata.Release, featureGates); err != nil {
+		// the argument checking the watch namespaces length enables or disables mesh detection. the mesh detect client
+		// attempts to use all namespaces and can't utilize a manager multi-namespaced cache, so if we need to limit
+		// namespace access we just disable mesh detection altogether.
+		if err := mgrutils.RunReport(ctx, kubeconfig, kongConfig, c.PublishService, metadata.Release,
+			len(c.WatchNamespaces) == 0, featureGates); err != nil {
 			setupLog.Error(err, "anonymous reporting failed")
 		}
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable mesh detection if the configuration uses --watch-namespaces. The mesh detector attempts to scan all namespaces and cannot be configured to use the multi-namespace cache used by the manager. Since it will fail when --watch-namespaces is set, disable it altogether.

**Which issue this PR fixes**:

Fix #3158 

**Special notes for your reviewer**:

Disabling altogether since the report data isn't critical. Alternatives are:

- Find some way to use the manager client for mesh detection. I don't think this is easily doable without taking it out of the reports system and instead building it into the Service controller. controller-runtime does not expose the manager client and I don't particularly want to roll my own [MNCB](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder)/Kubernetes API client integration just for this.
- Only scan the controller namespace. We should always have access to this, but it's not guaranteed to have a mesh enabled if there is one.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
