### PR TITLE
tests: don't share http.Client in tests

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -547,7 +547,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	proxyURL := "http://" + getKongProxyIP(ctx, t, env)
 	t.Log("ensuring Ingress does not become live")
 	require.Never(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -602,7 +602,7 @@ func TestDefaultIngressClass(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 // deployGateway deploys a gateway with a new created gateway class and a fixed name `kong`.
@@ -216,9 +217,9 @@ func verifyHTTPRoute(ctx context.Context, t *testing.T, env environments.Environ
 	proxyIP := getKongProxyIP(ctx, t, env)
 
 	t.Logf("waiting for route from Ingress to be operational at http://%s/httpbin", proxyIP)
-	httpc := http.Client{Timeout: time.Second * 10}
+
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/httpbin", proxyIP))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/httpbin", proxyIP))
 		if err != nil {
 			return false
 		}

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -160,7 +160,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	appURL := fmt.Sprintf("%s/httpbin", proxyURL)
 	appStatusOKUrl := fmt.Sprintf("%s/status/200", appURL)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(appStatusOKUrl)
+		resp, err := helpers.DefaultHTTPClient().Get(appStatusOKUrl)
 		if err != nil {
 			return false
 		}
@@ -185,7 +185,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Logf("retrieving the Kiali workload metrics for deployment %s", deployment.Name)
 	respData := kialiWorkloads{}
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/namespaces/%s/apps/%s", kialiAPIUrl, namespace.Name, deployment.Name))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/namespaces/%s/apps/%s", kialiAPIUrl, namespace.Name, deployment.Name))
 		if err != nil {
 			return false
 		}
@@ -210,7 +210,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	var health *workloadHealth
 	var inboundHTTPRequests map[string]float64
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(appStatusOKUrl)
+		resp, err := helpers.DefaultHTTPClient().Get(appStatusOKUrl)
 		if err != nil {
 			return false
 		}
@@ -293,7 +293,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Log("waiting for the rate-limiter plugin to be active")
 	var headers http.Header
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(appStatusOKUrl)
+		resp, err := helpers.DefaultHTTPClient().Get(appStatusOKUrl)
 		if err != nil {
 			return false
 		}
