### PR TITLE
chore(ci): don't run buildpulse if workflow has been cancelled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -309,7 +309,7 @@ jobs:
       - "unit-tests"
       - "integration-tests"
       - "conformance-tests"
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
 
@@ -326,7 +326,6 @@ jobs:
           path: report
 
       - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
         uses: Workshop64/buildpulse-action@a0e683af4e5070c379e9801ee9b33792ff414936
         with:
           account: 962416


### PR DESCRIPTION
**What this PR does / why we need it**:

There's no point in sending buildpulse report when the pipeline got cancelled so let's not do it. The same condition was set previously on the step inside buildpulse job but there's not point in run that job at all when we're cancelled.
