### PR TITLE
chore: add -trimpath when building debug binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ _build.debug:
 
 .PHONY: _build.template.debug
 _build.template.debug:
-	go build -o bin/manager-debug -gcflags=all="-N -l" -ldflags " \
+	go build -o bin/manager-debug -trimpath -gcflags=all="-N -l" -ldflags " \
 		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG) \
 		-X $(REPO_URL)/v2/internal/manager/metadata.Commit=$(COMMIT) \
 		-X $(REPO_URL)/v2/internal/manager/metadata.Repo=$(REPO_INFO)" ${MAIN}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `-trimpath` flag to the command building a debug binary. It solves the problem of not being able to set breakpoints when attaching to a remote process (local paths do not match the ones embedded in the binary that is being built in the Dockerfile).

```
go help build
        -trimpath
                remove all file system paths from the resulting executable.
                Instead of absolute file system paths, the recorded file names
                will begin either a module path@version (when using modules),
                or a plain import path (when using the standard library, or GOPATH).
```
