### PR TITLE
fix(tests): wait for expected status in TestIngressRegexMatchPath

### DIFF
--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -168,13 +168,5 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_essentials", ingressWait, waitTick, nil)
 }

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -128,15 +128,7 @@ func TestIngressEssentials(t *testing.T) {
 	}
 
 	t.Logf("verifying that removing the ingress.class annotation %q from ingress causes routes to disconnect", consts.IngressClass)
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingress_essentials", ingressWait, waitTick, nil)
 
 	t.Logf("putting the ingress.class annotation %q back on ingress", consts.IngressClass)
 	switch obj := ingress.(type) {
@@ -186,15 +178,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingress_essentials", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingress_essentials", ingressWait, waitTick, nil)
 }
 
 func TestGRPCIngressEssentials(t *testing.T) {
@@ -324,15 +308,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress causes routes to disconnect", consts.IngressClass)
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
 
 	t.Logf("putting the IngressClassName %q back on ingress", consts.IngressClass)
 	err = setIngressClassNameWithRetry(ctx, ns.Name, ingress, kong.String(consts.IngressClass))
@@ -361,15 +337,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_ingressclassname_spec", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
 }
 
 func TestIngressNamespaces(t *testing.T) {

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -184,15 +184,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_essentials", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_essentials", ingressWait, waitTick, nil)
 }
 
 func TestPluginOrdering(t *testing.T) {
@@ -350,13 +342,5 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/test_plugin_ordering", proxyURL))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		return helpers.ExpectHTTP404WithNoRoute(t, proxyURL, resp)
-	}, ingressWait, waitTick)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_ordering", ingressWait, waitTick, nil)
 }

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -82,25 +81,25 @@ func EventuallyGETPath(
 	}, waitDuration, waitTick)
 }
 
-// ExpectHTTP404WithNoRoute is used to check whether a given http response is (specifically) a Kong 404.
-func ExpectHTTP404WithNoRoute(t *testing.T, proxyURL *url.URL, resp *http.Response) bool {
-	if resp.StatusCode != http.StatusNotFound {
-		return false
-	}
-
-	// once the route is torn down and returning 404's, ensure that we got the expected response body back from Kong
-	// Expected: {"message":"no Route matched with those values"}
-	b := new(bytes.Buffer)
-	_, err := b.ReadFrom(resp.Body)
-	require.NoError(t, err)
-	body := struct {
-		Message string `json:"message"`
-	}{}
-	if err := json.NewDecoder(b).Decode(&body); err != nil {
-		t.Logf("WARNING: error decoding JSON from proxy while waiting for %s: %v", proxyURL, err)
-		return false
-	}
-	return body.Message == "no Route matched with those values"
+// EventuallyExpectHTTP404WithNoRoute is used to check whether a given http response is (specifically) a Kong 404.
+func EventuallyExpectHTTP404WithNoRoute(
+	t *testing.T,
+	proxyURL *url.URL,
+	path string,
+	waitDuration time.Duration,
+	waitTick time.Duration,
+	headers map[string]string,
+) {
+	EventuallyGETPath(
+		t,
+		proxyURL,
+		path,
+		http.StatusNotFound,
+		"no Route matched with those values",
+		headers,
+		waitDuration,
+		waitTick,
+	)
 }
 
 // ResponseMatcher is a function that returns match-name and whether the response


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the test code wait until the expected `404` code is returned from the Gateway. There was a case in our CI where Gateway returned `503` and it caused the test to fail (reported in #3786).

Bonus: following Patryk's comment I also sneaked in some replacements of redundant code checking HTTP status codes and responses' bodies with already existing helpers.

**Which issue this PR fixes**:

Solves #3786.

