### PR TITLE
fix: fake clientset not using the correct group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,8 @@ Adding a new version? You'll need three changes:
   [#3539](https://github.com/Kong/kubernetes-ingress-controller/pull/3539)
 - Updated the compiler to [Go v1.20](https://golang.org/doc/go1.20)
   [#3540](https://github.com/Kong/kubernetes-ingress-controller/issues/3540)
+- Fixed an issue with the fake clientset using the wrong group name
+  [#3517](https://github.com/Kong/kubernetes-ingress-controller/issues/3517)
 
 ### Deprecated
 

--- a/pkg/apis/configuration/v1/doc.go
+++ b/pkg/apis/configuration/v1/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1 contains API Schema definitions for the konghq.com v1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=configuration.konghq.com
+package v1

--- a/pkg/apis/configuration/v1/groupversion_info.go
+++ b/pkg/apis/configuration/v1/groupversion_info.go
@@ -14,16 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the konghq.com v1 API group.
 package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
-
-// +kubebuilder:object:generate=true
-// +groupName=configuration.konghq.com
 
 var (
 	// GroupVersion is group version used to register these objects.

--- a/pkg/apis/configuration/v1alpha1/doc.go
+++ b/pkg/apis/configuration/v1alpha1/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the configuration.konghq.com v1alpha1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=configuration.konghq.com
+package v1alpha1

--- a/pkg/apis/configuration/v1alpha1/groupversion_info.go
+++ b/pkg/apis/configuration/v1alpha1/groupversion_info.go
@@ -14,16 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the configuration.konghq.com v1alpha1 API group.
 package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
-
-// +kubebuilder:object:generate=true
-// +groupName=configuration.konghq.com
 
 var (
 	// GroupVersion is group version used to register these objects.

--- a/pkg/apis/configuration/v1beta1/doc.go
+++ b/pkg/apis/configuration/v1beta1/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1beta1 contains API Schema definitions for the configuration.konghq.com v1beta1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=configuration.konghq.com
+package v1beta1

--- a/pkg/apis/configuration/v1beta1/groupversion_info.go
+++ b/pkg/apis/configuration/v1beta1/groupversion_info.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the configuration.konghq.com v1beta1 API group.
-// +kubebuilder:object:generate=true
-// +groupName=configuration.konghq.com
 package v1beta1
 
 import (

--- a/pkg/clientset/typed/configuration/v1/configuration_client.go
+++ b/pkg/clientset/typed/configuration/v1/configuration_client.go
@@ -34,7 +34,7 @@ type ConfigurationV1Interface interface {
 	KongPluginsGetter
 }
 
-// ConfigurationV1Client is used to interact with features provided by the configuration group.
+// ConfigurationV1Client is used to interact with features provided by the configuration.konghq.com group.
 type ConfigurationV1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/clientset/typed/configuration/v1/fake/fake_kongclusterplugin.go
+++ b/pkg/clientset/typed/configuration/v1/fake/fake_kongclusterplugin.go
@@ -35,9 +35,9 @@ type FakeKongClusterPlugins struct {
 	Fake *FakeConfigurationV1
 }
 
-var kongclusterpluginsResource = schema.GroupVersionResource{Group: "configuration", Version: "v1", Resource: "kongclusterplugins"}
+var kongclusterpluginsResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1", Resource: "kongclusterplugins"}
 
-var kongclusterpluginsKind = schema.GroupVersionKind{Group: "configuration", Version: "v1", Kind: "KongClusterPlugin"}
+var kongclusterpluginsKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongClusterPlugin"}
 
 // Get takes name of the kongClusterPlugin, and returns the corresponding kongClusterPlugin object, and an error if there is any.
 func (c *FakeKongClusterPlugins) Get(ctx context.Context, name string, options v1.GetOptions) (result *configurationv1.KongClusterPlugin, err error) {

--- a/pkg/clientset/typed/configuration/v1/fake/fake_kongconsumer.go
+++ b/pkg/clientset/typed/configuration/v1/fake/fake_kongconsumer.go
@@ -36,9 +36,9 @@ type FakeKongConsumers struct {
 	ns   string
 }
 
-var kongconsumersResource = schema.GroupVersionResource{Group: "configuration", Version: "v1", Resource: "kongconsumers"}
+var kongconsumersResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1", Resource: "kongconsumers"}
 
-var kongconsumersKind = schema.GroupVersionKind{Group: "configuration", Version: "v1", Kind: "KongConsumer"}
+var kongconsumersKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongConsumer"}
 
 // Get takes name of the kongConsumer, and returns the corresponding kongConsumer object, and an error if there is any.
 func (c *FakeKongConsumers) Get(ctx context.Context, name string, options v1.GetOptions) (result *configurationv1.KongConsumer, err error) {

--- a/pkg/clientset/typed/configuration/v1/fake/fake_kongingress.go
+++ b/pkg/clientset/typed/configuration/v1/fake/fake_kongingress.go
@@ -36,9 +36,9 @@ type FakeKongIngresses struct {
 	ns   string
 }
 
-var kongingressesResource = schema.GroupVersionResource{Group: "configuration", Version: "v1", Resource: "kongingresses"}
+var kongingressesResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1", Resource: "kongingresses"}
 
-var kongingressesKind = schema.GroupVersionKind{Group: "configuration", Version: "v1", Kind: "KongIngress"}
+var kongingressesKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongIngress"}
 
 // Get takes name of the kongIngress, and returns the corresponding kongIngress object, and an error if there is any.
 func (c *FakeKongIngresses) Get(ctx context.Context, name string, options v1.GetOptions) (result *configurationv1.KongIngress, err error) {

--- a/pkg/clientset/typed/configuration/v1/fake/fake_kongplugin.go
+++ b/pkg/clientset/typed/configuration/v1/fake/fake_kongplugin.go
@@ -36,9 +36,9 @@ type FakeKongPlugins struct {
 	ns   string
 }
 
-var kongpluginsResource = schema.GroupVersionResource{Group: "configuration", Version: "v1", Resource: "kongplugins"}
+var kongpluginsResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1", Resource: "kongplugins"}
 
-var kongpluginsKind = schema.GroupVersionKind{Group: "configuration", Version: "v1", Kind: "KongPlugin"}
+var kongpluginsKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongPlugin"}
 
 // Get takes name of the kongPlugin, and returns the corresponding kongPlugin object, and an error if there is any.
 func (c *FakeKongPlugins) Get(ctx context.Context, name string, options v1.GetOptions) (result *configurationv1.KongPlugin, err error) {

--- a/pkg/clientset/typed/configuration/v1alpha1/configuration_client.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/configuration_client.go
@@ -31,7 +31,7 @@ type ConfigurationV1alpha1Interface interface {
 	IngressClassParametersesGetter
 }
 
-// ConfigurationV1alpha1Client is used to interact with features provided by the configuration group.
+// ConfigurationV1alpha1Client is used to interact with features provided by the configuration.konghq.com group.
 type ConfigurationV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/clientset/typed/configuration/v1alpha1/fake/fake_ingressclassparameters.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/fake/fake_ingressclassparameters.go
@@ -36,9 +36,9 @@ type FakeIngressClassParameterses struct {
 	ns   string
 }
 
-var ingressclassparametersesResource = schema.GroupVersionResource{Group: "configuration", Version: "v1alpha1", Resource: "ingressclassparameterses"}
+var ingressclassparametersesResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1alpha1", Resource: "ingressclassparameterses"}
 
-var ingressclassparametersesKind = schema.GroupVersionKind{Group: "configuration", Version: "v1alpha1", Kind: "IngressClassParameters"}
+var ingressclassparametersesKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "IngressClassParameters"}
 
 // Get takes name of the ingressClassParameters, and returns the corresponding ingressClassParameters object, and an error if there is any.
 func (c *FakeIngressClassParameterses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.IngressClassParameters, err error) {

--- a/pkg/clientset/typed/configuration/v1beta1/configuration_client.go
+++ b/pkg/clientset/typed/configuration/v1beta1/configuration_client.go
@@ -32,7 +32,7 @@ type ConfigurationV1beta1Interface interface {
 	UDPIngressesGetter
 }
 
-// ConfigurationV1beta1Client is used to interact with features provided by the configuration group.
+// ConfigurationV1beta1Client is used to interact with features provided by the configuration.konghq.com group.
 type ConfigurationV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/clientset/typed/configuration/v1beta1/fake/fake_tcpingress.go
+++ b/pkg/clientset/typed/configuration/v1beta1/fake/fake_tcpingress.go
@@ -36,9 +36,9 @@ type FakeTCPIngresses struct {
 	ns   string
 }
 
-var tcpingressesResource = schema.GroupVersionResource{Group: "configuration", Version: "v1beta1", Resource: "tcpingresses"}
+var tcpingressesResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1beta1", Resource: "tcpingresses"}
 
-var tcpingressesKind = schema.GroupVersionKind{Group: "configuration", Version: "v1beta1", Kind: "TCPIngress"}
+var tcpingressesKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1beta1", Kind: "TCPIngress"}
 
 // Get takes name of the tCPIngress, and returns the corresponding tCPIngress object, and an error if there is any.
 func (c *FakeTCPIngresses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.TCPIngress, err error) {

--- a/pkg/clientset/typed/configuration/v1beta1/fake/fake_udpingress.go
+++ b/pkg/clientset/typed/configuration/v1beta1/fake/fake_udpingress.go
@@ -36,9 +36,9 @@ type FakeUDPIngresses struct {
 	ns   string
 }
 
-var udpingressesResource = schema.GroupVersionResource{Group: "configuration", Version: "v1beta1", Resource: "udpingresses"}
+var udpingressesResource = schema.GroupVersionResource{Group: "configuration.konghq.com", Version: "v1beta1", Resource: "udpingresses"}
 
-var udpingressesKind = schema.GroupVersionKind{Group: "configuration", Version: "v1beta1", Kind: "UDPIngress"}
+var udpingressesKind = schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1beta1", Kind: "UDPIngress"}
 
 // Get takes name of the uDPIngress, and returns the corresponding uDPIngress object, and an error if there is any.
 func (c *FakeUDPIngresses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.UDPIngress, err error) {

--- a/pkg/clientset_test/clientset_test.go
+++ b/pkg/clientset_test/clientset_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	kongfake "github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/fake"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	
+	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongfake "github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/fake"
 )
 
 func TestClientset(t *testing.T) {

--- a/pkg/clientset_test/clientset_test.go
+++ b/pkg/clientset_test/clientset_test.go
@@ -1,0 +1,28 @@
+package clientset_test
+
+import (
+	"context"
+	"testing"
+
+	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongfake "github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClientset(t *testing.T) {
+	t.Run("it can retrieve a fake KongPlugin", func(t *testing.T) {
+		cl := kongfake.NewSimpleClientset(&configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-plugin",
+				Namespace: "test-ns",
+			},
+		})
+
+		plugin, err := cl.ConfigurationV1().KongPlugins("test-ns").
+			Get(context.Background(), "test-plugin", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, plugin)
+		require.Equal(t, "test-plugin", plugin.Name)
+	})
+}

--- a/pkg/clientset_test/clientset_test.go
+++ b/pkg/clientset_test/clientset_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	
+
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongfake "github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/fake"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR fixes the group mismatch reported in https://github.com/Kong/kubernetes-ingress-controller/issues/3517

**Which issue this PR fixes**:

fixes #3517 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
