### PR TITLE
fix(examples) link to updated GWAPI install guide

### DIFF
--- a/examples/gateway-grpcroute.yaml
+++ b/examples/gateway-grpcroute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize grpcs://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: v1
 kind: Service

--- a/examples/gateway-httproute.yaml
+++ b/examples/gateway-httproute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/gateway-referencegrant-httproute.yaml
+++ b/examples/gateway-referencegrant-httproute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: v1
 kind: Namespace

--- a/examples/gateway-tcproute.yaml
+++ b/examples/gateway-tcproute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/gateway-tlsroute.yaml
+++ b/examples/gateway-tlsroute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/gateway-udproute.yaml
+++ b/examples/gateway-udproute.yaml
@@ -1,7 +1,6 @@
-# NOTE: You need to install the Gateway APIs CRDs before using this example,
-#       they are external and can be deployed with the following one-liner:
-#
-# kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
+# NOTE The Gateway APIs are not yet available by default in Kubernetes.
+# Follow these instructions to install them before using this example:
+# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:

As noted by @gAmUssA, the command we put in the examples no longer works. Since the GWAPI team may change the install path again in the future, this changes the comment to link to their install page, rather than copying the current commands.