### PR TITLE
chore: remove redhat certification steps from workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -54,14 +54,6 @@ body:
       - label: Once the PR is merged, [initiate a release job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/release.yaml). Your tag must use `vX.Y.Z` format. Set `latest` to true if this will be the latest release.
       - label: CI will validate the requested version, build and push an image, and run tests against the image before finally creating a tag and publishing a release. If tests fail, CI will push the image but not the tag or release. Investigate the failure, correct it as needed, and start a new release job.
 - type: checkboxes
-  id: release_redhat
-  attributes:
-    label: "**For all releases** Publish images to Red Hat Catalog"
-    options:
-      - label: Verify the image was pushed by a pipeline to the [KIC project in Red Hat partners portal](https://connect.redhat.com/projects/5eab1b8ea165648bd1353266/images) to confirm that E2E tests are succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml).
-      - label: Click publish button for all tags related to the release that were pushed to the portal. That will publish the image to Red Hat Catalog.
-      - label: Make sure the latest tag was added when asked. If forgot, the tag can be added from the dropdown menu.
-- type: checkboxes
   id: release_documents
   attributes:
     label: "**For major/minor releases only** Update Release documents"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,16 +5,10 @@ on:
     - cron: '30 3 * * *'
   workflow_dispatch: {}
 
-env:
-  RH_SCAN_REGISTRY: quay.io
-  RH_SCAN_REGISTRY_IMAGE_NAME: redhat-isv-containers/5eab1b8ea165648bd1353266
-
 jobs:
   build-push-images:
     environment: 'Docker Push'
     runs-on: ubuntu-latest
-    outputs:
-      TAGS_REDHAT_STANDARD: ${{ steps.tags-redhat-standard.outputs.TAGS_REDHAT_STANDARD }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -28,13 +22,6 @@ jobs:
           echo "type=raw,value={{date 'YYYY-MM-DD'}}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - name: Add Red Hat standard tags
-        id: tags-redhat-standard
-        run: |
-          echo 'TAGS_REDHAT_STANDARD<<EOF' >> $GITHUB_OUTPUT
-          echo 'type=raw,value=nightly,suffix=-redhat' >> $GITHUB_OUTPUT
-          echo "type=raw,value={{date 'YYYY-MM-DD'}},suffix=-redhat" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -57,14 +44,6 @@ jobs:
         with:
           images: kong/nightly-ingress-controller
           tags: ${{ steps.tags-standard.outputs.TAGS_STANDARD }}
-      - name: Docker meta (redhat)
-        id: meta_redhat
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: kong/nightly-ingress-controller
-          flavor: |
-            latest=false
-          tags: ${{ steps.tags-redhat-standard.outputs.TAGS_REDHAT_STANDARD }}
       - name: Build binary
         id: docker_build_binary
         uses: docker/build-push-action@v4
@@ -93,86 +72,7 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat image to DockerHub
-        id: docker_build_redhat
-        env:
-          TAG: ${{ steps.meta.outputs.version }}
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          file: Dockerfile
-          tags: ${{ steps.meta_redhat.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          target: redhat
-          platforms: linux/amd64, linux/arm64
-          build-args: |
-            TAG=${{ steps.meta.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
 
-  redhat-certification-test:
-    environment: 'Docker Push'
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    needs: 
-      - build-push-images
-    env:
-      REDHAT_STANDARD_TAG: ${{ needs.build-push-images.outputs.TAGS_REDHAT_STANDARD }}
-
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Login to RH Scan Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.RH_SCAN_REGISTRY }}
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
-      - name: Docker meta (redhat scan registry)
-        id: meta_redhat_scan_registry
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: ${{ env.REDHAT_STANDARD_TAG }}
-      - name: Build image for local Preflight scan
-        id: docker_build_redhat_scan_registry
-        env:
-          TAG: ${{ steps.meta_redhat_scan_registry.outputs.version }}
-        uses: docker/build-push-action@v4
-        with:
-          push: false
-          file: Dockerfile
-          tags: ${{ steps.meta_redhat_scan_registry.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          target: redhat
-          # RedHat scan registry does not support multiarch images
-          platforms: linux/amd64
-          build-args: |
-            TAG=${{ steps.meta_redhat_scan_registry.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Run local Red Hat Certification Preflight scan
-        uses: ./.github/actions/redhat-opdev-preflight-action
-        with:
-          image: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}:${{ steps.meta_redhat_scan_registry.outputs.version }}
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
-          submit: false
-  
   # run integration test in latest version of kubernetes.
   test-current-kubernetes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,17 +8,14 @@ on:
           The version to release.
           Depending on the value, a production release will be published to GitHub or not.
             - In case of prerelease tags (e.g. v1.2.3-alpha.1) it will build-push the images (only standard tags,
-              i.e., v1.2.3-alpha.1 and v1.2.3-alpha.1-redhat), test them and publish a GitHub prerelease (labeled as non-production ready).
+              i.e., v1.2.3-alpha.1), test them and publish a GitHub prerelease (labeled as non-production ready).
             - In other cases (e.g. v1.2.3) it will build-push the images (standard and supplemental tags, 
-              i.e., v1.2.3, v1.2.3-redhat, v1.2 and v1.2-redhat), test them and publish a production Github release.
+              i.e., v1.2.3 and v1.2), test them and publish a production Github release.
         required: true
       latest:
         description: 'Whether to tag this release latest'
         required: true
         default: 'false'
-env:
-  RH_SCAN_REGISTRY: quay.io
-  RH_SCAN_REGISTRY_IMAGE_NAME: redhat-isv-containers/5eab1b8ea165648bd1353266
 
 jobs:
   verify-manifest-tag:
@@ -76,18 +73,6 @@ jobs:
           echo "" >> $GITHUB_ENV
           echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-      - name: Add Red Hat standard tags
-        run: |
-          echo 'REDHAT_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }},suffix=-redhat' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Add Red Hat major.minor tag
-        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
-        run: |
-          echo 'REDHAT_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }},suffix=-redhat' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -104,12 +89,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Login to RH Scan Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.RH_SCAN_REGISTRY }}
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4.3.0
@@ -118,22 +97,6 @@ jobs:
           flavor: |
             latest=${{ github.event.inputs.latest == 'true' }}
           tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
-      - name: Docker meta (redhat)
-        id: meta_redhat
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: kong/kubernetes-ingress-controller
-          flavor: |
-            latest=${{ github.event.inputs.latest == 'true' }}
-          tags: ${{ env.REDHAT_STANDARD }}${{ env.REDHAT_SUPPLEMENTAL }}
-      - name: Docker meta (redhat scan registry)
-        id: meta_redhat_scan_registry
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}
-          flavor: |
-            latest=${{ github.event.inputs.latest == 'true' }}
-          tags: ${{ env.REDHAT_STANDARD }}${{ env.REDHAT_SUPPLEMENTAL }}
       - name: Build binary
         id: docker_build_binary
         uses: docker/build-push-action@v4
@@ -162,49 +125,6 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat image to DockerHub
-        id: docker_build_redhat
-        env:
-          TAG: ${{ steps.meta_redhat.outputs.version }}
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          file: Dockerfile
-          tags: ${{ steps.meta_redhat.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          target: redhat
-          platforms: linux/amd64, linux/arm64
-          build-args: |
-            TAG=${{ steps.meta.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push Red Hat image to Red Hat Scan Registry
-        id: docker_build_redhat_scan_registry
-        env:
-          TAG: ${{ steps.meta_redhat_scan_registry.outputs.version }}
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          file: Dockerfile
-          tags: ${{ steps.meta_redhat_scan_registry.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          target: redhat
-          # RedHat scan registry does not support multiarch images
-          platforms: linux/amd64
-          build-args: |
-            TAG=${{ steps.meta_redhat_scan_registry.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Run Red Hat Certification Preflight scan
-        uses: ./.github/actions/redhat-opdev-preflight-action
-        with:
-          image: ${{ env.RH_SCAN_REGISTRY }}/${{ env.RH_SCAN_REGISTRY_IMAGE_NAME }}:${{ steps.meta_redhat_scan_registry.outputs.version }}
-          username: ${{ secrets.RH_USERNAME }}
-          password: ${{ secrets.RH_TOKEN }}
-          submit: true
-          apitoken: ${{ secrets.RH_PYXIS_TOKEN }}
-          certificationid: ${{ secrets.RH_CERTIFICATION_ID }}
-
   test-e2e:
     runs-on: ubuntu-latest
     needs: build-push-images


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes steps in the release and nightly workflows related to the Red Hat certification process (similar to https://github.com/Kong/gateway-operator/pull/642). I had an action item for this to happen but forgot to do that in KIC.

I created an issue to track the effort to bring this process back once we decide to do so: https://github.com/Kong/kubernetes-ingress-controller/issues/3689
