### PR TITLE
feat: assign Service, Route and Consumer entities stable IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ Adding a new version? You'll need three changes:
   [#3832](https://github.com/Kong/kubernetes-ingress-controller/pull/3832)
 - Added license agent for Konnect-managed instances.
   [#3883](https://github.com/Kong/kubernetes-ingress-controller/pull/3883)
+- `Service`, `Route` and `Consumer` Kong entities now get assigned deterministic
+  IDs based on their unique properties (name, username, etc.) instead of random
+  UUIDs.
+  [#3933](https://github.com/Kong/kubernetes-ingress-controller/pull/3933)
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/kong/deck v1.20.0
-	github.com/kong/go-kong v0.40.0
+	github.com/kong/go-kong v0.41.0
 	github.com/kong/kubernetes-telemetry v0.0.2
 	github.com/kong/kubernetes-testing-framework v0.30.1
 	github.com/lithammer/dedent v1.1.0
@@ -114,7 +114,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/huandu/xstrings v1.3.3 // indirect
+	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
@@ -281,8 +282,8 @@ github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v2.20.0+incompatible h1:4Xh3bDzO29j4TWNOI+24ubc0vbVFMg2PMnXKxK54/CA=
 github.com/gobuffalo/flect v0.2.4/go.mod h1:1ZyCLIbg0YD7sDkzvFdPoOydPtD8y9JQnrOROolUcM8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -467,8 +468,9 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
+github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -510,8 +512,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kong/deck v1.20.0 h1:q8+8VBnvv0O+9mYjcPdJP5prG3KzbvR4XfePwkTx+Zc=
 github.com/kong/deck v1.20.0/go.mod h1:yJWEu6/xnYiaNBg2vP4EsYLtbt33J67Zsolye3JpJmI=
-github.com/kong/go-kong v0.40.0 h1:6rd70L4GbPz90j3ey+wjHd4aC21uFgbqsoASJhbcbdU=
-github.com/kong/go-kong v0.40.0/go.mod h1:t3siZEEGBB3FA5EQv9CL5EcaiogPTG0A175VQ6KvEHE=
+github.com/kong/go-kong v0.41.0 h1:0rn+Haf8wfT0VWFVjQPNETLju5ZuNhfbrHYyjpliDBU=
+github.com/kong/go-kong v0.41.0/go.mod h1:S/Mx/ZjgwsREPcpMXgCFt5wX7LBpyFlTKENri7E3KTg=
 github.com/kong/kubernetes-telemetry v0.0.2 h1:ZLoctQzvo0onCxbMgFMGsIGu6qAXWaMrd4o5Rv//C68=
 github.com/kong/kubernetes-telemetry v0.0.2/go.mod h1:lOeCASSR93hssoiOI2HUHoMFLffo/4lLsk74pIqMcyo=
 github.com/kong/kubernetes-testing-framework v0.30.1 h1:FZCThCgf2xOi/pUbSzd5hW1ghUnZYihmvy9a3DHMRAE=
@@ -689,7 +691,7 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -135,6 +135,9 @@ func (p *Parser) Build() (*kongstate.KongState, []failures.ResourceFailure) {
 		result.Licenses = append(result.Licenses, *p.license)
 	}
 
+	// generate IDs for Kong entities
+	result.FillIDs(p.logger)
+
 	return &result, p.popTranslationFailures()
 }
 

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -1232,6 +1232,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Services[0].Routes),
@@ -1248,6 +1249,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			RegexPriority:     kong.Int(0),
 			ResponseBuffering: kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
+			ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("strip-path annotation is correctly processed (false)", func(t *testing.T) {
@@ -1316,6 +1318,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Services[0].Routes),
@@ -1332,6 +1335,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			RegexPriority:     kong.Int(0),
 			ResponseBuffering: kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
+			ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("https-redirect-status-code annotation is correctly processed",
@@ -1401,6 +1405,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			// parser tests do not check tags, these are tested independently
@@ -1418,6 +1423,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				RegexPriority:           kong.Int(0),
 				ResponseBuffering:       kong.Bool(true),
 				RequestBuffering:        kong.Bool(true),
+				ID:                      kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("bad https-redirect-status-code annotation is ignored",
@@ -1487,6 +1493,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -1503,6 +1510,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				RegexPriority:     kong.Int(0),
 				ResponseBuffering: kong.Bool(true),
 				RequestBuffering:  kong.Bool(true),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("preserve-host annotation is correctly processed",
@@ -1572,6 +1580,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -1588,6 +1597,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				RegexPriority:     kong.Int(0),
 				ResponseBuffering: kong.Bool(true),
 				RequestBuffering:  kong.Bool(true),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("preserve-host annotation with random string is correctly processed",
@@ -1657,6 +1667,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -1673,6 +1684,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				RegexPriority:     kong.Int(0),
 				ResponseBuffering: kong.Bool(true),
 				RequestBuffering:  kong.Bool(true),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("regex-priority annotation is correctly processed",
@@ -1742,6 +1754,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -1758,6 +1771,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				Protocols:         kong.StringSlice("http", "https"),
 				ResponseBuffering: kong.Bool(true),
 				RequestBuffering:  kong.Bool(true),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("non-integer regex-priority annotation is ignored",
@@ -1827,6 +1841,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -1843,6 +1858,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 				PreserveHost:      kong.Bool(true),
 				Paths:             kong.StringSlice("/"),
 				Protocols:         kong.StringSlice("http", "https"),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 	t.Run("route buffering options are processed (true)", func(t *testing.T) {
@@ -1911,6 +1927,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Services[0].Routes), "expected one route to be rendered")
@@ -1926,6 +1943,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Protocols:         kong.StringSlice("http", "https"),
 			RequestBuffering:  kong.Bool(true),
 			ResponseBuffering: kong.Bool(true),
+			ID:                kong.String("7baaf482-722d-5f33-802f-098d31491846"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route buffering options are processed (false)", func(t *testing.T) {
@@ -1994,6 +2012,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Services[0].Routes), "expected one route to be rendered")
@@ -2009,6 +2028,7 @@ func TestKongRouteAnnotations(t *testing.T) {
 			Protocols:         kong.StringSlice("http", "https"),
 			RequestBuffering:  kong.Bool(false),
 			ResponseBuffering: kong.Bool(false),
+			ID:                kong.String("7baaf482-722d-5f33-802f-098d31491846"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route buffering options are not processed with bad annotation values", func(t *testing.T) {
@@ -2505,6 +2525,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("c2ef7d3d-bb2a-5ae1-bc89-8b626ebab19e"),
 		}, svc.Service)
 
 		assert.Equal(1, len(svc.Plugins), "expected one request-transformer plugin")
@@ -2531,6 +2552,7 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 			RegexPriority:     kong.Int(0),
 			ResponseBuffering: kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
+			ID:                kong.String("464fe8ea-acc9-58fd-8bb2-00f046287a2c"),
 		}, svc.Routes[0].Route)
 
 		assert.Equal(1, len(state.Plugins), "expected one key-auth plugin")
@@ -2620,6 +2642,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Services[0].Routes),
@@ -2636,6 +2659,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			RegexPriority:     kong.Int(0),
 			ResponseBuffering: kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
+			ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 		}, state.Services[0].Routes[0].Route)
 	})
 
