### PR TITLE
chore: replace k8s.gcr.io registry usage

### DIFF
--- a/examples/gateway-udproute.yaml
+++ b/examples/gateway-udproute.yaml
@@ -49,7 +49,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         name: coredns
         ports:

--- a/examples/udpingress.yaml
+++ b/examples/udpingress.yaml
@@ -63,7 +63,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         name: coredns
         ports:

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -31,7 +31,7 @@ var udpMutex sync.Mutex
 
 // coreDNSImage is the image and version of CoreDNS that will be used for UDP
 // testing.
-const coreDNSImage = "k8s.gcr.io/coredns/coredns:v1.8.6"
+const coreDNSImage = "registry.k8s.io/coredns/coredns:v1.8.6"
 
 func TestUDPIngressEssentials(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Kubernetes is [replacing the k8s.gcr.io registry](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/). Besides it just becoming frozen soon the new registry.k8s.io registry is also less costly to use so the sooner we can stop using the old one the better to help out upstream.