### PR TITLE
ci: add backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,26 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a `backport.yaml` workflow that will automatically create backporting PRs if a label in the format `backport {branchName}` is assigned to a PR. It will be triggered once the original PR gets merged.

As we've introduced long-living feature branches, it can become useful for automatic backporting. 

Test run on my fork:
- Created a `release/2.9.x` release branch.
- Added a PR with main as a base: https://github.com/czeslavo/kubernetes-ingress-controller/pull/2.
- Labeled the PR with `backport release/2.9.x`.
- Merged the PR.
- The workflow created a backporting PR with `release/2.9.x` as a base: https://github.com/czeslavo/kubernetes-ingress-controller/pull/3
- Squash&merge of the backporting PR resulted in the following commit on `release/2.9.x`: https://github.com/czeslavo/kubernetes-ingress-controller/commit/f77a9b56d6547ba0fde78ead1dd685d2bb3da554

**Which issue this PR fixes**:

Action item from the recent team sync.

