### PR TITLE
fix(konnect): make NodeAgent manager.Runnable

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -211,7 +211,9 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 				konnectNodeAPIClient,
 				configStatusNotifier,
 			)
-			agent.Run(ctx)
+			if err := mgr.Add(agent); err != nil {
+				setupLog.Error(err, "failed adding konnect.NodeAgent runnable to the manager")
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensures that the NodeAgent goroutines are run only when the KIC instance has been elected a leader.

**Which issue this PR fixes**:

Part of #3438.

