### PR TITLE
feat(konnect): react to gateway clients updates in NodeAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ Adding a new version? You'll need three changes:
 
 > Release date: TBD
 
+### Added
+
+- Konnect Runtime Group's nodes are reactively updated on each discovered Gateway clients
+  change.
+  [#3727](https://github.com/Kong/kubernetes-ingress-controller/pull/3727)
+
 ### Fixed
 
 - Fixed the issue where the status of an ingress is not updated when `secretName` is

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -273,6 +273,7 @@ func setupKonnectNodeAgentWithMgr(
 		konnectNodeAPIClient,
 		configStatusNotifier,
 		konnect.NewGatewayClientGetter(logger, clientsManager),
+		clientsManager,
 	)
 	if err := mgr.Add(agent); err != nil {
 		return fmt.Errorf("failed adding konnect.NodeAgent runnable to the manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `konnect.NodeAgent` runs a loop with a fixed nodes updates period. It makes propagating the changes in Gateways configuration take longer than it could. In this PR, we subscribe to the Gateway clients' changes to reactively update nodes in the Konnect when a change in discovered Gateways is detected.

Additionally, it moves the `NodeAgent`'s tests into a separate test package to make them black-box.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3501.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
