### PR TITLE
chore(tests) use Kong minor tags for testing

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -52,10 +52,10 @@ jobs:
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
             echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2.1.0" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=3.2" >> $GITHUB_ENV
           else
             echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2.1" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=3.2" >> $GITHUB_ENV
           fi
 
       - name: checkout repository


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the Kong floating minor tags for testing instead of specific patch versions.

I don't think there was a reason for us to use exact patch versions, and we hit a bug in an older version. Using the minor tags should avoid this (and a bunch of routine maintenance) in the future.

**Which issue this PR fixes**:
https://github.com/Kong/kubernetes-ingress-controller/pull/3886 hacked startup diagnostics into suite_test.go. https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4694072692?pr=3886 found failures like:

```
./saml/utils/xmlcatalog.lua:21: file 'xml/xsd/saml-metadata.xml' not found
```

This is the read-only root issue described in FTI-4873.

**Special notes for your reviewer**:

Testing demonstrated some issues getting consistent diagnostics into early startup. It looks like timeouts cancel defers within tests, so we can't run them at arbitrary failure times. We can stick them into `exitOnErr` but that doesn't address issues where we never actually hit an error.

Internal timeouts in KTF may help with this a bit by allowing greater control (namely running diagnostics) over timeout behavior than the `go test` timeout.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ tests only
