### PR TITLE
tests: refactor GenerateTagsForObject and its UT

### DIFF
--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -183,7 +183,11 @@ func GenerateTagsForObject(obj client.Object) []*string {
 	if gvk.Version != "" {
 		tags = append(tags, K8sVersionTagPrefix+gvk.Version)
 	}
-	tags = append(tags, annotations.ExtractUserTags(obj.GetAnnotations())...)
-	tags = lo.Uniq(tags)
+
+	tags = append(tags,
+		lo.Uniq(
+			annotations.ExtractUserTags(obj.GetAnnotations()),
+		)...,
+	)
 	return kong.StringSlice(tags...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

- makes `TestGenerateTagsForObject` use `cmp.diff`
- makes `TestGenerateTagsForObject` test the order of returned tags since `GenerateTagsForObject` returns a slice of pointers to strings not a set or a map. This is to catch any changes in the order of returned values. In the end it shouldn't matter but better be explicit about it while we're at it.
- make `GenerateTagsForObject` use `lo.Uniq` only on the user provided tags. No need to call it on the tags that we set.
