### PR TITLE
refactor: pass parent ingress object

### DIFF
--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -3,8 +3,10 @@ package translators
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,10 +30,83 @@ func expectedParentIngress() *netv1.Ingress {
 
 func TestTranslateIngress(t *testing.T) {
 	tts := []struct {
-		name     string
-		ingress  *netv1.Ingress
-		expected []*kongstate.Service
+		name           string
+		ingress        *netv1.Ingress
+		addRegexPrefix bool
+		expected       []*kongstate.Service
 	}{
+		{
+			name:           "a basic ingress resource with a single rule and prefix path type",
+			addRegexPrefix: true,
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{{
+						Host: "konghq.com",
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{{
+									Path:     "/api",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: netv1.ServiceBackendPort{
+												Name:   "http",
+												Number: 80,
+											},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			expected: []*kongstate.Service{{
+				Namespace: corev1.NamespaceDefault,
+				Service: kong.Service{
+					Name:           kong.String("default.test-ingress.test-service.80"),
+					Host:           kong.String("test-service.default.80.svc"),
+					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					Path:           kong.String("/"),
+					Port:           kong.Int(80),
+					Protocol:       kong.String("http"),
+					Retries:        kong.Int(defaultRetries),
+					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
+					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+				},
+				Routes: []kongstate.Route{{
+					Ingress: util.K8sObjectInfo{
+						Name:      "test-ingress",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Route: kong.Route{
+						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
+						Hosts:             kong.StringSlice("konghq.com"),
+						Paths:             kong.StringSlice("/api/", "~/api$"),
+						PreserveHost:      kong.Bool(true),
+						Protocols:         kong.StringSlice("http", "https"),
+						RegexPriority:     kong.Int(0),
+						StripPath:         kong.Bool(false),
+						ResponseBuffering: kong.Bool(true),
+						RequestBuffering:  kong.Bool(true),
+					},
+				}},
+				Backends: []kongstate.ServiceBackend{{
+					Name:      "test-service",
+					Namespace: corev1.NamespaceDefault,
+					PortDef: kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				}},
+				Parent: expectedParentIngress(),
+			}},
+		},
 		{
 			name: "a basic ingress resource with a single rule, and only one path results in a single kong service and route",
 			ingress: &netv1.Ingress{
@@ -1085,6 +1160,10 @@ func TestTranslateIngress(t *testing.T) {
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
 				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "networking.k8s.io/v1",
+				},
 				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{{
 						Host: "konghq.com",
@@ -1150,8 +1229,17 @@ func TestTranslateIngress(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, TranslateIngress(tt.ingress, false))
+			checkOnlyObjectMeta := cmp.Transformer("checkOnlyObjectMeta", func(i *netv1.Ingress) *netv1.Ingress {
+				// In the result we only care about ingresses' metadata being equal.
+				// We ignore specification to simplify tests.
+				return &netv1.Ingress{
+					ObjectMeta: i.ObjectMeta,
+				}
+			})
+			diff := cmp.Diff(tt.expected, TranslateIngress(tt.ingress, tt.addRegexPrefix), checkOnlyObjectMeta)
+			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}
 }
@@ -1286,92 +1374,6 @@ func TestFlattenMultipleSlashes(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.out, flattenMultipleSlashes(tt.in))
-		})
-	}
-}
-
-func TestTranslateIngressRegexPrefix(t *testing.T) {
-	tts := []struct {
-		name     string
-		ingress  *netv1.Ingress
-		expected []*kongstate.Service
-	}{
-		{
-			name: "a basic ingress resource with a single rule and prefix path type",
-			ingress: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ingress",
-					Namespace: corev1.NamespaceDefault,
-				},
-				Spec: netv1.IngressSpec{
-					Rules: []netv1.IngressRule{{
-						Host: "konghq.com",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{{
-									Path:     "/api",
-									PathType: &pathTypePrefix,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Name:   "http",
-												Number: 80,
-											},
-										},
-									},
-								}},
-							},
-						},
-					}},
-				},
-			},
-			expected: []*kongstate.Service{{
-				Namespace: corev1.NamespaceDefault,
-				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
-					Host:           kong.String("test-service.default.80.svc"),
-					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
-					Path:           kong.String("/"),
-					Port:           kong.Int(80),
-					Protocol:       kong.String("http"),
-					Retries:        kong.Int(defaultRetries),
-					ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-					WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
-				},
-				Routes: []kongstate.Route{{
-					Ingress: util.K8sObjectInfo{
-						Name:      "test-ingress",
-						Namespace: corev1.NamespaceDefault,
-					},
-					Route: kong.Route{
-						Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
-						Hosts:             kong.StringSlice("konghq.com"),
-						Paths:             kong.StringSlice("/api/", "~/api$"),
-						PreserveHost:      kong.Bool(true),
-						Protocols:         kong.StringSlice("http", "https"),
-						RegexPriority:     kong.Int(0),
-						StripPath:         kong.Bool(false),
-						ResponseBuffering: kong.Bool(true),
-						RequestBuffering:  kong.Bool(true),
-					},
-				}},
-				Backends: []kongstate.ServiceBackend{{
-					Name:      "test-service",
-					Namespace: corev1.NamespaceDefault,
-					PortDef: kongstate.PortDef{
-						Mode:   kongstate.PortModeByNumber,
-						Number: 80,
-					},
-				}},
-				Parent: expectedParentIngress(),
-			}},
-		},
-	}
-
-	for _, tt := range tts {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, TranslateIngress(tt.ingress, true), tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the translator pass a parent Ingress object instead of its name/namespace/annotations in order to rebuild it later into Ingress object again.

**Which issue this PR fixes**:

Noticed the possibility to refactor this while reviewing #3359.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
