### PR TITLE
chore(ci): refine linter config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ run:
   - e2e_tests
   - conformance_tests
   - istio_tests
+  - envtest
 linters:
   enable:
   - asasalint
@@ -106,7 +107,8 @@ issues:
   fix: true
   max-same-issues: 0
   exclude-rules:
-  - linters:
-    - ineffassign
-    text: "ineffectual assignment" # ignore err not checked in test files
-    path: test\.go
+  # Ignore insecure TLS in tests and hardcoded credentials
+  - path: _test\.go
+    linters:
+      - gosec
+    text: "TLS InsecureSkipVerify set true|Potential hardcoded credentials"

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -226,12 +226,7 @@ func TestOverrideRoute(t *testing.T) {
 
 func TestOverrideRoutePriority(t *testing.T) {
 	assert := assert.New(t)
-	var route Route
-	route = Route{
-		Route: kong.Route{
-			Hosts: kong.StringSlice("foo.com", "bar.com"),
-		},
-	}
+
 	kongIngress := configurationv1.KongIngress{
 		Route: &configurationv1.KongIngressRoute{
 			Protocols: configurationv1.ProtocolSlice("http"),
@@ -244,7 +239,7 @@ func TestOverrideRoutePriority(t *testing.T) {
 		},
 	}
 
-	route = Route{
+	route := Route{
 		Route: kong.Route{
 			Hosts: kong.StringSlice("foo.com", "bar.com"),
 		},
@@ -278,12 +273,6 @@ func TestOverrideRouteByKongIngress(t *testing.T) {
 
 func TestOverrideRouteByAnnotation(t *testing.T) {
 	assert := assert.New(t)
-	var route Route
-	route = Route{
-		Route: kong.Route{
-			Hosts: kong.StringSlice("foo.com", "bar.com"),
-		},
-	}
 
 	ingMeta := util.K8sObjectInfo{
 		Annotations: map[string]string{
@@ -291,7 +280,7 @@ func TestOverrideRouteByAnnotation(t *testing.T) {
 		},
 	}
 
-	route = Route{
+	route := Route{
 		Route: kong.Route{
 			Hosts: kong.StringSlice("foo.com", "bar.com"),
 		},

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -37,7 +37,6 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 		}
 	}
 
-	//nolint:gosec
 	const (
 		secretID        = "8a3753e0-093b-43d9-9d39-27985c987d92"
 		anotherSecretID = "99fa09c7-f849-4449-891e-19b9a0015763"

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -129,7 +129,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.LogLevel, "log-level", "info", `Level of logging for the controller. Allowed values are trace, debug, info, warn, error, fatal and panic.`)
 	flagSet.StringVar(&c.LogFormat, "log-format", "text", `Format of logs of the controller. Allowed values are text and json.`)
 	flagSet.BoolVar(&c.LogReduceRedundancy, "debug-log-reduce-redundancy", false, `If enabled, repetitive log entries are suppressed. Built for testing environments - production use not recommended.`)
-	flagSet.MarkHidden("debug-log-reduce-redundancy") //nolint:errcheck
+	_ = flagSet.MarkHidden("debug-log-reduce-redundancy")
 
 	// Kong high-level controller manager configurations
 	flagSet.BoolVar(&c.KongAdminAPIConfig.TLSSkipVerify, "kong-admin-tls-skip-verify", false, "Disable verification of TLS certificate of Kong's Admin endpoint.")

--- a/internal/util/reports_test.go
+++ b/internal/util/reports_test.go
@@ -73,7 +73,7 @@ Gn+T2uCyOP4a1DTUoPyoNJXo
 func TestMain(m *testing.M) {
 	reportsHost = "localhost"
 	pingInterval = 1
-	tlsConf = tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	tlsConf = tls.Config{InsecureSkipVerify: true}
 	os.Exit(m.Run())
 }
 

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -374,7 +374,7 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 				Timeout: time.Second * 30,
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true, //nolint:gosec
+						InsecureSkipVerify: true,
 					},
 				},
 			}

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -256,7 +256,7 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Log("checking initial certificate")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", admissionAddress+":443",
-			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) //nolint:gosec
+			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true})
 		if err != nil {
 			t.Logf("failed to dial %s:443, error %v", admissionAddress, err)
 			return false
@@ -273,7 +273,7 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Log("checking second certificate")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", admissionAddress+":443",
-			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) //nolint:gosec
+			&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true})
 		if err != nil {
 			t.Logf("failed to dial %s:443, error %v", admissionAddress, err)
 			return false

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -205,7 +205,7 @@ func TestHTTPSIngress(t *testing.T) {
 			}
 			return dialer.DialContext(ctx, network, addr)
 		},
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	httpcStatic := http.Client{
 		Timeout:   httpcTimeout,

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -164,7 +164,7 @@ func accessKnativeSrv(ctx context.Context, proxy, nsn string, t *testing.T) bool
 	url := "http://" + proxy
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec
+			InsecureSkipVerify: true,
 		},
 	}
 	client := http.Client{

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -249,7 +249,7 @@ func TestTCPIngressTLS(t *testing.T) {
 		t.Logf("verifying TCP Ingress for %s.example operational", i)
 		require.Eventually(t, func() bool {
 			conn, err := tls.Dial("tcp", fmt.Sprintf("%s:8899", proxyURL.Hostname()), &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec
+				InsecureSkipVerify: true,
 				ServerName:         fmt.Sprintf("%s.example", i),
 			})
 			if err != nil {
@@ -280,7 +280,7 @@ func TestTCPIngressTLS(t *testing.T) {
 	t.Logf("verifying TCP Ingress routes to new upstream after update")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", fmt.Sprintf("%s:8899", proxyURL.Hostname()), &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec
+			InsecureSkipVerify: true,
 			ServerName:         fmt.Sprintf("%s.example", testServiceSuffixes[0]),
 		})
 		if err != nil {
@@ -462,7 +462,7 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 	t.Log("verifying TCP Ingress for redis.example operational")
 	require.Eventually(t, func() bool {
 		conn, err := tls.Dial("tcp", fmt.Sprintf("%s:8899", proxyURL.Hostname()), &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec
+			InsecureSkipVerify: true,
 			ServerName:         "redis.example",
 		})
 		if err != nil {

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -843,7 +843,7 @@ func tlsEchoResponds(
 		"tcp",
 		url,
 		&tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec
+			InsecureSkipVerify: true,
 			ServerName:         hostname,
 		})
 	if err != nil {

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -350,7 +350,7 @@ func eventsToString(events []corev1.Event) string {
 	return strings.Join(rows, "\n")
 }
 
-const invalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae" //nolint:gosec
+const invalidCASecretID = "8214a145-a328-4c56-ab72-2973a56d4eae"
 
 func invalidCASecret(ns string) *corev1.Secret {
 	return &corev1.Secret{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adjusts linter config by:

- allowing `TLS InsecureSkipVerify set true` and `Potential hardcoded credentials` linter errors in test files since those are not really cause for concern in tests
- removing `ineffassign` exception from test code
- adding newly introduced build tag: `envtest` to linter config

