### PR TITLE
chore(ci): don't run enterprise tests for PRs from forks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
 
     - name: Detect if we should run if we're running enterprise tests but no license is available
       id: detect_if_should_run
-      run: echo "result=${{ (steps.license.outputs.license != '' && matrix.enterprise) || (!matrix.enterprise) }}" >> $GITHUB_OUTPUT
+      run: echo "result=${{ toJSON((steps.license.outputs.license != '' && matrix.enterprise) || (!matrix.enterprise)) }}" >> $GITHUB_OUTPUT
 
     - name: Set image and tag for enterprise
       if: steps.detect_if_should_run.outputs.result && matrix.enterprise


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that #3508 missed the fact that a condition can end up being a string. Use `toJSON()` as suggested in https://github.com/actions/runner/issues/1483 to "cast" to boolean".

Exemplar CI that failed to check this condition as expected: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4287103315/jobs/7476535337
