### PR TITLE
chore(ci): remove explicit go cache

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -20,14 +20,6 @@ jobs:
         with:
           go-version: '^1.20'
 
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
-
       - name: cleanup orphaned test clusters
         run: go run hack/cleanup_gke_clusters.go
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,14 +62,6 @@ jobs:
         with:
           go-version: '^1.20'
 
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
-
       - uses: Kong/kong-license@master
         id: license
         with:
@@ -120,14 +112,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
 
       - uses: Kong/kong-license@master
         continue-on-error: true
@@ -188,14 +172,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
 
       - uses: Kong/kong-license@master
         id: license

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -96,14 +96,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
@@ -171,14 +163,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - uses: Kong/kong-license@master
       id: license
       with:
@@ -233,14 +217,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
 
     - uses: Kong/kong-license@master
       id: license

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,13 +147,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-      - name: cache go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-codegen-
       - uses: Kong/kong-license@master
         id: license
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,14 +31,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: Run lint
       run: make lint
 
@@ -89,14 +81,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
 
     - name: run unit tests
       run: make test.unit
@@ -191,15 +175,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: cache go modules
-      if: steps.detect_if_should_run.outputs.result != 'false'
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: run make test.integration.${{ matrix.test }}
       if: steps.detect_if_should_run.outputs.result != 'false'
       run: make test.integration.${{ matrix.test }}
@@ -244,14 +219,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
 
     - name: run conformance tests
       run: make test.conformance

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -27,14 +27,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: run integration tests
       run: make test.integration.enterprise.postgres
       env:
@@ -73,14 +65,6 @@ jobs:
       with:
         go-version: '^1.20'
 
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: run integration tests
       run: make test.integration.postgres
       env:
@@ -116,14 +100,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
-
-    - name: cache go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
 
     - name: run integration tests
       run: make test.integration.dbless


### PR DESCRIPTION
**What this PR does / why we need it**:

After bumping to https://github.com/actions/setup-go/releases/tag/v4.0.0 we can remove all the explicit steps for go cache as from this version it's enabled by default.

I noticed it's a thing to do after getting warnings in my workflows (example run that was affected by the cache errors: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4428778621/jobs/7768401060). That's expected according to the `setup-go` release notes:

>  The action won’t throw an error if the cache can’t be restored or saved. The action will throw a warning message but it won’t stop a build process.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


