### PR TITLE
chore(tests): do not hardcode deployments' names in e2e

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -44,9 +44,10 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, "../../deploy/single/all-in-one-dbless-legacy.yaml")
-	deployment := deployKong(ctx, t, env, manifest)
-
+	const manifestPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
+	manifest := getTestManifest(t, manifestPath)
+	deployKong(ctx, t, env, manifest)
+	deployment := getManifestDeployments(manifestPath).ControllerNN
 	forDeployment := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", deployment.Name),
 	}
@@ -118,10 +119,11 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getTestManifest(t, entDBLESSPath)
-	_ = deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecretYAML)
+	deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecretYAML)
+	deployments := getManifestDeployments(entDBLESSPath)
 
 	t.Log("exposing the admin api so that enterprise features can be verified")
-	exposeAdminAPI(ctx, t, env, "proxy-kong")
+	exposeAdminAPI(ctx, t, env, deployments.ProxyNN)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngress(ctx, t, env)
@@ -140,7 +142,7 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getTestManifest(t, postgresPath)
-	_ = deployKong(ctx, t, env, manifest)
+	deployKong(ctx, t, env, manifest)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -157,7 +159,8 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getTestManifest(t, postgresPath)
-	deployment := deployKong(ctx, t, env, manifest)
+	deployKong(ctx, t, env, manifest)
+	deployment := getManifestDeployments(postgresPath).ControllerNN
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -191,8 +194,10 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 
 	t.Log("verifying that scaling completes and the additional replicas come up")
 	require.Eventually(t, func() bool {
-		deployment, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
-		require.NoError(t, err)
+		deployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}, kongComponentWait, time.Second)
 
@@ -294,7 +299,8 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getTestManifest(t, entPostgresPath)
-	_ = deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecret)
+	deployKong(ctx, t, env, manifest, licenseSecret, adminPasswordSecret)
+	deployments := getManifestDeployments(entPostgresPath)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -304,7 +310,7 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	verifyIngress(ctx, t, env)
 
 	t.Log("exposing the admin api so that enterprise features can be verified")
-	exposeAdminAPI(ctx, t, env, "ingress-kong")
+	exposeAdminAPI(ctx, t, env, deployments.ProxyNN)
 
 	t.Log("this deployment used enterprise kong, verifying that enterprise functionality was set up properly")
 	verifyEnterprise(ctx, t, env, adminPassword)
@@ -324,28 +330,28 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getTestManifest(t, manifestFilePath)
-	deployment := deployKong(ctx, t, env, manifest)
+	deployKong(ctx, t, env, manifest)
+	deployments := getManifestDeployments(manifestFilePath)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngress(ctx, t, env)
 	verifyIngress(ctx, t, env)
 
-	gatewayDeployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, "proxy-kong", metav1.GetOptions{})
-	require.NoError(t, err)
-
 	const replicasCount = 3
+	gatewayDeployment := deployments.GetProxy(ctx, t, env)
 	gatewayDeployment.Spec.Replicas = lo.ToPtr(int32(replicasCount))
