### PR TITLE
fix(tests): overwrite an old enterprise image in ktf

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -59,6 +59,13 @@ func TestMain(m *testing.M) {
 	fmt.Println("INFO: setting up test environment")
 	kongbuilder, extraControllerArgs, err := helpers.GenerateKongBuilder(ctx)
 	exitOnErrWithCode(ctx, err, consts.ExitCodeEnvSetupFailed)
+	// TODO: We need a systematic approach to this. Either:
+	// - leave this call here and bump every GW release
+	// - remove this call and rely on bumping GW image in ktf
+	// - rely on a mechanism in ktf that will always, by default return the newest
+	//   GW image
+	// Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
+	kongbuilder.WithProxyImage("kong/kong-gateway", "3.1.1.3-alpine")
 	kongAddon := kongbuilder.Build()
 	builder := environments.NewBuilder().WithAddons(kongAddon)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a problem where we skip tests that we wouldn't like to skip, e.g. https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4086412787/jobs/7045676471#step:7:15296 

```
=== Skipped
=== SKIP: test/integration TestIngressRegexMatchPath (0.00s)
    ingress_regex_match_test.go:32: regex prefixes are only relevant for Kong 3.0+

=== SKIP: test/integration TestIngressRegexMatchHeader (0.00s)
    ingress_regex_match_test.go:186: regex prefixes are only relevant for Kong 3.0+

=== SKIP: test/integration TestIngressClassRegexToggle (1.00s)
    ingress_test.go:565: legacy regex detection is only relevant for Kong 3.0+

=== SKIP: test/integration TestIngressRegexPrefix (0.00s)
    ingress_test.go:698: regex prefixes are only relevant for Kong 3.0+

=== SKIP: test/integration TestIngressRecoverFromInvalidPath (0.00s)
    ingress_test.go:861: the case TestIngressRecoverFromInvalidPath should be run separately; please set TEST_RUN_INVALID_CONFIG_CASES to true to run this case

=== SKIP: test/integration TestPluginOrdering (1.00s)
    plugin_test.go:207: plugin ordering requires Kong Enterprise 3.0+
```

Related issues in ktf: https://github.com/Kong/kubernetes-testing-framework/issues/542

In essence then, this PR bumps enterprise image that we test from [`2.7.0.0-alpine`](https://github.com/Kong/kubernetes-testing-framework/blob/6cfb2cb793826053834fef949ff5f3f5a271874d/pkg/clusters/addons/kong/addon.go#L51)  to `3.1.1.3-alpine`

**Special notes for your reviewer**:

This adds a TODO which contains several options on how to approach this problem. PTAL