### PR TITLE
feat(konnect): assign gateway nodes their respective ids

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -67,6 +67,20 @@ func (c *Client) BaseRootURL() string {
 	return c.adminAPIClient.BaseRootURL()
 }
 
+func (c *Client) NodeID(ctx context.Context) (string, error) {
+	data, err := c.adminAPIClient.Root(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed fetching Kong client root: %w", err)
+	}
+
+	nodeID, ok := data["node_id"].(string)
+	if !ok {
+		return "", errors.New("malformed Kong node ID found in Kong client root")
+	}
+
+	return nodeID, nil
+}
+
 // GetKongVersion returns version of the kong gateway.
 func (c *Client) GetKongVersion(ctx context.Context) (string, error) {
 	if c.isKonnect {

--- a/internal/konnect/client.go
+++ b/internal/konnect/client.go
@@ -11,6 +11,8 @@ import (
 	neturl "net/url"
 	"strconv"
 
+	"github.com/samber/lo"
+
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v2/internal/util/tls"
 )
@@ -68,27 +70,27 @@ func (c *NodeAPIClient) CreateNode(ctx context.Context, req *CreateNodeRequest) 
 	url := c.kicNodeAPIEndpoint()
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, reqReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request for url %s: %w", url, err)
 	}
 	httpResp, err := c.Client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get response: %w", err)
+		return nil, fmt.Errorf("failed to get response from url %s: %w", url, err)
 	}
 	defer httpResp.Body.Close()
 
 	respBuf, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to read response body from url %s: %w", url, err)
 	}
 
 	if !isOKStatusCode(httpResp.StatusCode) {
-		return nil, fmt.Errorf("non-success response code from Koko: %d, resp body: %s", httpResp.StatusCode, string(respBuf))
+		return nil, fmt.Errorf("non-success response code from url %s: %d, resp body: %s", url, httpResp.StatusCode, string(respBuf))
 	}
 
 	resp := &CreateNodeResponse{}
 	err = json.Unmarshal(respBuf, resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JSON body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal create node response from body %q: %w", maxFirst64Bytes(respBuf), err)
 	}
 
 	return resp, nil
@@ -103,28 +105,28 @@ func (c *NodeAPIClient) UpdateNode(ctx context.Context, nodeID string, req *Upda
 	url := c.kicNodeAPIEndpointWithNodeID(nodeID)
 	httpReq, err := http.NewRequestWithContext(ctx, "PUT", url, reqReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request:%w", err)
+		return nil, fmt.Errorf("failed to create request for url %s: %w", url, err)
 	}
 	httpResp, err := c.Client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get response: %w", err)
+		return nil, fmt.Errorf("failed to get response from url %s: %w", url, err)
 	}
 	defer httpResp.Body.Close()
 
 	respBuf, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		err := fmt.Errorf("failed to read response body: %w", err)
+		err := fmt.Errorf("failed to read response body from url %s: %w", url, err)
 		return nil, err
 	}
 
 	if !isOKStatusCode(httpResp.StatusCode) {
-		return nil, fmt.Errorf("non-success response code from Koko: %d, resp body %s", httpResp.StatusCode, string(respBuf))
+		return nil, fmt.Errorf("non-success response code from url %s: %d, resp body %s", url, httpResp.StatusCode, string(respBuf))
 	}
 
 	resp := &UpdateNodeResponse{}
 	err = json.Unmarshal(respBuf, resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JSON body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal update node response from body %q: %w", maxFirst64Bytes(respBuf), err)
 	}
 	return resp, nil
 }
@@ -138,29 +140,29 @@ func (c *NodeAPIClient) ListNodes(ctx context.Context, pageNumber int) (*ListNod
 	}
 	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request for url %s: %w", url, err)
 	}
 
 	httpResp, err := c.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get response: %w", err)
+		return nil, fmt.Errorf("failed to get response from url %s: %w", url, err)
 	}
 
 	defer httpResp.Body.Close()
 
 	respBuf, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to read response body from url %s: %w", url, err)
 	}
 
 	if !isOKStatusCode(httpResp.StatusCode) {
-		return nil, fmt.Errorf("non-success response from Koko: %d, resp body %s", httpResp.StatusCode, string(respBuf))
+		return nil, fmt.Errorf("non-success response from url %s: %d, resp body %s", url, httpResp.StatusCode, string(respBuf))
 	}
 
 	resp := &ListNodeResponse{}
 	err = json.Unmarshal(respBuf, resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal node items from body %q: %w", maxFirst64Bytes(respBuf), err)
 	}
 	return resp, nil
 }
@@ -188,16 +190,16 @@ func (c *NodeAPIClient) DeleteNode(ctx context.Context, nodeID string) error {
 	url := c.kicNodeAPIEndpointWithNodeID(nodeID)
 	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return fmt.Errorf("failed to create request for url %s: %w", url, err)
 	}
 	httpResp, err := c.Client.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("failed to get response: %w", err)
