### PR TITLE
feat: add Config.Validate() to allow validation of configuration options before starting the manager

### DIFF
--- a/internal/cmd/rootcmd/rootcmd.go
+++ b/internal/cmd/rootcmd/rootcmd.go
@@ -14,40 +14,49 @@ import (
 // Execute is the entry point to the controller manager.
 func Execute() {
 	var (
-		cfg     manager.Config
-		rootCmd = &cobra.Command{
-			PersistentPreRunE: bindEnvVars,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return Run(cmd.Context(), &cfg)
-			},
-			SilenceUsage: true,
-			// We can silence the errors because cobra.CheckErr below will print
-			// the returned error and set the exit code to 1.
-			SilenceErrors: true,
-		}
-		versionCmd = &cobra.Command{
-			Use:   "version",
-			Short: "Show JSON version information",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				type Version struct {
-					Release string `json:"release"`
-					Repo    string `json:"repo"`
-					Commit  string `json:"commit"`
-				}
-				out, err := json.Marshal(Version{
-					Release: metadata.Release,
-					Repo:    metadata.Repo,
-					Commit:  metadata.Commit,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to print version information: %w", err)
-				}
-				fmt.Printf("%s\n", out)
-				return nil
-			},
-		}
+		cfg        manager.Config
+		rootCmd    = GetRootCmd(&cfg)
+		versionCmd = GetVersionCmd()
 	)
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.Flags().AddFlagSet(cfg.FlagSet())
 	cobra.CheckErr(rootCmd.Execute())
+}
+
+func GetRootCmd(cfg *manager.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		PersistentPreRunE: bindEnvVars,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Run(cmd.Context(), cfg)
+		},
+		SilenceUsage: true,
+		// We can silence the errors because cobra.CheckErr below will print
+		// the returned error and set the exit code to 1.
+		SilenceErrors: true,
+	}
+	cmd.Flags().AddFlagSet(cfg.FlagSet())
+	return cmd
+}
+
+func GetVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show JSON version information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			type Version struct {
+				Release string `json:"release"`
+				Repo    string `json:"repo"`
+				Commit  string `json:"commit"`
+			}
+			out, err := json.Marshal(Version{
+				Release: metadata.Release,
+				Repo:    metadata.Repo,
+				Commit:  metadata.Commit,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to print version information: %w", err)
+			}
+			fmt.Printf("%s\n", out)
+			return nil
+		},
+	}
 }

--- a/internal/cmd/rootcmd/rootcmd_test.go
+++ b/internal/cmd/rootcmd/rootcmd_test.go
@@ -38,7 +38,7 @@ func TestRootCmd(t *testing.T) {
 		var cfg manager.Config
 		rootCmd := GetRootCmd(&cfg)
 		require.Error(t, rootCmd.PersistentPreRunE(rootCmd, os.Args[:0]),
-			"binding env vars should fail becuase a non namespaced name of publish service was provided",
+			"binding env vars should fail because a non namespaced name of publish service was provided",
 		)
 	})
 }

