### PR TITLE
docs: fix `KongIngressService` docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -151,7 +151,7 @@ _Appears in:_
 
 
 
-KongIngressService contains KongIngress service configuration. Deprecated: use Service's annotations instead.
+KongIngressService contains KongIngress service configuration. It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress. Deprecated: use Service's annotations instead.
 
 
 

--- a/pkg/apis/configuration/v1/kongingress_types.go
+++ b/pkg/apis/configuration/v1/kongingress_types.go
@@ -59,7 +59,7 @@ type KongIngressList struct {
 }
 
 // KongIngressService contains KongIngress service configuration.
-// + It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress.
+// It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress.
 // Deprecated: use Service's annotations instead.
 type KongIngressService struct {
 	// The protocol used to communicate with the upstream.


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that an unwanted `+` sneaked into `KongIngressService` godoc comment.

This PR removes it and regenerates the docs.