### PR TITLE
fix: only check if condition contained in ensuring gateway associated of httproute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Adding a new version? You'll need three changes:
 
 - Disabled non-functioning mesh reporting when `--watch-namespaces` flag set.
   [#3336](https://github.com/Kong/kubernetes-ingress-controller/pull/3336)
+- Fixed the duplicate update of status of `HTTPRoute` caused by incorrect check
+  of whether status is changed.
+  [#3346](https://github.com/Kong/kubernetes-ingress-controller/pull/3346)
 
 ### Deprecated
 

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -435,10 +435,12 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 		// if the reference already exists and doesn't require any changes
 		// then just leave it alone.
 		if existingGatewayParentStatus, exists := parentStatuses[key]; exists {
-			//  check if the parentRef and controllerName are equal, and expected condition presents in conditions
+			//  check if the parentRef and controllerName are equal, and whether the new condition is present in existing conditions
 			if reflect.DeepEqual(existingGatewayParentStatus.ParentRef, gatewayParentStatus.ParentRef) &&
 				existingGatewayParentStatus.ControllerName == gatewayParentStatus.ControllerName &&
-				containsCondition(existingGatewayParentStatus.Conditions, gatewayParentStatus.Conditions[0]) {
+				lo.ContainsBy(existingGatewayParentStatus.Conditions, func(condition metav1.Condition) bool {
+					return sameCondition(gatewayParentStatus.Conditions[0], condition)
+				}) {
 				continue
 			}
 		}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -435,13 +435,10 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 		// if the reference already exists and doesn't require any changes
 		// then just leave it alone.
 		if existingGatewayParentStatus, exists := parentStatuses[key]; exists {
-			// fake the time of the existing status as this wont be equal
-			for i := range existingGatewayParentStatus.Conditions {
-				existingGatewayParentStatus.Conditions[i].LastTransitionTime = gatewayParentStatus.Conditions[0].LastTransitionTime
-			}
-
-			// other than the condition timestamps, check if the statuses are equal
-			if reflect.DeepEqual(existingGatewayParentStatus, gatewayParentStatus) {
+			//  check if the parentRef and controllerName are equal, and expected condition presents in conditions
+			if reflect.DeepEqual(existingGatewayParentStatus.ParentRef, gatewayParentStatus.ParentRef) &&
+				existingGatewayParentStatus.ControllerName == gatewayParentStatus.ControllerName &&
+				containsCondition(existingGatewayParentStatus.Conditions, gatewayParentStatus.Conditions[0]) {
 				continue
 			}
 		}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -630,3 +630,17 @@ func isHTTPReferenceGranted(grantSpec gatewayv1alpha2.ReferenceGrantSpec, backen
 	}
 	return false
 }
+
+// containsCondition returns true if a condition with same type, status, reason and message
+// of expectedCondition in conditions
+func containsCondition(conditions []metav1.Condition, expectedCondition metav1.Condition) bool {
+	for _, condition := range conditions {
+		if condition.Type == expectedCondition.Type &&
+			condition.Status == expectedCondition.Status &&
+			condition.Reason == expectedCondition.Reason &&
+			condition.Message == expectedCondition.Message {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -631,11 +631,10 @@ func isHTTPReferenceGranted(grantSpec gatewayv1alpha2.ReferenceGrantSpec, backen
 	return false
 }
 
-// sameCondition returns true if the condition has the same type, status, reason and message
-// with expectedCondition.
-func sameCondition(expectedCondition metav1.Condition, condition metav1.Condition) bool {
-	return condition.Type == expectedCondition.Type &&
-		condition.Status == expectedCondition.Status &&
-		condition.Reason == expectedCondition.Reason &&
-		condition.Message == expectedCondition.Message
+// sameCondition returns true if the conditions in parameter has the same type, status, reason and message.
+func sameCondition(a, b metav1.Condition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message
 }

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -631,16 +631,11 @@ func isHTTPReferenceGranted(grantSpec gatewayv1alpha2.ReferenceGrantSpec, backen
 	return false
 }
 
-// containsCondition returns true if a condition with same type, status, reason and message
-// of expectedCondition in conditions
-func containsCondition(conditions []metav1.Condition, expectedCondition metav1.Condition) bool {
-	for _, condition := range conditions {
-		if condition.Type == expectedCondition.Type &&
-			condition.Status == expectedCondition.Status &&
-			condition.Reason == expectedCondition.Reason &&
-			condition.Message == expectedCondition.Message {
-			return true
-		}
-	}
-	return false
+// sameCondition returns true if the condition has the same type, status, reason and message
+// with expectedCondition.
+func sameCondition(expectedCondition metav1.Condition, condition metav1.Condition) bool {
+	return condition.Type == expectedCondition.Type &&
+		condition.Status == expectedCondition.Status &&
+		condition.Reason == expectedCondition.Reason &&
+		condition.Message == expectedCondition.Message
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Now more than one conditions are added to HTTPRoute.status.parentStatus[*], so we need to change the method to check if parent status for gateways changed. Instead of making a full comparison of conditions, we check if the existing parentStatus contains the expected condtion.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3345

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
