### PR TITLE
tests: add matrix for integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,7 +116,8 @@ jobs:
         name: tests-report
         path: unit-tests.xml
 
-  integration-tests-enterprise-postgres:
+  integration-tests:
+    name: integration-tests-${{ matrix.name }}
     runs-on: ubuntu-latest
     env:
       PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
@@ -128,28 +129,51 @@ jobs:
     # secrets context is only available at this level.
     #
     # ref: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: dbless
+          test: dbless
+        - name: postgres
+          test: postgres
+        - name: feature-gates
+          test: dbless
+          feature_gates: "GatewayAlpha=true,CombinedRoutes=false"
+        - name: dbless-knative
+          test: dbless.knative
+        - name: postgres-knative
+          test: postgres.knative
+        - name: enterprise-postgres
+          test: enterprise.postgres
+          enterprise: true
+
     steps:
 
     - uses: Kong/kong-license@master
-      if: env.PULP_PASSWORD != ''
+      if: env.PULP_PASSWORD != '' && matrix.enterprise
       id: license
       with:
         password: ${{ env.PULP_PASSWORD }}
 
+    - name: Detect if we should run if we're running enterprise tests but no license is available
+      id: detect_if_should_run
+      run: echo "result=${{ (steps.license.outputs.license != '' && matrix.enterprise) || (!matrix.enterprise) }}" >> $GITHUB_OUTPUT
+
     - name: checkout repository
-      if: env.PULP_PASSWORD != ''
+      if: steps.detect_if_should_run.outputs.result
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: setup golang
-      if: env.PULP_PASSWORD != ''
+      if: steps.detect_if_should_run.outputs.result
       uses: actions/setup-go@v3
       with:
         go-version: '^1.19'
 
     - name: cache go modules
-      if: env.PULP_PASSWORD != ''
+      if: steps.detect_if_should_run.outputs.result
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
@@ -157,183 +181,36 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-codegen-
 
-    - name: run integration tests
-      if: env.PULP_PASSWORD != ''
-      run: make test.integration.enterprise.postgres
+    - name: run make test.integration.${{ matrix.test }}
+      if: steps.detect_if_should_run.outputs.result
+      run: make test.integration.${{ matrix.test }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        GOTESTSUM_JUNITFILE: "integration-tests-enterprise-postgres.xml"
+        KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
+        GOTESTSUM_JUNITFILE: "integration-tests-${{ matrix.name }}.xml"
 
     - name: collect test coverage
-      if: env.PULP_PASSWORD != ''
+      if: steps.detect_if_should_run.outputs.result
       uses: actions/upload-artifact@v3
       with:
         name: coverage
-        path: coverage.enterprisepostgres.out
+        path: coverage.*.out
 
     - name: upload diagnostics
-      if: ${{ failure() && env.PULP_PASSWORD != '' }}
+      if: ${{ !cancelled() && steps.detect_if_should_run.outputs.result }}
       uses: actions/upload-artifact@v3
       with:
-        name: diagnostics-integration-tests-enterprise-postgres
+        name: diagnostics-integration-tests-${{ matrix.name }}
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
 
     - name: collect test report
-      if: env.PULP_PASSWORD != ''
+      if: ${{ !cancelled() && steps.detect_if_should_run.outputs.result }}
       uses: actions/upload-artifact@v3
       with:
         name: tests-report
-        path: integration-tests-enterprise-postgres.xml
-
-  integration-tests-dbless:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
-    - name: run integration tests
-      run: make test.integration.dbless
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOTESTSUM_JUNITFILE: "integration-tests-dbless.xml"
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: coverage.dbless.out
-
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-integration-tests-dbless
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: integration-tests-dbless.xml
-
-  integration-tests-postgres:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
-    - name: run integration tests
-      run: make test.integration.postgres
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOTESTSUM_JUNITFILE: "integration-tests-postgres.xml"
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: coverage.postgres.out
-
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-integration-tests-postgres
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: integration-tests-postgres.xml
-
-  integration-tests-feature-gates:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: setup golang
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
-    - name: run integration tests
-      run: make test.integration.dbless
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KONG_CONTROLLER_FEATURE_GATES: "GatewayAlpha=true,CombinedRoutes=false"
-        GOTESTSUM_JUNITFILE: "integration-tests-feature-gates.xml"
-
-    - name: collect test coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: coverage.featuregates.out
-
-    - name: upload diagnostics
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: diagnostics-integration-tests-feature-gates
-        path: /tmp/ktf-diag*
-        if-no-files-found: ignore
-
-    - name: collect test report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests-report
-        path: integration-tests-feature-gates.xml
+        path: integration-tests-${{ matrix.name }}.xml
 
   conformance-tests:
     runs-on: ubuntu-latest
@@ -369,13 +246,22 @@ jobs:
         name: tests-report
         path: conformance-tests.xml
 
+  test-passed:
+    runs-on: ubuntu-latest
+    needs:
+      - "unit-tests"
+      - "integration-tests"
+      - "conformance-tests"
+    if: always()
+    steps:
+    - name: Set workflow outcome
+      if: needs.test.result == 'failure' || needs.test.result == 'cancelled'
+      run: ${{ false }}
+
   coverage:
     needs:
       - "unit-tests"
-      - "integration-tests-dbless"
-      - "integration-tests-postgres"
-      - "integration-tests-enterprise-postgres"
-      - "integration-tests-feature-gates"
+      - "integration-tests"
     runs-on: ubuntu-latest
     steps:
 
@@ -403,10 +289,7 @@ jobs:
   buildpulse-report:
     needs:
       - "unit-tests"
-      - "integration-tests-dbless"
-      - "integration-tests-postgres"
-      - "integration-tests-enterprise-postgres"
-      - "integration-tests-feature-gates"
+      - "integration-tests"
       - "conformance-tests"
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ _check.container.environment:
 .PHONY: _test.integration
 _test.integration: _check.container.environment gotestsum
 	TEST_DATABASE_MODE="$(DBMODE)" \
-		GOFLAGS="-tags=integration_tests" \
+		GOFLAGS="-tags=$(GOTAGS)" \
 		KONG_CONTROLLER_FEATURE_GATES=$(KONG_CONTROLLER_FEATURE_GATES) \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) -- $(GOTESTFLAGS) \
