### PR TITLE
chore(gateway-api): extract common programmed condition helper

### DIFF
--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -364,7 +364,10 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if configurationStatus == k8sobj.ConfigurationStatusFailed {
 			debug(log, grpcroute, "grpcroute configuration failed")
-			statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, grpcroute, gateways, metav1.ConditionFalse, ConditionReasonTranslationError, "")
+			statusUpdated, err := ensureParentsProgrammedCondition(ctx, r.Status(), grpcroute, grpcroute.Status.Parents, gateways, metav1.Condition{
+				Status: metav1.ConditionFalse,
+				Reason: string(ConditionReasonTranslationError),
+			})
 			if err != nil {
 				// don't proceed until the statuses can be updated appropriately
 				debug(log, grpcroute, "failed to update programmed condition")
@@ -373,7 +376,10 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{Requeue: !statusUpdated}, nil
 		}
 
-		statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, grpcroute, gateways, metav1.ConditionTrue, ConditionReasonConfiguredInGateway, "")
+		statusUpdated, err := ensureParentsProgrammedCondition(ctx, r.Status(), grpcroute, grpcroute.Status.Parents, gateways, metav1.Condition{
+			Status: metav1.ConditionTrue,
+			Reason: string(ConditionReasonConfiguredInGateway),
+		})
 		if err != nil {
 			// don't proceed until the statuses can be updated appropriately
 			debug(log, grpcroute, "failed to update programmed condition")
@@ -516,62 +522,4 @@ func (r *GRPCRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Co
 
 	// the status needed an update and it was updated successfully
 	return true, nil
-}
-
-func (r *GRPCRouteReconciler) ensureParentsProgrammedCondition(
-	ctx context.Context,
-	grpcroute *gatewayv1alpha2.GRPCRoute,
-	gateways []supportedGatewayWithCondition,
-	conditionStatus metav1.ConditionStatus,
-	conditionReason gatewayv1beta1.RouteConditionReason,
-	conditionMessage string,
-) (bool, error) {
-	// map the existing parentStatues to avoid duplications
-	parentStatuses := getParentStatuses(grpcroute, grpcroute.Status.Parents)
-
-	programmedCondition := metav1.Condition{
-		Type:               ConditionTypeProgrammed,
-		Status:             conditionStatus,
-		Reason:             string(conditionReason),
-		ObservedGeneration: grpcroute.Generation,
-		Message:            conditionMessage,
-		LastTransitionTime: metav1.Now(),
-	}
-	statusChanged := false
-	for _, g := range gateways {
-		gateway := g.gateway
-		parentRefKey := gateway.Namespace + "/" + gateway.Name
-		parentStatus, ok := parentStatuses[parentRefKey]
-		if ok {
-			// update existing parent in status.
-			changed := setRouteParentStatusCondition(parentStatus, programmedCondition)
-			statusChanged = statusChanged || changed
-		} else {
-			// add a new parent if the parent is not found in status.
-			newParentStatus := &gatewayv1alpha2.RouteParentStatus{
-				ParentRef: gatewayv1alpha2.ParentReference{
-					Namespace: lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
-					Name:      gatewayv1alpha2.ObjectName(gateway.Name),
-					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
-				},
-				ControllerName: GetControllerName(),
-				Conditions: []metav1.Condition{
-					programmedCondition,
-				},
-			}
-			grpcroute.Status.Parents = append(grpcroute.Status.Parents, *newParentStatus)
-			parentStatuses[parentRefKey] = newParentStatus
-			statusChanged = true
-		}
-	}
-
-	// update status if needed.
-	if statusChanged {
-		if err := r.Status().Update(ctx, grpcroute); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	// no need to update if no status is changed.
-	return false, nil
 }

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,21 @@ type supportedGatewayWithCondition struct {
 	gateway      *Gateway
 	condition    metav1.Condition
 	listenerName string
+}
+
+func (g supportedGatewayWithCondition) GetName() string {
+	return g.gateway.GetName()
+}
+
+func (g supportedGatewayWithCondition) GetNamespace() string {
+	return g.gateway.GetNamespace()
+}
+
+func (g supportedGatewayWithCondition) GetSectionName() mo.Option[string] {
+	if g.listenerName != "" {
+		return mo.Some(g.listenerName)
+	}
+	return mo.None[string]()
 }
 
 // parentRefsForRoute provides a list of the parentRefs given a Gateway APIs route object
@@ -690,4 +706,174 @@ func parentStatusHasProgrammedCondition(parentStatus *gatewayv1beta1.RouteParent
 		}
 	}
 	return false
+}
+
+// ensureParentsProgrammedCondition ensures that provided route's parent statuses
+// have Programmed condition set properly. It returns a boolean flag indicating
+// whether an update to the provided route has been performed.
+//
+// Use the condition argument to specify the Reason, Status and Message.
+// Type will be set to Programmed whereas ObservedGeneration and LastTransitionTime
+// will be set accordingly based on the route's generation and current time.
+func ensureParentsProgrammedCondition[
+	routeT types.RouteT,
+](
+	ctx context.Context,
+	client client.SubResourceWriter,
+	route routeT,
+	routeParentStatuses []RouteParentStatus,
+	gateways []supportedGatewayWithCondition,
+	condition metav1.Condition,
+) (bool, error) {
+	// map the existing parentStatues to avoid duplications
+	parentStatuses := getParentStatuses(route, routeParentStatuses)
+
+	condition.Type = ConditionTypeProgrammed
+	condition.ObservedGeneration = route.GetGeneration()
+	condition.LastTransitionTime = metav1.Now()
+
+	statusChanged := false
+	for _, g := range gateways {
+		gateway := g.gateway
+
+		parentRefKey := routeParentStatusKey(route, g)
+		parentStatus, ok := parentStatuses[parentRefKey]
+		if ok {
+			// update existing parent in status.
+			changed := setRouteParentStatusCondition(parentStatus, condition)
+			if changed {
+				parentStatuses[parentRefKey] = parentStatus
+				setRouteParentInStatusForParent(route, *parentStatus, g)
+			}
+			statusChanged = statusChanged || changed
+		} else {
+			// add a new parent if the parent is not found in status.
+			newParentStatus := RouteParentStatus{
+				ParentRef: ParentReference{
+					Namespace: lo.ToPtr(Namespace(gateway.Namespace)),
+					Name:      ObjectName(gateway.Name),
+					Kind:      lo.ToPtr(Kind("Gateway")),
+					Group:     lo.ToPtr(Group(gatewayv1beta1.GroupName)),
+
+					// TODO: set port after gateway port matching implemented:
+					// https://github.com/Kong/kubernetes-ingress-controller/issues/3016
+				},
+				ControllerName: GetControllerName(),
+				Conditions: []metav1.Condition{
+					condition,
+				},
+			}
+			setRouteParentInStatusForParent(route, newParentStatus, g)
+
+			routeParentStatuses = append(routeParentStatuses, newParentStatus)
+			parentStatuses[parentRefKey] = &newParentStatus
+			statusChanged = true
+		}
+	}
+
+	// update status if needed.
+	if statusChanged {
+		if err := client.Update(ctx, route); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	// no need to update if no status is changed.
+	return false, nil
+}
+
+// setRouteParentInStatusForParent checks if the provided route Status, contains
+// status for the provided parent and if it does it sets it to the provided
+// RouteStatusParent. If it does not then it appends the provided RouteStatusParent
+// to provided route's Status.Parents field.
+//
+// This might come in useful when the caller wants to set only one parent's
+// status.
+func setRouteParentInStatusForParent[
+	routeT types.RouteT,
+	parentT namespacedNamer,
+](
+	route routeT,
+	routeStatusParent RouteParentStatus,
+	parent parentT,
+) {
+	switch r := any(route).(type) {
+	case *HTTPRoute:
+		for i, p := range r.Status.Parents {
+			if ensureParentsStatusUpdated(p.ParentRef, parent, r.Status.Parents, i, routeStatusParent) {
+				return
+			}
+		}
+		r.Status.Parents = append(r.Status.Parents, routeStatusParent)
+	case *TCPRoute:
+		for i, p := range r.Status.Parents {
+			if ensureParentsStatusUpdated(p.ParentRef, parent, r.Status.Parents, i, routeStatusParent) {
+				return
+			}
+		}
+		r.Status.Parents = append(r.Status.Parents, routeStatusParent)
+	case *UDPRoute:
+		for i, p := range r.Status.Parents {
+			if ensureParentsStatusUpdated(p.ParentRef, parent, r.Status.Parents, i, routeStatusParent) {
+				return
+			}
+		}
+		r.Status.Parents = append(r.Status.Parents, routeStatusParent)
+	case *TLSRoute:
+		for i, p := range r.Status.Parents {
+			if ensureParentsStatusUpdated(p.ParentRef, parent, r.Status.Parents, i, routeStatusParent) {
+				return
+			}
+		}
+		r.Status.Parents = append(r.Status.Parents, routeStatusParent)
+	case *GRPCRoute:
+		for i, p := range r.Status.Parents {
+			if ensureParentsStatusUpdated(p.ParentRef, parent, r.Status.Parents, i, routeStatusParent) {
+				return
+			}
+		}
+		r.Status.Parents = append(r.Status.Parents, routeStatusParent)
+	}
+}
+
+func ensureParentsStatusUpdated[
+	parentT namespacedNamer,
+](
+	parentRef ParentReference,
+	parent parentT,
+	routeStatusParents []RouteParentStatus,
+	i int,
+	routeStatusParent RouteParentStatus,
+) bool {
+	if !isParentRefEqualToParent(parentRef, parent) {
+		return false
+	}
+
+	routeStatusParents[i] = routeStatusParent
+	return true
+}
+
+func isParentRefEqualToParent[
+	parentT namespacedNamer,
+](
+	parentRef ParentReference,
+	parent parentT,
+) bool {
+	if *parentRef.Group != gatewayv1beta1.GroupName {
+		return false
+	}
+	if *parentRef.Kind != "Gateway" {
+		return false
+	}
+	if string(parentRef.Name) != parent.GetName() {
+		return false
+	}
+	if parentRef.Namespace != nil && string(*parentRef.Namespace) != parent.GetNamespace() {
+		return false
+	}
+	if parentRef.SectionName != nil && string(*parentRef.Namespace) != parent.GetSectionName().OrEmpty() {
+		return false
+	}
+
+	return true
 }

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -370,7 +370,10 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		if configurationStatus == k8sobj.ConfigurationStatusFailed {
 			debug(log, tcproute, "tcproute configuration failed")
-			statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, tcproute, gateways, metav1.ConditionFalse, ConditionReasonTranslationError, "")
+			statusUpdated, err := ensureParentsProgrammedCondition(ctx, r.Status(), tcproute, tcproute.Status.Parents, gateways, metav1.Condition{
+				Status: metav1.ConditionFalse,
+				Reason: string(ConditionReasonTranslationError),
+			})
 			if err != nil {
 				// don't proceed until the statuses can be updated appropriately
 				debug(log, tcproute, "failed to update programmed condition")
@@ -379,7 +382,10 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{Requeue: !statusUpdated}, nil
 		}
 
-		statusUpdated, err := r.ensureParentsProgrammedCondition(ctx, tcproute, gateways, metav1.ConditionTrue, ConditionReasonConfiguredInGateway, "")
+		statusUpdated, err := ensureParentsProgrammedCondition(ctx, r.Status(), tcproute, tcproute.Status.Parents, gateways, metav1.Condition{
+			Status: metav1.ConditionTrue,
+			Reason: string(ConditionReasonConfiguredInGateway),
+		})
 		if err != nil {
 			// don't proceed until the statuses can be updated appropriately
 			debug(log, tcproute, "failed to update programmed condition")
@@ -520,62 +526,4 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Con
 
 	// the status needed an update and it was updated successfully
 	return true, nil
-}
-
-func (r *TCPRouteReconciler) ensureParentsProgrammedCondition(
-	ctx context.Context,
-	tcproute *gatewayv1alpha2.TCPRoute,
-	gateways []supportedGatewayWithCondition,
-	conditionStatus metav1.ConditionStatus,
-	conditionReason gatewayv1beta1.RouteConditionReason,
-	conditionMessage string,
-) (bool, error) {
-	// map the existing parentStatues to avoid duplications
-	parentStatuses := getParentStatuses(tcproute, tcproute.Status.Parents)
-
-	programmedCondition := metav1.Condition{
-		Type:               ConditionTypeProgrammed,
-		Status:             conditionStatus,
-		Reason:             string(conditionReason),
-		ObservedGeneration: tcproute.Generation,
-		Message:            conditionMessage,
-		LastTransitionTime: metav1.Now(),
-	}
-	statusChanged := false
-	for _, g := range gateways {
-		gateway := g.gateway
-		parentRefKey := gateway.Namespace + "/" + gateway.Name
-		parentStatus, ok := parentStatuses[parentRefKey]
-		if ok {
-			// update existing parent in status.
-			changed := setRouteParentStatusCondition(parentStatus, programmedCondition)
-			statusChanged = statusChanged || changed
-		} else {
-			// add a new parent if the parent is not found in status.
-			newParentStatus := &gatewayv1alpha2.RouteParentStatus{
-				ParentRef: gatewayv1alpha2.ParentReference{
-					Namespace: lo.ToPtr(gatewayv1alpha2.Namespace(gateway.Namespace)),
-					Name:      gatewayv1alpha2.ObjectName(gateway.Name),
-					// TODO: set port after gateway port matching implemented: https://github.com/Kong/kubernetes-ingress-controller/issues/3016
-				},
-				ControllerName: GetControllerName(),
-				Conditions: []metav1.Condition{
-					programmedCondition,
-				},
-			}
-			tcproute.Status.Parents = append(tcproute.Status.Parents, *newParentStatus)
-			parentStatuses[parentRefKey] = newParentStatus
-			statusChanged = true
-		}
-	}
-
-	// update status if needed.
-	if statusChanged {
-		if err := r.Status().Update(ctx, tcproute); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	// no need to update if no status is changed.
-	return false, nil
 }

--- a/internal/controllers/gateway/types.go
+++ b/internal/controllers/gateway/types.go
@@ -25,9 +25,10 @@ type (
 	RouteParentStatus = gatewayv1beta1.RouteParentStatus
 	SectionName       = gatewayv1beta1.SectionName
 
-	TCPRoute = gatewayv1alpha2.TCPRoute
-	UDPRoute = gatewayv1alpha2.UDPRoute
-	TLSRoute = gatewayv1alpha2.TLSRoute
+	TCPRoute  = gatewayv1alpha2.TCPRoute
+	UDPRoute  = gatewayv1alpha2.UDPRoute
+	TLSRoute  = gatewayv1alpha2.TLSRoute
+	GRPCRoute = gatewayv1alpha2.GRPCRoute
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts `ensureParentsProgrammedCondition` from all `*RouteController`s to share 1 implementation.

**Which issue this PR fixes**:

Closes: #3390

