### PR TITLE
refactor: reorganize ingressRulesFromIngressV1 into smaller pieces

### DIFF
--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 func serviceBackendPortToStr(port netv1.ServiceBackendPort) string {
@@ -199,17 +200,14 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 		}
 	}
 
-	var allDefaultBackends []netv1.Ingress
 	sort.SliceStable(ingressList, func(i, j int) bool {
 		return ingressList[i].CreationTimestamp.Before(
 			&ingressList[j].CreationTimestamp)
 	})
 
+	servicesCache := make(kongServicesCache)
+	var allDefaultBackends []netv1.Ingress
 	for _, ingress := range ingressList {
-		regexPrefix := translators.ControllerPathRegexPrefix
-		if prefix, ok := ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.RegexPrefixKey]; ok {
-			regexPrefix = prefix
-		}
 		ingressSpec := ingress.Spec
 
 		if ingressSpec.DefaultBackend != nil {
@@ -218,135 +216,204 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 
 		result.SecretNameToSNIs.addFromIngressV1TLS(ingressSpec.TLS, ingress)
 
-		var objectSuccessfullyParsed bool
-
-		if p.featureEnabledCombinedServiceRoutes {
-			for _, kongStateService := range translators.TranslateIngress(ingress, p.flagEnabledRegexPathPrefix) {
-				for _, route := range kongStateService.Routes {
-					for i, path := range route.Paths {
-						newPath := maybePrependRegexPrefix(*path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
-						route.Paths[i] = &newPath
-					}
-				}
-				result.ServiceNameToServices[*kongStateService.Service.Name] = *kongStateService
-				result.ServiceNameToParent[*kongStateService.Service.Name] = ingress
-				objectSuccessfullyParsed = true
-			}
-		} else {
-			for i, rule := range ingressSpec.Rules {
-				if rule.HTTP == nil {
-					continue
-				}
-				for j, rulePath := range rule.HTTP.Paths {
-					pathTypeImplementationSpecific := netv1.PathTypeImplementationSpecific
-					if rulePath.PathType == nil {
-						rulePath.PathType = &pathTypeImplementationSpecific
-					}
-
-					paths := translators.PathsFromIngressPaths(rulePath, p.flagEnabledRegexPathPrefix)
-					if paths == nil {
-						// registering a failure, but technically it should never happen thanks to Kubernetes API validations
-						p.registerTranslationFailure(
-							fmt.Sprintf("could not translate Ingress Path %s to Kong paths", rulePath.Path), ingress,
-						)
-						continue
-					}
-
-					for i, path := range paths {
-						newPath := maybePrependRegexPrefix(*path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
-						paths[i] = &newPath
-					}
-
-					r := kongstate.Route{
-						Ingress: util.FromK8sObject(ingress),
-						Route: kong.Route{
-							Name:              kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
-							Paths:             paths,
-							StripPath:         kong.Bool(false),
-							PreserveHost:      kong.Bool(true),
-							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(priorityForPath[*rulePath.PathType]),
-							RequestBuffering:  kong.Bool(true),
-							ResponseBuffering: kong.Bool(true),
-							Tags:              util.GenerateTagsForObject(ingress),
-						},
-					}
-					if rule.Host != "" {
-						r.Hosts = kong.StringSlice(rule.Host)
-					}
-
-					port := translators.PortDefFromServiceBackendPort(&rulePath.Backend.Service.Port)
-					serviceName := fmt.Sprintf("%s.%s.%s", ingress.Namespace, rulePath.Backend.Service.Name,
-						serviceBackendPortToStr(rulePath.Backend.Service.Port))
-					service, ok := result.ServiceNameToServices[serviceName]
-					if !ok {
-						service = kongstate.Service{
-							Service: kong.Service{
-								Name: kong.String(serviceName),
-								Host: kong.String(fmt.Sprintf("%s.%s.%s.svc", rulePath.Backend.Service.Name, ingress.Namespace,
-									port.CanonicalString())),
-								Port:           kong.Int(DefaultHTTPPort),
-								Protocol:       kong.String("http"),
-								Path:           kong.String("/"),
-								ConnectTimeout: kong.Int(DefaultServiceTimeout),
-								ReadTimeout:    kong.Int(DefaultServiceTimeout),
-								WriteTimeout:   kong.Int(DefaultServiceTimeout),
-								Retries:        kong.Int(DefaultRetries),
-							},
-							Namespace: ingress.Namespace,
-							Backends: []kongstate.ServiceBackend{{
-								Name:    rulePath.Backend.Service.Name,
-								PortDef: port,
-							}},
-							Parent: ingress,
-						}
-					}
-					service.Routes = append(service.Routes, r)
-					result.ServiceNameToServices[serviceName] = service
-					result.ServiceNameToParent[serviceName] = ingress
-					objectSuccessfullyParsed = true
-				}
-			}
-		}
-
-		if objectSuccessfullyParsed {
+		if wasServicesCacheUpdated := p.ingressV1ToKongService(ingress, icp, servicesCache); wasServicesCacheUpdated {
 			p.ReportKubernetesObjectUpdate(ingress)
 		}
 	}
 
+	for _, service := range servicesCache {
+		result.ServiceNameToServices[*service.Name] = service
+		result.ServiceNameToParent[*service.Name] = service.Parent
+	}
+
+	// Add a default backend if it exists.
+	defaultBackendService, ok := getDefaultBackendService(allDefaultBackends)
+	if ok {
+		result.ServiceNameToServices[*defaultBackendService.Name] = defaultBackendService
+		result.ServiceNameToParent[*defaultBackendService.Name] = defaultBackendService.Parent
+	}
+
+	return result
+}
+
+// ingressV1ToKongServicesCache is a cache of Kong Services indexed by their name.
+type kongServicesCache map[string]kongstate.Service
+
+// ingressV1ToKongService translates IngressV1 object into Kong Service. It inserts the Kong Service into the passed servicesCache.
+// Returns true if the passed servicesCache was updated.
+func (p *Parser) ingressV1ToKongService(
+	ingress *netv1.Ingress,
+	icp v1alpha1.IngressClassParametersSpec,
+	servicesCache kongServicesCache,
+) bool {
+	if p.featureEnabledCombinedServiceRoutes {
+		return p.ingressV1ToKongServiceCombinedRoutes(ingress, icp, servicesCache)
+	}
+
+	return p.ingressV1ToKongServiceLegacy(ingress, icp, servicesCache)
+}
+
+// ingressV1ToKongServiceLegacy translates IngressV1 object into Kong Service. It inserts the Kong Service into the passed servicesCache.
+// Returns true if the passed servicesCache was updated. It is used when CombinedRoutes feature flag is enabled.
+func (p *Parser) ingressV1ToKongServiceCombinedRoutes(
+	ingress *netv1.Ingress,
+	icp v1alpha1.IngressClassParametersSpec,
+	servicesCache kongServicesCache,
+) bool {
+	wasServicesCacheUpdated := false
+
+	regexPrefix := translators.ControllerPathRegexPrefix
+	if prefix, ok := ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.RegexPrefixKey]; ok {
+		regexPrefix = prefix
+	}
+	for _, kongStateService := range translators.TranslateIngress(ingress, p.flagEnabledRegexPathPrefix) {
+		for _, route := range kongStateService.Routes {
+			for i, path := range route.Paths {
+				newPath := translators.MaybePrependRegexPrefix(*path, regexPrefix, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
+				route.Paths[i] = &newPath
+			}
+		}
+
+		servicesCache[*kongStateService.Service.Name] = *kongStateService
+		wasServicesCacheUpdated = true
+	}
+
+	return wasServicesCacheUpdated
+}
+
+// ingressV1ToKongServiceLegacy translates IngressV1 object into Kong Service. It inserts the Kong Service into the passed servicesCache.
+// Returns true if the passed servicesCache was updated. It is used when the CombinedRoutes feature flag is disabled.
+func (p *Parser) ingressV1ToKongServiceLegacy(
+	ingress *netv1.Ingress,
+	icp v1alpha1.IngressClassParametersSpec,
+	servicesCache kongServicesCache,
+) bool {
+	wasServicesCacheUpdated := false
+
+	ingressSpec := ingress.Spec
+	maybePrependRegexPrefixFn := translators.MaybePrependRegexPrefixForIngressV1Fn(ingress, icp.EnableLegacyRegexDetection && p.flagEnabledRegexPathPrefix)
+	for i, rule := range ingressSpec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for j, rulePath := range rule.HTTP.Paths {
+			pathTypeImplementationSpecific := netv1.PathTypeImplementationSpecific
+			if rulePath.PathType == nil {
+				rulePath.PathType = &pathTypeImplementationSpecific
+			}
+
+			paths := translators.PathsFromIngressPaths(rulePath, p.flagEnabledRegexPathPrefix)
+			if paths == nil {
+				// registering a failure, but technically it should never happen thanks to Kubernetes API validations
+				p.registerTranslationFailure(
+					fmt.Sprintf("could not translate Ingress Path %s to Kong paths", rulePath.Path), ingress,
+				)
+				continue
+			}
+
+			for i, path := range paths {
+				paths[i] = maybePrependRegexPrefixFn(*path)
+			}
+
+			r := kongstate.Route{
+				Ingress: util.FromK8sObject(ingress),
+				Route: kong.Route{
+					Name:              kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
+					Paths:             paths,
+					StripPath:         kong.Bool(false),
+					PreserveHost:      kong.Bool(true),
+					Protocols:         kong.StringSlice("http", "https"),
+					RegexPriority:     kong.Int(priorityForPath[*rulePath.PathType]),
+					RequestBuffering:  kong.Bool(true),
+					ResponseBuffering: kong.Bool(true),
+					Tags:              util.GenerateTagsForObject(ingress),
+				},
+			}
+			if rule.Host != "" {
+				r.Hosts = kong.StringSlice(rule.Host)
+			}
+
+			port := translators.PortDefFromServiceBackendPort(&rulePath.Backend.Service.Port)
+			serviceName := fmt.Sprintf(
+				"%s.%s.%s",
+				ingress.Namespace,
+				rulePath.Backend.Service.Name,
+				serviceBackendPortToStr(rulePath.Backend.Service.Port),
+			)
+			service, ok := servicesCache[serviceName]
+			if !ok {
+				service = kongstate.Service{
+					Service: kong.Service{
+						Name: kong.String(serviceName),
+						Host: kong.String(fmt.Sprintf(
+							"%s.%s.%s.svc",
+							rulePath.Backend.Service.Name,
+							ingress.Namespace,
+							port.CanonicalString(),
+						)),
+						Port:           kong.Int(DefaultHTTPPort),
+						Protocol:       kong.String("http"),
+						Path:           kong.String("/"),
+						ConnectTimeout: kong.Int(DefaultServiceTimeout),
+						ReadTimeout:    kong.Int(DefaultServiceTimeout),
+						WriteTimeout:   kong.Int(DefaultServiceTimeout),
+						Retries:        kong.Int(DefaultRetries),
+					},
+					Namespace: ingress.Namespace,
+					Backends: []kongstate.ServiceBackend{{
+						Name:    rulePath.Backend.Service.Name,
+						PortDef: port,
+					}},
+					Parent: ingress,
+				}
+			}
+			service.Routes = append(service.Routes, r)
+			servicesCache[serviceName] = service
+			wasServicesCacheUpdated = true
+		}
+	}
+
+	return wasServicesCacheUpdated
+}
+
+func getDefaultBackendService(allDefaultBackends []netv1.Ingress) (kongstate.Service, bool) {
 	sort.SliceStable(allDefaultBackends, func(i, j int) bool {
 		return allDefaultBackends[i].CreationTimestamp.Before(&allDefaultBackends[j].CreationTimestamp)
 	})
 
-	// Process the default backend
 	if len(allDefaultBackends) > 0 {
 		ingress := allDefaultBackends[0]
 		defaultBackend := allDefaultBackends[0].Spec.DefaultBackend
 		port := translators.PortDefFromServiceBackendPort(&defaultBackend.Service.Port)
-		serviceName := fmt.Sprintf("%s.%s.%s", allDefaultBackends[0].Namespace, defaultBackend.Service.Name,
-			port.CanonicalString())
-		service, ok := result.ServiceNameToServices[serviceName]
-		if !ok {
-			service = kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String(serviceName),
-					Host: kong.String(fmt.Sprintf("%s.%s.%d.svc", defaultBackend.Service.Name, ingress.Namespace,
-						defaultBackend.Service.Port.Number)),
-					Port:           kong.Int(DefaultHTTPPort),
-					Protocol:       kong.String("http"),
-					ConnectTimeout: kong.Int(DefaultServiceTimeout),
-					ReadTimeout:    kong.Int(DefaultServiceTimeout),
-					WriteTimeout:   kong.Int(DefaultServiceTimeout),
-					Retries:        kong.Int(DefaultRetries),
-					Tags:           util.GenerateTagsForObject(result.ServiceNameToParent[serviceName]),
-				},
-				Namespace: ingress.Namespace,
-				Backends: []kongstate.ServiceBackend{{
-					Name:    defaultBackend.Service.Name,
-					PortDef: translators.PortDefFromServiceBackendPort(&defaultBackend.Service.Port),
-				}},
-				Parent: &ingress,
-			}
+		serviceName := fmt.Sprintf(
+			"%s.%s.%s",
+			allDefaultBackends[0].Namespace,
+			defaultBackend.Service.Name,
+			port.CanonicalString(),
+		)
+		service := kongstate.Service{
+			Service: kong.Service{
+				Name: kong.String(serviceName),
+				Host: kong.String(fmt.Sprintf(
+					"%s.%s.%s.svc",
+					defaultBackend.Service.Name,
+					ingress.Namespace,
+					port.CanonicalString(),
+				)),
+				Port:           kong.Int(DefaultHTTPPort),
+				Protocol:       kong.String("http"),
+				ConnectTimeout: kong.Int(DefaultServiceTimeout),
+				ReadTimeout:    kong.Int(DefaultServiceTimeout),
+				WriteTimeout:   kong.Int(DefaultServiceTimeout),
+				Retries:        kong.Int(DefaultRetries),
+				Tags:           util.GenerateTagsForObject(&ingress),
+			},
+			Namespace: ingress.Namespace,
+			Backends: []kongstate.ServiceBackend{{
+				Name:    defaultBackend.Service.Name,
+				PortDef: port,
+			}},
+			Parent: &ingress,
 		}
 		r := kongstate.Route{
 			Ingress: util.FromK8sObject(&ingress),
@@ -359,13 +426,12 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 				RegexPriority:     kong.Int(0),
 				RequestBuffering:  kong.Bool(true),
 				ResponseBuffering: kong.Bool(true),
-				Tags:              util.GenerateTagsForObject(result.ServiceNameToParent[serviceName]),
+				Tags:              util.GenerateTagsForObject(&ingress),
 			},
 		}
 		service.Routes = append(service.Routes, r)
-		result.ServiceNameToServices[serviceName] = service
-		result.ServiceNameToParent[serviceName] = &ingress
+		return service, true
 	}
 
