### PR TITLE
feat: set leader election when single controller deployments are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ Adding a new version? You'll need three changes:
   that all time series for those metrics will get a new label designating the
   address of the dataplane that the configuration push has been targeted for.
   [#3521](https://github.com/Kong/kubernetes-ingress-controller/pull/3521)
+- Leader election is enabled by default then kong admin service discovery is enabled.
+  [#3529](https://github.com/Kong/kubernetes-ingress-controller/pull/3529)
 
 ### Fixed
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -16,6 +16,7 @@ import (
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -168,12 +169,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to setup healthz: %w", err)
 	}
-	if err := mgr.AddReadyzCheck("check", func(_ *http.Request) error {
-		if !synchronizer.IsReady() {
-			return errors.New("synchronizer not yet configured")
-		}
-		return nil
-	}); err != nil {
+	if err := mgr.AddReadyzCheck("check", readyzHandler(mgr, synchronizer)); err != nil {
 		return fmt.Errorf("unable to setup readyz: %w", err)
 	}
 
@@ -204,6 +200,26 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	setupLog.Info("Starting manager")
 	return mgr.Start(ctx)
+}
+
+type IsReady interface {
+	IsReady() bool
+}
+
+func readyzHandler(mgr manager.Manager, dataplaneSynchronizer IsReady) func(*http.Request) error {
+	return func(_ *http.Request) error {
+		select {
+		// If we're elected as leader then report readiness based on the readiness
+		// of dataplane synchronizer.
+		case <-mgr.Elected():
+			if !dataplaneSynchronizer.IsReady() {
+				return errors.New("synchronizer not yet configured")
+			}
+		// If we're not the leader then just report as ready.
+		default:
+		}
+		return nil
+	}
 }
 
 func getScheme() (*runtime.Scheme, error) {

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -107,6 +107,10 @@ func leaderElectionEnabled(logger logr.Logger, c *Config, dbmode string) bool {
 	}
 
 	if dbmode == "off" {
+		if c.KongAdminSvc.Name != "" {
+			logger.Info("DB-less mode detected with service detection, enabling leader election")
+			return true
+		}
 		logger.Info("DB-less mode detected, disabling leader election")
 		return false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures we enable leader election when Admin API service discovery is enabled.

**Which issue this PR fixes**:

Fixes #3528

**Special notes for your reviewer**:

~When implemented this way (the same we used to do it for other configurations, dbless or not) KIC's deployment has only 1 ready Pod - the leader - and all the other ones are not ready, because the readiness probe set to~

https://github.com/Kong/kubernetes-ingress-controller/blob/22f6bad0f1c25e973aa6def5db79fab7fcf058bb/internal/manager/run.go#L171-L178

~is not responding since the dataplane synchronizer is not ready yet.~

~Is that desired? Or do we want non-leader pods to be ready as well?~

The readyz handler was changed to allow all Pods from KIC's Deployment to be marked as ready. The leader will be marked as ready when the dataplane synchronizer is ready whereas the other Pods will be ready regardless (given that it responds to readiness probe requests).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
