### PR TITLE
chore: don't get pod info when not necessary

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -198,14 +198,13 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 			setupLog.Error(err, "failed creating konnect client, skipping running NodeAgent")
 		} else {
 			var hostname string
-			podName := os.Getenv("POD_NAME")
-			podNs := os.Getenv("POD_NAMESPACE")
-			if podName == "" || podNs == "" {
-				setupLog.Info("pod namespace or pod name not found, fallback to use hostname as node name in konnect")
+			nn, err := util.GetPodNN()
+			if err != nil {
+				setupLog.Error(err, "failed to get pod name and/or namespace, fallback to use hostname as node name in konnect")
 				hostname, _ = os.Hostname()
 			} else {
-				hostname = podNs + "/" + podName
-				setupLog.Info(fmt.Sprintf("using %s as node name in konnect", hostname))
+				hostname = nn.String()
+				setupLog.Info(fmt.Sprintf("use %s as node name in konnect", hostname))
 			}
 			version := metadata.Release
 			// set channel to send config status.

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -83,7 +83,7 @@ func TestCreateManager(t *testing.T) {
 		Platform:     "linux/amd64",
 	}
 
-	mgr, err := createManager(ctx, k8sclient, dyn, ctrlClient, payload, featureGates, meshDetection, publishService,
+	mgr, err := createManager(k8sclient, dyn, ctrlClient, payload, featureGates, meshDetection, publishService,
 		telemetry.OptManagerPeriod(time.Hour),
 		telemetry.OptManagerLogger(logr.Discard()),
 	)

--- a/internal/manager/telemetry/reports.go
+++ b/internal/manager/telemetry/reports.go
@@ -65,7 +65,7 @@ func SetupAnonymousReports(
 		"id": uuid.NewString(), // universal unique identifier for this system
 	}
 
-	tMgr, err := CreateManager(ctx, kubeCfg, fixedPayload, featureGates, meshDetection, publishService)
+	tMgr, err := CreateManager(kubeCfg, fixedPayload, featureGates, meshDetection, publishService)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create anonymous reports manager: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

No need to query the pod info if the only thing that we need is pod's name and namespace.

Add `util.GetPodNN()` solely for that purpose.


