### PR TITLE
fix(ci): checkout repo before caching to use SHA of go.sum

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -10,6 +10,11 @@ jobs:
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: setup golang
         uses: actions/setup-go@v3
         with:
@@ -22,11 +27,6 @@ jobs:
           key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-build-codegen-
-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: cleanup orphaned test clusters
         run: go run hack/e2e/cluster/cleanup/main.go all

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,6 +36,11 @@ jobs:
           - 'v1.26.0'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -48,11 +53,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: Kong/kong-license@master
       id: license
@@ -103,6 +103,11 @@ jobs:
             istio-version: 'v1.14.6'
 
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -115,11 +120,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: Kong/kong-license@master
       id: license
@@ -160,6 +160,11 @@ jobs:
         kubernetes-version: # the GKE setup script ignores the patch version here and uses the latest, but we still include it for consistency with the other E2E jobs
           - 'v1.24.7'
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -172,11 +177,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: Kong/kong-license@master
       id: license

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -24,6 +24,11 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -36,11 +41,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Set up QEMU
       if: ${{ github.event.inputs.controller-image == 'kong/kubernetes-ingress-controller:ci' }}
@@ -102,6 +102,11 @@ jobs:
     if: ${{ github.event.inputs.include-integration == 'true' }}
     runs-on: ubuntu-latest
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -114,11 +119,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: Kong/kong-license@master
       id: license

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -190,6 +190,10 @@ jobs:
           - 'traditional'
           - 'traditional_compatible'
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v3
         with:
@@ -201,10 +205,6 @@ jobs:
           key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-build-codegen-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Kubernetes ${{ matrix.kubernetes-version }} ${{ matrix.dbmode }} Integration Tests With ${{ matrix.kong-router-flavor }} Kong Router
         run: KONG_CLUSTER_VERSION=${{ matrix.kubernetes-version }} make test.integration.${{ matrix.dbmode }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,6 +209,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-push-images
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v3
         with:
@@ -220,10 +224,6 @@ jobs:
           key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-build-codegen-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: Kong/kong-license@master
         id: license
         with:
@@ -257,6 +257,10 @@ jobs:
           - 'v1.24.2'
           - 'v1.25.3'
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v3
         with:
@@ -268,10 +272,6 @@ jobs:
           key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-build-codegen-
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: Kong/kong-license@master
         id: license
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Setup go
       uses: actions/setup-go@v3
@@ -28,11 +32,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Run lint
       run: make lint
@@ -75,6 +74,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -88,11 +91,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run unit tests
       run: make test.unit
@@ -132,6 +130,12 @@ jobs:
       with:
         password: ${{ env.PULP_PASSWORD }}
 
+    - name: checkout repository
+      if: env.PULP_PASSWORD != ''
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       if: env.PULP_PASSWORD != ''
       uses: actions/setup-go@v3
@@ -146,12 +150,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      if: env.PULP_PASSWORD != ''
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       if: env.PULP_PASSWORD != ''
@@ -187,6 +185,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -199,11 +202,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.dbless
@@ -236,6 +234,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -248,11 +251,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.postgres
@@ -285,6 +283,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -297,11 +300,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.dbless
@@ -335,6 +333,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -347,11 +350,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run conformance tests
       run: make test.conformance

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -17,6 +17,11 @@ jobs:
       with:
         password: ${{ secrets.PULP_PASSWORD }}
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -29,11 +34,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.enterprise.postgres
@@ -63,6 +63,10 @@ jobs:
     if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -76,11 +80,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.postgres
@@ -108,6 +107,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -120,11 +124,6 @@ jobs:
         key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-build-codegen-
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: run integration tests
       run: make test.integration.dbless


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that we never really used Github Actions cache because we used a key that relies on hash of all `go.sum` files from the repo: `${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}` but we never really checked out the repo before the step that uses the checked out files 🤦 .

This PR aims to fix that.
