### PR TITLE
docs: add Gateway Discovery to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Custom Resource Definitions (CRDs) and Kubernetes-native tooling.
   Protect your services using authentication methods of your choice.
 - **Declarative configuration for Kong**
   Configure all of Kong using CRDs in Kubernetes and manage Kong declaratively.
+- **Gateway Discovery**
+  Dynamically provision and scale your Kong Gateway deployments for KIC to discover.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Custom Resource Definitions (CRDs) and Kubernetes-native tooling.
 - **Declarative configuration for Kong**
   Configure all of Kong using CRDs in Kubernetes and manage Kong declaratively.
 - **Gateway Discovery**
-  Dynamically provision and scale your Kong Gateway deployments for KIC to discover.
+  Monitors your Kong Gateways and pushes configuration to all replicas.
 
 ## Get started
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a mention about Gateway Discovery to README.md.

**Which issue this PR fixes**:

Related: #3604

**Special notes for your reviewer**:

Unfortunately, for some reason when specifying a link with an anchor e.g.  https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/deployment/#kong-gateway-oss the browser would not scroll down and since the newly added chapter about Gateway Discovery is under an anchor adding it would direct the user to a screen where he'd need to scroll down manually.

Would we want to include that link anyway?