+		return fmt.Errorf("failed to get response from url %s: %w", url, err)
 	}
 	defer httpResp.Body.Close()
 
 	if !isOKStatusCode(httpResp.StatusCode) {
-		return fmt.Errorf("non-success response from Koko: %d", httpResp.StatusCode)
+		return fmt.Errorf("non-success response from url %s: %d", url, httpResp.StatusCode)
 	}
 
 	return nil
@@ -207,27 +209,27 @@ func (c *NodeAPIClient) GetNode(ctx context.Context, nodeID string) (*NodeItem, 
 	url := c.kicNodeAPIEndpointWithNodeID(nodeID)
 	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request for url %s: %w", url, err)
 	}
 	httpResp, err := c.Client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get response: %w", err)
+		return nil, fmt.Errorf("failed to get response from url %s: %w", url, err)
 	}
 	defer httpResp.Body.Close()
 
 	respBuf, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to read response body from url %s: %w", url, err)
 	}
 
 	if !isOKStatusCode(httpResp.StatusCode) {
-		return nil, fmt.Errorf("non-success response from Koko: %d, resp body %s", httpResp.StatusCode, string(respBuf))
+		return nil, fmt.Errorf("non-success response from url %s: %d, resp body %s", url, httpResp.StatusCode, maxFirst64Bytes(respBuf))
 	}
 
 	resp := &NodeItem{}
 	err = json.Unmarshal(respBuf, resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal node item from body %q: %w", maxFirst64Bytes(respBuf), err)
 	}
 	return resp, nil
 }
@@ -235,4 +237,9 @@ func (c *NodeAPIClient) GetNode(ctx context.Context, nodeID string) (*NodeItem, 
 // isOKStatusCode returns true if the input HTTP status code is 2xx, in [200,300).
 func isOKStatusCode(code int) bool {
 	return code >= 200 && code < 300
+}
+
+// maxFirst64Bytes returns the first 64 bytes of the input byte slice as a string for debug purposes.
+func maxFirst64Bytes(b []byte) string {
+	return string(b[:lo.Clamp(len(b), 0, 64)])
 }

--- a/internal/manager/id.go
+++ b/internal/manager/id.go
@@ -1,0 +1,21 @@
+package manager
+
+import (
+	"github.com/google/uuid"
+)
+
+// InstanceIDProvider provides a unique identifier for a running instance of the manager.
+// It should be used by all components that register the instance in any external system.
+type InstanceIDProvider struct {
+	id uuid.UUID
+}
+
+func NewInstanceIDProvider() *InstanceIDProvider {
+	return &InstanceIDProvider{
+		id: uuid.New(),
+	}
+}
+
+func (p *InstanceIDProvider) GetID() uuid.UUID {
+	return p.id
+}

--- a/internal/manager/telemetry/reports.go
+++ b/internal/manager/telemetry/reports.go
@@ -17,6 +17,10 @@ type GatewayClientsProvider interface {
 	GatewayClientsCount() int
 }
 
+type InstanceIDProvider interface {
+	GetID() uuid.UUID
+}
+
 // SetupAnonymousReports sets up and starts the anonymous reporting and returns
 // a cleanup function and an error.
 // The caller is responsible to call the returned function - when the returned
@@ -26,6 +30,7 @@ func SetupAnonymousReports(
 	kubeCfg *rest.Config,
 	clientsProvider GatewayClientsProvider,
 	rv ReportValues,
+	instanceIDProvider InstanceIDProvider,
 ) (func(), error) {
 	// if anonymous reports are enabled this helps provide Kong with insights about usage of the ingress controller
 	// which is non-sensitive and predominantly informs us of the controller and cluster versions in use.
@@ -64,7 +69,7 @@ func SetupAnonymousReports(
 		"v":  metadata.Release,
 		"kv": kongVersion,
 		"db": kongDB,
-		"id": uuid.NewString(), // universal unique identifier for this system
+		"id": instanceIDProvider.GetID(), // universal unique identifier for this system
 	}
 
 	tMgr, err := CreateManager(kubeCfg, clientsProvider, fixedPayload, rv)

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -326,8 +326,11 @@ func requireKonnectNodesConsistentWithK8s(ctx context.Context, t *testing.T, env
 	}, konnectNodeRegistrationTimeout, konnectNodeRegistrationCheck)
 }
 
-// requireAllProxyReplicasIDsConsistentWithKonnect ensures that all proxy replicas are registered in Konnect's Node API with
-// their respective IDs.
+// requireAllProxyReplicasIDsConsistentWithKonnect ensures that all proxy replicas are registered in Konnect's Node API
+// with their respective Admin API Node IDs.
+// It's required because when a proxy replica connects with Konnect (e.g. to report Analytics data), it uses its locally
+// generated Node ID (KIC knows it via calling gateway's Admin API) to identify itself. If the Node is not registered
+// in Konnect using the same ID, it won't be possible to associate requests with the correct node.
 func requireAllProxyReplicasIDsConsistentWithKonnect(
 	ctx context.Context,
 	t *testing.T,


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses NodeIDs of discovered Gateways to register them in Konnect's Node API.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes #3907.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
