### PR TITLE
feat: add service discovery for kong admin service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,13 @@ Adding a new version? You'll need three changes:
   [#3507](https://github.com/Kong/kubernetes-ingress-controller/pull/3507)
 - Enable `ReferenceGrant` if `Gateway` feature gate is turned on (default).
   [#3519](https://github.com/Kong/kubernetes-ingress-controller/pull/3519)
-- Added Konnect client to upload status of KIC instance to Konnect cloud if 
+- Added Konnect client to upload status of KIC instance to Konnect cloud if
   flag `--konnect-sync-enabled` is set to `true`.
   [#3469](https://github.com/Kong/kubernetes-ingress-controller/pull/3469)
+- Added service discovery for kong admin service configured via `--kong-admin-svc`
+  which accepts a namespaced name of headless kong admin service which should have
+  Admin API endpoints exposed under a named port called `admin`
+  [#3421](https://github.com/Kong/kubernetes-ingress-controller/pull/3421)
 
 ### Fixed
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -178,6 +178,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/config/variants/multi-gw/base/manager_multi_gateway_patch.yaml
+++ b/config/variants/multi-gw/base/manager_multi_gateway_patch.yaml
@@ -11,8 +11,7 @@ spec:
       containers:
       - name: ingress-controller
         env:
-        - name: CONTROLLER_LOG_LEVEL
-          value: debug
         - name: CONTROLLER_KONG_ADMIN_SVC
           value: kong/kong-admin
-        image: kic-placeholder:placeholder
+        - name: CONTROLLER_KONG_ADMIN_URL
+          $patch: delete

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/deploy/single/all-in-one-dbless-multi-gw.yaml
+++ b/deploy/single/all-in-one-dbless-multi-gw.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses
@@ -1650,12 +1658,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
-        - name: CONTROLLER_LOG_LEVEL
-          value: debug
         - name: CONTROLLER_KONG_ADMIN_SVC
           value: kong/kong-admin
-        - name: CONTROLLER_KONG_ADMIN_URL
-          value: https://127.0.0.1:8444
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
@@ -1670,7 +1674,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kic-placeholder:placeholder
+        image: kong/kubernetes-ingress-controller:2.8.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1338,6 +1338,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -1,0 +1,162 @@
+package configuration
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// KongAdminAPIServiceReconciler reconciles Kong Admin API Service Endpointslices
+// and notifies the provided notifier about those.
+type KongAdminAPIServiceReconciler struct {
+	client.Client
+
+	// ServiceNN is the service NamespacedName to watch EndpointSlices for.
+	ServiceNN        types.NamespacedName
+	Log              logr.Logger
+	CacheSyncTimeout time.Duration
+	// EndpointsNotifier is used to notify about Admin API endpoints changes.
+	// We're going to call this only with endpoints when they change.
+	EndpointsNotifier EndpointsNotifier
+
+	Cache CacheT
+}
+
+type CacheT map[types.NamespacedName]sets.Set[string]
+
+type EndpointsNotifier interface {
+	Notify(addresses []string)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *KongAdminAPIServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("KongAdminAPIEndpoints", mgr, controller.Options{
+		Reconciler: r,
+		LogConstructor: func(_ *reconcile.Request) logr.Logger {
+			return r.Log
+		},
+		CacheSyncTimeout: r.CacheSyncTimeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	if r.Cache == nil {
+		r.Cache = make(CacheT)
+	}
+
+	return c.Watch(
+		&source.Kind{Type: &discoveryv1.EndpointSlice{}},
+		&handler.EnqueueRequestForObject{},
+		predicate.NewPredicateFuncs(r.shouldReconcileEndpointSlice),
+	)
+}
+
+func (r *KongAdminAPIServiceReconciler) shouldReconcileEndpointSlice(obj client.Object) bool {
+	endpoints, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return false
+	}
+
+	if endpoints.Namespace != r.ServiceNN.Namespace {
+		return false
+	}
+
+	if !lo.ContainsBy(endpoints.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "Service" && ref.Name == r.ServiceNN.Name
+	}) {
+		return false
+	}
+
+	return true
+}
+
+//+kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
+
+// Reconcile processes the watched objects.
+func (r *KongAdminAPIServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var endpoints discoveryv1.EndpointSlice
+	if err := r.Get(ctx, req.NamespacedName, &endpoints); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.Log.Info("reconciling EndpointSlice", "namespace", req.Namespace, "name", req.Name)
+
+	nn := types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}
+
+	if !endpoints.DeletionTimestamp.IsZero() {
+		r.Log.V(util.DebugLevel).Info("EndpointSlice is being deleted",
+			"type", "EndpointSlice", "namespace", req.Namespace, "name", req.Name,
+		)
+
+		// If we have an entry for this EndpointSlice...
+		if _, ok := r.Cache[nn]; ok {
+			// ... remove it and notify about the change.
+			delete(r.Cache, nn)
+			r.notify()
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	cached, ok := r.Cache[nn]
+	if !ok {
+		// If we don't have an entry for this EndpointSlice then save it and notify
+		// about the change.
+		r.Cache[nn] = adminapi.AddressesFromEndpointSlice(endpoints)
+		r.notify()
+		return ctrl.Result{}, nil
+	}
+
+	// We do have an entry for this EndpointSlice.
+	// Let's check if it's the same that we're already aware of...
+	addresses := adminapi.AddressesFromEndpointSlice(endpoints)
+	if cached.Equal(addresses) {
+		// No change, don't notify
+		return ctrl.Result{}, nil
+	}
+
+	// ... it's not the same. Store it and notify.
+	r.Cache[nn] = addresses
+	r.notify()
+
+	return ctrl.Result{}, nil
+}
+
+func (r *KongAdminAPIServiceReconciler) notify() {
+	addresses := addressesFromAddressesMap(r.Cache)
+
+	r.Log.V(util.DebugLevel).
+		Info("notifying about newly detected Admin API addresses", "addresses", addresses)
+	r.EndpointsNotifier.Notify(addresses)
+}
+
+func addressesFromAddressesMap(cache CacheT) []string {
+	addresses := []string{}
+	for _, v := range cache {
+		addresses = append(addresses, v.UnsortedList()...)
+	}
+	return addresses
+}

--- a/internal/dataplane/client.go
+++ b/internal/dataplane/client.go
@@ -29,4 +29,8 @@ type Client interface {
 	// Update the data-plane by parsing the current configuring and applying
 	// it to the backend API.
 	Update(ctx context.Context) error
+
+	// Shutdown shuts down the client, all the synchronization loops and all its
+	// internal data structures.
+	Shutdown(ctx context.Context) error
 }

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -126,11 +126,26 @@ type KongClient struct {
 
 	// SHAs is a slice is configuration hashes send in last batch send.
 	SHAs []string
+
+	// adminAPIClientFactory is a factory used for creating Admin API clients.
+	adminAPIClientFactory ClientFactory
+
+	// adminAPIAddressNotifyChan is used for notifications that contain Admin API
+	// endpoints list that should be used for configuring the dataplane.
+	adminAPIAddressNotifyChan chan []string
+
+	close     chan struct{}
+	onceClose sync.Once
+}
+
+type ClientFactory interface {
+	CreateAdminAPIClient(ctx context.Context, address string) (adminapi.Client, error)
 }
 
 // NewKongClient provides a new KongClient object after connecting to the
 // data-plane API and verifying integrity.
 func NewKongClient(
+	ctx context.Context,
 	logger logrus.FieldLogger,
 	timeout time.Duration,
 	ingressClass string,
@@ -140,22 +155,28 @@ func NewKongClient(
 	kongConfig sendconfig.Kong,
 	eventRecorder record.EventRecorder,
 	dbMode string,
+	kongClientFactory ClientFactory,
 ) (*KongClient, error) {
 	// build the client object
 	cache := store.NewCacheStores()
 	c := &KongClient{
-		logger:             logger,
-		ingressClass:       ingressClass,
-		enableReverseSync:  enableReverseSync,
-		skipCACertificates: skipCACertificates,
-		requestTimeout:     timeout,
-		diagnostic:         diagnostic,
-		prometheusMetrics:  metrics.NewCtrlFuncMetrics(),
-		cache:              &cache,
-		kongConfig:         kongConfig,
-		eventRecorder:      eventRecorder,
-		dbmode:             dbMode,
+		logger:                    logger,
+		ingressClass:              ingressClass,
+		enableReverseSync:         enableReverseSync,
+		skipCACertificates:        skipCACertificates,
+		requestTimeout:            timeout,
+		diagnostic:                diagnostic,
+		prometheusMetrics:         metrics.NewCtrlFuncMetrics(),
+		cache:                     &cache,
+		kongConfig:                kongConfig,
+		eventRecorder:             eventRecorder,
+		dbmode:                    dbMode,
+		adminAPIClientFactory:     kongClientFactory,
+		adminAPIAddressNotifyChan: make(chan []string),
+		close:                     make(chan struct{}),
 	}
+
+	go c.adminAPIAddressNotifyLoop(ctx)
 
 	return c, nil
 }
@@ -368,6 +389,14 @@ func (c *KongClient) DBMode() string {
 	return c.dbmode
 }
 
+// Shutdown shuts down the internal loops and synchronization workers.
+func (c *KongClient) Shutdown(ctx context.Context) error {
+	c.onceClose.Do(func() {
+		close(c.close)
+	})
+	return nil
+}
+
 // Update parses the Cache present in the client and converts current
 // Kubernetes state into Kong objects and state, and then ships the
 // resulting configuration to the data-plane (Kong Admin API).
@@ -438,6 +467,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 func (c *KongClient) sendOutToClients(
 	ctx context.Context, s *kongstate.KongState, formatVersion string, config sendconfig.Config,
 ) ([]string, error) {
+	c.logger.Debugf("sending configuration to %d clients", len(c.kongConfig.Clients))
 	shas, err := iter.MapErr(c.kongConfig.Clients, func(client *adminapi.Client) (string, error) {
 		return c.sendToClient(ctx, client, s, formatVersion, config)
 	},
@@ -497,6 +527,97 @@ func (c *KongClient) sendToClient(
 	client.SetLastConfigSHA(newConfigSHA)
 
 	return string(newConfigSHA), nil
+}
+
+// adminAPIAddressNotifyLoop is an inner loop listening on notifyChan which are received via
+// Notify() calls. Each time it receives on notifyChan tt will take the provided
+// list of addresses and update the internally held list of clients such that:
+//   - the internal list of kong clients contains only the provided addresses
+//   - if a client for a provided address already exists it's not recreated again
+//     (hence no external calls are made to check the provided endpoint if there
+//     exists a client already using it)
+//   - client that do not exist in the provided address list are removed if they
+//     are present in the current state
+//
+// This function whill acquire the internal lock to prevent the modification of
+// internal clients list.
+func (c *KongClient) adminAPIAddressNotifyLoop(ctx context.Context) {
+	for {
+		select {
+		case <-c.close:
+			c.adminAPIAddressNotifyChan = nil
+			return
+
+		case addresses := <-c.adminAPIAddressNotifyChan:
+			// This call will only log errors e.g. during creation of new clients.
+			// If need be we might consider propagating those errors up the stack.
+			c.adjustKongClients(ctx, addresses)
+		}
+	}
+}
+
+// adjustKongClients adjusts internally stored clients slice based on the provided
+// addresses slice. It consults BaseRootURLs of already stored clients with each
+// of the addreses and creates only those clients that we don't have.
+func (c *KongClient) adjustKongClients(ctx context.Context, addresses []string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	toAdd := lo.Filter(addresses, func(addr string, _ int) bool {
+		// If we already have a client with a provided address then great, no need
+		// to do anything.
+
+		// If we don't have a client with new address then filter it and add
+		// a client for this address.
+		return !lo.ContainsBy(c.kongConfig.Clients, func(cl adminapi.Client) bool {
+			return addr == cl.BaseRootURL()
+		})
+	})
+
+	var idxToRemove []int
+	for i, cl := range c.kongConfig.Clients {
+		// If the new address set contains a client that we already have then
+		// good, no need to do anything for it.
+		if lo.Contains(addresses, cl.BaseRootURL()) {
+			continue
+		}
+		// If the new address set does not contain an address that we already
+		// have then remove it.
+		idxToRemove = append(idxToRemove, i)
+	}
+
+	for i := len(idxToRemove) - 1; i >= 0; i-- {
+		idx := idxToRemove[i]
+		c.kongConfig.Clients = append(c.kongConfig.Clients[:idx], c.kongConfig.Clients[idx+1:]...)
+	}
+
+	for _, addr := range toAdd {
+		client, err := c.adminAPIClientFactory.CreateAdminAPIClient(ctx, addr)
+		if err != nil {
+			c.logger.WithError(err).Errorf("failed to create a client for %s", addr)
+			continue
+		}
+
+		c.kongConfig.Clients = append(c.kongConfig.Clients, client)
+	}
+}
+
+// Notify receives a list of addresses that KongClient should use from now on as
+// a list of Kong Admin API endpoints.
+func (c *KongClient) Notify(addresses []string) {
+	// Ensure here that we're not closed.
+	select {
+	case <-c.close:
+		return
+	default:
+	}
+
+	// And here also listen on c.close to allow the notification to be interrupted
+	// by Shutdown().
+	select {
+	case <-c.close:
+	case c.adminAPIAddressNotifyChan <- addresses:
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -1,8 +1,18 @@
 package dataplane
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -10,7 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 func TestUniqueObjects(t *testing.T) {
@@ -105,3 +118,179 @@ var (
 		Kind:    "Ingress",
 	}
 )
+
+// clientFactoryWithExpected implements ClientFactory interface and can be used
+// in tests to assert which clients have been created and signal failure if:
+// - client for an unexpected address gets created
+// - client which already got created was tried to be created second time.
+type clientFactoryWithExpected struct {
+	expected map[string]bool
+	t        *testing.T
+}
+
+func (cf clientFactoryWithExpected) CreateAdminAPIClient(ctx context.Context, address string) (adminapi.Client, error) {
+	num, ok := cf.expected[address]
+	if !ok {
+		cf.t.Errorf("got %s which was unexpected", address)
+		return adminapi.Client{}, fmt.Errorf("got %s which was unexpected", address)
+	}
+	if !num {
+		cf.t.Errorf("got %s more than once", address)
+		return adminapi.Client{}, fmt.Errorf("got %s more than once", address)
+	}
+	cf.expected[address] = false
+
+	kongClient, err := kong.NewTestClient(lo.ToPtr(address), &http.Client{})
+	if err != nil {
+		return adminapi.Client{}, err
+	}
+
+	return adminapi.NewClient(kongClient), nil
+}
+
+func TestClientAddressesNotifications(t *testing.T) {
+	var (
+		ctx         = context.Background()
+		logger      = logrus.New()
+		expected    = map[string]bool{}
+		serverCalls int32
+	)
+
+	const numberOfServers = 2
+
+	createTestServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// This test server serves as kong Admin API checking that we only get
+			// as many calls as new clients requests.
+			// That said: when we have 1 client with url1 and we receive a notification
+			// with url1 and url2 we should only create the second client with
+			// url2 and leave the existing one (for url1) in place and reuse it.
+
+			atomic.AddInt32(&serverCalls, 1)
+			n := int(atomic.LoadInt32(&serverCalls))
+
+			if n > numberOfServers {
+				t.Errorf("clients should only call out to the server %d times, but we received %d requests",
+					numberOfServers, n,
+				)
+			}
+		}))
+	}
+
+	srv := createTestServer()
+	defer srv.Close()
+	expected[srv.URL] = true
+
+	srv2 := createTestServer()
+	defer srv2.Close()
+	expected[srv2.URL] = true
+
+	client, err := NewKongClient(ctx, logger, time.Second, "", false, true, util.ConfigDumpDiagnostic{},
+		sendconfig.New(ctx, logr.Discard(), []adminapi.Client{},
+			sendconfig.Config{
+				InMemory:    true,
+				Concurrency: 10,
+			},
+		),
+		nil,
+		"off",
+		clientFactoryWithExpected{
+			expected: expected,
+			t:        t,
+		},
+	)
+	require.NoError(t, err)
+
+	requireClientsCountEventually := func(t *testing.T, c *KongClient, n int, args ...any) {
+		require.Eventually(t, func() bool {
+			c.lock.RLock()
+			defer c.lock.RUnlock()
+			return len(c.kongConfig.Clients) == n
+		}, time.Second, time.Millisecond, args...,
+		)
+	}
+
+	requireClientsCountEventually(t, client, 0,
+		"initially there should be 0 clients")
+
+	client.Notify([]string{srv.URL})
+	requireClientsCountEventually(t, client, 1,
+		"after notifying about a new address we should get 1 client eventually")
+
+	client.Notify([]string{srv.URL})
+	requireClientsCountEventually(t, client, 1,
+		"after notifying the same address there's no update in clients")
+
+	client.Notify([]string{srv.URL, srv2.URL})
+	requireClientsCountEventually(t, client, 2,
+		"after notifying new address set including the old already existing one we get both the old and the new")
+
+	client.Notify([]string{srv.URL, srv2.URL})
+	requireClientsCountEventually(t, client, 2,
+		"notifying again with the same set of URLs should not change the existing URLs")
+
+	client.Notify([]string{srv.URL})
+	requireClientsCountEventually(t, client, 1,
+		"notifying again with just one URL should decrease the set of URLs to just this one")
+
+	client.Notify([]string{})
+	requireClientsCountEventually(t, client, 0)
+
+	// We could test here notifying about srv.URL and srv2.URL again but there's
+	// no data structure in the client that could notify us about a removal of
+	// a client which we could use here.
+
+	require.NoError(t, client.Shutdown(context.Background()), "closing shouldn't return an error")
+	require.NoError(t, client.Shutdown(context.Background()), "closing second time shouldn't return an error")
+
+	require.NotPanics(t, func() { client.Notify([]string{}) }, "notifying about new clients after client has been shut down shouldn't panic")
+}
+
+func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		logger = logrus.New()
+	)
+
+	cf := &clientFactoryWithExpected{
+		t: t,
+	}
+	client, err := NewKongClient(ctx, logger, time.Second, "", false, true, util.ConfigDumpDiagnostic{},
+		sendconfig.New(ctx, logr.Discard(), []adminapi.Client{},
+			sendconfig.Config{
+				InMemory:    true,
+				Concurrency: 10,
+			},
+		),
+		nil,
+		"off",
+		cf,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Run("2 new clients", func(t *testing.T) {
+		// Change expected addresses
+		cf.expected = map[string]bool{"localhost:8080": true, "localhost:8081": true}
+
+		// there are 2 addresses contained in the notification of which 2 are new
+		// and client creator should be called exactly 2 times
+		client.adjustKongClients(ctx, []string{"localhost:8080", "localhost:8081"})
+	})
+
+	t.Run("1 addresses, no new client", func(t *testing.T) {
+		// Change expected addresses
+		cf.expected = map[string]bool{"localhost:8080": true}
+		// there is address contained in the notification but a client for that
+		// address already exists, client creator should not be called
+		client.adjustKongClients(ctx, []string{"localhost:8080"})
+	})
+
+	t.Run("2 addresses, 1 new client", func(t *testing.T) {
+		// Change expected addresses
+		cf.expected = map[string]bool{"localhost:8080": true, "localhost:8081": true}
+		// there are 2 addresses contained in the notification but only 1 is new
+		// hence the client creator should be called only once
+		client.adjustKongClients(ctx, []string{"localhost:8080", "localhost:8081"})
+	})
+}

--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -174,6 +174,10 @@ func (p *Synchronizer) startUpdateServer(ctx context.Context) {
 			}
 			p.syncTicker.Stop()
 
+			if err := p.dataplaneClient.Shutdown(ctx); err != nil {
+				p.logger.Error(err, "failed to shut down the dataplane client")
+			}
+
 			p.lock.Lock()
 			defer p.lock.Unlock()
 			p.isServerRunning = false

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -102,6 +102,10 @@ func (c *fakeDataplaneClient) Update(ctx context.Context) error {
 	return nil
 }
 
+func (c *fakeDataplaneClient) Shutdown(ctx context.Context) error {
+	return nil
+}
+
 func (c *fakeDataplaneClient) totalUpdates() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -37,6 +37,12 @@ func gatewayAPIControllerNameFromFlagValue(flagValue string) (string, error) {
 // Validate validates the config. It should be used to validate the config variables' interdependencies.
 // When a single variable is to be validated, *FromFlagValue function should be implemented.
 func (c *Config) Validate() error {
+	if c.flagSet != nil {
+		if c.flagSet.Changed("kong-admin-svc") && c.flagSet.Changed("kong-admin-url") {
+			return fmt.Errorf("can't set both --kong-admin-svc and --kong-admin-url")
+		}
+	}
+
 	if err := c.validateKonnect(); err != nil {
 		return fmt.Errorf("invalid konnect configuration: %w", err)
 	}

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -63,6 +63,7 @@ func setupControllers(
 	kubernetesStatusQueue *status.Queue,
 	c *Config,
 	featureGates map[string]bool,
+	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 ) ([]ControllerDef, error) {
 	restMapper := mgr.GetClient().RESTMapper()
 
@@ -84,6 +85,19 @@ func setupControllers(
 	referenceIndexers := ctrlref.NewCacheIndexers()
 
 	controllers := []ControllerDef{
+		// ---------------------------------------------------------------------------
+		// Kong Gateway Admin API Service discovery
+		// ---------------------------------------------------------------------------
+		{
+			Enabled: c.KongAdminSvc.Name != "",
+			Controller: &configuration.KongAdminAPIServiceReconciler{
+				Client:            mgr.GetClient(),
+				ServiceNN:         c.KongAdminSvc,
+				Log:               ctrl.Log.WithName("controllers").WithName("KongAdminAPIService"),
+				CacheSyncTimeout:  c.CacheSyncTimeout,
+				EndpointsNotifier: kongAdminAPIEndpointsNotifier,
+			},
+		},
 		// ---------------------------------------------------------------------------
 		// Core API Controllers
 		// ---------------------------------------------------------------------------

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/bombsimon/logrusr/v2"
 	"github.com/go-logr/logr"
 	"github.com/kong/deck/cprint"
@@ -159,7 +160,7 @@ func setupAdmissionServer(
 		return nil
 	}
 
-	kongclients, err := getKongClients(ctx, managerConfig)
+	kongclients, err := managerConfig.getKongClients(ctx)
 	if err != nil {
 		return err
 	}
@@ -259,21 +260,67 @@ func generateAddressFinderGetter(mgrc client.Client, publishServiceNn types.Name
 	}
 }
 
-// getKongClients returns the kong clients.
-func getKongClients(ctx context.Context, cfg *Config) ([]adminapi.Client, error) {
-	httpclient, err := adminapi.MakeHTTPClient(&cfg.KongAdminAPIConfig)
+// getKongClients returns the kong clients given the config.
+// When a list of URLs is provided via --kong-admin-url then those are used
+// to create the list of clients.
+// When a headless service name is provided via --kong-admin-svc then that is used
+// to obtain a list of endpoints via EndpointSlice lookup in kubernetes API.
+func (c *Config) getKongClients(ctx context.Context) ([]adminapi.Client, error) {
+	httpclient, err := adminapi.MakeHTTPClient(&c.KongAdminAPIConfig, c.KongAdminToken)
 	if err != nil {
 		return nil, err
 	}
 
-	clients := make([]adminapi.Client, 0, len(cfg.KongAdminURL))
-	for _, url := range cfg.KongAdminURL {
-		client, err := adminapi.NewKongClientForWorkspace(ctx, url, cfg.KongWorkspace, httpclient)
+	var addresses []string
+
+	// If kong-admin-svc flag has been specified then use it to get the list
+	// of Kong Admin API endpoints.
+	if c.KongAdminSvc.Name != "" {
+		kubeClient, err := c.GetKubeClient()
+		if err != nil {
+			return nil, err
+		}
+
+		// Retry this as we may encounter an error of getting 0 addresses,
+		// which can mean that Kong instances meant to be configured by this controller
+		// are not yet ready.
+		// If we end up in a situation where none of them are ready then bail
+		// because we have more code that relies on the configuration of Kong
+		// instance and without an address and there's no way to initialize the
+		// configuration validation and sending code.
+		err = retry.Do(func() error {
+			s, err := adminapi.GetURLsForService(ctx, kubeClient, c.KongAdminSvc)
+			if err != nil {
+				return err
+			}
+			if s.Len() == 0 {
+				return fmt.Errorf("no endpoints for kong admin service: %q", c.KongAdminSvc)
+			}
+			addresses = s.UnsortedList()
+			return nil
+		},
+			retry.Attempts(60),
+			retry.DelayType(retry.FixedDelay),
+			retry.Delay(time.Second),
+			retry.OnRetry(func(_ uint, err error) {
+				logrus.New().WithError(err).Error("failed to create kong client(s)")
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Otherwise fallback to the list of kong admin URLs.
+		addresses = c.KongAdminURLs
+	}
+
+	clients := make([]adminapi.Client, 0, len(addresses))
+	for _, address := range addresses {
+		client, err := adminapi.NewKongClientForWorkspace(ctx, address, c.KongWorkspace, httpclient)
 		if err != nil {
 			return nil, err
 		}
 		clients = append(clients, client)
 	}
-
 	return clients, nil
 }

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -27,9 +27,9 @@ func ValidateRoots(roots []Root, skipCACerts bool) (string, kong.Version, error)
 	}
 
 	uniqs := lo.UniqBy(roots, getRootKeyFunc(skipCACerts))
-	if len(uniqs) > 1 {
+	if len(uniqs) != 1 {
 		return "", kong.Version{},
-			fmt.Errorf("there should only be one dbmode:version combination across configured kong instances while there are: %v", uniqs)
+			fmt.Errorf("there should only be one dbmode:version combination across configured kong instances while there are (%d): %v", len(uniqs), uniqs)
 	}
 
 	dbMode, err := DBModeFromRoot(uniqs[0])

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -117,7 +117,7 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 		return nil, err
 	}
 
-	manifestsReader, err = patchControllerImageHelper(manifestsReader, baseManifestPath)
+	manifestsReader, err = patchControllerImageFromEnv(manifestsReader, baseManifestPath)
 	if err != nil {
 		t.Logf("failed patching controller image (%v), using default manifest %v", err, baseManifestPath)
 		return manifestsReader, nil

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -167,7 +167,8 @@ func getTestManifest(t *testing.T, baseManifestPath string) (io.Reader, error) {
 	return manifestsReader, nil
 }
 
-func patchControllerImageHelper(manifestReader io.Reader, baseManifestPath string) (io.Reader, error) {
+// patchControllerImageFromEnv will optionally replace a default controller image in manifests with one of `imageLoad` or `imageOverride` if any is set.
+func patchControllerImageFromEnv(manifestReader io.Reader, baseManifestPath string) (io.Reader, error) {
 	var imageFullname string
 	if imageLoad != "" {
 		imageFullname = imageLoad

--- a/test/internal/helpers/teardown.go
+++ b/test/internal/helpers/teardown.go
@@ -3,9 +3,12 @@ package helpers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 // TeardownCluster dumps the diagnostics from the test cluster if the test failed
@@ -13,8 +16,19 @@ import (
 func TeardownCluster(ctx context.Context, t *testing.T, cluster clusters.Cluster) {
 	t.Helper()
 
+	const (
+		environmentCleanupTimeout = 3 * time.Minute
+	)
+
 	DumpDiagnosticsIfFailed(ctx, t, cluster)
-	assert.NoError(t, cluster.Cleanup(ctx))
+
+	if testenv.KeepTestCluster() == "" && testenv.ExistingClusterName() == "" {
+		ctx, cancel := context.WithTimeout(ctx, environmentCleanupTimeout)
+		defer cancel()
+		t.Logf("INFO: cluster %s is being deleted\n", cluster.Name())
+		assert.NoError(t, cluster.Cleanup(ctx))
+		return
+	}
 }
 
 // DumpDiagnosticsIfFailed dumps the diagnostics if the test failed.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces kong Admin API service discovery via the `--kong-admin-svc` flag (to be discussed).

When that flag is specified (as `namespace/service_name`) KIC will watch `EndpointSlice`s for that `Service` and add (and remove when the endpoint gets removed) a kong client for each endpoint for that `Service`.

This in its current form does not take into account the fact that gateway should be made ready only when its config is applied and ready (Admin API readines != Gateway Proxy readiness). We don't yet have a mechanism to be sure that a config has been applied (it can come in one of the upcoming Gateway releases) but we could implement a mechanism to make Gateway Proxy service marked as ready after the config has been sent.

#3499 covers whether we'd like to introduce said mechanism.

**Which issue this PR fixes**:

Fixes #3400

**Special notes for your reviewer**:

~This is not yet 100% ready but ready for review.~

The multi gw manifests that are also slightly changed in this PR are almost working, that is: they deploy KIC 2.8.1 which doesn't yet support `--kong-admin-svc` flag and since `--kong-admin-url` has a default of `[]string{"http://localhost:8001"}` then it uses that but since with those manifests we deploy 2 separate deployments this address cannot be reached and KIC fails.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
