### PR TITLE
chore(ci): run konnect e2e tests on gke

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -183,6 +183,7 @@ jobs:
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
           TEST_KONG_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           KONG_TEST_CLUSTER_PROVIDER: gke
           E2E_TEST_RUN: ${{ matrix.test }}


### PR DESCRIPTION
**What this PR does / why we need it**:

`TEST_KONG_KONNECT_ACCESS_TOKEN` was missing and Konnect tests were skipped on GKE.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

