### PR TITLE
feat: add adminapi endpoints helpers

### DIFF
--- a/internal/adminapi/endpoints.go
+++ b/internal/adminapi/endpoints.go
@@ -1,0 +1,83 @@
+package adminapi
+
+import (
+	"context"
+	"fmt"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetURLsForService performs an endpoint lookup, using provided kubeClient
+// to list provided Admin API Service EndpointSlices.
+func GetURLsForService(ctx context.Context, kubeClient client.Client, service types.NamespacedName) (sets.Set[string], error) {
+	const (
+		defaultEndpointSliceListPagingLimit = 100
+	)
+
+	// Get all the EndpointSlices assigned to the provided service.
+	labelReq, err := labels.NewRequirement("kubernetes.io/service-name", selection.Equals, []string{service.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		addresses     = sets.New[string]()
+		continueToken string
+		labelSelector = labels.NewSelector().Add(*labelReq)
+	)
+	for {
+		var endpointsList discoveryv1.EndpointSliceList
+		if err := kubeClient.List(ctx, &endpointsList, &client.ListOptions{
+			LabelSelector: labelSelector,
+			Namespace:     service.Namespace,
+			Continue:      continueToken,
+			Limit:         defaultEndpointSliceListPagingLimit,
+		}); err != nil {
+			return nil, err
+		}
+
+		for _, es := range endpointsList.Items {
+			addresses = addresses.Union(AddressesFromEndpointSlice(es))
+		}
+
+		if endpointsList.Continue == "" {
+			break
+		}
+	}
+	return addresses, nil
+}
+
+// AddressesFromEndpointSlice returns a list of Admin API addresses when given
+// an Endpointslice.
+func AddressesFromEndpointSlice(endpoints discoveryv1.EndpointSlice) sets.Set[string] {
+	addresses := sets.New[string]()
+	for _, p := range endpoints.Ports {
+		if p.Name == nil {
+			continue
+		}
+
+		// NOTE: consider making this configurable.
+		if *p.Name != "admin" {
+			continue
+		}
+
+		for _, e := range endpoints.Endpoints {
+			if e.Conditions.Ready == nil || !*e.Conditions.Ready {
+				continue
+			}
+
+			for _, addr := range e.Addresses {
+				// NOTE: We assume https here because the referenced Admin API
+				// server will live in another Pod/elsewhere so allowing http would
+				// not be considered best practice.
+				addresses.Insert(fmt.Sprintf("https://%s:%d", addr, *p.Port))
+			}
+		}
+	}
+	return addresses
+}

--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -1,0 +1,356 @@
+package adminapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAddressesFromEndpointSlice(t *testing.T) {
+	endpointsSliceObjectMeta := metav1.ObjectMeta{
+		Name:      uuid.NewString(),
+		Namespace: "ns",
+	}
+
+	tests := []struct {
+		name      string
+		enspoints discoveryv1.EndpointSlice
+		want      sets.Set[string]
+	}{
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Name: lo.ToPtr("admin"),
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "basic",
+			want: sets.New("https://10.0.0.1:8444", "https://10.0.0.2:8444"),
+		},
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(false),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Name: lo.ToPtr("admin"),
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "not ready endpoints are not returned",
+			want: sets.New[string](),
+		},
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.NewString(),
+					Namespace: "ns",
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(false),
+							Terminating: lo.ToPtr(true),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Name: lo.ToPtr("admin"),
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "not ready and terminating endpoints are not returned",
+			want: sets.New[string](),
+		},
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+					{
+						Addresses: []string{"10.0.1.1", "10.0.1.2"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+					{
+						Addresses: []string{"10.0.2.1"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(false),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Name: lo.ToPtr("admin"),
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "multiple enpoints are concatenated properly",
+			want: sets.New("https://10.0.0.1:8444", "https://10.0.0.2:8444", "https://10.0.0.3:8444", "https://10.0.1.1:8444", "https://10.0.1.2:8444"),
+		},
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+					{
+						Addresses: []string{"10.0.1.1", "10.0.1.2"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+					{
+						Addresses: []string{"10.0.2.1"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(false),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Name: lo.ToPtr("non-admin-port-name"),
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "ports not called 'admin' are not added",
+			want: sets.New[string](),
+		},
+		{
+			enspoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+					},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{
+						Port: lo.ToPtr(int32(8444)),
+					},
+				},
+			},
+			name: "ports without names are not taken into account ",
+			want: sets.New[string](),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, AddressesFromEndpointSlice(tt.enspoints))
+		})
+	}
+}
+
+func TestGetURLsForService(t *testing.T) {
+	var (
+		serviceName                   = uuid.NewString()
+		matchingServiceObjectMetaFunc = func() metav1.ObjectMeta {
+			return metav1.ObjectMeta{
+				Name:      uuid.NewString(),
+				Namespace: "ns",
+				Labels: map[string]string{
+					"kubernetes.io/service-name": serviceName,
+				},
+			}
+		}
+	)
+
+	tests := []struct {
+		name    string
+		service types.NamespacedName
+		objects []client.ObjectList
+		want    sets.Set[string]
+		wantErr bool
+	}{
+		{
+			service: types.NamespacedName{
+				Namespace: "ns",
+				Name:      serviceName,
+			},
+			objects: []client.ObjectList{
+				&discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{
+						{
+							ObjectMeta:  matchingServiceObjectMetaFunc(),
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses: []string{"10.0.0.1", "10.0.0.2"},
+									Conditions: discoveryv1.EndpointConditions{
+										Ready:       lo.ToPtr(true),
+										Terminating: lo.ToPtr(false),
+									},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{
+									Name: lo.ToPtr("admin"),
+									Port: lo.ToPtr(int32(8444)),
+								},
+							},
+						},
+					},
+				},
+				&discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{
+						{
+							ObjectMeta:  matchingServiceObjectMetaFunc(),
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses: []string{"9.0.0.1"},
+									Conditions: discoveryv1.EndpointConditions{
+										Ready:       lo.ToPtr(true),
+										Terminating: lo.ToPtr(false),
+									},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{
+									Name: lo.ToPtr("admin"),
+									Port: lo.ToPtr(int32(8444)),
+								},
+							},
+						},
+					},
+				},
+				&discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{
+						{
+							ObjectMeta:  matchingServiceObjectMetaFunc(),
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses: []string{"8.0.0.1"},
+									Conditions: discoveryv1.EndpointConditions{
+										Ready:       lo.ToPtr(false),
+										Terminating: lo.ToPtr(false),
+									},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{
+									Name: lo.ToPtr("admin"),
+									Port: lo.ToPtr(int32(8444)),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: sets.New("https://10.0.0.1:8444", "https://10.0.0.2:8444", "https://9.0.0.1:8444"),
+			name: "basic",
+		},
+		{
+			service: types.NamespacedName{
+				Namespace: "ns",
+				Name:      serviceName,
+			},
+			objects: []client.ObjectList{
+				&discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{
+						{
+							ObjectMeta:  matchingServiceObjectMetaFunc(),
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses: []string{"7.0.0.1"},
+									Conditions: discoveryv1.EndpointConditions{
+										Ready:       lo.ToPtr(true),
+										Terminating: lo.ToPtr(false),
+									},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{
+									Name: lo.ToPtr("non-admin-port"),
+									Port: lo.ToPtr(int32(8444)),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: sets.New[string](),
+			name: "port not called 'admin' are not taken into account",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fakeclient.NewClientBuilder().
+				WithLists(tt.objects...).
+				Build()
+
+			got, err := GetURLsForService(context.Background(), fakeClient, tt.service)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds 2 helpers for handling Admin API EndpointsSlices together with tests. These are not used currently but in order to minimize the size of #3421 they were extracted here.
