### PR TITLE
chore(ci): move 'concurrency' property from job to workflow level

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,9 @@
 name: e2e tests
 
+# Putting concurrency on the workflow level as we run every GKE E2E test as a separate job.
+# Leaving it on the job level would make all the GKE E2E jobs block each other.
+concurrency: gke
+
 on:
   schedule:
     - cron: '30 4 * * *'
@@ -86,7 +90,6 @@ jobs:
 
   e2e-gke-tests:
     environment: "gcloud"
-    concurrency: gke
     runs-on: ubuntu-latest
     needs: setup-e2e-tests
     strategy:


### PR DESCRIPTION
**What this PR does / why we need it**:

As we run every GKE E2E test as a separate job, leaving the property on the job level would make all the GKE E2E jobs block each other.

**Which issue this PR fixes**:

Part of #3348. 
