### PR TITLE
chore(tests): fix receivedNotificationsCount log

### DIFF
--- a/internal/dataplane/clients_manager_test.go
+++ b/internal/dataplane/clients_manager_test.go
@@ -430,8 +430,8 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		if receivedNotificationsCount.Load() != 10 {
-			t.Logf("Received %d notifications, expected 10, waiting...", receivedNotificationsCount.Load())
+		if count := receivedNotificationsCount.Load(); count != 10 {
+			t.Logf("Received %d notifications, expected 10, waiting...", count)
 			return false
 		}
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:

Calling `.Load()` two times can end up with two different results, giving a user incorrect information in the log. 

