### PR TITLE
tests: use cleanup for locking gateway ports to prevent `defer` and `t.Cleanup` ordering issues

### DIFF
--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -38,13 +38,12 @@ func TestTCPIngressEssentials(t *testing.T) {
 
 	t.Parallel()
 	// Ensure no other TCP tests run concurrently to avoid fights over the port
-	// Free it when done
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TCP port")
 		tcpMutex.Unlock()
-	}()
+	})
 
 	ns, cleaner := setup(ctx, t)
 
@@ -141,16 +140,16 @@ func TestTCPIngressEssentials(t *testing.T) {
 }
 
 func TestTCPIngressTLS(t *testing.T) {
-	ctx := context.Background()
-
 	t.Parallel()
-	t.Log("locking TLS port")
+
+	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TLS port")
 		tlsMutex.Unlock()
-	}()
+	})
 
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	t.Log("setting up the TCPIngress tests")
@@ -300,8 +299,6 @@ func TestTCPIngressTLS(t *testing.T) {
 }
 
 func TestTCPIngressTLSPassthrough(t *testing.T) {
-	ctx := context.Background()
-
 	version, err := getKongVersion()
 	if err != nil {
 		t.Logf("attempting TLS passthrough test despite unknown kong version: %v", err)
@@ -310,13 +307,15 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 	}
 
 	t.Parallel()
-	t.Log("locking TLS port")
+
+	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TLS port")
 		tlsMutex.Unlock()
-	}()
+	})
 
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	t.Log("setting up the TCPIngress TLS passthrough tests")

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -38,11 +38,10 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
-	defer func() {
-		// Free up the TCP port
+	t.Cleanup(func() {
 		t.Log("unlocking TCP port")
 		tcpMutex.Unlock()
-	}()
+	})
 
 	ns, cleaner := setup(ctx, t)
 
@@ -422,10 +421,10 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TCP port")
 		tcpMutex.Unlock()
-	}()
+	})
 
 	ns, cleaner := setup(ctx, t)
 

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -99,16 +99,14 @@ const (
 )
 
 func TestTLSRouteEssentials(t *testing.T) {
-	ctx := context.Background()
-
-	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
-	t.Log("locking TLS port")
+	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TLS port")
 		tlsMutex.Unlock()
-	}()
+	})
 
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting gateway client")
@@ -207,6 +205,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(service2)
 
+	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsRoute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -468,16 +467,14 @@ func TestTLSRouteEssentials(t *testing.T) {
 // TestTLSRouteReferenceGrant tests cross-namespace certificate references. These are technically implemented within
 // Gateway Listeners, but require an attached Route to see the associated certificate behavior on the proxy.
 func TestTLSRouteReferenceGrant(t *testing.T) {
-	ctx := context.Background()
-
-	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
-	t.Log("locking TLS port")
+	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TLS port")
 		tlsMutex.Unlock()
-	}()
+	})
 
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	otherNs, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
@@ -607,6 +604,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(service)
 
+	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsroute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -699,16 +697,14 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 }
 
 func TestTLSRoutePassthrough(t *testing.T) {
-	ctx := context.Background()
-
-	backendTLSPort := gatewayv1alpha2.PortNumber(tlsEchoPort)
-	t.Log("locking TLS port")
+	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
-	defer func() {
+	t.Cleanup(func() {
 		t.Log("unlocking TLS port")
 		tlsMutex.Unlock()
-	}()
+	})
 
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	t.Log("getting gateway client")
@@ -792,6 +788,7 @@ func TestTLSRoutePassthrough(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(service)
 
+	backendTLSPort := gatewayv1alpha2.PortNumber(tlsEchoPort)
 	t.Logf("create a TLSRoute using passthrough listner")
 	sectionName := gatewayv1alpha2.SectionName("tls-passthrough")
 	tlsroute := &gatewayv1alpha2.TLSRoute{

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -32,19 +32,18 @@ var udpMutex sync.Mutex
 const coreDNSImage = "k8s.gcr.io/coredns/coredns:v1.8.6"
 
 func TestUDPIngressEssentials(t *testing.T) {
-	ctx := context.Background()
-
 	t.Parallel()
-	ns, cleaner := setup(ctx, t)
 
 	// Ensure no other UDP tests run concurrently to avoid fights over the port
 	t.Log("locking UDP port")
 	udpMutex.Lock()
-	defer func() {
-		// Free up the UDP port
+	t.Cleanup(func() {
 		t.Log("unlocking UDP port")
 		udpMutex.Unlock()
-	}()
+	})
+
+	ctx := context.Background()
+	ns, cleaner := setup(ctx, t)
 
 	t.Log("configuring coredns corefile")
 	cfgmap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns"}, Data: map[string]string{"Corefile": corefile}}
@@ -155,16 +154,17 @@ func TestUDPIngressEssentials(t *testing.T) {
 }
 
 func TestUDPIngressTCPIngressCollision(t *testing.T) {
-	ctx := context.Background()
-
 	t.Parallel()
+
 	t.Log("locking TCP and UDP ports")
 	udpMutex.Lock()
 	tcpMutex.Lock()
+	t.Cleanup(func() {
+		udpMutex.Unlock()
+		tcpMutex.Unlock()
+	})
 
-	defer udpMutex.Unlock()
-	defer tcpMutex.Unlock()
-
+	ctx := context.Background()
 	ns, cleaner := setup(ctx, t)
 
 	t.Log("configuring coredns corefile")


### PR DESCRIPTION
**What this PR does / why we need it**:

After running

```go
package main

import "testing"

func TestX(t *testing.T) {
        t.Cleanup(func() {
                t.Log("cleanup 1")
        })
        defer func() {
                t.Log("defer 1")
        }()
        t.Cleanup(func() {
                t.Log("cleanup 2")
        })
        defer func() {
                t.Log("defer 2")
        }()
}
```

and getting the following output:

```
=== RUN   TestX
    main_test.go:16: defer 2
    main_test.go:10: defer 1
    main_test.go:13: cleanup 2
    main_test.go:7: cleanup 1
--- PASS: TestX (0.00s)
PASS
ok      defercleanup    0.004s
```

I realized that our approach in tests where we do:

```go
func TestUDPRouteExample(t *testing.T) {
	_, cleaner := setup(ctx, t)

	t.Log("locking Gateway UDP ports")
	udpMutex.Lock()
	defer udpMutex.Unlock()
...
```

Might cause issues because:
- `setup()` registers `cleaner.Cleanup()` via `t.Cleanup()`
- unlocking the mutex is being done via `defer` which as we can see in the output above will always run before cleanup code
- this means that we are first unlocking the port mutex and doing the cleanup afterwards which might lead to other tests attempting to use ports which might still be used.

This PR tries to remediate that by using `t.Cleanup()` for unlocking the mutexes and places those invocations above `setup()` so that first we get the `cleaner.Cleanup()` on test teardown and only afterwards the lock is released.