### PR TITLE
tests(dataplane): cover `KongClient.Update` with unit tests

### DIFF
--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -1,9 +1,18 @@
-package dataplane
+package dataplane_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/kong/deck/file"
+	gokong "github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,9 +20,15 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 func TestUniqueObjects(t *testing.T) {
@@ -93,7 +108,7 @@ func TestUniqueObjects(t *testing.T) {
 				require.NoError(t, err)
 				translationFailures = append(translationFailures, translationFailure)
 			}
-			uniqueObjs := uniqueObjects(tc.reportedObjs, translationFailures)
+			uniqueObjs := dataplane.UniqueObjects(tc.reportedObjs, translationFailures)
 			require.Len(t, uniqueObjs, len(tc.uniqueObjs))
 			require.ElementsMatch(t, tc.uniqueObjs, uniqueObjs)
 		})
@@ -164,9 +179,287 @@ func TestHandleSendToClientResult(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := konnectClient{isKonnect: tc.isKonnect}
-			resultSHA, err := handleSendToClientResult(c, logrus.New(), tc.inputSHA, tc.inputErr)
+			resultSHA, err := dataplane.HandleSendToClientResult(c, logrus.New(), tc.inputSHA, tc.inputErr)
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, tc.expectedSHA, resultSHA)
 		})
 	}
