### PR TITLE
tests: fix TestHealthCheckServer_Start flaky test

### DIFF
--- a/internal/manager/health_check_test.go
+++ b/internal/manager/health_check_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr/testr"
+	"github.com/go-logr/logr"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -85,13 +85,27 @@ func TestHealthCheckServer_Start(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	addr := fmt.Sprintf("localhost:%d", port)
-	h.Start(ctx, addr, testr.New(t))
+	// Use discard logger to prevent:
+	// panic: Log in goroutine after TestHealthCheckServer_Start has completed: "level"=0 "msg"="healthz server closed"
+	h.Start(ctx, addr, logr.Discard())
 
 	healtzEndpoint := fmt.Sprintf("http://%s/healthz", addr)
-	resp, err := http.Get(healtzEndpoint)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	defer resp.Body.Close()
+	// Allow some failures just after the server gets started.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(healtzEndpoint)
+		if err != nil {
+			t.Logf("got error: %v but none expected", err)
+			return false
+		}
+
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("got %d status code but expected 200", resp.StatusCode)
+			return false
+		}
+
+		return true
+	}, time.Second, time.Millisecond)
 
 	// Cancel the context to stop the server and check it is no longer listening.
 	cancel()
@@ -101,7 +115,7 @@ func TestHealthCheckServer_Start(t *testing.T) {
 		if err == nil {
 			defer resp.Body.Close()
 		}
-		if !strings.Contains(err.Error(), "connection refused") {
+		if err != nil && !strings.Contains(err.Error(), "connection refused") {
 			t.Log("expected error to contain 'connection refused', got:", err)
 			return false
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that recently added `TestHealthCheckServer_Start` has a tendency to sporadically fail.

This PR should fix that by allowing some failures when issuing requests towards at just after start and using a discard logger which prevents:

```
panic: Log in goroutine after TestHealthCheckServer_Start has completed: "level"=0 "msg"="healthz server closed"
```

It also checks if the `err` is not `nil` at line:

```
if err != nil && !strings.Contains(err.Error(), "connection refused")
```

to prevent accessing `.Error()` for `nil` errors.

---

Exemplar CI failure: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4414460387/jobs/7736204246#step:5:2831

```
=== FAIL: internal/manager TestHealthCheckServer_Start (0.00s)
    health_check_test.go:92: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/manager/health_check_test.go:92
        	Error:      	Received unexpected error:
        	            	Get "http://localhost:44593/healthz": dial tcp [::1]:44593: connect: connection refused
        	Test:       	TestHealthCheckServer_Start
```