### PR TITLE
chore(tests): do not return error from getTestManifest

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -44,8 +44,7 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, "../../deploy/single/all-in-one-dbless-legacy.yaml")
-	require.NoError(t, err)
+	manifest := getTestManifest(t, "../../deploy/single/all-in-one-dbless-legacy.yaml")
 	deployment := deployKong(ctx, t, env, manifest)
 
 	forDeployment := metav1.ListOptions{
@@ -92,8 +91,7 @@ func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
 
 	t.Logf("deploying current version %s kong manifest", curTag)
 
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	deployKong(ctx, t, env, manifest)
 	verifyIngress(ctx, t, env)
 }
@@ -119,8 +117,7 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, entDBLESSPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, entDBLESSPath)
 	_ = deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecretYAML)
 
 	t.Log("exposing the admin api so that enterprise features can be verified")
@@ -142,8 +139,7 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, postgresPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, postgresPath)
 	_ = deployKong(ctx, t, env, manifest)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
@@ -160,8 +156,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, postgresPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, postgresPath)
 	deployment := deployKong(ctx, t, env, manifest)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
@@ -298,8 +293,7 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, entPostgresPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, entPostgresPath)
 	_ = deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecret)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
@@ -329,8 +323,7 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, manifestFilePath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, manifestFilePath)
 	deployment := deployKong(ctx, t, env, manifest)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -23,8 +23,7 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	cluster := env.Cluster()
 
 	t.Log("deploying kong components with traditional Kong router")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	_ = deployKong(ctx, t, env, manifest)
 	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, "traditional")
 

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -175,8 +175,7 @@ func TestWebhookUpdate(t *testing.T) {
 	}()
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	deployment := deployKong(ctx, t, env, manifest)
 
 	firstCertificate := &corev1.Secret{
@@ -292,8 +291,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	deployment := deployKong(ctx, t, env, manifest)
 	deploymentListOptions := metav1.ListOptions{
 		LabelSelector: "app=" + deployment.Name,
@@ -450,8 +448,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	deployment := deployKong(ctx, t, env, manifest)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
@@ -462,7 +459,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	t.Logf("deploying Gateway APIs CRDs from %s", consts.GatewayExperimentalCRDsKustomizeURL)
 	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), consts.GatewayExperimentalCRDsKustomizeURL))
 
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	t.Log("updating kong deployment to enable Gateway feature gate")
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -499,14 +496,13 @@ func TestDefaultIngressClass(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	kongDeployment := deployKong(ctx, t, env, manifest)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
@@ -608,8 +604,7 @@ func TestMissingCRDsDontCrashTheController(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 
 	manifest = stripCRDs(t, manifest)
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -100,8 +100,7 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	const manifestFile = "../../deploy/single/all-in-one-dbless-konnect.yaml"
 	t.Logf("deploying %s manifest file", manifestFile)
 
-	manifest, err := getTestManifest(t, manifestFile)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, manifestFile)
 	_ = deployKong(ctx, t, env, manifest)
 }
 

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -25,8 +25,7 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, kuma.New())
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, dblessPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, dblessPath)
 	_ = deployKong(ctx, t, env, manifest)
 
 	t.Log("adding Kuma mesh")
@@ -45,7 +44,7 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	deployIngress(ctx, t, env)
 
 	// use retry.RetryOnConflict to update service, to avoid conflicts from different source.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -114,8 +113,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	}()
 
 	t.Log("deploying kong components")
-	manifest, err := getTestManifest(t, postgresPath)
-	require.NoError(t, err)
+	manifest := getTestManifest(t, postgresPath)
 	_ = deployKong(ctx, t, env, manifest)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")


### PR DESCRIPTION
**What this PR does / why we need it**:

We can `require.NoError` in the helper itself.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


