### PR TITLE
fix(tests): fix e2e data race when starting port forwarding

### DIFF
--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -330,7 +330,7 @@ func startPortForwarder(ctx context.Context, t *testing.T, env environments.Envi
 			return true
 		}
 
-		t.Logf("port forwarding command %q output so far: %s", cmd.String(), out.String())
+		t.Logf("port forwarding (via %q) not ready....", cmd.String())
 		return false
 	}, kongComponentWait, time.Second)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a data race where a port forwarding function would access the buffer provided to the `cmd.Start()` at the same time the command is writing to it.

**Which issue this PR fixes:**

Fixes #3424