### PR TITLE
refactor: extract gateway controller name utils

### DIFF
--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -314,7 +314,7 @@ func (validator KongHTTPValidator) ValidateGateway(
 
 	// validate whether the gatewayclass is a supported class, if not
 	// then this gateway belongs to another controller.
-	if gwc.Spec.ControllerName != gatewaycontroller.ControllerName {
+	if gwc.Spec.ControllerName != gatewaycontroller.GetControllerName() {
 		return true, "", nil
 	}
 
@@ -352,7 +352,7 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 		}
 
 		// determine ultimately whether the Gateway is managed by this controller implementation
-		if string(gatewayClass.Spec.ControllerName) == string(gatewaycontroller.ControllerName) {
+		if gatewayClass.Spec.ControllerName == gatewaycontroller.GetControllerName() {
 			managedGateways = append(managedGateways, &gateway)
 		}
 	}

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -320,7 +320,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		debug(log, gateway, "ensured gateway was removed from the data-plane (if ever present)")
 		return ctrl.Result{}, nil
 	}
-	if gwc.Spec.ControllerName != ControllerName {
+	if gwc.Spec.ControllerName != GetControllerName() {
 		debug(log, gateway, "unsupported gatewayclass controllername, ignoring", "gatewayclass", gwc.Name, "controllername", gwc.Spec.ControllerName)
 		// delete reference relationships where the gateway is the referrer, as we will not process the gateway.
 		err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, gateway)

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -237,7 +237,7 @@ func TestReconcileGatewaysIfClassMatches(t *testing.T) {
 			Name: "us",
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: ControllerName,
+			ControllerName: GetControllerName(),
 		},
 	}
 
@@ -367,7 +367,7 @@ func TestIsGatewayControlledAndUnmanagedMode(t *testing.T) {
 					Name: "controlled-managed",
 				},
 				Spec: gatewayv1beta1.GatewayClassSpec{
-					ControllerName: ControllerName,
+					ControllerName: GetControllerName(),
 				},
 			},
 			expectedResult: false,
