### PR TITLE
tests: introduce `testenv.WaitForClusterDelete()` to make wait for cluster deletion configurable

### DIFF
--- a/test/e2e/clusters.go
+++ b/test/e2e/clusters.go
@@ -33,6 +33,8 @@ func gkeTestClusterLabels() map[string]string {
 }
 
 func logClusterInfo(t *testing.T, cluster clusters.Cluster) {
+	t.Helper()
+
 	v, err := cluster.Version()
 	require.NoError(t, err)
 	t.Logf("cluster %s (type: %s, v: %s) is up", cluster.Name(), cluster.Type(), v)

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -87,7 +87,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	defer cancel()
 
 	t.Log("building test cluster and environment")
-	builder, err := getEnvironmentBuilder(ctx)
+	builder, err := getEnvironmentBuilder(ctx, t)
 	require.NoError(t, err)
 	builder = builder.WithAddons(kuma.New())
 	env, err := builder.Build(ctx)

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -324,6 +324,8 @@ func getKongProxyNodePortIP(ctx context.Context, t *testing.T, env environments.
 // startPortForwarder runs "kubectl port-forward" in the background. It returns a local port that the traffic gets forward to.
 // It stops the forward when the provided context ends.
 func startPortForwarder(ctx context.Context, t *testing.T, env environments.Environment, namespace, name, targetPort string) int {
+	t.Helper()
+
 	localPort, err := freeport.GetFreePort()
 	require.NoError(t, err)
 

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -90,3 +90,8 @@ func KeepTestCluster() string {
 func ExistingClusterName() string {
 	return os.Getenv("KONG_TEST_CLUSTER")
 }
+
+// WaitForClusterDelete indicates whether or not to wait for cluster deletion to complete.
+func WaitForClusterDelete() bool {
+	return os.Getenv("KONG_TEST_CLUSTER_WAIT_FOR_DELETE") == "true"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `testenv.WaitForClusterDelete()` which looks at the value of `KONG_TEST_CLUSTER_WAIT_FOR_DELETE` environment variable and if it's set to `true` then it wait for the cluster deletion to complete.

This should help in our recent problems with e2e tests timing out.
