### PR TITLE
feat(konnect): make sure Konnect misconfiguration doesn't affect ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@ Adding a new version? You'll need three changes:
 - Made Admission Webhook fetch the latest list of Gateways to avoid calling
   outdated services set statically during the setup.
   [#3601](https://github.com/Kong/kubernetes-ingress-controller/pull/3601)
+- Konnect sync misconfiguration (e.g. specifying incorrect Runtime Group ID)
+  won't affect the basic functionality of the controller.
+  [#3617](https://github.com/Kong/kubernetes-ingress-controller/pull/3617)
 
 ### Under the hood
 

--- a/internal/adminapi/konnect_test.go
+++ b/internal/adminapi/konnect_test.go
@@ -18,7 +18,7 @@ func TestNewKongClientForKonnectRuntimeGroup(t *testing.T) {
 	ctx := context.Background()
 	const runtimeGroupID = "adf78c28-5763-4394-a9a4-a9436a1bea7d"
 
-	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(ctx, adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(adminapi.KonnectConfig{
 		ConfigSynchronizationEnabled: true,
 		RuntimeGroupID:               runtimeGroupID,
 		Address:                      "https://us.kic.api.konghq.tech",

--- a/internal/dataplane/config_status_test.go
+++ b/internal/dataplane/config_status_test.go
@@ -1,0 +1,33 @@
+package dataplane_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+)
+
+func TestChannelConfigNotifier(t *testing.T) {
+	logger := testr.New(t)
+	n := dataplane.NewChannelConfigNotifier(logger)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch := n.SubscribeConfigStatus()
+
+	// Call NotifyConfigStatus 5 times to make sure that the method is non-blocking.
+	for i := 0; i < 5; i++ {
+		n.NotifyConfigStatus(ctx, dataplane.ConfigStatusOK)
+	}
+
+	for i := 0; i < 5; i++ {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for config status i=%d", i)
+		}
+	}
+}

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -136,7 +136,7 @@ type KongClient struct {
 	// clientsProvider allows retrieving the most recent set of clients.
 	clientsProvider AdminAPIClientsProvider
 
-	// configStatusNotifier notifies status of cofiguring kong gateway.
+	// configStatusNotifier notifies status of configuring kong gateway.
 	configStatusNotifier ConfigStatusNotifier
 }
 
@@ -426,7 +426,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 
 	shas, err := c.sendOutToClients(ctx, kongstate, formatVersion, c.kongConfig)
 	if err != nil {
-		c.configStatusNotifier.NotifyConfigStatus(ConfigStatusApplyFailed)
+		c.configStatusNotifier.NotifyConfigStatus(ctx, ConfigStatusApplyFailed)
 		return err
 	}
 
@@ -434,9 +434,9 @@ func (c *KongClient) Update(ctx context.Context) error {
 	// notify the receiver of config status that translation error happened when there are translation errors,
 	// otherwise notify that config status is OK.
 	if len(translationFailures) > 0 {
-		c.configStatusNotifier.NotifyConfigStatus(ConfigStatusTranslationErrorHappened)
+		c.configStatusNotifier.NotifyConfigStatus(ctx, ConfigStatusTranslationErrorHappened)
 	} else {
-		c.configStatusNotifier.NotifyConfigStatus(ConfigStatusOK)
+		c.configStatusNotifier.NotifyConfigStatus(ctx, ConfigStatusOK)
 	}
 
 	// report on configured Kubernetes objects if enabled

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -58,8 +58,28 @@ func TestKonnectConfigPush(t *testing.T) {
 	verifyIngress(ctx, t, env)
 
 	t.Log("ensuring ingress resources are correctly populated in Konnect Runtime Group's Admin API")
-	konnectAdminAPIClient := createKonnectAdminAPIClient(ctx, t, rgID, cert, key)
+	konnectAdminAPIClient := createKonnectAdminAPIClient(t, rgID, cert, key)
 	requireIngressConfiguredInAdminAPIEventually(ctx, t, konnectAdminAPIClient.AdminAPIClient())
+}
+
+func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
+	t.Parallel()
+	skipIfMissingRequiredKonnectEnvVariables(t)
+
+	ctx, env := setupE2ETest(t)
+
+	rgID := createTestRuntimeGroup(ctx, t)
+	cert, key := createClientCertificate(ctx, t, rgID)
+
+	// create a Konnect client secret and config map with a non-existing runtime group ID to simulate misconfiguration
+	notExistingRgID := "not-existing-rg-id"
+	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, notExistingRgID)
+
+	deployAllInOneKonnectManifest(ctx, t, env)
+
+	t.Log("running ingress tests to verify misconfiguration doesn't affect basic ingress functionality")
+	deployIngress(ctx, t, env)
+	verifyIngress(ctx, t, env)
 }
 
 func skipIfMissingRequiredKonnectEnvVariables(t *testing.T) {
@@ -213,10 +233,10 @@ func createKonnectClientSecretAndConfigMap(ctx context.Context, t *testing.T, en
 }
 
 // createKonnectAdminAPIClient creates an *kong.Client that will communicate with Konnect Runtime Group's Admin API.
-func createKonnectAdminAPIClient(ctx context.Context, t *testing.T, rgID, cert, key string) *adminapi.Client {
+func createKonnectAdminAPIClient(t *testing.T, rgID, cert, key string) *adminapi.Client {
 	t.Helper()
 
-	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(ctx, adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(adminapi.KonnectConfig{
 		RuntimeGroupID: rgID,
 		Address:        konnectRuntimeGroupAdminAPIBaseURL,
 		TLSClient: adminapi.TLSClientConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensures that even if the user misconfigures Konnect, the basic ingress controller functionality is not affected. It includes:

- propagate context in `NodeAPIClient` methods to ensure they properly close when the context gets canceled
- never return an error from `NodeAgent.Start` to not interrupt the `controller-runtime.Manager` (and unit-test it)
- propagate context in `NodeAgent` methods to ensure it can be aborted properly
- setup Konnect Admin API client in a goroutine to not block the main setup flow
- ensure that config status notifications are not blocking (and unit-test it)
- cleanup logging
- cover the case with misconfigured Konnect integration in an E2E test to ensure the basic ingress functionality doesn't get broken

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4285818571

**Which issue this PR fixes**:

Part of #3430.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
