### PR TITLE
build: add staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ ifeq ($(wildcard $(SKAFFOLD)),)
 	@mv skaffold ./bin/
 endif
 
+STATICCHECK = $(PROJECT_DIR)/bin/staticcheck
+.PHONY: staticcheck
+staticcheck.download: ## Download staticcheck locally if necessary.
+	@$(MAKE) _download_tool TOOL=staticcheck
+
 # ------------------------------------------------------------------------------
 # Build
 # ------------------------------------------------------------------------------
@@ -114,8 +119,14 @@ vet:
 	go vet ./...
 
 .PHONY: lint
-lint: verify.tidy golangci-lint
+lint: verify.tidy golangci-lint staticcheck
 	$(GOLANGCI_LINT) run -v
+
+.PHONY: staticcheck
+staticcheck: staticcheck.download
+	$(STATICCHECK) -tags e2e_tests,integration_tests,istio_tests,conformance_tests \
+		-f stylish \
+		./...
 
 .PHONY: verify.tidy
 verify.tidy:

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -130,6 +130,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -132,6 +132,8 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
+                  description: KongProtocol is a valid Kong protocol This alias is
+                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -126,6 +126,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -187,6 +187,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -411,6 +413,8 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
+                  description: KongProtocol is a valid Kong protocol This alias is
+                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https
@@ -753,6 +757,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -187,6 +187,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -411,6 +413,8 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
+                  description: KongProtocol is a valid Kong protocol This alias is
+                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https
@@ -753,6 +757,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -187,6 +187,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -411,6 +413,8 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
+                  description: KongProtocol is a valid Kong protocol This alias is
+                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https
@@ -753,6 +757,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -187,6 +187,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -411,6 +413,8 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
+                  description: KongProtocol is a valid Kong protocol This alias is
+                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https
@@ -753,6 +757,8 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              description: KongProtocol is a valid Kong protocol This alias is necessary
+                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -201,7 +201,7 @@ _Appears in:_
 
 _Underlying type:_ `string`
 
-
+KongProtocol is a valid Kong protocol This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 
 
 

--- a/internal/dataplane/parser/translators/httproute.go
+++ b/internal/dataplane/parser/translators/httproute.go
@@ -26,7 +26,7 @@ type KongRouteTranslation struct {
 	Filters []gatewayv1beta1.HTTPRouteFilter
 }
 
-// TranslateHTTPRoutes translates a list of HTTPRoutes into a list of HTTPRouteTranslationMeta
+// TranslateHTTPRoute translates a list of HTTPRoutes into a list of HTTPRouteTranslationMeta
 // objects that can be used to instantiate Kong routes and services.
 // The translation is done by grouping the HTTPRoutes by their backendRefs.
 // This means that all the rules of a single HTTPRoute will be grouped together

--- a/internal/dataplane/parser/wrappers_backendref.go
+++ b/internal/dataplane/parser/wrappers_backendref.go
@@ -121,7 +121,10 @@ func backendRefsToKongStateBackends[T types.BackendRefT](
 			// these, we do not want a single impermissible ref to take the entire rule offline. in the case of edits,
 			// failing the entire rule could potentially delete routes that were previously online and in use, and
 			// that remain viable (because they still have some permissible backendRefs)
-			var namespace, kind string = route.GetNamespace(), ""
+			var (
+				namespace = route.GetNamespace()
+				kind      string
+			)
 			if brw.Namespace() != nil {
 				namespace = *brw.Namespace()
 			}

--- a/internal/manager/conditions.go
+++ b/internal/manager/conditions.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 )
 
@@ -102,7 +101,7 @@ func negotiateIngressAPI(config *Config, mapper meta.RESTMapper) (IngressAPI, er
 }
 
 func ShouldEnableCRDController(gvr schema.GroupVersionResource, restMapper meta.RESTMapper) bool {
-	if !utils.CRDExists(restMapper, gvr) {
+	if !ctrlutils.CRDExists(restMapper, gvr) {
 		ctrl.Log.WithName("controllers").WithName("crdCondition").
 			Info(fmt.Sprintf("disabling the '%s' controller due to missing CRD installation", gvr.Resource))
 		return false

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -839,7 +839,8 @@ func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
 	return p.(*netv1.IngressClass), nil
 }
 
-// GetIngressClassV1 returns the 'name' IngressClass resource.
+// GetIngressClassParametersV1Alpha1 returns IngressClassParameters of configured
+// IngressClass.
 func (s Store) GetIngressClassParametersV1Alpha1() (*kongv1alpha1.IngressClassParameters, error) {
 	class, exists, err := s.stores.IngressClassV1.GetByKey(s.ingressClass)
 	if err != nil {

--- a/internal/util/test/webhooks.go
+++ b/internal/util/test/webhooks.go
@@ -125,6 +125,7 @@ ctFsgXhf5+tDgbBZpcuTMpd3KnaDUYg=
 // from which 192.168.5.2 routes to the host (https://github.com/abiosoft/colima/issues/220)
 //
 // This works if the test runs against a KIND cluster, and does not work against cloud providers (like GKE).
+
 var AdmissionWebhookListenHost = admissionWebhookListenHost()
 
 const (

--- a/pkg/apis/configuration/v1/kongprotocol_types.go
+++ b/pkg/apis/configuration/v1/kongprotocol_types.go
@@ -1,7 +1,7 @@
 package v1
 
-// + KongProtocol is a valid Kong protocol
-// + This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+// KongProtocol is a valid Kong protocol
+// This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 // +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
 // +kubebuilder:object:generate=true
 type KongProtocol string

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,2 @@
+# Configuration options described in: https://staticcheck.io/docs/configuration/options/
+checks = ["all", "-ST1000", "-ST1005"]

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-delve/delve v1.20.1
 	github.com/golangci/golangci-lint v1.50.1
 	gotest.tools/gotestsum v1.8.2
+	honnef.co/go/tools v0.3.3
 	k8s.io/code-generator v0.26.0
 	sigs.k8s.io/controller-tools v0.11.1
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
@@ -220,7 +221,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	honnef.co/go/tools v0.3.3 // indirect
 	k8s.io/api v0.26.0 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/apimachinery v0.26.0 // indirect

--- a/third_party/staticcheck.go
+++ b/third_party/staticcheck.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "honnef.co/go/tools/cmd/staticcheck"
+)
+
+//go:generate go install -modfile go.mod honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
**What this PR does / why we need it**:

Add https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck to the set of linters we run.

We add this separately from golangci-lint because:

> The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
