### PR TITLE
fix: don't panic when calling NewCtrlFuncMetrics() more than once

### DIFF
--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -58,6 +59,8 @@ const (
 	MetricNameConfigPushDuration = "ingress_controller_configuration_push_duration_milliseconds"
 )
 
+var _once sync.Once
+
 func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 	controllerMetrics := &CtrlFuncMetrics{}
 
@@ -104,7 +107,9 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 		[]string{SuccessKey, ProtocolKey},
 	)
 
-	metrics.Registry.MustRegister(controllerMetrics.ConfigPushCount, controllerMetrics.TranslationCount, controllerMetrics.ConfigPushDuration)
+	_once.Do(func() {
+		metrics.Registry.MustRegister(controllerMetrics.ConfigPushCount, controllerMetrics.TranslationCount, controllerMetrics.ConfigPushDuration)
+	})
 
 	return controllerMetrics
 }

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCtrlFuncMetricsDoesNotPanicWhenCalledTwice(t *testing.T) {
+	require.NotPanics(t, func() {
+		NewCtrlFuncMetrics()
+	})
+	require.NotPanics(t, func() {
+		NewCtrlFuncMetrics()
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that we never tested calling `dataplane.NewKongClient()`, specifically more than once.

This PR fixes a panic which occurs when calling `NewKongClient()` twice. This is due to the fact that we call `.MustRegister()` on https://github.com/Kong/kubernetes-ingress-controller/blob/0f55f293fca8ae71af6de780f7b7d1d05d2b0abb/internal/metrics/prometheus.go#L111 on prometheus `RegistererGatherer`.

**Special notes for your reviewer**:

Found when adding tests for #3421 