### PR TITLE
fix: do not return an error when IngressClass does not reference IngressClassParameters

### DIFF
--- a/internal/dataplane/parser/ingressclassparemeters_test.go
+++ b/internal/dataplane/parser/ingressclassparemeters_test.go
@@ -38,13 +38,12 @@ func TestGetIngressClassParameters(t *testing.T) {
 		name          string
 		paramRef      *netv1.IngressClassParametersReference
 		parameterSpec *configurationv1alpha1.IngressClassParametersSpec
-		hasError      bool
 		err           error
 	}{
 		{
 			name:          "nil-paramref",
 			parameterSpec: defaultIcpSpec,
-			err:           fmt.Errorf("IngressClass nil-paramref doesn't reference any parameters"),
+			// No error: it's OK to not reference ingress class parameters.
 		},
 		{
 			name: "nil-apigroup",
@@ -110,7 +109,6 @@ func TestGetIngressClassParameters(t *testing.T) {
 				Name:      testIcpName,
 			},
 			parameterSpec: defaultIcpSpec,
-			hasError:      true,
 			err:           store.ErrNotFound{Message: "IngressClassParameters test-icp not found"},
 		},
 		{

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -614,7 +614,7 @@ func getServiceEndpoints(
 func getIngressClassParametersOrDefault(s store.Storer) (configurationv1alpha1.IngressClassParametersSpec, error) {
 	ingressClassName := s.GetIngressClassName()
 	ingressClass, err := s.GetIngressClassV1(ingressClassName)
-	if err != nil || ingressClass == nil {
+	if err != nil {
 		return configurationv1alpha1.IngressClassParametersSpec{}, err
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -844,7 +844,7 @@ func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
 	return p.(*netv1.IngressClass), nil
 }
 
-// GetIngressClassParametersV1Alpha1 returns IngressClassParameters of configured
+// GetIngressClassParametersV1Alpha1 returns IngressClassParameters for provided
 // IngressClass.
 func (s Store) GetIngressClassParametersV1Alpha1(ingressClass *netv1.IngressClass) (*kongv1alpha1.IngressClassParameters, error) {
 	if ingressClass == nil {
@@ -852,7 +852,7 @@ func (s Store) GetIngressClassParametersV1Alpha1(ingressClass *netv1.IngressClas
 	}
 
 	if ingressClass.Spec.Parameters == nil {
-		return nil, fmt.Errorf("IngressClass %s doesn't reference any parameters", ingressClass.Name)
+		return &kongv1alpha1.IngressClassParameters{}, nil
 	}
 
 	if ingressClass.Spec.Parameters.APIGroup == nil ||


### PR DESCRIPTION
**What this PR does / why we need it**:

With #3385 merged, there's still one more thing to cover, which is to avoid errors when an IngressClass does not reference any IngressClassParameters. It's perfectly normal to do so. In that case we fall back to using [defaults](https://github.com/Kong/kubernetes-ingress-controller/blob/51185a91f2c6aa86a8acafa6eee4f73dc51acfc0/pkg/apis/configuration/v1alpha1/ingress_class_param_types.go#L54-L64).

