### PR TITLE
feat(config): make all all-in-one dbless manifests use multi-gw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,11 @@ Adding a new version? You'll need three changes:
   gateway pod. If gateway discovery is disabled, the Kong gateway nodes will use `gateway_<address>` 
   as the hostname, where `address` is the Admin API address used by KIC.
   [#3587](https://github.com/Kong/kubernetes-ingress-controller/pull/3587)
+- All all-in-one DB-less deployment manifests will now use separate deployments 
+  for the controller and the proxy. This enables the proxy to be scaled independently
+  of the controller. The old `all-in-one-dbless.yaml` manifest has been deprecated and 
+  renamed to `all-in-one-dbless-legacy.yaml`. It will be removed in a future release.
+  [#3692](https://github.com/Kong/kubernetes-ingress-controller/pull/3629)
 
 ### Fixed
 

--- a/config/variants/enterprise/kong-enterprise.yaml
+++ b/config/variants/enterprise/kong-enterprise.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ingress-kong
+  name: proxy-kong
   namespace: kong
 spec:
   template:

--- a/config/variants/enterprise/kustomization.yaml
+++ b/config/variants/enterprise/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- ../../base/
+- ../multi-gw/base
 patchesStrategicMerge:
 - kong-enterprise.yaml
 images:

--- a/config/variants/multi-gw/base/gateway_deployment.yaml
+++ b/config/variants/multi-gw/base/gateway_deployment.yaml
@@ -24,15 +24,22 @@ spec:
       automountServiceAccountToken: false
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          secretName: kong-serviceaccount-token
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
+        projected:
+          sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                name: kube-root-ca.crt
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
       containers:
       - name: proxy
         image: kong-placeholder:placeholder # This is replaced by the config/image.yaml component

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1593,6 +1593,21 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  name: kong-admin
+  namespace: kong
+spec:
+  clusterIP: None
+  ports:
+  - name: admin
+    port: 8444
+    protocol: TCP
+    targetPort: 8444
+  selector:
+    app: proxy-kong
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -1609,7 +1624,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: ingress-kong
+    app: proxy-kong
   type: LoadBalancer
 ---
 apiVersion: v1
@@ -1650,6 +1665,100 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: CONTROLLER_KONG_ADMIN_SVC
+          value: kong/kong-admin
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: kong/kubernetes-ingress-controller:2.8.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: ingress-controller
+        ports:
+        - containerPort: 8080
+          name: webhook
+          protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kong-serviceaccount-token
+          readOnly: true
+      serviceAccountName: kong-serviceaccount
+      volumes:
+      - name: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: proxy-kong
+  name: proxy-kong
+  namespace: kong
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: proxy-kong
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: proxy-kong
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
         - name: KONG_LICENSE_DATA
           valueFrom:
             secretKeyRef:
@@ -1661,7 +1770,7 @@ spec:
         - name: KONG_PORT_MAPS
           value: 80:8000, 443:8443
         - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
+          value: 0.0.0.0:8444 http2 ssl reuseport backlog=16384
         - name: KONG_STATUS_LISTEN
           value: 0.0.0.0:8100
         - name: KONG_DATABASE
@@ -1717,57 +1826,6 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-      - env:
-        - name: CONTROLLER_KONG_ADMIN_URL
-          value: https://127.0.0.1:8444
-        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-          value: "true"
-        - name: CONTROLLER_PUBLISH_SERVICE
-          value: kong/kong-proxy
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.8.1
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        name: ingress-controller
-        ports:
-        - containerPort: 8080
-          name: webhook
-          protocol: TCP
-        - containerPort: 10255
-          name: cmetrics
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kong-serviceaccount-token
-          readOnly: true
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
       serviceAccountName: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1839,15 +1839,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -1593,21 +1593,6 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kong-admin
-  namespace: kong
-spec:
-  clusterIP: None
-  ports:
-  - name: admin
-    port: 8444
-    protocol: TCP
-    targetPort: 8444
-  selector:
-    app: proxy-kong
----
-apiVersion: v1
-kind: Service
-metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -1624,7 +1609,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: proxy-kong
+    app: ingress-kong
   type: LoadBalancer
 ---
 apiVersion: v1
@@ -1665,8 +1650,71 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
-        - name: CONTROLLER_KONG_ADMIN_SVC
-          value: kong/kong-admin
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_KIC
+          value: "on"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
+        image: kong:3.1
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kong quit
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: proxy
+        ports:
+        - containerPort: 8000
+          name: proxy
+          protocol: TCP
+        - containerPort: 8443
+          name: proxy-ssl
+          protocol: TCP
+        - containerPort: 8100
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
@@ -1734,105 +1782,6 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: proxy-kong
-  name: proxy-kong
-  namespace: kong
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: proxy-kong
-  template:
-    metadata:
-      annotations:
-        kuma.io/gateway: enabled
-        kuma.io/service-account-token-volume: kong-serviceaccount-token
-        traffic.sidecar.istio.io/includeInboundPorts: ""
-      labels:
-        app: proxy-kong
-    spec:
-      automountServiceAccountToken: false
-      containers:
-      - env:
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
-            backlog=16384
-        - name: KONG_PORT_MAPS
-          value: 80:8000, 443:8443
-        - name: KONG_ADMIN_LISTEN
-          value: 0.0.0.0:8444 http2 ssl reuseport backlog=16384
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: "off"
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
-        - name: KONG_KIC
-          value: "on"
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
-        - name: KONG_PROXY_ERROR_LOG
-          value: /dev/stderr
-        - name: KONG_ROUTER_FLAVOR
-          value: traditional
-        image: kong:3.1
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - kong quit
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /status
-            port: 8100
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        name: proxy
-        ports:
-        - containerPort: 8000
-          name: proxy
-          protocol: TCP
-        - containerPort: 8443
-          name: proxy-ssl
-          protocol: TCP
-        - containerPort: 8100
-          name: metrics
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /status
-            port: 8100
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-      serviceAccountName: kong-serviceaccount
-      volumes:
-      - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1593,6 +1593,21 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  name: kong-admin
+  namespace: kong
+spec:
+  clusterIP: None
+  ports:
+  - name: admin
+    port: 8444
+    protocol: TCP
+    targetPort: 8444
+  selector:
+    app: proxy-kong
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -1609,7 +1624,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: ingress-kong
+    app: proxy-kong
   type: LoadBalancer
 ---
 apiVersion: v1
@@ -1650,71 +1665,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
-            backlog=16384
-        - name: KONG_PORT_MAPS
-          value: 80:8000, 443:8443
-        - name: KONG_ADMIN_LISTEN
-          value: 127.0.0.1:8444 http2 ssl reuseport backlog=16384
-        - name: KONG_STATUS_LISTEN
-          value: 0.0.0.0:8100
-        - name: KONG_DATABASE
-          value: "off"
-        - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
-        - name: KONG_KIC
-          value: "on"
-        - name: KONG_ADMIN_ACCESS_LOG
-          value: /dev/stdout
-        - name: KONG_ADMIN_ERROR_LOG
-          value: /dev/stderr
-        - name: KONG_PROXY_ERROR_LOG
-          value: /dev/stderr
-        - name: KONG_ROUTER_FLAVOR
-          value: traditional
-        image: kong:3.1
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - kong quit
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /status
-            port: 8100
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        name: proxy
-        ports:
-        - containerPort: 8000
-          name: proxy
-          protocol: TCP
-        - containerPort: 8443
-          name: proxy-ssl
-          protocol: TCP
-        - containerPort: 8100
-          name: metrics
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /status
-            port: 8100
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-      - env:
-        - name: CONTROLLER_KONG_ADMIN_URL
-          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_SVC
+          value: kong/kong-admin
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
@@ -1782,6 +1734,105 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: proxy-kong
+  name: proxy-kong
+  namespace: kong
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: proxy-kong
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: kong-serviceaccount-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: proxy-kong
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
+            backlog=16384
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 0.0.0.0:8444 http2 ssl reuseport backlog=16384
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_KIC
+          value: "on"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional
+        image: kong:3.1
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kong quit
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: proxy
+        ports:
+        - containerPort: 8000
+          name: proxy
+          protocol: TCP
+        - containerPort: 8443
+          name: proxy-ssl
+          protocol: TCP
+        - containerPort: 8100
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      serviceAccountName: kong-serviceaccount
+      volumes:
+      - name: kong-serviceaccount-token
+        secret:
+          items:
+          - key: token
+            path: token
+          - key: ca.crt
+            path: ca.crt
+          - key: namespace
+            path: namespace
+          secretName: kong-serviceaccount-token
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1824,15 +1824,22 @@ spec:
       serviceAccountName: kong-serviceaccount
       volumes:
       - name: kong-serviceaccount-token
-        secret:
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-          secretName: kong-serviceaccount-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/scripts/build-single-manifests.sh
+++ b/scripts/build-single-manifests.sh
@@ -8,9 +8,9 @@ REPO_ROOT=$(dirname ${BASH_SOURCE})/..
 
 cd $REPO_ROOT
 
-${REPO_ROOT}/bin/kustomize build config/base > deploy/single/all-in-one-dbless.yaml
+${REPO_ROOT}/bin/kustomize build config/base > deploy/single/all-in-one-dbless-legacy.yaml
 ${REPO_ROOT}/bin/kustomize build config/variants/postgres > deploy/single/all-in-one-postgres.yaml
 ${REPO_ROOT}/bin/kustomize build config/variants/enterprise > deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ${REPO_ROOT}/bin/kustomize build config/variants/enterprise-postgres > deploy/single/all-in-one-postgres-enterprise.yaml
 ${REPO_ROOT}/bin/kustomize build config/variants/konnect/base > deploy/single/all-in-one-dbless-konnect.yaml
-${REPO_ROOT}/bin/kustomize build config/variants/multi-gw/base > deploy/single/all-in-one-dbless-multi-gw.yaml
+${REPO_ROOT}/bin/kustomize build config/variants/multi-gw/base > deploy/single/all-in-one-dbless.yaml

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -39,13 +39,13 @@ const (
 	dblessURL  = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%v.%v.x/deploy/single/all-in-one-dbless.yaml"
 )
 
-func TestDeployAllInOneDBLESS(t *testing.T) {
-	t.Log("configuring all-in-one-dbless.yaml manifest test")
+func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
+	t.Log("configuring all-in-one-dbless-legacy.yaml manifest test")
 	t.Parallel()
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
+	manifest, err := getTestManifest(t, "../../deploy/single/all-in-one-dbless-legacy.yaml")
 	require.NoError(t, err)
 	deployment := deployKong(ctx, t, env, manifest)
 
@@ -315,11 +315,11 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	verifyEnterpriseWithPostgres(ctx, t, env, adminPassword)
 }
 
-func TestDeployAllInOneDBLESSMultiGW(t *testing.T) {
+func TestDeployAllInOneDBLESS(t *testing.T) {
 	t.Parallel()
 
 	const (
-		manifestFileName = "all-in-one-dbless-multi-gw.yaml"
+		manifestFileName = "all-in-one-dbless.yaml"
 		manifestFilePath = "../../deploy/single/" + manifestFileName
 	)
 

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -4,10 +4,13 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,52 +25,63 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	t.Log("deploying kong components with traditional Kong router")
 	manifest, err := getTestManifest(t, dblessPath)
 	require.NoError(t, err)
-	deployment := deployKong(ctx, t, env, manifest)
-	labelsForDeployment := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", deployment.Name),
-	}
-	require.Eventually(t, func() bool {
-		podList, err := env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, labelsForDeployment)
-		require.NoError(t, err)
-		if len(podList.Items) != 1 {
-			return false
-		}
-		pod := podList.Items[0]
-		proxyContainer := getContainerInPodSpec(&pod.Spec, "proxy")
-		require.NotNil(t, proxyContainer)
-		return getEnvValueInContainer(proxyContainer, "KONG_ROUTER_FLAVOR") == "traditional"
-	}, kongComponentWait, time.Second)
+	_ = deployKong(ctx, t, env, manifest)
+	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, "traditional")
 
 	t.Log("running ingress tests to verify that KIC with traditonal Kong router works")
 	deployIngress(ctx, t, env)
 	verifyIngress(ctx, t, env)
 
+	setGatewayRouterFlavor(ctx, t, cluster, "traditional_compatible")
+
+	t.Log("waiting for Kong with traditional_compatible router to start")
+	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, "traditional_compatible")
+
+	t.Log("running ingress tests to verify that KIC with traditonal_compatible Kong router works")
+	verifyIngress(ctx, t, env)
+}
+
+func setGatewayRouterFlavor(ctx context.Context, t *testing.T, cluster clusters.Cluster, flavor string) {
 	// Since we cannot replace env vars in kustomize, here we update the deployment to set KONG_ROUTER_FLAVOR to traditional_compatible.
 	t.Log("update deployment to modify Kong's router to traditional_compatible")
-	deployment, err = cluster.Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	gatewayDeployment, err := cluster.Client().AppsV1().Deployments(namespace).Get(ctx, "proxy-kong", metav1.GetOptions{})
 	require.NoError(t, err)
-	container := getContainerInPodSpec(&deployment.Spec.Template.Spec, "proxy")
+	container := getContainerInPodSpec(&gatewayDeployment.Spec.Template.Spec, "proxy")
 	require.NotNil(t, container)
 	for i, env := range container.Env {
 		if env.Name == "KONG_ROUTER_FLAVOR" {
-			container.Env[i].Value = "traditional_compatible"
+			container.Env[i].Value = flavor
 		}
 	}
-	_, err = cluster.Client().AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	_, err = cluster.Client().AppsV1().Deployments(namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
+}
 
-	t.Log("waiting for Kong with traditional_compatible router to start")
+func ensureGatewayDeployedWithRouterFlavor(ctx context.Context, t *testing.T, env environments.Environment, expectedFlavor string) {
+	labelsForDeployment := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", "proxy-kong"),
+	}
 	require.Eventually(t, func() bool {
-		podList, err := env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, labelsForDeployment)
+		podList, err := env.Cluster().Client().CoreV1().Pods(namespace).List(ctx, labelsForDeployment)
 		require.NoError(t, err)
-		if len(podList.Items) != 1 {
+		if len(podList.Items) < 1 {
 			return false
 		}
-		pod := podList.Items[0]
-		proxyContainer := getContainerInPodSpec(&pod.Spec, "proxy")
-		require.NotNil(t, proxyContainer)
-		return getEnvValueInContainer(proxyContainer, "KONG_ROUTER_FLAVOR") == "traditional_compatible"
-	}, 2*time.Minute, time.Second)
-	t.Log("running ingress tests to verify that KIC with traditonal_compatible Kong router works")
-	verifyIngress(ctx, t, env)
+
+		allPodsMatch := true
+		for _, pod := range podList.Items {
+			proxyContainer := getContainerInPodSpec(&pod.Spec, "proxy")
+			if proxyContainer == nil {
+				t.Logf("proxy container not found for Pod %s", pod.Name)
+				allPodsMatch = false
+				continue
+			}
+			if getEnvValueInContainer(proxyContainer, "KONG_ROUTER_FLAVOR") != expectedFlavor {
+				t.Logf("KONG_ROUTER_FLAVOR is not set to expected value for Pod %s", pod.Name)
+				allPodsMatch = false
+			}
+		}
+
+		return allPodsMatch
+	}, kongComponentWait, time.Second)
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -65,7 +65,7 @@ const (
 
 	ingressClass     = "kong"
 	namespace        = "kong"
-	adminServiceName = "kong-admin"
+	adminServiceName = "kong-admin-lb"
 
 	tcpEchoPort    = 1025
 	tcpListnerPort = 8888

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -93,12 +92,8 @@ func skipIfMissingRequiredKonnectEnvVariables(t *testing.T) {
 func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env environment.Environment) {
 	const manifestFile = "../../deploy/single/all-in-one-dbless-konnect.yaml"
 	t.Logf("deploying %s manifest file", manifestFile)
-	f, err := os.Open(manifestFile)
-	require.NoError(t, err)
-	defer f.Close()
-	var manifest io.Reader = f
 
-	manifest, err = patchControllerImageFromEnv(f, manifestFile)
+	manifest, err := getTestManifest(t, manifestFile)
 	require.NoError(t, err)
 	_ = deployKong(ctx, t, env, manifest)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Makes all all-in-one DB-less manifests use multi-gw config.
- Renames old single-Deployment `all-in-one-dbless.yaml` to `all-in-one-dbless-legacy.yaml`.
- Uses a projected volume instead of a static SA secret in the multi-gw proxy deployment.
- Aligns all the affected E2E tests to work with multi-gw config as expected.

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4308118461

**Which issue this PR fixes**:

Closes #3423.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
