### PR TITLE
docs: fix KongProtocol doc

### DIFF
--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -130,7 +130,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -132,7 +132,7 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
-                  description: KongProtocol is a valid Kong protocol This alias is
+                  description: KongProtocol is a valid Kong protocol. This alias is
                     necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -126,7 +126,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -187,7 +187,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
@@ -413,7 +413,7 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
-                  description: KongProtocol is a valid Kong protocol This alias is
+                  description: KongProtocol is a valid Kong protocol. This alias is
                     necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
@@ -757,7 +757,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -187,7 +187,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
@@ -413,7 +413,7 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
-                  description: KongProtocol is a valid Kong protocol This alias is
+                  description: KongProtocol is a valid Kong protocol. This alias is
                     necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
@@ -757,7 +757,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -187,7 +187,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
@@ -413,7 +413,7 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
-                  description: KongProtocol is a valid Kong protocol This alias is
+                  description: KongProtocol is a valid Kong protocol. This alias is
                     necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
@@ -757,7 +757,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -187,7 +187,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
@@ -413,7 +413,7 @@ spec:
                   allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
                   instead.'
                 items:
-                  description: KongProtocol is a valid Kong protocol This alias is
+                  description: KongProtocol is a valid Kong protocol. This alias is
                     necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
@@ -757,7 +757,7 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
-              description: KongProtocol is a valid Kong protocol This alias is necessary
+              description: KongProtocol is a valid Kong protocol. This alias is necessary
                 to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -201,7 +201,7 @@ _Appears in:_
 
 _Underlying type:_ `string`
 
-KongProtocol is a valid Kong protocol This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+KongProtocol is a valid Kong protocol. This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 
 
 

--- a/pkg/apis/configuration/v1/kongprotocol_types.go
+++ b/pkg/apis/configuration/v1/kongprotocol_types.go
@@ -1,6 +1,6 @@
 package v1
 
-// KongProtocol is a valid Kong protocol
+// KongProtocol is a valid Kong protocol.
 // This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 // +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
 // +kubebuilder:object:generate=true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes KongProtocol doc by adding a missing dot at the end.

