### PR TITLE
fix: don't constrain test helpers with build tags

### DIFF
--- a/test/internal/helpers/teardown.go
+++ b/test/internal/helpers/teardown.go
@@ -1,6 +1,3 @@
-//go:build integration_tests || e2e_tests
-// +build integration_tests e2e_tests
-
 package helpers
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent test failures like : https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4012330723/jobs/6890689291#step:6:37 don't constrain test helpers with build tags.

Just let anyone use them from wherever.
