### PR TITLE
[Backport release/2.9.x] fix: fix reconciliation for Admin API EndpointSlice deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## [2.9.3]
+
+> Release date: TBA
+
+### Fixed
+
+- Fixed a missing reconciliation behavior for Admin API EndpointSlice reconciler
+  when the EndpointSlice that we receive a reconciliation request for is already
+  missing
+  [#3889](https://github.com/Kong/kubernetes-ingress-controller/pull/3889)
+- Update enterprise manifests to use Kong Gateway 3.2
+  [#3885](https://github.com/Kong/kubernetes-ingress-controller/pull/3885)
+
 ## [2.9.2]
 
 > Release date: 2023-04-03

--- a/internal/dataplane/clients_manager.go
+++ b/internal/dataplane/clients_manager.go
@@ -203,6 +203,12 @@ func (c *AdminAPIClientsManager) adjustGatewayClients(discoveredAdminAPIs []admi
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	// Short circuit
+	if len(discoveredAdminAPIs) == 0 {
+		c.gatewayClients = c.gatewayClients[:0]
+		return
+	}
+
 	toAdd := lo.Filter(discoveredAdminAPIs, func(api adminapi.DiscoveredAdminAPI, _ int) bool {
 		// If we already have a client with a provided address then great, no need
 		// to do anything.

--- a/internal/dataplane/clients_manager_test.go
+++ b/internal/dataplane/clients_manager_test.go
@@ -215,6 +215,15 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080"), testDiscoveredAdminAPI("localhost:8081")})
 		requireNoExpectedCallsLeftEventually(t)
 	})
+
+	t.Run("0 addresses", func(t *testing.T) {
+		// Change expected addresses
+		cf.expected = map[string]bool{}
+		// there are 0 addresses contained in the notification hence the client
+		// creator should not be called
+		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI(nil))
+		requireNoExpectedCallsLeftEventually(t)
+	})
 }
 
 func TestNewAdminAPIClientsManager_NoInitialClientsDisallowed(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a backport of #3889 