-	return result
+	return kongstate.Service{}, false
 }

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -376,6 +376,7 @@ func (p *Parser) ingressV1ToKongServiceLegacy(
 	return wasServicesCacheUpdated
 }
 
+// getDefaultBackendService picks the oldest Ingress with a DefaultBackend defined and returns a Kong Service for it.
 func getDefaultBackendService(allDefaultBackends []netv1.Ingress) (kongstate.Service, bool) {
 	sort.SliceStable(allDefaultBackends, func(i, j int) bool {
 		return allDefaultBackends[i].CreationTimestamp.Before(&allDefaultBackends[j].CreationTimestamp)

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -794,7 +795,7 @@ func TestFromIngressV1(t *testing.T) {
 			p := mustNewParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 1)
 			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
 
@@ -812,16 +813,16 @@ func TestFromIngressV1(t *testing.T) {
 			p := mustNewParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 2, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 2)
 			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
 
 			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
 			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
 
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+			assert.Len(t, parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes, 1)
 			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-			assert.Equal(t, 0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+			assert.Empty(t, parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts)
 		})
 		t.Run("ingress rule with TLS", func(t *testing.T) {
 			store, err := store.NewFakeStore(store.FakeObjects{
@@ -833,8 +834,8 @@ func TestFromIngressV1(t *testing.T) {
 			p := mustNewParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+			assert.Len(t, parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret"), 2)
+			assert.Len(t, parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2"), 2)
 		})
 		t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 			store, err := store.NewFakeStore(store.FakeObjects{
@@ -846,7 +847,7 @@ func TestFromIngressV1(t *testing.T) {
 			p := mustNewParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 1)
 			assert.Equal(t, "cert-manager-solver-pod.foo-namespace.80.svc",
 				*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Port)
@@ -956,7 +957,7 @@ func TestFromIngressV1(t *testing.T) {
 			p := setupParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 1)
 			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Port)
 
@@ -974,16 +975,16 @@ func TestFromIngressV1(t *testing.T) {
 			p := setupParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 2, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 2)
 			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Port)
 
 			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Paths[0])
 			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Hosts[0])
 
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+			assert.Len(t, parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes, 1)
 			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-			assert.Equal(t, 0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+			assert.Empty(t, parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts)
 		})
 		t.Run("ingress rule with TLS", func(t *testing.T) {
 			store, err := store.NewFakeStore(store.FakeObjects{
@@ -995,8 +996,8 @@ func TestFromIngressV1(t *testing.T) {
 			p := setupParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+			assert.Len(t, parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret"), 2)
+			assert.Len(t, parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2"), 2)
 		})
 		t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 			store, err := store.NewFakeStore(store.FakeObjects{
@@ -1008,7 +1009,7 @@ func TestFromIngressV1(t *testing.T) {
 			p := setupParser(t, store)
 
 			parsedInfo := p.ingressRulesFromIngressV1()
-			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Len(t, parsedInfo.ServiceNameToServices, 1)
 			assert.Equal(t, "cert-manager-solver-pod.foo-namespace.80.svc",
 				*parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Host)
 			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Port)
@@ -1154,5 +1155,66 @@ func TestFromIngressV1_RegexPrefix(t *testing.T) {
 
 		parsedInfo := p.ingressRulesFromIngressV1()
 		assert.Equal("~/whatever$", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+	})
+}
+
+func TestGetDefaultBackendService(t *testing.T) {
+	someIngress := func(creationTimestamp time.Time, serviceName string) netv1.Ingress {
+		return netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo",
+				Namespace:         "foo-namespace",
+				CreationTimestamp: metav1.NewTime(creationTimestamp),
+			},
+			Spec: netv1.IngressSpec{
+				DefaultBackend: &netv1.IngressBackend{
+					Service: &netv1.IngressServiceBackend{
+						Name: serviceName,
+						Port: netv1.ServiceBackendPort{Number: 80},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("no ingresses", func(t *testing.T) {
+		_, ok := getDefaultBackendService([]netv1.Ingress{})
+		require.False(t, ok, "expected no default backend service when no ingress has one defined")
+	})
+
+	t.Run("one ingress with default backend", func(t *testing.T) {
+		ingresses := []netv1.Ingress{
+			someIngress(time.Now(), "foo-svc"),
+		}
+
+		svc, ok := getDefaultBackendService(ingresses)
+		require.True(t, ok, "expected default backend service when one ingress has one defined")
+
+		assert.Equal(t, "foo-namespace.foo-svc.80", *svc.Name)
+		assert.Equal(t, "foo-svc.foo-namespace.80.svc", *svc.Host)
+		assert.NotNil(t, svc.Parent)
+
+		require.Len(t, svc.Routes, 1)
+		require.Len(t, svc.Routes[0].Paths, 1)
+		assert.Equal(t, "/", *svc.Routes[0].Paths[0])
+	})
+
+	t.Run("multiple ingresses with default backend", func(t *testing.T) {
+		now := time.Now()
+		ingresses := []netv1.Ingress{
+			someIngress(now.Add(time.Second), "newer"),
+			someIngress(now, "older"),
+		}
+
+		svc, ok := getDefaultBackendService(ingresses)
+		require.True(t, ok, "expected default backend service when there's at least one ingress with one defined")
+
+		assert.Equal(t, "foo-namespace.older.80", *svc.Name, "expected older ingress to be selected")
+		assert.Equal(t, "older.foo-namespace.80.svc", *svc.Host)
+		assert.NotNil(t, svc.Parent)
+
+		require.Len(t, svc.Routes, 1)
+		require.Len(t, svc.Routes[0].Paths, 1)
+		assert.Equal(t, "/", *svc.Routes[0].Paths[0])
 	})
 }

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFromIngressV1beta1(t *testing.T) {
-	assert := assert.New(t)
 	ingressList := []*netv1beta1.Ingress{
 		// 0
 		{
@@ -273,7 +272,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(ingressRules{
+		assert.Equal(t, ingressRules{
 			ServiceNameToServices: make(map[string]kongstate.Service),
 			ServiceNameToParent:   make(map[string]client.Object),
 			SecretNameToSNIs:      newSecretNameToSNIs(),
@@ -289,12 +288,12 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+		assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+		assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+		assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
 
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+		assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+		assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
 	})
 	t.Run("ingress rule with default backend", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -304,16 +303,16 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
+		assert.Equal(t, 2, len(parsedInfo.ServiceNameToServices))
+		assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+		assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Port)
 
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+		assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+		assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
 
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-		assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+		assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+		assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
+		assert.Equal(t, 0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
 	})
 	t.Run("ingress rule with TLS", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -325,8 +324,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+		assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+		assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 	})
 	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -338,16 +337,16 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
+		assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+		assert.Equal(t, "cert-manager-solver-pod.foo-namespace.80.svc",
 			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Port)
+		assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Port)
 
-		assert.Equal("/.well-known/acme-challenge/yolo",
+		assert.Equal(t, "/.well-known/acme-challenge/yolo",
 			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Paths[0])
-		assert.Equal("example.com",
+		assert.Equal(t, "example.com",
 			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].Hosts[0])
-		assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].StripPath)
+		assert.False(t, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.80"].Routes[0].StripPath)
 	})
 	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -359,8 +358,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
+		assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+		assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Hosts[0])
 	})
 	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -371,7 +370,7 @@ func TestFromIngressV1beta1(t *testing.T) {
 		require.NoError(t, err)
 		p := mustNewParser(t, store)
 
-		assert.NotPanics(func() {
+		assert.NotPanics(t, func() {
 			p.ingressRulesFromIngressV1beta1()
 		})
 	})
@@ -385,8 +384,8 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
-		assert.Equal("foo-svc.foo-namespace.8000.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.8000"].Host)
+		assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Host)
+		assert.Equal(t, "foo-svc.foo-namespace.8000.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.8000"].Host)
 	})
 	t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
@@ -398,12 +397,11 @@ func TestFromIngressV1beta1(t *testing.T) {
 		p := mustNewParser(t, store)
 
 		parsedInfo := p.ingressRulesFromIngressV1beta1()
-		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
+		assert.Equal(t, translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.80"].Routes[0].Paths[0])
 	})
 }
 
 func TestFromIngressV1(t *testing.T) {
-	assert := assert.New(t)
 	ingressList := []*netv1.Ingress{
 		// 0
 		{
@@ -737,160 +735,371 @@ func TestFromIngressV1(t *testing.T) {
 				},
 			},
 		},
+		// 10
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-2",
+				Namespace: "foo-namespace",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: "foo-svc",
+												Port: netv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	t.Run("no ingress returns empty info", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+	t.Run("CombinedRoutes=off", func(t *testing.T) {
+		t.Run("no ingress returns empty info", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(ingressRules{
-			ServiceNameToServices: make(map[string]kongstate.Service),
-			ServiceNameToParent:   make(map[string]client.Object),
-			SecretNameToSNIs:      newSecretNameToSNIs(),
-		}, parsedInfo)
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, ingressRules{
+				ServiceNameToServices: make(map[string]kongstate.Service),
+				ServiceNameToParent:   make(map[string]client.Object),
+				SecretNameToSNIs:      newSecretNameToSNIs(),
+			}, parsedInfo)
+		})
+		t.Run("simple ingress rule is parsed", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[0],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
+
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
+		})
+		t.Run("ingress rule with default backend", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[0],
+					ingressList[2],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 2, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
+
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
+
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
+			assert.Equal(t, 0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
+		})
+		t.Run("ingress rule with TLS", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[1],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
+		})
+		t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[3],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "cert-manager-solver-pod.foo-namespace.80.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Port)
+
+			assert.Equal(t, "/.well-known/acme-challenge/yolo",
+				*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com",
+				*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Hosts[0])
+			assert.False(t, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].StripPath)
+		})
+		t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[4],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
+		})
+		t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[5],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			assert.NotPanics(t, func() {
+				p.ingressRulesFromIngressV1()
+			})
+		})
+		t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[6],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
+			assert.Equal(t, "foo-svc.foo-namespace.8000.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-8000"].Host)
+		})
+		t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[9],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"]
+			assert.True(t, ok)
+		})
+		t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[9],
+				},
+			})
+			require.NoError(t, err)
+			p := mustNewParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+		})
 	})
