### PR TITLE
Fix the Enterprise DB-less manifest overlay

### DIFF
--- a/config/variants/enterprise/kustomization.yaml
+++ b/config/variants/enterprise/kustomization.yaml
@@ -2,7 +2,6 @@ resources:
 - ../multi-gw/base
 patchesStrategicMerge:
 - kong-enterprise.yaml
-images:
-- name: kong
-  newName: kong/kong-gateway
-  newTag: '3.1'
+
+components:
+  - ../../image/enterprise/

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1771,7 +1771,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.1
+        image: kong/kong-gateway:3.2
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
**What this PR does / why we need it**:

We should use a single Kong image source to bump all versions at once. At some point we added a separate image override to the Enterprise DB-less kustomization, causing it to get stuck at 3.1.

This uses the standard override component, which keeps it in line with the current value, 3.2.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ I think we do want a release for this, since some 2.9 features rely on 3.2, but I also think making the changelog update here will break the backport.