### PR TITLE
fix: get Admin API services dynamically in admission webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,16 +159,12 @@ Adding a new version? You'll need three changes:
 - Event messages for invalid multi-Service backends now indicate their derived
   Kong resource name.
   [#3318](https://github.com/Kong/kubernetes-ingress-controller/pull/3318)
-- `--konnect-sync-enabled` feature flag has been introduced. It enables the
-  integration with Kong's Konnect cloud. It's turned off by default.
-  When enabled, it allows synchronising data-plane configuration with
-  a Konnect Runtime Group specified by `--konnect-runtime-group-id`.
-  It requires `--konnect-tls-client-*` set of flags to be set to provide
-  Runtime Group's TLS client certificates for authentication.
-  [#3455](https://github.com/Kong/kubernetes-ingress-controller/pull/3455)
 - Removed a duplicated status update of the HTTPRoute, which led to a potential
   status flickering.
   [#3451](https://github.com/Kong/kubernetes-ingress-controller/pull/3451)
+- Made Admission Webhook fetch the latest list of Gateways to avoid calling
+  outdated services set statically during the setup.
+  [#3601](https://github.com/Kong/kubernetes-ingress-controller/pull/3601)
 
 ### Under the hood
 

--- a/internal/admission/adminapi_provider.go
+++ b/internal/admission/adminapi_provider.go
@@ -1,0 +1,55 @@
+package admission
+
+import (
+	"github.com/kong/go-kong/kong"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+)
+
+// GatewayClientsProvider returns the most recent set of Gateway Admin API clients.
+type GatewayClientsProvider interface {
+	GatewayClients() []*adminapi.Client
+}
+
+// DefaultAdminAPIServicesProvider allows getting Admin API services that require having at least one Gateway discovered.
+// In the case there's no Gateways, it will return `false` from every method, signalling there's no Gateway available.
+type DefaultAdminAPIServicesProvider struct {
+	gatewayClientsProvider GatewayClientsProvider
+}
+
+func NewDefaultAdminAPIServicesProvider(gatewaysProvider GatewayClientsProvider) *DefaultAdminAPIServicesProvider {
+	return &DefaultAdminAPIServicesProvider{gatewayClientsProvider: gatewaysProvider}
+}
+
+func (p DefaultAdminAPIServicesProvider) GetConsumersService() (kong.AbstractConsumerService, bool) {
+	c, ok := p.designatedAdminAPIClient()
+	if !ok {
+		return nil, ok
+	}
+	return c.Consumers, true
+}
+
+func (p DefaultAdminAPIServicesProvider) GetPluginsService() (kong.AbstractPluginService, bool) {
+	c, ok := p.designatedAdminAPIClient()
+	if !ok {
+		return nil, ok
+	}
+	return c.Plugins, true
+}
+
+func (p DefaultAdminAPIServicesProvider) designatedAdminAPIClient() (*kong.Client, bool) {
+	gwClients := p.gatewayClientsProvider.GatewayClients()
+	if len(gwClients) == 0 {
+		return nil, false
+	}
+
+	// For now using first client is kind of OK. Using Consumer and Plugin
+	// services from first kong client should theoretically return the same
+	// results as for all other clients. There might be instances where
+	// configurations in different Kong Gateways are ever so slightly
+	// different but that shouldn't cause a fatal failure.
+	//
+	// TODO: We should take a look at this sooner rather than later.
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/3363
+	return gwClients[0].AdminAPIClient(), true
+}

--- a/internal/admission/adminapi_provider_test.go
+++ b/internal/admission/adminapi_provider_test.go
@@ -1,0 +1,49 @@
+package admission_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/admission"
+)
+
+type fakeGatewayClientsProvider struct {
+	clients []*adminapi.Client
+}
+
+func (f fakeGatewayClientsProvider) GatewayClients() []*adminapi.Client {
+	return f.clients
+}
+
+func TestDefaultAdminAPIServicesProvider(t *testing.T) {
+	t.Run("no clients available should return false from methods", func(t *testing.T) {
+		p := admission.NewDefaultAdminAPIServicesProvider(fakeGatewayClientsProvider{})
+
+		_, ok := p.GetConsumersService()
+		require.False(t, ok)
+
+		_, ok = p.GetPluginsService()
+		require.False(t, ok)
+	})
+
+	t.Run("when clients available should return first one", func(t *testing.T) {
+		firstClient := lo.Must(adminapi.NewTestClient("localhost:8080"))
+		p := admission.NewDefaultAdminAPIServicesProvider(fakeGatewayClientsProvider{
+			clients: []*adminapi.Client{
+				firstClient,
+				lo.Must(adminapi.NewTestClient("localhost:8081")),
+			},
+		})
+
+		consumersSvc, ok := p.GetConsumersService()
+		require.True(t, ok)
+		require.Equal(t, firstClient.AdminAPIClient().Consumers, consumersSvc)
+
+		pluginsSvc, ok := p.GetPluginsService()
+		require.True(t, ok)
+		require.Equal(t, firstClient.AdminAPIClient().Plugins, pluginsSvc)
+	})
+}

--- a/internal/konnect/client.go
+++ b/internal/konnect/client.go
@@ -169,7 +169,7 @@ func (c *NodeAPIClient) ListAllNodes() ([]*NodeItem, error) {
 			return nil, err
 		}
 		nodes = append(nodes, resp.Items...)
-		if resp.Page.NextPageNum == 0 {
+		if resp.Page == nil || resp.Page.NextPageNum == 0 {
 			return nodes, nil
 		}
 		// if konnect returns a non-0 NextPageNum, the node are not all listed

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -157,6 +157,7 @@ func setupDataplaneSynchronizer(
 func setupAdmissionServer(
 	ctx context.Context,
 	managerConfig *Config,
+	clientsManager *dataplane.AdminAPIClientsManager,
 	managerClient client.Client,
 	deprecatedLogger logrus.FieldLogger,
 ) error {
@@ -167,26 +168,13 @@ func setupAdmissionServer(
 		return nil
 	}
 
-	kongclients, err := managerConfig.adminAPIClients(ctx)
-	if err != nil {
-		return err
-	}
-	// For now using first client is kind of OK. Using Consumer and Plugin
-	// services from first kong client should theoretically return the same
-	// results as for all other clients. There might be instances where
-	// configurations in different Kong Gateways are ever so slightly
-	// different but that shouldn't cause a fatal failure.
-	//
-	// TODO: We should take a look at this sooner rather than later.
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3363
-	designatedKongClient := kongclients[0].AdminAPIClient()
+	adminAPIServicesProvider := admission.NewDefaultAdminAPIServicesProvider(clientsManager)
 	srv, err := admission.MakeTLSServer(ctx, &managerConfig.AdmissionServer, &admission.RequestHandler{
 		Validator: admission.NewKongHTTPValidator(
-			designatedKongClient.Consumers,
-			designatedKongClient.Plugins,
 			logger,
 			managerClient,
 			managerConfig.IngressClassName,
+			adminAPIServicesProvider,
 		),
 		Logger: logger,
 	}, logger)


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the `AdminAPIClientsManager` to always get the latest list of clients in the admission webhook
to avoid calling outdated services that were set statically during the setup.

Also includes a quick-fix for nil dereference in `konnect.NodeAPIClient`.

E2E run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4264473116/jobs/7422655686

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #3600.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