--- a/internal/cmd/rootcmd/rootcmd_test.go
+++ b/internal/cmd/rootcmd/rootcmd_test.go
@@ -1,0 +1,44 @@
+package rootcmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+)
+
+func TestRootCmd(t *testing.T) {
+	t.Run("root command succeeds by default", func(t *testing.T) {
+		var cfg manager.Config
+		rootCmd := GetRootCmd(&cfg)
+		require.NoError(t, rootCmd.PersistentPreRunE(rootCmd, os.Args[:0]))
+	})
+
+	t.Run("root command succeeds when correct flags where provided", func(t *testing.T) {
+		var cfg manager.Config
+		rootCmd := GetRootCmd(&cfg)
+		require.NoError(t, rootCmd.PersistentPreRunE(rootCmd,
+			append(os.Args[:0],
+				"--publish-service", "namespace/servicename",
+			),
+		))
+	})
+
+	t.Run("binding environment variables succeeds when flag validation passes", func(t *testing.T) {
+		t.Setenv("CONTROLLER_PUBLISH_SERVICE", "namespace/servicename")
+		var cfg manager.Config
+		rootCmd := GetRootCmd(&cfg)
+		require.NoError(t, rootCmd.PersistentPreRunE(rootCmd, os.Args[:0]))
+	})
+
+	t.Run("binding environment variables fails when flag validation fails", func(t *testing.T) {
+		t.Setenv("CONTROLLER_PUBLISH_SERVICE", "servicename")
+		var cfg manager.Config
+		rootCmd := GetRootCmd(&cfg)
+		require.Error(t, rootCmd.PersistentPreRunE(rootCmd, os.Args[:0]),
+			"binding env vars should fail becuase a non namespaced name of publish service was provided",
+		)
+	})
+}

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -28,9 +28,14 @@ func RunWithLogger(ctx context.Context, c *manager.Config, deprecatedLogger logr
 		return fmt.Errorf("failed to setup signal handler: %w", err)
 	}
 
+	if err := c.Validate(); err != nil {
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
+
 	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c, logger)
 	if err != nil {
 		return fmt.Errorf("failed to start diagnostics server: %w", err)
 	}
