### PR TITLE
refactor: don't send empty configs when no config detected in dataplace

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -482,7 +482,7 @@ func (c *KongClient) sendToClient(
 	formatVersion string,
 	config sendconfig.Config,
 ) (string, error) {
-	logger := c.logger.WithField("kong_url", client.AdminAPIClient().BaseRootURL())
+	logger := c.logger.WithField("url", client.AdminAPIClient().BaseRootURL())
 
 	// generate the deck configuration to be applied to the admin API
 	logger.Debug("converting configuration to deck config")

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -290,7 +290,7 @@ type mockConfigurationChangeDetector struct {
 }
 
 func (m mockConfigurationChangeDetector) HasConfigurationChanged(
-	context.Context, []byte, []byte, sendconfig.KonnectAwareClient, sendconfig.StatusClient,
+	context.Context, []byte, []byte, *file.Content, sendconfig.KonnectAwareClient, sendconfig.StatusClient,
 ) (bool, error) {
 	return m.hasConfigurationChanged, nil
 }

--- a/internal/dataplane/sendconfig/config_change_detector.go
+++ b/internal/dataplane/sendconfig/config_change_detector.go
@@ -3,10 +3,10 @@ package sendconfig
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
-	"sync"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 )
@@ -17,9 +17,19 @@ const (
 )
 
 type ConfigurationChangeDetector interface {
-	// HasConfigurationChanged verifies whether configuration has changed by comparing old and new config's SHAs.
-	// In case the SHAs are equal, it still can return true if a client is considered crashed based on its status.
-	HasConfigurationChanged(ctx context.Context, oldSHA, newSHA []byte, client KonnectAwareClient, statusClient StatusClient) (bool, error)
+	// HasConfigurationChanged verifies whether configuration has changed by comparing
+	// old and new config's SHAs.
+	// In case the SHAs are equal, it still can return true if a client is considered
+	// crashed or just booted up based on its status.
+	// In case the status indicates an empty config and the desired config is also empty
+	// this will return false to prevent continuously sending empty configuration to Gateway.
+	HasConfigurationChanged(
+		ctx context.Context,
+		oldSHA, newSHA []byte,
+		targetConfig *file.Content,
+		client KonnectAwareClient,
+		statusClient StatusClient,
+	) (bool, error)
 }
 
 type KonnectAwareClient interface {
@@ -31,9 +41,7 @@ type StatusClient interface {
 }
 
 type DefaultConfigurationChangeDetector struct {
-	latestReportedSHA []byte
-	shaLock           sync.RWMutex
-	log               logrus.FieldLogger
+	log logrus.FieldLogger
 }
 
 func NewDefaultClientConfigurationChangeDetector(log logrus.FieldLogger) *DefaultConfigurationChangeDetector {
@@ -43,15 +51,14 @@ func NewDefaultClientConfigurationChangeDetector(log logrus.FieldLogger) *Defaul
 func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
 	ctx context.Context,
 	oldSHA, newSHA []byte,
+	targetConfig *file.Content,
 	client KonnectAwareClient,
 	statusClient StatusClient,
 ) (bool, error) {
 	if !bytes.Equal(oldSHA, newSHA) {
 		return true, nil
 	}
-	if !d.hasSHAUpdateAlreadyBeenReported(newSHA) {
-		d.log.Debugf("sha %s has been reported", hex.EncodeToString(newSHA))
-	}
+
 	// In case of Konnect, we skip further steps that are meant to detect Kong instances crash/reset
 	// that are not relevant for Konnect.
 	// We're sure that if oldSHA and newSHA are equal, we are safe to skip the update.
@@ -64,28 +71,26 @@ func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
 	if err != nil {
 		return false, fmt.Errorf("failed to verify kong readiness: %w", err)
 	}
-	// Kong instance has no configuration, we should push despite the oldSHA and newSHA being equal.
+
+	// Kong instance has no configuration, we should push despite the oldSHA and newSHA being equal...
 	if hasNoConfiguration {
+		// ... unless we're trying to push an empty config in such case skip.
+		if cmp.Equal(targetConfig, &file.Content{},
+			cmp.FilterPath(
+				func(p cmp.Path) bool {
+					path := p.String()
+					return path == "FormatVersion" || path == "Info"
+				},
+				cmp.Ignore(),
+			),
+		) {
+			return false, nil
+		}
+
 		return true, nil
 	}
 
 	return false, nil
-}
-
-// hasSHAUpdateAlreadyBeenReported is a helper function to allow
-// sendconfig internals to be aware of the last logged/reported
-// update to the Kong Admin API. Given the most recent update SHA,
-// it will return true/false whether or not that SHA has previously
-// been reported (logged, e.t.c.) so that the caller can make
-// decisions (such as staggering or stifling duplicate log lines).
-func (d *DefaultConfigurationChangeDetector) hasSHAUpdateAlreadyBeenReported(latestUpdateSHA []byte) bool {
-	d.shaLock.Lock()
-	defer d.shaLock.Unlock()
-	if bytes.Equal(d.latestReportedSHA, latestUpdateSHA) {
-		return true
-	}
-	d.latestReportedSHA = latestUpdateSHA
-	return false
 }
 
 // kongHasNoConfiguration checks Kong's status endpoint and read its config hash.
@@ -99,7 +104,6 @@ func kongHasNoConfiguration(ctx context.Context, client StatusClient, log logrus
 	}
 
 	if hasNoConfig := status.ConfigurationHash == WellKnownInitialHash; hasNoConfig {
-		log.Debugf("starting to send configuration (hash: %s)", status.ConfigurationHash)
 		return true, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR

- prevents KIC continuously sending empty configs when Gateway already has an empty config
- refactors logging around sending the configuration
- additionally this adds a distinction in the logs between clients sending config to Konnect and to Gateway in `internal/dataplane/sendconfig/sendconfig.go`

As an effect of this PR, when debug logging is enabled we're going from:

```
time="2023-04-05T12:51:53Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:51:53Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:51:53Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:51:53Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:53Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:53Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:53Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:53Z" level=debug msg="triggering report for 0 configured Kubernetes objects"
time="2023-04-05T12:51:56Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:51:56Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:51:56Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:51:56Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:56Z" level=debug msg="sha c45bb17af3175fa9276c453cfdf237beed68002141f2f22ff093177867cceb76 has been reported"
time="2023-04-05T12:51:56Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:56Z" level=debug msg="starting to send configuration (hash: 00000000000000000000000000000000)"
time="2023-04-05T12:51:56Z" level=debug msg="starting to send configuration (hash: 00000000000000000000000000000000)"
time="2023-04-05T12:51:56Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:56Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:56Z" level=debug msg="no configuration change; resource status update not necessary, skipping"
time="2023-04-05T12:51:59Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:51:59Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:51:59Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:51:59Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:59Z" level=debug msg="converting configuration to deck config" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:59Z" level=debug msg="starting to send configuration (hash: 00000000000000000000000000000000)"
time="2023-04-05T12:51:59Z" level=debug msg="starting to send configuration (hash: 00000000000000000000000000000000)"
time="2023-04-05T12:51:59Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.53:8444"
time="2023-04-05T12:51:59Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.54:8444"
time="2023-04-05T12:51:59Z" level=debug msg="no configuration change; resource status update not necessary, skipping"
```

to this:

```
time="2023-04-05T12:53:08Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:53:08Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:53:08Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:53:08Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:08Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:08Z" level=info msg="successfully synced configuration to Kong" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:08Z" level=info msg="successfully synced configuration to Kong" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:08Z" level=debug msg="triggering report for 0 configured Kubernetes objects"
time="2023-04-05T12:53:11Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:53:11Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:53:11Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:53:11Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:11Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:11Z" level=debug msg="no configuration change, skipping sync to Kong" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:11Z" level=debug msg="no configuration change, skipping sync to Kong" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:11Z" level=debug msg="no configuration change; resource status update not necessary, skipping"
time="2023-04-05T12:53:14Z" level=debug msg="parsing kubernetes objects into data-plane configuration"
time="2023-04-05T12:53:14Z" level=debug msg="successfully built data-plane configuration"
time="2023-04-05T12:53:14Z" level=debug msg="sending configuration to 2 clients"
time="2023-04-05T12:53:14Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:14Z" level=debug msg="converting configuration to deck config" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:14Z" level=debug msg="no configuration change, skipping sync to Kong" url="https://10.244.0.53:8444"
time="2023-04-05T12:53:14Z" level=debug msg="no configuration change, skipping sync to Kong" url="https://10.244.0.54:8444"
time="2023-04-05T12:53:14Z" level=debug msg="no configuration change; resource status update not necessary, skipping"
```

Notice also that the bookkeeping around last reported sha is removed and hence the line

```
sha c45bb17af3175fa9276c453cfdf237beed68002141f2f22ff093177867cceb76 has been reported
```

which was at the "incorrect place" anyway: it was mentioning the previous SHA that was reported.
