### PR TITLE
ci: add concurrency to run tests only on most recent PR commit

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,11 @@
 name: codeql
 
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 name: tests
 
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to use Github Actions' [`concurrency`](https://docs.github.com/en/actions/using-jobs/using-concurrency) to run tests and code scanning only on most recent PR commits and cancel anything prior to that.

This seems to work but unfortunately it notifies you whenever a job gets cancelled and it's impossible to suppress this notification

It's supposedly on Github's roadmap to address this: https://github.com/community/community/discussions/13015
