### PR TITLE
feat: enable ReferenceGrant controller if Gateway feature gate turned on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Adding a new version? You'll need three changes:
   [#3496](https://github.com/Kong/kubernetes-ingress-controller/pull/3496)
 - The `ReferenceGrant` has been promoted to beta.
   [#3507](https://github.com/Kong/kubernetes-ingress-controller/pull/3507)
+  Enable `ReferenceGrant` if `Gateway` feature gate is turned on.
+- [#3519](https://github.com/Kong/kubernetes-ingress-controller/pull/3519)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@ Adding a new version? You'll need three changes:
   [#3496](https://github.com/Kong/kubernetes-ingress-controller/pull/3496)
 - The `ReferenceGrant` has been promoted to beta.
   [#3507](https://github.com/Kong/kubernetes-ingress-controller/pull/3507)
-  Enable `ReferenceGrant` if `Gateway` feature gate is turned on.
-- [#3519](https://github.com/Kong/kubernetes-ingress-controller/pull/3519)
+- Enable `ReferenceGrant` if `Gateway` feature gate is turned on (default).
+  [#3519](https://github.com/Kong/kubernetes-ingress-controller/pull/3519)
 
 ### Fixed
 

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -72,10 +72,10 @@ func setupControllers(
 		return nil, fmt.Errorf("ingress version picker failed: %w", err)
 	}
 
-	referenceGrantsEnabled := featureGates[gatewayAlphaFeature] && ShouldEnableCRDController(
+	referenceGrantsEnabled := featureGates[gatewayFeature] && ShouldEnableCRDController(
 		schema.GroupVersionResource{
-			Group:    gatewayv1alpha2.GroupVersion.Group,
-			Version:  gatewayv1alpha2.GroupVersion.Version,
+			Group:    gatewayv1beta1.GroupVersion.Group,
+			Version:  gatewayv1beta1.GroupVersion.Version,
 			Resource: "referencegrants",
 		},
 		restMapper,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Since `ReferenceGrant` has been promoted to beta, we should enable it by default if `gateway` turned on.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
