### PR TITLE
chore(ci): cleanup gke related scripts

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   gcloud:
     environment: gcloud
-    concurrency: gke # do not clean up while tests using GKE are still running
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,5 @@
 name: e2e tests
 
-# Putting concurrency on the workflow level as we run every GKE E2E test as a separate job.
-# Leaving it on the job level would make all the GKE E2E jobs block each other.
-concurrency: gke
-
 on:
   schedule:
     - cron: '30 4 * * *'

--- a/Makefile
+++ b/Makefile
@@ -380,42 +380,6 @@ test.integration.enterprise.postgres.pretty:
 		GOTESTFLAGS="-json" \
 		COVERAGE_OUT=coverage.enterprisepostgres.out
 
-.PHONY: test.integration.cp
-_test.integration.cp: gotestsum
-	CLUSTER_NAME="e2e-$(uuidgen)" \
-		KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/cluster/deploy/main.go \
-		GOFLAGS="-tags=integration_tests" \
-		KONG_TEST_CLUSTER="${CP}:${CLUSTER_NAME}" \
-		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
-		$(GOTESTSUM) -- -parallel "${NCPU}" -timeout $(INTEGRATION_TEST_TIMEOUT) \
-		./test/integration/... \
-    	go run hack/e2e/cluster/cleanup/main.go ${CLUSTER_NAME} \
-		trap cleanup EXIT SIGINT SIGQUIT
-
-.PHONY: test.integration.gke
-test.integration.gke:
-	@$(MAKE) _test.integration.cp \
-		CP="gke"
-
-.PHONY: test.integration.kind
-test.integration.kind:
-	@$(MAKE) _test.integration.cp \
-		CP="kind"
-
-.PHONY: test.e2e.gke
-test.e2e.gke:
-	CLUSTER_NAME="e2e-$(uuidgen)" \
-		KUBERNETES_CLUSTER_NAME="${CLUSTER_NAME}" go run hack/e2e/cluster/deploy/main.go \
-		KONG_TEST_CLUSTER="gke:${CLUSTER_NAME}" \
-		GOFLAGS="-tags=e2e_tests" $(GOTESTSUM) -- $(GOTESTFLAGS) \
-			-race \
-			-run $(E2E_TEST_RUN) \
-			-parallel $(NCPU) \
-			-timeout $(E2E_TEST_TIMEOUT) \
-			./test/e2e/... \
-		go run hack/e2e/cluster/cleanup/main.go ${CLUSTER_NAME} \
-		trap cleanup EXIT SIGINT SIGQUIT
-
 .PHONY: test.e2e
 test.e2e: gotestsum
 	GOFLAGS="-tags=e2e_tests" \

--- a/test/e2e/clusters.go
+++ b/test/e2e/clusters.go
@@ -1,0 +1,14 @@
+package e2e
+
+import "strings"
+
+const (
+	// GKETestClusterNamePrefix defines a prefix that is used for naming GKE clusters created in tests.
+	// It allows hack/cleanup_gke_clusters.go script to deterministically tell whether a cluster should
+	// be taken into account in the cleanup procedure.
+	gkeTestClusterNamePrefix = "e2e-"
+)
+
+func IsCreatedByE2ETests(clusterName string) bool {
+	return strings.HasPrefix(clusterName, gkeTestClusterNamePrefix)
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -125,10 +125,6 @@ func createExistingKINDBuilder(name string) (*environments.Builder, error) {
 	return builder, nil
 }
 
-// existing GKE patterns rely on running hack/e2e/cluster/deploy/main.go (integration too) and then just loading
-// an existing cluster. this could probably avoid the hack script, and may be reasonable to integrate into KTF.
-// there is no default GKE builder as such: https://github.com/Kong/kubernetes-ingress-controller/issues/1613
-
 func createExistingGKEBuilder(ctx context.Context, name string) (*environments.Builder, error) {
 	cluster, err := gke.NewFromExistingWithEnv(ctx, name)
 	if err != nil {
@@ -141,7 +137,7 @@ func createExistingGKEBuilder(ctx context.Context, name string) (*environments.B
 
 func createGKEBuilder() (*environments.Builder, error) {
 	var (
-		name        = "e2e-" + uuid.NewString()
+		name        = gkeTestClusterNamePrefix + uuid.NewString()
 		gkeCreds    = os.Getenv(gke.GKECredsVar)
 		gkeProject  = os.Getenv(gke.GKEProjectVar)
 		gkeLocation = os.Getenv(gke.GKELocationVar)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Removes unused `deploy.go` script and Makefile targets
- Turns `cleanup.go` into `cleanup_gke_clusters.go` with a single purpose of being used in the `cleanup.yml` workflow 
- Removes the `concurrency` property from workflows as it's proven to not work well in our case (it doesn't allow queueing more than 1 job, more on that [in the discussion](https://github.com/community/community/discussions/5435)). In order to mitigate the possible issue with clusters being deleted by the cleanup job before E2E tests are finished, clusters are considered orphaned after 1h from their creation (instead of 30min).

**Which issue this PR fixes**:

Part of #3378.
