### PR TITLE
fix: do not update secret when tls.secretName is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- Fixed the issue that status of ingress is not updated when `secretName` is
-  not spefied in `ingress.spec.tls`.
+- Fixed the issue where the status of an ingress is not updated when `secretName` is
+  not specified in `ingress.spec.tls`.
   [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
 
 ## [2.9.0-rc.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
-
+ - [2.9.0](#290)
  - [2.9.0-rc.1](#290-rc1)
  - [2.8.1](#281)
  - [2.8.0](#280)
@@ -62,6 +62,16 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.9.0]
+
+> Release date: TBD
+
+### Fixed
+
+- Fixed the issue that status of ingress is not updated when `secretName` is
+  not spefied in `ingress.spec.tls`.
+  [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
 
 ## [2.9.0-rc.1]
 

--- a/internal/controllers/configuration/object_references.go
+++ b/internal/controllers/configuration/object_references.go
@@ -75,6 +75,9 @@ func listCoreV1ServiceReferredSecrets(service *corev1.Service) []types.Namespace
 func listNetV1IngressReferredSecrets(ingress *netv1.Ingress) []types.NamespacedName {
 	referredSecretNames := make([]types.NamespacedName, 0, len(ingress.Spec.TLS))
 	for _, tls := range ingress.Spec.TLS {
+		if tls.SecretName == "" {
+			continue
+		}
 		nsName := types.NamespacedName{
 			Namespace: ingress.Namespace,
 			Name:      tls.SecretName,
@@ -87,6 +90,9 @@ func listNetV1IngressReferredSecrets(ingress *netv1.Ingress) []types.NamespacedN
 func listNetV1beta1IngressReferredSecrets(ingress *netv1beta1.Ingress) []types.NamespacedName {
 	referredSecretNames := make([]types.NamespacedName, 0, len(ingress.Spec.TLS))
 	for _, tls := range ingress.Spec.TLS {
+		if tls.SecretName == "" {
+			continue
+		}
 		nsName := types.NamespacedName{
 			Namespace: ingress.Namespace,
 			Name:      tls.SecretName,
@@ -99,6 +105,9 @@ func listNetV1beta1IngressReferredSecrets(ingress *netv1beta1.Ingress) []types.N
 func listExtensionV1beta1IngressReferredSecrets(ingress *extv1beta1.Ingress) []types.NamespacedName {
 	referredSecretNames := make([]types.NamespacedName, 0, len(ingress.Spec.TLS))
 	for _, tls := range ingress.Spec.TLS {
+		if tls.SecretName == "" {
+			continue
+		}
 		nsName := types.NamespacedName{
 			Namespace: ingress.Namespace,
 			Name:      tls.SecretName,
@@ -147,6 +156,9 @@ func listKongConsumerReferredSecrets(consumer *kongv1.KongConsumer) []types.Name
 func listTCPIngressReferredSecrets(tcpIngress *kongv1beta1.TCPIngress) []types.NamespacedName {
 	referredSecretNames := make([]types.NamespacedName, 0, len(tcpIngress.Spec.TLS))
 	for _, tls := range tcpIngress.Spec.TLS {
+		if tls.SecretName == "" {
+			continue
+		}
 		nsName := types.NamespacedName{
 			Namespace: tcpIngress.Namespace,
 			Name:      tls.SecretName,

--- a/internal/controllers/configuration/object_references_test.go
+++ b/internal/controllers/configuration/object_references_test.go
@@ -104,6 +104,21 @@ func TestListIngressReferredSecrets(t *testing.T) {
 			secretNum:     1,
 			refSecretName: types.NamespacedName{Namespace: "ns", Name: "secret1"},
 		},
+		{
+			name: "ingress_has_tls_without_secretName_should_refer_no_secrets",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "ing1",
+				},
+				Spec: netv1.IngressSpec{
+					TLS: []netv1.IngressTLS{
+						{Hosts: []string{"example.com"}},
+					},
+				},
+			},
+			secretNum: 0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -289,11 +304,11 @@ func TestListTCPIngressReferredSecrets(t *testing.T) {
 				Spec: kongv1beta1.TCPIngressSpec{
 					TLS: []kongv1beta1.IngressTLS{
 						{Hosts: []string{"example.com"}, SecretName: "secret1"},
-						{Hosts: []string{"konghq.com"}, SecretName: "secret2"},
+						{Hosts: []string{"konghq.com"}, SecretName: ""},
 					},
 				},
 			},
-			secretNum: 2,
+			secretNum: 1,
 			refSecretName: types.NamespacedName{
 				Namespace: "ns",
 				Name:      "secret1",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When `ingress.Spec.TLS` does not contain a secret, skip the updating of referred secrets because they are "Optional".

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3711 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