+}
+
+// mockGatewayClientsProvider is a mock implementation of dataplane.AdminAPIClientsProvider.
+type mockGatewayClientsProvider struct {
+	gatewayClients []*adminapi.Client
+	konnectClient  *adminapi.Client
+}
+
+func (f mockGatewayClientsProvider) AllClients() []*adminapi.Client {
+	all := make([]*adminapi.Client, len(f.gatewayClients))
+	copy(all, f.gatewayClients)
+	if f.konnectClient != nil {
+		all = append(all, f.konnectClient)
+	}
+	return all
+}
+
+func (f mockGatewayClientsProvider) GatewayClients() []*adminapi.Client {
+	return f.gatewayClients
+}
+
+// mockUpdateStrategy is a mock implementation of sendconfig.UpdateStrategyResolver.
+type mockUpdateStrategyResolver struct {
+	updateCalledForURLs       []string
+	shouldReturnErrorOnUpdate map[string]struct{}
+	t                         *testing.T
+	lock                      sync.RWMutex
+}
+
+func newMockUpdateStrategyResolver(t *testing.T) *mockUpdateStrategyResolver {
+	return &mockUpdateStrategyResolver{
+		t:                         t,
+		shouldReturnErrorOnUpdate: map[string]struct{}{},
+	}
+}
+
+func (f *mockUpdateStrategyResolver) ResolveUpdateStrategy(c sendconfig.UpdateClient) sendconfig.UpdateStrategy {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	url := c.AdminAPIClient().BaseRootURL()
+	return &mockUpdateStrategy{onUpdate: f.updateCalledForURLCallback(url)}
+}
+
+// returnErrorOnUpdate will cause the mockUpdateStrategy with a given Admin API URL to return an error on Update().
+func (f *mockUpdateStrategyResolver) returnErrorOnUpdate(url string) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.shouldReturnErrorOnUpdate[url] = struct{}{}
+}
+
+// updateCalledForURLCallback returns a function that will be called when the mockUpdateStrategy is called.
+// That enables us to track which URLs were called.
+func (f *mockUpdateStrategyResolver) updateCalledForURLCallback(url string) func() error {
+	return func() error {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		f.updateCalledForURLs = append(f.updateCalledForURLs, url)
+		if _, ok := f.shouldReturnErrorOnUpdate[url]; ok {
+			return errors.New("error on update")
+		}
+		return nil
+	}
+}
+
+// assertUpdateCalledForURLs asserts that the mockUpdateStrategy was called for the given URLs.
+func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLs(urls []string) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	require.ElementsMatch(f.t, urls, f.updateCalledForURLs, "update was not called for all URLs")
+}
+
+func (f *mockUpdateStrategyResolver) assertNoUpdateCalled() {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	require.Empty(f.t, f.updateCalledForURLs, "update was called")
+}
+
+// mockUpdateStrategy is a mock implementation of sendconfig.UpdateStrategy.
+type mockUpdateStrategy struct {
+	onUpdate func() error
+}
+
+func (m *mockUpdateStrategy) Update(context.Context, *file.Content) (
+	err error,
+	resourceErrors []sendconfig.ResourceError,
+	resourceErrorsParseErr error,
+) {
+	err = m.onUpdate()
+	return err, nil, nil
+}
+
+func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {
+	return metrics.ProtocolDBLess
+}
+
+// mockConfigurationChangeDetector is a mock implementation of sendconfig.ConfigurationChangeDetector.
+type mockConfigurationChangeDetector struct {
+	hasConfigurationChanged bool
+}
+
+func (m mockConfigurationChangeDetector) HasConfigurationChanged(
+	context.Context, []byte, []byte, sendconfig.KonnectAwareClient, sendconfig.StatusClient,
+) (bool, error) {
+	return m.hasConfigurationChanged, nil
+}
+
+func TestKongClientUpdate_AllExpectedClientsAreCalled(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx                = context.Background()
+		testKonnectClient  = mustSampleKonnectClient(t)
+		testGatewayClients = []*adminapi.Client{
+			mustSampleGatewayClient(t),
+			mustSampleGatewayClient(t),
+		}
+	)
+
+	testCases := []struct {
+		name                 string
+		gatewayClients       []*adminapi.Client
+		konnectClient        *adminapi.Client
+		errorOnUpdateForURLs []string
+		expectError          bool
+	}{
+		{
+			name:           "2 gateway clients and konnect with no errors",
+			gatewayClients: testGatewayClients,
+			konnectClient:  testKonnectClient,
+			expectError:    false,
+		},
+		{
+			name:                 "2 gateway clients and konnect with error on konnect",
+			gatewayClients:       testGatewayClients,
+			konnectClient:        testKonnectClient,
+			errorOnUpdateForURLs: []string{testKonnectClient.BaseRootURL()},
+			expectError:          false,
+		},
+		{
+			name:                 "2 gateway clients with error on one of them",
+			gatewayClients:       testGatewayClients,
+			errorOnUpdateForURLs: []string{testGatewayClients[0].BaseRootURL()},
+			expectError:          true,
+		},
+		{
+			name:           "2 gateway clients and konnect with error on one of gateways and konnect",
+			gatewayClients: testGatewayClients,
+			errorOnUpdateForURLs: []string{
+				testGatewayClients[0].BaseRootURL(),
+				testKonnectClient.BaseRootURL(),
+			},
+			expectError: true,
+		},
+		{
+			name:          "only konnect client with no error",
+			konnectClient: testKonnectClient,
+			expectError:   false,
+		},
+		{
+			name:                 "only konnect client with error on it",
+			konnectClient:        testKonnectClient,
+			errorOnUpdateForURLs: []string{testKonnectClient.BaseRootURL()},
+			expectError:          false,
+		},
+		{
+			name:        "no clients at all",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clientsProvider := mockGatewayClientsProvider{
+				gatewayClients: tc.gatewayClients,
+				konnectClient:  tc.konnectClient,
+			}
+			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			for _, url := range tc.errorOnUpdateForURLs {
+				updateStrategyResolver.returnErrorOnUpdate(url)
+			}
+			// always return true for HasConfigurationChanged to trigger an update
+			configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
+
+			kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector)
+
+			err := kongClient.Update(ctx)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			allExpectedURLs := mapClientsToUrls(clientsProvider.AllClients())
+			updateStrategyResolver.assertUpdateCalledForURLs(allExpectedURLs)
+		})
+	}
+}
+
+func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
+	clientsProvider := mockGatewayClientsProvider{
+		gatewayClients: []*adminapi.Client{
+			mustSampleGatewayClient(t),
+			mustSampleGatewayClient(t),
+		},
+		konnectClient: mustSampleKonnectClient(t),
+	}
+	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+
+	// no change in config, we'll expect no update to be called
+	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: false}
+
+	kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector)
+
+	ctx := context.Background()
+	err := kongClient.Update(ctx)
+	require.NoError(t, err)
+
+	updateStrategyResolver.assertNoUpdateCalled()
+}
+
+// setupTestKongClient creates a KongClient with mocked dependencies.
+func setupTestKongClient(
+	t *testing.T,
+	updateStrategyResolver *mockUpdateStrategyResolver,
+	clientsProvider mockGatewayClientsProvider,
+	configChangeDetector sendconfig.ConfigurationChangeDetector,
+) *dataplane.KongClient {
+	logger := logrus.New()
+	timeout := time.Second
+	ingressClass := "kong"
+	diagnostic := util.ConfigDumpDiagnostic{}
+	config := sendconfig.Config{}
+	eventRecorder := record.NewFakeRecorder(0)
+	dbMode := "off"
+
+	kongClient, err := dataplane.NewKongClient(
+		logger,
+		timeout,
+		ingressClass,
+		diagnostic,
+		config,
+		eventRecorder,
+		dbMode,
+		clientsProvider,
+		updateStrategyResolver,
+		configChangeDetector,
+	)
+	require.NoError(t, err)
+	return kongClient
+}
+
+func mustSampleGatewayClient(t *testing.T) *adminapi.Client {
+	t.Helper()
+	c, err := adminapi.NewTestClient(fmt.Sprintf("https://%s:8080", uuid.NewString()))
+	require.NoError(t, err)
+	return c
+}
+
+func mustSampleKonnectClient(t *testing.T) *adminapi.Client {
+	t.Helper()
+
+	c, err := gokong.NewClient(lo.ToPtr(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString())), &http.Client{})
+	require.NoError(t, err)
+
+	rgID := uuid.NewString()
+	return adminapi.NewKonnectClient(c, rgID)
+}
+
+func mapClientsToUrls(clients []*adminapi.Client) []string {
+	return lo.Map(clients, func(c *adminapi.Client, _ int) string {
+		return c.BaseRootURL()
+	})
 }

