### PR TITLE
fix: do not create separate service for every ingress when combinedRoutes enabled

### DIFF
--- a/internal/dataplane/kongstate/types.go
+++ b/internal/dataplane/kongstate/types.go
@@ -30,7 +30,7 @@ type PortDef struct {
 
 const ImplicitPort = "implicitPort"
 
-func (p *PortDef) CanonicalString() string {
+func (p PortDef) CanonicalString() string {
 	switch p.Mode {
 	case PortModeByNumber:
 		return fmt.Sprintf("%d", p.Number)

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -265,141 +266,156 @@ func TestFromIngressV1beta1(t *testing.T) {
 		},
 	}
 
-	t.Run("no ingress returns empty info", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{},
+	// Run all test cases with both combinedServiceRoutesEnabled on and off to ensure that the behavior is consistent.
+	for _, combinedServiceRoutesEnabled := range []bool{true, false} {
+		combinedServiceRoutesEnabled := combinedServiceRoutesEnabled
+
+		t.Run(fmt.Sprintf("combinedServiceRoutesEnabled=%v", combinedServiceRoutesEnabled), func(t *testing.T) {
+			t.Run("no ingress returns empty info", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(ingressRules{
+					ServiceNameToServices: make(map[string]kongstate.Service),
+					ServiceNameToParent:   make(map[string]client.Object),
+					SecretNameToSNIs:      newSecretNameToSNIs(),
+				}, parsedInfo)
+			})
+			t.Run("simple ingress rule is parsed", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[0],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+			})
+			t.Run("ingress rule with default backend", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{ingressList[0], ingressList[2]},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(2, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
+				assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+			})
+			t.Run("ingress rule with TLS", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[1],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+				assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+			})
+			t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[3],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Port)
+
+				assert.Equal("/.well-known/acme-challenge/yolo",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Paths[0])
+				assert.Equal("example.com",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Hosts[0])
+				assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].StripPath)
+			})
+			t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[4],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+			})
+			t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[5],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				assert.NotPanics(func() {
+					p.ingressRulesFromIngressV1beta1()
+				})
+			})
+			t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[6],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal("foo-svc.foo-namespace.8000.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.8000"].Host)
+			})
+			t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1beta1: []*netv1beta1.Ingress{
+						ingressList[7],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1beta1()
+				assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+			})
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(ingressRules{
-			ServiceNameToServices: make(map[string]kongstate.Service),
-			ServiceNameToParent:   make(map[string]client.Object),
-			SecretNameToSNIs:      newSecretNameToSNIs(),
-		}, parsedInfo)
-	})
-	t.Run("simple ingress rule is parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[0],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
-
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
-	})
-	t.Run("ingress rule with default backend", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{ingressList[0], ingressList[2]},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
-
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
-
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-		assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
-	})
-	t.Run("ingress rule with TLS", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[1],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
-	})
-	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[3],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Port)
-
-		assert.Equal("/.well-known/acme-challenge/yolo",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Paths[0])
-		assert.Equal("example.com",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Hosts[0])
-		assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].StripPath)
-	})
-	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[4],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
-	})
-	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[5],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		assert.NotPanics(func() {
-			p.ingressRulesFromIngressV1beta1()
-		})
-	})
-	t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[6],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal("foo-svc.foo-namespace.8000.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.8000"].Host)
-	})
-	t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1beta1: []*netv1beta1.Ingress{
-				ingressList[7],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-	})
+	}
 }
 
 func TestFromIngressV1(t *testing.T) {
@@ -739,159 +755,188 @@ func TestFromIngressV1(t *testing.T) {
 		},
 	}
 
