### PR TITLE
refactor: add a generic version of getting route parent refs map

### DIFF
--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -392,19 +392,7 @@ var httprouteParentKind = "Gateway"
 // for the HTTPRoute is updated appropriately.
 func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Context, httproute *gatewayv1beta1.HTTPRoute, gateways ...supportedGatewayWithCondition) (bool, error) {
 	// map the existing parentStatues to avoid duplications
-	parentStatuses := make(map[string]*gatewayv1beta1.RouteParentStatus)
-	for _, existingParent := range httproute.Status.Parents {
-		namespace := httproute.Namespace
-		if existingParent.ParentRef.Namespace != nil {
-			namespace = string(*existingParent.ParentRef.Namespace)
-		}
-		existingParentCopy := existingParent
-		var sectionName string
-		if existingParent.ParentRef.SectionName != nil {
-			sectionName = string(*existingParent.ParentRef.SectionName)
-		}
-		parentStatuses[fmt.Sprintf("%s/%s/%s", namespace, existingParent.ParentRef.Name, sectionName)] = &existingParentCopy
-	}
+	parentStatuses := getParentStatuses(httproute, httproute.Status.Parents)
 
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false

--- a/internal/controllers/gateway/route_parent_status.go
+++ b/internal/controllers/gateway/route_parent_status.go
@@ -1,0 +1,85 @@
+package gateway
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type RouteParentStatusT interface {
+	gatewayv1beta1.RouteParentStatus | gatewayv1alpha2.RouteParentStatus
+}
+
+// getParentStatuses creates a parent status map for the provided route given the
+// route parent status slice.
+func getParentStatuses[routeT interface {
+	GetNamespace() string
+}, parentStatusT RouteParentStatusT](
+	route routeT, parentStatuses []parentStatusT,
+) map[string]*parentStatusT {
+	var (
+		namespace = route.GetNamespace()
+		m         = make(map[string]*parentStatusT)
+	)
+
+	for _, existingParent := range parentStatuses {
+		parentRef := getParentRef(existingParent)
+
+		if parentRef.Namespace != nil {
+			namespace = *parentRef.Namespace
+		}
+		var sectionName string
+		if parentRef.SectionName != nil {
+			sectionName = *parentRef.SectionName
+		}
+
+		var key string
+		switch any(route).(type) {
+		case *gatewayv1beta1.HTTPRoute:
+			key = fmt.Sprintf("%s/%s/%s", namespace, parentRef.Name, sectionName)
+
+		default:
+			key = fmt.Sprintf("%s/%s", namespace, parentRef.Name)
+		}
+
+		existingParentCopy := existingParent
+		m[key] = &existingParentCopy
+	}
+	return m
+}
+
+type parentRef struct {
+	Namespace   *string
+	Name        string
+	SectionName *string
+}
+
+// getParentRef serves as glue code to generically get parentRef from either
+// gatewayv1alpha2.RouteParentStatus or gatewayv1beta1.RouteParentStatus.
+func getParentRef[T RouteParentStatusT](parentStatus T) parentRef {
+	var sectionName *string
+
+	switch ps := any(parentStatus).(type) {
+	case gatewayv1beta1.RouteParentStatus:
+		if ps.ParentRef.SectionName != nil {
+			sectionName = lo.ToPtr(string(*ps.ParentRef.SectionName))
+		}
+		return parentRef{
+			Namespace:   lo.ToPtr(string(*ps.ParentRef.Namespace)),
+			Name:        string(ps.ParentRef.Name),
+			SectionName: sectionName,
+		}
+	case gatewayv1alpha2.RouteParentStatus:
+		if ps.ParentRef.SectionName != nil {
+			sectionName = lo.ToPtr(string(*ps.ParentRef.SectionName))
+		}
+		return parentRef{
+			Namespace:   lo.ToPtr(string(*ps.ParentRef.Namespace)),
+			Name:        string(ps.ParentRef.Name),
+			SectionName: sectionName,
+		}
+	}
+	return parentRef{}
+}

--- a/internal/controllers/gateway/route_parent_status.go
+++ b/internal/controllers/gateway/route_parent_status.go
@@ -12,11 +12,13 @@ type RouteParentStatusT interface {
 	gatewayv1beta1.RouteParentStatus | gatewayv1alpha2.RouteParentStatus
 }
 
+type namespacedObjectT interface {
+    GetNamespace() string
+}
+
 // getParentStatuses creates a parent status map for the provided route given the
 // route parent status slice.
-func getParentStatuses[routeT interface {
-	GetNamespace() string
-}, parentStatusT RouteParentStatusT](
+func getParentStatuses[routeT namespacedObjectT, parentStatusT RouteParentStatusT](
 	route routeT, parentStatuses []parentStatusT,
 ) map[string]*parentStatusT {
 	var (

--- a/internal/controllers/gateway/route_parent_status.go
+++ b/internal/controllers/gateway/route_parent_status.go
@@ -13,7 +13,7 @@ type RouteParentStatusT interface {
 }
 
 type namespacedObjectT interface {
-    GetNamespace() string
+	GetNamespace() string
 }
 
 // getParentStatuses creates a parent status map for the provided route given the

--- a/internal/controllers/gateway/route_parent_status_test.go
+++ b/internal/controllers/gateway/route_parent_status_test.go
@@ -1,0 +1,208 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestGetParentStatuses(t *testing.T) {
+	t.Run("HTTPRoute", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			route *gatewayv1beta1.HTTPRoute
+			want  map[string]*gatewayv1beta1.RouteParentStatus
+		}{
+			{
+				name: "basic",
+				route: &gatewayv1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      uuid.NewString(),
+						Namespace: uuid.NewString(),
+					},
+					Status: gatewayv1beta1.HTTPRouteStatus{
+						RouteStatus: gatewayv1beta1.RouteStatus{
+							Parents: []gatewayv1beta1.RouteParentStatus{
+								{
+									ParentRef: gatewayv1beta1.ParentReference{
+										Group:       lo.ToPtr(gatewayv1beta1.Group("group")),
+										Kind:        lo.ToPtr(gatewayv1beta1.Kind("kind")),
+										Namespace:   lo.ToPtr(gatewayv1beta1.Namespace("namespace")),
+										Name:        gatewayv1beta1.ObjectName("name"),
+										SectionName: lo.ToPtr(gatewayv1beta1.SectionName("section1")),
+									},
+								},
+							},
+						},
+					},
+				},
+				want: map[string]*gatewayv1beta1.RouteParentStatus{
+					"namespace/name/section1": {
+						ParentRef: gatewayv1beta1.ParentReference{
+							Group:       lo.ToPtr(gatewayv1beta1.Group("group")),
+							Kind:        lo.ToPtr(gatewayv1beta1.Kind("kind")),
+							Namespace:   lo.ToPtr(gatewayv1beta1.Namespace("namespace")),
+							Name:        gatewayv1beta1.ObjectName("name"),
+							SectionName: lo.ToPtr(gatewayv1beta1.SectionName("section1")),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, getParentStatuses(tt.route, tt.route.Status.Parents))
+			})
+		}
+	})
+
+	t.Run("UDPRoute", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			route *gatewayv1alpha2.UDPRoute
+			want  map[string]*gatewayv1alpha2.RouteParentStatus
+		}{
+			{
+				name: "basic",
+				route: &gatewayv1alpha2.UDPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      uuid.NewString(),
+						Namespace: uuid.NewString(),
+					},
+					Status: gatewayv1alpha2.UDPRouteStatus{
+						RouteStatus: gatewayv1alpha2.RouteStatus{
+							Parents: []gatewayv1alpha2.RouteParentStatus{
+								{
+									ParentRef: gatewayv1alpha2.ParentReference{
+										Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+										Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+										Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+										Name:      gatewayv1alpha2.ObjectName("name"),
+									},
+								},
+							},
+						},
+					},
+				},
+				want: map[string]*gatewayv1alpha2.RouteParentStatus{
+					"namespace/name": {
+						ParentRef: gatewayv1alpha2.ParentReference{
+							Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+							Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+							Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+							Name:      gatewayv1alpha2.ObjectName("name"),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, getParentStatuses(tt.route, tt.route.Status.Parents))
+			})
+		}
+	})
+
+	t.Run("TCPRoute", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			route *gatewayv1alpha2.TCPRoute
+			want  map[string]*gatewayv1alpha2.RouteParentStatus
+		}{
+			{
+				name: "basic",
+				route: &gatewayv1alpha2.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      uuid.NewString(),
+						Namespace: uuid.NewString(),
+					},
+					Status: gatewayv1alpha2.TCPRouteStatus{
+						RouteStatus: gatewayv1alpha2.RouteStatus{
+							Parents: []gatewayv1alpha2.RouteParentStatus{
+								{
+									ParentRef: gatewayv1alpha2.ParentReference{
+										Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+										Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+										Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+										Name:      gatewayv1alpha2.ObjectName("name"),
+									},
+								},
+							},
+						},
+					},
+				},
+				want: map[string]*gatewayv1alpha2.RouteParentStatus{
+					"namespace/name": {
+						ParentRef: gatewayv1alpha2.ParentReference{
+							Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+							Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+							Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+							Name:      gatewayv1alpha2.ObjectName("name"),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, getParentStatuses(tt.route, tt.route.Status.Parents))
+			})
+		}
+	})
+
+	t.Run("TLSRoute", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			route *gatewayv1alpha2.TLSRoute
+			want  map[string]*gatewayv1alpha2.RouteParentStatus
+		}{
+			{
+				name: "basic",
+				route: &gatewayv1alpha2.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      uuid.NewString(),
+						Namespace: uuid.NewString(),
+					},
+					Status: gatewayv1alpha2.TLSRouteStatus{
+						RouteStatus: gatewayv1alpha2.RouteStatus{
+							Parents: []gatewayv1alpha2.RouteParentStatus{
+								{
+									ParentRef: gatewayv1alpha2.ParentReference{
+										Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+										Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+										Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+										Name:      gatewayv1alpha2.ObjectName("name"),
+									},
+								},
+							},
+						},
+					},
+				},
+				want: map[string]*gatewayv1alpha2.RouteParentStatus{
+					"namespace/name": {
+						ParentRef: gatewayv1alpha2.ParentReference{
+							Group:     lo.ToPtr(gatewayv1alpha2.Group("group")),
+							Kind:      lo.ToPtr(gatewayv1alpha2.Kind("kind")),
+							Namespace: lo.ToPtr(gatewayv1alpha2.Namespace("namespace")),
+							Name:      gatewayv1alpha2.ObjectName("name"),
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, getParentStatuses(tt.route, tt.route.Status.Parents))
+			})
+		}
+	})
+}

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -371,15 +371,7 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 	gateways ...supportedGatewayWithCondition,
 ) (bool, error) {
 	// map the existing parentStatues to avoid duplications
-	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
-	for _, existingParent := range tcproute.Status.Parents {
-		namespace := tcproute.Namespace
-		if existingParent.ParentRef.Namespace != nil {
-			namespace = string(*existingParent.ParentRef.Namespace)
-		}
-		existingParentCopy := existingParent
-		parentStatuses[namespace+string(existingParent.ParentRef.Name)] = &existingParentCopy
-	}
+	parentStatuses := getParentStatuses(tcproute, tcproute.Status.Parents)
 
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -367,15 +367,7 @@ var tlsrouteParentKind = "Gateway"
 // for the TLSRoute is updated appropriately.
 func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Context, tlsroute *gatewayv1alpha2.TLSRoute, gateways ...supportedGatewayWithCondition) (bool, error) {
 	// map the existing parentStatues to avoid duplications
-	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
-	for _, existingParent := range tlsroute.Status.Parents {
-		namespace := tlsroute.Namespace
-		if existingParent.ParentRef.Namespace != nil {
-			namespace = string(*existingParent.ParentRef.Namespace)
-		}
-		existingParentCopy := existingParent
-		parentStatuses[namespace+string(existingParent.ParentRef.Name)] = &existingParentCopy
-	}
+	parentStatuses := getParentStatuses(tlsroute, tlsroute.Status.Parents)
 
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -362,15 +362,7 @@ var udprouteParentKind = "Gateway"
 // for the UDPRoute is updated appropriately.
 func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Context, udproute *gatewayv1alpha2.UDPRoute, gateways ...supportedGatewayWithCondition) (bool, error) {
 	// map the existing parentStatues to avoid duplications
-	parentStatuses := make(map[string]*gatewayv1alpha2.RouteParentStatus)
-	for _, existingParent := range udproute.Status.Parents {
-		namespace := udproute.Namespace
-		if existingParent.ParentRef.Namespace != nil {
-			namespace = string(*existingParent.ParentRef.Namespace)
-		}
-		existingParentCopy := existingParent
-		parentStatuses[namespace+string(existingParent.ParentRef.Name)] = &existingParentCopy
-	}
+	parentStatuses := getParentStatuses(udproute, udproute.Status.Parents)
 
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a generic version of getting route's parent ref map.

**Special notes for your reviewer**:

With this PR you can learn how to write 289 lines of code to replace 44 lines just to make it reusable 😄 