### PR TITLE
feat: add configurable Admin API service port names to be used for service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ Adding a new version? You'll need three changes:
   which accepts a namespaced name of headless kong admin service which should have
   Admin API endpoints exposed under a named port called `admin`
   [#3421](https://github.com/Kong/kubernetes-ingress-controller/pull/3421)
+- Added configurable port names for Admin API service discovery through
+  `--kong-admin-svc-port-names`. This flag accepts a list of port names that
+  Admin API Service ports will be matched against.
+  [#3556](https://github.com/Kong/kubernetes-ingress-controller/pull/3556)
 - Added `dataplane` metrics label for `ingress_controller_configuration_push_count`
   and `ingress_controller_configuration_push_duration_milliseconds`. This means
   that all time series for those metrics will get a new label designating the

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -46,15 +46,16 @@ type Config struct {
 	CacheSyncTimeout                  time.Duration
 
 	// Kong Proxy configurations
-	APIServerHost       string
-	APIServerQPS        int
-	APIServerBurst      int
-	MetricsAddr         string
-	ProbeAddr           string
-	KongAdminURLs       []string
-	KongAdminSvc        types.NamespacedName
-	ProxySyncSeconds    float32
-	ProxyTimeoutSeconds float32
+	APIServerHost         string
+	APIServerQPS          int
+	APIServerBurst        int
+	MetricsAddr           string
+	ProbeAddr             string
+	KongAdminURLs         []string
+	KongAdminSvc          types.NamespacedName
+	KondAdminSvcPortNames []string
+	ProxySyncSeconds      float32
+	ProxyTimeoutSeconds   float32
 
 	// Kubernetes configurations
 	KubeconfigPath           string
@@ -151,6 +152,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 			`More than 1 URL can be provided, in such case the flag should be used multiple times or a corresponding env variable should use comma delimited addresses.`)
 	flagSet.Var(NewValidatedValue(&c.KongAdminSvc, namespacedNameFromFlagValue), "kong-admin-svc",
 		`Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery.`)
+	flagSet.StringSliceVar(&c.KondAdminSvcPortNames, "kong-admin-svc-port-names", []string{"admin", "admin-tls", "kong-admin", "kong-admin-tls"},
+		"Names of ports on Kong Admin API service to take into account when doing service discovery.")
 
 	// Kong Proxy and Proxy Cache configurations
 	flagSet.StringVar(&c.APIServerHost, "apiserver-host", "", `The Kubernetes API server URL. If not set, the controller will use cluster config discovery.`)

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -94,6 +95,7 @@ func setupControllers(
 			Controller: &configuration.KongAdminAPIServiceReconciler{
 				Client:            mgr.GetClient(),
 				ServiceNN:         c.KongAdminSvc,
+				PortNames:         sets.New(c.KondAdminSvcPortNames...),
 				Log:               ctrl.Log.WithName("controllers").WithName("KongAdminAPIService"),
 				CacheSyncTimeout:  c.CacheSyncTimeout,
 				EndpointsNotifier: kongAdminAPIEndpointsNotifier,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -294,7 +295,7 @@ func (c *Config) getKongClients(ctx context.Context) ([]*adminapi.Client, error)
 		// instance and without an address and there's no way to initialize the
 		// configuration validation and sending code.
 		err = retry.Do(func() error {
-			s, err := adminapi.GetURLsForService(ctx, kubeClient, c.KongAdminSvc)
+			s, err := adminapi.GetURLsForService(ctx, kubeClient, c.KongAdminSvc, sets.New(c.KondAdminSvcPortNames...))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to allow more flexible usage of Admin API service discovery this PR introduces configurable port names that will be used for matching against port from Admin API Service during service discovery.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
