### PR TITLE
chore(ci): don't run e2e in GKE clusters

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -151,66 +151,9 @@ jobs:
         name: tests-report
         path: istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml
 
-  e2e-gke-tests:
-    environment: "gcloud"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        kubernetes-version: # the GKE setup script ignores the patch version here and uses the latest, but we still include it for consistency with the other E2E jobs
-          - 'v1.24.7'
-    steps:
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        password: ${{ secrets.PULP_PASSWORD }}
-
-    - name: run ${{ matrix.kubernetes-version }}
-      run: make test.e2e.gke
-      env:
-        GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-        GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-        GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        GOTESTSUM_JUNITFILE: "gke-${{ matrix.kubernetes-version }}-tests.xml"
-
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-e2e-tests
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-    
-    - name: collect test report
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: gke-${{ matrix.kubernetes-version }}-tests.xml
-
   buildpulse-report:
     needs:
       - "e2e-tests"
-      - "e2e-gke-tests"
       - "istio-tests"
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,7 +217,6 @@ jobs:
           - 'v1.23.6'
           - 'v1.24.2'
           - 'v1.25.3'
-          - 'v1.26.0'
     steps:
       - name: setup golang
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,46 +205,7 @@ jobs:
           apitoken: ${{ secrets.RH_PYXIS_TOKEN }}
           certificationid: ${{ secrets.RH_CERTIFICATION_ID }}
 
-  test-current-kubernetes:
-    runs-on: ubuntu-latest
-    needs: build-push-images
-    steps:
-      - name: setup golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.19'
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: Kong/kong-license@master
-        id: license
-        with:
-          password: ${{ secrets.PULP_PASSWORD }}
-      - name: Parse semver string
-        id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1
-        with:
-          input_string: ${{ github.event.inputs.tag }}
-          version_extractor_regex: 'v(.*)$'
-      - name: e2e current kubernetes
-        run: make test.e2e
-        env:
-          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/kubernetes-ingress-controller:${{ steps.semver_parser.outputs.fullversion }}"
-          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          KONG_CLUSTER_VERSION: 'v1.26.0'
-          NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
-          # multiple kind clusters within a single job, so only 1 is allowed at a time.
-
-  test-previous-kubernetes:
-    environment: gcloud
+  test-e2e:
     runs-on: ubuntu-latest
     needs: build-push-images
     strategy:
@@ -256,6 +217,7 @@ jobs:
           - 'v1.23.6'
           - 'v1.24.2'
           - 'v1.25.3'
+          - 'v1.26.0'
     steps:
       - name: setup golang
         uses: actions/setup-go@v3
@@ -282,15 +244,14 @@ jobs:
         with:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'
-      - name: e2e ${{ matrix.kubernetes-version }}
-        run: make test.e2e.gke
+      - name: e2e - ${{ matrix.kubernetes-version }}
+        run: make test.e2e
         env:
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/kubernetes-ingress-controller:${{ steps.semver_parser.outputs.fullversion }}"
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+          NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
+          # multiple kind clusters within a single job, so only 1 is allowed at a time.
 
   publish-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to the issues with running E2E tests on GKE we have (https://github.com/Kong/kubernetes-ingress-controller/issues/3331), we decided to switch all the tests to Kind for now, until we find a working solution for the problems described in the mentioned issue.

Issue for tracking the enablement of GKE E2E tests back once the problems are figured out: https://github.com/Kong/kubernetes-ingress-controller/issues/3348

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Workaround for https://github.com/Kong/kubernetes-ingress-controller/issues/3331. 