### PR TITLE
test(conformance): tls conformance test enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ Adding a new version? You'll need three changes:
   [#4211](https://github.com/Kong/kubernetes-ingress-controller/pull/4211)
 - Assign priorities to routes translated from Ingresses when parser translate
   them to expression based Kong routes. The assigning method is basically the
-  same as in Kong gateway's `traditional_compatible` router, except that 
+  same as in Kong gateway's `traditional_compatible` router, except that
   `regex_priority` field in Kong traditional route is not supported. This
   method is adopted to keep the compatibility with traditional router on
   maximum effort.
@@ -148,7 +148,7 @@ Adding a new version? You'll need three changes:
   [specification on priorities of matches in `HTTPRoute`][httproute-specification].
   [#4296](https://github.com/Kong/kubernetes-ingress-controller/pull/4296)
   [#4434](https://github.com/Kong/kubernetes-ingress-controller/pull/4434)
-- Assign priorities to routes translated from GRPCRoutes when the parser translates 
+- Assign priorities to routes translated from GRPCRoutes when the parser translates
   them to expression based Kong routes. The priority order follows the
   [specification on match priorities in GRPCRoute][grpcroute-specification].
   [#4364](https://github.com/Kong/kubernetes-ingress-controller/pull/4364)
@@ -165,10 +165,11 @@ Adding a new version? You'll need three changes:
   in terms of accepting data-plane traffic, but are ready to accept configuration
   updates. The controller will now send configuration to such Gateways and will
   actively monitor their readiness for accepting configuration updates.
-  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
-- `KongConsumer`, `KongConsumerGroup` `KongPlugin`, and `KongClusterPlugin` CRDs were extended with
-  `Status.Conditions` field. It will contain the `Programmed` condition describing
-  whether an object was successfully translated into Kong entities and sent to Kong.
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368)
+- `KongConsumer`, `KongConsumerGroup` `KongPlugin`, and `KongClusterPlugin` CRDs
+  were extended with `Status.Conditions` field. It will contain the `Programmed`
+  condition describing whether an object was successfully translated into Kong
+  entities and sent to Kong.
   [#4409](https://github.com/Kong/kubernetes-ingress-controller/pull/4409)
   [#4412](https://github.com/Kong/kubernetes-ingress-controller/pull/4412)
   [#4423](https://github.com/Kong/kubernetes-ingress-controller/pull/4423)
@@ -182,6 +183,9 @@ Adding a new version? You'll need three changes:
   in the `Programmed` condition of the object being set to `False` and an
   event being emitted.
   [#4428](https://github.com/Kong/kubernetes-ingress-controller/pull/4428)
+- A new `--publish-service-tls` flag has been added to expose Kong TLS stream port
+  (default value is 8899) through a service using a different port.
+  [#3797](https://github.com/Kong/kubernetes-ingress-controller/pull/3797)
 
 ### Changed
 
@@ -200,11 +204,11 @@ Adding a new version? You'll need three changes:
 - Changed the Gateway's readiness probe in all-in-one manifests from `/status`
   to `/status/ready`. Gateways will be considered ready only after an initial
   configuration is applied by the controller.
-  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
-- When translating to expression based Kong routes, annotations to specify 
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368)
+- When translating to expression based Kong routes, annotations to specify
   protocols are translated to `protocols` field of the result Kong route,
-  instead of putting the conditions to match protocols inside expressions. 
-  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422) 
+  instead of putting the conditions to match protocols inside expressions.
+  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422)
 
 ### Fixed
 

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -628,7 +628,10 @@ func (r *GatewayReconciler) determineServiceForGateway(ctx context.Context, ref 
 	var name k8stypes.NamespacedName
 	switch {
 	case ref == r.PublishServiceRef.String():
-		if protocol == gatewayv1beta1.HTTPProtocolType || protocol == gatewayv1beta1.HTTPSProtocolType || protocol == gatewayv1beta1.TCPProtocolType {
+		if protocol == gatewayv1beta1.HTTPProtocolType ||
+			protocol == gatewayv1beta1.HTTPSProtocolType ||
+			protocol == gatewayv1beta1.TCPProtocolType ||
+			r.PublishServiceTLSRef.IsAbsent() && protocol == TLSProtocolType {
 			name = r.PublishServiceRef
 		}
 	case r.PublishServiceUDPRef.IsPresent() && ref == r.PublishServiceUDPRef.MustGet().String():

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -770,7 +770,6 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 	// are configured for them in the data-plane.
 	upgradedListeners := make([]Listener, 0, len(listeners))
 	for _, listener := range listeners {
-		newListeners := make([]Listener, 0)
 		if streamListener, ok := streamListenersMap[portMapper[int(listener.Port)]]; ok {
 			if streamListener.SSL {
 				listener.Protocol = gatewayv1beta1.TLSProtocolType
@@ -779,7 +778,6 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 						{Group: &gatewayV1beta1Group, Kind: (Kind)("TLSRoute")},
 					},
 				}
-				newListeners = append(newListeners, listener)
 			}
 		}
 		if proxyListener, ok := proxyListenersMap[portMapper[int(listener.Port)]]; ok {
@@ -790,12 +788,6 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 						{Group: &gatewayV1beta1Group, Kind: (Kind)("HTTPRoute")},
 					},
 				}
-				tlsListener := listener
-				tlsListener.Protocol = gatewayv1beta1.TLSProtocolType
-				tlsListener.AllowedRoutes.Kinds = append(tlsListener.AllowedRoutes.Kinds,
-					gatewayv1beta1.RouteGroupKind{Group: &gatewayV1beta1Group, Kind: (Kind)("TLSRoute")})
-				newListeners = append(newListeners, listener)
-				newListeners = append(newListeners, tlsListener)
 			} else {
 				listener.Protocol = gatewayv1beta1.HTTPProtocolType
 				listener.AllowedRoutes = &gatewayv1beta1.AllowedRoutes{
@@ -803,10 +795,9 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 						{Group: &gatewayV1beta1Group, Kind: (Kind)("HTTPRoute")},
 					},
 				}
-				newListeners = append(newListeners, listener)
 			}
 		}
-		upgradedListeners = append(upgradedListeners, newListeners...)
+		upgradedListeners = append(upgradedListeners, listener)
 	}
 
 	return upgradedListeners, nil

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -631,13 +631,11 @@ func (r *GatewayReconciler) determineServiceForGateway(ctx context.Context, ref 
 		if protocol == gatewayv1beta1.HTTPProtocolType || protocol == gatewayv1beta1.HTTPSProtocolType || protocol == gatewayv1beta1.TCPProtocolType {
 			name = r.PublishServiceRef
 		}
-		fallthrough
-	case r.PublishServiceUDPRef.IsPresent():
+	case r.PublishServiceUDPRef.IsPresent() && ref == r.PublishServiceUDPRef.MustGet().String():
 		if protocol == gatewayv1beta1.UDPProtocolType {
 			name = r.PublishServiceUDPRef.MustGet()
 		}
-		fallthrough
-	case r.PublishServiceTLSRef.IsPresent():
+	case r.PublishServiceTLSRef.IsPresent() && ref == r.PublishServiceTLSRef.MustGet().String():
 		if protocol == gatewayv1beta1.TLSProtocolType {
 			name = r.PublishServiceTLSRef.MustGet()
 		}
@@ -778,6 +776,8 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 						{Group: &gatewayV1beta1Group, Kind: (Kind)("TLSRoute")},
 					},
 				}
+				upgradedListeners = append(upgradedListeners, listener)
+				continue
 			}
 		}
 		if proxyListener, ok := proxyListenersMap[portMapper[int(listener.Port)]]; ok {

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -136,7 +136,7 @@ func (p *Parser) isTLSRoutePassthrough(tlsroute *gatewayv1alpha2.TLSRoute) (bool
 		// If any of the gateway's listeners is configured to passthrough
 		// TLS requests, we return true.
 		for _, listener := range gateway.Spec.Listeners {
-			if listener.Name == *parentRef.SectionName {
+			if parentRef.SectionName == nil || listener.Name == *parentRef.SectionName {
 				if listener.TLS != nil && listener.TLS.Mode != nil &&
 					*listener.TLS.Mode == gatewayv1beta1.TLSModePassthrough {
 					return true, nil

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -136,7 +136,7 @@ func (p *Parser) isTLSRoutePassthrough(tlsroute *gatewayv1alpha2.TLSRoute) (bool
 		// If any of the gateway's listeners is configured to passthrough
 		// TLS requests, we return true.
 		for _, listener := range gateway.Spec.Listeners {
-			if parentRef.SectionName == nil || listener.Name == *parentRef.SectionName {
+			if listener.Name == *parentRef.SectionName {
 				if listener.TLS != nil && listener.TLS.Mode != nil &&
 					*listener.TLS.Mode == gatewayv1beta1.TLSModePassthrough {
 					return true, nil

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -85,6 +85,7 @@ type Config struct {
 
 	// Ingress status
 	PublishServiceUDP       OptionalNamespacedName
+	PublishServiceTLS       OptionalNamespacedName
 	PublishService          OptionalNamespacedName
 	PublishStatusAddress    []string
 	PublishStatusAddressUDP []string
@@ -208,6 +209,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 			`when that Service lacks useful address information (for example, in bare-metal environments).`)
 	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceUDP, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-udp", `Service fronting UDP routing resources in `+
 		`"namespace/name" format. The controller will update UDP route status information with this Service's `+
+		`endpoints. If omitted, the same Service will be used for both TCP and UDP routes.`)
+	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceTLS, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-tls", `Service fronting TLS routing resources in `+
+		`"namespace/name" format. The controller will update TLS route status information with this Service's `+
 		`endpoints. If omitted, the same Service will be used for both TCP and UDP routes.`)
 	flagSet.StringSliceVar(&c.PublishStatusAddressUDP, "publish-status-address-udp", []string{},
 		`User-provided address CSV, for use in lieu of "publish-service-udp" when that Service lacks useful address information.`)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -210,9 +210,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceUDP, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-udp", `Service fronting UDP routing resources in `+
 		`"namespace/name" format. The controller will update UDP route status information with this Service's `+
 		`endpoints. If omitted, the same Service will be used for both TCP and UDP routes.`)
-	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceTLS, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-tls", `Service fronting TLS routing resources in `+
-		`"namespace/name" format. The controller will update TLS route status information with this Service's `+
-		`endpoints. If omitted, the same Service will be used for both HTTP and TLS routes.`)
+	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceTLS, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-tls", `Optional Service for TLS Gateway Listeners in `+
+		`"namespace/name" format. When omitted, TLS Listeners use the --publish-service Service.`+
+		`Only necessary if TLS and HTTPS Listeners share the same port.`)
 	flagSet.StringSliceVar(&c.PublishStatusAddressUDP, "publish-status-address-udp", []string{},
 		`User-provided address CSV, for use in lieu of "publish-service-udp" when that Service lacks useful address information.`)
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -212,7 +212,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		`endpoints. If omitted, the same Service will be used for both TCP and UDP routes.`)
 	flagSet.Var(flags.NewValidatedValue(&c.PublishServiceTLS, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service-tls", `Service fronting TLS routing resources in `+
 		`"namespace/name" format. The controller will update TLS route status information with this Service's `+
-		`endpoints. If omitted, the same Service will be used for both TCP and UDP routes.`)
+		`endpoints. If omitted, the same Service will be used for both HTTP and TLS routes.`)
 	flagSet.StringSliceVar(&c.PublishStatusAddressUDP, "publish-status-address-udp", []string{},
 		`User-provided address CSV, for use in lieu of "publish-service-udp" when that Service lacks useful address information.`)
 

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -361,6 +361,7 @@ func setupControllers(
 					DataplaneClient:      dataplaneClient,
 					PublishServiceRef:    c.PublishService.OrEmpty(),
 					PublishServiceUDPRef: c.PublishServiceUDP,
+					PublishServiceTLSRef: c.PublishServiceTLS,
 					WatchNamespaces:      c.WatchNamespaces,
 					CacheSyncTimeout:     c.CacheSyncTimeout,
 					ReferenceIndexers:    referenceIndexers,

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -41,7 +41,7 @@ var skippedTestsForExpressionRoutes = []string{
 	tests.HTTPRouteRedirectPortAndScheme.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3680
 	tests.GatewayClassObservedGenerationBump.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3678
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4312
 	tests.TLSRouteSimpleSameNamespace.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 	tests.HTTPRouteQueryParamMatching.ShortName,
@@ -101,6 +101,8 @@ func TestGatewayConformance(t *testing.T) {
 	require.NoError(t, gatewayv1alpha2.AddToScheme(client.Scheme()))
 	require.NoError(t, gatewayv1beta1.AddToScheme(client.Scheme()))
 
+	// This service creation is a temporary solution, intended to be replaced by
+	// https://github.com/Kong/charts/issues/848
 	t.Log("creating tls service for gateway conformance tests")
 	tlsService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -4,6 +4,7 @@ package conformance
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -104,9 +105,10 @@ func TestGatewayConformance(t *testing.T) {
 	// This service creation is a temporary solution, intended to be replaced by
 	// https://github.com/Kong/charts/issues/848
 	t.Log("creating tls service for gateway conformance tests")
+	svcNameSuffix, _, _ := strings.Cut(uuid.NewString(), "-")
 	tlsService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-proxy-" + uuid.NewString(),
+			Name:      "ingress-controller-kong-tls-proxy-" + svcNameSuffix,
 			Namespace: "kong-system",
 		},
 		Spec: corev1.ServiceSpec{
@@ -179,11 +181,10 @@ func TestGatewayConformance(t *testing.T) {
 		GatewayClassName:           gatewayClass.Name,
 		Debug:                      showDebug,
 		CleanupBaseResources:       shouldCleanup,
+		EnableAllSupportedFeatures: enableAllSupportedFeatures,
 		ExemptFeatures:             exemptFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,
 		SkipTests:                  skippedTests,
-		EnableAllSupportedFeatures: false,
-		SupportedFeatures:          suite.TLSCoreFeatures,
 	})
 	cSuite.Setup(t)
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -109,7 +109,7 @@ func TestGatewayConformance(t *testing.T) {
 	tlsService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ingress-controller-kong-tls-proxy-" + svcNameSuffix,
-			Namespace: "kong-system",
+			Namespace: "kong",
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -75,7 +75,7 @@ var skippedTestsForTraditionalRoutes = []string{
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3680
 	tests.GatewayClassObservedGenerationBump.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3678
-	tests.TLSRouteSimpleSameNamespace.ShortName,
+	//tests.TLSRouteSimpleSameNamespace.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 	tests.HTTPRouteQueryParamMatching.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3681
@@ -120,6 +120,7 @@ func TestGatewayConformance(t *testing.T) {
 		"--debug-log-reduce-redundancy",
 		featureGateFlag,
 		"--anonymous-reports=false",
+		"--publish-service-tls=kong-system/ingress-controller-kong-tls-proxy",
 	}
 
 	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalDeprecatedLogger, globalLogger, env.Cluster(), args...))
@@ -147,14 +148,14 @@ func TestGatewayConformance(t *testing.T) {
 		skippedTests = skippedTestsForExpressionRoutes
 	}
 	cSuite := suite.New(suite.Options{
-		Client:                     client,
-		GatewayClassName:           gatewayClass.Name,
-		Debug:                      showDebug,
-		CleanupBaseResources:       shouldCleanup,
-		EnableAllSupportedFeatures: enableAllSupportedFeatures,
-		ExemptFeatures:             exemptFeatures,
-		BaseManifests:              conformanceTestsBaseManifests,
-		SkipTests:                  skippedTests,
+		Client:               client,
+		GatewayClassName:     gatewayClass.Name,
+		Debug:                showDebug,
+		CleanupBaseResources: shouldCleanup,
+		ExemptFeatures:       exemptFeatures,
+		BaseManifests:        conformanceTestsBaseManifests,
+		SkipTests:            skippedTests,
+		SupportedFeatures:    suite.TLSCoreFeatures,
 	})
 	cSuite.Setup(t)
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -76,8 +76,6 @@ var skippedTestsForTraditionalRoutes = []string{
 	tests.HTTPRouteRedirectPortAndScheme.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3680
 	tests.GatewayClassObservedGenerationBump.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3678
-	//tests.TLSRouteSimpleSameNamespace.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 	tests.HTTPRouteQueryParamMatching.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3681
@@ -175,14 +173,14 @@ func TestGatewayConformance(t *testing.T) {
 		skippedTests = skippedTestsForExpressionRoutes
 	}
 	cSuite := suite.New(suite.Options{
-		Client:               client,
-		GatewayClassName:     gatewayClass.Name,
-		Debug:                showDebug,
-		CleanupBaseResources: shouldCleanup,
-		ExemptFeatures:       exemptFeatures,
-		BaseManifests:        conformanceTestsBaseManifests,
-		SkipTests:            skippedTests,
-		SupportedFeatures:    suite.TLSCoreFeatures,
+		Client:                     client,
+		GatewayClassName:           gatewayClass.Name,
+		Debug:                      showDebug,
+		CleanupBaseResources:       shouldCleanup,
+		ExemptFeatures:             exemptFeatures,
+		BaseManifests:              conformanceTestsBaseManifests,
+		SkipTests:                  skippedTests,
+		EnableAllSupportedFeatures: true,
 	})
 	cSuite.Setup(t)
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -182,7 +182,8 @@ func TestGatewayConformance(t *testing.T) {
 		ExemptFeatures:             exemptFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,
 		SkipTests:                  skippedTests,
-		EnableAllSupportedFeatures: true,
+		EnableAllSupportedFeatures: false,
+		SupportedFeatures:          suite.TLSCoreFeatures,
 	})
 	cSuite.Setup(t)
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #3678

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

We had `TLSRoute` integration tests with both Passthrough and terminate, but KIC [currently supports Passthrough only](https://github.com/Kong/kubernetes-ingress-controller/blob/caf7f1a25a8be9e9a2dba30aab04bdb33ab629d8/internal/controllers/gateway/route_utils.go#L384-L389) due to an [upstream docs inconsistency](https://github.com/kubernetes-sigs/gateway-api/issues/1474). 
The integration test with terminate was actually using a gateway with passthrough (we were not really testing the terminate mode). For this reason, the integration test with terminate has been removed, and the one with Passthrough has been massively improved.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
