### PR TITLE
feat: print kong version when skipping tests

### DIFF
--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -34,9 +34,8 @@ func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayv1beta1.
 				string(header.Name))
 		}
 		if header.Type != nil && *header.Type == gatewayv1beta1.HeaderMatchRegularExpression {
-			if !versions.GetKongVersion().MajorMinorOnly().GTE(versions.RegexHeaderVersionCutoff) {
-				return nil, fmt.Errorf("Kong version %s does not support HeaderMatchRegularExpression",
-					versions.GetKongVersion().Full().String())
+			if v := versions.GetKongVersion(); !v.MajorMinorOnly().GTE(versions.RegexHeaderVersionCutoff) {
+				return nil, fmt.Errorf("Kong version %s does not support HeaderMatchRegularExpression", v.Full())
 			}
 			convertedHeaders[string(header.Name)] = []string{kongHeaderRegexPrefix + header.Value}
 		} else if header.Type == nil || *header.Type == gatewayv1beta1.HeaderMatchExact {

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 func TestIngressRegexMatchPath(t *testing.T) {
-	ctx := context.Background()
-
-	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skip("regex prefixes are only relevant for Kong 3.0+")
+	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
+		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
 	}
+
+	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	pathRegexPrefix := "/~"
@@ -180,11 +180,11 @@ func TestIngressRegexMatchPath(t *testing.T) {
 }
 
 func TestIngressRegexMatchHeader(t *testing.T) {
-	ctx := context.Background()
-
-	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skip("regex prefixes are only relevant for Kong 3.0+")
+	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
+		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
 	}
+
+	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	headerRegexPrefix := "~*"

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -561,8 +561,8 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return !versions.GetKongVersion().Full().EQ(semver.MustParse("0.0.0"))
 	}, time.Minute, time.Second)
-	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skip("legacy regex detection is only relevant for Kong 3.0+")
+	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
+		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
 	}
 
 	// skip the test if the cluster does not support namespaced ingress class parameter (<=1.21).
@@ -694,8 +694,8 @@ func TestIngressClassRegexToggle(t *testing.T) {
 }
 
 func TestIngressRegexPrefix(t *testing.T) {
-	if !versions.GetKongVersion().MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skip("regex prefixes are only relevant for Kong 3.0+")
+	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
+		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:

As a follow up to #3486, let's print kong version when we decide to skip a test.
This way we'll actually know what version we were running against and it'll be easier to debug what that was the case (if it wasn't supposed to be).
