### PR TITLE
chore: remove unused rhel dockerfile targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,73 +64,12 @@ ARG REPO_INFO
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.fips
 
-### RHEL
-# Build UBI image
-FROM registry.access.redhat.com/ubi8/ubi AS redhat
-ARG TAG
-ARG TARGETPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
-
-LABEL name="Kong Ingress Controller" \
-      vendor="Kong" \
-      version="$TAG" \
-      release="1" \
-      url="https://github.com/Kong/kubernetes-ingress-controller" \
-      summary="Kong for Kubernetes Ingress" \
-      description="Use Kong for Kubernetes Ingress. Configure plugins, health checking, load balancing and more in Kong for Kubernetes Services, all using Custom Resource Definitions (CRDs) and Kubernetes-native tooling."
-
-# Create the user (ID 1000) and group that will be used in the
-# running container to run the process as an unprivileged user.
-RUN groupadd --system kic && \
-    adduser --system kic -g kic -u 1000
-
-COPY --from=builder /workspace/bin/manager .
-COPY LICENSE /licenses/
-COPY LICENSES /licenses/
-
-# Run yum update to prevent vulnerable packages getting into the final image
-# and preventing publishing on Redhat connect registry.
-RUN yum update -y
-
-# Perform any further action as an unprivileged user.
-USER 1000
-
-# Run the compiled binary.
-ENTRYPOINT ["/manager"]
-
 ### distroless FIPS 140-2
 FROM gcr.io/distroless/static:nonroot AS distroless-fips
 WORKDIR /
 COPY --from=builder-fips /workspace/manager .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
-
-### RHEL FIPS 140-2
-FROM registry.access.redhat.com/ubi8/ubi AS redhat-fips
-ARG TAG
-
-LABEL name="Kong Ingress Controller" \
-      vendor="Kong" \
-      version="$TAG" \
-      release="1" \
-      url="https://github.com/Kong/kubernetes-ingress-controller" \
-      summary="Kong for Kubernetes Ingress" \
-      description="Use Kong for Kubernetes Ingress. Configure plugins, health checking, load balancing and more in Kong for Kubernetes Services, all using Custom Resource Definitions (CRDs) and Kubernetes-native tooling."
-
-# Create the user (ID 1000) and group that will be used in the
-# running container to run the process as an unprivileged user.
-RUN groupadd --system kic && \
-    adduser --system kic -g kic -u 1000
-
-COPY --from=builder-fips /workspace/manager .
-COPY LICENSE /licenses/
-
-# Perform any further action as an unprivileged user.
-USER 1000
-
-# Run the compiled binary.
 ENTRYPOINT ["/manager"]
 
 ### Distroless/default


### PR DESCRIPTION
**What this PR does / why we need it**:

As @pmalek [noticed](https://github.com/Kong/kubernetes-ingress-controller/issues/3689#issuecomment-1460059605), we can also remove RedHat dockerfile targets as they're not in use right now.
