### PR TITLE
chore: don't run e2es in pr workflow

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -56,17 +56,6 @@ jobs:
     uses: ./.github/workflows/_docker_build.yaml
     secrets: inherit
 
-  e2e-tests:
-    needs:
-      - should-run-with-secrets
-      - build-docker-image
-    if: ${{ needs.should-run-with-secrets.outputs.result == 'true' }}
-    uses: ./.github/workflows/_e2e_tests.yaml
-    secrets: inherit
-    with:
-      kic-image: ${{ needs.build-docker-image.outputs.image }}
-      load-local-image: true
-
   # We need this step to fail the workflow if any of the previous steps failed or were cancelled.
   # It allows to use this particular job as a required check for PRs.
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
@@ -78,7 +67,6 @@ jobs:
       - integration-tests
       - conformance-tests
       - build-docker-image
-      - e2e-tests
     if: always()
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
@@ -92,7 +80,6 @@ jobs:
       - unit-tests
       - integration-tests
       - conformance-tests
-      - e2e-tests
     if: ${{ needs.should-run-with-secrets.outputs.result == 'true' }}
     uses: ./.github/workflows/_test_reports.yaml
     secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:

It turned out they take too much resources and contribute to job queueing.

**Which issue this PR fixes**:

Closes #3725.

