### PR TITLE
feat(annotations) support user-supplied tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Adding a new version? You'll need three changes:
 - Telemetry reports now include a number of discovered Gateways when the Gateway Discovery
   feature is turned on.
   [#3783](https://github.com/Kong/kubernetes-ingress-controller/pull/3783)
+- Adding the `konghq.com/tags: csv,of,tags` annotation will add tags to
+  generated resources.
+  [#3778](https://github.com/Kong/kubernetes-ingress-controller/pull/3778)
 
 ### Fixed
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -62,6 +62,7 @@ const (
 	RetriesKey           = "/retries"
 	HeadersKey           = "/headers"
 	PathHandlingKey      = "/path-handling"
+	UserTagKey           = "/tags"
 
 	// GatewayClassUnmanagedAnnotationSuffix is an annotation used on a Gateway resource to
 	// indicate that the GatewayClass should be reconciled according to unmanaged
@@ -335,4 +336,15 @@ func ExtractUnmanagedGatewayClassMode(anns map[string]string) string {
 // UpdateUnmanagedAnnotation updates the value of the annotation konghq.com/gatewayclass-unmanaged.
 func UpdateUnmanagedAnnotation(anns map[string]string, annotationValue string) {
 	anns[GatewayClassUnmanagedAnnotation] = annotationValue
+}
+
+// ExtractUserTags extracts a set of tags from a comma-separated string.
+func ExtractUserTags(anns map[string]string) []string {
+	val := anns[AnnotationPrefix+UserTagKey]
+	// If the annotation is not present, the map provides an empty value, and splitting that will create a slice
+	// containing a single empty string tag. These aren't valid, hence this special case.
+	if len(val) == 0 {
+		return []string{}
+	}
+	return strings.Split(val, ",")
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -182,7 +183,7 @@ func GenerateTagsForObject(obj client.Object) []*string {
 	if gvk.Version != "" {
 		tags = append(tags, K8sVersionTagPrefix+gvk.Version)
 	}
-	user := annotations.ExtractUserTags(obj.GetAnnotations())
-	tags = append(tags, user...)
+	tags = append(tags, annotations.ExtractUserTags(obj.GetAnnotations())...)
+	tags = lo.Uniq(tags)
 	return kong.StringSlice(tags...)
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -29,6 +29,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 )
 
 // ParseNameNS parses a string searching a namespace and name.
@@ -180,5 +182,7 @@ func GenerateTagsForObject(obj client.Object) []*string {
 	if gvk.Version != "" {
 		tags = append(tags, K8sVersionTagPrefix+gvk.Version)
 	}
+	user := annotations.ExtractUserTags(obj.GetAnnotations())
+	tags = append(tags, user...)
 	return kong.StringSlice(tags...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `konghq.com/tags` annotation. Given a CSV of tags, Kong resources generated from the Kubernetes resource with this annotation will have the tags from the CSV. This allows users to set additional tags on generated Kong resources.

**Which issue this PR fixes**:

Fix #3198

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
