### PR TITLE
fix: don't return address to package variable

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -46,26 +46,26 @@ func SetKongVersion(version semver.Version) {
 }
 
 // GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version.
-func GetKongVersion() *KongVersion {
-	return &kongVersion
+func GetKongVersion() KongVersion {
+	return kongVersion
 }
 
 // Full returns a complete Kong version as a semver.Version.
-func (v *KongVersion) Full() semver.Version {
-	return semver.Version(*v)
+func (v KongVersion) Full() semver.Version {
+	return semver.Version(v)
 }
 
 // MajorOnly returns a semver.Version with a KongVersion's major version only.
-func (v *KongVersion) MajorOnly() semver.Version {
+func (v KongVersion) MajorOnly() semver.Version {
 	return semver.Version{Major: v.Major}
 }
 
 // MajorMinorOnly returns a semver.Version with a KongVersion's major and minor versions only.
-func (v *KongVersion) MajorMinorOnly() semver.Version {
+func (v KongVersion) MajorMinorOnly() semver.Version {
 	return semver.Version{Major: v.Major, Minor: v.Minor}
 }
 
 // MajorMinorPatchOnly returns a semver.Version with a KongVersion's major, minor, and patch versions only.
-func (v *KongVersion) MajorMinorPatchOnly() semver.Version {
+func (v KongVersion) MajorMinorPatchOnly() semver.Version {
 	return semver.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

To prevent data races like [this one](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4204271323/jobs/7294710834#step:8:13738):

```
==================
WARNING: DATA RACE
Read at 0x0000061fd9e0 by goroutine 211:
  github.com/kong/kubernetes-ingress-controller/v2/internal/versions.(*KongVersion).MajorMinorOnly()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/versions/versions.go:65 +0x184
  github.com/kong/kubernetes-ingress-controller/v2/test/integration.TestConfigErrorEventGeneration()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/config_error_event_test.go:31 +0x147
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1629 +0x47

Previous write at 0x0000061fd9e0 by goroutine 195:
  github.com/kong/kubernetes-ingress-controller/v2/internal/manager.Run.func1()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/versions/versions.go:44 +0x48
  sync.(*Once).doSlow()
      /opt/hostedtoolcache/go/1.20.1/x64/src/sync/once.go:74 +0x101
  sync.(*Once).Do()
      /opt/hostedtoolcache/go/1.20.1/x64/src/sync/once.go:65 +0x46
  github.com/kong/kubernetes-ingress-controller/v2/internal/versions.SetKongVersion()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/versions/versions.go:43 +0xf65
  github.com/kong/kubernetes-ingress-controller/v2/internal/manager.Run()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/manager/run.go:73 +0xe2d
  github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd.RunWithLogger()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/cmd/rootcmd/run.go:40 +0x472
  github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster.func1()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:95 +0x232

Goroutine 211 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1906 +0xb44
  github.com/kong/kubernetes-ingress-controller/v2/test/integration.TestMain()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/suite_test.go:211 +0x35a4
  main.main()
      _testmain.go:190 +0x33d

Goroutine 195 (running) created at:
  github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:92 +0xbcf
  github.com/kong/kubernetes-ingress-controller/v2/test/integration.TestMain()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/suite_test.go:165 +0x2c51
  main.main()
      _testmain.go:190 +0x33d
==================
```

don't return pointers to package variable.
