### PR TITLE
tests: fix flaky gateway conformance `HTTPRouteListenerHostnameMatching` test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ Adding a new version? You'll need three changes:
 - Fixed the issue where the status of an ingress is not updated when `secretName` is
   not specified in `ingress.spec.tls`.
   [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
+- Fixed incorrectly set parent status for Gateway API routes
+  [#3732](https://github.com/Kong/kubernetes-ingress-controller/pull/3732)
 
 ## [2.9.0-rc.1]
 

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,8 @@ test.conformance: gotestsum
 	@./scripts/check-container-environment.sh
 	@TEST_DATABASE_MODE="off" GOFLAGS="-tags=conformance_tests" \
 	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
-	$(GOTESTSUM) -- -race \
+	$(GOTESTSUM) -- \
+		-race $(GOTESTFLAGS) \
 		-timeout $(INTEGRATION_TEST_TIMEOUT) \
 		-parallel $(NCPU) \
 		./test/conformance


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes setting the incorrect status for Gateway API routes.

- It sets the section name in `ParentReference` when it was specified
- It adds unit tests for cases where section names are specified and where more than 1 gateway is matching the route's `ParentRefs`
- It prevents adding multiple parentRefs status for the same parent which was found in local debugging

The relevant conformance test was run multiple times in a loop locally to ensure the fix is in place.

**Which issue this PR fixes**:

Fixes: #3721

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
