### PR TITLE
feat(ci): allow triggering e2e tests via Github labels

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,17 @@
 name: e2e tests
+run-name: e2e tests, branch:${{ github.ref_name }}, triggered by @${{ github.actor }}
+
+concurrency:
+  # Limit the concurrency of e2e tests to run only 1 workflow for ref (branch).
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   schedule:
     - cron: '30 4 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   setup-e2e-tests:

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -1,4 +1,11 @@
 name: e2e tests (targeted)
+run-name: e2e tests (targeted), branch:${{ github.ref_name }}, triggered by @${{ github.actor }}
+
+concurrency:
+  # Limit the concurrency of e2e tests to run only 1 workflow for ref (branch).
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:
@@ -19,8 +26,37 @@ on:
         description: 'Set to "true" to run integration tests also'
         required: true
         default: 'false'
+      pr-number:
+        description:
+          Optional PR number, this workflow has been triggered from.
+          This will be used for commenting and removing the ci/run-e2e label.
+        required: false
 
 jobs:
+  post-comment-in-pr:
+    if: ${{ github.event.inputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      # URL is the current's workflow run URL.
+      # Sadly this is not readily available in github's context.
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PR_NUMBER: ${{ github.event.inputs.pr-number }}
+    steps:
+    - uses: actions/checkout@v3
+    # We use github.sha in the comment to indicate which SHA was used to build
+    # the controller image which is fine becuase this is only meant to be run
+    # with default params which build tha controller from current SHA sources.
+    - run: |
+        gh pr comment ${PR_NUMBER} --body \
+          "E2E (targeted) tests were started at ${URL}
+          
+          | controller version | k8s | istio |
+          | - | - | - |
+          | ${{ github.sha }} | \`${{ github.event.inputs.kubernetes-version }}\` | \`${{ github.event.inputs.istio-version }}\` |
+          "
+    - run: gh pr edit ${PR_NUMBER} --remove-label ci/run-e2e
+
   setup-e2e-tests:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -1,0 +1,21 @@
+name: trigger e2e (targeted) on label
+
+on:
+  pull_request:
+    types:
+    - labeled
+
+jobs:
+  trigger-e2e-tests-targeted:
+    if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
+
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      WORKFLOW: .github/workflows/e2e_targeted.yaml
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - run: gh workflow run ${WORKFLOW} --ref ${BRANCH} -f pr-number=${PR_NUMBER}


### PR DESCRIPTION
**What this PR does / why we need it**:

(After recent @czeslavo's [comment](https://github.com/Kong/kubernetes-ingress-controller/pull/3715#discussion_r1135429071) all e2e references here, refer to e2e targeted)

This PR bring the ability to run e2e tests via PR labels.

The flow is as follows:

- user adds a label to a PR: either `ci/run-e2e`
- [`trigger e2e on label` workflow](https://github.com/Kong/kubernetes-ingress-controller/blob/f78a20686e828f8b3cbb45315b7cb44ff2aa71fd/.github/workflows/e2e_trigger_via_label.yaml) picks it up and if those labels are detected then it starts appropriate workflow (either e2e).
- a conditional job has been added in e2e workflows, to check if `pr-number` input has been provided. If that's the case then it uses that number to
  - add a comment with e2e workflow URL
  - remove the label so that user can keep requesting more e2e runs

Sadly adding a comment with workflow link isn't as easy when tried to be done in the same workflow as triggering it as

- `gh workflow run ...` doesn't return anything that could be useful for us
- triggering a workflow run with the API (as cumbersome as it might be) also only dispatches an event and doesn't return anything useful: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event

Additionally, [`run-name`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name) has been added to allow us making the spun up e2e runs more identifiable. This way, when a user: @pmalek starts an e2e run on a branch `trigger-e2e-via-label`, then the created workflow run will be called: `e2e tests, branch:trigger-e2e-via-label, triggered by @pmalek` (subject to change, after review).

Last but not least this adds e2e concurrency, so that only 1 run per branch can be triggered.

This only aims to add e2e (**not** targeted) tests to be able to to be triggered via a label because targeted tests have input which have to be specified. Hence this wouldn't with with a label which can't have inputs but it could work via comments like e.g. k8s prow bot:

So a comment in the following form:

```
/trigger e2e-targeted kubernetes-version=v1.26.0 istio-version=v1.17.1 controller-image=kong/kubernetes-ingress-controller:ci include-integration=false
```

could trigger an e2e-targeted workflow. But that's for another discussion if we'd like to allow that.

---

Some examples might be observed in https://github.com/pmalek/gha_trigger/actions and https://github.com/pmalek/gha_trigger/pull/2

**Special notes for your reviewer**:

This reuses the `K8S_TEAM_BOT_GH_PAT` personal access token (which got required `read:org` permission for the needs of commenting and removing labels) but if we desire so that can use a separate one.

If not then I'll rename the token name to not be specifically targeted to only be used by the docs creation job.
