### PR TITLE
chore(docs): collapse 2.9.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
+ - [2.9.3](#293)
  - [2.9.2](#292)
  - [2.9.1](#291)
  - [2.9.0](#290)
- - [2.9.0-rc.1](#290-rc1)
  - [2.8.1](#281)
  - [2.8.0](#280)
  - [2.7.0](#270)
@@ -103,34 +103,6 @@ backported properly. It is included in the next patch release.
 
 ### Added
 
-- Konnect Runtime Group's nodes are reactively updated on each discovered Gateway clients
-  change.
-  [#3727](https://github.com/Kong/kubernetes-ingress-controller/pull/3727)
-- Telemetry reports now include a number of discovered Gateways when the Gateway Discovery
-  feature is turned on.
-  [#3783](https://github.com/Kong/kubernetes-ingress-controller/pull/3783)
-- Adding the `konghq.com/tags: csv,of,tags` annotation will add tags to
-  generated resources.
-  [#3778](https://github.com/Kong/kubernetes-ingress-controller/pull/3778)
-- `HTTPRoute` reconciler now watches relevant `ReferenceGrant`s for changes.
-  [#3759](https://github.com/Kong/kubernetes-ingress-controller/pull/3759)
-- Bumped Kong version in manifests to 3.2.
-  [#3804](https://github.com/Kong/kubernetes-ingress-controller/pull/3804)
-
-### Fixed
-
-- Fixed the issue where the status of an ingress is not updated when `secretName` is
-  not specified in `ingress.spec.tls`.
-  [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
-- Fixed incorrectly set parent status for Gateway API routes
-  [#3732](https://github.com/Kong/kubernetes-ingress-controller/pull/3732)
-
-## [2.9.0-rc.1]
-
-> Release date: 2023-03-09
-
-### Added
-
 - Store status of whether configuration succeeded or failed for Kubernetes
   objects in dataplane client and publish the events to let controllers know
   if the controlled objects succeeded or failed to be translated to Kong
@@ -217,6 +189,19 @@ backported properly. It is included in the next patch release.
 - The RequestRedirect Gateway API filter is now supported and translated
   to the proper set of Kong plugins.
   [#3702](https://github.com/Kong/kubernetes-ingress-controller/pull/3702)
+- Konnect Runtime Group's nodes are reactively updated on each discovered Gateway clients
+  change.
+  [#3727](https://github.com/Kong/kubernetes-ingress-controller/pull/3727)
+- Telemetry reports now include a number of discovered Gateways when the Gateway Discovery
+  feature is turned on.
+  [#3783](https://github.com/Kong/kubernetes-ingress-controller/pull/3783)
+- Adding the `konghq.com/tags: csv,of,tags` annotation will add tags to
+  generated resources.
+  [#3778](https://github.com/Kong/kubernetes-ingress-controller/pull/3778)
+- `HTTPRoute` reconciler now watches relevant `ReferenceGrant`s for changes.
+  [#3759](https://github.com/Kong/kubernetes-ingress-controller/pull/3759)
+- Bumped Kong version in manifests to 3.2.
+  [#3804](https://github.com/Kong/kubernetes-ingress-controller/pull/3804)
 
 ### Fixed
 
@@ -240,6 +225,11 @@ backported properly. It is included in the next patch release.
 - Fixed the way configuration flags `KongAdminSvc` and `PublishService` are
   checked for being set. The old one was always evaluating to `true`.
   [#3602](https://github.com/Kong/kubernetes-ingress-controller/pull/3602)
+- Fixed the issue where the status of an ingress is not updated when `secretName` is
+  not specified in `ingress.spec.tls`.
+  [#3719](https://github.com/Kong/kubernetes-ingress-controller/pull/3719)
+- Fixed incorrectly set parent status for Gateway API routes
+  [#3732](https://github.com/Kong/kubernetes-ingress-controller/pull/3732)
 
 ### Under the hood
 
@@ -2358,6 +2348,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.9.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.2...v2.9.3
 [2.9.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.1...v2.9.2
 [2.9.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.1...v2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2348,7 +2348,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
-[2.9.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.2...v2.9.3
+[2.9.3]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.2...v2.9.3
 [2.9.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.1...v2.9.2
 [2.9.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.8.1...v2.9.0


### PR DESCRIPTION
As we decided to collapse release candidates' changelogs into the proper releases, let's do that for 2.9.0 and 2.9.0-rc.1.
