### PR TITLE
chore(e2e): simplify loading images

### DIFF
--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -168,30 +168,12 @@ jobs:
       with:
         password: ${{ secrets.PULP_PASSWORD }}
 
-    # The only reason we need those 2 is the fact that TEST_KONG_CONTROLLER_IMAGE_LOAD
-    # is ultimately passed down to ktf's loadimage.Addon which uses "kind load docker-image ..."
-    # which fails when an image is not available on the cluster.
-    # Hence the non local version (where the image is pulled from an external registry)
-    # doesn't define TEST_KONG_CONTROLLER_IMAGE_LOAD.
-
     - name: run ${{ matrix.test }} with ${{ github.event.inputs.controller-image }} image
-      if: ${{ github.event.inputs.controller-image != 'kong/kubernetes-ingress-controller:ci' }}
       run: make test.e2e
       env:
         E2E_TEST_RUN: ${{ matrix.test }}
         TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ github.event.inputs.controller-image }}
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}
-        ISTIO_VERSION: ${{ github.event.inputs.istio-version }}
-
-    - name: run ${{ matrix.test }} with ${{ github.event.inputs.controller-image }} image (local)
-      if: ${{ github.event.inputs.controller-image == 'kong/kubernetes-ingress-controller:ci' }}
-      run: make test.e2e
-      env:
-        E2E_TEST_RUN: ${{ matrix.test }}
-        TEST_KONG_CONTROLLER_IMAGE_LOAD: ${{ github.event.inputs.controller-image }}
-        TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ github.event.inputs.controller-image }}
-        TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
+        TEST_KONG_LOAD_IMAGES: ${{ github.event.inputs.controller-image == 'kong/kubernetes-ingress-controller:ci' }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ github.event.inputs.kubernetes-version }}
         ISTIO_VERSION: ${{ github.event.inputs.istio-version }}

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -9,10 +9,14 @@ var (
 	// provisioner in the testing framework will be used.
 	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
 
-	imageOverride         = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
-	imageLoad             = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_LOAD")
+	// controllerImageOverride is the controller image to use in lieu of the default.
+	controllerImageOverride = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
+
+	// imageLoad is a boolean flag that indicates whether the controller and kong images should be loaded into the cluster.
+	imageLoad = os.Getenv("TEST_KONG_LOAD_IMAGES")
+
+	// kongImageOverride is the Kong image to use in lieu of the default.
 	kongImageOverride     = os.Getenv("TEST_KONG_IMAGE_OVERRIDE")
-	kongImageLoad         = os.Getenv("TEST_KONG_IMAGE_LOAD")
 	kongImagePullUsername = os.Getenv("TEST_KONG_PULL_USERNAME")
 	kongImagePullPassword = os.Getenv("TEST_KONG_PULL_PASSWORD")
 
@@ -26,3 +30,8 @@ var (
 	// It's not used when KONG_TEST_CLUSTER is set.
 	clusterProvider = os.Getenv("KONG_TEST_CLUSTER_PROVIDER")
 )
+
+// shouldLoadImages tells whether the controller and kong images should be loaded into the cluster.
+func shouldLoadImages() bool {
+	return imageLoad == "true"
+}

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -163,8 +163,10 @@ func TestWebhookUpdate(t *testing.T) {
 	require.NoError(t, err)
 	addons := []clusters.Addon{}
 	addons = append(addons, metallb.New())
-	if b, err := loadimage.NewBuilder().WithImage(imageLoad); err == nil {
-		addons = append(addons, b.Build())
+	if shouldLoadImages() {
+		if b, err := loadimage.NewBuilder().WithImage(controllerImageOverride); err == nil {
+			addons = append(addons, b.Build())
+		}
 	}
 	builder := environments.NewBuilder().WithExistingCluster(cluster).WithAddons(addons...)
 	env, err := builder.Build(ctx)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -151,7 +151,9 @@ func createKINDBuilder() *environments.Builder {
 	}
 	builder = builder.WithClusterBuilder(clusterBuilder)
 	builder = builder.WithAddons(metallb.New())
-	builder = builder.WithAddons(buildImageLoadAddons(imageLoad, kongImageLoad)...)
+	if shouldLoadImages() {
+		builder = builder.WithAddons(buildImageLoadAddons(controllerImageOverride, kongImageOverride)...)
+	}
 	return builder
 }
 
@@ -163,7 +165,9 @@ func createExistingKINDBuilder(name string) (*environments.Builder, error) {
 	}
 	builder = builder.WithExistingCluster(cluster)
 	builder = builder.WithAddons(metallb.New())
-	builder = builder.WithAddons(buildImageLoadAddons(imageLoad, kongImageLoad)...)
+	if shouldLoadImages() {
+		builder = builder.WithAddons(buildImageLoadAddons(controllerImageOverride, kongImageOverride)...)
+	}
 	return builder, nil
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -149,27 +149,20 @@ func getTestManifest(t *testing.T, baseManifestPath string) io.Reader {
 	return manifestsReader
 }
 
-// patchGatewayImageFromEnv will optionally replace a default controller image in manifests with one of `kongImageLoad`
-// or `kongImageOverride` if any is set.
+// patchGatewayImageFromEnv will optionally replace a default controller image in manifests with `kongImageOverride`
+// if it's set.
 func patchGatewayImageFromEnv(t *testing.T, manifestsReader io.Reader) (io.Reader, error) {
-	var kongImageFullname string
-	if kongImageLoad != "" {
-		kongImageFullname = kongImageLoad
-	} else {
-		kongImageFullname = kongImageOverride
-	}
-
-	if kongImageFullname != "" {
-		t.Logf("replace kong image to %s", kongImageFullname)
-		split := strings.Split(kongImageFullname, ":")
+	if kongImageOverride != "" {
+		t.Logf("replace kong image to %s", kongImageOverride)
+		split := strings.Split(kongImageOverride, ":")
 		if len(split) < 2 {
-			return nil, fmt.Errorf("invalid image name '%s', expected <repo>:<tag> format", kongImageFullname)
+			return nil, fmt.Errorf("invalid image name '%s', expected <repo>:<tag> format", kongImageOverride)
 		}
 		repo := strings.Join(split[0:len(split)-1], ":")
 		tag := split[len(split)-1]
 		patchedManifestsReader, err := patchKongImage(manifestsReader, repo, tag)
 		if err != nil {
-			return nil, fmt.Errorf("failed patching override image '%v'", kongImageFullname)
+			return nil, fmt.Errorf("failed patching override image '%v'", kongImageOverride)
 		}
 		return patchedManifestsReader, nil
 	}
@@ -177,27 +170,20 @@ func patchGatewayImageFromEnv(t *testing.T, manifestsReader io.Reader) (io.Reade
 	return manifestsReader, nil
 }
 
-// patchControllerImageFromEnv will optionally replace a default controller image in manifests with one of `imageLoad`
-// or `imageOverride` if any is set.
+// patchControllerImageFromEnv will optionally replace a default controller image in manifests with `controllerImageOverride`
+// if it's set.
 func patchControllerImageFromEnv(manifestReader io.Reader) (io.Reader, error) {
-	var imageFullname string
-	if imageLoad != "" {
-		imageFullname = imageLoad
-	} else {
-		imageFullname = imageOverride
-	}
-
-	if imageFullname != "" {
-		split := strings.Split(imageFullname, ":")
+	if controllerImageOverride != "" {
+		split := strings.Split(controllerImageOverride, ":")
 		if len(split) < 2 {
-			return nil, fmt.Errorf("could not parse override image '%v', expected <repo>:<tag> format", imageFullname)
+			return nil, fmt.Errorf("could not parse override image '%v', expected <repo>:<tag> format", controllerImageOverride)
 		}
 		repo := strings.Join(split[0:len(split)-1], ":")
 		tag := split[len(split)-1]
 		var err error
 		manifestReader, err = patchControllerImage(manifestReader, repo, tag)
 		if err != nil {
-			return nil, fmt.Errorf("failed patching override image '%v': %w", imageFullname, err)
+			return nil, fmt.Errorf("failed patching override image '%v': %w", controllerImageOverride, err)
 		}
 	}
 	return manifestReader, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of depending on both `TEST_KONG_CONTROLLER_IMAGE_OVERRIDE` and `TEST_KONG_CONTROLLER_IMAGE_LOAD` when patching the controller image, let's just always use `TEST_KONG_CONTROLLER_IMAGE_OVERRIDE`. 

Instead of using `TEST_KONG_CONTROLLER_IMAGE_LOAD`, let's have a boolean `TEST_KONG_LOAD_IMAGES` that will tell whether to load overridden images to the cluster or not.

E2E tests run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4437636384
