### PR TITLE
refactor: refactor rootcmd, add command context, mark deprecated flags with `flagSet.MarkDeprecated`

### DIFF
--- a/internal/cmd/rootcmd/rootcmd.go
+++ b/internal/cmd/rootcmd/rootcmd.go
@@ -7,21 +7,18 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 )
 
-var cfg manager.Config
-
-func init() {
-	rootCmd.Flags().AddFlagSet(cfg.FlagSet())
-}
-
-var rootCmd = &cobra.Command{
-	PersistentPreRunE: bindEnvVars,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return Run(&cfg)
-	},
-	SilenceUsage: true,
-}
-
 // Execute is the entry point to the controller manager.
 func Execute() {
+	var (
+		cfg     manager.Config
+		rootCmd = &cobra.Command{
+			PersistentPreRunE: bindEnvVars,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return Run(cmd.Context(), &cfg)
+			},
+			SilenceUsage: true,
+		}
+	)
+	rootCmd.Flags().AddFlagSet(cfg.FlagSet())
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -1,6 +1,7 @@
 package rootcmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,26 +12,18 @@ import (
 )
 
 // Run sets up a default stderr logger and starts the controller manager.
-func Run(c *manager.Config) error {
+func Run(ctx context.Context, c *manager.Config) error {
 	deprecatedLogger, logger, err := manager.SetupLoggers(c, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
-	ctx, err := SetupSignalHandler(c, logger)
-	if err != nil {
-		return fmt.Errorf("failed to setup signal handler: %w", err)
-	}
 
-	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c, logger)
-	if err != nil {
-		return fmt.Errorf("failed to start diagnostics server: %w", err)
-	}
-	return manager.Run(ctx, c, diag.ConfigDumps, deprecatedLogger)
+	return RunWithLogger(ctx, c, deprecatedLogger, logger)
 }
 
 // RunWithLogger starts the controller manager with a provided logger.
-func RunWithLogger(c *manager.Config, deprecatedLogger logrus.FieldLogger, logger logr.Logger) error {
-	ctx, err := SetupSignalHandler(c, logger)
+func RunWithLogger(ctx context.Context, c *manager.Config, deprecatedLogger logrus.FieldLogger, logger logr.Logger) error {
+	ctx, err := SetupSignalHandler(ctx, c, logger)
 	if err != nil {
 		return fmt.Errorf("failed to setup signal handler: %w", err)
 	}

--- a/internal/cmd/rootcmd/signal.go
+++ b/internal/cmd/rootcmd/signal.go
@@ -23,13 +23,14 @@ var (
 // which is canceled on one of these signals. If a second signal is not caught, the program
 // will delay for the configured period of time before terminating. If a second signal is caught,
 // the program is terminated with exit code 1.
-func SetupSignalHandler(cfg *manager.Config, logger logr.Logger) (context.Context, error) {
+func SetupSignalHandler(ctx context.Context, cfg *manager.Config, logger logr.Logger) (context.Context, error) {
 	// This will prevent multiple signal handlers from being created
 	if ok := mutex.TryLock(); !ok {
 		return nil, errors.New("signal handler can only be setup once")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	var cancel func()
+	ctx, cancel = context.WithCancel(ctx)
 
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -152,14 +152,10 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		"Sets the timeout (in seconds) for all requests to Kong's Admin API.",
 	)
 
-	_ = flagSet.String("kong-custom-entities-secret", "", "Will be removed in next major release.")
-	flagSet.MarkDeprecated("kong-custom-entities-secret", "Will be removed in next major release.") //nolint:errcheck
-
 	// Kubernetes configurations
 	flagSet.StringVar(&c.GatewayAPIControllerName, "gateway-api-controller-name", string(gateway.ControllerName), "The controller name to match on Gateway API resources.")
 	flagSet.StringVar(&c.KubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file.")
 	flagSet.StringVar(&c.IngressClassName, "ingress-class", annotations.DefaultIngressClass, `Name of the ingress class to route through this controller.`)
-	flagSet.BoolVar(&c.EnableLeaderElection, "leader-elect", false, "DEPRECATED as of 2.1.0 leader election behavior is determined automatically and this flag has no effect")
 	flagSet.StringVar(&c.LeaderElectionID, "election-id", "5b374a9e.konghq.com", `Election id to use for status update.`)
 	flagSet.StringVar(&c.LeaderElectionNamespace, "election-namespace", "", `Leader election namespace to use when running outside a cluster`)
 	flagSet.StringSliceVar(&c.FilterTags, "kong-admin-filter-tag", []string{"managed-by-ingress-controller"}, "The tag used to manage and filter entities in Kong. This flag can be specified multiple times to specify multiple tags. This setting will be silently ignored if the Kong instance has no tags support.")
@@ -218,12 +214,22 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	// SIGTERM or SIGINT signal delay
 	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before SIGTERM or SIGINT will shut down the Ingress Controller")
 
-	// Deprecated (to be removed in future releases)
-	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", dataplane.DefaultSyncSeconds,
-		"Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API (DEPRECATED, use --proxy-sync-seconds instead)",
-	)
-	flagSet.Int("stderrthreshold", 0, "DEPRECATED: has no effect and will be removed in future releases (see github issue #1297)")
-	flagSet.Bool("update-status-on-shutdown", false, `DEPRECATED: no longer has any effect and will be removed in a later release (see github issue #1304)`)
+	// Deprecated flags
+
+	flagSet.Float32Var(&c.ProxySyncSeconds, "sync-rate-limit", dataplane.DefaultSyncSeconds, "Use --proxy-sync-seconds instead")
+	_ = flagSet.MarkDeprecated("sync-rate-limit", "Use --proxy-sync-seconds instead")
+
+	_ = flagSet.Int("stderrthreshold", 0, "Has no effect and will be removed in future releases (see github issue #1297)")
+	_ = flagSet.MarkDeprecated("stderrthreshold", "Has no effect and will be removed in future releases (see github issue #1297)")
+
+	_ = flagSet.Bool("update-status-on-shutdown", false, "No longer has any effect and will be removed in a later release (see github issue #1304)")
+	_ = flagSet.MarkDeprecated("update-status-on-shutdown", "No longer has any effect and will be removed in a later release (see github issue #1304)")
+
+	_ = flagSet.String("kong-custom-entities-secret", "", "Will be removed in next major release.")
+	_ = flagSet.MarkDeprecated("kong-custom-entities-secret", "Will be removed in next major release.")
+
+	flagSet.BoolVar(&c.EnableLeaderElection, "leader-elect", false, "DEPRECATED as of 2.1.0 leader election behavior is determined automatically and this flag has no effect")
+	_ = flagSet.MarkDeprecated("leader-elect", "DEPRECATED as of 2.1.0 leader election behavior is determined automatically and this flag has no effect")
 
 	return flagSet
 }

--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -90,7 +90,7 @@ func DeployControllerManagerForCluster(
 	go func() {
 		defer os.Remove(kubeconfig.Name())
 		fmt.Fprintf(os.Stderr, "INFO: Starting Controller Manager for Cluster %s with Configuration: %+v\n", cluster.Name(), config)
-		if err := rootcmd.RunWithLogger(&config, deprecatedLogger, logger); err != nil {
+		if err := rootcmd.RunWithLogger(ctx, &config, deprecatedLogger, logger); err != nil {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR

- performs a minor cleanup around rootcmd
- adds passing context through `cobra.Command`'s `.Context()`
- marks via `flagSet.MarkDeprecated()` flags that have already been deprecated: this has an effect that those flags are now hidden when showing the usage and an explicit log message is being logged when they are used, e.g.:

  ```
  Flag --sync-rate-limit has been deprecated, Use --proxy-sync-seconds instead
  ```
