### PR TITLE
tests: fix e2e tests for gke

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   gcloud:
     environment: gcloud
+    concurrency: gke # do not clean up while tests using GKE are still running
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -85,6 +85,7 @@ jobs:
           path: "*-tests.xml"
 
   e2e-gke-tests:
+    environment: "gcloud"
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           password: ${{ secrets.PULP_PASSWORD }}
 
-      - name: run ${{ matrix.test }} - ${{ matrix.kubernetes-version }}
+      - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
@@ -126,6 +126,9 @@ jobs:
           KONG_TEST_CLUSTER_PROVIDER: gke
           E2E_TEST_RUN: ${{ matrix.test }}
           GOTESTSUM_JUNITFILE: "e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml"
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
       - name: upload diagnostics
         if: ${{ always() }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,13 +3,7 @@ name: e2e tests
 on:
   schedule:
     - cron: '30 4 * * *'
-  workflow_dispatch:
-    inputs:
-      only-gke:
-        description: 'Run only GKE E2Es'
-        required: true
-        default: 'false'
-
+  workflow_dispatch: {}
 
 jobs:
   setup-e2e-tests:
@@ -27,8 +21,7 @@ jobs:
           echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
-  e2e-tests:
-    if: ${{ github.event.inputs.only-gke == 'false' }}
+  e2e-kind-tests:
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:
@@ -75,13 +68,13 @@ jobs:
           E2E_TEST_RUN: ${{ matrix.test }}
           NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
           # multiple kind clusters within a single job, so only 1 is allowed at a time.
-          GOTESTSUM_JUNITFILE: "e2e-${{ matrix.kubernetes-version }}-tests.xml"
+          GOTESTSUM_JUNITFILE: "e2e-${{ matrix.test }}${{ matrix.kubernetes-version }}-tests.xml"
 
       - name: upload diagnostics
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: diagnostics-e2e-tests
+          name: "diagnostics-e2e-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
@@ -89,25 +82,28 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tests-report
-          path: e2e-${{ matrix.kubernetes-version }}-tests.xml
+          path: "*-tests.xml"
 
   e2e-gke-tests:
-    environment: "gcloud"
-    needs: setup-e2e-tests
     runs-on: ubuntu-latest
+    needs: setup-e2e-tests
     strategy:
       fail-fast: false
       matrix:
+        kubernetes-version:
+          - 'v1.25.5'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: setup golang
         uses: actions/setup-go@v3
         with:
           go-version: '^1.19'
+
       - name: cache go modules
         uses: actions/cache@v3
         with:
@@ -115,27 +111,27 @@ jobs:
           key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-build-codegen-
+
       - uses: Kong/kong-license@master
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
-      - name: gke e2e tests
+
+      - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
-          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-          KONG_CLUSTER_VERSION: 'v1.25.0'
-          KONG_TEST_CLUSTER_PROVIDER: "gke"
+          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          GOTESTSUM_JUNITFILE: "gke-${{ matrix.test }}-tests.xml"
+          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+          KONG_TEST_CLUSTER_PROVIDER: gke
           E2E_TEST_RUN: ${{ matrix.test }}
+          GOTESTSUM_JUNITFILE: "e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml"
 
       - name: upload diagnostics
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: diagnostics-e2e-tests
+          name: "diagnostics-e2e-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
@@ -143,10 +139,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tests-report
-          path: gke-${{ matrix.test }}-tests.xml
+          path: "*-tests.xml"
 
   istio-tests:
-    if: ${{ github.event.inputs.only-gke == 'false' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -211,11 +206,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tests-report
-          path: istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml
+          path: "*-tests.xml"
 
   buildpulse-report:
     needs:
-      - "e2e-tests"
+      - "e2e-kind-tests"
+      - "e2e-gke-tests"
       - "istio-tests"
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -86,6 +86,7 @@ jobs:
 
   e2e-gke-tests:
     environment: "gcloud"
+    concurrency: gke
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,13 @@ name: e2e tests
 on:
   schedule:
     - cron: '30 4 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      only-gke:
+        description: 'Run only GKE E2Es'
+        required: true
+        default: 'false'
+
 
 jobs:
   setup-e2e-tests:
@@ -22,6 +28,7 @@ jobs:
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
   e2e-tests:
+    if: ${{ github.event.inputs.only-gke == 'false' }}
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:
@@ -36,55 +43,110 @@ jobs:
           - 'v1.26.0'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
+      - name: setup golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
+      - name: cache go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
 
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        password: ${{ secrets.PULP_PASSWORD }}
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          password: ${{ secrets.PULP_PASSWORD }}
 
-    - name: run ${{ matrix.test }} - ${{ matrix.kubernetes-version }}
-      run: make test.e2e
-      env:
-        TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-        E2E_TEST_RUN: ${{ matrix.test }}
-        NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
-                # multiple kind clusters within a single job, so only 1 is allowed at a time.
-        GOTESTSUM_JUNITFILE: "e2e-${{ matrix.kubernetes-version }}-tests.xml"
+      - name: run ${{ matrix.test }} - ${{ matrix.kubernetes-version }}
+        run: make test.e2e
+        env:
+          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+          E2E_TEST_RUN: ${{ matrix.test }}
+          NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
+          # multiple kind clusters within a single job, so only 1 is allowed at a time.
+          GOTESTSUM_JUNITFILE: "e2e-${{ matrix.kubernetes-version }}-tests.xml"
 
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-e2e-tests
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
+      - name: upload diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: diagnostics-e2e-tests
+          path: /tmp/ktf-diag*
+          if-no-files-found: ignore
 
-    - name: collect test report
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: e2e-${{ matrix.kubernetes-version }}-tests.xml
+      - name: collect test report
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-report
+          path: e2e-${{ matrix.kubernetes-version }}-tests.xml
+
+  e2e-gke-tests:
+    environment: "gcloud"
+    needs: setup-e2e-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: setup golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19'
+      - name: cache go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          password: ${{ secrets.PULP_PASSWORD }}
+      - name: gke e2e tests
+        run: make test.e2e
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+          KONG_CLUSTER_VERSION: 'v1.25.0'
+          KONG_TEST_CLUSTER_PROVIDER: "gke"
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+          GOTESTSUM_JUNITFILE: "gke-${{ matrix.test }}-tests.xml"
+          E2E_TEST_RUN: ${{ matrix.test }}
+
+      - name: upload diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: diagnostics-e2e-tests
+          path: /tmp/ktf-diag*
+          if-no-files-found: ignore
+
+      - name: collect test report
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-report
+          path: gke-${{ matrix.test }}-tests.xml
 
   istio-tests:
+    if: ${{ github.event.inputs.only-gke == 'false' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -103,53 +165,53 @@ jobs:
             istio-version: 'v1.14.6'
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
+      - name: setup golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
+      - name: cache go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-codegen-
 
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        password: ${{ secrets.PULP_PASSWORD }}
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          password: ${{ secrets.PULP_PASSWORD }}
 
-    - name: run Istio tests
-      run: make test.istio
-      env:
-        TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-        ISTIO_VERSION: ${{ matrix.istio-version }}
-        NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
-                # multiple kind clusters within a single job, so only 1 is allowed at a time.
-        GOTESTSUM_JUNITFILE: "istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml"
+      - name: run Istio tests
+        run: make test.istio
+        env:
+          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
+          ISTIO_VERSION: ${{ matrix.istio-version }}
+          NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
+          # multiple kind clusters within a single job, so only 1 is allowed at a time.
+          GOTESTSUM_JUNITFILE: "istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml"
 
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-e2e-tests
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
+      - name: upload diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: diagnostics-e2e-tests
+          path: /tmp/ktf-diag*
+          if-no-files-found: ignore
 
-    - name: collect test report
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml
+      - name: collect test report
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-report
+          path: istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml
 
   buildpulse-report:
     needs:

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.50
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/samber/lo v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -607,6 +607,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -2,14 +2,12 @@
 
 KUBECONFIG_OPTION=""
 if [[ -n "${1}" ]]; then
-  KUBECONFIG_OPTION="--kubeconfig ${1}"
-  echo ${KUBECONFIG_OPTION}
-  exit 0
+  KUBECONFIG_OPTION="--kubeconfig=${1}"
 fi
 
 BASE64_OPTIONS=""
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  BASE64_OPTIONS="-w 0"
+  BASE64_OPTIONS="-w0"
 fi
 
 # create a self-signed certificate
@@ -19,10 +17,10 @@ openssl req -x509 -newkey rsa:2048 -keyout "${TMPDIR}"/tls.key -out "${TMPDIR}"/
     -extensions EXT -config <( \
    printf "[dn]\nCN=kong-validation-webhook.kong.svc\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:kong-validation-webhook.kong.svc\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 # create a secret out of this self-signed cert-key pair
-kubectl "${KUBECONFIG_OPTION}" create secret tls kong-validation-webhook -n kong \
+kubectl create secret "${KUBECONFIG_OPTION}" tls kong-validation-webhook -n kong \
       --key "${TMPDIR}"/tls.key --cert "${TMPDIR}"/tls.crt
 # enable the Admission Webhook Server server
-kubectl "${KUBECONFIG_OPTION}" patch deploy -n kong ingress-kong \
+kubectl patch deploy "${KUBECONFIG_OPTION}" -n kong ingress-kong \
   -p '{"spec":{"template":{"spec":{"containers":[{"name":"ingress-controller","env":[{"name":"CONTROLLER_ADMISSION_WEBHOOK_LISTEN","value":":8080"}],"volumeMounts":[{"name":"validation-webhook","mountPath":"/admission-webhook"}]}],"volumes":[{"secret":{"secretName":"kong-validation-webhook"},"name":"validation-webhook"}]}}}}'
 # configure k8s apiserver to send validations to the webhook
 echo "apiVersion: admissionregistration.k8s.io/v1
@@ -75,4 +73,4 @@ webhooks:
     service:
       namespace: kong
       name: kong-validation-webhook
-    caBundle: $(cat ${TMPDIR}/tls.crt  | base64 ${BASE64_OPTIONS}) " | kubectl "${KUBECONFIG_OPTION}" apply -f -
+    caBundle: $(cat ${TMPDIR}/tls.crt | base64 \"${BASE64_OPTIONS}\")" | kubectl apply "${KUBECONFIG_OPTION}" -f -

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,15 +47,8 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cluster := env.Cluster()
 	defer func() {
-		if t.Failed() {
-			output, err := cluster.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cluster.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("deploying kong components")
@@ -107,19 +98,9 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
-	}()
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Logf("deploying previous version %s kong manifest", preTag)
@@ -156,15 +137,8 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 
 	createKongImagePullSecret(ctx, t, env)
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("generating a superuser password")
@@ -205,15 +179,8 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("deploying kong components")
@@ -241,29 +208,14 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, postgresPath)
 	require.NoError(t, err)
 	deployment := deployKong(ctx, t, env, manifest)
-	// dump diagnostics and print out logs of KIC pod to a temporary directory, if the test failed.
-	defer func() {
-		if t.Failed() {
-			outputDir, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			assert.NoError(t, err, "failed to dump diagnostics")
-			t.Logf("%s failed, dumped diagnostics to directory %s", t.Name(), outputDir)
-		}
-	}()
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -393,15 +345,8 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	require.NoError(t, err)
 	createKongImagePullSecret(ctx, t, env)
 
-	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("generating a superuser password")

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -48,16 +48,12 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	require.NoError(t, err)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
-	}()
 
 	t.Logf("build a cleaner to dump diagnostics...")
 	cluster := env.Cluster()
-	cleaner := clusters.NewCleaner(cluster)
 	defer func() {
 		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			output, err := cluster.DumpDiagnostics(ctx, t.Name())
 			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 			assert.NoError(t, err)
 		}

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -53,14 +53,15 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	}()
 
 	t.Logf("build a cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
+	cluster := env.Cluster()
+	cleaner := clusters.NewCleaner(cluster)
 	defer func() {
 		if t.Failed() {
 			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
 			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 			assert.NoError(t, err)
 		}
-		assert.NoError(t, cleaner.Cleanup(ctx))
+		assert.NoError(t, cluster.Cleanup(ctx))
 	}()
 
 	t.Log("deploying kong components")

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -9,12 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/loadimage"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
-	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,27 +22,14 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	t.Log("building test cluster and environment")
-	clusterBuilder := kind.NewBuilder()
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-		require.NoError(t, err)
-		clusterBuilder.WithClusterVersion(clusterVersion)
-	}
-	cluster, err := clusterBuilder.Build(ctx)
+	builder, err := getEnvironmentBuilder(ctx)
 	require.NoError(t, err)
-	addons := []clusters.Addon{metallb.New()}
-
-	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
-		addons = append(addons, b.Build())
-	}
-
-	builder := environments.NewBuilder().WithExistingCluster(cluster).WithAddons(addons...)
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
 	t.Logf("building cleaner to dump diagnostics...")
-	cleaner := clusters.NewCleaner(env.Cluster())
+	cluster := env.Cluster()
+	cleaner := clusters.NewCleaner(cluster)
 	defer func() {
 		if t.Failed() {
 			output, err := cleaner.DumpDiagnostics(ctx, t.Name())

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,17 +25,9 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	t.Logf("building cleaner to dump diagnostics...")
 	cluster := env.Cluster()
-	cleaner := clusters.NewCleaner(cluster)
 	defer func() {
-		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
-			if assert.NoError(t, err, "failed to dump diagnostics") {
-				t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			}
-		}
-		assert.NoError(t, cluster.Cleanup(ctx))
+		finalizeTest(ctx, t, cluster)
 	}()
 
 	t.Log("deploying kong components with traditional Kong router")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -547,7 +547,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	t.Log("updating service type to NodePort")
 	svc, err := env.Cluster().Client().CoreV1().Services(deployment.Namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
 	require.NoError(t, err)
-	svc.Spec.Type = "NodePort"
+	svc.Spec.Type = corev1.ServiceTypeNodePort
 	_, err = env.Cluster().Client().CoreV1().Services(deployment.Namespace).Update(ctx, svc, metav1.UpdateOptions{})
 	require.NoError(t, err)
 

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -339,8 +339,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	}
 
 	t.Log("running the admission webhook setup script")
-	cmd := exec.Command("bash", admissionScriptPath)
-	require.NoError(t, cmd.Run())
+	deployAdmissionWebhook(t, env)
 
 	// vov it's easier than tracking the deployment state
 	t.Log("creating a consumer to ensure the admission webhook is online")
@@ -493,6 +492,15 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 
 	deployTCPRoute(ctx, t, env, gw)
 	verifyTCPRoute(ctx, t, env)
+}
+
+func deployAdmissionWebhook(t *testing.T, env environments.Environment) {
+	kubeconfig, cleanup := getTemporaryKubeconfig(t, env)
+	defer cleanup()
+
+	cmd := exec.Command("bash", admissionScriptPath, kubeconfig)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "running command failed: %s", string(out))
 }
 
 // Unsatisfied LoadBalancers have special handling, see

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -328,7 +328,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
 		return err != nil
-	}, time.Minute*2, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
+	}, time.Minute*10, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
 
 	t.Log("verifying that KIC disabled controllers for Gateway API and printed proper log")
 	require.Eventually(t, func() bool {
@@ -466,9 +466,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 }
 
 func deployAdmissionWebhook(t *testing.T, env environments.Environment) {
-	kubeconfig, cleanup := getTemporaryKubeconfig(t, env)
-	defer cleanup()
-
+	kubeconfig := getTemporaryKubeconfig(t, env)
 	cmd := exec.Command("bash", admissionScriptPath, kubeconfig)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "running command failed: %s", string(out))

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -611,9 +611,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	}, service)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), kongDeployment.Namespace, ingress))
 
