### PR TITLE
build: remove manifests.single from verify.manifest as it's already part of manifests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ verify.versions:
 	./scripts/verify-versions.sh $(TAG)
 
 .PHONY: verify.manifests
-verify.manifests: verify.repo manifests manifests.single verify.diff
+verify.manifests: verify.repo manifests verify.diff
 
 .PHONY: verify.generators
 verify.generators: verify.repo generate verify.diff


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove manifests.single from verify.manifest as it's already part of manifests target
