### PR TITLE
fix(release): fix workflow dependencies & allow pre-releases to not update kustomize

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [build-push-images, test-current-kubernetes, test-previous-kubernetes]
+    needs: [build-push-images, test-e2e]
     steps:
     - name: Parse semver string
       id: semver_parser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'
       - name: Verify manifests have requested KIC tag
+        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
         env:
           TAG: ${{ steps.semver_parser.outputs.fullversion }}
         run: make verify.versions


### PR DESCRIPTION
This PR has two fixes that are necessary for the 2.9.0-rc.1 pre-release:
- the `release` workflow mentions `test-current-kubernetes` and `test-previous-kubernetes` that got replaced by a single `test-e2e` step in #3347.
- the current `release` workflow fails if the update mainfests are not updated to the version being released. This requirement does not make sense for pre-releases. This PR lifts that requirement if the semver parses into a pre-release (that is, has a `-...` suffix).