### PR TITLE
chore: don't send anonymous reports when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,7 @@ _ensure-namespace:
 .PHONY: debug
 debug: install _ensure-namespace
 	$(DLV) debug ./internal/cmd/main.go -- \
+		--anonymous-reports=false \
 		--kong-admin-url $(KONG_ADMIN_URL) \
 		--publish-service $(KONG_NAMESPACE)/$(KONG_PROXY_SERVICE) \
 		--kubeconfig $(KUBECONFIG) \
@@ -490,6 +491,7 @@ run: install _ensure-namespace
 .PHONY: _run
 _run:
 	go run ./internal/cmd/main.go \
+		--anonymous-reports=false \
 		--kong-admin-url $(KONG_ADMIN_URL) \
 		--publish-service $(KONG_NAMESPACE)/$(KONG_PROXY_SERVICE) \
 		--kubeconfig $(KUBECONFIG) \


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent sending anonymous reports when running locally.
