### PR TITLE
fix(parser) copy parent info when consolidating

### DIFF
--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -41,6 +41,9 @@ func mergeIngressRules(objs ...ingressRules) ingressRules {
 		for k, v := range obj.ServiceNameToServices {
 			result.ServiceNameToServices[k] = v
 		}
+		for k, v := range obj.ServiceNameToParent {
+			result.ServiceNameToParent[k] = v
+		}
 	}
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Properly copies the parent info from different sources when consolidating ingress rules.

**Which issue this PR fixes**:

Fix #3570