### PR TITLE
chore(ci): filter out istio tests from general e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,13 +12,22 @@ jobs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
     steps:
       - uses: actions/checkout@v3
+      - id: test_files
+        name: Get test file names
+        working-directory: test/e2e/
+        # go list used to extract the test names from only those test files that
+        # match the specified tags: here e2e_tests.
+        # This filters out e.g. istio tests which we run separately.
+        run: echo "result=$(go list -tags e2e_tests -f '{{ range .TestGoFiles }} {{- . }} {{ end }}' .)" >> $GITHUB_OUTPUT
+      - name: Print test file names
+        run: echo "Test file names ${{ steps.test_files.outputs.result }}"
       - id: set_test_names
         name: Set test names
         working-directory: test/e2e/
         # grep magic described in https://unix.stackexchange.com/a/13472
         # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
         run: |
-          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" ${{ steps.test_files.outputs.result }} | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
   e2e-kind-tests:

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -27,13 +27,22 @@ jobs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
     steps:
       - uses: actions/checkout@v3
+      - id: test_files
+        name: Get test file names
+        working-directory: test/e2e/
+        # go list used to extract the test names from only those test files that
+        # match the specified tags: here e2e_tests.
+        # This filters out e.g. istio tests which we run separately.
+        run: echo "result=$(go list -tags e2e_tests -f '{{ range .TestGoFiles }} {{- . }} {{ end }}' .)" >> $GITHUB_OUTPUT
+      - name: Print test file names
+        run: echo "Test file names ${{ steps.test_files.outputs.result }}"
       - id: set_test_names
         name: Set test names
         working-directory: test/e2e/
         # grep magic described in https://unix.stackexchange.com/a/13472
         # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
         run: |
-          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+          echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" ${{ steps.test_files.outputs.result }} | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Istio tests are [run separately](https://github.com/Kong/kubernetes-ingress-controller/blob/4c92de5567678f8f6ac2741a994a18141b5abc07/.github/workflows/e2e.yaml#L157-L222) in e2e (and not run in e2e targeted: works as designed?)

Since we use `grep` and `sed` magic to get test names in github actions yaml and we don't use builds tags there we also include istio tests names in the matrix which causes CI to run a workflow for each but not run it because the tags do not match.

Example: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4182210606/jobs/7245050991

```
(cd third_party && go mod tidy && \
	GOBIN=/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/bin go generate -tags=third_party ./gotestsum.go )
GOFLAGS="-tags=e2e_tests" \
GOTESTSUM_FORMAT=standard-verbose \
/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/bin/gotestsum --  \
	-race \
	-run TestIstioWithKongIngressGateway$ \
	-parallel 1 \
	-timeout "45m" \
	./test/e2e/...
go: downloading github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
go: downloading google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc
go: downloading google.golang.org/grpc v1.53.0
go: downloading google.golang.org/api v0.110.0
go: downloading cloud.google.com/go/compute v1.18.0
go: downloading github.com/googleapis/enterprise-certificate-proxy v0.2.3
testing: warning: no tests to run
PASS
ok  	github.com/kong/kubernetes-ingress-controller/v2/test/e2e	0.[12](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4182210606/jobs/7245050991#step:6:13)7s [no tests to run]

DONE 0 tests in [13](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4182210606/jobs/7245050991#step:6:14)9.802s
```

To avoid creating workflows for those tests ( and increasing queueing in our repos ) filter out test that are not defined in files that contain `e2e_tests` build tag.

Given our current matrices we go down from 102 to 96 e2e test workflows and from 17 to 16 for gke e2e tests.