### PR TITLE
tests: fix logClusterInfo not defined in istio tests

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/kong/deck/dump"
 	gokong "github.com/kong/go-kong/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -41,12 +40,6 @@ const (
 	dblessPath = "../../deploy/single/all-in-one-dbless.yaml"
 	dblessURL  = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%v.%v.x/deploy/single/all-in-one-dbless.yaml"
 )
-
-func logClusterInfo(t *testing.T, cluster clusters.Cluster) {
-	v, err := cluster.Version()
-	require.NoError(t, err)
-	t.Logf("cluster %s (type: %s, v: %s) is up", cluster.Name(), cluster.Type(), v)
-}
 
 func TestDeployAllInOneDBLESS(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test")

--- a/test/e2e/clusters.go
+++ b/test/e2e/clusters.go
@@ -1,7 +1,11 @@
 package e2e
 
 import (
+	"testing"
+
 	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -26,4 +30,10 @@ func gkeTestClusterLabels() map[string]string {
 	return map[string]string{
 		gkeTestClusterLabel: gkeLabelValueTrue,
 	}
+}
+
+func logClusterInfo(t *testing.T, cluster clusters.Cluster) {
+	v, err := cluster.Version()
+	require.NoError(t, err)
+	t.Logf("cluster %s (type: %s, v: %s) is up", cluster.Name(), cluster.Type(), v)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

move function `logClusterInfo` to `clusters.go` which does not contain build tags, to fix `logClusterInfo` not found in istio tests.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR 