@@ -338,28 +338,48 @@ _test.integration: _check.container.environment gotestsum
 		-coverprofile=$(COVERAGE_OUT) \
 		./test/integration
 
+.PHONY: test.integration.dbless.knative
+test.integration.dbless.knative:
+	@$(MAKE) _test.integration \
+		GOTAGS="integration_tests,knative" \
+		GOTESTFLAGS="-run TestKnative" \
+		DBMODE=off \
+		COVERAGE_OUT=coverage.dbless.knative.out
+
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@$(MAKE) _test.integration \
+		GOTAGS="integration_tests" \
 		DBMODE=off \
 		COVERAGE_OUT=coverage.dbless.out
 
 .PHONY: test.integration.dbless.pretty
 test.integration.dbless.pretty:
 	@$(MAKE) GOTESTSUM_FORMAT=pkgname _test.integration \
+		GOTAGS="integration_tests" \
 		DBMODE=off \
 		GOTESTFLAGS="-json" \
 		COVERAGE_OUT=coverage.dbless.out
 
+.PHONY: test.integration.postgres.knative
+test.integration.postgres.knative:
+	@$(MAKE) _test.integration \
+		GOTAGS="integration_tests,knative" \
+		GOTESTFLAGS="-run TestKnative" \
+		DBMODE=postgres \
+		COVERAGE_OUT=coverage.postgres.knative.out
+
 .PHONY: test.integration.postgres
 test.integration.postgres:
 	@$(MAKE) _test.integration \
+		GOTAGS="integration_tests" \
 		DBMODE=postgres \
 		COVERAGE_OUT=coverage.postgres.out
 
 .PHONY: test.integration.postgres.pretty
 test.integration.postgres.pretty:
 	@$(MAKE) GOTESTSUM_FORMAT=pkgname _test.integration \
+		GOTAGS="integration_tests" \
 		DBMODE=postgres \
 		GOTESTFLAGS="-json" \
 		COVERAGE_OUT=coverage.postgres.out
@@ -367,6 +387,7 @@ test.integration.postgres.pretty:
 .PHONY: test.integration.enterprise.postgres
 test.integration.enterprise.postgres:
 	@TEST_KONG_ENTERPRISE="true" \