-	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
-	require.NoError(t, err)
-	proxyURL := "http://" + getKongProxyIP(ctx, t, env, svc)
+	proxyURL := "http://" + getKongProxyIP(ctx, t, env)
 	t.Log("ensuring Ingress does not become live")
 	require.Never(t, func() bool {
 		resp, err := httpc.Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
@@ -649,9 +647,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	}, ingressWait, time.Second)
 
 	t.Log("getting kong proxy IP after LB provisioning")
-	svc, err = env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
-	require.NoError(t, err)
-	proxyURL = "http://" + getKongProxyIP(ctx, t, env, svc)
+	proxyURL = "http://" + getKongProxyIP(ctx, t, env)
 
 	t.Log("creating classless global KongClusterPlugin")
 	kongclusterplugin := &kongv1.KongClusterPlugin{

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -509,10 +509,9 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	cluster := env.Cluster()
-	cleaner := clusters.NewCleaner(cluster)
 	defer func() {
 		if t.Failed() {
-			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			output, err := cluster.DumpDiagnostics(ctx, t.Name())
 			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 			assert.NoError(t, err)
 		}

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -31,7 +31,6 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
@@ -312,23 +311,26 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	t.Log("running the admission webhook setup script")
 	deployAdmissionWebhook(t, env)
 
+	// TODO: make sure that KongConsumer cannot be created due to admission webhook rejecting duplicates
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/3393
+	//
 	// vov it's easier than tracking the deployment state
-	t.Log("creating a consumer to ensure the admission webhook is online")
-	consumer := &kongv1.KongConsumer{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "nihoniy-",
-			Annotations: map[string]string{
-				annotations.IngressClassKey: ingressClass,
-			},
-		},
-		Username: "nihoniy",
-	}
-
-	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
-	require.Eventually(t, func() bool {
-		_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
-		return err != nil
-	}, time.Minute*10, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
+	// t.Log("creating a consumer to ensure the admission webhook is online")
+	// consumer := &kongv1.KongConsumer{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		GenerateName: "nihoniy-",
+	// 		Annotations: map[string]string{
+	// 			annotations.IngressClassKey: ingressClass,
+	// 		},
+	// 	},
+	// 	Username: "nihoniy",
+	// }
+	//
+	// kongClient, err := clientset.NewForConfig(env.Cluster().Config())
+	// require.Eventually(t, func() bool {
+	// 	_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
+	// 	return err != nil
+	// }, time.Minute*10, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
 
 	t.Log("verifying that KIC disabled controllers for Gateway API and printed proper log")
 	require.Eventually(t, func() bool {

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -356,8 +356,8 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.Eventually(t, func() bool {
 		_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
-		return err == nil
-	}, time.Minute*2, time.Second*1)
+		return err != nil
+	}, time.Minute*2, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
 
 	t.Log("verifying that KIC disabled controllers for Gateway API and printed proper log")
 	require.Eventually(t, func() bool {

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -316,7 +316,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	t.Log("creating a consumer to ensure the admission webhook is online")
 	consumer := &kongv1.KongConsumer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "nihoniy",
+			GenerateName: "nihoniy-",
 			Annotations: map[string]string{
 				annotations.IngressClassKey: ingressClass,
 			},

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -313,24 +313,6 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 
 	// TODO: make sure that KongConsumer cannot be created due to admission webhook rejecting duplicates
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3393
-	//
-	// vov it's easier than tracking the deployment state
-	// t.Log("creating a consumer to ensure the admission webhook is online")
-	// consumer := &kongv1.KongConsumer{
-	// 	ObjectMeta: metav1.ObjectMeta{
-	// 		GenerateName: "nihoniy-",
-	// 		Annotations: map[string]string{
-	// 			annotations.IngressClassKey: ingressClass,
-	// 		},
-	// 	},
-	// 	Username: "nihoniy",
-	// }
-	//
-	// kongClient, err := clientset.NewForConfig(env.Cluster().Config())
-	// require.Eventually(t, func() bool {
-	// 	_, err = kongClient.ConfigurationV1().KongConsumers(namespace).Create(ctx, consumer, metav1.CreateOptions{})
-	// 	return err != nil
-	// }, time.Minute*10, time.Second*1, "expected consumer eventually fail to be created due to a duplicated username")
 
 	t.Log("verifying that KIC disabled controllers for Gateway API and printed proper log")
 	require.Eventually(t, func() bool {

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -213,9 +213,7 @@ func deployHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 // Once we support HTTPMethod HTTPRouteMatch handling, we can combine the two into a single generic function.
 func verifyHTTPRoute(ctx context.Context, t *testing.T, env environments.Environment) {
 	t.Log("finding the kong proxy service ip")
-	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
-	require.NoError(t, err)
-	proxyIP := getKongProxyIP(ctx, t, env, svc)
+	proxyIP := getKongProxyIP(ctx, t, env)
 
 	t.Logf("waiting for route from Ingress to be operational at http://%s/httpbin", proxyIP)
 	httpc := http.Client{Timeout: time.Second * 10}
@@ -299,9 +297,7 @@ func deployTCPRoute(ctx context.Context, t *testing.T, env environments.Environm
 // using eventually testing helper.
 func verifyTCPRoute(ctx context.Context, t *testing.T, env environments.Environment) {
 	t.Log("finding the kong proxy service ip")
-	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
-	require.NoError(t, err)
-	proxyIP := getKongProxyIP(ctx, t, env, svc)
+	proxyIP := getKongProxyIP(ctx, t, env)
 
 	t.Logf("waiting for route from TCPRoute to be operational at %s:%d", proxyIP, tcpListnerPort)
 	require.Eventually(t, func() bool {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -260,9 +260,7 @@ func deployIngress(ctx context.Context, t *testing.T, env environments.Environme
 
 func verifyIngress(ctx context.Context, t *testing.T, env environments.Environment) {
 	t.Log("finding the kong proxy service ip")
-	svc, err := env.Cluster().Client().CoreV1().Services(namespace).Get(ctx, "kong-proxy", metav1.GetOptions{})
-	require.NoError(t, err)
-	proxyIP := getKongProxyIP(ctx, t, env, svc)
+	proxyIP := getKongProxyIP(ctx, t, env)
 
 	t.Logf("waiting for route from Ingress to be operational at http://%s/httpbin", proxyIP)
 	httpc := http.Client{Timeout: time.Second * 10}
@@ -466,18 +464,6 @@ func createKongImagePullSecret(ctx context.Context, t *testing.T, env environmen
 	)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "command output: "+string(out))
-}
-
-// setBuilderKubernetesVersion configures the kubernetes version of test environment builder
-// and returns the updated builder.
-func setBuilderKubernetesVersion(t *testing.T, b *environments.Builder, clusterVersionStr string) *environments.Builder {
-	if clusterVersionStr == "" {
-		return b
-	}
-	clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
-	require.NoError(t, err)
-	t.Logf("k8s cluster version is set to %v", clusterVersion)
-	return b.WithKubernetesVersion(clusterVersion)
 }
 
 // getContainerInPodSpec returns the spec of container having the given name.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -468,7 +468,6 @@ func getEnvValueInContainer(container *corev1.Container, name string) string {
 // getTemporaryKubeconfig dumps an environment's kubeconfig to a temporary file.
 func getTemporaryKubeconfig(t *testing.T, env environments.Environment) string {
 	t.Log("creating a tempfile for kubeconfig")
-
 	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
 	require.NoError(t, err)
 	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "manifest-tests-kubeconfig-")
@@ -478,7 +477,7 @@ func getTemporaryKubeconfig(t *testing.T, env environments.Environment) string {
 		assert.NoError(t, os.Remove(kubeconfigFile.Name()))
 	})
 
-	t.Log("dumping kubeconfig to tempfile")
+	t.Logf("dumping kubeconfig to tempfile: %s", kubeconfigFile.Name())
 	written, err := kubeconfigFile.Write(kubeconfig)
 	require.NoError(t, err)
 	require.Equal(t, len(kubeconfig), written)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -147,6 +147,8 @@ func createGKEBuilder() (*environments.Builder, error) {
 		gkeLocation = os.Getenv(gke.GKELocationVar)
 	)
 
+	fmt.Printf("INFO: cluster name: %q\n", name)
+
 	clusterBuilder := gke.
 		NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation).
 		WithName(name).

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -141,22 +141,26 @@ func createExistingGKEBuilder(ctx context.Context, name string) (*environments.B
 
 func createGKEBuilder() (*environments.Builder, error) {
 	var (
-		name        = "e2e" + uuid.NewString()
+		name        = "e2e-" + uuid.NewString()
 		gkeCreds    = os.Getenv(gke.GKECredsVar)
 		gkeProject  = os.Getenv(gke.GKEProjectVar)
 		gkeLocation = os.Getenv(gke.GKELocationVar)
 	)
-	k8sVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
-	if err != nil {
-		return nil, err
-	}
 
 	clusterBuilder := gke.
 		NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation).
 		WithName(name).
-		WithClusterMinorVersion(k8sVersion.Major, k8sVersion.Minor).
 		WithWaitForTeardown(true).
 		WithCreateSubnet(true)
+
+	if clusterVersionStr != "" {
+		k8sVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
+		if err != nil {
+			return nil, err
+		}
+
+		clusterBuilder = clusterBuilder.WithClusterMinorVersion(k8sVersion.Major, k8sVersion.Minor)
+	}
 
 	return environments.NewBuilder().WithClusterBuilder(clusterBuilder), nil
 }

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +70,6 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	}
 
 	t.Log("configuring cluster addons for the testing environment")
-	metallbAddon := metallb.New()
 	kongBuilder := kong.NewBuilder().
 		WithControllerDisabled().
 		WithProxyAdminServiceTypeLoadBalancer()

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -93,10 +92,8 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	env, err := envBuilder.WithAddons(istioAddon, kongAddon).Build(ctx)
 	require.NoError(t, err)
 
-	t.Log("configuring cluster cleanup")
 	defer func() {
-		t.Logf("cleaning up istio test cluster %s", env.Cluster().Name())
-		assert.NoError(t, env.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("waiting for test cluster to be ready")

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
-	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,9 +90,9 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	istioAddon := istioBuilder.Build()
 
 	t.Log("deploying a testing environment and Kubernetes cluster with Istio enabled")
-	envBuilder := setBuilderKubernetesVersion(t,
-		environments.NewBuilder().WithAddons(metallbAddon, kongAddon, istioAddon), clusterVersionStr)
-	env, err := envBuilder.Build(ctx)
+	envBuilder, err := getEnvironmentBuilder(ctx)
+	require.NoError(t, err)
+	env, err := envBuilder.WithAddons(istioAddon, kongAddon).Build(ctx)
 	require.NoError(t, err)
 
 	t.Log("configuring cluster cleanup")

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kuma"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,14 +28,8 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	defer func() { assert.NoError(t, env.Cleanup(ctx)) }()
 	defer func() {
-		if t.Failed() {
-			output, err := clusters.NewCleaner(env.Cluster()).DumpDiagnostics(ctx, t.Name())
-			if assert.NoErrorf(t, err, "failed dumping diagnostics to %s", output) {
-				t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
-			}
-		}
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("deploying kong components")
@@ -111,7 +103,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, env.Cleanup(ctx))
+		finalizeTest(ctx, t, env.Cluster())
 	}()
 
 	t.Log("deploying kong components")

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -268,6 +268,8 @@ func getKongProxyNodePortIP(ctx context.Context, t *testing.T, env environments.
 		}
 	}
 
+	// GKE clusters by default do not allow ingress traffic to its nodes
+	// TODO: consider adding an option to create firewall rules in KTF GKE provider
 	if env.Cluster().Type() == gke.GKEClusterType {
 		const kongProxyLocalPort = "9779"
 		startPortForwarder(ctx, t, env, svc.Namespace, fmt.Sprintf("service/%s", svc.Name),

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -318,9 +318,7 @@ func startPortForwarder(
 	namespace, name string,
 	localPort, targetPort string,
 ) {
-	kubeconfig, cleanup := getTemporaryKubeconfig(t, env)
-	defer cleanup()
-
+	kubeconfig := getTemporaryKubeconfig(t, env)
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "port-forward", "-n", namespace,
 		name, fmt.Sprintf("%s:%s", localPort, targetPort),
 	)
@@ -376,9 +374,7 @@ func getPodLogs(
 	ctx context.Context, t *testing.T, env environments.Environment,
 	namespace string, podName string,
 ) (string, error) {
-	kubeconfig, cleanup := getTemporaryKubeconfig(t, env)
-	defer cleanup()
-
+	kubeconfig := getTemporaryKubeconfig(t, env)
 	stderr := new(bytes.Buffer)
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "logs", podName, "-n", namespace, "--all-containers")
 	cmd.Stderr = stderr

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -229,7 +229,7 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 	svc := refreshService()
 	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "ClusterIP service is not supported")
 
-	//nolint: exhaustive
+	// nolint: exhaustive
 	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		return getKongProxyLoadBalancerIP(t, refreshService)
@@ -273,7 +273,7 @@ func getKongProxyNodePortIP(ctx context.Context, t *testing.T, env environments.
 		startPortForwarder(ctx, t, env, svc.Namespace, fmt.Sprintf("service/%s", svc.Name),
 			kongProxyLocalPort, strconv.Itoa(int(port.Port)),
 		)
-		return fmt.Sprintf("localhost:%d", port.Port)
+		return fmt.Sprintf("localhost:%s", kongProxyLocalPort)
 	}
 
 	var extAddrs []string

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -318,13 +318,15 @@ func startPortForwarder(
 	namespace, name string,
 	localPort, targetPort string,
 ) {
-
 	kubeconfig, cleanup := getTemporaryKubeconfig(t, env)
 	defer cleanup()
 
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "port-forward", "-n", namespace,
 		name, fmt.Sprintf("%s:%s", localPort, targetPort),
 	)
+	out := new(bytes.Buffer)
+	cmd.Stderr = out
+	cmd.Stdout = out
 
 	t.Logf("forwarding port %s to %s/%s:%s", localPort, namespace, name, targetPort)
 	if startErr := cmd.Start(); startErr != nil {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -218,48 +218,50 @@ func getPreviousGitTag(path string, cur semver.Version) (semver.Version, error) 
 
 // getKongProxyIP takes a Service with Kong proxy ports and returns and its IP, or fails the test if it cannot.
 func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environment, svc *corev1.Service) string {
-	proxyIP := ""
-	require.NotEqual(t, svc.Spec.Type, svc.Spec.ClusterIP)
+	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP)
+
 	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		if len(svc.Status.LoadBalancer.Ingress) > 0 {
-			proxyIP = svc.Status.LoadBalancer.Ingress[0].IP
-			t.Logf("found loadbalancer IP for the Kong Proxy: %s", proxyIP)
+			ip := svc.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("found loadbalancer IP for the Kong Proxy: %s", ip)
+			return ip
 		}
 	}
+
 	// the above failed to find an address. either the LB didn't provision or we're using a NodePort
-	if proxyIP == "" {
-		var port int32
-		for _, sport := range svc.Spec.Ports {
-			if sport.Name == "kong-proxy" || sport.Name == "proxy" {
-				port = sport.NodePort
-			}
-		}
-		var extAddrs []string
-		var intAddrs []string
-		nodes, err := env.Cluster().Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-		require.NoError(t, err)
-		for _, node := range nodes.Items {
-			for _, naddr := range node.Status.Addresses {
-				if naddr.Type == corev1.NodeExternalIP {
-					extAddrs = append(extAddrs, naddr.Address)
-				}
-				if naddr.Type == corev1.NodeInternalIP {
-					extAddrs = append(intAddrs, naddr.Address)
-				}
-			}
-		}
-		// local clusters (KIND, minikube) typically provide no external addresses, but their internal addresses are
-		// routeable from their host. We prefer external addresses if they're available, but fall back to internal
-		// in their absence
-		if len(extAddrs) > 0 {
-			proxyIP = fmt.Sprintf("%v:%v", extAddrs[0], port)
-		} else if len(intAddrs) > 0 {
-			proxyIP = fmt.Sprintf("%v:%v", intAddrs[0], port)
-		} else {
-			assert.Fail(t, "both extAddrs and intAddrs are empty")
+	var port int32
+	for _, sport := range svc.Spec.Ports {
+		if sport.Name == "kong-proxy" || sport.Name == "proxy" {
+			port = sport.NodePort
 		}
 	}
-	return proxyIP
+	var extAddrs []string
+	var intAddrs []string
+	nodes, err := env.Cluster().Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	for _, node := range nodes.Items {
+		for _, naddr := range node.Status.Addresses {
+			if naddr.Type == corev1.NodeExternalIP {
+				extAddrs = append(extAddrs, naddr.Address)
+			}
+			if naddr.Type == corev1.NodeInternalIP {
+				extAddrs = append(intAddrs, naddr.Address)
+			}
+		}
+	}
+	// local clusters (KIND, minikube) typically provide no external addresses, but their internal addresses are
+	// routeable from their host. We prefer external addresses if they're available, but fall back to internal
+	// in their absence
+	if len(extAddrs) > 0 {
+		t.Logf("picking an external NodePort address: %s", extAddrs[0])
+		return fmt.Sprintf("%v:%v", extAddrs[0], port)
+	} else if len(intAddrs) > 0 {
+		t.Logf("picking an internal NodePort address: %s", intAddrs[0])
+		return fmt.Sprintf("%v:%v", intAddrs[0], port)
+	}
+
+	assert.Fail(t, "both extAddrs and intAddrs are empty")
+	return ""
 }
 
 // startPortForwarder runs "kubectl port-forward" in the background. It stops the forward when the provided context

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -232,7 +232,7 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 	svc := refreshService()
 	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "ClusterIP service is not supported")
 
-	// nolint: exhaustive
+	//nolint: exhaustive
 	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		return getKongProxyLoadBalancerIP(t, refreshService)
@@ -288,7 +288,7 @@ func getKongProxyNodePortIP(ctx context.Context, t *testing.T, env environments.
 				extAddrs = append(extAddrs, naddr.Address)
 			}
 			if naddr.Type == corev1.NodeInternalIP {
-				extAddrs = append(intAddrs, naddr.Address)
+				intAddrs = append(intAddrs, naddr.Address)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Brings GKE tests back to `e2e.yaml` workflow
- Adapts `hack/deploy-admission-controller.sh` to accept kubeconfig as an argument to make it possible to run against GKE cluster
- Cleans up test cleanup code into `finalizeTest` helper
- Extracts `runOnlyOnKindClusters` helper and handles new `KONG_TEST_CLUSTER_PROVIDER` env var in it
- Refactors `getKongProxyIP` to work with GKE clusters properly
- Deduplicates temporary kubeconfig dumping by extracting `getTemporaryKubeconfig`

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/3348 and https://github.com/Kong/kubernetes-ingress-controller/issues/3331

**Note to reviewers**: 

Successful run of the e2e workflow with GKE tests actually running: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3940441183/jobs/6741563482