### PR TITLE
feat: set "Programmed" condition for *Route in gateway APIs

### DIFF
--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -744,7 +744,8 @@ func updateAcceptedConditionInRouteParentStatus(
 	return changed
 }
 
-// TODO: extract method for different types of *Routes to update conditions.
+// TODO: extract method for different types of *Routes to update conditions:
+// https://github.com/Kong/kubernetes-ingress-controller/issues/3390
 func (r *HTTPRouteReconciler) ensureParentsProgrammedCondition(
 	ctx context.Context,
 	httproute *gatewayv1beta1.HTTPRoute,

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 )
 
 // -----------------------------------------------------------------------------
@@ -342,15 +343,6 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			debug(log, httproute, "failed to update object in data-plane, requeueing")
 			return ctrl.Result{}, err
 		}
-		if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-			// if the dataplane client has reporting enabled (this is the default and is
-			// tied in with status updates being enabled in the controller manager) then
-			// we will wait until the object is reported as successfully configured before
-			// moving on to status updates.
-			if !r.DataplaneClient.KubernetesObjectIsConfigured(httproute) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-		}
 	} else {
 		// route is not accepted, remove it from kong store
 		if err := r.DataplaneClient.DeleteObject(httproute); err != nil {
@@ -374,8 +366,50 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// update "Programmed" condition if HTTPRoute is translated to Kong configuration.
+
+	debug(log, httproute, "ensuring status contains Programmed condition")
+	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
+		// if the dataplane client has reporting enabled (this is the default and is
+		// tied in with status updates being enabled in the controller manager) then
+		// we will wait until the object is reported as successfully configured before
+		// moving on to status updates.
+
+		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(httproute)
+		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
+			// requeue until httproute is configured.
+			debug(log, httproute, "httproute not configured,requeueing")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if configurationStatus == k8sobj.ConfigurationStatusFailed {
+			debug(log, httproute, "httproute configuration failed")
+			statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, httproute, gateways, metav1.ConditionFalse, ConditionReasonTranslationError, "")
+			if err != nil {
+				// don't proceed until the statuses can be updated appropriately
+				debug(log, httproute, "failed to update programmed condition")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: !statusUpdated}, nil
+		}
+
+		statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, httproute, gateways, metav1.ConditionTrue, ConditionReasonConfiguredInGateway, "")
+		if err != nil {
+			// don't proceed until the statuses can be updated appropriately
+			debug(log, httproute, "failed to update programmed condition")
+			return ctrl.Result{}, err
+		}
+		if statusUpdated {
+			// if the status was updated it will trigger a follow-up reconciliation
+			// so we don't need to do anything further here.
+			debug(log, httproute, "programmed condition updated")
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// once the data-plane has accepted the HTTPRoute object, we're all set.
 	info(log, httproute, "httproute has been configured on the data-plane")
+
 	return ctrl.Result{}, nil
 }
 
@@ -443,8 +477,26 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 		return false, err
 	}
 
+	// initialize "programmed" condition to Unknown.
+	// do not update the condition If a "Programmed" condition is already present.
+	programmedConditionChanged := false
+	programmedConditionUnknown := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             metav1.ConditionUnknown,
+		Reason:             string(ConditionReasonProgrammedUnknown),
+		ObservedGeneration: httproute.Generation,
+		LastTransitionTime: metav1.Now(),
+	}
+	for _, parentStatus := range parentStatuses {
+		if !parentStatusHasProgrammedCondition(parentStatus) {
+			programmedConditionChanged = true
+			parentStatus.Conditions = append(parentStatus.Conditions, programmedConditionUnknown)
+		}
+
+	}
+
 	// if we didn't have to actually make any changes, no status update is needed
-	if !statusChangesWereMade && !resolvedRefsChanged {
+	if !statusChangesWereMade && !resolvedRefsChanged && !programmedConditionChanged {
 		return false, nil
 	}
 
@@ -690,4 +742,74 @@ func updateAcceptedConditionInRouteParentStatus(
 		}
 	}
 	return changed
