### PR TITLE
tests(e2e): extract setup function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sourcegraph/conc v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -785,9 +785,8 @@ github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtm
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/shirou/gopsutil/v3 v3.22.12 h1:oG0ns6poeUSxf78JtOsfygNWuEHYYz8hnnNg7P04TJs=

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 // -----------------------------------------------------------------------------
@@ -44,19 +43,7 @@ const (
 func TestDeployAllInOneDBLESS(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
@@ -96,20 +83,7 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Logf("deploying previous version %s kong manifest", preTag)
 	deployKong(ctx, t, env, oldManifest.Body)
@@ -134,21 +108,9 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 		t.Skipf("no license available to test enterprise: %s was not provided", kong.LicenseDataEnvVar)
 	}
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
+	ctx, env := setupE2ETest(t)
 
 	createKongImagePullSecret(ctx, t, env)
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
 
 	t.Log("generating a superuser password")
 	adminPassword, adminPasswordSecretYAML, err := generateAdminPasswordSecret()
@@ -179,19 +141,7 @@ const postgresPath = "../../deploy/single/all-in-one-postgres.yaml"
 func TestDeployAllInOnePostgres(t *testing.T) {
 	t.Log("configuring all-in-one-postgres.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, postgresPath)
@@ -209,19 +159,7 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	t.Log("configuring all-in-one-postgres.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, postgresPath)
@@ -349,21 +287,9 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 		t.Skipf("no license available to test enterprise: %s was not provided", kong.LicenseDataEnvVar)
 	}
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
+	ctx, env := setupE2ETest(t)
 
 	createKongImagePullSecret(ctx, t, env)
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
 
 	t.Log("generating a superuser password")
 	adminPassword, adminPasswordSecret, err := generateAdminPasswordSecret()
@@ -399,19 +325,7 @@ func TestDeployAllInOneDBLESSMultiGW(t *testing.T) {
 	)
 
 	t.Logf("configuring %s manifest test", manifestFileName)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	f, err := os.Open(manifestFilePath)

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -4,34 +4,20 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 // TestKongRouterCompatibility verifies that KIC behaves consistently with Kong routers
 // `traditional` and `traditional_compatible`.
 func TestKongRouterFlavorCompatibility(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
+	ctx, env := setupE2ETest(t)
 	cluster := env.Cluster()
-	logClusterInfo(t, cluster)
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, cluster)
-	}()
 
 	t.Log("deploying kong components with traditional Kong router")
 	manifest, err := getTestManifest(t, dblessPath)

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -289,20 +289,7 @@ func TestWebhookUpdate(t *testing.T) {
 func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test for Gateway")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	cluster := env.Cluster()
-	logClusterInfo(t, cluster)
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
@@ -452,19 +439,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
@@ -513,19 +488,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 func TestDefaultIngressClass(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)
@@ -634,19 +597,7 @@ func TestDefaultIngressClass(t *testing.T) {
 // controllers are disabled, this fact is properly logged, and the controller doesn't crash.
 func TestMissingCRDsDontCrashTheController(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,9 +53,6 @@ var (
 func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	// Logger needs to be configured before anything else happens.
 	// This is because the controller manager has a timeout for
 	// logger initialization, and if the logger isn't configured
@@ -87,17 +83,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	}
 	istioAddon := istioBuilder.Build()
 
-	t.Log("deploying a testing environment and Kubernetes cluster with Istio enabled")
-	envBuilder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	env, err := envBuilder.WithAddons(istioAddon, kongAddon).Build(ctx)
-	require.NoError(t, err)
-
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t, istioAddon, kongAddon)
 
 	t.Log("waiting for test cluster to be ready")
 	require.NoError(t, <-env.WaitForReady(ctx))

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -20,20 +20,7 @@ import (
 func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
-	require.NoError(t, err)
-	builder = builder.WithAddons(kuma.New())
-	env, err := builder.Build(ctx)
-	require.NoError(t, err)
-	logClusterInfo(t, env.Cluster())
-
-	defer func() {
-		helpers.TeardownCluster(ctx, t, env.Cluster())
-	}()
+	ctx, env := setupE2ETest(t, kuma.New())
 
 	t.Log("deploying kong components")
 	manifest, err := getTestManifest(t, dblessPath)


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts a helper function that sets up a cluster, returns a test context, and prepares cleanup calls.

Successful targeted E2E run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4173464849
