### PR TITLE
test: add timeout to context to trigger cleanup on wait for env ready

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 var (
@@ -71,7 +72,9 @@ func TestMain(m *testing.M) {
 	}()
 
 	fmt.Println("INFO: waiting for cluster and addons to be ready")
-	exitOnErr(<-env.WaitForReady(ctx))
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, testenv.EnvironmentReadyTimeout())
+	defer envReadyCancel()
+	exitOnErr(<-env.WaitForReady(envReadyCtx))
 
 	// To allow running conformance tests in a loop to e.g. detect flaky tests
 	// let's ensure that conformance related namespaced are deleted from the cluster.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -217,7 +217,9 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 	t.Helper()
 
 	t.Log("waiting for testing environment to be ready")
-	require.NoError(t, <-env.WaitForReady(ctx))
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, testenv.EnvironmentReadyTimeout())
+	defer envReadyCancel()
+	require.NoError(t, <-env.WaitForReady(envReadyCtx))
 
 	t.Log("creating the kong namespace")
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kong"}}

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,6 +30,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 var (
@@ -86,7 +88,9 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	ctx, env := setupE2ETest(t, istioAddon, kongAddon)
 
 	t.Log("waiting for test cluster to be ready")
-	require.NoError(t, <-env.WaitForReady(ctx))
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, testenv.EnvironmentReadyTimeout())
+	defer envReadyCancel()
+	require.NoError(t, <-env.WaitForReady(envReadyCtx))
 
 	t.Logf("istio version %s was deployed, enabling istio mesh network for the Kong Gateway's namespace", istioAddon.Version().String())
 	require.NoError(t, istioAddon.EnableMeshForNamespace(ctx, env.Cluster(), kongAddon.Namespace()))

--- a/test/expressionrouter/suite_test.go
+++ b/test/expressionrouter/suite_test.go
@@ -61,7 +61,9 @@ func TestMain(m *testing.M) {
 	cleaner := clusters.NewCleaner(env.Cluster())
 
 	fmt.Println("INFO: waiting for cluster and addons to be ready")
-	exitOnErr(<-env.WaitForReady(ctx))
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, testenv.EnvironmentReadyTimeout())
+	defer envReadyCancel()
+	exitOnErr(<-env.WaitForReady(envReadyCtx))
 
 	code = m.Run()
 

--- a/test/integration/consts_test.go
+++ b/test/integration/consts_test.go
@@ -16,12 +16,6 @@ const (
 	// httpcTimeout is the default client timeout for HTTP clients used in tests.
 	httpcTimeout = time.Second * 3
 
-	// environmentReadyTimeout is the amout of time that will be given to wait for the environemnt
-	// of the test suite ready, including all the dependencies (kong, metallb, etc)
-	// used here to make up a context to pass into environments.WaitForReady to trigger cleanup when timed out.
-	// TODO: make it configurable by environment variable.
-	environmentReadyTimeout = time.Minute * 10
-
 	// environmentCleanupTimeout is the amount of time that will be given by the test suite to the
 	// testing environment to perform its cleanup when the test suite is shutting down.
 	environmentCleanupTimeout = time.Minute * 3

--- a/test/integration/consts_test.go
+++ b/test/integration/consts_test.go
@@ -16,6 +16,12 @@ const (
 	// httpcTimeout is the default client timeout for HTTP clients used in tests.
 	httpcTimeout = time.Second * 3
 
+	// environmentReadyTimeout is the amout of time that will be given to wait for the environemnt
+	// of the test suite ready, including all the dependencies (kong, metallb, etc)
+	// used here to make up a context to pass into environments.WaitForReady to trigger cleanup when timed out.
+	// TODO: make it configurable by environment variable.
+	environmentReadyTimeout = time.Minute * 10
+
 	// environmentCleanupTimeout is the amount of time that will be given by the test suite to the
 	// testing environment to perform its cleanup when the test suite is shutting down.
 	environmentCleanupTimeout = time.Minute * 3

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -124,7 +124,9 @@ func TestMain(m *testing.M) {
 
 	exitOnErr(ctx, DeployAddonsForCluster(ctx, env.Cluster()))
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
-	exitOnErr(ctx, <-env.WaitForReady(ctx))
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, environmentReadyTimeout)
+	defer envReadyCancel()
+	exitOnErr(ctx, <-env.WaitForReady(envReadyCtx))
 
 	fmt.Println("INFO: collecting urls from the kong proxy deployment")
 	proxyURL, err = kongAddon.ProxyURL(ctx, env.Cluster())

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -124,7 +124,7 @@ func TestMain(m *testing.M) {
 
 	exitOnErr(ctx, DeployAddonsForCluster(ctx, env.Cluster()))
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
-	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, environmentReadyTimeout)
+	envReadyCtx, envReadyCancel := context.WithTimeout(ctx, testenv.EnvironmentReadyTimeout())
 	defer envReadyCancel()
 	exitOnErr(ctx, <-env.WaitForReady(envReadyCtx))
 

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -2,6 +2,7 @@ package testenv
 
 import (
 	"os"
+	"time"
 )
 
 // -----------------------------------------------------------------------------
@@ -37,6 +38,7 @@ func KongTag() string {
 // KongRouterFlavor returns router mode of Kong in tests. Currently supports:
 // - `traditional`
 // - `traditional_compatible`.
+// - `expressions` (experimental, only for testing expression route related tests).
 func KongRouterFlavor() string {
 	rf := os.Getenv("TEST_KONG_ROUTER_FLAVOR")
 	if rf != "" && rf != "traditional" && rf != "traditional_compatible" && rf != "expressions" {
@@ -99,4 +101,16 @@ func ExistingClusterName() string {
 // WaitForClusterDelete indicates whether or not to wait for cluster deletion to complete.
 func WaitForClusterDelete() bool {
 	return os.Getenv("KONG_TEST_CLUSTER_WAIT_FOR_DELETE") == "true"
+}
+
+// EnvironmentReadyTimeout returns the amount of time that will be given to wait for the environment
+// ready, including all the dependencies (kong, metallb, etc)
+// used here to make up a context to pass into environments.WaitForReady to trigger cleanup when timed out.
+func EnvironmentReadyTimeout() time.Duration {
+	const DefaultEnvironmentReadyTimeout = time.Minute * 10
+	timeout, err := time.ParseDuration(os.Getenv("KONG_TEST_ENVIRONMENT_READY_TIMEOUT"))
+	if err != nil {
+		timeout = DefaultEnvironmentReadyTimeout
+	}
+	return timeout
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Add a `timeout` to context passed into `env.WaitForReady` to trigger returning errors and cleanup, to avoid the timeout of test command that will not call the env cleanup, thus no diagnostics are outputted.  

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~~  Just affect integration tests
