### PR TITLE
chore(doc) collapse 2.9 changelog and update release guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -46,7 +46,7 @@ body:
     options:
       - label: "Ensure that you have up to date copy of `main`: `git checkout main; git pull` or a targeted release branch e.g. `release/2.7.x`: `git checkout release/2.7.x; git pull`"
       - label: "Create the `prepare-release` branch for the version (e.g. `prepare-release/2.7.1`): `git branch -m prepare-release/2.7.1`"
-      - label: Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end.
+      - label: Make any final adjustments to CHANGELOG.md. Double-check that dates are correct, that link anchors point to the correct header, and that you've included a link to the Github compare link at the end. If there were any RC releases before this version, fold their changes into the final release entry.
       - label: Resolve all licensing issues that FOSSA has detected. Go to Issues tab in FOSSA's KIC project and resolve every issue, inspecting if it's a false positive or not. [ignored.go](https://github.com/Kong/team-k8s/blob/main/fossa/ignored.go) script should be useful to look for issues that have been already resolved and reappeared due to version changes.
       - label: Update [ignored.json](https://github.com/Kong/team-k8s/blob/main/fossa/kubernetes-ingress-controller/ignored.json) following instructions in [README](https://github.com/Kong/team-k8s/blob/main/fossa/README.md).
       - label: Retrieve the latest license report from FOSSA and save it to LICENSES (go to Reports tab in FOSSA's KIC project, select 'plain text' format, tick 'direct dependencies' and download it).
@@ -58,8 +58,8 @@ body:
     label: "**For all releases** Create a Release Pull Request"
     options:
       - label: Check the [latest E2E nightly test run](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_nightly.yaml) to confirm that E2E tests are succeeding. If you are backporting features into a non-main branch, run a [targeted E2E job against that branch](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_targeted.yaml) or use `ci/run-e2e` label on the PR preparing the release.
-      - label: Open a PR from your branch to `main`.
-      - label: Once the PR is merged (the `prepare-release/x.y.z` branch will get automatically removed), [initiate a release job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/release.yaml). Your tag must use `vX.Y.Z` format. Set `latest` to true if this will be the latest release.
+      - label: Open a PR from your branch to `main`. Set a `backport release/X.Y.Z` label.
+      - label: Once the PR is merged (the `prepare-release/x.y.z` branch will get automatically removed), approve and merge the automatic backport PR and [initiate a release job](https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/release.yaml) on the release branch. Your tag must use `vX.Y.Z` format. Set `latest` to true if this will be the latest release.
       - label: CI will validate the requested version, build and push an image, and run tests against the image before finally creating a tag and publishing a release. If tests fail, CI will push the image but not the tag or release. Investigate the failure, correct it as needed, and start a new release job.
 - type: checkboxes
   id: release_documents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Adding a new version? You'll need three changes:
   This is all the way at the bottom. It's the thing we always forget.
 --->
  - [2.9.0](#290)
- - [2.9.0-rc.1](#290-rc1)
  - [2.8.1](#281)
  - [2.8.0](#280)
  - [2.7.0](#270)
@@ -90,21 +89,6 @@ Adding a new version? You'll need three changes:
   [#3759](https://github.com/Kong/kubernetes-ingress-controller/pull/3759)
 - Bumped Kong version in manifests to 3.2.
   [#3804](https://github.com/Kong/kubernetes-ingress-controller/pull/3804)
-
-### Fixed
-
-- Fixed the issue where the status of an ingress is not updated when `secretName` is
-  not specified in `ingress.spec.tls`.
-  [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
-- Fixed incorrectly set parent status for Gateway API routes
-  [#3732](https://github.com/Kong/kubernetes-ingress-controller/pull/3732)
-
-## [2.9.0-rc.1]
-
-> Release date: 2023-03-09
-
-### Added
-
 - Store status of whether configuration succeeded or failed for Kubernetes
   objects in dataplane client and publish the events to let controllers know
   if the controlled objects succeeded or failed to be translated to Kong
@@ -194,6 +178,11 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
+- Fixed the issue where the status of an ingress is not updated when `secretName` is
+  not specified in `ingress.spec.tls`.
+  [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
+- Fixed incorrectly set parent status for Gateway API routes
+  [#3732](https://github.com/Kong/kubernetes-ingress-controller/pull/3732)
 - Disabled non-functioning mesh reporting when `--watch-namespaces` flag set.
   [#3336](https://github.com/Kong/kubernetes-ingress-controller/pull/3336)
 - Fixed the duplicate update of status of `HTTPRoute` caused by incorrect check
@@ -2332,7 +2321,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
-[2.9.0-rc.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.1...v2.9.0-rc.1
+[2.9.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.6.0...v2.7.0


### PR DESCRIPTION
**What this PR does / why we need it**:

We should actually fold RC changelog entries into the final release like Kong/kong does, but I didn't think to do this originally.

Fold the old 2.9.0-rc1 entries into 2.9.0.

Replace the 2.9.0-rc1 diff link with a 2.9.0 link.

Update the release guide to reflect these steps. The additional "merge to main and backport to the release branch always" did work for 2.9.0, so formalizing it.

**Which issue this PR fixes**:

See above.