### PR TITLE
fix(ci): don't use gotestsum in integration tests

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: run conformance tests
         run: make test.conformance
         env:
-          GOTESTSUM_JUNITFILE: "conformance-tests.xml"
+          JUNIT_REPORT: "conformance-tests.xml"
 
       - name: collect test report
         if: ${{ always() }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -74,7 +74,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
-          GOTESTSUM_JUNITFILE: "integration-tests-${{ matrix.name }}.xml"
+          JUNIT_REPORT: "integration-tests-${{ matrix.name }}.xml"
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
 
       - name: run ${{ matrix.name }} - invalid config
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
-          GOTESTSUM_JUNITFILE: "integration-tests-invalid-config-${{ matrix.name }}.xml"
+          JUNIT_REPORT: "integration-tests-invalid-config-${{ matrix.name }}.xml"
           GOTESTFLAGS: "-run=TestIngressRecoverFromInvalidPath"
           TEST_RUN_INVALID_CONFIG_CASES: "true"
 

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: run unit tests
         run: make test.unit
         env:
-          JUNIT_REPORT: unit-tests.xml
+          GOTESTSUM_JUNITFILE: unit-tests.xml
 
       - name: collect test coverage
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: run unit tests
         run: make test.unit
         env:
-          GOTESTSUM_JUNITFILE: unit-tests.xml
+          JUNIT_REPORT: unit-tests.xml
 
       - name: collect test coverage
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,13 @@ test.unit.pretty:
 _check.container.environment:
 	@./scripts/check-container-environment.sh
 
+# Integration tests don't use gotestsum because there's a data race issue
+# when go toolchain is writing to os.Stderr which is being read in go-kong
+# https://github.com/Kong/go-kong/blob/c71247b5c8aae2/kong/client.go#L182
+# which in turn produces a data race becuase gotestsum needs go test invoked with
+# -json which enables the problematic branch in go toolchain (that writes to os.Stderr).
+#
+# Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/3754
 .PHONY: _test.integration
 _test.integration: _check.container.environment go-junit-report
 	KONG_CLUSTER_VERSION="$(KONG_CLUSTER_VERSION)" \

--- a/third_party/go-junit-report.go
+++ b/third_party/go-junit-report.go
@@ -1,0 +1,10 @@
+//go:build third_party
+// +build third_party
+
+package third_party
+
+import (
+	_ "github.com/jstemmer/go-junit-report/v2"
+)
+
+//go:generate go install -modfile go.mod github.com/jstemmer/go-junit-report/v2

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elastic/crd-ref-docs v0.0.8
 	github.com/go-delve/delve v1.20.1
 	github.com/golangci/golangci-lint v1.51.2
+	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	gotest.tools/gotestsum v1.9.0
 	honnef.co/go/tools v0.4.3
 	k8s.io/code-generator v0.26.2

--- a/third_party/go.sum
+++ b/third_party/go.sum
@@ -1886,6 +1886,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
+github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to solve a rather convoluted issue with using `-json` when used in `go test`.

https://github.com/golang/go/commit/295516813efb84589a2417178741f31cbb050298#diff-b3e6126779b5ec9d3d6cea7cc54054ba78f4d7a0a6248d9e458bbd9b3d72fce3R1828 (from this CR: https://go-review.googlesource.com/c/go/+/443596) introduced a write to `os.Stderr` when using `-json` with `go test` (which is what `gotestsum` uses).

That creates a (rather rare) data race with https://github.com/Kong/go-kong/blob/c71247b5c8aae2a0afe76da4dcfaf48a17f10bd5/kong/client.go#L182.

This PR aims to fix that by not using `gotestsum` in integration tests (which used `standard-verbose` format by default anyway).

Examplar CI run that contains this data race: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4439161953/jobs/7791273577#step:8:694

```
==================
WARNING: DATA RACE
Write at 0x000006029430 by main goroutine:
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.20.2/x64/src/testing/testing.go:1854 +0x279
  github.com/kong/kubernetes-ingress-controller/v2/test/integration.TestMain()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/suite_test.go:211 +0x35a4
  main.main()
      _testmain.go:192 +0x33d

Previous read at 0x000006029430 by goroutine 326:
  github.com/kong/go-kong/kong.NewClient()
      /home/runner/go/pkg/mod/github.com/kong/go-kong@v0.38.1/kong/client.go:182 +0x11e4
  github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi.NewKongClientForWorkspace()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/adminapi/kong.go:25 +0xea
  github.com/kong/kubernetes-ingress-controller/v2/internal/manager.(*Config).adminAPIClients()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/manager/setup.go:278 +0x3d2
  github.com/kong/kubernetes-ingress-controller/v2/internal/manager.Run()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/manager/run.go:64 +0xa8c
  github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd.RunWithLogger()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/cmd/rootcmd/run.go:40 +0x472
  github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster.func1()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:95 +0x232

Goroutine 326 (running) created at:
  github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:92 +0xbc9
  github.com/kong/kubernetes-ingress-controller/v2/test/integration.TestMain()
      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/suite_test.go:165 +0x2c51
  main.main()
      _testmain.go:192 +0x33d
==================
```

Suggestions on how we'd like to tackle this differently are more than welcome.

---

Related: #3754 