### PR TITLE
fix: fix reconciliation for Admin API EndpointSlice deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,10 @@ Adding a new version? You'll need three changes:
   [#3846](https://github.com/Kong/kubernetes-ingress-controller/pull/3846)
 - Fixed a race condition in the version-specific feature system.
   [#3852](https://github.com/Kong/kubernetes-ingress-controller/pull/3852)
-
+- Fixed a missing reconciliation behavior for Admin API EndpointSlice reconciler
+  when the EndpointSlice that we receive a reconciliation request for is already
+  missing
+  [#3889](https://github.com/Kong/kubernetes-ingress-controller/pull/3889)
 
 ### Deprecated
 

--- a/internal/dataplane/clients_manager.go
+++ b/internal/dataplane/clients_manager.go
@@ -203,6 +203,12 @@ func (c *AdminAPIClientsManager) adjustGatewayClients(discoveredAdminAPIs []admi
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	// Short circuit
+	if len(discoveredAdminAPIs) == 0 {
+		c.gatewayClients = c.gatewayClients[:0]
+		return
+	}
+
 	toAdd := lo.Filter(discoveredAdminAPIs, func(api adminapi.DiscoveredAdminAPI, _ int) bool {
 		// If we already have a client with a provided address then great, no need
 		// to do anything.

--- a/internal/dataplane/clients_manager_test.go
+++ b/internal/dataplane/clients_manager_test.go
@@ -215,6 +215,15 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080"), testDiscoveredAdminAPI("localhost:8081")})
 		requireNoExpectedCallsLeftEventually(t)
 	})
+
+	t.Run("0 addresses", func(t *testing.T) {
+		// Change expected addresses
+		cf.expected = map[string]bool{}
+		// there are 0 addresses contained in the notification hence the client
+		// creator should not be called
+		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI(nil))
+		requireNoExpectedCallsLeftEventually(t)
+	})
 }
 
 func TestNewAdminAPIClientsManager_NoInitialClientsDisallowed(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to fix a situation where `KongAdminAPIServiceReconciler` would not update the stored Admin API endpoints because it didn't react to the EndpointSlice not being found properly.

It also adds several tests for this scenario which fail without this patch.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
