### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Kong/team-k8s
+* @Kong/k8s-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently added contributor/maintainer/admin levels to `team-k8s`. This PR updates CODEOWNERS to ensure that only `k8s-maintainers` can merge PRs

**Which issue this PR fixes**:

N/A

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [N/A] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
