### PR TITLE
chore(ci): extend test environment cleanup timeout to unblock e2e tests

### DIFF
--- a/test/internal/helpers/teardown.go
+++ b/test/internal/helpers/teardown.go
@@ -17,7 +17,7 @@ func TeardownCluster(ctx context.Context, t *testing.T, cluster clusters.Cluster
 	t.Helper()
 
 	const (
-		environmentCleanupTimeout = 3 * time.Minute
+		environmentCleanupTimeout = 10 * time.Minute
 	)
 
 	DumpDiagnosticsIfFailed(ctx, t, cluster)


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason, e2e tests on GKE v1.25 take longer to clean up the environment, so to unblock extend the timeout.

**Special notes for your reviewer**:

There's an issue in ktf https://github.com/Kong/kubernetes-testing-framework/issues/565 to track an effort to extend cleaner's API to allow e.g. configuration whether to wait for namespaces to be deleted.
