### PR TITLE
[DO NOT MERGE] set kong image to 3.2 in per-PR tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,6 +160,13 @@ jobs:
       id: detect_if_should_run
       run: echo "result=${{ (steps.license.outputs.license != '' && matrix.enterprise) || (!matrix.enterprise) }}" >> $GITHUB_OUTPUT
 
+    - name: Set image of Kong
+      id: set_kong_image
+      if: ! matrix.enterprise
+      run: |
+        echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=3.2.1" >> $GITHUB_ENV
+
     - name: Set image and tag for enterprise
       if: steps.detect_if_should_run.outputs.result != 'false' && matrix.enterprise
       # TODO: We need a systematic approach to this. Either:
@@ -170,7 +177,7 @@ jobs:
       # Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
       run: |
         echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
-        echo "TEST_KONG_TAG=3.1.1.3-alpine" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=3.2.1.0-alpine" >> $GITHUB_ENV
 
     - name: checkout repository
       if: steps.detect_if_should_run.outputs.result != 'false'

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -60,7 +60,7 @@ func exitOnErrWithCode(ctx context.Context, err error, exitCode int) {
 
 		fmt.Printf("INFO: cluster %s is being deleted\n", env.Cluster().Name())
 		if cleanupErr := env.Cleanup(ctx); cleanupErr != nil {
-			err = fmt.Errorf("cleanup failed after test failure occurred CLEANUP_FAILURE=(%w): %w", cleanupErr, err)
+			err = fmt.Errorf("cleanup failed after test failure occurred CLEANUP_FAILURE=(%v): %w", cleanupErr, err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

change kong image to 3.2.1(community) / 3.2.1.0(enterprise) to trigger integration tests against kong 3.2.
just for triggering CI, DO NOT MERGE.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

part of #3220 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