-	t.Run("no ingress returns empty info", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{},
+	// Run all test cases with both combinedServiceRoutesEnabled on and off to ensure that the behavior is consistent.
+	for _, combinedServiceRoutesEnabled := range []bool{true, false} {
+		combinedServiceRoutesEnabled := combinedServiceRoutesEnabled
+
+		t.Run(fmt.Sprintf("combinedServiceRoutesEnabled=%v", combinedServiceRoutesEnabled), func(t *testing.T) {
+			t.Run("no ingress returns empty info", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(ingressRules{
+					ServiceNameToServices: make(map[string]kongstate.Service),
+					ServiceNameToParent:   make(map[string]client.Object),
+					SecretNameToSNIs:      newSecretNameToSNIs(),
+				}, parsedInfo)
+			})
+			t.Run("simple ingress rule is parsed", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[0],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+			})
+			t.Run("ingress rule with default backend", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[0],
+						ingressList[2],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(2, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
+				assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+			})
+			t.Run("ingress rule with TLS", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[1],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+				assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+			})
+			t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[3],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(1, len(parsedInfo.ServiceNameToServices))
+				assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Host)
+				assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Port)
+
+				assert.Equal("/.well-known/acme-challenge/yolo",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Paths[0])
+				assert.Equal("example.com",
+					*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Hosts[0])
+				assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].StripPath)
+			})
+			t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[4],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+				assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+			})
+			t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[5],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+
+				assert.NotPanics(func() {
+					p.ingressRulesFromIngressV1()
+				})
+			})
+			t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[6],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal("foo-svc.foo-namespace.80.svc",
+					*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+				assert.Equal("foo-svc.foo-namespace.8000.svc",
+					*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.8000"].Host)
+			})
+			t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[9],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"]
+				assert.True(ok)
+			})
+			t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[9],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+			})
+			t.Run("two ingresses referring the same service", func(t *testing.T) {
+				store, err := store.NewFakeStore(store.FakeObjects{
+					IngressesV1: []*netv1.Ingress{
+						ingressList[0],
+						ingressList[4],
+					},
+				})
+				require.NoError(t, err)
+				p := mustNewParser(t, store)
+				p.featureEnabledCombinedServiceRoutes = combinedServiceRoutesEnabled
+
+				parsedInfo := p.ingressRulesFromIngressV1()
+				require.Len(t, parsedInfo.ServiceNameToServices, 1, "if two ingresses refer the same service, only one service should be created")
+			})
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(ingressRules{
-			ServiceNameToServices: make(map[string]kongstate.Service),
-			ServiceNameToParent:   make(map[string]client.Object),
-			SecretNameToSNIs:      newSecretNameToSNIs(),
-		}, parsedInfo)
-	})
-	t.Run("simple ingress rule is parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[0],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
-
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
-	})
-	t.Run("ingress rule with default backend", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[0],
-				ingressList[2],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
-
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
-
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-		assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
-	})
-	t.Run("ingress rule with TLS", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[1],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
-	})
-	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[3],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Port)
-
-		assert.Equal("/.well-known/acme-challenge/yolo",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Hosts[0])
-		assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].StripPath)
-	})
-	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[4],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
-	})
-	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[5],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		assert.NotPanics(func() {
-			p.ingressRulesFromIngressV1()
-		})
-	})
-	t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[6],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal("foo-svc.foo-namespace.80.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal("foo-svc.foo-namespace.8000.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-8000"].Host)
-	})
-	t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[9],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"]
-		assert.True(ok)
-	})
-	t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[9],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
-
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-	})
+	}
 }
 
 func TestFromIngressV1_RegexPrefix(t *testing.T) {
@@ -944,6 +989,6 @@ func TestFromIngressV1_RegexPrefix(t *testing.T) {
 		p.EnableRegexPathPrefix()
 
 		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal("~/whatever$", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+		assert.Equal("~/whatever$", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
 	})
 }

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -61,7 +61,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 			for j, rule := range rule.HTTP.Paths {
 				path := rule.Path
 
-				path = maybePrependRegexPrefix(path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
+				path = translators.MaybePrependRegexPrefix(path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
 				if path == "" {
 					path = "/"
 				}

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -82,8 +82,13 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 				r.Hosts = kong.StringSlice(hosts...)
 
 				knativeBackend := knativeSelectSplit(rule.Splits)
-				serviceName := fmt.Sprintf("%s.%s.%s", knativeBackend.ServiceNamespace, knativeBackend.ServiceName,
-					knativeBackend.ServicePort.String())
+				port := translators.PortDefFromIntStr(knativeBackend.ServicePort)
+				serviceName := fmt.Sprintf(
+					"%s.%s.%s",
+					knativeBackend.ServiceNamespace,
+					knativeBackend.ServiceName,
+					port.CanonicalString(),
+				)
 				serviceHost := fmt.Sprintf("%s.%s.%s.svc", knativeBackend.ServiceName, knativeBackend.ServiceNamespace,
 					knativeBackend.ServicePort.String())
 				service, ok := services[serviceName]

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
@@ -12,7 +11,6 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
@@ -162,21 +160,4 @@ func generateKongServiceFromBackendRefWithRuleNumber(
 		protocol,
 		backendRefs...,
 	)
-}
-
-// maybePrependRegexPrefix takes a path, controller regex prefix, and a legacy heuristic toggle. It returns the path
-// with the Kong regex path prefix if it either began with the controller prefix or did not, but matched the legacy
-// heuristic, and the heuristic was enabled.
-func maybePrependRegexPrefix(path, controllerPrefix string, applyLegacyHeuristic bool) string {
-	if strings.HasPrefix(path, controllerPrefix) {
-		path = strings.Replace(path, controllerPrefix, translators.KongPathRegexPrefix, 1)
-	} else if applyLegacyHeuristic {
-		// this regex matches if the path _is not_ considered a regex by Kong 2.x
-		if LegacyRegexPathExpression.FindString(path) == "" {
-			if !strings.HasPrefix(path, translators.KongPathRegexPrefix) {
-				path = translators.KongPathRegexPrefix + path
-			}
-		}
-	}
-	return path
 }

--- a/internal/dataplane/parser/translate_vars.go
+++ b/internal/dataplane/parser/translate_vars.go
@@ -1,9 +1,5 @@
 package parser
 
-import (
-	"regexp"
-)
-
 // -----------------------------------------------------------------------------
 // Translation - Vars & Constants
 // -----------------------------------------------------------------------------
@@ -26,6 +22,3 @@ const (
 	// as a regex.
 	kongHeaderRegexPrefix = "~*"
 )
-
-// LegacyRegexPathExpression is the regular expression used by Kong <3.0 to determine if a path is not a regex.
-var LegacyRegexPathExpression = regexp.MustCompile(`^[a-zA-Z0-9\.\-_~/%]*$`)

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -140,7 +141,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -212,7 +213,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -284,7 +285,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -356,7 +357,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -427,7 +428,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -498,7 +499,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -634,7 +635,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -776,7 +777,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -868,7 +869,7 @@ func TestTranslateIngress(t *testing.T) {
 				{
 					Namespace: corev1.NamespaceDefault,
 					Service: kong.Service{
-						Name:           kong.String("default.test-ingress.test-service1.80"),
+						Name:           kong.String("default.test-service1.80"),
 						Host:           kong.String("test-service1.default.80.svc"),
 						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 						Path:           kong.String("/"),
@@ -911,7 +912,7 @@ func TestTranslateIngress(t *testing.T) {
 				{
 					Namespace: corev1.NamespaceDefault,
 					Service: kong.Service{
-						Name:           kong.String("default.test-ingress.test-service2.80"),
+						Name:           kong.String("default.test-service2.80"),
 						Host:           kong.String("test-service2.default.80.svc"),
 						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 						Path:           kong.String("/"),
@@ -1011,7 +1012,7 @@ func TestTranslateIngress(t *testing.T) {
 				{
 					Namespace: corev1.NamespaceDefault,
 					Service: kong.Service{
-						Name:           kong.String("default.test-ingress.ad-service.80"),
+						Name:           kong.String("default.ad-service.80"),
 						Host:           kong.String("ad-service.default.80.svc"),
 						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 						Path:           kong.String("/"),
@@ -1054,7 +1055,7 @@ func TestTranslateIngress(t *testing.T) {
 				{
 					Namespace: corev1.NamespaceDefault,
 					Service: kong.Service{
-						Name:           kong.String("default.test-ingress.mad-service.80"),
+						Name:           kong.String("default.mad-service.80"),
 						Host:           kong.String("mad-service.default.80.svc"),
 						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 						Path:           kong.String("/"),
@@ -1128,7 +1129,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.80"),
+					Name:           kong.String("default.test-service.80"),
 					Host:           kong.String("test-service.default.80.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -1202,7 +1203,7 @@ func TestTranslateIngress(t *testing.T) {
 			expected: []*kongstate.Service{{
 				Namespace: corev1.NamespaceDefault,
 				Service: kong.Service{
-					Name:           kong.String("default.test-ingress.test-service.http"),
+					Name:           kong.String("default.test-service.http"),
 					Host:           kong.String("test-service.default.http.svc"),
 					ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
 					Path:           kong.String("/"),
@@ -1252,6 +1253,8 @@ func TestTranslateIngress(t *testing.T) {
 	for _, tt := range tts {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			index := NewIngressTranslationIndex()
+
 			checkOnlyObjectMeta := cmp.Transformer("checkOnlyObjectMeta", func(i *netv1.Ingress) *netv1.Ingress {
 				// In the result we only care about ingresses' metadata being equal.
 				// We ignore specification to simplify tests.
@@ -1259,7 +1262,8 @@ func TestTranslateIngress(t *testing.T) {
 					ObjectMeta: i.ObjectMeta,
 				}
 			})
-			diff := cmp.Diff(tt.expected, TranslateIngress(tt.ingress, tt.addRegexPrefix), checkOnlyObjectMeta)
+			noopAddRegexPrefix := func(s string) *string { return lo.ToPtr(s) }
+			diff := cmp.Diff(tt.expected, TranslateIngress(tt.ingress, index, noopAddRegexPrefix, tt.addRegexPrefix), checkOnlyObjectMeta)
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

I think we should not create a separate kong service for every ingress that uses a k8s service when combinedRoutes feature is enabled.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
