### PR TITLE
chore(ci): don't set PATH for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,6 @@ _test.integration: _check.container.environment gotestsum
 		GOFLAGS="-tags=$(GOTAGS)" \
 		KONG_CONTROLLER_FEATURE_GATES=$(KONG_CONTROLLER_FEATURE_GATES) \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
-		PATH=$$PATH:$(PROJECT_DIR)/bin \
 		$(GOTESTSUM) -- $(GOTESTFLAGS) \
 		-timeout $(INTEGRATION_TEST_TIMEOUT) \
 		-parallel $(NCPU) \


### PR DESCRIPTION
**What this PR does / why we need it**:

After #3660 got merged we don't seem to need to set the PATH in integration tests anymore.
