### PR TITLE
chore: bump k8s versions for 2.9 release

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.21.14'
           - 'v1.22.15'
           - 'v1.23.13'
           - 'v1.24.7'
@@ -159,18 +158,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version:
-          # v1.25 is the latest Kubernetes version supported by Istio: https://istio.io/latest/docs/releases/supported-releases/
-          - 'v1.25.3'
-          - 'v1.24.7'
-        istio-version:
-          - 'v1.16.1'
-          - 'v1.15.4'
-          - 'v1.14.6'
-        exclude:
-          # Istio v1.14 does not support Kubernetes v1.25: https://istio.io/latest/docs/releases/supported-releases/
+        include:
+          - kubernetes-version: 'v1.26.0'
+            istio-version: 'v1.17.1'
           - kubernetes-version: 'v1.25.3'
-            istio-version: 'v1.14.6'
+            istio-version: 'v1.17.1'
+          - kubernetes-version: 'v1.25.3'
+            istio-version: 'v1.16.3'
+          - kubernetes-version: 'v1.25.3'
+            istio-version: 'v1.15.6'
 
     steps:
       - name: checkout repository

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -10,7 +10,7 @@ on:
       istio-version:
         description: 'Istio version to test with'
         required: true
-        default: 'v1.15.1'
+        default: 'v1.17.1'
       controller-image:
         description: 'KIC Docker image to test with. The default "kong/kubernetes-ingress-controller:ci" builds an image from the dispatch branch'
         required: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -212,11 +212,11 @@ jobs:
       fail-fast: true
       matrix:
         kubernetes-version:
-          - 'v1.21.12'
-          - 'v1.22.9'
-          - 'v1.23.6'
-          - 'v1.24.2'
+          - 'v1.22.15'
+          - 'v1.23.13'
+          - 'v1.24.7'
           - 'v1.25.3'
+          - 'v1.26.0'
     steps:
       - name: checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps k8s versions for 2.9 release.

Most notably this makes the complete list of k8s versions that we test to be:

- 'v1.22.15'
- 'v1.23.13'
- 'v1.24.7'
- 'v1.25.3'
- 'v1.26.0'

It also:

- drops istio v1.14 (which has reached End of Life as in https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases)
- adds v1.17.

Version | Currently Supported | Release Date | End of Life | Supported Kubernetes Versions | Tested, but not supported
-- | -- | -- | -- | -- | --
1.17 | Yes | February 14, 2023 | ~Sept 2023 (Expected) | 1.23, 1.24, 1.25, 1.26 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22
1.16 | Yes | November 15, 2022 | ~June 2023 (Expected) | 1.22, 1.23, 1.24, 1.25 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21
1.15 | Yes | August 31, 2022 | ~March 2023 (Expected) | 1.22, 1.23, 1.24, 1.25 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21
1.14 | No | May 24, 2022 | Dec 27, 2022 | 1.21, 1.22, 1.23, 1.24 | 1.16, 1.17, 1.18, 1.19, 1.20

Passing e2e CI pipeline: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4354640108



**Related issue**

#3672