### PR TITLE
refactor: extract hasConfigurationChanged

### DIFF
--- a/internal/dataplane/sendconfig/sendconfig_test.go
+++ b/internal/dataplane/sendconfig/sendconfig_test.go
@@ -1,6 +1,7 @@
 package sendconfig
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +10,7 @@ import (
 
 	deckutils "github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -102,4 +104,88 @@ func TestPushFailureReason(t *testing.T) {
 			require.Equal(t, tc.expectedReason, reason)
 		})
 	}
+}
+
+type konnectAwareClientMock struct {
+	expected bool
+}
+
+func (c konnectAwareClientMock) IsKonnect() bool {
+	return c.expected
+}
+
+type statusClientMock struct {
+	expectedValue *kong.Status
+}
+
+func (c statusClientMock) Status(context.Context) (*kong.Status, error) {
+	return c.expectedValue, nil
+}
+
+func TestHasConfigurationChanged(t *testing.T) {
+	ctx := context.Background()
+	testSHAs := [][]byte{
+		[]byte("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
+		[]byte("82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbf9"),
+	}
+
+	testCases := []struct {
+		name           string
+		oldSHA, newSHA []byte
+		statusSHA      string
+		isKonnect      bool
+		expectedResult bool
+	}{
+		{
+			name:           "oldSHA != newSHA",
+			oldSHA:         testSHAs[0],
+			newSHA:         testSHAs[1],
+			expectedResult: true,
+		},
+		{
+			name:           "oldSHA == newSHA, but status signals crash",
+			oldSHA:         testSHAs[0],
+			newSHA:         testSHAs[0],
+			statusSHA:      wellKnownInitialHash,
+			expectedResult: true,
+		},
+		{
+			name:           "oldSHA == newSHA and status signals same",
+			oldSHA:         testSHAs[0],
+			newSHA:         testSHAs[0],
+			statusSHA:      string(testSHAs[0]),
+			expectedResult: false,
+		},
+		{
+			name:           "oldSHA == newSHA and status signals other",
+			oldSHA:         testSHAs[0],
+			newSHA:         testSHAs[0],
+			statusSHA:      string(testSHAs[1]),
+			expectedResult: false,
+		},
+		{
+			name:           "oldSHA == newSHA, status would signal crash, but it's konnect",
+			oldSHA:         testSHAs[0],
+			newSHA:         testSHAs[0],
+			statusSHA:      wellKnownInitialHash,
+			isKonnect:      true,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			konnectAwareClient := konnectAwareClientMock{expected: tc.isKonnect}
+			statusClient := statusClientMock{
+				expectedValue: &kong.Status{
+					ConfigurationHash: tc.statusSHA,
+				},
+			}
+
+			result, err := hasConfigurationChanged(ctx, tc.oldSHA, tc.newSHA, konnectAwareClient, statusClient, logrus.New())
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts `hasConfigurationChanged` helper function and covers it with tests to make this code easier to reason about.

**Which issue this PR fixes**:

Part of #3437.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
