### PR TITLE
chore: reword log entry for skipping object status update

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -446,7 +446,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 			c.logger.Debugf("triggering report for %d configured Kubernetes objects", len(report))
 			c.triggerKubernetesObjectReport(report, translationFailures)
 		} else {
-			c.logger.Debug("no configuration change, skipping kubernetes object report")
+			c.logger.Debug("no configuration change; resource status update not necessary, skipping")
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to disambiguate the log entry about the skipped object status update, let's change the debug log entry that notifies about this.