+}
+
+func (r *HTTPRouteReconciler) ensureParentsProgrammedCondition(
+	ctx context.Context,
+	httproute *gatewayv1beta1.HTTPRoute,
+	gateways []supportedGatewayWithCondition,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason gatewayv1beta1.RouteConditionReason,
+	conditionMessage string,
+) (bool, error) {
+	// map the existing parentStatues to avoid duplications
+	parentStatuses := make(map[string]*gatewayv1beta1.RouteParentStatus)
+	for _, existingParent := range httproute.Status.Parents {
+		namespace := httproute.Namespace
+		if existingParent.ParentRef.Namespace != nil {
+			namespace = string(*existingParent.ParentRef.Namespace)
+		}
+		existingParentCopy := existingParent
+		var sectionName string
+		if existingParent.ParentRef.SectionName != nil {
+			sectionName = string(*existingParent.ParentRef.SectionName)
+		}
+		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
+	}
+
+	programmedCondition := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             conditionStatus,
+		Reason:             string(conditionReason),
+		ObservedGeneration: httproute.Generation,
+		Message:            conditionMessage,
+		LastTransitionTime: metav1.Now(),
+	}
+	statusChanged := false
+	for _, g := range gateways {
+		gateway := g.gateway
+		parentRefKey := fmt.Sprintf("%s/%s/%s", gateway.Namespace, gateway.Name, g.listenerName)
+		parentStatus, ok := parentStatuses[parentRefKey]
+		if ok {
+			// update existing parent in status.
+			changed := setRouteParentStatusCondition(parentStatus, programmedCondition)
+			statusChanged = statusChanged || changed
+		} else {
+			// add a new parent if the parent is not found in status.
+			newParentStatus := &gatewayv1beta1.RouteParentStatus{
+				ParentRef: gatewayv1beta1.ParentReference{
+					Namespace:   lo.ToPtr(gatewayv1beta1.Namespace(gateway.Namespace)),
+					Name:        gatewayv1beta1.ObjectName(gateway.Name),
+					SectionName: lo.ToPtr(gatewayv1beta1.SectionName(g.listenerName)),
+					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
+				},
+				Conditions: []metav1.Condition{
+					programmedCondition,
+				},
+			}
+			httproute.Status.Parents = append(httproute.Status.Parents, *newParentStatus)
+			parentStatuses[parentRefKey] = newParentStatus
+			statusChanged = true
+		}
+	}
+
+	// update status if needed.
+	if statusChanged {
+		if err := r.Status().Update(ctx, httproute); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	// no need to update if no status is changed.
+	return false, nil
 }

