### PR TITLE
tests: don't set plugin annotation when not needed

### DIFF
--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -80,8 +80,9 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}
 	pluginClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
-	_, err = pluginClient.ConfigurationV1().KongPlugins(ns.Name).Create(ctx, kongplugin, metav1.CreateOptions{})
+	kongplugin, err = pluginClient.ConfigurationV1().KongPlugins(ns.Name).Create(ctx, kongplugin, metav1.CreateOptions{})
 	require.NoError(t, err)
+	cleaner.Add(kongplugin)
 
 	t.Logf("creating an httproute to access deployment %s via kong", deployment.Name)
 	httpPort := gatewayv1beta1.PortNumber(80)
@@ -538,7 +539,6 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
 				annotations.AnnotationPrefix + annotations.StripPathKey: "true",
-				annotations.AnnotationPrefix + annotations.PluginsKey:   "correlation",
 			},
 		},
 		Spec: gatewayv1beta1.HTTPRouteSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't set the plugin annotation in test where it's not needed and additionally add the plugin (created in another test) to `cleaner`.