@@ -316,7 +316,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 // verifyStatusForURL is a helper function which given a URL and a status code performs
 // a GET and verifies the status code returning an error if the result isn't as expected.
 func verifyStatusForURL(getURL string, statusCode int) error {
-	resp, err := httpc.Get(getURL)
+	resp, err := helpers.DefaultHTTPClient().Get(getURL)
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func getKialiWorkloadHealth(t *testing.T, kialiAPIUrl string, namespace, workloa
 	req.URL.RawQuery = query.Encode()
 
 	// make the health metrics request
-	resp, err := httpc.Do(req)
+	resp, err := helpers.DefaultHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -31,10 +31,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// httpc is a standard HTTP client for tests to use that has a low default
-// timeout instead of the longer default provided by the http stdlib.
-var httpc = http.Client{Timeout: time.Second * 10}
-
 const (
 	// adminPasswordSecretName is the name of the secret which will house the admin
 	// API admin password.

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -25,6 +25,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 func TestConsumerCredential(t *testing.T) {
@@ -58,7 +59,7 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -112,7 +113,7 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_consumer_credential", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -157,7 +158,7 @@ func TestConsumerCredential(t *testing.T) {
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "test_consumer_credential"), nil)
 		require.NoError(t, err)
 		req.SetBasicAuth("test_consumer_credential", "test_consumer_credential")
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			return false
 		}
@@ -168,7 +169,7 @@ func TestConsumerCredential(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 func TestHealthEndpoint(t *testing.T) {
 	t.Parallel()
 	assert.Eventually(t, func() bool {
 		healthzURL := fmt.Sprintf("http://localhost:%v/healthz", manager.HealthzPort)
-		resp, err := httpc.Get(healthzURL)
+		resp, err := helpers.DefaultHTTPClient().Get(healthzURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", healthzURL, err)
 			return false
@@ -31,7 +32,7 @@ func TestReadyEndpoint(t *testing.T) {
 	t.Parallel()
 	assert.Eventually(t, func() bool {
 		readyzURL := fmt.Sprintf("http://localhost:%v/readyz", manager.HealthzPort)
-		resp, err := httpc.Get(readyzURL)
+		resp, err := helpers.DefaultHTTPClient().Get(readyzURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", readyzURL, err)
 			return false
@@ -45,7 +46,7 @@ func TestProfilingEndpoint(t *testing.T) {
 	t.Parallel()
 	assert.Eventually(t, func() bool {
 		profilingURL := fmt.Sprintf("http://localhost:%v/debug/pprof/", manager.DiagnosticsPort)
-		resp, err := httpc.Get(profilingURL)
+		resp, err := helpers.DefaultHTTPClient().Get(profilingURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", profilingURL, err)
 			return false
@@ -60,13 +61,13 @@ func TestConfigEndpoint(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		successURL := fmt.Sprintf("http://localhost:%v/debug/config/successful", manager.DiagnosticsPort)
 		failURL := fmt.Sprintf("http://localhost:%v/debug/config/failed", manager.DiagnosticsPort)
-		successResp, err := httpc.Get(successURL)
+		successResp, err := helpers.DefaultHTTPClient().Get(successURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", successURL, err)
 			return false
 		}
 		defer successResp.Body.Close()
-		failResp, err := httpc.Get(failURL)
+		failResp, err := helpers.DefaultHTTPClient().Get(failURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", failURL, err)
 			return false

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -25,6 +25,7 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 const examplesDIR = "../../examples"
@@ -67,7 +68,7 @@ func TestHTTPRouteExample(t *testing.T) {
 
 	t.Logf("verifying that the HTTPRoute becomes routable")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
 		if err != nil {
 			return false
 		}
@@ -84,7 +85,7 @@ func TestHTTPRouteExample(t *testing.T) {
 
 	t.Logf("verifying that the backendRefs are being loadbalanced")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
 		if err != nil {
 			return false
 		}
@@ -237,7 +238,7 @@ func TestIngressExample(t *testing.T) {
 
 	t.Logf("verifying that the Ingress resource becomes routable")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("http://%s/", ingAddr))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/", ingAddr))
 		if err != nil {
 			return false
 		}

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -29,6 +29,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 var emptyHeaderSet = make(map[string]string)
@@ -173,7 +174,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 			t.Logf("WARNING: failed to create HTTP request: %v", err)
 			return false
 		}
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, "test-http-route-essentials", err)
 			return false
@@ -569,7 +570,7 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 		req, err := http.NewRequest("GET", proxyURL.String()+"/test-http-route-filter-hosts", nil)
 		require.NoError(t, err)
 		req.Host = host
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			return false
 		}

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 func TestIngressRegexMatchPath(t *testing.T) {
@@ -139,7 +140,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 			require.Eventually(t, func() bool {
 				notMatchedPaths = []string{}
 				for _, path := range tc.matchPaths {
-					resp, err := httpc.Get(fmt.Sprintf("%s%s", proxyURL, path))
+					resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s%s", proxyURL, path))
 					if err != nil {
 						t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 						notMatchedPaths = append(notMatchedPaths, path)
@@ -168,7 +169,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 
 			t.Log("testing paths expected not to match")
 			for _, path := range tc.notMatchPaths {
-				resp, err := httpc.Get(fmt.Sprintf("%s%s", proxyURL, path))
+				resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s%s", proxyURL, path))
 				require.NoError(t, err)
 				defer resp.Body.Close()
 				require.Equalf(t, http.StatusNotFound, resp.StatusCode, "should not match path %s: %s", path, tc.description)
@@ -269,7 +270,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 					req, err := http.NewRequest("GET", proxyURL.String(), nil)
 					req.Header.Add(matchHeaderKey, header)
 					require.NoError(t, err)
-					resp, err := httpc.Do(req)
+					resp, err := helpers.DefaultHTTPClient().Do(req)
 					if err != nil {
 						t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 						return false
@@ -297,7 +298,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 				req, err := http.NewRequest("GET", proxyURL.String(), nil)
 				req.Header.Add(matchHeaderKey, header)
 				require.NoError(t, err)
-				resp, err := httpc.Do(req)
+				resp, err := helpers.DefaultHTTPClient().Do(req)
 				require.NoError(t, err)
 				defer resp.Body.Close()
 				require.Equalf(t, http.StatusNotFound, resp.StatusCode, "should not match host %s", header)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 var ingressClassMutex = sync.Mutex{}
@@ -81,7 +82,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -127,7 +128,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Logf("verifying that removing the ingress.class annotation %q from ingress causes routes to disconnect", ingressClass)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -164,7 +165,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational after reintroducing ingress class annotation")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -185,7 +186,7 @@ func TestIngressEssentials(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -288,7 +289,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Log("waiting for routes from Ingress to be operational")
 	defer func() {
 		if t.Failed() {
-			resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
+			resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 			if err != nil {
 				t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			}
@@ -299,7 +300,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -323,7 +324,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress causes routes to disconnect", ingressClass)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -338,7 +339,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational after reintroducing ingress class annotation")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -360,7 +361,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -403,7 +404,7 @@ func TestIngressNamespaces(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/elsewhere", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/elsewhere", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -674,7 +675,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	// entirely, which would be bad for other tests.
 	t.Log("waiting for ingress path to become available")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_class_regex_toggle/999", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_class_regex_toggle/999", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -804,7 +805,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 
 	t.Log("waiting for ingress path to become available")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_regex_prefix/999", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_regex_prefix/999", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -820,7 +821,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_ingress_regex_prefix_nonstandard/999", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_regex_prefix_nonstandard/999", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -836,7 +837,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/~/test_ingress_regex_prefix_nonstandard_default", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/~/test_ingress_regex_prefix_nonstandard_default", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -917,7 +918,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 
 	t.Log("waiting for ingress path to become available")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/foo/", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/foo/", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -983,7 +984,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("verifying new configuration is not applied to kong proxy")
 	require.Never(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/bar/", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/bar/", proxyURL))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
@@ -991,7 +992,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 
 	t.Log("verifying routes configured before invalid config is still available")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/foo/", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/foo/", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1046,7 +1047,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 
 	t.Log("waiting for ingress path to recover and new path available")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/bar/", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/bar/", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1098,7 +1099,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	require.NoError(t, err)
 	req.Host = "test.example"
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1116,7 +1117,7 @@ func TestIngressMatchByHost(t *testing.T) {
 
 	t.Log("try to access the ingress by unmatching host, should return 404")
 	req.Host = "foo.example"
-	resp, err := httpc.Do(req)
+	resp, err := helpers.DefaultHTTPClient().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -1135,7 +1136,7 @@ func TestIngressMatchByHost(t *testing.T) {
 
 	req.Host = "test0.example"
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1153,7 +1154,7 @@ func TestIngressMatchByHost(t *testing.T) {
 
 	t.Log("try to access the ingress by unmatching host, should return 404")
 	req.Host = "test.another"
-	resp, err = httpc.Do(req)
+	resp, err = helpers.DefaultHTTPClient().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -1224,7 +1225,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(proxyURL.String())
+		resp, err := helpers.DefaultHTTPClient().Get(proxyURL.String())
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 func TestMetricsEndpoint(t *testing.T) {
@@ -26,7 +27,7 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		metricsURL := fmt.Sprintf("http://localhost:%v/metrics", manager.MetricsPort)
-		resp, err := httpc.Get(metricsURL)
+		resp, err := helpers.DefaultHTTPClient().Get(metricsURL)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", metricsURL, err)
 			return false

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -29,6 +29,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 func TestPluginEssentials(t *testing.T) {
@@ -62,7 +63,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -136,7 +137,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -170,7 +171,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Logf("validating that clusterplugin %s was successfully configured", kongclusterplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -182,7 +183,7 @@ func TestPluginEssentials(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -228,7 +229,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -286,7 +287,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", termplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -308,7 +309,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", authplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -330,7 +331,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("validating that plugin %s now takes precedence", termplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -342,7 +343,7 @@ func TestPluginOrdering(t *testing.T) {
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	assert.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -26,6 +26,7 @@ import (
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 var (
@@ -110,7 +111,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 	tcpProxyURL, err := url.Parse(fmt.Sprintf("http://%s:8888/", proxyURL.Hostname()))
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(tcpProxyURL.String())
+		resp, err := helpers.DefaultHTTPClient().Get(tcpProxyURL.String())
 		if err != nil {
 			return false
 		}
@@ -130,7 +131,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 	t.Logf("tearing down TCPIngress %s and ensuring that the relevant backend routes are removed", tcp.Name)
 	require.NoError(t, gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(tcpProxyURL.String())
+		resp, err := helpers.DefaultHTTPClient().Get(tcpProxyURL.String())
 		if err != nil {
 			return true
 		}

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -70,9 +70,6 @@ const (
 )
 
 var (
-	// httpc is the default HTTP client to use for tests.
-	httpc = http.Client{Timeout: httpcTimeout}
-
 	// env is the primary testing environment object which includes access to the Kubernetes cluster
 	// and all the addons deployed in support of the tests.
 	env environments.Environment
@@ -196,13 +193,13 @@ func getKongVersion() (semver.Version, error) {
 		}
 		return semver.Version{Major: version.Major(), Minor: version.Minor(), Patch: version.Patch()}, nil
 	}
-	client := &http.Client{}
+
 	req, err := http.NewRequest("GET", proxyAdminURL.String(), nil)
 	if err != nil {
 		return semver.Version{}, err
 	}
 	req.Header.Set("kong-admin-token", kongTestPassword)
-	resp, err := client.Do(req)
+	resp, err := helpers.DefaultHTTPClient().Do(req)
 	if err != nil {
 		return semver.Version{}, err
 	}
@@ -255,7 +252,7 @@ func eventuallyGETPath(t *testing.T, path string, statusCode int, bodyContents s
 	req := newRequest(t, http.MethodGet, path, headers)
 
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Do(req)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {
 			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, path, err)
 			return false
@@ -322,7 +319,7 @@ func countHTTPGetResponses(t *testing.T,
 }
 
 func countHTTPGetResponse(t *testing.T, req *http.Request, matchCounter map[string]int, matchers ...responseMatcher) {
-	resp, err := httpc.Do(req)
+	resp, err := helpers.DefaultHTTPClient().Do(req)
 	if err != nil {
 		return
 	}

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -1,0 +1,14 @@
+package helpers
+
+import (
+	"net/http"
+	"time"
+)
+
+// DefaultHTTPClient returns a client that should be used by default in tests.
+// All defaults that should be propagated to tests for use should be changed in here.
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the shared `http.Client` instance and changes all references to it to call introduced in this PR `helpers.DefaultHTTPClient()` function.

This is part of an effort to extract everything from `utils_test.go` and `suite_test.go` so that we're able to initiate tests from different directories and not share variables.