@@ -2707,6 +2731,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			WriteTimeout:   kong.Int(60000),
 			Retries:        kong.Int(5),
 			Protocol:       kong.String("http"),
+			ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 		}, state.Services[0].Service)
 
 		assert.Equal(1, len(state.Upstreams),
@@ -2732,6 +2757,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 			RegexPriority:     kong.Int(0),
 			ResponseBuffering: kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
+			ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 		}, state.Services[0].Routes[0].Route)
 	})
 
@@ -2802,6 +2828,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 				WriteTimeout:   kong.Int(60000),
 				Retries:        kong.Int(5),
 				Protocol:       kong.String("http"),
+				ID:             kong.String("d0bb3cdf-7dee-5d1a-8219-a44f840c8845"),
 			}, state.Services[0].Service)
 
 			assert.Equal(1, len(state.Services[0].Routes),
@@ -2819,6 +2846,7 @@ func TestKongServiceAnnotations(t *testing.T) {
 				Paths:             kong.StringSlice("/"),
 				Protocols:         kong.StringSlice("http", "https"),
 				Methods:           kong.StringSlice("POST", "GET"),
+				ID:                kong.String("0977b208-1478-5280-90cf-037af9ffc3ef"),
 			}, state.Services[0].Routes[0].Route)
 		})
 }
