### PR TITLE
chore(konnect): cleanup license agent

### DIFF
--- a/internal/license/agent.go
+++ b/internal/license/agent.go
@@ -13,17 +13,26 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
-// NewLicenseAgent creates a new license agent that retrieves a license from the given url once every given period.
-func NewLicenseAgent(
-	period time.Duration,
-	url string,
-	konnectAPIClient *konnect.LicenseAPIClient,
+const (
+	// PollingInterval is the interval at which the license agent will poll for license updates.
+	PollingInterval = time.Hour * 12
+
+	// PollingTimeout is the timeout for retrieving a license from upstream.
+	PollingTimeout = time.Minute * 5
+)
+
+type UpstreamClient interface {
+	List(ctx context.Context, pageNumber int) (*konnect.ListLicenseResponse, error)
+}
+
+// NewAgent creates a new license agent that retrieves a license from the given url once every given period.
+func NewAgent(
+	konnectAPIClient UpstreamClient,
 	logger logr.Logger,
 ) *Agent {
 	return &Agent{
 		logger:           logger,
-		upstreamURL:      url,
-		ticker:           time.NewTicker(period),
+		ticker:           time.NewTicker(PollingInterval),
 		mutex:            sync.RWMutex{},
 		konnectAPIClient: konnectAPIClient,
 	}
@@ -31,12 +40,13 @@ func NewLicenseAgent(
 
 // Agent handles retrieving a Kong license and providing it to other KIC subsystems.
 type Agent struct {
-	license          konnect.LicenseItem
 	logger           logr.Logger
-	upstreamURL      string
 	ticker           *time.Ticker
 	mutex            sync.RWMutex
-	konnectAPIClient *konnect.LicenseAPIClient
+	konnectAPIClient UpstreamClient
+
+	// license is the current license retrieved from upstream.
+	license konnect.LicenseItem
 }
 
 // NeedLeaderElection indicates if the Agent requires leadership to run. It always returns true.
@@ -44,48 +54,55 @@ func (a *Agent) NeedLeaderElection() bool {
 	return true
 }
 
-// Start starts the Agent. It attempts to pull an initial license from upstream, and failing that, pulls it from local
-// cache. If both fail, startup fails.
+// Start starts the Agent. It attempts to pull an initial license from upstream, and then polls for updates on a
+// regular interval defined by PollingInterval.
 func (a *Agent) Start(ctx context.Context) error {
 	a.logger.V(util.DebugLevel).Info("starting license agent")
-	updateTimeout, cancel := context.WithTimeout(ctx, time.Minute*1)
-	defer cancel()
-	err := a.updateLicense(updateTimeout)
+
+	err := a.updateLicense(ctx)
 	if err != nil {
 		a.logger.Error(err, "could not retrieve license from upstream")
-		err := a.updateLicenseFromCache(ctx)
-		if err != nil {
-			a.logger.Error(err, "could not retrieve license from local cache")
-		}
 	}
-	a.Run(ctx)
-	return nil
+
+	return a.run(ctx)
 }
 
-// Run updates the license on a regular interval until the context is cancelled.
-func (a *Agent) Run(ctx context.Context) {
+// GetLicense returns the agent's current license as a go-kong License struct. It omits the origin timestamps,
+// as Kong will auto-populate these when adding the license to its config database.
+func (a *Agent) GetLicense() kong.License {
+	a.logger.V(util.DebugLevel).Info("retrieving license from cache")
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+	return kong.License{
+		ID:      kong.String(a.license.ID),
+		Payload: kong.String(a.license.License),
+	}
+}
+
+// run updates the license on a regular interval until the context is cancelled.
+func (a *Agent) run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
 			a.logger.Info("context done, shutting down license agent")
 			a.ticker.Stop()
-			return
+			return ctx.Err()
 		case <-a.ticker.C:
 			a.logger.V(util.DebugLevel).Info("retrieving license from external service")
-			updateTimeout, cancel := context.WithTimeout(ctx, time.Minute*5)
-			defer cancel()
-			if err := a.updateLicense(updateTimeout); err != nil {
+			if err := a.updateLicense(ctx); err != nil {
 				a.logger.Error(err, "could not update license")
 			}
 		}
 	}
 }
 
-// updateLicense retrievs a license from an outside system. If it successfully retrieves a license, it updates the in-memory
-// and persistent license caches.
+// updateLicense retrievs a license from an outside system. If it successfully retrieves a license, it updates the
+// in-memory license cache.
 func (a *Agent) updateLicense(ctx context.Context) error {
-	// TODO this is an array because it's a Kong entity collection, even though we only expect to have
-	// exactly one license. this is manageable, but a bit messy
+	ctx, cancel := context.WithTimeout(ctx, PollingTimeout)
+	defer cancel()
+
+	// This is an array because it's a Kong entity collection, even though we only expect to have exactly one license.
 	licenses, err := a.konnectAPIClient.List(ctx, 0)
 	if err != nil {
 		return fmt.Errorf("could not retrieve license: %w", err)
@@ -95,39 +112,16 @@ func (a *Agent) updateLicense(ctx context.Context) error {
 	}
 	license := licenses.Items[0]
 	if license.UpdatedAt > a.license.UpdatedAt {
-		a.logger.V(util.DebugLevel).Info("retrieved license has later expiration than current license, updating license cache")
+		a.logger.V(util.InfoLevel).Info("updating license cache",
+			"old_updated_at", time.Unix(int64(a.license.UpdatedAt), 0).String(),
+			"new_updated_at", time.Unix(int64(license.UpdatedAt), 0).String(),
+		)
 		a.mutex.Lock()
 		defer a.mutex.Unlock()
 		a.license = *license
-
-		err = persistLicense(license.License)
-		if err != nil {
-			a.logger.Error(err, "could not store license in Secret")
-		}
+	} else {
+		a.logger.V(util.DebugLevel).Info("license cache is up to date")
 	}
-	return nil
-}
 
-// updateLicenseFromCache retrieves a license from a local cache.
-func (a *Agent) updateLicenseFromCache(_ context.Context) error {
-	// TODO make this not a stub https://github.com/Kong/kubernetes-ingress-controller/issues/3923
-	return fmt.Errorf("not implemented")
-}
-
-// GetLicense returns the agent's current license as a go-kong License struct. It omits the origin timestamps,
-// as Kong will auto-populate these when adding the license to its config database.
-func (a *Agent) GetLicense() kong.License {
-	a.mutex.RLock()
-	a.logger.V(util.DebugLevel).Info("retrieving license from cache")
-	defer a.mutex.RUnlock()
-	return kong.License{
-		ID:      kong.String(a.license.ID),
-		Payload: kong.String(a.license.License),
-	}
-}
-
-// PersistLicense saves the current license to a Secret.
-func persistLicense(_ string) error {
-	// TODO make this not a stub https://github.com/Kong/kubernetes-ingress-controller/issues/3923
 	return nil
 }

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -1,0 +1,50 @@
+package license_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/license"
+)
+
+type mockUpstreamClient struct {
+	listResponse *konnect.ListLicenseResponse
+}
+
+func (m *mockUpstreamClient) List(context.Context, int) (*konnect.ListLicenseResponse, error) {
+	return m.listResponse, nil
+}
+
+func TestAgent(t *testing.T) {
+	expectedLicense := &konnect.LicenseItem{
+		License:   "test-license",
+		UpdatedAt: 1234567890,
+	}
+	upstreamClient := &mockUpstreamClient{
+		listResponse: &konnect.ListLicenseResponse{
+			Items: []*konnect.LicenseItem{
+				expectedLicense,
+			},
+		},
+	}
+
+	a := license.NewAgent(upstreamClient, logr.Discard())
+	ctx := context.Background()
+	go func() {
+		err := a.Start(ctx)
+		require.NoError(t, err)
+	}()
+
+	require.Eventually(t, func() bool {
+		actualLicense := a.GetLicense()
+		if actualLicense.Payload == nil {
+			return false
+		}
+		return *actualLicense.Payload == expectedLicense.License
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -46,5 +46,5 @@ func TestAgent(t *testing.T) {
 			return false
 		}
 		return *actualLicense.Payload == expectedLicense.License
-	}, time.Second*5, time.Millisecond*100)
+	}, time.Second*5, time.Millisecond)
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -230,8 +230,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 			return fmt.Errorf("failed creating konnect client: %w", err)
 		}
 		setupLog.Info("starting license agent")
-		agent := license.NewLicenseAgent(time.Hour*12, "http://example.com", konnectLicenseAPIClient,
-			ctrl.Log.WithName("license-agent"))
+		agent := license.NewAgent(konnectLicenseAPIClient, ctrl.Log.WithName("license-agent"))
 		err = mgr.Add(agent)
 		if err != nil {
 			return fmt.Errorf("could not add license agent to manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up `license.Agent`, adds a unit test and removes dead code with TODOs that are no longer relevant.
