### PR TITLE
feat: add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Adding a new version? You'll need three changes:
   if the controlled objects succeeded or failed to be translated to Kong 
   configuration.
   [#3359](https://github.com/Kong/kubernetes-ingress-controller/pull/3359)  
+- Added `version` command
+  [#3379](https://github.com/Kong/kubernetes-ingress-controller/pull/3379)  
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Configuration - Repository
 # ------------------------------------------------------------------------------
 
+MAKEFLAGS += --no-print-directory
 REPO_URL ?= github.com/kong/kubernetes-ingress-controller
 REPO_INFO ?= $(shell git config --get remote.origin.url)
 TAG ?= $(shell git describe --tags)

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,36 @@ clean:
 	@rm -f coverage*.out
 
 .PHONY: build
-build: generate fmt vet lint
-	go build -a -o bin/manager -ldflags "-s -w \
-		-X $(REPO_URL)/v2/internal/metadata.Release=$(TAG) \
-		-X $(REPO_URL)/v2/internal/metadata.Commit=$(COMMIT) \
-		-X $(REPO_URL)/v2/internal/metadata.Repo=$(REPO_INFO)" internal/cmd/main.go
+build: generate fmt vet lint _build
+
+.PHONY: build.fips
+build.fips: generate fmt vet lint _build.fips
+
+.PHONY: _build
+_build:
+	$(MAKE) _build.template MAIN=./internal/cmd/main.go
+
+.PHONY: _build.fips
+_build.fips:
+	$(MAKE) _build.template MAIN=./internal/cmd/fips/main.go
+
+.PHONY: _build.template
+_build.template:
+	go build -o bin/manager -ldflags "-s -w \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Commit=$(COMMIT) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Repo=$(REPO_INFO)" ${MAIN}
+
+.PHONY: _build.debug
+_build.debug:
+	$(MAKE) _build.template.debug MAIN=./internal/cmd/main.go
+
+.PHONY: _build.template.debug
+_build.template.debug:
+	go build -o bin/manager-debug -gcflags=all="-N -l" -ldflags " \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Commit=$(COMMIT) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Repo=$(REPO_INFO)" ${MAIN}
 
 .PHONY: fmt
 fmt:
@@ -229,8 +254,8 @@ container:
 		--build-arg REPO_INFO=${REPO_INFO} \
 		-t ${IMAGE}:${TAG} .
 
-.PHONY: container
-debug-container:
+.PHONY: container.debug
+container.debug:
 	docker buildx build \
 		-f Dockerfile \
 		--target debug \

--- a/internal/cmd/rootcmd/rootcmd.go
+++ b/internal/cmd/rootcmd/rootcmd.go
@@ -2,9 +2,13 @@
 package rootcmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/metadata"
 )
 
 // Execute is the entry point to the controller manager.
@@ -18,7 +22,29 @@ func Execute() {
 			},
 			SilenceUsage: true,
 		}
+		versionCmd = &cobra.Command{
+			Use:   "version",
+			Short: "Show JSON version information",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				type Version struct {
+					Release string `json:"release"`
+					Repo    string `json:"repo"`
+					Commit  string `json:"commit"`
+				}
+				out, err := json.Marshal(Version{
+					Release: metadata.Release,
+					Repo:    metadata.Repo,
+					Commit:  metadata.Commit,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to print version information: %w", err)
+				}
+				fmt.Printf("%s\n", out)
+				return nil
+			},
+		}
 	)
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.Flags().AddFlagSet(cfg.FlagSet())
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -161,15 +161,15 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringSliceVar(&c.FilterTags, "kong-admin-filter-tag", []string{"managed-by-ingress-controller"}, "The tag used to manage and filter entities in Kong. This flag can be specified multiple times to specify multiple tags. This setting will be silently ignored if the Kong instance has no tags support.")
 	flagSet.IntVar(&c.Concurrency, "kong-admin-concurrency", 10, "Max number of concurrent requests sent to Kong's Admin API.")
 	flagSet.StringSliceVar(&c.WatchNamespaces, "watch-namespace", nil,
-		`Namespace(s) to watch for Kubernetes resources. Defaults to all namespaces. To watch multiple namespaces, use
-		a comma-separated list of namespaces.`)
+		`Namespace(s) to watch for Kubernetes resources. Defaults to all namespaces.`+
+			`To watch multiple namespaces, use a comma-separated list of namespaces.`)
 
 	// Ingress status
-	flagSet.StringVar(&c.PublishService, "publish-service", "", `Service fronting Ingress resources in "namespace/name"
-			format. The controller will update Ingress status information with this Service's endpoints.`)
-	flagSet.StringSliceVar(&c.PublishStatusAddress, "publish-status-address", []string{}, `User-provided addresses in
-			comma-separated string format, for use in lieu of "publish-service" when that Service lacks useful address
-			information (for example, in bare-metal environments).`)
+	flagSet.StringVar(&c.PublishService, "publish-service", "",
+		`Service fronting Ingress resources in "namespace/name" format. The controller will update Ingress status information with this Service's endpoints.`)
+	flagSet.StringSliceVar(&c.PublishStatusAddress, "publish-status-address", []string{},
+		`User-provided addresses in comma-separated string format, for use in lieu of "publish-service" `+
+			`when that Service lacks useful address information (for example, in bare-metal environments).`)
 	flagSet.BoolVar(&c.UpdateStatus, "update-status", true,
 		`Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, e.t.c.)`)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a bit more than the commit message would say it is but when I was going through the `Makefile` I discovered that the `build` target uses incorrect paths to set the `ldflags`, i.e. 

    $(REPO_URL)/v2/internal/metadata.Release=$(TAG)

should be 

    $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG)

Hence this PR also contains that change and propagates usage of unified `Makefile` targets for building in `Dockerfile`.

Additionally in order to actually test that the binary contains the desired version information that we'd like it to I added `version` command so that the binary can be run for the sole reason to check the version information and get it in the following form:

    {"release":"v2.8.1-23-gde3af6e2","repo":"git@github.com:Kong/kubernetes-ingress-controller.git","commit":"de3af6e2"}

As a cleanup exercises this PR also reformats some of the flags descriptions so that they align properly when binary usage information is printed out.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