-	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
+	_, err := env.Cluster().Client().AppsV1().Deployments(gatewayDeployment.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	var podList *corev1.PodList
 
 	t.Log("waiting all the dataplane instances to be ready")
 	require.Eventually(t, func() bool {
+		appLabel := gatewayDeployment.Labels["app"]
 		forDeployment := metav1.ListOptions{
-			LabelSelector: "app=proxy-kong",
+			LabelSelector: fmt.Sprintf("app=%s", appLabel),
 		}
-		podList, err = env.Cluster().Client().CoreV1().Pods(deployment.Namespace).List(ctx, forDeployment)
+		podList, err = env.Cluster().Client().CoreV1().Pods(gatewayDeployment.Namespace).List(ctx, forDeployment)
 		require.NoError(t, err)
 
 		readyReplicasCount := lo.CountBy(podList.Items, func(pod corev1.Pod) bool {
@@ -369,7 +375,7 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 
 		forwardCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		localPort := startPortForwarder(forwardCtx, t, env, deployment.Namespace, pod.Name, "8444")
+		localPort := startPortForwarder(forwardCtx, t, env, gatewayDeployment.Namespace, pod.Name, "8444")
 		address := fmt.Sprintf("https://localhost:%d", localPort)
 
 		kongClient, err := gokong.NewClient(lo.ToPtr(address), client)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -34,8 +34,9 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	dblessPath = "../../deploy/single/all-in-one-dbless.yaml"
-	dblessURL  = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%v.%v.x/deploy/single/all-in-one-dbless.yaml"
+	dblessLegacyPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
+	dblessPath       = "../../deploy/single/all-in-one-dbless.yaml"
+	dblessURL        = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%v.%v.x/deploy/single/all-in-one-dbless.yaml"
 )
 
 func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
@@ -44,10 +45,9 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	const manifestPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
-	manifest := getTestManifest(t, manifestPath)
+	manifest := getTestManifest(t, dblessLegacyPath)
 	deployKong(ctx, t, env, manifest)
-	deployment := getManifestDeployments(manifestPath).ControllerNN
+	deployment := getManifestDeployments(dblessLegacyPath).ControllerNN
 	forDeployment := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", deployment.Name),
 	}

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -51,7 +51,8 @@ func setGatewayRouterFlavor(
 ) {
 	// Since we cannot replace env vars in kustomize, here we update the deployment to set KONG_ROUTER_FLAVOR to traditional_compatible.
 	t.Log("update deployment to modify Kong's router to traditional_compatible")
-	gatewayDeployment, err := cluster.Client().AppsV1().Deployments(proxyDeploymentNN.Namespace).Get(ctx, proxyDeploymentNN.Name, metav1.GetOptions{})
+	deployments := cluster.Client().AppsV1().Deployments(proxyDeploymentNN.Namespace)
+	gatewayDeployment, err := deployments.Get(ctx, proxyDeploymentNN.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	container := getContainerInPodSpec(&gatewayDeployment.Spec.Template.Spec, proxyContainerName)
 	require.NotNil(t, container)
@@ -60,7 +61,7 @@ func setGatewayRouterFlavor(
 			container.Env[i].Value = flavor
 		}
 	}
-	_, err = cluster.Client().AppsV1().Deployments(proxyDeploymentNN.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
+	_, err = deployments.Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 }
 

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // TestKongRouterCompatibility verifies that KIC behaves consistently with Kong routers
@@ -24,41 +25,54 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 
 	t.Log("deploying kong components with traditional Kong router")
 	manifest := getTestManifest(t, dblessPath)
-	_ = deployKong(ctx, t, env, manifest)
-	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, "traditional")
+	deployKong(ctx, t, env, manifest)
+	proxyDeploymentNN := getManifestDeployments(dblessPath).ProxyNN
+	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional")
 
 	t.Log("running ingress tests to verify that KIC with traditonal Kong router works")
 	deployIngress(ctx, t, env)
 	verifyIngress(ctx, t, env)
 
-	setGatewayRouterFlavor(ctx, t, cluster, "traditional_compatible")
+	setGatewayRouterFlavor(ctx, t, cluster, proxyDeploymentNN, "traditional_compatible")
 
 	t.Log("waiting for Kong with traditional_compatible router to start")
-	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, "traditional_compatible")
+	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional_compatible")
 
 	t.Log("running ingress tests to verify that KIC with traditonal_compatible Kong router works")
 	verifyIngress(ctx, t, env)
 }
 
-func setGatewayRouterFlavor(ctx context.Context, t *testing.T, cluster clusters.Cluster, flavor string) {
+func setGatewayRouterFlavor(
+	ctx context.Context,
+	t *testing.T,
+	cluster clusters.Cluster,
+	proxyDeploymentNN types.NamespacedName,
+	flavor string,
+) {
 	// Since we cannot replace env vars in kustomize, here we update the deployment to set KONG_ROUTER_FLAVOR to traditional_compatible.
 	t.Log("update deployment to modify Kong's router to traditional_compatible")
-	gatewayDeployment, err := cluster.Client().AppsV1().Deployments(namespace).Get(ctx, "proxy-kong", metav1.GetOptions{})
+	gatewayDeployment, err := cluster.Client().AppsV1().Deployments(proxyDeploymentNN.Namespace).Get(ctx, proxyDeploymentNN.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	container := getContainerInPodSpec(&gatewayDeployment.Spec.Template.Spec, "proxy")
+	container := getContainerInPodSpec(&gatewayDeployment.Spec.Template.Spec, proxyContainerName)
 	require.NotNil(t, container)
 	for i, env := range container.Env {
 		if env.Name == "KONG_ROUTER_FLAVOR" {
 			container.Env[i].Value = flavor
 		}
 	}
-	_, err = cluster.Client().AppsV1().Deployments(namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
+	_, err = cluster.Client().AppsV1().Deployments(proxyDeploymentNN.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 }
 
-func ensureGatewayDeployedWithRouterFlavor(ctx context.Context, t *testing.T, env environments.Environment, expectedFlavor string) {
+func ensureGatewayDeployedWithRouterFlavor(
+	ctx context.Context,
+	t *testing.T,
+	env environments.Environment,
+	proxyDeploymentNN types.NamespacedName,
+	expectedFlavor string,
+) {
 	labelsForDeployment := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", "proxy-kong"),
+		LabelSelector: fmt.Sprintf("app=%s", proxyDeploymentNN.Name),
 	}
 	require.Eventually(t, func() bool {
 		podList, err := env.Cluster().Client().CoreV1().Pods(namespace).List(ctx, labelsForDeployment)
@@ -69,7 +83,7 @@ func ensureGatewayDeployedWithRouterFlavor(ctx context.Context, t *testing.T, en
 
 		allPodsMatch := true
 		for _, pod := range podList.Items {
-			proxyContainer := getContainerInPodSpec(&pod.Spec, "proxy")
+			proxyContainer := getContainerInPodSpec(&pod.Spec, proxyContainerName)
 			if proxyContainer == nil {
 				t.Logf("proxy container not found for Pod %s", pod.Name)
 				allPodsMatch = false

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -695,11 +695,12 @@ func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environ
 			Replicas: replicas,
 		},
 	}
-	_, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).UpdateScale(ctx, deployment.Name, scale, metav1.UpdateOptions{})
+	deployments := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace)
+	_, err := deployments.UpdateScale(ctx, deployment.Name, scale, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		deployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		deployment, err := deployments.Get(ctx, deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -71,6 +73,15 @@ const (
 
 	tcpEchoPort    = 1025
 	tcpListnerPort = 8888
+
+	// controllerDeploymentName is the name of the controller deployment in all manifests variants.
+	controllerDeploymentName = "ingress-kong"
+
+	// controllerContainerName is the name of the controller container in all manifests variants.
+	controllerContainerName = "ingress-controller"
+
+	// proxyContainerName is the name of the proxy container in all manifests variants.
+	proxyContainerName = "proxy"
 )
 
 // setupE2ETest builds a testing environment for the E2E test. It also sets up the environment's teardown and test
@@ -198,7 +209,7 @@ func createGKEBuilder(t *testing.T) (*environments.Builder, error) {
 	return environments.NewBuilder().WithClusterBuilder(clusterBuilder), nil
 }
 
-func deployKong(ctx context.Context, t *testing.T, env environments.Environment, manifest io.Reader, additionalSecrets ...*corev1.Secret) *appsv1.Deployment {
+func deployKong(ctx context.Context, t *testing.T, env environments.Environment, manifest io.Reader, additionalSecrets ...*corev1.Secret) {
 	t.Helper()
 
 	t.Log("waiting for testing environment to be ready")
@@ -213,7 +224,7 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 
 	t.Logf("deploying any supplemental secrets (found: %d)", len(additionalSecrets))
 	for _, secret := range additionalSecrets {
-		_, err := env.Cluster().Client().CoreV1().Secrets("kong").Create(ctx, secret, metav1.CreateOptions{})
+		_, err := env.Cluster().Client().CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			require.NoError(t, err)
 		}
@@ -226,10 +237,10 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	t.Log("waiting for kong to be ready")
+	t.Log("waiting for controller to be ready")
 	var deployment *appsv1.Deployment
 	require.Eventually(t, func() bool {
-		deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace).Get(ctx, "ingress-kong", metav1.GetOptions{})
+		deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace).Get(ctx, controllerDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -245,7 +256,63 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 			)
 		}(),
 	)
+}
+
+// Deployments represent the deployments that are deployed by the all-in-one manifests.
+type Deployments struct {
+	ProxyNN      types.NamespacedName
+	ControllerNN types.NamespacedName
+}
+
+// GetProxy gets the proxy deployment from the cluster.
+func (d Deployments) GetProxy(ctx context.Context, t *testing.T, env environments.Environment) *appsv1.Deployment {
+	t.Helper()
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(d.ProxyNN.Namespace).Get(ctx, d.ProxyNN.Name, metav1.GetOptions{})
+	require.NoError(t, err)
 	return deployment
+}
+
+// GetController gets the controller deployment from the cluster.
+func (d Deployments) GetController(ctx context.Context, t *testing.T, env environments.Environment) *appsv1.Deployment {
+	t.Helper()
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(d.ControllerNN.Namespace).Get(ctx, d.ControllerNN.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return deployment
+}
+
+// getManifestDeployments returns the deployments for the proxy and controller that are expected to be deployed for a given
+// manifest.
+func getManifestDeployments(manifestPath string) Deployments {
+	proxyDeploymentName := getProxyDeploymentName(manifestPath)
+	return Deployments{
+		ProxyNN: types.NamespacedName{
+			Namespace: namespace,
+			Name:      proxyDeploymentName,
+		},
+		ControllerNN: types.NamespacedName{
+			Namespace: namespace,
+			Name:      controllerDeploymentName,
+		},
+	}
+}
+
+// getProxyDeploymentName returns the name of the proxy deployment that is expected to be deployed for a given manifest.
+func getProxyDeploymentName(manifestPath string) string {
+	const (
+		singlePodDeploymentName = controllerDeploymentName
+		multiPodDeploymentName  = "proxy-kong"
+	)
+
+	// special case for the old dbless-legacy that's still using a single-pod deployment
+	if strings.Contains(manifestPath, "dbless-legacy") {
+		return singlePodDeploymentName
+	}
+	// all non-legacy dbless manifests use a multi-pod deployment
+	if strings.Contains(manifestPath, "dbless") {
+		return multiPodDeploymentName
+	}
+
+	return singlePodDeploymentName
 }
 
 func deployIngress(ctx context.Context, t *testing.T, env environments.Environment) {
@@ -468,7 +535,7 @@ func killKong(ctx context.Context, t *testing.T, env environments.Environment, p
 
 	var orig, after int32
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.Name == "proxy" {
+		if status.Name == proxyContainerName {
 			orig = status.RestartCount
 		}
 	}
@@ -484,7 +551,7 @@ func killKong(ctx context.Context, t *testing.T, env environments.Environment, p
 		pod, err = env.Cluster().Client().CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, status := range pod.Status.ContainerStatuses {
-			if status.Name == "proxy" {
+			if status.Name == proxyContainerName {
 				if status.RestartCount > orig {
 					after = status.RestartCount
 					return true
@@ -613,4 +680,29 @@ func getPodByLabels(ctx context.Context,
 		return nil, err
 	}
 	return podList.Items, nil
+}
+
+// scaleDeployment scales the deployment to the given number of replicas and waits for the replicas to be ready.
+func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environment, deployment types.NamespacedName, replicas int32) {
+	t.Helper()
+
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: deployment.Namespace,
+			Name:      deployment.Name,
+		},
+		Spec: autoscalingv1.ScaleSpec{
+			Replicas: replicas,
+		},
+	}
+	_, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).UpdateScale(ctx, deployment.Name, scale, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		deployment, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return deployment.Status.ReadyReplicas == replicas
+	}, time.Minute*3, time.Second, "deployment %s did not scale to %d replicas", deployment.Name, replicas)
 }

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -101,7 +101,7 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	t.Logf("deploying %s manifest file", manifestFile)
 
 	manifest := getTestManifest(t, manifestFile)
-	_ = deployKong(ctx, t, env, manifest)
+	deployKong(ctx, t, env, manifest)
 }
 
 // createTestRuntimeGroup creates a runtime group to be used in tests. It returns the created runtime group's ID.

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/kubectl"
 	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 )
@@ -94,7 +95,7 @@ func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay 
 							Version: "v1",
 							Kind:    "Deployment",
 						},
-						Name:      "ingress-kong",
+						Name:      controllerDeploymentName,
 						Namespace: "kong",
 					},
 				},
@@ -106,7 +107,7 @@ func patchControllerStartTimeout(baseManifestReader io.Reader, tries int, delay 
 
 // patchLivenessProbes patches the given deployment's liveness probe, replacing the initial delay, period, and failure
 // threshold.
-func patchLivenessProbes(baseManifestReader io.Reader, deployment string, failure int, initial, period time.Duration) (io.Reader, error) {
+func patchLivenessProbes(baseManifestReader io.Reader, deployment k8stypes.NamespacedName, failure int, initial, period time.Duration) (io.Reader, error) {
 	kustomization := types.Kustomization{
 		Patches: []types.Patch{
 			{
@@ -118,8 +119,8 @@ func patchLivenessProbes(baseManifestReader io.Reader, deployment string, failur
 							Version: "v1",
 							Kind:    "Deployment",
 						},
-						Name:      deployment,
-						Namespace: "kong",
+						Name:      deployment.Name,
+						Namespace: deployment.Namespace,
 					},
 				},
 			},
@@ -141,7 +142,7 @@ func addControllerEnv(t *testing.T, baseManifestReader io.Reader, envName, value
 							Version: "v1",
 							Kind:    "Deployment",
 						},
-						Name:      "ingress-kong",
+						Name:      controllerDeploymentName,
 						Namespace: "kong",
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `getManifestDeployments` to programmatically dispatch expected names of the deployments. Also provides helpers to get the deployments from the cluster. Adds consts for deployments and containers names.

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4314114019

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Inspired by the https://github.com/Kong/kubernetes-ingress-controller/pull/3643#pullrequestreview-1321248515 comment.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->