--- a/internal/controllers/gateway/route_parent_status.go
+++ b/internal/controllers/gateway/route_parent_status.go
@@ -41,7 +41,6 @@ func getParentStatuses[routeT namespacedObjectT, parentStatusT RouteParentStatus
 		switch any(route).(type) {
 		case *gatewayv1beta1.HTTPRoute:
 			key = fmt.Sprintf("%s/%s/%s", namespace, parentRef.Name, sectionName)
-
 		default:
 			key = fmt.Sprintf("%s/%s", namespace, parentRef.Name)
 		}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -653,9 +653,7 @@ func setRouteParentStatusCondition[T types.ParentStatusT](parentStatus T, newCon
 		for i, condition := range p.Conditions {
 			if condition.Type == newCondition.Type {
 				conditionFound = true
-				if condition.Status != newCondition.Status ||
-					condition.Reason != newCondition.Reason ||
-					condition.Message != newCondition.Message {
+				if !sameCondition(condition, newCondition) {
 					p.Conditions[i] = newCondition
 					changed = true
 				}
@@ -670,9 +668,7 @@ func setRouteParentStatusCondition[T types.ParentStatusT](parentStatus T, newCon
 		for i, condition := range p.Conditions {
 			if condition.Type == newCondition.Type {
 				conditionFound = true
-				if condition.Status != newCondition.Status ||
-					condition.Reason != newCondition.Reason ||
-					condition.Message != newCondition.Message {
+				if !sameCondition(condition, newCondition) {
 					p.Conditions[i] = newCondition
 					changed = true
 				}

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 )
 
 // -----------------------------------------------------------------------------
@@ -349,6 +351,35 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
+	// update "Programmed" condition if the TCPRoute is translated to Kong configuration.
+	// if the TCPRoute is not configured ad Kong side, leave it unchanged and requeue.
+	// if it is successfully configured, update its "Programmed" condition to True.
+	// if translation failures happens, update its "Programmed" condition to False.
+	debug(log, tcproute, "ensuring status contains Programmed condition")
+	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
+		// if the dataplane client has reporting enabled (this is the default and is
+		// tied in with status updates being enabled in the controller manager) then
+		// we will wait until the object is reported as successfully configured before
+		// moving on to status updates.
+		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(tcproute)
+		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
+			// requeue until tcproute is configured.
+			debug(log, tcproute, "tcproute not configured,requeueing")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if configurationStatus == k8sobj.ConfigurationStatusFailed {
+			debug(log, tcproute, "tcproute configuration failed")
+			statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, tcproute, gateways, metav1.ConditionFalse, ConditionReasonTranslationError, "")
+			if err != nil {
+				// don't proceed until the statuses can be updated appropriately
+				debug(log, tcproute, "failed to update programmed condition")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: !statusUpdated}, nil
+		}
+	}
+
 	// once the data-plane has accepted the TCPRoute object, we're all set.
 	info(log, tcproute, "tcproute has been configured on the data-plane")
 	return ctrl.Result{}, nil
@@ -397,13 +428,12 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 		// if the reference already exists and doesn't require any changes
 		// then just leave it alone.
 		if existingGatewayParentStatus, exists := parentStatuses[gateway.gateway.Namespace+gateway.gateway.Name]; exists {
-			// fake the time of the existing status as this wont be equal
-			for i := range existingGatewayParentStatus.Conditions {
-				existingGatewayParentStatus.Conditions[i].LastTransitionTime = gatewayParentStatus.Conditions[0].LastTransitionTime
-			}
-
-			// other than the condition timestamps, check if the statuses are equal
-			if reflect.DeepEqual(existingGatewayParentStatus, gatewayParentStatus) {
+			//  check if the parentRef and controllerName are equal, and whether the new condition is present in existing conditions
+			if reflect.DeepEqual(existingGatewayParentStatus.ParentRef, gatewayParentStatus.ParentRef) &&
+				existingGatewayParentStatus.ControllerName == gatewayParentStatus.ControllerName &&
+				lo.ContainsBy(existingGatewayParentStatus.Conditions, func(condition metav1.Condition) bool {
+					return sameCondition(gatewayParentStatus.Conditions[0], condition)
+				}) {
 				continue
 			}
 		}
@@ -413,8 +443,25 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 		statusChangesWereMade = true
 	}
 
+	// initialize "programmed" condition to Unknown.
+	// do not update the condition If a "Programmed" condition is already present.
+	programmedConditionChanged := false
+	programmedConditionUnknown := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             metav1.ConditionUnknown,
+		Reason:             string(ConditionReasonProgrammedUnknown),
+		ObservedGeneration: tcproute.Generation,
+		LastTransitionTime: metav1.Now(),
+	}
+	for _, parentStatus := range parentStatuses {
+		if !parentStatusHasProgrammedCondition(parentStatus) {
+			programmedConditionChanged = true
+			parentStatus.Conditions = append(parentStatus.Conditions, programmedConditionUnknown)
+		}
+	}
+
 	// if we didn't have to actually make any changes, no status update is needed
-	if !statusChangesWereMade {
+	if !statusChangesWereMade && !programmedConditionChanged {
 		return false, nil
 	}
 
@@ -459,4 +506,74 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 
 	// the status needed an update and it was updated successfully
 	return true, nil
+}
+
+func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
+	ctx context.Context,
+	tcproute *gatewayv1alpha2.TCPRoute,
+	gateways []supportedGatewayWithCondition,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason gatewayv1beta1.RouteConditionReason,
+	conditionMessage string,
+) (bool, error) {
+	// map the existing parentStatues to avoid duplications
+	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
+	for _, existingParent := range tcproute.Status.Parents {
+		namespace := tcproute.Namespace
+		if existingParent.ParentRef.Namespace != nil {
+			namespace = string(*existingParent.ParentRef.Namespace)
+		}
+		existingParentCopy := existingParent
+		var sectionName string
+		if existingParent.ParentRef.SectionName != nil {
+			sectionName = string(*existingParent.ParentRef.SectionName)
+		}
+		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
+	}
+
+	programmedCondition := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             conditionStatus,
+		Reason:             string(conditionReason),
+		ObservedGeneration: tcproute.Generation,
+		Message:            conditionMessage,
+		LastTransitionTime: metav1.Now(),
+	}
+	statusChanged := false
+	for _, g := range gateways {
+		gateway := g.gateway
+		parentRefKey := fmt.Sprintf("%s/%s/%s", gateway.Namespace, gateway.Name, g.listenerName)
+		parentStatus, ok := parentStatuses[parentRefKey]
+		if ok {
+			// update existing parent in status.
+			changed := setRouteParentStatusCondition(parentStatus, programmedCondition)
+			statusChanged = statusChanged || changed
+		} else {
+			// add a new parent if the parent is not found in status.
+			newParentStatus := &gatewayv1alpha2.RouteParentStatus{
+				ParentRef: gatewayv1alpha2.ParentReference{
+					Namespace:   lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
+					Name:        gatewayv1alpha2.ObjectName(gateway.Name),
+					SectionName: lo.ToPtr(gatewayv1alpha2.SectionName(g.listenerName)),
+					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
+				},
+				Conditions: []metav1.Condition{
+					programmedCondition,
+				},
+			}
+			tcproute.Status.Parents = append(tcproute.Status.Parents, *newParentStatus)
+			parentStatuses[parentRefKey] = newParentStatus
+			statusChanged = true
+		}
+	}
+
+	// update status if needed.
+	if statusChanged {
+		if err := r.Status().Update(ctx, tcproute); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	// no need to update if no status is changed.
+	return false, nil
 }

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -352,9 +352,9 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// update "Programmed" condition if the TCPRoute is translated to Kong configuration.
-	// if the TCPRoute is not configured ad Kong side, leave it unchanged and requeue.
+	// if the TCPRoute is not configured in the dataplane, leave it unchanged and requeue.
 	// if it is successfully configured, update its "Programmed" condition to True.
-	// if translation failures happens, update its "Programmed" condition to False.
+	// if translation failure happens, update its "Programmed" condition to False.
 	debug(log, tcproute, "ensuring status contains Programmed condition")
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		// if the dataplane client has reporting enabled (this is the default and is
@@ -377,6 +377,19 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{Requeue: !statusUpdated}, nil
+		}
+
+		statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, tcproute, gateways, metav1.ConditionTrue, ConditionReasonConfiguredInGateway, "")
+		if err != nil {
+			// don't proceed until the statuses can be updated appropriately
+			debug(log, tcproute, "failed to update programmed condition")
+			return ctrl.Result{}, err
+		}
+		if statusUpdated {
+			// if the status was updated it will trigger a follow-up reconciliation
+			// so we don't need to do anything further here.
+			debug(log, tcproute, "programmed condition updated")
+			return ctrl.Result{}, nil
 		}
 	}
 
@@ -427,7 +440,8 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 
 		// if the reference already exists and doesn't require any changes
 		// then just leave it alone.
-		if existingGatewayParentStatus, exists := parentStatuses[gateway.gateway.Namespace+gateway.gateway.Name]; exists {
+		parentRefKey := gateway.gateway.Namespace + "/" + gateway.gateway.Name
+		if existingGatewayParentStatus, exists := parentStatuses[parentRefKey]; exists {
 			//  check if the parentRef and controllerName are equal, and whether the new condition is present in existing conditions
 			if reflect.DeepEqual(existingGatewayParentStatus.ParentRef, gatewayParentStatus.ParentRef) &&
 				existingGatewayParentStatus.ControllerName == gatewayParentStatus.ControllerName &&
@@ -439,7 +453,7 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 		}
 
 		// otherwise overlay the new status on top the list of parentStatuses
-		parentStatuses[gateway.gateway.Namespace+gateway.gateway.Name] = gatewayParentStatus
+		parentStatuses[parentRefKey] = gatewayParentStatus
 		statusChangesWereMade = true
 	}
 
@@ -517,19 +531,7 @@ func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
 	conditionMessage string,
 ) (bool, error) {
 	// map the existing parentStatues to avoid duplications
-	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
-	for _, existingParent := range tcproute.Status.Parents {
-		namespace := tcproute.Namespace
-		if existingParent.ParentRef.Namespace != nil {
-			namespace = string(*existingParent.ParentRef.Namespace)
-		}
-		existingParentCopy := existingParent
-		var sectionName string
-		if existingParent.ParentRef.SectionName != nil {
-			sectionName = string(*existingParent.ParentRef.SectionName)
-		}
-		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
-	}
+	parentStatuses := getParentStatuses(tcproute, tcproute.Status.Parents)
 
 	programmedCondition := metav1.Condition{
 		Type:               ConditionTypeProgrammed,
@@ -542,7 +544,7 @@ func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
 	statusChanged := false
 	for _, g := range gateways {
 		gateway := g.gateway
-		parentRefKey := fmt.Sprintf("%s/%s/%s", gateway.Namespace, gateway.Name, g.listenerName)
+		parentRefKey := gateway.Namespace + "/" + gateway.Name
 		parentStatus, ok := parentStatuses[parentRefKey]
 		if ok {
 			// update existing parent in status.
@@ -552,11 +554,11 @@ func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
 			// add a new parent if the parent is not found in status.
 			newParentStatus := &gatewayv1alpha2.RouteParentStatus{
 				ParentRef: gatewayv1alpha2.ParentReference{
-					Namespace:   lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
-					Name:        gatewayv1alpha2.ObjectName(gateway.Name),
-					SectionName: lo.ToPtr(gatewayv1alpha2.SectionName(g.listenerName)),
+					Namespace: lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
+					Name:      gatewayv1alpha2.ObjectName(gateway.Name),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
+				ControllerName: gatewayv1alpha2.GatewayController(ControllerName),
 				Conditions: []metav1.Condition{
 					programmedCondition,
 				},

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 )
 
 // -----------------------------------------------------------------------------
@@ -319,15 +321,6 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		debug(log, udproute, "failed to update object in data-plane, requeueing")
 		return ctrl.Result{}, err
 	}
-	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		// if the dataplane client has reporting enabled (this is the default and is
-		// tied in with status updates being enabled in the controller manager) then
-		// we will wait until the object is reported as successfully configured before
-		// moving on to status updates.
-		if !r.DataplaneClient.KubernetesObjectIsConfigured(udproute) {
-			return ctrl.Result{Requeue: true}, nil
-		}
-	}
 
 	// now that the object has been successfully configured for in the dataplane
 	// we can update the object status to indicate that it's now properly linked
@@ -342,6 +335,30 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// if the status was updated it will trigger a follow-up reconciliation
 		// so we don't need to do anything further here.
 		return ctrl.Result{}, nil
+	}
+
+	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
+		// if the dataplane client has reporting enabled (this is the default and is
+		// tied in with status updates being enabled in the controller manager) then
+		// we will wait until the object is reported as successfully configured before
+		// moving on to status updates.
+		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(udproute)
+		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
+			// requeue until udproute is configured.
+			debug(log, udproute, "udproute not configured,requeueing")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if configurationStatus == k8sobj.ConfigurationStatusFailed {
+			debug(log, udproute, "tcproute configuration failed")
+			statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, udproute, gateways, metav1.ConditionFalse, ConditionReasonTranslationError, "")
+			if err != nil {
+				// don't proceed until the statuses can be updated appropriately
+				debug(log, udproute, "failed to update programmed condition")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: !statusUpdated}, nil
+		}
 	}
 
 	// once the data-plane has accepted the UDPRoute object, we're all set.