--- a/internal/dataplane/sendconfig/config_change_detector.go
+++ b/internal/dataplane/sendconfig/config_change_detector.go
@@ -1,0 +1,107 @@
+package sendconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// WellKnownInitialHash is the hash of an empty configuration.
+	WellKnownInitialHash = "00000000000000000000000000000000"
+)
+
+type ConfigurationChangeDetector interface {
+	// HasConfigurationChanged verifies whether configuration has changed by comparing old and new config's SHAs.
+	// In case the SHAs are equal, it still can return true if a client is considered crashed based on its status.
+	HasConfigurationChanged(ctx context.Context, oldSHA, newSHA []byte, client KonnectAwareClient, statusClient StatusClient) (bool, error)
+}
+
+type KonnectAwareClient interface {
+	IsKonnect() bool
+}
+
+type StatusClient interface {
+	Status(context.Context) (*kong.Status, error)
+}
+
+type DefaultConfigurationChangeDetector struct {
+	latestReportedSHA []byte
+	shaLock           sync.RWMutex
+	log               logrus.FieldLogger
+}
+
+func NewDefaultClientConfigurationChangeDetector(log logrus.FieldLogger) *DefaultConfigurationChangeDetector {
+	return &DefaultConfigurationChangeDetector{log: log}
+}
+
+func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
+	ctx context.Context,
+	oldSHA, newSHA []byte,
+	client KonnectAwareClient,
+	statusClient StatusClient,
+) (bool, error) {
+	if !bytes.Equal(oldSHA, newSHA) {
+		return true, nil
+	}
+	if !d.hasSHAUpdateAlreadyBeenReported(newSHA) {
+		d.log.Debugf("sha %s has been reported", hex.EncodeToString(newSHA))
+	}
+	// In case of Konnect, we skip further steps that are meant to detect Kong instances crash/reset
+	// that are not relevant for Konnect.
+	// We're sure that if oldSHA and newSHA are equal, we are safe to skip the update.
+	if client.IsKonnect() {
+		return false, nil
+	}
+
+	// Check if a Kong instance has no configuration yet (could mean it crashed, was rebooted, etc.).
+	hasNoConfiguration, err := kongHasNoConfiguration(ctx, statusClient, d.log)
+	if err != nil {
+		return false, fmt.Errorf("failed to verify kong readiness: %w", err)
+	}
+	// Kong instance has no configuration, we should push despite the oldSHA and newSHA being equal.
+	if hasNoConfiguration {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// hasSHAUpdateAlreadyBeenReported is a helper function to allow
+// sendconfig internals to be aware of the last logged/reported
+// update to the Kong Admin API. Given the most recent update SHA,
+// it will return true/false whether or not that SHA has previously
+// been reported (logged, e.t.c.) so that the caller can make
+// decisions (such as staggering or stifling duplicate log lines).
+func (d *DefaultConfigurationChangeDetector) hasSHAUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
+	d.shaLock.Lock()
+	defer d.shaLock.Unlock()
+	if bytes.Equal(d.latestReportedSHA, latestUpdateSHA) {
+		return true
+	}
+	d.latestReportedSHA = latestUpdateSHA
+	return false
+}
+
+// kongHasNoConfiguration checks Kong's status endpoint and read its config hash.
+// If the config hash reported by Kong is the known empty hash, it's considered crashed.
+// This allows providing configuration to Kong instances that have unexpectedly crashed and
+// lost their configuration.
+func kongHasNoConfiguration(ctx context.Context, client StatusClient, log logrus.FieldLogger) (bool, error) {
+	status, err := client.Status(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if hasNoConfig := status.ConfigurationHash == WellKnownInitialHash; hasNoConfig {
+		log.Debugf("starting to send configuration (hash: %s)", status.ConfigurationHash)
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -1,15 +1,11 @@
 package sendconfig
 
 import (
-	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/kong/deck/file"
-	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,6 +20,10 @@ import (
 // Sendconfig - Public Functions
 // -----------------------------------------------------------------------------
 
+type UpdateStrategyResolver interface {
+	ResolveUpdateStrategy(client UpdateClient) UpdateStrategy
+}
+
 // PerformUpdate writes `targetContent` to Kong Admin API specified by `kongConfig`.
 func PerformUpdate(
 	ctx context.Context,
@@ -32,6 +32,8 @@ func PerformUpdate(
 	config Config,
 	targetContent *file.Content,
 	promMetrics *metrics.CtrlFuncMetrics,
+	updateStrategyResolver UpdateStrategyResolver,
+	configChangeDetector ConfigurationChangeDetector,
 ) ([]byte, []failures.ResourceFailure, error) {
 	oldSHA := client.LastConfigSHA()
 	newSHA, err := deckgen.GenerateSHA(targetContent)
@@ -41,7 +43,7 @@ func PerformUpdate(
 
 	// disable optimization if reverse sync is enabled
 	if !config.EnableReverseSync {
-		configurationChanged, err := hasConfigurationChanged(ctx, oldSHA, newSHA, client, client.AdminAPIClient(), log)
+		configurationChanged, err := configChangeDetector.HasConfigurationChanged(ctx, oldSHA, newSHA, client, client.AdminAPIClient())
 		if err != nil {
 			return nil, []failures.ResourceFailure{}, err
 		}
@@ -51,8 +53,7 @@ func PerformUpdate(
 		}
 	}
 
-	updateStrategy := ResolveUpdateStrategy(client, config, log)
-
+	updateStrategy := updateStrategyResolver.ResolveUpdateStrategy(client)
 	timeStart := time.Now()
 	err, resourceErrors, resourceErrorsParseErr := updateStrategy.Update(ctx, targetContent)
 	duration := time.Since(timeStart)
@@ -72,95 +73,6 @@ func PerformUpdate(
 // -----------------------------------------------------------------------------
 // Sendconfig - Private Functions
 // -----------------------------------------------------------------------------
-
-type KonnectAwareClient interface {
-	IsKonnect() bool
-}
-
-type StatusClient interface {
-	Status(context.Context) (*kong.Status, error)
-}
-
-// hasConfigurationChanged verifies whether configuration has changed by comparing old and new config's SHAs.
-// In case the SHAs are equal, it still can return true if a client is considered crashed based on its status.
-func hasConfigurationChanged(
-	ctx context.Context,
-	oldSHA, newSHA []byte,
-	client KonnectAwareClient,
-	statusClient StatusClient,
-	log logrus.FieldLogger,
-) (bool, error) {
-	if !bytes.Equal(oldSHA, newSHA) {
-		return true, nil
-	}
-	if !hasSHAUpdateAlreadyBeenReported(newSHA) {
-		log.Debugf("sha %s has been reported", hex.EncodeToString(newSHA))
-	}
-	// In case of Konnect, we skip further steps that are meant to detect Kong instances crash/reset
-	// that are not relevant for Konnect.
-	// We're sure that if oldSHA and newSHA are equal, we are safe to skip the update.
-	if client.IsKonnect() {
-		return false, nil
-	}
-
-	// Check if a Kong instance has no configuration yet (could mean it crashed, was rebooted, etc.).
-	hasNoConfiguration, err := kongHasNoConfiguration(ctx, statusClient, log)
-	if err != nil {
-		return false, fmt.Errorf("failed to verify kong readiness: %w", err)
-	}
-	// Kong instance has no configuration, we should push despite the oldSHA and newSHA being equal.
-	if hasNoConfiguration {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-var (
-	latestReportedSHA []byte
-	shaLock           sync.RWMutex
-)
-
-// hasSHAUpdateAlreadyBeenReported is a helper function to allow
-// sendconfig internals to be aware of the last logged/reported
-// update to the Kong Admin API. Given the most recent update SHA,
-// it will return true/false whether or not that SHA has previously
-// been reported (logged, e.t.c.) so that the caller can make
-// decisions (such as staggering or stifling duplicate log lines).
-//
-// TODO: This is a bit of a hack for now to keep backwards compat,
-// but in the future we might configure rolling this into
-// some object/interface which has this functionality as an
-// inherent behavior.
-func hasSHAUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
-	shaLock.Lock()
-	defer shaLock.Unlock()
-	if bytes.Equal(latestReportedSHA, latestUpdateSHA) {
-		return true
-	}
-	latestReportedSHA = latestUpdateSHA
-	return false
-}
-
-const wellKnownInitialHash = "00000000000000000000000000000000"
-
-// kongHasNoConfiguration checks Kong's status endpoint and read its config hash.
-// If the config hash reported by Kong is the known empty hash, it's considered crashed.
-// This allows providing configuration to Kong instances that have unexpectedly crashed and
-// lost their configuration.
-func kongHasNoConfiguration(ctx context.Context, client StatusClient, log logrus.FieldLogger) (bool, error) {
-	status, err := client.Status(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if hasNoConfig := status.ConfigurationHash == wellKnownInitialHash; hasNoConfig {
-		log.Debugf("starting to send configuration (hash: %s)", status.ConfigurationHash)
-		return true, nil
-	}
-
-	return false, nil
-}
 
 // resourceErrorsToResourceFailures translates a slice of ResourceError to a slice of failures.ResourceFailure.
 // In case of parseErr being not nil, it just returns a nil slice.

--- a/internal/dataplane/sendconfig/strategy_test.go
+++ b/internal/dataplane/sendconfig/strategy_test.go
@@ -34,7 +34,7 @@ func (c *clientMock) AdminAPIClient() *kong.Client {
 	return &kong.Client{}
 }
 
-func TestResolveUpdateStrategy(t *testing.T) {
+func TestDefaultUpdateStrategyResolver_ResolveUpdateStrategy(t *testing.T) {
 	testCases := []struct {
 		isKonnect                     bool
 		inMemory                      bool
@@ -71,9 +71,11 @@ func TestResolveUpdateStrategy(t *testing.T) {
 				isKonnect: tc.isKonnect,
 			}
 
-			strategy := sendconfig.ResolveUpdateStrategy(client, sendconfig.Config{
+			resolver := sendconfig.NewDefaultUpdateStrategyResolver(sendconfig.Config{
 				InMemory: tc.inMemory,
 			}, logrus.New())
+
+			strategy := resolver.ResolveUpdateStrategy(client)
 			require.IsType(t, tc.expectedStrategy, strategy)
 			assert.True(t, client.adminAPIClientWasCalled)
 			assert.Equal(t, tc.expectKonnectRuntimeGroupCall, client.konnectRuntimeGroupWasCalled)

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -115,17 +115,19 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		return err
 	}
 
+	updateStrategyResolver := sendconfig.NewDefaultUpdateStrategyResolver(kongConfig, deprecatedLogger)
+	configurationChangeDetector := sendconfig.NewDefaultClientConfigurationChangeDetector(deprecatedLogger)
 	dataplaneClient, err := dataplane.NewKongClient(
 		deprecatedLogger,
 		time.Duration(c.ProxyTimeoutSeconds*float32(time.Second)),
 		c.IngressClassName,
-		c.EnableReverseSync,
-		c.SkipCACertificates,
 		diagnostic,
 		kongConfig,
 		eventRecorder,
 		dbMode,
 		clientsManager,
+		updateStrategyResolver,
+		configurationChangeDetector,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize kong data-plane client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors `dataplane.KongClient` to accept `UpdateStrategyResolver` and `ConfigurationChangeDetector` interfaces and covers the `Update` method with unit tests.

E2E tests run just in case: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4325511573

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes #3634.


