### PR TITLE
fix: pass Konnect PAT to E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -134,6 +134,7 @@ jobs:
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           KONG_TEST_CLUSTER_PROVIDER: gke
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           E2E_TEST_RUN: ${{ matrix.test }}
           GOTESTSUM_JUNITFILE: "e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml"
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Konnect E2E tests should be run in the E2E job and lack of the secret prevented it.
