### PR TITLE
chore(tests): fix data race in `TestAdminAPIClientsManager_ConcurrentNotify`

### DIFF
--- a/internal/dataplane/clients_manager_test.go
+++ b/internal/dataplane/clients_manager_test.go
@@ -423,7 +423,6 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 				require.Len(t, m.GatewayClients(), 1, "expected to get 1 client")
 				receivedNotificationsCount.Add(1)
 			case <-ctx.Done():
-				t.Log("Test is done, stopping subscriber worker")
 				return
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This aims to prevent a data race described in #3893.

**Which issue this PR fixes**:

Fixes #3893.
