### PR TITLE
fix: add context to retry in `getKongClients()` and `kongconfig.GetRoots()` to allow proper cancellation

### DIFF
--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -300,11 +300,12 @@ func (c *Config) getKongClients(ctx context.Context) ([]*adminapi.Client, error)
 				return err
 			}
 			if s.Len() == 0 {
-				return fmt.Errorf("no endpoints for kong admin service: %q", c.KongAdminSvc)
+				return fmt.Errorf("no endpoints for kong admin service: %s", c.KongAdminSvc)
 			}
 			addresses = s.UnsortedList()
 			return nil
 		},
+			retry.Context(ctx),
 			retry.Attempts(60),
 			retry.DelayType(retry.FixedDelay),
 			retry.Delay(time.Second),

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -179,6 +179,7 @@ func GetRoots(
 					lock.Unlock()
 					return nil
 				},
+				retry.Context(ctx),
 				retry.Attempts(retries),
 				retry.Delay(retryDelay),
 				retry.DelayType(retry.FixedDelay),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds context to `getKongClients()` so that cancellation e.g. coming from os signals can get through.

It also adds it to `kongconfig.GetRoots()`.