### PR TITLE
fix: not accepted when unsupportedProtocol

### DIFF
--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -321,13 +321,6 @@ func getListenerStatus(
 				Status:             metav1.ConditionFalse,
 				LastTransitionTime: metav1.Now(),
 				ObservedGeneration: gateway.Generation,
-			}, metav1.Condition{
-				Type:               string(gatewayv1beta1.ListenerConditionReady),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: gateway.Generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1beta1.ListenerReasonInvalid),
-				Message:            "the listener is not ready and available for routing",
 			})
 		}
 
@@ -383,7 +376,7 @@ func getListenerStatus(
 		if len(kongProtocolsToPort[listener.Protocol]) == 0 {
 			status.Conditions = append(status.Conditions, metav1.Condition{
 				Type:               string(gatewayv1beta1.ListenerConditionAccepted),
-				Status:             metav1.ConditionTrue,
+				Status:             metav1.ConditionFalse,
 				ObservedGeneration: gateway.Generation,
 				LastTransitionTime: metav1.Now(),
 				Reason:             string(gatewayv1beta1.ListenerReasonUnsupportedProtocol),
@@ -393,7 +386,7 @@ func getListenerStatus(
 			if _, ok := kongProtocolsToPort[listener.Protocol][listener.Port]; !ok {
 				status.Conditions = append(status.Conditions, metav1.Condition{
 					Type:               string(gatewayv1beta1.ListenerConditionAccepted),
-					Status:             metav1.ConditionTrue,
+					Status:             metav1.ConditionFalse,
 					ObservedGeneration: gateway.Generation,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(gatewayv1beta1.ListenerReasonPortUnavailable),
@@ -443,7 +436,7 @@ func getListenerStatus(
 				Status:             metav1.ConditionFalse,
 				ObservedGeneration: gateway.Generation,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1beta1.ListenerReasonPending),
+				Reason:             string(gatewayv1beta1.ListenerReasonInvalid),
 				Message:            "the listener is not ready and cannot route requests",
 			})
 		}


### PR DESCRIPTION
The *Route Accepted condition is set to false when the reason is UnsupportedProtocol.

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
