### PR TITLE
chore: silence cobra errors to prevent double message about exit error

### DIFF
--- a/internal/cmd/rootcmd/rootcmd.go
+++ b/internal/cmd/rootcmd/rootcmd.go
@@ -17,6 +17,9 @@ func Execute() {
 				return Run(cmd.Context(), &cfg)
 			},
 			SilenceUsage: true,
+			// We can silence the errors because cobra.CheckErr below will print
+			// the returned error and set the exit code to 1.
+			SilenceErrors: true,
 		}
 	)
 	rootCmd.Flags().AddFlagSet(cfg.FlagSet())


### PR DESCRIPTION
**What this PR does / why we need it**:

When errors are not silenced in `cobra` then `cobra.CheckErr()` is used then we get 2 times the same error message when an error occurs. For example:

```
go run ./internal/cmd/main.go --asd
Error: unknown flag: --asd
Error: unknown flag: --asd
exit status 1
```

Or interrupted launch:

```
go run ./internal/cmd/main.go ... <flags> ...
...
INFO[0000] getting enabled options and features          logger=setup
INFO[0000] found configuration option for gated feature  enabled=true feature=GatewayAlpha logger=setup
INFO[0000] getting the kubernetes client configuration   logger=setup
INFO[0000] getting the kong admin api client configuration  logger=setup
...
^CINFO[0001] Signal received, shutting down                graceful_period=0s signal=interrupt
Error: could not retrieve Kong admin root: making HTTP request: Get "http://:8001/": context canceled
Error: could not retrieve Kong admin root: making HTTP request: Get "http://:8001/": context canceled
exit status 1
```

In order to prevent this we can use `SilenceErrors` which will silence the errors within the `cobra` framework.

The alternative would be to remove the `cobra.CheckErr()` call and handle the error ourselves.