-	t.Run("simple ingress rule is parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[0],
-			},
+
+	t.Run("CombinedRoutes=on", func(t *testing.T) {
+		setupParser := func(t *testing.T, store store.Storer) *Parser {
+			p := mustNewParser(t, store)
+			p.EnableCombinedServiceRoutes()
+			return p
+		}
+
+		t.Run("no ingress returns empty info", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, ingressRules{
+				ServiceNameToServices: make(map[string]kongstate.Service),
+				ServiceNameToParent:   make(map[string]client.Object),
+				SecretNameToSNIs:      newSecretNameToSNIs(),
+			}, parsedInfo)
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("simple ingress rule is parsed", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[0],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Port)
 
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
-	})
-	t.Run("ingress rule with default backend", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[0],
-				ingressList[2],
-			},
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Hosts[0])
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("ingress rule with default backend", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[0],
+					ingressList[2],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Port)
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 2, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Port)
 
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Hosts[0])
 
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
-		assert.Equal(0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
-	})
-	t.Run("ingress rule with TLS", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[1],
-			},
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes))
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Paths[0])
+			assert.Equal(t, 0, len(parsedInfo.ServiceNameToServices["bar-namespace.default-svc.80"].Routes[0].Hosts))
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("ingress rule with TLS", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[1],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
-		assert.Equal(2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
-	})
-	t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[3],
-			},
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret")))
+			assert.Equal(t, 2, len(parsedInfo.SecretNameToSNIs.Hosts("bar-namespace/sooper-secret2")))
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("ingress rule with ACME like path has strip_path set to false", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[3],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(1, len(parsedInfo.ServiceNameToServices))
-		assert.Equal("cert-manager-solver-pod.foo-namespace.80.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Host)
-		assert.Equal(80, *parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Port)
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, 1, len(parsedInfo.ServiceNameToServices))
+			assert.Equal(t, "cert-manager-solver-pod.foo-namespace.80.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Host)
+			assert.Equal(t, 80, *parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Port)
 
-		assert.Equal("/.well-known/acme-challenge/yolo",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com",
-			*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].Hosts[0])
-		assert.False(*parsedInfo.ServiceNameToServices["foo-namespace.cert-manager-solver-pod.pnum-80"].Routes[0].StripPath)
-	})
-	t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[4],
-			},
+			assert.Equal(t, "/.well-known/acme-challenge/yolo",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Routes[0].Hosts[0])
+			assert.False(t, *parsedInfo.ServiceNameToServices["foo-namespace.foo.cert-manager-solver-pod.80"].Routes[0].StripPath)
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("ingress with empty path is correctly parsed", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[4],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal("/", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
-		assert.Equal("example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Hosts[0])
-	})
-	t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[5],
-			},
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, "/", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Paths[0])
+			assert.Equal(t, "example.com", *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Routes[0].Hosts[0])
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("empty Ingress rule doesn't cause a panic", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[5],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		assert.NotPanics(func() {
-			p.ingressRulesFromIngressV1()
+			assert.NotPanics(t, func() {
+				p.ingressRulesFromIngressV1()
+			})
 		})
-	})
-	t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[6],
-			},
-		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("Ingress rules with multiple ports for one Service use separate hostnames for each port", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[6],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal("foo-svc.foo-namespace.80.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Host)
-		assert.Equal("foo-svc.foo-namespace.8000.svc",
-			*parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-8000"].Host)
-	})
-	t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[9],
-			},
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, "foo-svc.foo-namespace.80.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host)
+			assert.Equal(t, "foo-svc.foo-namespace.8000.svc",
+				*parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.8000"].Host)
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("Ingress rule with ports defined by name", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[9],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		_, ok := parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"]
-		assert.True(ok)
-	})
-	t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
-		store, err := store.NewFakeStore(store.FakeObjects{
-			IngressesV1: []*netv1.Ingress{
-				ingressList[9],
-			},
+			parsedInfo := p.ingressRulesFromIngressV1()
+			_, ok := parsedInfo.ServiceNameToServices["foo-namespace.regex-prefix.foo-svc.80"]
+			assert.True(t, ok)
 		})