+
 	return manager.Run(ctx, c, diag.ConfigDumps, deprecatedLogger)
 }

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -1,0 +1,59 @@
+package manager
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("--gateway-api-controller-name", func(t *testing.T) {
+		t.Run("valid config", func(t *testing.T) {
+			var c Config
+			require.NoError(t, c.FlagSet().Parse(
+				[]string{
+					os.Args[0],
+					`--gateway-api-controller-name`, `example.com/controller-name`,
+				},
+			))
+			require.NoError(t, c.Validate())
+		})
+
+		t.Run("invalid config", func(t *testing.T) {
+			var c Config
+			require.NoError(t, c.FlagSet().Parse(
+				[]string{
+					os.Args[0],
+					`--gateway-api-controller-name`, `%invalid_controller_name$`,
+				},
+			))
+			require.Error(t, c.Validate())
+		})
+	})
+
+	t.Run("--publish-service", func(t *testing.T) {
+		t.Run("valid config", func(t *testing.T) {
+			var c Config
+			require.NoError(t, c.FlagSet().Parse(
+				[]string{
+					os.Args[0],
+					`--publish-service`, `namespace/servicename`,
+				},
+			))
+			require.NoError(t, c.Validate())
+		})
+
+		t.Run("invalid config", func(t *testing.T) {
+			var c Config
+			require.Error(t, c.FlagSet().Parse(
+				[]string{
+					os.Args[0],
+					`--publish-service`, `servicename`,
+				},
+			))
+			// publish service is validated through FlagNamespacedName validation logic.
+			require.NoError(t, c.Validate())
+		})
+	})
+}

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -360,7 +360,7 @@ func setupControllers(
 				Log:                  ctrl.Log.WithName("controllers").WithName(gatewayFeature),
 				Scheme:               mgr.GetScheme(),
 				DataplaneClient:      dataplaneClient,
-				PublishService:       c.PublishService,
+				PublishService:       c.PublishService.String(),
 				WatchNamespaces:      c.WatchNamespaces,
 				EnableReferenceGrant: referenceGrantsEnabled,
 				CacheSyncTimeout:     c.CacheSyncTimeout,

--- a/internal/manager/feature_gates.go
+++ b/internal/manager/feature_gates.go
@@ -31,12 +31,12 @@ const (
 )
 
 // setupFeatureGates converts feature gates to controller enablement.
-func setupFeatureGates(setupLog logr.Logger, c *Config) (map[string]bool, error) {
+func setupFeatureGates(setupLog logr.Logger, featureGates map[string]bool) (map[string]bool, error) {
 	// generate a map of feature gates by string names to their controller enablement
 	ctrlMap := getFeatureGatesDefaults()
 
 	// override the default settings
-	for feature, enabled := range c.FeatureGates {
+	for feature, enabled := range featureGates {
 		setupLog.Info("found configuration option for gated feature", "feature", feature, "enabled", enabled)
 		_, ok := ctrlMap[feature]
 		if !ok {

--- a/internal/manager/feature_gates_test.go
+++ b/internal/manager/feature_gates_test.go
@@ -16,24 +16,23 @@ func TestFeatureGates(t *testing.T) {
 	baseLogger.SetOutput(out)
 	baseLogger.SetLevel(logrus.DebugLevel)
 	setupLog := logrusr.New(baseLogger)
-	config := new(Config)
 
 	t.Log("verifying feature gates setup defaults when no feature gates are configured")
-	fgs, err := setupFeatureGates(setupLog, config)
+	fgs, err := setupFeatureGates(setupLog, nil)
 	assert.NoError(t, err)
 	assert.Len(t, fgs, len(getFeatureGatesDefaults()))
 
 	t.Log("verifying feature gates setup results when valid feature gates options are present")
-	config.FeatureGates = map[string]bool{gatewayFeature: true}
-	fgs, err = setupFeatureGates(setupLog, config)
+	featureGates := map[string]bool{gatewayFeature: true}
+	fgs, err = setupFeatureGates(setupLog, featureGates)
 	assert.NoError(t, err)
 	assert.True(t, fgs[gatewayFeature])
 
 	t.Log("configuring several invalid feature gates options")
-	config.FeatureGates = map[string]bool{"invalidGateway": true}
+	featureGates = map[string]bool{"invalidGateway": true}
 
 	t.Log("verifying feature gates setup results when invalid feature gates options are present")
-	_, err = setupFeatureGates(setupLog, config)
+	_, err = setupFeatureGates(setupLog, featureGates)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalidGateway is not a valid feature")
 }

--- a/internal/manager/flagnamespacedname.go
+++ b/internal/manager/flagnamespacedname.go
@@ -1,0 +1,33 @@
+package manager
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// FlagNamespacedName allows parsing command line flags straight to types.NamespacedName.
+type FlagNamespacedName struct {
+	NN types.NamespacedName
+}
+
+func (f *FlagNamespacedName) String() string {
+	return f.NN.String()
+}
+
+func (f *FlagNamespacedName) Set(v string) error {
+	s := strings.SplitN(v, "/", 3)
+	if len(s) != 2 {
+		return fmt.Errorf("namespaced name should be in the format: <namespace>/<name>")
+	}
+	f.NN = types.NamespacedName{
+		Namespace: s[0],
+		Name:      s[1],
+	}
+	return nil
+}
+
+func (f *FlagNamespacedName) Type() string {
+	return "FlagNamespacedName"
+}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -173,7 +173,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		// the argument checking the watch namespaces length enables or disables mesh detection. the mesh detect client
 		// attempts to use all namespaces and can't utilize a manager multi-namespaced cache, so if we need to limit
 		// namespace access we just disable mesh detection altogether.
-		if err := mgrutils.RunReport(ctx, kubeconfig, kongConfig, c.PublishService, metadata.Release,
+		if err := mgrutils.RunReport(ctx, kubeconfig, kongConfig, c.PublishService.String(), metadata.Release,
 			len(c.WatchNamespaces) == 0, featureGates); err != nil {
 			setupLog.Error(err, "anonymous reporting failed")
 		}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,23 +40,10 @@ import (
 func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, deprecatedLogger logrus.FieldLogger) error {
 	setupLog := ctrl.Log.WithName("setup")
 	setupLog.Info("starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
-	setupLog.V(util.DebugLevel).Info("the ingress class name has been set", "value", c.IngressClassName)
-	setupLog.V(util.DebugLevel).Info("building the manager runtime scheme and loading apis into the scheme")
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(konghqcomv1.AddToScheme(scheme))
-	utilruntime.Must(konghqcomv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(configurationv1beta1.AddToScheme(scheme))
-	utilruntime.Must(knativev1alpha1.AddToScheme(scheme))
-	utilruntime.Must(gatewayv1alpha2.AddToScheme(scheme))
-	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
-
-	if c.EnableLeaderElection {
-		setupLog.V(0).Info("the --leader-elect flag is deprecated and no longer has any effect: leader election is set based on the Kong database setting")
-	}
+	setupLog.Info("the ingress class name has been set", "value", c.IngressClassName)
 
 	setupLog.Info("getting enabled options and features")
-	featureGates, err := setupFeatureGates(setupLog, c)
+	featureGates, err := setupFeatureGates(setupLog, c.FeatureGates)
 	if err != nil {
 		return fmt.Errorf("failed to configure feature gates: %w", err)
 	}
@@ -68,11 +53,11 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	if err != nil {
 		return fmt.Errorf("get kubeconfig from file %q: %w", c.KubeconfigPath, err)
 	}
-
 	setupLog.Info("getting the kong admin api client configuration")
 	if c.KongAdminToken != "" {
 		c.KongAdminAPIConfig.Headers = append(c.KongAdminAPIConfig.Headers, "kong-admin-token:"+c.KongAdminToken)
 	}
+
 	kongClients, err := getKongClients(ctx, c.KongAdminURL, c.KongWorkspace, c.KongAdminAPIConfig)
 	if err != nil {
 		return fmt.Errorf("unable to build kong api client(s): %w", err)
@@ -87,13 +72,12 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	if err != nil {
 		return fmt.Errorf("could not validate Kong admin root(s) configuration: %w", err)
 	}
-
 	semV := semver.Version{Major: v.Major(), Minor: v.Minor(), Patch: v.Patch()}
 	versions.SetKongVersion(semV)
 	kongConfig := sendconfig.New(ctx, setupLog, kongClients, semV, dbMode, c.Concurrency, c.FilterTags)
 
 	setupLog.Info("configuring and building the controller manager")
-	controllerOpts, err := setupControllerOptions(setupLog, c, scheme, dbMode)
+	controllerOpts, err := setupControllerOptions(setupLog, c, dbMode)
 	if err != nil {
 		return fmt.Errorf("unable to setup controller options: %w", err)
 	}
@@ -126,7 +110,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	}
 
 	setupLog.Info("Initializing Dataplane Synchronizer")
-	synchronizer, err := setupDataplaneSynchronizer(setupLog, deprecatedLogger, mgr, dataplaneClient, c)
+	synchronizer, err := setupDataplaneSynchronizer(setupLog, deprecatedLogger, mgr, dataplaneClient, c.ProxySyncSeconds)
 	if err != nil {
 		return fmt.Errorf("unable to initialize dataplane synchronizer: %w", err)
 	}
@@ -201,8 +185,30 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	return mgr.Start(ctx)
 }
 
-func isControllerNameValid(controllerName string) bool {
-	// https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463
-	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
-	return re.Match([]byte(controllerName))
+func getScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := konghqcomv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := konghqcomv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := configurationv1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := knativev1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := gatewayv1alpha2.Install(scheme); err != nil {
+		return nil, err
+	}
+	if err := gatewayv1beta1.Install(scheme); err != nil {
+		return nil, err
+	}
+
+	return scheme, nil
 }

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/bombsimon/logrusr/v2"
@@ -12,8 +11,6 @@ import (
 	"github.com/kong/deck/cprint"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,25 +48,7 @@ func SetupLoggers(c *Config, output io.Writer) (logrus.FieldLogger, logr.Logger,
 	return deprecatedLogger, logger, nil
 }
 
-func setupControllerOptions(logger logr.Logger, c *Config, scheme *runtime.Scheme,
-	dbmode string,
-) (ctrl.Options, error) {
-	// some controllers may require additional namespaces to be cached and this
-	// is currently done using the global manager client cache.
-	//
-	// See: https://github.com/Kong/kubernetes-ingress-controller/issues/2004
-	requiredCacheNamespaces := make([]string, 0)
-
-	// if publish service has been provided the namespace for it should be
-	// watched so that controllers can see updates to the service.
-	if c.PublishService != "" {
-		publishServiceSplit := strings.SplitN(c.PublishService, "/", 3)
-		if len(publishServiceSplit) != 2 {
-			return ctrl.Options{}, fmt.Errorf("--publish-service was expected to be in format <namespace>/<name> but got %s", c.PublishService)
-		}
-		requiredCacheNamespaces = append(requiredCacheNamespaces, publishServiceSplit[0])
-	}
-
+func setupControllerOptions(logger logr.Logger, c *Config, dbmode string) (ctrl.Options, error) {
 	var leaderElection bool
 	if dbmode == "off" {
 		logger.Info("DB-less mode detected, disabling leader election")
@@ -77,6 +56,12 @@ func setupControllerOptions(logger logr.Logger, c *Config, scheme *runtime.Schem
 	} else {
 		logger.Info("Database mode detected, enabling leader election")
 		leaderElection = true
+	}
+
+	logger.Info("building the manager runtime scheme and loading apis into the scheme")
+	scheme, err := getScheme()
+	if err != nil {
+		return ctrl.Options{}, err
 	}
 
 	// configure the general controller options
@@ -96,13 +81,21 @@ func setupControllerOptions(logger logr.Logger, c *Config, scheme *runtime.Schem
 		// and we don't have to bother individually caching any particular namespaces
 		controllerOpts.Namespace = corev1.NamespaceAll
 	} else {
+		watchNamespaces := c.WatchNamespaces
+
 		// in all other cases we are a multi-namespace setup and must watch all the
-		// c.WatchNamespaces and additionalNamespacesToCache defined namespaces.
+		// c.WatchNamespaces.
 		// this mode does not set the Namespace option, so the manager will default to watching all namespaces
 		// MultiNamespacedCacheBuilder imposes a filter on top of that watch to retrieve scoped resources
 		// from the watched namespaces only.
-		logger.Info("manager set up with multiple namespaces", "namespaces", c.WatchNamespaces)
-		controllerOpts.NewCache = cache.MultiNamespacedCacheBuilder(append(c.WatchNamespaces, requiredCacheNamespaces...))
+		logger.Info("manager set up with multiple namespaces", "namespaces", watchNamespaces)
+
+		// if publish service has been provided the namespace for it should be
+		// watched so that controllers can see updates to the service.
+		if c.publishServiceNamespaceName.String() != "" {
+			watchNamespaces = append(c.WatchNamespaces, c.publishServiceNamespaceName.Namespace)
+		}
+		controllerOpts.NewCache = cache.MultiNamespacedCacheBuilder(watchNamespaces)
 	}
 
 	if len(c.LeaderElectionNamespace) > 0 {
@@ -117,19 +110,20 @@ func setupDataplaneSynchronizer(
 	fieldLogger logrus.FieldLogger,
 	mgr manager.Manager,
 	dataplaneClient dataplane.Client,
-	c *Config,
+	proxySyncSeconds float32,
 ) (*dataplane.Synchronizer, error) {
-	if c.ProxySyncSeconds < dataplane.DefaultSyncSeconds {
-		logger.Info(fmt.Sprintf("WARNING: --proxy-sync-seconds is configured for %fs, in DBLESS mode this may result in"+
-			" problems of inconsistency in the proxy state. For DBLESS mode %fs+ is recommended (3s is the default).",
-			c.ProxySyncSeconds, dataplane.DefaultSyncSeconds,
+	if proxySyncSeconds < dataplane.DefaultSyncSeconds {
+		logger.Info(fmt.Sprintf(
+			"WARNING: --proxy-sync-seconds is configured for %fs, in DBLESS mode this may result in"+
+				" problems of inconsistency in the proxy state. For DBLESS mode %fs+ is recommended (3s is the default).",
+			proxySyncSeconds, dataplane.DefaultSyncSeconds,
 		))
 	}
 
 	dataplaneSynchronizer, err := dataplane.NewSynchronizer(
 		fieldLogger.WithField("subsystem", "dataplane-synchronizer"),
 		dataplaneClient,
-		dataplane.WithStagger(time.Second*time.Duration(c.ProxySyncSeconds)),
+		dataplane.WithStagger(time.Duration(proxySyncSeconds*float32(time.Second))),
 	)
 	if err != nil {
 		return nil, err
@@ -198,17 +192,10 @@ func setupDataplaneAddressFinder(ctx context.Context, mgrc client.Client, c *Con
 		if overrideAddrs := c.PublishStatusAddress; len(overrideAddrs) > 0 {
 			dataplaneAddressFinder.SetOverrides(overrideAddrs)
 		} else if c.PublishService != "" {
-			parts := strings.Split(c.PublishService, "/")
-			if len(parts) != 2 {
-				return nil, fmt.Errorf("publish service %s is invalid, expecting <namespace>/<name>", c.PublishService)
-			}
-			nsn := types.NamespacedName{
-				Namespace: parts[0],
-				Name:      parts[1],
-			}
+			publishServiceNn := c.publishServiceNamespaceName
 			dataplaneAddressFinder.SetGetter(func() ([]string, error) {
 				svc := new(corev1.Service)
-				if err := mgrc.Get(ctx, nsn, svc); err != nil {
+				if err := mgrc.Get(ctx, publishServiceNn, svc); err != nil {
 					return nil, err
 				}
 
@@ -228,7 +215,7 @@ func setupDataplaneAddressFinder(ctx context.Context, mgrc client.Client, c *Con
 				}
 
 				if len(addrs) == 0 {
-					return nil, fmt.Errorf("waiting for addresses to be provisioned for publish service %s/%s", nsn.Namespace, nsn.Name)
+					return nil, fmt.Errorf("waiting for addresses to be provisioned for publish service %s", publishServiceNn)
 				}
 
 				return addrs, nil

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -92,8 +92,8 @@ func setupControllerOptions(logger logr.Logger, c *Config, dbmode string) (ctrl.
 
 		// if publish service has been provided the namespace for it should be
 		// watched so that controllers can see updates to the service.
-		if c.publishServiceNamespaceName.String() != "" {
-			watchNamespaces = append(c.WatchNamespaces, c.publishServiceNamespaceName.Namespace)
+		if c.PublishService.NN.String() != "" {
+			watchNamespaces = append(c.WatchNamespaces, c.PublishService.NN.Namespace)
 		}
 		controllerOpts.NewCache = cache.MultiNamespacedCacheBuilder(watchNamespaces)
 	}
@@ -191,8 +191,8 @@ func setupDataplaneAddressFinder(ctx context.Context, mgrc client.Client, c *Con
 	if c.UpdateStatus {
 		if overrideAddrs := c.PublishStatusAddress; len(overrideAddrs) > 0 {
 			dataplaneAddressFinder.SetOverrides(overrideAddrs)
-		} else if c.PublishService != "" {
-			publishServiceNn := c.publishServiceNamespaceName
+		} else if c.PublishService.String() != "" {
+			publishServiceNn := c.PublishService.NN
 			dataplaneAddressFinder.SetGetter(func() ([]string, error) {
 				svc := new(corev1.Service)
 				if err := mgrc.Get(ctx, publishServiceNn, svc); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `Config.Validate()` to allow validation of configuration options before starting the manager.

This will also set the stage to allow stopping the manager boot up process when mutually exclusive options are being provided (e.g. as in single controller deployments `kong-admin-url` and potential future Admin API service name specified for service discovery).

Additionally this performs some minor refactor around config and passing down the configuration options to downstream consumers of said options. It also stores the flagset in the `Config` so that we can use `c.flagSet.Changed()` to verify if the flag has been provided by the user ( in case the default flag value is a non empty/default value).