### PR TITLE
feat(ci): add pending author feedback cleaner

### DIFF
--- a/.github/workflows/pending_author_feedback_label_cleaner.yaml
+++ b/.github/workflows/pending_author_feedback_label_cleaner.yaml
@@ -1,0 +1,22 @@
+name: Pending author feedback label cleaner
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  issue_commented:
+    runs-on: ubuntu-latest
+    # This job only runs for issue comments
+    name: |
+      Remove "pending author feedback" label if it exists on issue #${{ github.event.issue.number }}
+      and if the commenter - ${{ github.event.comment.user.login }} - is the issue author -
+      ${{ github.event.issue.user.login }}.
+    if: ${{ !github.event.issue.pull_request && github.event.comment.user.login == github.event.issue.user.login && contains(github.event.issue.labels.*.name, 'pending author feedback')}}
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+
+    steps:
+    # Specifying --repo saves us the checkout
+    - run: |
+        gh --repo ${{ github.repositoryUrl }} issue edit ${{ github.event.issue.number }} --remove-label "pending author feedback"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a CI workflow which will remove "pending author feedback" label from issues were the label exists and the commenter is the original author of the issue.

This can help us (maintainers) keep this label up to date and to have a clearer view on the issues that we should focus on (e.g. filtering out issues with "pending author feedback" label).
