### PR TITLE
tests: wait for all pods ready in multi-gw e2e

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -357,9 +357,9 @@ func TestDeployAllInOneDBLESSMultiGW(t *testing.T) {
 		require.NoError(t, err)
 
 		readyCount := lo.CountBy(podList.Items, func(item corev1.Pod) bool {
-			return lo.CountBy(item.Status.Conditions, func(item corev1.PodCondition) bool {
+			return lo.ContainsBy(item.Status.Conditions, func(item corev1.PodCondition) bool {
 				return item.Type == corev1.PodReady && item.Status == corev1.ConditionTrue
-			}) == 1
+			})
 		})
 		return readyCount == 3
 	}, time.Minute, time.Second)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -342,7 +342,9 @@ func TestDeployAllInOneDBLESSMultiGW(t *testing.T) {
 
 	gatewayDeployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, "proxy-kong", metav1.GetOptions{})
 	require.NoError(t, err)
-	gatewayDeployment.Spec.Replicas = lo.ToPtr(int32(3))
+
+	const replicasCount = 3
+	gatewayDeployment.Spec.Replicas = lo.ToPtr(int32(replicasCount))
 	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -356,12 +358,12 @@ func TestDeployAllInOneDBLESSMultiGW(t *testing.T) {
 		podList, err = env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, forDeployment)
 		require.NoError(t, err)
 
-		readyCount := lo.CountBy(podList.Items, func(item corev1.Pod) bool {
-			return lo.ContainsBy(item.Status.Conditions, func(item corev1.PodCondition) bool {
-				return item.Type == corev1.PodReady && item.Status == corev1.ConditionTrue
+		readyReplicasCount := lo.CountBy(podList.Items, func(pod corev1.Pod) bool {
+			return lo.ContainsBy(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
+				return cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue
 			})
 		})
-		return readyCount == 3
+		return readyReplicasCount == replicasCount
 	}, time.Minute, time.Second)
 
 	t.Log("confirming that all dataplanes got the config")


### PR DESCRIPTION
**What this PR does / why we need it**:

Wait until all pods are ready to be sure we can safely port-forward to them. Also pass build args when building ci docker image in targeted e2e workflow so that `metadata.Release` (aka version) is properly populated in the binary (which when missing made [KonnectConfigPush test to fail](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4194316203/jobs/7272381057))

E2Es run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4197202223
