### PR TITLE
chore(deps): remove unneeded mergo replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/kong/kubernetes-ingress-controller/v2
 
 go 1.19
 
-replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
-
 require (
 	cloud.google.com/go/container v1.13.1
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
**What this PR does / why we need it**:

After deck has [already bumped](https://github.com/Kong/deck/blob/f6e8ee2fcf1eaab991c18c6fa8f2b87f83635848/go.mod#L19) `imdario/mergo` to `v0.3.13` and `v0.3.13` does include the one patch https://github.com/imdario/mergo/blob/v0.3.13/merge.go#L82 that we needed (diff between kong's fork and upstream: https://github.com/imdario/mergo/compare/master...Kong:mergo:v0.3.13 we can do away with the replace in our `go.mod`.