+		GOTAGS="integration_tests" \
 		$(MAKE) _test.integration \
 		DBMODE=postgres \
 		COVERAGE_OUT=coverage.enterprisepostgres.out
@@ -374,6 +395,7 @@ test.integration.enterprise.postgres:
 .PHONY: test.integration.enterprise.postgres.pretty
 test.integration.enterprise.postgres.pretty:
 	@TEST_KONG_ENTERPRISE="true" \
+		GOTAGS="integration_tests" \
 		GOTESTSUM_FORMAT=pkgname \
 		$(MAKE) _test.integration \
 		DBMODE=postgres \

--- a/test/integration/addons_knative_test.go
+++ b/test/integration/addons_knative_test.go
@@ -1,0 +1,35 @@
+//go:build integration_tests && knative
+// +build integration_tests,knative
+
+package integration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
+)
+
+// knativeMinKubernetesVersion indicates the minimum Kubernetes version
+// required in order to successfully run Knative tests.
+var knativeMinKubernetesVersion = semver.MustParse("1.22.0")
+
+func DeployAddonsForCluster(ctx context.Context, cluster clusters.Cluster) error {
+	v, err := cluster.Version()
+	if err != nil {
+		return err
+	}
+
+	if v.GE(knativeMinKubernetesVersion) {
+		knativeAddon := knative.NewBuilder().Build()
+		fmt.Println("INFO: deploying knative addon")
+		err := env.Cluster().DeployAddon(ctx, knativeAddon)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -1,0 +1,14 @@
+//go:build integration_tests && !knative
+// +build integration_tests,!knative
+
+package integration
+
+import (
+	"context"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+func DeployAddonsForCluster(ctx context.Context, cluster clusters.Cluster) error {
+	return nil
+}

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -1,5 +1,5 @@
-//go:build integration_tests
-// +build integration_tests
+//go:build integration_tests && knative
+// +build integration_tests,knative
 
 package integration
 
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/stretchr/testify/assert"
@@ -32,10 +31,6 @@ const (
 	// on the cluster. The current value is based on deployment times seen in a GKE environment.
 	knativeWaitTime = time.Minute * 2
 )
-
-// knativeMinKubernetesVersion indicates the minimum Kubernetes version
-// required in order to successfully run Knative tests.
-var knativeMinKubernetesVersion = semver.MustParse("1.22.0")
 
 func TestKnativeIngress(t *testing.T) {
 	ctx := context.Background()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/knative"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
@@ -165,13 +164,8 @@ func TestMain(m *testing.M) {
 	exitOnErr(ctx, err)
 	clusterVersion, err = env.Cluster().Version()
 	exitOnErr(ctx, err)
-	if clusterVersion.GE(knativeMinKubernetesVersion) {
-		fmt.Println("INFO: deploying knative addon")
-		knativeBuilder := knative.NewBuilder()
-		knativeAddon := knativeBuilder.Build()
-		exitOnErr(ctx, env.Cluster().DeployAddon(ctx, knativeAddon))
-	}
 
+	exitOnErr(ctx, DeployAddonsForCluster(ctx, env.Cluster()))
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
 	exitOnErr(ctx, <-env.WaitForReady(ctx))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds matrix for integration tests and extracts knative tests into a separate build tag: `knative`.

By doing this:

- we avoid the need for deploying knative addon where it's not needed (nowhere besides the knative test)
- we extract knative test into a separate Github job (via `matrix`) so we isolate the workflows even further

---

Adding new matrix entries (hence separate, parallel workflow runs for integration tests) is as easy as adding a new intro into:

```yaml
  integration-tests:
    name: integration-tests-${{ matrix.name }}
    runs-on: ubuntu-latest
    ...
    strategy:
      fail-fast: false
      matrix:
        include:
        - name: dbless
          test: dbless
        - name: postgres
          test: postgres
        - name: feature-gates
          test: dbless
          feature_gates: "GatewayAlpha=true,CombinedRoutes=false"
        - name: dbless-knative
          test: dbless.knative
        - name: postgres-knative
          test: postgres.knative
        - name: enterprise-postgres
          test: enterprise.postgres
          enterprise: true
```