@@ -3388,6 +3416,7 @@ func TestParserSNI(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("95b19369-8def-5255-a40f-dd459cd689e8"),
 		}, state.Services[0].Routes[0].Route)
 		assert.Equal(kong.Route{
 			Name:              kong.String("default.foo.10"),
@@ -3400,6 +3429,7 @@ func TestParserSNI(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("9c78e74b-423f-5d44-abad-29d1cd137520"),
 		}, state.Services[0].Routes[1].Route)
 	})
 	t.Run("route does not include SNI when TLS info absent", func(t *testing.T) {
@@ -3456,6 +3486,7 @@ func TestParserSNI(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("95b19369-8def-5255-a40f-dd459cd689e8"),
 		}, state.Services[0].Routes[0].Route)
 	})
 }
@@ -3517,6 +3548,7 @@ func TestParserHostAliases(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("95b19369-8def-5255-a40f-dd459cd689e8"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route Hosts remain unmodified when Host-Aliases are not present", func(t *testing.T) {
@@ -3572,6 +3604,7 @@ func TestParserHostAliases(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("95b19369-8def-5255-a40f-dd459cd689e8"),
 		}, state.Services[0].Routes[0].Route)
 	})
 	t.Run("route Hosts will not contain duplicates when Host-Aliases duplicates the host", func(t *testing.T) {
@@ -3628,6 +3661,7 @@ func TestParserHostAliases(t *testing.T) {
 			PreserveHost:      kong.Bool(true),
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("95b19369-8def-5255-a40f-dd459cd689e8"),
 		}, state.Services[0].Routes[0].Route)
 	})
 }
@@ -4926,6 +4960,92 @@ func TestCertificate(t *testing.T) {
 		state.Certificates[0].Tags = nil
 		assert.Equal(state.Certificates[0], fooCertificate)
 	})
+}
+
+func TestParser_FillsEntitiesIDs(t *testing.T) {
+	s, err := store.NewFakeStore(store.FakeObjects{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc.foo",
+					Namespace: "ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "foo",
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+		IngressesV1: []*netv1.Ingress{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress.foo",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
+					},
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							Host: "foo.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "svc.foo",
+													Port: netv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		KongConsumers: []*configurationv1.KongConsumer{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user.foo",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.DefaultIngressClass,
+					},
+				},
+				Username: "user.foo",
+			},
+		},
+	})
+	require.NoError(t, err)
+	p := mustNewParser(t, s)
+
+	state, translationFailures := p.Build()
+	require.Empty(t, translationFailures)
+	require.NotNil(t, state)
+
+	require.Len(t, state.Services, 1)
+	require.NotNil(t, state.Services[0].ID)
+	assert.Equal(t, "10157742-edd5-51f6-8141-f21dc8017e87", *state.Services[0].ID, "expected deterministic ID")
+
+	require.Len(t, state.Services[0].Routes, 1)
+	require.NotNil(t, state.Services[0].Routes[0].ID)
+	assert.Equal(t, "1474bf56-c263-5919-b3e6-e9bc6e4b237f", *state.Services[0].Routes[0].ID, "expected deterministic ID")
+
+	require.Len(t, state.Consumers, 1)
+	require.NotNil(t, state.Consumers[0].ID)
+	assert.Equal(t, "93c4b796-7cc1-5f86-834c-3bbdf00a806c", *state.Consumers[0].ID, "expected deterministic ID")
 }
 
 func mustNewParser(t *testing.T, storer store.Storer) *Parser {


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses the `FillID` function from `go-kong` to assign deterministic IDs for `Service`, `Route`, and `Consumer` Kong entities that are generated in the K8s -> Kong translation process.

**Which issue this PR fixes**:

Closes #3906.


- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
