### PR TITLE
fix(tests): fix e2e webhook test condition

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -653,11 +653,21 @@ func runOnlyOnKindClusters(t *testing.T) {
 	t.Helper()
 
 	existingClusterIsKind := strings.Split(existingCluster, ":")[0] == string(kind.KindClusterType)
-	clusterProviderIsKind := clusterProvider == "" || clusterProvider == string(kind.KindClusterType)
-
-	if !existingClusterIsKind || !clusterProviderIsKind {
-		t.Skip("test is supported only on Kind clusters")
+	if existingClusterIsKind {
+		return
 	}
+
+	clusterProviderIsKind := clusterProvider == string(kind.KindClusterType)
+	if clusterProviderIsKind {
+		return
+	}
+
+	clusterProviderUnspecified := clusterProvider == ""
+	if clusterProviderUnspecified {
+		return
+	}
+
+	t.Skip("test is supported only on Kind clusters")
 }
 
 // listPodsByLabels returns a list of pods in the given namespace that match the given labels map.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -663,7 +663,8 @@ func runOnlyOnKindClusters(t *testing.T) {
 	}
 
 	clusterProviderUnspecified := clusterProvider == ""
-	if clusterProviderUnspecified {
+	existingClusterUnspecified := existingCluster == ""
+	if clusterProviderUnspecified && existingClusterUnspecified {
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Current logic in `runOnlyOnKindClusters()` skipped tests running against kind clusters when `strings.Split(existingCluster, ":")[0] == string(kind.KindClusterType)` was equal to `false` which is the case for our e2e tests when we run "by default" against kind, relying on test code to create the cluster.

```
	existingClusterIsKind := strings.Split(existingCluster, ":")[0] == string(kind.KindClusterType)
	clusterProviderIsKind := clusterProvider == "" || clusterProvider == string(kind.KindClusterType)

	if !existingClusterIsKind || !clusterProviderIsKind {
		t.Skip("test is supported only on Kind clusters")
	}
```

This PR changes the logic to fix that particular case and to make the conditions a bit more verbose.

Working e2e webhook test on kind: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4354860764/jobs/7610831995#step:6:22
Skipped (correctly) e2e webhook test when run on gke: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4354860764/jobs/7610825810#step:6:33
