### PR TITLE
chore: fix linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ lint: verify.tidy golangci-lint staticcheck
 
 .PHONY: staticcheck
 staticcheck: staticcheck.download
-	$(STATICCHECK) -tags e2e_tests,integration_tests,istio_tests,conformance_tests \
+	$(STATICCHECK) -tags envtest,e2e_tests,integration_tests,istio_tests,conformance_tests \
 		-f stylish \
 		./...
 

--- a/test/integration/grpcroute_test.go
+++ b/test/integration/grpcroute_test.go
@@ -18,7 +18,7 @@ func grpcEchoResponds(ctx context.Context, url, hostname, input string) error {
 		grpc.WithTransportCredentials(credentials.NewTLS(
 			&tls.Config{
 				ServerName:         hostname,
-				InsecureSkipVerify: true, //nolint:gosec
+				InsecureSkipVerify: true,
 			},
 		)),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue that was missed when #3661 got merged (with come commits already in `main` that #3661 didn't check).

Additionally this also adds `envtest` build tag for `staticcheck` that #3661 forgot.
