### PR TITLE
chore: add multi gateway dev config

### DIFF
--- a/config/variants/multi-gw/dev/kustomization.yaml
+++ b/config/variants/multi-gw/dev/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kong
+
+resources:
+- ../base/
+
+patchesStrategicMerge:
+- manager.yaml

--- a/config/variants/multi-gw/dev/manager.yaml
+++ b/config/variants/multi-gw/dev/manager.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ingress-kong
+  name: ingress-kong
+  namespace: kong
+spec:
+  selector:
+    matchLabels:
+      app: ingress-kong
+  template:
+    metadata:
+      labels:
+        app: ingress-kong
+    spec:
+      containers:
+      - name: ingress-controller
+        args:
+          - --feature-gates=GatewayAlpha=true
+          - --anonymous-reports=false
+        env:
+        - name: CONTROLLER_LOG_LEVEL
+          value: debug
+        image: kic-placeholder:placeholder

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,6 +57,21 @@ profiles:
           TAG: ${{ .TAG }}
           COMMIT: ${{ .COMMIT }}
           REPO_INFO: ${{ .REPO_INFO }}
+- name: multi_gw
+  manifests:
+    kustomize:
+      paths:
+      - config/variants/multi-gw/dev
+  build:
+    artifacts:
+    - image: kic-placeholder
+      docker:
+        dockerfile: Dockerfile
+        target: distroless
+        buildArgs:
+          TAG: ${{ .TAG }}
+          COMMIT: ${{ .COMMIT }}
+          REPO_INFO: ${{ .REPO_INFO }}
 - name: debug_multi_gw
   manifests:
     kustomize:


### PR DESCRIPTION
**What this PR does / why we need it**:

To add to what has been introduced in #3474 this PR adds non-debug skaffold config for multi gateways.

To utilize it one use the following command:

```
make run.skaffold SKAFFOLD_RUN_PROFILE=multi_gw
```

This **is expected to fail** before #3421 gets merged because KIC doesn't know about `--kong-admin-svc` flag yet.