-		require.NoError(t, err)
-		p := mustNewParser(t, store)
+		t.Run("Ingress rule with regex prefixed path creates route with Kong regex prefix", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[9],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
 
-		parsedInfo := p.ingressRulesFromIngressV1()
-		assert.Equal(translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.foo-svc.pnum-80"].Routes[0].Paths[0])
+			parsedInfo := p.ingressRulesFromIngressV1()
+			assert.Equal(t, translators.KongPathRegexPrefix+"/foo/\\d{3}", *parsedInfo.ServiceNameToServices["foo-namespace.regex-prefix.foo-svc.80"].Routes[0].Paths[0])
+		})
+		t.Run("single service in multiple ingresses generates multiple kong services", func(t *testing.T) {
+			store, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					ingressList[0],
+					ingressList[10],
+				},
+			})
+			require.NoError(t, err)
+			p := setupParser(t, store)
+
+			parsedInfo := p.ingressRulesFromIngressV1()
+			require.Len(t, parsedInfo.ServiceNameToServices, 2)
+			assert.Equal(t, *parsedInfo.ServiceNameToServices["foo-namespace.foo.foo-svc.80"].Host, "foo-svc.foo-namespace.80.svc")
+			assert.Equal(t, *parsedInfo.ServiceNameToServices["foo-namespace.foo-2.foo-svc.80"].Host, "foo-svc.foo-namespace.80.svc")
+		})
 	})
 }
 

--- a/internal/dataplane/parser/translators/translator_vars.go
+++ b/internal/dataplane/parser/translators/translator_vars.go
@@ -4,7 +4,7 @@ const (
 	// KongPathRegexPrefix is the reserved prefix string that instructs Kong 3.0+ to interpret a path as a regex.
 	KongPathRegexPrefix = "~"
 
-	// ControllerPathRegePrefix is the prefix string used to indicate that the controller should treat a path as a
+	// ControllerPathRegexPrefix is the prefix string used to indicate that the controller should treat a path as a
 	// regular expression. The controller replaces this prefix with KongPathRegexPrefix when sending routes to Kong.
 	ControllerPathRegexPrefix = "/~"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Reorganizes `ingressRulesFromIngressV1` `Parser`'s method so that we can clearly see the boundary between the code called when `CombinedRoutes` feature flag is enabled or not. It also adds missing unit tests for `CombinedRoutes=on` that will be useful for further work on #3777.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Preparation for #3777.