@@ -382,7 +382,7 @@ func TestIsGatewayControlledAndUnmanagedMode(t *testing.T) {
 					},
 				},
 				Spec: gatewayv1beta1.GatewayClassSpec{
-					ControllerName: ControllerName,
+					ControllerName: GetControllerName(),
 				},
 			},
 			expectedResult: true,

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -82,7 +82,7 @@ func isObjectUnmanaged(anns map[string]string) bool {
 // isGatewayClassControlledAndUnmanaged returns boolean if the GatewayClass
 // is controlled by this controller and is configured for unmanaged mode.
 func isGatewayClassControlledAndUnmanaged(gatewayClass *GatewayClass) bool {
-	return gatewayClass.Spec.ControllerName == ControllerName && isObjectUnmanaged(gatewayClass.Annotations)
+	return gatewayClass.Spec.ControllerName == GetControllerName() && isObjectUnmanaged(gatewayClass.Annotations)
 }
 
 // getRefFromPublishService splits a publish service string in the format namespace/name into a types.NamespacedName
@@ -597,7 +597,7 @@ func isGatewayClassEventInClass(log logr.Logger, watchEvent interface{}) bool {
 			log.Error(fmt.Errorf("invalid type"), "received invalid object type in event handlers", "expected", "GatewayClass", "found", reflect.TypeOf(obj))
 			continue
 		}
-		if gwc.Spec.ControllerName == ControllerName {
+		if gwc.Spec.ControllerName == GetControllerName() {
 			return true
 		}
 	}

--- a/internal/controllers/gateway/gatewayclass_controller.go
+++ b/internal/controllers/gateway/gatewayclass_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,10 +27,27 @@ import (
 // GatewayClass Controller - Vars & Consts
 // -----------------------------------------------------------------------------
 
-// ControllerName is the unique identifier for this controller and is used
-// within GatewayClass resources to indicate that this controller should
-// support connected Gateway resources.
-var ControllerName gatewayv1beta1.GatewayController = "konghq.com/kic-gateway-controller"
+var (
+	// _controllerName is the unique identifier for this controller and is used
+	// within GatewayClass resources to indicate that this controller should
+	// support connected Gateway resources.
+	_controllerName gatewayv1beta1.GatewayController = "konghq.com/kic-gateway-controller"
+
+	// _controllerNameLock guards access to _controllerName.
+	_controllerNameLock sync.RWMutex
+)
+
+func SetControllerName(name gatewayv1beta1.GatewayController) {
+	_controllerNameLock.Lock()
+	defer _controllerNameLock.Unlock()
+	_controllerName = name
+}
+
+func GetControllerName() gatewayv1beta1.GatewayController {
+	_controllerNameLock.RLock()
+	defer _controllerNameLock.RUnlock()
+	return _controllerName
+}
 
 // -----------------------------------------------------------------------------
 // GatewayClass Controller - Reconciler

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -440,7 +440,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 				Namespace: (*gatewayv1beta1.Namespace)(&gateway.gateway.Namespace),
 				Name:      gatewayv1beta1.ObjectName(gateway.gateway.Name),
 			},
-			ControllerName: ControllerName,
+			ControllerName: GetControllerName(),
 			Conditions: []metav1.Condition{{
 				Type:               gateway.condition.Type,
 				Status:             gateway.condition.Status,
@@ -522,7 +522,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Co
 	// drop all status references to supported Gateway objects
 	newStatuses := make([]gatewayv1beta1.RouteParentStatus, 0)
 	for _, status := range httproute.Status.Parents {
-		if status.ControllerName != ControllerName {
+		if status.ControllerName != GetControllerName() {
 			newStatuses = append(newStatuses, status)
 		}
 	}
@@ -783,7 +783,7 @@ func (r *HTTPRouteReconciler) ensureParentsProgrammedCondition(
 					SectionName: lo.ToPtr(gatewayv1beta1.SectionName(g.listenerName)),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
-				ControllerName: ControllerName,
+				ControllerName: GetControllerName(),
 				Conditions: []metav1.Condition{
 					programmedCondition,
 				},

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -146,7 +146,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 		}
 
 		// If the GatewayClass does not match this controller then skip it
-		if gatewayClass.Spec.ControllerName != ControllerName {
+		if gatewayClass.Spec.ControllerName != GetControllerName() {
 			continue
 		}
 

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -428,7 +428,7 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 				Namespace: (*gatewayv1alpha2.Namespace)(&gateway.gateway.Namespace),
 				Name:      (gatewayv1alpha2.ObjectName)(gateway.gateway.Name),
 			},
-			ControllerName: (gatewayv1alpha2.GatewayController)(ControllerName),
+			ControllerName: (gatewayv1alpha2.GatewayController)(GetControllerName()),
 			Conditions: []metav1.Condition{{
 				Type:               string(gatewayv1beta1.RouteConditionAccepted),
 				Status:             metav1.ConditionTrue,
@@ -501,7 +501,7 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 	// drop all status references to supported Gateway objects
 	newStatuses := make([]gatewayv1alpha2.RouteParentStatus, 0)
 	for _, status := range tcproute.Status.Parents {
-		if status.ControllerName != (gatewayv1alpha2.GatewayController)(ControllerName) {
+		if status.ControllerName != (gatewayv1alpha2.GatewayController)(GetControllerName()) {
 			newStatuses = append(newStatuses, status)
 		}
 	}
@@ -558,7 +558,7 @@ func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
 					Name:      gatewayv1alpha2.ObjectName(gateway.Name),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
-				ControllerName: gatewayv1alpha2.GatewayController(ControllerName),
+				ControllerName: gatewayv1alpha2.GatewayController(GetControllerName()),
 				Conditions: []metav1.Condition{
 					programmedCondition,
 				},

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -414,7 +414,7 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 				Namespace: (*gatewayv1alpha2.Namespace)(&gateway.gateway.Namespace),
 				Name:      gatewayv1alpha2.ObjectName(gateway.gateway.Name),
 			},
-			ControllerName: (gatewayv1alpha2.GatewayController)(ControllerName),
+			ControllerName: (gatewayv1alpha2.GatewayController)(GetControllerName()),
 			Conditions: []metav1.Condition{{
 				Type:               string(gatewayv1alpha2.RouteConditionAccepted),
 				Status:             metav1.ConditionTrue,
@@ -492,7 +492,7 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 	// drop all status references to supported Gateway objects
 	newStatuses := make([]gatewayv1alpha2.RouteParentStatus, 0)
 	for _, status := range tlsroute.Status.Parents {
-		if status.ControllerName != (gatewayv1alpha2.GatewayController)(ControllerName) {
+		if status.ControllerName != (gatewayv1alpha2.GatewayController)(GetControllerName()) {
 			newStatuses = append(newStatuses, status)
 		}
 	}
@@ -549,7 +549,7 @@ func (r *TLSRouteReconciler) ensureParentsProgrammedCondition(
 					Name:      gatewayv1alpha2.ObjectName(gateway.Name),
 					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
 				},
-				ControllerName: gatewayv1alpha2.GatewayController(ControllerName),
+				ControllerName: gatewayv1alpha2.GatewayController(GetControllerName()),
 				Conditions: []metav1.Condition{
 					programmedCondition,
 				},

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -405,7 +405,7 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 				Namespace: (*gatewayv1alpha2.Namespace)(&gateway.gateway.Namespace),
 				Name:      gatewayv1alpha2.ObjectName(gateway.gateway.Name),
 			},
-			ControllerName: (gatewayv1alpha2.GatewayController)(ControllerName),
+			ControllerName: (gatewayv1alpha2.GatewayController)(GetControllerName()),
 			Conditions: []metav1.Condition{{
 				Type:               string(gatewayv1alpha2.RouteConditionAccepted),
 				Status:             metav1.ConditionTrue,
@@ -478,7 +478,7 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 	// drop all status references to supported Gateway objects
 	newStatuses := make([]gatewayv1alpha2.RouteParentStatus, 0)
 	for _, status := range udproute.Status.Parents {
-		if status.ControllerName != (gatewayv1alpha2.GatewayController)(ControllerName) {
+		if status.ControllerName != (gatewayv1alpha2.GatewayController)(GetControllerName()) {
 			newStatuses = append(newStatuses, status)
 		}
 	}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -159,7 +159,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	)
 
 	// Kubernetes configurations
-	flagSet.Var(NewValidatedValueWithDefault(&c.GatewayAPIControllerName, gatewayAPIControllerNameFromFlagValue, string(gateway.ControllerName)), "gateway-api-controller-name", "The controller name to match on Gateway API resources.")
+	flagSet.Var(NewValidatedValueWithDefault(&c.GatewayAPIControllerName, gatewayAPIControllerNameFromFlagValue, string(gateway.GetControllerName())), "gateway-api-controller-name", "The controller name to match on Gateway API resources.")
 	flagSet.StringVar(&c.KubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file.")
 	flagSet.StringVar(&c.IngressClassName, "ingress-class", annotations.DefaultIngressClass, `Name of the ingress class to route through this controller.`)
 	flagSet.StringVar(&c.LeaderElectionID, "election-id", "5b374a9e.konghq.com", `Election id to use for status update.`)

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -34,7 +34,7 @@ func TestConfigValidatedVars(t *testing.T) {
 				ExtractValueFn: func(c manager.Config) any {
 					return c.GatewayAPIControllerName
 				},
-				ExpectedValue: string(gateway.ControllerName),
+				ExpectedValue: string(gateway.GetControllerName()),
 			},
 			{
 				Input:                 "%invalid_controller_name$",

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -42,6 +42,8 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	setupLog.Info("starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.Info("the ingress class name has been set", "value", c.IngressClassName)
 
+	gateway.SetControllerName(gatewayv1beta1.GatewayController(c.GatewayAPIControllerName))
+
 	setupLog.Info("getting enabled options and features")
 	featureGates, err := setupFeatureGates(setupLog, c.FeatureGates)
 	if err != nil {
@@ -132,8 +134,6 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	if err != nil {
 		return err
 	}
-
-	gateway.ControllerName = gatewayv1beta1.GatewayController(c.GatewayAPIControllerName)
 
 	setupLog.Info("Starting Enabled Controllers")
 	controllers, err := setupControllers(mgr, dataplaneClient,

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -62,7 +62,7 @@ func TestGatewayConformance(t *testing.T) {
 			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+			ControllerName: gateway.GetControllerName(),
 		},
 	}
 	require.NoError(t, client.Create(ctx, gwc))

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -48,7 +48,7 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+			ControllerName: gateway.GetControllerName(),
 		},
 	}
 	supportedGatewayClass, err = gc.GatewayV1beta1().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})
@@ -112,7 +112,7 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+			ControllerName: gateway.GetControllerName(),
 		},
 	}
 	supportedGatewayClass, err = gc.GatewayV1beta1().GatewayClasses().Create(ctx, supportedGatewayClass, metav1.CreateOptions{})

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -48,7 +48,7 @@ func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, ga
 			},
 		},
 		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: gateway.ControllerName,
+			ControllerName: gateway.GetControllerName(),
 		},
 	}
 
@@ -250,7 +250,7 @@ func gatewayLinkStatusMatches(
 			t.Logf("error getting http route: %v", err)
 		} else {
 			return newRouteParentsStatus(route.Status.Parents).
-				check(verifyLinked, string(gateway.ControllerName))
+				check(verifyLinked, string(gateway.GetControllerName()))
 		}
 	case (gatewayv1beta1.ProtocolType)(gatewayv1alpha2.TCPProtocolType):
 		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -258,7 +258,7 @@ func gatewayLinkStatusMatches(
 			t.Logf("error getting tcp route: %v", err)
 		} else {
 			return newRouteParentsStatus(route.Status.Parents).
-				check(verifyLinked, string(gateway.ControllerName))
+				check(verifyLinked, string(gateway.GetControllerName()))
 		}
 	case (gatewayv1beta1.ProtocolType)(gatewayv1alpha2.UDPProtocolType):
 		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -266,7 +266,7 @@ func gatewayLinkStatusMatches(
 			t.Logf("error getting udp route: %v", err)
 		} else {
 			return newRouteParentsStatus(route.Status.Parents).
-				check(verifyLinked, string(gateway.ControllerName))
+				check(verifyLinked, string(gateway.GetControllerName()))
 		}
 	case (gatewayv1beta1.ProtocolType)(gatewayv1alpha2.TLSProtocolType):
 		route, err := c.GatewayV1alpha2().TLSRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -274,7 +274,7 @@ func gatewayLinkStatusMatches(
 			t.Logf("error getting tls route: %v", err)
 		} else {
 			return newRouteParentsStatus(route.Status.Parents).
-				check(verifyLinked, string(gateway.ControllerName))
+				check(verifyLinked, string(gateway.GetControllerName()))
 		}
 	default:
 		t.Fatalf("protocol %s not supported", string(protocolType))
@@ -331,28 +331,28 @@ func verifyProgrammedConditionStatus(t *testing.T,
 		if err != nil {
 			t.Logf("error getting http route: %v", err)
 		} else {
-			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.GetControllerName(), expectedStatus)
 		}
 	case gateway.TCPProtocolType:
 		route, err := c.GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting tcp route: %v", err)
 		} else {
-			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.GetControllerName(), expectedStatus)
 		}
 	case gateway.TLSProtocolType:
 		route, err := c.GatewayV1alpha2().TLSRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting tls route: %v", err)
 		} else {
-			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.GetControllerName(), expectedStatus)
 		}
 	case gateway.UDPProtocolType:
 		route, err := c.GatewayV1alpha2().UDPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error getting udp route: %v", err)
 		} else {
-			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.ControllerName, expectedStatus)
+			return parentStatusContainsProgrammedCondition(route.Status.Parents, gateway.GetControllerName(), expectedStatus)
 		}
 	default:
 		t.Fatalf("protocol %s not supported", string(protocolType))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extracts gateway controller name utilities from #3421 which will be useful when getting or setting controller name from different goroutines (e.g. in tests).
