### PR TITLE
Handle empty matchers in ATC generator

### DIFF
--- a/internal/dataplane/parser/atc/expression_test.go
+++ b/internal/dataplane/parser/atc/expression_test.go
@@ -20,7 +20,7 @@ func TestGenerateExpression(t *testing.T) {
 		{
 			name:       "simple predicate matching HTTP header",
 			matcher:    NewPredicateHTTPHeader("X-Kong-Test", OpEqual, "test"),
-			expression: `http.header.x_kong_test == "test"`,
+			expression: `http.headers.x_kong_test == "test"`,
 		},
 		{
 			name: "simple predicate with lower() transformer",
@@ -38,7 +38,7 @@ func TestGenerateExpression(t *testing.T) {
 				NewPrediacteHTTPHost(OpSuffixMatch, ".konghq.com"),
 				NewPredicateTLSSNI(OpSuffixMatch, ".konghq.com"),
 			),
-			expression: `(http.header.x_kong_test == "test") && (http.host =^ ".konghq.com") && (tls.sni =^ ".konghq.com")`,
+			expression: `(http.headers.x_kong_test == "test") && (http.host =^ ".konghq.com") && (tls.sni =^ ".konghq.com")`,
 		},
 		{
 			name: "multiple predicates connected by OR(||)",
@@ -86,7 +86,7 @@ func TestGenerateExpression(t *testing.T) {
 				NewPredicateHTTPHeader("X-Header-1", OpEqual, "v1"),
 				nil,
 			).And(NewPredicateHTTPHeader("X-Header-2", OpEqual, "v2")).And(nil),
-			expression: `(http.header.x_header_1 == "v1") && (http.header.x_header_2 == "v2")`,
+			expression: `(http.headers.x_header_1 == "v1") && (http.headers.x_header_2 == "v2")`,
 		},
 		{
 			name: "empty expression in Or",

--- a/internal/dataplane/parser/atc/field.go
+++ b/internal/dataplane/parser/atc/field.go
@@ -66,5 +66,5 @@ func (f FieldHTTPHeader) FieldType() FieldType {
 }
 
 func (f FieldHTTPHeader) String() string {
-	return "http.header." + strings.ToLower(strings.ReplaceAll(f.HeaderName, "-", "_"))
+	return "http.headers." + strings.ToLower(strings.ReplaceAll(f.HeaderName, "-", "_"))
 }

--- a/internal/dataplane/parser/atc/matcher.go
+++ b/internal/dataplane/parser/atc/matcher.go
@@ -31,10 +31,7 @@ func (m *OrMatcher) IsEmpty() bool {
 }
 
 func (m *OrMatcher) Expression() string {
-	if m == nil {
-		return ""
-	}
-	if m.IsEmpty() {
+	if m == nil || m.IsEmpty() {
 		return ""
 	}
 	if len(m.subMatchers) == 1 {
@@ -51,10 +48,7 @@ func (m *OrMatcher) Expression() string {
 }
 
 func (m *OrMatcher) Or(matcher Matcher) *OrMatcher {
-	if matcher == nil {
-		return m
-	}
-	if !matcher.IsEmpty() {
+	if matcher != nil && !matcher.IsEmpty() {
 		m.subMatchers = append(m.subMatchers, matcher)
 	}
 	return m
@@ -86,10 +80,7 @@ func (m *AndMatcher) IsEmpty() bool {
 }
 
 func (m *AndMatcher) Expression() string {
-	if m == nil {
-		return ""
-	}
-	if m.IsEmpty() {
+	if m == nil || m.IsEmpty() {
 		return ""
 	}
 	if len(m.subMatchers) == 1 {
@@ -106,10 +97,7 @@ func (m *AndMatcher) Expression() string {
 }
 
 func (m *AndMatcher) And(matcher Matcher) *AndMatcher {
-	if matcher == nil {
-		return m
-	}
-	if !matcher.IsEmpty() {
+	if matcher != nil && !matcher.IsEmpty() {
 		m.subMatchers = append(m.subMatchers, matcher)
 	}
 	return m

--- a/internal/dataplane/parser/atc/predicate.go
+++ b/internal/dataplane/parser/atc/predicate.go
@@ -96,6 +96,10 @@ func (p Predicate) Expression() string {
 	return lhs + " " + op + " " + rhs
 }
 
+func (p Predicate) IsEmpty() bool {
+	return p.value == nil
+}
+
 // NewPredicate generates a single predicate.
 // TODO: check validity of LHS, op and RHS.
 func NewPredicate(lhs LHS, op BinaryOperator, rhs Literal) Predicate {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a 

**Which issue this PR fixes**:

Additional issues found while getting https://github.com/Kong/kubernetes-ingress-controller/tree/feat/httproute-expression to work:

- The headers predicate string is plural.
- To allow translators to add matchers without checking the number of match criteria in the source resource up front, the matcher adders need to handle both literally `nil` values (though we probably shouldn't get these in practice) and matchers that are _empty_. This occurs if you `And` or `Or` a predicate with no value, or if you combine an empty slice of predicates.

**Special notes for your reviewer**:

Local integration test against the above branch successfully tests an expression with multiple criteria (a path and a header from a single-match HTTPRoute) as a baseline test of the matcher system, to demonstrate a basic PoC of the expression system from start to finish.

This does require a bit of a cheat to pause the test and  switch the engine to `expressions` manually, since the test harness doesn't do that.

I also goofed a bit and wrote against a slightly outdated version of the target branch, which did not have the new `NewPredicateNetProtocol` and similar functions split out from `NewPredicate`. I originally checked if _all_ fields in the predicate were `nil` or zero values, but that's no longer possible since these always set the field and op. The revised version only checks if the value is unset, since I don't think we ever have a reason to actually do that.
