### PR TITLE
tests: don't share context in integration tests

### DIFF
--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,8 +28,10 @@ import (
 )
 
 func TestConsumerCredential(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)

--- a/test/integration/crd_validations_test.go
+++ b/test/integration/crd_validations_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -19,6 +20,8 @@ import (
 
 // TestCRDValidations ensures that CRD validations we expect to exist are properly disallowing faulty objects to be created.
 func TestCRDValidations(t *testing.T) {
+	ctx := context.Background()
+
 	testCases := []struct {
 		name          string
 		scenario      func(t *testing.T, cleaner *clusters.Cleaner, ns string)
@@ -90,7 +93,7 @@ func TestCRDValidations(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ns, cleaner := setup(t)
+			ns, cleaner := setup(ctx, t)
 
 			tt.scenario(t, cleaner, ns.GetName())
 		})
@@ -104,7 +107,7 @@ func createFaultyTCPIngress(t *testing.T, cleaner *clusters.Cleaner, ns string, 
 	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
-	ingress, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns).Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns).Create(context.Background(), ingress, metav1.CreateOptions{})
 	if !assert.Error(t, err) {
 		cleaner.Add(ingress)
 	}
@@ -140,7 +143,7 @@ func createFaultyUDPIngress(t *testing.T, cleaner *clusters.Cleaner, ns string, 
 	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
-	ingress, err = gatewayClient.ConfigurationV1beta1().UDPIngresses(ns).Create(ctx, ingress, metav1.CreateOptions{})
+	ingress, err = gatewayClient.ConfigurationV1beta1().UDPIngresses(ns).Create(context.Background(), ingress, metav1.CreateOptions{})
 	if !assert.Error(t, err) {
 		cleaner.Add(ingress)
 	}

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -32,7 +32,9 @@ const examplesDIR = "../../examples"
 var httprouteExampleManifests = fmt.Sprintf("%s/gateway-httproute.yaml", examplesDIR)
 
 func TestHTTPRouteExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Logf("configuring test and setting up API clients")
 	gwc, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -100,7 +102,9 @@ func TestHTTPRouteExample(t *testing.T) {
 var udpRouteExampleManifests = fmt.Sprintf("%s/gateway-udproute.yaml", examplesDIR)
 
 func TestUDPRouteExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Log("locking Gateway UDP ports")
 	udpMutex.Lock()
@@ -138,7 +142,9 @@ func TestUDPRouteExample(t *testing.T) {
 var tcprouteExampleManifests = fmt.Sprintf("%s/gateway-tcproute.yaml", examplesDIR)
 
 func TestTCPRouteExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Log("locking Gateway TCP ports")
 	tcpMutex.Lock()
@@ -160,7 +166,9 @@ func TestTCPRouteExample(t *testing.T) {
 var tlsrouteExampleManifests = fmt.Sprintf("%s/gateway-tlsroute.yaml", examplesDIR)
 
 func TestTLSRouteExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
@@ -186,7 +194,9 @@ func TestTLSRouteExample(t *testing.T) {
 var ingressExampleManifests = fmt.Sprintf("%s/ingress.yaml", examplesDIR)
 
 func TestIngressExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Logf("applying yaml manifest %s", strings.TrimPrefix(ingressExampleManifests, examplesDIR))
 	b, err := os.ReadFile(ingressExampleManifests)
@@ -234,7 +244,9 @@ func TestIngressExample(t *testing.T) {
 var udpingressExampleManifests = fmt.Sprintf("%s/udpingress.yaml", examplesDIR)
 
 func TestUDPIngressExample(t *testing.T) {
-	_, cleaner := setup(t)
+	ctx := context.Background()
+
+	_, cleaner := setup(ctx, t)
 
 	t.Log("locking Gateway UDP ports")
 	udpMutex.Lock()

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -37,9 +38,11 @@ const (
 )
 
 func TestUnmanagedGatewayBasics(t *testing.T) {
+	ctx := context.Background()
+
 	var gw *gatewayv1beta1.Gateway
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("gathering test data and generating a gateway kubernetes client")
 	pubsvc, err := env.Cluster().Client().CoreV1().Services(controllerNamespace).Get(ctx, "ingress-controller-kong-proxy", metav1.GetOptions{})
@@ -125,9 +128,11 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 }
 
 func TestGatewayListenerConflicts(t *testing.T) {
+	ctx := context.Background()
+
 	var gw *gatewayv1beta1.Gateway
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("generating a gateway kubernetes client and gathering test data")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -349,7 +354,9 @@ func TestGatewayListenerConflicts(t *testing.T) {
 }
 
 func TestUnmanagedGatewayControllerSupport(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("generating a gateway kubernetes client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -378,7 +385,9 @@ func TestUnmanagedGatewayControllerSupport(t *testing.T) {
 }
 
 func TestUnmanagedGatewayClass(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("generating a gateway kubernetes client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -421,7 +430,9 @@ func TestUnmanagedGatewayClass(t *testing.T) {
 }
 
 func TestManagedGatewayClass(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("generating a gateway kubernetes client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -470,7 +481,9 @@ func TestManagedGatewayClass(t *testing.T) {
 }
 
 func TestGatewayFilters(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	other, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name()+"other")
 	require.NoError(t, err)

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -21,13 +22,15 @@ import (
 )
 
 func TestGatewayValidationWebhook(t *testing.T) {
-	ns := namespace(t)
+	ctx := context.Background()
+
+	ns := namespace(ctx, t)
 
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")
 	}
 
-	closer, err := ensureAdmissionRegistration(
+	closer, err := ensureAdmissionRegistration(ctx,
 		"kong-validations-gateway",
 		[]admregv1.RuleWithOperations{
 			{

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -153,7 +153,7 @@ func HTTPRouteMatchesAcceptedCallback(t *testing.T, c *gatewayclient.Clientset, 
 
 func httpRouteAcceptedConditionMatches(t *testing.T, c *gatewayclient.Clientset, httpRoute *gatewayv1beta1.HTTPRoute, accepted bool, reason gatewayv1beta1.RouteConditionReason) bool {
 	var err error
-	httpRoute, err = c.GatewayV1beta1().HTTPRoutes(httpRoute.Namespace).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+	httpRoute, err = c.GatewayV1beta1().HTTPRoutes(httpRoute.Namespace).Get(context.Background(), httpRoute.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	if len(httpRoute.Status.Parents) <= 0 {
@@ -240,6 +240,8 @@ func gatewayLinkStatusMatches(
 	protocolType gatewayv1beta1.ProtocolType,
 	namespace, name string,
 ) bool {
+	ctx := context.Background()
+
 	// gather a fresh copy of the route, given the specific protocol type
 	switch protocolType { //nolint:exhaustive
 	case gatewayv1beta1.HTTPProtocolType:
@@ -320,6 +322,8 @@ func verifyProgrammedConditionStatus(t *testing.T,
 	namespace, name string,
 	expectedStatus metav1.ConditionStatus,
 ) bool {
+	ctx := context.Background()
+
 	// gather a fresh copy of the route, given the specific protocol type
 	switch protocolType { //nolint:exhaustive
 	case gatewayv1beta1.HTTPProtocolType:

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -33,7 +34,9 @@ import (
 var emptyHeaderSet = make(map[string]string)
 
 func TestHTTPRouteEssentials(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting a gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -303,7 +306,9 @@ func TestHTTPRouteEssentials(t *testing.T) {
 }
 
 func TestHTTPRouteMultipleServices(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting a gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -486,7 +491,9 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 }
 
 func TestHTTPRouteFilterHosts(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	listenerHostname := gatewayv1beta1.Hostname("test.specific.io")
 

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -17,7 +18,9 @@ import (
 )
 
 func TestHTTPRouteValidationWebhook(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")
@@ -25,7 +28,7 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 
 	pathMatchRegex := gatewayv1beta1.PathMatchRegularExpression
 
-	closer, err := ensureAdmissionRegistration(
+	closer, err := ensureAdmissionRegistration(ctx,
 		"kong-validations-gateway",
 		[]admregv1.RuleWithOperations{
 			{

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -133,8 +133,10 @@ QLAtVaZd9SSi4Z/RX6B4L3Rj0Mwfn+tbrtYO5Pyhi40hiXf4aMgbVDFYMR0MMmH0
 }
 
 func TestHTTPSRedirect(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("creating an HTTP container via deployment to test redirect functionality")
 	container := generators.NewContainer("alsohttpbin", test.HTTPBinImage, 80)
@@ -179,8 +181,10 @@ func TestHTTPSRedirect(t *testing.T) {
 }
 
 func TestHTTPSIngress(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -23,10 +24,12 @@ import (
 )
 
 func TestIngressRegexMatchPath(t *testing.T) {
+	ctx := context.Background()
+
 	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
 		t.Skip("regex prefixes are only relevant for Kong 3.0+")
 	}
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	pathRegexPrefix := "/~"
 	pathTypeImplementationSpecific := netv1.PathTypeImplementationSpecific
@@ -175,10 +178,12 @@ func TestIngressRegexMatchPath(t *testing.T) {
 }
 
 func TestIngressRegexMatchHeader(t *testing.T) {
+	ctx := context.Background()
+
 	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
 		t.Skip("regex prefixes are only relevant for Kong 3.0+")
 	}
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	headerRegexPrefix := "~*"
 	matchHeaderKey := "X-Kic-Test-Match"

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -39,6 +40,8 @@ const extraIngressNamespace = "elsewhere"
 var ingressClassMutex = sync.Mutex{}
 
 func TestIngressEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	t.Log("locking IngressClass management")
 	ingressClassMutex.Lock()
@@ -46,7 +49,7 @@ func TestIngressEssentials(t *testing.T) {
 		t.Log("unlocking IngressClass management")
 		ingressClassMutex.Unlock()
 	}()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -197,8 +200,10 @@ func TestIngressEssentials(t *testing.T) {
 }
 
 func TestGRPCIngressEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns := namespace(t)
+	ns := namespace(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("grpcbin", "moul/grpcbin", 9001)
@@ -262,6 +267,8 @@ func TestGRPCIngressEssentials(t *testing.T) {
 }
 
 func TestIngressClassNameSpec(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	t.Log("locking IngressClass management")
 	ingressClassMutex.Lock()
@@ -269,7 +276,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 		t.Log("unlocking IngressClass management")
 		ingressClassMutex.Unlock()
 	}()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	if clusterVersion.Major < uint64(2) && clusterVersion.Minor < uint64(19) {
 		t.Skip("ingress spec tests can not be properly validated against old clusters")
@@ -387,6 +394,8 @@ func TestIngressClassNameSpec(t *testing.T) {
 }
 
 func TestIngressNamespaces(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 
 	t.Log("creating extra testing namespaces")
@@ -459,8 +468,10 @@ func TestIngressNamespaces(t *testing.T) {
 }
 
 func TestIngressStatusUpdatesExtended(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns := namespace(t)
+	ns := namespace(ctx, t)
 
 	if clusterVersion.Major == uint64(1) && clusterVersion.Minor < uint64(19) {
 		t.Skip("status test disabled for old cluster versions")
@@ -605,6 +616,8 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 // parallel: parts of the test may add this route _without_ the prefix, and the 3.x router really hates this and will
 // stop working altogether.
 func TestIngressClassRegexToggle(t *testing.T) {
+	ctx := context.Background()
+
 	// the manager runs in a goroutine and may not have pulled the version before this test starts
 	require.Eventually(t, func() bool {
 		return !versions.GetKongVersion().Full().EQ(semver.MustParse("0.0.0"))
@@ -626,7 +639,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 		t.Log("unlocking IngressClass management")
 		ingressClassMutex.Unlock()
 	}()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -740,10 +753,12 @@ func TestIngressClassRegexToggle(t *testing.T) {
 }
 
 func TestIngressRegexPrefix(t *testing.T) {
+	ctx := context.Background()
+
 	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
 		t.Skip("regex prefixes are only relevant for Kong 3.0+")
 	}
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -900,7 +915,9 @@ func TestIngressRegexPrefix(t *testing.T) {
 }
 
 func TestIngressRecoverFromInvalidPath(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	// TODO: run this separately, make it not to affect other tests for sharing Kong.
 	if !runInvalidConfigTests {
@@ -1109,7 +1126,9 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 }
 
 func TestIngressMatchByHost(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -1203,8 +1222,10 @@ func TestIngressMatchByHost(t *testing.T) {
 }
 
 func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	client := env.Cluster().Client()
 

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -38,12 +38,14 @@ const (
 var knativeMinKubernetesVersion = semver.MustParse("1.22.0")
 
 func TestKnativeIngress(t *testing.T) {
+	ctx := context.Background()
+
 	if clusterVersion.LT(knativeMinKubernetesVersion) {
 		t.Skip("knative tests can't be run on cluster versions prior to", knativeMinKubernetesVersion)
 	}
 
 	t.Parallel()
-	ns := namespace(t)
+	ns := namespace(ctx, t)
 
 	t.Log("generating a knative clientset")
 	dynamicClient, err := dynamic.NewForConfig(env.Cluster().Config())

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,8 +27,10 @@ import (
 )
 
 func TestKongIngressEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns := namespace(t)
+	ns := namespace(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	testName := "minking"

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
@@ -20,13 +21,15 @@ import (
 )
 
 func TestKongIngressValidationWebhook(t *testing.T) {
+	ctx := context.Background()
+
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")
 	}
 
-	ns, _ := setup(t)
+	ns, _ := setup(ctx, t)
 
-	closer, err := ensureAdmissionRegistration(
+	closer, err := ensureAdmissionRegistration(ctx,
 		"kong-validations-kongingress",
 		[]admregv1.RuleWithOperations{
 			{

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,8 +32,10 @@ import (
 )
 
 func TestPluginEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
@@ -190,6 +193,8 @@ func TestPluginEssentials(t *testing.T) {
 }
 
 func TestPluginOrdering(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	// the manager runs in a goroutine and may not have pulled the version before this test starts
 	require.Eventually(t, func() bool {
@@ -198,7 +203,7 @@ func TestPluginOrdering(t *testing.T) {
 	if !versions.GetKongVersion().MajorOnly().GTE(versions.PluginOrderingVersionCutoff) || kongEnterpriseEnabled == "" {
 		t.Skip("plugin ordering requires Kong Enterprise 3.0+")
 	}
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -37,7 +37,7 @@ var k8sClient *kubernetes.Clientset
 
 // generateKongBuilder returns a Kong KTF addon builder and a string slice of controller arguments needed to interact
 // with the addon.
-func generateKongBuilder() (*kong.Builder, []string) {
+func generateKongBuilder(ctx context.Context) (*kong.Builder, []string) {
 	kongbuilder := kong.NewBuilder()
 	extraControllerArgs := []string{}
 	if kongEnterpriseEnabled == "true" {
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 	defer func() {
 		os.Exit(code)
 	}()
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Logger needs to be configured before anything else happens.
@@ -101,7 +101,7 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Println("INFO: setting up test environment")
-	kongbuilder, extraControllerArgs := generateKongBuilder()
+	kongbuilder, extraControllerArgs := generateKongBuilder(ctx)
 	kongAddon := kongbuilder.Build()
 	builder := environments.NewBuilder().WithAddons(kongAddon)
 

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -33,6 +34,8 @@ var (
 )
 
 func TestTCPIngressEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	// Ensure no other TCP tests run concurrently to avoid fights over the port
 	// Free it when done
@@ -43,7 +46,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 		tcpMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("setting up the TCPIngress tests")
 	testName := "tcpingress"
@@ -138,6 +141,8 @@ func TestTCPIngressEssentials(t *testing.T) {
 }
 
 func TestTCPIngressTLS(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	t.Log("locking TLS port")
 	tlsMutex.Lock()
@@ -146,7 +151,7 @@ func TestTCPIngressTLS(t *testing.T) {
 		tlsMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("setting up the TCPIngress tests")
 	testName := "tcpingress-%s"
@@ -295,6 +300,8 @@ func TestTCPIngressTLS(t *testing.T) {
 }
 
 func TestTCPIngressTLSPassthrough(t *testing.T) {
+	ctx := context.Background()
+
 	version, err := getKongVersion()
 	if err != nil {
 		t.Logf("attempting TLS passthrough test despite unknown kong version: %v", err)
@@ -310,7 +317,7 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 		tlsMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("setting up the TCPIngress TLS passthrough tests")
 	testName := "tlspass"

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +34,8 @@ const (
 )
 
 func TestTCPRouteEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	defer func() {
@@ -41,7 +44,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 		tcpMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -415,6 +418,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 }
 
 func TestTCPRouteReferenceGrant(t *testing.T) {
+	ctx := context.Background()
+
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	defer func() {
@@ -422,7 +427,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 		tcpMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	otherNs, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
 	require.NoError(t, err)

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -98,6 +99,8 @@ const (
 )
 
 func TestTLSRouteEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
 	t.Log("locking TLS port")
 	tlsMutex.Lock()
@@ -106,7 +109,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 		tlsMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
@@ -465,6 +468,8 @@ func TestTLSRouteEssentials(t *testing.T) {
 // TestTLSRouteReferenceGrant tests cross-namespace certificate references. These are technically implemented within
 // Gateway Listeners, but require an attached Route to see the associated certificate behavior on the proxy.
 func TestTLSRouteReferenceGrant(t *testing.T) {
+	ctx := context.Background()
+
 	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
 	t.Log("locking TLS port")
 	tlsMutex.Lock()
@@ -473,7 +478,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 		tlsMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	otherNs, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
 	require.NoError(t, err)
@@ -694,6 +699,8 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 }
 
 func TestTLSRoutePassthrough(t *testing.T) {
+	ctx := context.Background()
+
 	backendTLSPort := gatewayv1alpha2.PortNumber(tlsEchoPort)
 	t.Log("locking TLS port")
 	tlsMutex.Lock()
@@ -702,7 +709,7 @@ func TestTLSRoutePassthrough(t *testing.T) {
 		tlsMutex.Unlock()
 	}()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -36,6 +37,8 @@ const testTranslationFailuresObjectsPrefix = "translation-failures-"
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
+	ctx := context.Background()
+
 	type expectedTranslationFailure struct {
 		causingObjects []client.Object
 		reasonContains string
@@ -208,7 +211,7 @@ func TestTranslationFailures(t *testing.T) {
 				require.NoError(t, err)
 				cleaner.Add(secret2)
 
-				gateway := deployGatewayReferringSecrets(t, cleaner, ns, secret1, secret2)
+				gateway := deployGatewayReferringSecrets(ctx, t, cleaner, ns, secret1, secret2)
 
 				return expectedTranslationFailure{
 					causingObjects: []client.Object{gateway},
@@ -226,7 +229,7 @@ func TestTranslationFailures(t *testing.T) {
 				require.NoError(t, err)
 				cleaner.Add(emptySecret)
 
-				gateway := deployGatewayReferringSecrets(t, cleaner, ns, emptySecret)
+				gateway := deployGatewayReferringSecrets(ctx, t, cleaner, ns, emptySecret)
 
 				return expectedTranslationFailure{
 					causingObjects: []client.Object{gateway, emptySecret},
@@ -322,7 +325,7 @@ func TestTranslationFailures(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ns, cleaner := setup(t)
+			ns, cleaner := setup(ctx, t)
 
 			expected := tt.translationFailureTrigger(t, cleaner, ns.GetName())
 
@@ -527,7 +530,7 @@ func validService() *corev1.Service {
 	}
 }
 
-func deployGatewayReferringSecrets(t *testing.T, cleaner *clusters.Cleaner, ns string, secrets ...*corev1.Secret) *gatewayv1beta1.Gateway {
+func deployGatewayReferringSecrets(ctx context.Context, t *testing.T, cleaner *clusters.Cleaner, ns string, secrets ...*corev1.Secret) *gatewayv1beta1.Gateway {
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -32,8 +32,10 @@ var udpMutex sync.Mutex
 const coreDNSImage = "k8s.gcr.io/coredns/coredns:v1.8.6"
 
 func TestUDPIngressEssentials(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	// Ensure no other UDP tests run concurrently to avoid fights over the port
 	t.Log("locking UDP port")
@@ -153,6 +155,8 @@ func TestUDPIngressEssentials(t *testing.T) {
 }
 
 func TestUDPIngressTCPIngressCollision(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	t.Log("locking TCP and UDP ports")
 	udpMutex.Lock()
@@ -161,7 +165,7 @@ func TestUDPIngressTCPIngressCollision(t *testing.T) {
 	defer udpMutex.Unlock()
 	defer tcpMutex.Unlock()
 
-	ns, cleaner := setup(t)
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("configuring coredns corefile")
 	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -27,7 +27,9 @@ import (
 const testdomain = "konghq.com"
 
 func TestUDPRouteEssentials(t *testing.T) {
-	ns, cleaner := setup(t)
+	ctx := context.Background()
+
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("locking UDP port")
 	udpMutex.Lock()
@@ -334,10 +336,10 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that DNS queries are being load-balanced between multiple CoreDNS pods")
-	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
-	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
-	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
-	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(ctx, resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(ctx, resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(ctx, resolver, testdomain, "10.0.0.1") }, ingressWait, waitTick)
+	require.Eventually(t, func() bool { return isDNSResolverReturningExpectedResult(ctx, resolver, testdomain, "10.0.0.2") }, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
@@ -354,7 +356,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 }
 
-func isDNSResolverReturningExpectedResult(resolver *net.Resolver, host, addr string) bool { //nolint:unparam
+func isDNSResolverReturningExpectedResult(ctx context.Context, resolver *net.Resolver, host, addr string) bool { //nolint:unparam
 	addrs, err := resolver.LookupHost(ctx, host)
 	if err != nil {
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the shared `context.Context` and `context.CancelFunc` from integration tests.

This makes us one step closer to more isolated tests.
