### PR TITLE
build: extract debug related targets from Dockerfile to separate one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,26 +64,6 @@ ARG REPO_INFO
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.fips
 
-# Build a manager binary with debug symbols and download Delve
-FROM builder as builder-delve
-
-ARG TARGETPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.debug
-
-### Debug
-# Create an image that runs a debug build with a Delve remote server on port 2345
-FROM golang:1.19.5 AS debug
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-# We want all source so Delve file location operations work
-COPY --from=builder-delve /workspace/ /workspace/
-USER 65532:65532
-
-ENTRYPOINT ["/go/bin/dlv"]
-CMD ["exec", "--continue", "--accept-multiclient",  "--headless", "--api-version=2", "--listen=:2345", "--log", "/workspace/manager-debug"]
-
 ### RHEL
 # Build UBI image
 FROM registry.access.redhat.com/ubi8/ubi AS redhat

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,42 @@
+# Build a manager binary with debug symbols and download Delve
+FROM golang:1.19.5 as builder
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN printf "Building for TARGETPLATFORM=${TARGETPLATFORM}" \
+    && printf ", TARGETARCH=${TARGETARCH}" \
+    && printf ", TARGETOS=${TARGETOS}" \
+    && printf ", TARGETVARIANT=${TARGETVARIANT} \n" \
+    && printf "With 'uname -s': $(uname -s) and 'uname -m': $(uname -m)"
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+COPY pkg/ pkg/
+COPY internal/ internal/
+COPY Makefile .
+
+# Build
+ARG TAG
+ARG COMMIT
+ARG REPO_INFO
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.debug
+
+### Debug
+# Create an image that runs a debug build with Delve installed
+FROM golang:1.19.5 AS debug
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+# We want all source so Delve file location operations work
+COPY --from=builder /workspace/bin/manager-debug /
+USER 65532:65532
+
+ENTRYPOINT ["/go/bin/dlv"]
+CMD ["exec", "--continue", "--accept-multiclient",  "--headless", "--api-version=2", "--listen=:2345", "--log", "/manager-debug"]

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ container:
 .PHONY: container.debug
 container.debug:
 	docker buildx build \
-		-f Dockerfile \
+		-f Dockerfile.debug \
 		--target debug \
 		--build-arg TAG=${TAG}-debug \
 		--build-arg COMMIT=${COMMIT} \
@@ -502,7 +502,8 @@ debug.connect:
 # port with debugger/IDE of your choice
 .PHONY: debug.skaffold
 debug.skaffold: skaffold
-	$(SKAFFOLD) debug --port-forward=pods --profile=debug $(SKAFFOLD_FLAGS)
+	TAG=$(TAG)-debug REPO_INFO=$(REPO_INFO) COMMIT=$(COMMIT) \
+		$(SKAFFOLD) debug --port-forward=pods --profile=debug $(SKAFFOLD_FLAGS)
 
 # This will port-forward 40000 from KIC's debugger to localhost. Connect to that
 # port with debugger/IDE of your choice
@@ -512,7 +513,8 @@ debug.skaffold.sync: skaffold
 
 .PHONY: run.skaffold
 run.skaffold: skaffold
-	$(SKAFFOLD) dev --port-forward=pods --profile=dev
+	TAG=$(TAG)-debug REPO_INFO=$(REPO_INFO) COMMIT=$(COMMIT) \
+		$(SKAFFOLD) dev --port-forward=pods --profile=dev
 
 .PHONY: run
 run: install _ensure-namespace

--- a/config/debug/manager_debug.yaml
+++ b/config/debug/manager_debug.yaml
@@ -27,7 +27,7 @@ spec:
           - --log=true
           - --log-output=debugger,debuglineerr,gdbwire
           - exec
-          - /workspace/manager-debug
+          - /manager-debug
           - --
         args:
           - --feature-gates=GatewayAlpha=true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,6 +23,10 @@ profiles:
       docker:
         dockerfile: Dockerfile
         target: distroless
+        buildArgs:
+          TAG: ${{ .TAG }}
+          COMMIT: ${{ .COMMIT }}
+          REPO_INFO: ${{ .REPO_INFO }}
 - name: dev
   manifests:
     kustomize:
@@ -34,6 +38,10 @@ profiles:
       docker:
         dockerfile: Dockerfile
         target: distroless
+        buildArgs:
+          TAG: ${{ .TAG }}
+          COMMIT: ${{ .COMMIT }}
+          REPO_INFO: ${{ .REPO_INFO }}
 - name: debug
   manifests:
     kustomize:
@@ -43,5 +51,9 @@ profiles:
     artifacts:
     - image: kic-placeholder
       docker:
-        dockerfile: Dockerfile
+        dockerfile: Dockerfile.debug
         target: debug
+        buildArgs:
+          TAG: ${{ .TAG }}
+          COMMIT: ${{ .COMMIT }}
+          REPO_INFO: ${{ .REPO_INFO }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extracts debug related image build instructions from `Dockerfile` to `Dockerfile.debug` and fixes skaffold config so that version information is injected during build process (instead of relying on running git commands in the image itself, to prevent copying `.git`)
