### PR TITLE
chore(ci): disallow golang.org/x/net/context

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -89,13 +89,14 @@ linters-settings:
           - sigs.k8s.io/yaml
       - github.com/pkg/errors:
           recommendations:
-            - fmt
-            - errors
+          - fmt
+          - errors
   depguard:
-    list-type: blacklist
+    list-type: denylist
     include-go-root: false
     packages-with-error-message:
       - k8s.io/utils/pointer: "Use github.com/samber/lo ToPtr instead"
+      - golang.org/x/net/context: "use regular context instead"
   tenv:
     all: true
   loggercheck:

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/net v0.8.0
 	google.golang.org/api v0.111.0
 	k8s.io/api v0.26.2
 	k8s.io/apiextensions-apiserver v0.26.2
@@ -57,6 +56,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.4.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
 )
 
 require (

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -1,6 +1,7 @@
 package dataplane
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -8,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestSynchronizer(t *testing.T) {

--- a/internal/manager/health_check_test.go
+++ b/internal/manager/health_check_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason we ended up using https://pkg.go.dev/golang.org/x/net@v0.8.0/context which was AFAIK the original context package when context was introduced.

Instead of that we should use the regular `context` package from std library.

This PR enforces that through linter config.