@@ -388,13 +405,12 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 		// if the reference already exists and doesn't require any changes
 		// then just leave it alone.
 		if existingGatewayParentStatus, exists := parentStatuses[gateway.gateway.Namespace+gateway.gateway.Name]; exists {
-			// fake the time of the existing status as this wont be equal
-			for i := range existingGatewayParentStatus.Conditions {
-				existingGatewayParentStatus.Conditions[i].LastTransitionTime = gatewayParentStatus.Conditions[0].LastTransitionTime
-			}
-
-			// other than the condition timestamps, check if the statuses are equal
-			if reflect.DeepEqual(existingGatewayParentStatus, gatewayParentStatus) {
+			//  check if the parentRef and controllerName are equal, and whether the new condition is present in existing conditions
+			if reflect.DeepEqual(existingGatewayParentStatus.ParentRef, gatewayParentStatus.ParentRef) &&
+				existingGatewayParentStatus.ControllerName == gatewayParentStatus.ControllerName &&
+				lo.ContainsBy(existingGatewayParentStatus.Conditions, func(condition metav1.Condition) bool {
+					return sameCondition(gatewayParentStatus.Conditions[0], condition)
+				}) {
 				continue
 			}
 		}
@@ -404,8 +420,25 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 		statusChangesWereMade = true
 	}
 
