### PR TITLE
feat(telemetry): add `discovered_gateways_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Adding a new version? You'll need three changes:
 - Konnect Runtime Group's nodes are reactively updated on each discovered Gateway clients
   change.
   [#3727](https://github.com/Kong/kubernetes-ingress-controller/pull/3727)
+- Telemetry reports now include a number of discovered Gateways when the Gateway Discovery
+  feature is turned on.
+  [#3783](https://github.com/Kong/kubernetes-ingress-controller/pull/3783)
 
 ### Fixed
 

--- a/internal/dataplane/clients_manager.go
+++ b/internal/dataplane/clients_manager.go
@@ -133,6 +133,12 @@ func (c *AdminAPIClientsManager) GatewayClients() []*adminapi.Client {
 	return copied
 }
 
+func (c *AdminAPIClientsManager) GatewayClientsCount() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.gatewayClients)
+}
+
 // SubscribeToGatewayClientsChanges returns a channel that will receive a notification on every Gateway clients update.
 // Can be used to receive a signal when immediate reaction to the changes is needed. After receiving the notification,
 // GatewayClients call will return an already updated slice of clients.

--- a/internal/dataplane/clients_manager_test.go
+++ b/internal/dataplane/clients_manager_test.go
@@ -256,12 +256,14 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, m.GatewayClients(), 1, "expecting one initial client")
+	require.Equal(t, m.GatewayClientsCount(), 1, "expecting one initial client")
 	require.Len(t, m.AllClients(), 1, "expecting one initial client")
 
 	konnectTestClient, err := adminapi.NewTestClient("https://us.api.konghq.tech")
 	require.NoError(t, err)
 	m.SetKonnectClient(konnectTestClient)
 	require.Len(t, m.GatewayClients(), 1, "konnect client should not be returned from GatewayClients")
+	require.Equal(t, m.GatewayClientsCount(), 1, "konnect client should not be counted in GatewayClientsCount")
 	require.Len(t, m.AllClients(), 2, "konnect client should be returned from AllClients")
 }
 

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -27,10 +27,10 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-type mockGatewaysCounter struct{}
+type mockGatewaysCounter int
 
 func (m mockGatewaysCounter) GatewayClientsCount() int {
-	return 5
+	return int(m)
 }
 
 func TestCreateManager(t *testing.T) {
@@ -100,7 +100,7 @@ func TestCreateManager(t *testing.T) {
 		k8sclient,
 		dyn,
 		ctrlClient,
-		mockGatewaysCounter{},
+		mockGatewaysCounter(5),
 		payload,
 		reportValues,
 		func(t *testing.T, actualReport string) {
@@ -177,7 +177,7 @@ func TestCreateManager_GatewayDiscoverySpecifics(t *testing.T) {
 				k8sclient,
 				dyn,
 				ctrlClient,
-				mockGatewaysCounter{},
+				mockGatewaysCounter(5),
 				Payload{},
 				ReportValues{
 					GatewayServiceDiscoveryEnabled: tc.gatewayServiceDiscoveryEnabled,

--- a/internal/manager/telemetry/workflows/gateway_discovery.go
+++ b/internal/manager/telemetry/workflows/gateway_discovery.go
@@ -1,0 +1,63 @@
+package workflows
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kong/kubernetes-telemetry/pkg/provider"
+	"github.com/kong/kubernetes-telemetry/pkg/telemetry"
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const GatewayDiscoveryWorkflowName = "gateway_discovery"
+
+// DiscoveredGatewaysCounter is an interface that allows to count currently discovered Gateways.
+type DiscoveredGatewaysCounter interface {
+	GatewayClientsCount() int
+}
+
+func NewGatewayDiscoveryWorkflow(gatewaysCounter DiscoveredGatewaysCounter) (telemetry.Workflow, error) {
+	w := telemetry.NewWorkflow(GatewayDiscoveryWorkflowName)
+
+	discoveredGatewaysCountProvider, err := NewDiscoveredGatewaysCountProvider(gatewaysCounter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovered gateways count provider: %w", err)
+	}
+	w.AddProvider(discoveredGatewaysCountProvider)
+
+	return w, nil
+}
+
+// DiscoveredGatewaysCountProvider is a provider that reports the number of currently discovered Gateways.
+type DiscoveredGatewaysCountProvider struct {
+	counter DiscoveredGatewaysCounter
+}
+
+func NewDiscoveredGatewaysCountProvider(counter DiscoveredGatewaysCounter) (*DiscoveredGatewaysCountProvider, error) {
+	if counter == nil {
+		return nil, errors.New("discovered gateways counter is required")
+	}
+
+	return &DiscoveredGatewaysCountProvider{counter: counter}, nil
+}
+
+const (
+	DiscoveredGatewaysCountProviderName = "discovered_gateways_count"
+	DiscoveredGatewaysCountProviderKind = provider.Kind(DiscoveredGatewaysCountProviderName)
+	DiscoveredGatewaysCountKey          = types.ProviderReportKey(DiscoveredGatewaysCountProviderName)
+)
+
+func (d *DiscoveredGatewaysCountProvider) Name() string {
+	return DiscoveredGatewaysCountProviderName
+}
+
+func (d *DiscoveredGatewaysCountProvider) Kind() provider.Kind {
+	return DiscoveredGatewaysCountProviderKind
+}
+
+func (d *DiscoveredGatewaysCountProvider) Provide(context.Context) (types.ProviderReport, error) {
+	return types.ProviderReport{
+		DiscoveredGatewaysCountKey: d.counter.GatewayClientsCount(),
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `discovered_gateways_count` to a telemetry signal when the Gateway Discovery feature is turned on.

**Which issue this PR fixes**:

Solves #3779.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
