### PR TITLE
fix: add namespace for scale request in e2e tests

### DIFF
--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -76,7 +76,8 @@ func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environ
 
 	scale := &autoscalingv1.Scale{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: deploymentName,
+			Namespace: namespace,
+			Name:      deploymentName,
 		},
 		Spec: autoscalingv1.ScaleSpec{
 			Replicas: replicas,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

k8s <= 1.23 does not support absence of namespace in `autoscalingv1/scale`, so e2e tests for kuma would fail because namespace was not specified.

failing e2e run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4310619858/jobs/7519243677 
passing e2e run with k8s 1.21: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4311227099/jobs/7520460878

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
