### PR TITLE
fix: don't leak timer

### DIFF
--- a/internal/dataplane/config_status.go
+++ b/internal/dataplane/config_status.go
@@ -47,11 +47,14 @@ func (n *ChannelConfigNotifier) NotifyConfigStatus(ctx context.Context, status C
 	const notifyTimeout = time.Second
 
 	go func() {
+		timeout := time.NewTimer(notifyTimeout)
+		defer timeout.Stop()
+
 		select {
 		case n.ch <- status:
 		case <-ctx.Done():
 			n.logger.Info("Context done, not notifying config status", "status", status)
-		case <-time.After(notifyTimeout):
+		case <-timeout.C:
 			n.logger.Info("Timed out notifying config status", "status", status)
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

`time.After` spawns a goroutine that could be stopped sooner than the timeout itself.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Addresses https://github.com/Kong/kubernetes-ingress-controller/pull/3617#discussion_r1119756192 comment.