### PR TITLE
fix(tests): don't use 2.x style path regex where requiring 3.x one

### DIFF
--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -650,7 +650,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 						HTTP: &netv1.HTTPIngressRuleValue{
 							Paths: []netv1.HTTPIngressPath{
 								{
-									Path:     `/test_ingress_class_regex_toggle/\d+`,
+									Path:     `/~/test_ingress_class_regex_toggle/\d+`,
 									PathType: &pathTypeImplementationSpecific,
 									Backend: netv1.IngressBackend{
 										Service: &netv1.IngressServiceBackend{


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the following deck warning:

```
time="2023-02-03T13:45:21+01:00" level=debug msg="converting configuration to deck config" kong_url="http://172.18.1.1:8001/"
1 unsupported routes' paths format with Kong version 3.0
or above were detected. Some of these routes are (not an exhaustive list):

18a19edb-0b01-4d9a-988b-146c3c086e04

Please upgrade your configuration to account for 3.0
breaking changes using the following command:

deck convert --from kong-gateway-2.x --to kong-gateway-3.x

This command performs the following changes:
  - upgrade the `_format_version` value to `3.0`
  - add the `~` prefix to all routes' paths containing a regex-pattern

These changes may not be correct or exhaustive enough.
It is strongly recommended to perform a manual audit
of the updated configuration file before applying
the configuration in production. Incorrect changes will result in
unintended traffic routing by Kong Gateway.

For more information about this and related changes,
please visit: https://docs.konghq.com/deck/latest/3.0-upgrade

updating route 8ec040df-5096-467e-b571-da89a2803a09.regex-toggle.httpbin..80  {
   "https_redirect_status_code": 426,
   "id": "18a19edb-0b01-4d9a-988b-146c3c086e04",
   "name": "8ec040df-5096-467e-b571-da89a2803a09.regex-toggle.httpbin..80",
   "path_handling": "v0",
   "paths": [
-    "~/test_ingress_class_regex_toggle/\d+"
+    "/test_ingress_class_regex_toggle/\d+"
   ],
   "preserve_host": true,
   "protocols": [
     "http",
     "https"
   ],
   "regex_priority": 0,
   "request_buffering": true,
   "response_buffering": true,
   "service": {
     "id": "1f195e3d-4b76-4b27-b03b-14c69f84f02d",
     "name": "8ec040df-5096-467e-b571-da89a2803a09.regex-toggle.httpbin.80"
   },
   "strip_path": true,
   "tags": [
     "managed-by-ingress-controller"
   ]
 }
```

Sadly there's no way to check/assert this now (or is there?). Perhaps we could introduce event for deck conversion warning/errors? 🤔 