### PR TITLE
fix: correct catch-all matcher for translating default backend of ingresses to expression routes

### DIFF
--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -441,7 +441,7 @@ func translateIngressDefaultBackendRoute(ingress *netv1.Ingress, tags []*string,
 
 	if expressionRoutes {
 		catchAllMatcher := atc.And(
-			atc.NewPredicateHTTPPath(atc.OpEqual, "/"),
+			atc.NewPredicateHTTPPath(atc.OpPrefixMatch, "/"),
 			atc.Or(atc.NewPredicateNetProtocol(atc.OpEqual, "http"), atc.NewPredicateNetProtocol(atc.OpEqual, "https")),
 		)
 		atc.ApplyExpression(&r.Route, catchAllMatcher, translators.IngressDefaultBackendPriority)

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -1179,41 +1179,40 @@ func TestGetDefaultBackendService(t *testing.T) {
 
 	now := time.Now()
 	testCases := []struct {
-		name             string
-		ingresses        []netv1.Ingress
-		expressionRoutes bool
-		// expected results.
-		haveBackendService bool
-		serviceName        string
-		serciceHost        string
+		name                      string
+		ingresses                 []netv1.Ingress
+		expressionRoutes          bool
+		expectedHveBackendService bool
+		expectedServiceName       string
+		expectedServiceHost       string
 	}{
 		{
-			name:               "no ingresses",
-			ingresses:          []netv1.Ingress{},
-			expressionRoutes:   false,
-			haveBackendService: false,
+			name:                      "no ingresses",
+			ingresses:                 []netv1.Ingress{},
+			expressionRoutes:          false,
+			expectedHveBackendService: false,
 		},
 		{
-			name:               "no ingresses with expression routes",
-			ingresses:          []netv1.Ingress{},
-			expressionRoutes:   true,
-			haveBackendService: false,
+			name:                      "no ingresses with expression routes",
+			ingresses:                 []netv1.Ingress{},
+			expressionRoutes:          true,
+			expectedHveBackendService: false,
 		},
 		{
-			name:               "one ingress with default backend",
-			ingresses:          []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:   false,
-			haveBackendService: true,
-			serviceName:        "foo-namespace.foo-svc.80",
-			serciceHost:        "foo-svc.foo-namespace.80.svc",
+			name:                      "one ingress with default backend",
+			ingresses:                 []netv1.Ingress{someIngress(now, "foo-svc")},
+			expressionRoutes:          false,
+			expectedHveBackendService: true,
+			expectedServiceName:       "foo-namespace.foo-svc.80",
+			expectedServiceHost:       "foo-svc.foo-namespace.80.svc",
 		},
 		{
-			name:               "one ingress with default backend and expression routes enabled",
-			ingresses:          []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:   true,
-			haveBackendService: true,
-			serviceName:        "foo-namespace.foo-svc.80",
-			serciceHost:        "foo-svc.foo-namespace.80.svc",
+			name:                      "one ingress with default backend and expression routes enabled",
+			ingresses:                 []netv1.Ingress{someIngress(now, "foo-svc")},
+			expressionRoutes:          true,
+			expectedHveBackendService: true,
+			expectedServiceName:       "foo-namespace.foo-svc.80",
+			expectedServiceHost:       "foo-svc.foo-namespace.80.svc",
 		},
 		{
 			name: "multiple ingresses with default backend",
@@ -1221,10 +1220,10 @@ func TestGetDefaultBackendService(t *testing.T) {
 				someIngress(now.Add(time.Second), "newer"),
 				someIngress(now, "older"),
 			},
-			expressionRoutes:   false,
-			haveBackendService: true,
-			serviceName:        "foo-namespace.older.80",
-			serciceHost:        "older.foo-namespace.80.svc",
+			expressionRoutes:          false,
+			expectedHveBackendService: true,
+			expectedServiceName:       "foo-namespace.older.80",
+			expectedServiceHost:       "older.foo-namespace.80.svc",
 		},
 		{
 			name: "multiple ingresses with default backend and expression routes enabled",
@@ -1232,10 +1231,10 @@ func TestGetDefaultBackendService(t *testing.T) {
 				someIngress(now.Add(time.Second), "newer"),
 				someIngress(now, "older"),
 			},
-			expressionRoutes:   true,
-			haveBackendService: true,
-			serviceName:        "foo-namespace.older.80",
-			serciceHost:        "older.foo-namespace.80.svc",
+			expressionRoutes:          true,
+			expectedHveBackendService: true,
+			expectedServiceName:       "foo-namespace.older.80",
+			expectedServiceHost:       "older.foo-namespace.80.svc",
 		},
 	}
 
@@ -1243,10 +1242,10 @@ func TestGetDefaultBackendService(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			svc, ok := getDefaultBackendService(tc.ingresses, tc.expressionRoutes)
-			require.Equal(t, tc.haveBackendService, ok)
-			if tc.haveBackendService {
-				require.Equal(t, tc.serviceName, *svc.Name)
-				require.Equal(t, tc.serciceHost, *svc.Host)
+			require.Equal(t, tc.expectedHveBackendService, ok)
+			if tc.expectedHveBackendService {
+				require.Equal(t, tc.expectedServiceName, *svc.Name)
+				require.Equal(t, tc.expectedServiceHost, *svc.Host)
 				require.Len(t, svc.Routes, 1)
 				route := svc.Routes[0]
 				if tc.expressionRoutes {

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -1179,40 +1179,40 @@ func TestGetDefaultBackendService(t *testing.T) {
 
 	now := time.Now()
 	testCases := []struct {
-		name                      string
-		ingresses                 []netv1.Ingress
-		expressionRoutes          bool
-		expectedHveBackendService bool
-		expectedServiceName       string
-		expectedServiceHost       string
+		name                       string
+		ingresses                  []netv1.Ingress
+		expressionRoutes           bool
+		expectedHaveBackendService bool
+		expectedServiceName        string
+		expectedServiceHost        string
 	}{
 		{
-			name:                      "no ingresses",
-			ingresses:                 []netv1.Ingress{},
-			expressionRoutes:          false,
-			expectedHveBackendService: false,
+			name:                       "no ingresses",
+			ingresses:                  []netv1.Ingress{},
+			expressionRoutes:           false,
+			expectedHaveBackendService: false,
 		},
 		{
-			name:                      "no ingresses with expression routes",
-			ingresses:                 []netv1.Ingress{},
-			expressionRoutes:          true,
-			expectedHveBackendService: false,
+			name:                       "no ingresses with expression routes",
+			ingresses:                  []netv1.Ingress{},
+			expressionRoutes:           true,
+			expectedHaveBackendService: false,
 		},
 		{
-			name:                      "one ingress with default backend",
-			ingresses:                 []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:          false,
-			expectedHveBackendService: true,
-			expectedServiceName:       "foo-namespace.foo-svc.80",
-			expectedServiceHost:       "foo-svc.foo-namespace.80.svc",
+			name:                       "one ingress with default backend",
+			ingresses:                  []netv1.Ingress{someIngress(now, "foo-svc")},
+			expressionRoutes:           false,
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.foo-svc.80",
+			expectedServiceHost:        "foo-svc.foo-namespace.80.svc",
 		},
 		{
-			name:                      "one ingress with default backend and expression routes enabled",
-			ingresses:                 []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:          true,
-			expectedHveBackendService: true,
-			expectedServiceName:       "foo-namespace.foo-svc.80",
-			expectedServiceHost:       "foo-svc.foo-namespace.80.svc",
+			name:                       "one ingress with default backend and expression routes enabled",
+			ingresses:                  []netv1.Ingress{someIngress(now, "foo-svc")},
+			expressionRoutes:           true,
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.foo-svc.80",
+			expectedServiceHost:        "foo-svc.foo-namespace.80.svc",
 		},
 		{
 			name: "multiple ingresses with default backend",
@@ -1220,10 +1220,10 @@ func TestGetDefaultBackendService(t *testing.T) {
 				someIngress(now.Add(time.Second), "newer"),
 				someIngress(now, "older"),
 			},
-			expressionRoutes:          false,
-			expectedHveBackendService: true,
-			expectedServiceName:       "foo-namespace.older.80",
-			expectedServiceHost:       "older.foo-namespace.80.svc",
+			expressionRoutes:           false,
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.older.80",
+			expectedServiceHost:        "older.foo-namespace.80.svc",
 		},
 		{
 			name: "multiple ingresses with default backend and expression routes enabled",
@@ -1231,10 +1231,10 @@ func TestGetDefaultBackendService(t *testing.T) {
 				someIngress(now.Add(time.Second), "newer"),
 				someIngress(now, "older"),
 			},
-			expressionRoutes:          true,
-			expectedHveBackendService: true,
-			expectedServiceName:       "foo-namespace.older.80",
-			expectedServiceHost:       "older.foo-namespace.80.svc",
+			expressionRoutes:           true,
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.older.80",
+			expectedServiceHost:        "older.foo-namespace.80.svc",
 		},
 	}
 
@@ -1242,8 +1242,8 @@ func TestGetDefaultBackendService(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			svc, ok := getDefaultBackendService(tc.ingresses, tc.expressionRoutes)
-			require.Equal(t, tc.expectedHveBackendService, ok)
-			if tc.expectedHveBackendService {
+			require.Equal(t, tc.expectedHaveBackendService, ok)
+			if tc.expectedHaveBackendService {
 				require.Equal(t, tc.expectedServiceName, *svc.Name)
 				require.Equal(t, tc.expectedServiceHost, *svc.Host)
 				require.Len(t, svc.Routes, 1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

- fixed the generated matcher for default backends in expression routes and added unit tests (exact match of `/` to prefix match of `/`)
- changed `TestGetDefaultBackendService` into table driven format

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~~ The fix does not affect released features 