+	// initialize "programmed" condition to Unknown.
+	// do not update the condition If a "Programmed" condition is already present.
+	programmedConditionChanged := false
+	programmedConditionUnknown := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             metav1.ConditionUnknown,
+		Reason:             string(ConditionReasonProgrammedUnknown),
+		ObservedGeneration: udproute.Generation,
+		LastTransitionTime: metav1.Now(),
+	}
+	for _, parentStatus := range parentStatuses {
+		if !parentStatusHasProgrammedCondition(parentStatus) {
+			programmedConditionChanged = true
+			parentStatus.Conditions = append(parentStatus.Conditions, programmedConditionUnknown)
+		}
+	}
+
 	// if we didn't have to actually make any changes, no status update is needed
-	if !statusChangesWereMade {
+	if !statusChangesWereMade && !programmedConditionChanged {
 		return false, nil
 	}
 
@@ -450,4 +483,74 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 
 	// the status needed an update and it was updated successfully
 	return true, nil
+}
+
+func (r *UDPRouteReconciler) ensureParentsProgrammedCondition(
+	ctx context.Context,
+	udproute *gatewayv1alpha2.UDPRoute,
+	gateways []supportedGatewayWithCondition,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason gatewayv1beta1.RouteConditionReason,
+	conditionMessage string,
+) (bool, error) {
+	// map the existing parentStatues to avoid duplications
+	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
+	for _, existingParent := range udproute.Status.Parents {
+		namespace := udproute.Namespace
+		if existingParent.ParentRef.Namespace != nil {
+			namespace = string(*existingParent.ParentRef.Namespace)
+		}
+		existingParentCopy := existingParent
+		var sectionName string
+		if existingParent.ParentRef.SectionName != nil {
+			sectionName = string(*existingParent.ParentRef.SectionName)
+		}
+		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
+	}
+
+	programmedCondition := metav1.Condition{
+		Type:               ConditionTypeProgrammed,
+		Status:             conditionStatus,
+		Reason:             string(conditionReason),
+		ObservedGeneration: udproute.Generation,
+		Message:            conditionMessage,
+		LastTransitionTime: metav1.Now(),
+	}
+	statusChanged := false
+	for _, g := range gateways {
+		gateway := g.gateway
+		parentRefKey := fmt.Sprintf("%s/%s/%s", gateway.Namespace, gateway.Name, g.listenerName)
+		parentStatus, ok := parentStatuses[parentRefKey]
+		if ok {
+			// update existing parent in status.
+			changed := setRouteParentStatusCondition(parentStatus, programmedCondition)
+			statusChanged = statusChanged || changed
+		} else {
+			// add a new parent if the parent is not found in status.
+			newParentStatus := &gatewayv1alpha2.RouteParentStatus{
+				ParentRef: gatewayv1alpha2.ParentReference{
+					Namespace:   lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
+					Name:        gatewayv1alpha2.ObjectName(gateway.Name),
+					SectionName: lo.ToPtr(gatewayv1alpha2.SectionName(g.listenerName)),
+					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
+				},
+				Conditions: []metav1.Condition{
+					programmedCondition,
+				},
+			}
+			udproute.Status.Parents = append(udproute.Status.Parents, *newParentStatus)
+			parentStatuses[parentRefKey] = newParentStatus
+			statusChanged = true
+		}
+	}
+
+	// update status if needed.
+	if statusChanged {
+		if err := r.Status().Update(ctx, udproute); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	// no need to update if no status is changed.
+	return false, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -33,3 +33,7 @@ type BackendRefT interface {
 		gatewayv1alpha2.SecretObjectReference |
 		gatewayv1beta1.SecretObjectReference
 }
+
+type ParentStatusT interface {
+	*gatewayv1alpha2.RouteParentStatus | *gatewayv1beta1.RouteParentStatus
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -283,7 +283,8 @@ func gatewayLinkStatusMatches(
 }
 
 func parentStatusContainsProgrammedCondition[T routeParentStatusT](
-	parentStatuses []T, controllerName gatewayv1beta1.GatewayController, expectedStatus metav1.ConditionStatus) bool {
+	parentStatuses []T, controllerName gatewayv1beta1.GatewayController, expectedStatus metav1.ConditionStatus,
+) bool {
 	var conditions []metav1.Condition
 	parentFound := false
 	for _, parentStatus := range parentStatuses {
@@ -317,7 +318,8 @@ func verifyProgrammedConditionStatus(t *testing.T,
 	c *gatewayclient.Clientset,
 	protocolType gatewayv1beta1.ProtocolType,
 	namespace, name string,
-	expectedStatus metav1.ConditionStatus) bool {
+	expectedStatus metav1.ConditionStatus,
+) bool {
 	// gather a fresh copy of the route, given the specific protocol type
 	switch protocolType { //nolint:exhaustive
 	case gatewayv1beta1.HTTPProtocolType:
@@ -359,7 +361,8 @@ func GetVerifyProgrammedConditionCallback(t *testing.T,
 	c *gatewayclient.Clientset,
 	protocolType gatewayv1beta1.ProtocolType,
 	namespace, name string,
-	expectedStatus metav1.ConditionStatus) func() bool {
+	expectedStatus metav1.ConditionStatus,
+) func() bool {
 	return func() bool {
 		return verifyProgrammedConditionStatus(t, c, protocolType, namespace, name, expectedStatus)
 	}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
@@ -279,6 +280,89 @@ func gatewayLinkStatusMatches(
 
 	t.Fatal("this should not happen")
 	return false
+}
+
+func parentStatusContainsProgrammedCondition[T routeParentStatusT](
+	parentStatuses []T, controllerName gatewayv1beta1.GatewayController, expectedStatus metav1.ConditionStatus) bool {
+	var conditions []metav1.Condition
+	parentFound := false
+	for _, parentStatus := range parentStatuses {
+		switch p := (any)(parentStatus).(type) {
+		case gatewayv1beta1.RouteParentStatus:
+			if p.ControllerName == controllerName {
+				conditions = p.Conditions
+				parentFound = true
+			}
+		case gatewayv1alpha2.RouteParentStatus:
+			if gatewayv1beta1.GatewayController(p.ControllerName) == controllerName {
+				conditions = p.Conditions
+				parentFound = true
+			}
+		}
+
+		if parentFound {
+			break
+		}
+	}
+
+	if !parentFound {
+		return false
+	}
+	return lo.ContainsBy(conditions, func(cond metav1.Condition) bool {
+		return cond.Type == "Programmed" && cond.Status == expectedStatus
+	})
+}
+
+func verifyProgrammedConditionStatus(t *testing.T,
+	c *gatewayclient.Clientset,
+	protocolType gatewayv1beta1.ProtocolType,
+	namespace, name string,
+	expectedStatus metav1.ConditionStatus) bool {
+	// gather a fresh copy of the route, given the specific protocol type
+	switch protocolType { //nolint:exhaustive
+	case gatewayv1beta1.HTTPProtocolType:
+		route, err := c.GatewayV1beta1().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error getting http route: %v", err)
+		} else {
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+		}
+	case gateway.TCPProtocolType:
+		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error getting tcp route: %v", err)
+		} else {
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+		}
+	case gateway.TLSProtocolType:
+		route, err := c.GatewayV1alpha2().TLSRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error getting tls route: %v", err)
+		} else {
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+		}
+	case gateway.UDPProtocolType:
+		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error getting udp route: %v", err)
+		} else {
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+		}
+	default:
+		t.Fatalf("protocol %s not supported", string(protocolType))
+	}
+
+	return false
+}
+
+func GetVerifyProgrammedConditionCallback(t *testing.T,
+	c *gatewayclient.Clientset,
+	protocolType gatewayv1beta1.ProtocolType,
+	namespace, name string,
+	expectedStatus metav1.ConditionStatus) func() bool {
+	return func() bool {
+		return verifyProgrammedConditionStatus(t, c, protocolType, namespace, name, expectedStatus)
+	}
 }
 
 // setIngressClassNameWithRetry changes Ingress.Spec.IngressClassName to specified value

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -158,6 +158,11 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	t.Log("verifying that the Gateway gets linked to the route via status")
 	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.HTTPProtocolType, ns.Name, httpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
+	t.Log("verifying that the httproute contains 'Programmed' condition")
+	require.Eventually(t,
+		GetVerifyProgrammedConditionCallback(t, gatewayClient, gatewayv1beta1.HTTPProtocolType, ns.Name, httpRoute.Name, metav1.ConditionTrue),
+		ingressWait, waitTick,
+	)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
 	eventuallyGETPath(t, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet)

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -168,6 +168,11 @@ func TestTCPRouteEssentials(t *testing.T) {
 	t.Log("verifying that the Gateway gets linked to the route via status")
 	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
+	t.Log("verifying that the tcproute contains 'Programmed' condition")
+	require.Eventually(t,
+		GetVerifyProgrammedConditionCallback(t, gatewayClient, gatewayv1beta1.TCPProtocolType, ns.Name, tcpRoute.Name, metav1.ConditionTrue),
+		ingressWait, waitTick,
+	)
 
 	t.Log("verifying that the tcpecho is responding properly")
 	require.Eventually(t, func() bool {

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -236,6 +236,11 @@ func TestTLSRouteEssentials(t *testing.T) {
 	t.Log("verifying that the Gateway gets linked to the route via status")
 	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
+	t.Log("verifying that the tlsroute contains 'Programmed' condition")
+	require.Eventually(t,
+		GetVerifyProgrammedConditionCallback(t, gatewayClient, gatewayv1beta1.TLSProtocolType, ns.Name, tlsRoute.Name, metav1.ConditionTrue),
+		ingressWait, waitTick,
+	)
 
 	t.Log("verifying that the tcpecho is responding properly over TLS")
 	require.Eventually(t, func() bool {

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -193,6 +193,11 @@ func TestUDPRouteEssentials(t *testing.T) {
 	t.Log("verifying that the Gateway gets linked to the route via status")
 	callback := GetGatewayIsLinkedCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
+	t.Log("verifying that the udproute contains 'Programmed' condition")
+	require.Eventually(t,
+		GetVerifyProgrammedConditionCallback(t, gatewayClient, gatewayv1beta1.UDPProtocolType, ns.Name, udpRoute.Name, metav1.ConditionTrue),
+		ingressWait, waitTick,
+	)
 
 	t.Logf("checking DNS to resolve via UDPIngress %s", udpRoute.Name)
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

As described in [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/#programmed), gateway API has published "Programmed" condition in release 0.6.0. We will add the condition to the following managed objects:
- `HTTPRoute`
- `TCPRoute`
- `TLSRoute`
- `UDPRoute`

Also, setting "Programmed" condition properly is a prerequisite for bumping gateway API to 0.6.0 because conformance tests includes tests for setting the "Programmed" condition.
**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

expected to fix #3343

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
