### PR TITLE
[Backport release/2.6.x] fix: fill config defaults for array of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+ - [2.6.1](#261)
  - [2.6.0](#260)
  - [2.5.0](#250)
  - [2.4.2](#242)
@@ -50,6 +51,14 @@
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.6.1]
+
+> Release date: 2023-04-04
+
+#### Fixed
+
+- Backport commit [9787cb5](https://github.com/Kong/go-kong/commit/9787cb561e4c40bbc6392be4a61960c711e63a84) applied in [go-kong](https://github.com/Kong/go-kong) which fixes handling of records nested under array in plugin config while filling default values. Fixes #3805 
 
 ## [2.6.0]
 
@@ -1934,6 +1943,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.6.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.2...v2.5.0
 [2.4.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.1...v2.4.2

--- a/internal/dataplane/deckgen/deckgen_test.go
+++ b/internal/dataplane/deckgen/deckgen_test.go
@@ -569,6 +569,127 @@ var (
 			"querystring": []
 		}
 	}`
+	StatsDConfigNonEmptyConfig = `{
+		"host": "localhost",
+        "metrics": [
+            {
+                "name": "request_count",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            },
+            {
+                "name": "latency",
+                "stat_type": "timer"
+            },
+            {
+                "name": "request_size",
+                "stat_type": "timer"
+            },
+            {
+                "name": "status_count",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            },
+            {
+                "name": "response_size",
+                "stat_type": "timer"
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "unique_users",
+                "stat_type": "set"
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "request_per_user",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            },
+            {
+                "name": "upstream_latency",
+                "stat_type": "timer"
+            },
+            {
+                "name": "kong_latency",
+                "stat_type": "timer"
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "status_count_per_user",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            }
+        ],
+        "port": 8125,
+        "prefix": "kong"
+	}`
+	StatsDConfigNonEmptyFilledConfig = `{
+		"host": "localhost",
+        "metrics": [
+            {
+                "name": "request_count",
+                "sample_rate": 1,
+                "stat_type": "counter",
+				"consumer_identifier": null
+            },
+            {
+                "name": "latency",
+                "stat_type": "timer",
+				"sample_rate": null,
+				"consumer_identifier": null
+            },
+            {
+                "name": "request_size",
+                "stat_type": "timer",
+				"sample_rate": null,
+				"consumer_identifier": null
+            },
+            {
+                "name": "status_count",
+                "sample_rate": 1,
+                "stat_type": "counter",
+				"consumer_identifier": null
+            },
+            {
+                "name": "response_size",
+                "stat_type": "timer",
+				"sample_rate": null,
+				"consumer_identifier": null
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "unique_users",
+                "stat_type": "set",
+				"sample_rate": null
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "request_per_user",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            },
+            {
+                "name": "upstream_latency",
+                "stat_type": "timer",
+				"sample_rate": null,
+				"consumer_identifier": null
+            },
+            {
+                "name": "kong_latency",
+                "stat_type": "timer",
+				"sample_rate": null,
+				"consumer_identifier": null
+            },
+            {
+                "consumer_identifier": "custom_id",
+                "name": "status_count_per_user",
+                "sample_rate": 1,
+                "stat_type": "counter"
+            }
+        ],
+        "port": 8125,
+        "prefix": "kong"
+	}`
 )
 
 func TestFillNil(t *testing.T) {
@@ -659,6 +780,23 @@ func TestFillReqeustTransformerNestedConfig(t *testing.T) {
 	assert.Nil(err)
 	want := make(kong.Configuration)
 	err = json.Unmarshal([]byte(RequestTransformerNonEmptyFilledConfig), &want)
+	assert.NoError(err)
+	res, err := FillPluginConfig(schema, config)
+	assert.Equal(want, res)
+	assert.Nil(err)
+}
+
+func Test_FillPluginConfig(t *testing.T) {
+	assert := assert.New(t)
+	var schema map[string]interface{}
+	err := json.Unmarshal([]byte(StatsDSchema), &schema)
+	assert.Nil(err)
+
+	config := make(kong.Configuration)
+	err = json.Unmarshal([]byte(StatsDConfigNonEmptyConfig), &config)
+	assert.Nil(err)
+	want := make(kong.Configuration)
+	err = json.Unmarshal([]byte(StatsDConfigNonEmptyFilledConfig), &want)
 	assert.NoError(err)
 	res, err := FillPluginConfig(schema, config)
 	assert.Equal(want, res)


### PR DESCRIPTION
This Commit backports the fix applied in commit [9787cb5](https://github.com/Kong/go-kong/commit/9787cb561e4c40bbc6392be4a61960c711e63a84) in [go-kong](https://github.com/Kong/go-kong)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
Handling for records nested under array while filling default values. 
Adds test using the default kong statsd plugin which is impacted by this bug.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:
fixes #3805 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

<!-- **Special notes for your reviewer**: -->

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
