### PR TITLE
fix(versions) add mutex to version functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Adding a new version? You'll need three changes:
 - Fix paging in `GetAdminAPIsForService` which might have caused the controller
   to only return the head of the list of Endpoints for Admin API service.
   [#3846](https://github.com/Kong/kubernetes-ingress-controller/pull/3846)
+- Fixed a race condition in the version-specific feature system.
+  [#3852](https://github.com/Kong/kubernetes-ingress-controller/pull/3852)
 
 ### Deprecated
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -32,6 +32,8 @@ var (
 	kongVersion = KongVersion(semver.MustParse("0.0.0"))
 
 	kongVersionOnce sync.Once
+
+	kongVersionLock sync.RWMutex
 )
 
 // KongVersion is a Kong version.
@@ -41,12 +43,16 @@ type KongVersion semver.Version
 // version.
 func SetKongVersion(version semver.Version) {
 	kongVersionOnce.Do(func() {
+		kongVersionLock.Lock()
+		defer kongVersionLock.Unlock()
 		kongVersion = KongVersion(version)
 	})
 }
 
 // GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version.
 func GetKongVersion() KongVersion {
+	kongVersionLock.Lock()
+	defer kongVersionLock.Unlock()
 	return kongVersion
 }
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -51,8 +51,8 @@ func SetKongVersion(version semver.Version) {
 
 // GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version.
 func GetKongVersion() KongVersion {
-	kongVersionLock.Lock()
-	defer kongVersionLock.Unlock()
+	kongVersionLock.RLock()
+	defer kongVersionLock.RUnlock()
 	return kongVersion
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Lock the Kong version singleton with an RWMutex in its getter/setter functions.

**Which issue this PR fixes**:

Fixes a data race detected in an unrelated test run:
[race.txt](https://github.com/Kong/kubernetes-ingress-controller/files/11153415/race.txt)

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
