### PR TITLE
tests(e2e): extend multi-gw test with scaling to 0

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -9,16 +9,19 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	gokong "github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 )
@@ -336,52 +339,60 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngress(ctx, t, env)
 	verifyIngress(ctx, t, env)
+	ensureAllProxyReplicasAreConfigured(ctx, t, env, deployments.ProxyNN)
 
-	const replicasCount = 3
-	gatewayDeployment := deployments.GetProxy(ctx, t, env)
-	gatewayDeployment.Spec.Replicas = lo.ToPtr(int32(replicasCount))
-	_, err := env.Cluster().Client().AppsV1().Deployments(gatewayDeployment.Namespace).Update(ctx, gatewayDeployment, metav1.UpdateOptions{})
+	expectedControllerReplicas := *(deployments.GetController(ctx, t, env).Spec.Replicas)
+	t.Logf("store expected controller replicas count = %d", expectedControllerReplicas)
+
+	t.Log("scale proxy to 0 replicas")
+	scaleDeployment(ctx, t, env, deployments.ProxyNN, 0)
+
+	t.Log("wait for 10 seconds to let controller reconcile")
+	<-time.After(10 * time.Second)
+
+	t.Log("ensure that controller pods didn't crash after scaling proxy to 0")
+	ensureNoneOfDeploymentPodsHasCrashed(ctx, t, env, deployments.ControllerNN)
+
+	t.Log("scale proxy to 3 replicas and wait for all instances to be ready")
+	scaleDeployment(ctx, t, env, deployments.ProxyNN, 3)
+	ensureAllProxyReplicasAreConfigured(ctx, t, env, deployments.ProxyNN)
+}
+
+func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env environments.Environment, proxyDeploymentNN types.NamespacedName) {
+	forDeployment := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", proxyDeploymentNN.Name),
+	}
+	podList, err := env.Cluster().Client().CoreV1().Pods(proxyDeploymentNN.Namespace).List(ctx, forDeployment)
 	require.NoError(t, err)
 
-	var podList *corev1.PodList
-
-	t.Log("waiting all the dataplane instances to be ready")
-	require.Eventually(t, func() bool {
-		appLabel := gatewayDeployment.Labels["app"]
-		forDeployment := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app=%s", appLabel),
-		}
-		podList, err = env.Cluster().Client().CoreV1().Pods(gatewayDeployment.Namespace).List(ctx, forDeployment)
-		require.NoError(t, err)
-
-		readyReplicasCount := lo.CountBy(podList.Items, func(pod corev1.Pod) bool {
-			return lo.ContainsBy(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
-				return cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue
-			})
-		})
-		return readyReplicasCount == replicasCount
-	}, time.Minute, time.Second)
-
-	t.Log("confirming that all dataplanes got the config")
+	t.Logf("ensuring all %d proxy replicas are configured", len(podList.Items))
+	wg := sync.WaitGroup{}
 	for _, pod := range podList.Items {
-		client := &http.Client{
-			Timeout: time.Second * 30,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true, //nolint:gosec
+		pod := pod
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client := &http.Client{
+				Timeout: time.Second * 30,
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true, //nolint:gosec
+					},
 				},
-			},
-		}
+			}
 
-		forwardCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		localPort := startPortForwarder(forwardCtx, t, env, gatewayDeployment.Namespace, pod.Name, "8444")
-		address := fmt.Sprintf("https://localhost:%d", localPort)
+			forwardCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			localPort := startPortForwarder(forwardCtx, t, env, proxyDeploymentNN.Namespace, pod.Name, "8444")
+			address := fmt.Sprintf("https://localhost:%d", localPort)
 
-		kongClient, err := gokong.NewClient(lo.ToPtr(address), client)
-		require.NoError(t, err)
+			kongClient, err := gokong.NewClient(lo.ToPtr(address), client)
+			require.NoError(t, err)
 
-		requireIngressConfiguredInAdminAPIEventually(ctx, t, kongClient)
-		t.Logf("proxy pod %s/%s: got the config", pod.Namespace, pod.Name)
+			requireIngressConfiguredInAdminAPIEventually(ctx, t, kongClient)
+			t.Logf("proxy pod %s/%s: got the config", pod.Namespace, pod.Name)
+		}()
 	}
+
+	wg.Wait()
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -660,16 +660,18 @@ func runOnlyOnKindClusters(t *testing.T) {
 	}
 }
 
-func getPodByLabels(ctx context.Context,
-	t *testing.T, env environments.Environment, namespace string, podLabels map[string]string,
+// listPodsByLabels returns a list of pods in the given namespace that match the given labels map.
+func listPodsByLabels(
+	ctx context.Context, env environments.Environment, namespace string, podLabels map[string]string,
 ) ([]corev1.Pod, error) {
-	t.Helper()
 	podClient := env.Cluster().Client().CoreV1().Pods(namespace)
 	selector := labels.NewSelector()
 
 	for k, v := range podLabels {
 		req, err := labels.NewRequirement(k, selection.Equals, []string{v})
-		require.NoError(t, err)
+		if err != nil {
+			return nil, err
+		}
 		selector = selector.Add(*req)
 	}
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -275,12 +275,12 @@ func requireKonnectNodesConsistentWithK8s(ctx context.Context, t *testing.T, env
 			return false
 		}
 
-		kicPods, err := getPodByLabels(ctx, t, env, "kong", map[string]string{"app": "ingress-kong"})
+		kicPods, err := listPodsByLabels(ctx, env, "kong", map[string]string{"app": "ingress-kong"})
 		if err != nil || len(kicPods) != 1 {
 			return false
 		}
 
-		kongPods, err := getPodByLabels(ctx, t, env, "kong", map[string]string{"app": "proxy-kong"})
+		kongPods, err := listPodsByLabels(ctx, env, "kong", map[string]string{"app": "proxy-kong"})
 		if err != nil || len(kongPods) != 2 {
 			return false
 		}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -457,13 +457,9 @@ func isPodReady(pod corev1.Pod) bool {
 // ensureNoneOfDeploymentPodsHasCrashed ensures that none of the pods of a deployment has crashed.
 func ensureNoneOfDeploymentPodsHasCrashed(ctx context.Context, t *testing.T, env environments.Environment, deploymentNN types.NamespacedName) {
 	t.Logf("ensuring none of %s deployment pods has crashed", deploymentNN.String())
-
-	pods, err := env.Cluster().Client().CoreV1().Pods(deploymentNN.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", deploymentNN.Name),
-	})
+	pods, err := listPodsByLabels(ctx, env, deploymentNN.Namespace, map[string]string{"app": deploymentNN.Name})
 	require.NoError(t, err)
-
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
 			require.Truef(t, containerDidntCrash(pod, container.Name), "controller pod %s/%s crashed", pod.Namespace, pod.Name)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves E2E coverage by verifying that when multi-gateway configuration is used, scaling proxy deployment to 0 replicas doesn't break anything and the controller pods remain ready as expected.

Effectively turns the test scenario from "2 replicas, scale to 3 replicas and ensure all configured" into "2 replicas, ensure all configured, scale down to 0, ensure controller pods didn't crash, scale up to 3, ensure all configured".

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4317334266

**Which issue this PR fixes**:

Part of #3429.