### PR TITLE
chore(tests): allow creating gke clusters using getEnvironmentBuilder

### DIFF
--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -15,5 +15,14 @@ var (
 	kongImageLoad         = os.Getenv("TEST_KONG_IMAGE_LOAD")
 	kongImagePullUsername = os.Getenv("TEST_KONG_PULL_USERNAME")
 	kongImagePullPassword = os.Getenv("TEST_KONG_PULL_PASSWORD")
-	existingCluster       = os.Getenv("KONG_TEST_CLUSTER")
+
+	// KONG_TEST_CLUSTER is to be filled when an already existing cluster should be used
+	// in tests. It should be in a `<gke|kind>:<name>` format.
+	// It takes precedence over KONG_TEST_CLUSTER_PROVIDER.
+	existingCluster = os.Getenv("KONG_TEST_CLUSTER")
+
+	// KONG_TEST_CLUSTER_PROVIDER is to be filled when a cluster of a given kind should
+	// be created in tests. It can be either `gke` or `kind`.
+	// It's not used when KONG_TEST_CLUSTER is set.
+	clusterProvider = os.Getenv("KONG_TEST_CLUSTER_PROVIDER")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KONG_TEST_CLUSTER_PROVIDER` env variable to unblock creating GKE clusters from code instead of using setup scripts. Uses the new features of KTF cluster provider (`WithWaitForTeardown`, `WithCreateSubnet`).

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3331.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

