### PR TITLE
ci: make codeql workflow happy by targeting only main

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,10 +10,9 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
   pull_request:
     branches:
-      - '*'
+      - 'main'
   schedule:
     - cron: '27 0 * * 4'
   workflow_dispatch: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to make codeql happy and prevent the following warning:

> 1 issue was detected with this workflow: Please make sure that every branch in on.pull_request is also in on.push so that Code Scanning can compare pull requests against the state of the base branch.

Let's just run codeql on branches that are in PRs that target `main`.

Codeql run from this branch seems indeed happy: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4025032677