### PR TITLE
fix(ci): fix pinned enterprise tag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,6 +160,18 @@ jobs:
       id: detect_if_should_run
       run: echo "result=${{ (steps.license.outputs.license != '' && matrix.enterprise) || (!matrix.enterprise) }}" >> $GITHUB_OUTPUT
 
+    - name: Set image and tag for enterprise
+      if: steps.detect_if_should_run.outputs.result && matrix.enterprise
+      # TODO: We need a systematic approach to this. Either:
+      # - leave this here and bump every GW release
+      # - remove this and rely on bumping GW image in ktf
+      # - rely on a mechanism in ktf that will always, by default return the newest
+      #   Gateway tag.
+      # Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
+      run: |
+        echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=3.1.1.3-alpine" >> $GITHUB_ENV
+
     - name: checkout repository
       if: steps.detect_if_should_run.outputs.result
       uses: actions/checkout@v3

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -59,13 +59,6 @@ func TestMain(m *testing.M) {
 	fmt.Println("INFO: setting up test environment")
 	kongbuilder, extraControllerArgs, err := helpers.GenerateKongBuilder(ctx)
 	exitOnErrWithCode(ctx, err, consts.ExitCodeEnvSetupFailed)
-	// TODO: We need a systematic approach to this. Either:
-	// - leave this call here and bump every GW release
-	// - remove this call and rely on bumping GW image in ktf
-	// - rely on a mechanism in ktf that will always, by default return the newest
-	//   GW image
-	// Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
-	kongbuilder.WithProxyImage("kong/kong-gateway", "3.1.1.3-alpine")
 	kongAddon := kongbuilder.Build()
 	builder := environments.NewBuilder().WithAddons(kongAddon)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR unpins the enterprise tag that we set in integration tests. This way the nightly tests and locally run tests will respect `TEST_KONG_IMAGE` and `TEST_KONG_TAG` through https://github.com/Kong/kubernetes-ingress-controller/blob/3ce7c14afd2099e991c4dcd3370f23ef8c742a5e/test/internal/testenv/testenv.go#L24-L32 and https://github.com/Kong/kubernetes-ingress-controller/blob/3ce7c14afd2099e991c4dcd3370f23ef8c742a5e/test/internal/helpers/ktf.go#L32-L37

**Special notes for your reviewer**:

This is just unblocking and kicking the can down the road. We need to figure out an approach for this.

Related: https://github.com/Kong/kubernetes-testing-framework/issues/542

- If we set a default in ktf then we'd need to bump that every GW release, release ktf and then use that version in KIC
- If we set a default in KIC (in CI just like this PR does it?) then we need to maintain it here
- If we add a mechanism in KIC that always returns the latest GW tag:
  - This will get this data from Github so without tokens we have to take into account rate limiting
  - Without changing code and/or ktf version a version that we test against might change, hence surprises might happen.
- Any other ideas?

Since that essentially sets a value in chart's values we're basically overriding what's set there by default. So we're sort of having a special case for enterprise whereas CE has it's tag set in respective chart's version values.