### PR TITLE
chore: remove redundant shutdown messages

### DIFF
--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -166,7 +167,7 @@ func (p *Synchronizer) startUpdateServer(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			p.logger.Info("context done: shutting down the proxy update server")
-			if err := ctx.Err(); err != nil {
+			if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
 				p.logger.Error(err, "context completed with error")
 			}
 			p.syncTicker.Stop()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes some of the redundant shutdown messages (mostly related to diagnostics server) treating context cancellation (typical shutdown via a signal for instance) as not an error to bother the user with.