### PR TITLE
chore: remove `go.uber.org/multierr` direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	go.uber.org/multierr v1.11.0
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4
 	golang.org/x/mod v0.8.0 // indirect

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
@@ -22,7 +21,7 @@ import (
 // - database setting
 // - kong version.
 func ValidateRoots(roots []Root, skipCACerts bool) (string, kong.Version, error) {
-	if err := multierr.Combine(lo.Map(roots, validateRootFunc(skipCACerts))...); err != nil {
+	if err := errors.Join(lo.Map(roots, validateRootFunc(skipCACerts))...); err != nil {
 		return "", kong.Version{}, fmt.Errorf("failed to validate kong Roots: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.20 added [`errors.Join()`](https://pkg.go.dev/errors#Join) which provides the same functionality as `go.uber.org/multierr`'s `Combine()` so let's remove it from our direct dependencies.
