### PR TITLE
feat(config): use projected volume for SA token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ Adding a new version? You'll need three changes:
 - Added flag `--konnect-refresh-node-period` to set the period of uploading 
   status of KIC instance to Konnect runtime group.
   [#3533](https://github.com/Kong/kubernetes-ingress-controller/pull/3533)
+- Replaced service account's token static secret with a projected volume in 
+  deployment manifests.
+  [#3563](https://github.com/Kong/kubernetes-ingress-controller/pull/3563)
 
 ### Fixed
 

--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -24,15 +24,22 @@ spec:
       automountServiceAccountToken: false
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          secretName: kong-serviceaccount-token
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
+        projected:
+          sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                name: kube-root-ca.crt
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
       containers:
       - name: proxy
         image: kong-placeholder:placeholder # This is replaced by the config/image.yaml component
@@ -151,4 +158,3 @@ spec:
         - name: kong-serviceaccount-token
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
-

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1766,15 +1766,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1774,15 +1774,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless-multi-gw.yaml
+++ b/deploy/single/all-in-one-dbless-multi-gw.yaml
@@ -1711,15 +1711,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1759,15 +1759,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1853,15 +1853,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1790,15 +1790,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports the changes from helm chart: https://github.com/Kong/charts/pull/722. A projected volume is used instead of a static secret.

That effectively makes our manifests not compatible with Kubernetes < 1.21 versions. According to our [support matrix](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/), we already do not support such. 

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4187269214

**Which issue this PR fixes**:

Closes #3475.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
