### PR TITLE
feat(gwapi): setup controllers dynamically when required CRDs get installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ Adding a new version? You'll need three changes:
   strategy that prevents KIC from exceeding API calls limits.
   [#3989](https://github.com/Kong/kubernetes-ingress-controller/pull/3989)
   [#4015](https://github.com/Kong/kubernetes-ingress-controller/pull/4015)
+- When Gateway API CRDs are not installed, the controllers of those are not started
+  during the start-up phase. From now on, they will be dynamically started in runtime
+  once their installation is detected, making restarting the process unnecessary.
+  [#3996](https://github.com/Kong/kubernetes-ingress-controller/pull/3996)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ manifests.rbac: controller-gen
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress paths="./internal/controllers/configuration/"
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-knative paths="./internal/controllers/knative/" output:rbac:artifacts:config=config/rbac/knative
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-gateway paths="./internal/controllers/gateway/" output:rbac:artifacts:config=config/rbac/gateway
+	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-crds paths="./internal/controllers/crds/" output:rbac:artifacts:config=config/rbac/crds
 
 .PHONY: manifests.single
 manifests.single: kustomize ## Compose single-file deployment manifests from building blocks

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../rbac
 - ../rbac/gateway
 - ../rbac/knative
+- ../rbac/crds
 - ingressclass.yaml
 - service.yaml
 - serviceaccount.yaml

--- a/config/rbac/crds/kustomization.yaml
+++ b/config/rbac/crds/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/config/rbac/crds/role.yaml
+++ b/config/rbac/crds/role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch

--- a/config/rbac/crds/role_binding.yaml
+++ b/config/rbac/crds/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1375,6 +1375,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kong-ingress-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kong-ingress-gateway
 rules:
 - apiGroups:
@@ -1543,6 +1556,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-crds
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount

--- a/internal/controllers/crds/dynamic_controller.go
+++ b/internal/controllers/crds/dynamic_controller.go
@@ -1,0 +1,134 @@
+package crds
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;watch
+
+type Controller interface {
+	SetupWithManager(mgr ctrl.Manager) error
+}
+
+// DynamicController ensures that RequiredCRDs are installed in the cluster and only then sets up all of its Controllers
+// that depends on them.
+// In case the CRDs are not installed at start-up time, DynamicController will set up a watch for CustomResourceDefinition
+// and will dynamically set up its Controllers once it detects that all RequiredCRDs are already in place.
+type DynamicController struct {
+	Log              logr.Logger
+	Manager          ctrl.Manager
+	CacheSyncTimeout time.Duration
+	Controllers      []Controller
+	RequiredCRDs     []schema.GroupVersionResource
+
+	startControllersOnce sync.Once
+}
+
+func (r *DynamicController) SetupWithManager(mgr ctrl.Manager) error {
+	if r.allRequiredCRDsInstalled() {
+		r.Log.V(util.DebugLevel).Info("All required CustomResourceDefinitions are installed, skipping DynamicController set up")
+		return r.setupControllers(mgr)
+	}
+
+	r.Log.Info("Required CustomResourceDefinitions are not installed, setting up a watch for them in case they are installed afterward")
+
+	c, err := controller.New("DynamicController", mgr, controller.Options{
+		Reconciler: r,
+		LogConstructor: func(_ *reconcile.Request) logr.Logger {
+			return r.Log
+		},
+		CacheSyncTimeout: r.CacheSyncTimeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(
+		&source.Kind{Type: &apiextensionsv1.CustomResourceDefinition{}},
+		&handler.EnqueueRequestForObject{},
+		predicate.NewPredicateFuncs(r.isOneOfRequiredCRDs),
+	)
+}
+
+func (r *DynamicController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("CustomResourceDefinition", req.NamespacedName)
+
+	crd := new(apiextensionsv1.CustomResourceDefinition)
+	if err := r.Manager.GetClient().Get(ctx, req.NamespacedName, crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(util.DebugLevel).Info("Object enqueued no longer exists, skipping", "name", req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	log.V(util.DebugLevel).Info("Processing CustomResourceDefinition", "name", req.Name)
+
+	if !r.allRequiredCRDsInstalled() {
+		log.V(util.DebugLevel).Info("Still not all required CustomResourceDefinitions are installed, waiting")
+		return ctrl.Result{}, nil
+	}
+
+	var startControllersErr error
+	r.startControllersOnce.Do(func() {
+		log.V(util.InfoLevel).Info("All required CustomResourceDefinitions are installed, setting up the controllers")
+		startControllersErr = r.setupControllers(r.Manager)
+	})
+	if startControllersErr != nil {
+		return ctrl.Result{}, startControllersErr
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DynamicController) allRequiredCRDsInstalled() bool {
+	return lo.EveryBy(r.RequiredCRDs, func(gvr schema.GroupVersionResource) bool {
+		return utils.CRDExists(r.Manager.GetClient().RESTMapper(), gvr)
+	})
+}
+
+func (r *DynamicController) isOneOfRequiredCRDs(obj client.Object) bool {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return false
+	}
+
+	return lo.ContainsBy(r.RequiredCRDs, func(gvr schema.GroupVersionResource) bool {
+		versionMatches := lo.ContainsBy(crd.Spec.Versions, func(crdv apiextensionsv1.CustomResourceDefinitionVersion) bool {
+			return crdv.Name == gvr.Version
+		})
+
+		return crd.Spec.Group == gvr.Group &&
+			crd.Status.AcceptedNames.Plural == gvr.Resource &&
+			versionMatches
+	})
+}
+
+func (r *DynamicController) setupControllers(mgr ctrl.Manager) error {
+	errs := lo.FilterMap(r.Controllers, func(c Controller, _ int) (error, bool) {
+		if err := c.SetupWithManager(mgr); err != nil {
+			return err, true
+		}
+		return nil, false
+	})
+
+	return errors.Join(errs...)
+}

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
+	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
@@ -71,6 +73,12 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.PublishServiceRef.Name == "" || r.PublishServiceRef.Namespace == "" {
 		return fmt.Errorf("publish service must be configured")
 	}
+
+	r.EnableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
+		Group:    gatewayv1beta1.GroupVersion.Group,
+		Version:  gatewayv1beta1.GroupVersion.Version,
+		Resource: "referencegrants",
+	})
 
 	// generate the controller object and attach it to the manager and link the reconciler object
 	c, err := controller.New("gateway-controller", mgr, controller.Options{

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 )
@@ -57,6 +59,12 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+
+	r.EnableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
+		Group:    gatewayv1beta1.GroupVersion.Group,
+		Version:  gatewayv1beta1.GroupVersion.Version,
+		Resource: "referencegrants",
+	})
 
 	// if a GatewayClass updates then we need to enqueue the linked HTTPRoutes to
 	// ensure that any route objects that may have been orphaned by that change get

--- a/internal/controllers/gateway/httproute_controller_envtest_test.go
+++ b/internal/controllers/gateway/httproute_controller_envtest_test.go
@@ -52,282 +52,236 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// In tests below we use a deferred cancel to stop the manager and not wait
-	// for its timeout.
+	reconciler := &gateway.HTTPRouteReconciler{
+		Client:          client,
+		DataplaneClient: gateway.DataplaneMock{},
+	}
 
-	testcases := []struct {
-		name       string
-		reconciler *gateway.HTTPRouteReconciler
-	}{
-		{
-			name: "with ReferenceGrant enabled",
-			reconciler: &gateway.HTTPRouteReconciler{
-				Client:               client,
-				EnableReferenceGrant: true,
-			},
+	// We use a deferred cancel to stop the manager and not wait for its timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns := envtest.CreateNamespace(ctx, t, client)
+	nsRoute := envtest.CreateNamespace(ctx, t, client)
+
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "backend-1",
 		},
-		{
-			name: "with ReferenceGrant disabled",
-			reconciler: &gateway.HTTPRouteReconciler{
-				Client:               client,
-				EnableReferenceGrant: false,
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+				},
 			},
 		},
 	}
+	require.NoError(t, client.Create(ctx, &svc))
+	envtest.StartReconciler(ctx, t, client.Scheme(), cfg, reconciler, nil)
 
-	for _, tc := range testcases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+	gwc := gatewayv1beta1.GatewayClass{
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gateway.GetControllerName(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				"konghq.com/gatewayclass-unmanaged": "placeholder",
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gwc))
+	t.Cleanup(func() { _ = client.Delete(ctx, &gwc) })
 
-			ns := envtest.CreateNamespace(ctx, t, client)
-			nsRoute := envtest.CreateNamespace(ctx, t, client)
-
-			svc := corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.Name,
-					Name:      "backend-1",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "http",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       80,
-							TargetPort: intstr.FromInt(80),
+	gw := gatewayv1beta1.Gateway{
+		Spec: gatewayv1beta1.GatewaySpec{
+			GatewayClassName: gatewayv1beta1.ObjectName(gwc.Name),
+			Listeners: []gatewayv1beta1.Listener{
+				{
+					Name:     gatewayv1beta1.SectionName("http"),
+					Port:     gatewayv1beta1.PortNumber(80),
+					Protocol: gatewayv1beta1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+						Namespaces: &gatewayv1beta1.RouteNamespaces{
+							From: lo.ToPtr(gatewayv1beta1.NamespacesFromAll),
 						},
 					},
 				},
-			}
-			require.NoError(t, client.Create(ctx, &svc))
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      uuid.NewString(),
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gw))
 
-			tc.reconciler.DataplaneClient = gateway.DataplaneMock{}
-			envtest.StartReconciler(ctx, t, client.Scheme(), cfg, tc.reconciler, nil)
-
-			gwc := gatewayv1beta1.GatewayClass{
-				Spec: gatewayv1beta1.GatewayClassSpec{
-					ControllerName: gateway.GetControllerName(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uuid.NewString(),
-					Annotations: map[string]string{
-						"konghq.com/gatewayclass-unmanaged": "placeholder",
-					},
-				},
-			}
-			require.NoError(t, client.Create(ctx, &gwc))
-			t.Cleanup(func() { _ = client.Delete(ctx, &gwc) })
-
-			gw := gatewayv1beta1.Gateway{
-				Spec: gatewayv1beta1.GatewaySpec{
-					GatewayClassName: gatewayv1beta1.ObjectName(gwc.Name),
-					Listeners: []gatewayv1beta1.Listener{
-						{
-							Name:     gatewayv1beta1.SectionName("http"),
-							Port:     gatewayv1beta1.PortNumber(80),
-							Protocol: gatewayv1beta1.HTTPProtocolType,
-							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
-								Namespaces: &gatewayv1beta1.RouteNamespaces{
-									From: lo.ToPtr(gatewayv1beta1.NamespacesFromAll),
-								},
-							},
-						},
-					},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.Name,
-					Name:      uuid.NewString(),
-				},
-			}
-			require.NoError(t, client.Create(ctx, &gw))
-
-			gwOld := gw.DeepCopy()
-			gw.Status = gatewayv1beta1.GatewayStatus{
-				Addresses: []gatewayv1beta1.GatewayAddress{
-					{
-						Type:  lo.ToPtr(gatewayv1beta1.IPAddressType),
-						Value: "10.0.0.1",
-					},
-				},
+	gwOld := gw.DeepCopy()
+	gw.Status = gatewayv1beta1.GatewayStatus{
+		Addresses: []gatewayv1beta1.GatewayAddress{
+			{
+				Type:  lo.ToPtr(gatewayv1beta1.IPAddressType),
+				Value: "10.0.0.1",
+			},
+		},
+		Conditions: []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: gw.Generation,
+			},
+			{
+				Type:               "Accepted",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: gw.Generation,
+			},
+			{
+				Type:               "Programmed",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Programmed",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: gw.Generation,
+			},
+		},
+		Listeners: []gatewayv1beta1.ListenerStatus{
+			{
+				Name: "http",
 				Conditions: []metav1.Condition{
-					{
-						Type:               "Ready",
-						Status:             metav1.ConditionTrue,
-						Reason:             "Ready",
-						LastTransitionTime: metav1.Now(),
-						ObservedGeneration: gw.Generation,
-					},
 					{
 						Type:               "Accepted",
 						Status:             metav1.ConditionTrue,
 						Reason:             "Accepted",
 						LastTransitionTime: metav1.Now(),
-						ObservedGeneration: gw.Generation,
 					},
 					{
-						Type:               "Programmed",
+						Type:               "Ready",
 						Status:             metav1.ConditionTrue,
-						Reason:             "Programmed",
+						Reason:             "Ready",
 						LastTransitionTime: metav1.Now(),
-						ObservedGeneration: gw.Generation,
 					},
 				},
-				Listeners: []gatewayv1beta1.ListenerStatus{
+				SupportedKinds: []gatewayv1beta1.RouteGroupKind{
 					{
-						Name: gatewayv1beta1.SectionName("http"),
-						Conditions: []metav1.Condition{
-							{
-								Type:               "Accepted",
-								Status:             metav1.ConditionTrue,
-								Reason:             "Accepted",
-								LastTransitionTime: metav1.Now(),
-							},
-							{
-								Type:               "Ready",
-								Status:             metav1.ConditionTrue,
-								Reason:             "Ready",
-								LastTransitionTime: metav1.Now(),
-							},
-						},
-						SupportedKinds: []gatewayv1beta1.RouteGroupKind{
-							{
-								Group: lo.ToPtr(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
-								Kind:  "HTTPRoute",
-							},
-						},
+						Group: lo.ToPtr(gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group)),
+						Kind:  "HTTPRoute",
 					},
 				},
-			}
-			require.NoError(t, client.Status().Patch(ctx, &gw, ctrlclient.MergeFrom(gwOld)))
+			},
+		},
+	}
+	require.NoError(t, client.Status().Patch(ctx, &gw, ctrlclient.MergeFrom(gwOld)))
 
-			route := gatewayv1beta1.HTTPRoute{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "HTTPRoute",
-					APIVersion: "v1beta1",
+	route := gatewayv1beta1.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HTTPRoute",
+			APIVersion: "v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsRoute.Name,
+			Name:      uuid.NewString(),
+		},
+		Spec: gatewayv1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayv1beta1.ParentReference{{
+					Name:      gatewayv1beta1.ObjectName(gw.Name),
+					Namespace: lo.ToPtr(gatewayv1beta1.Namespace(ns.Name)),
+				}},
+			},
+			Rules: []gatewayv1beta1.HTTPRouteRule{{
+				BackendRefs: builder.NewHTTPBackendRef("backend-1").WithNamespace(ns.Name).ToSlice(),
+			}},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &route))
+
+	nn := types.NamespacedName{
+		Namespace: route.GetNamespace(),
+		Name:      route.GetName(),
+	}
+
+	t.Logf("verifying that HTTPRoute has ResolvedRefs set to Status False and Reason RefNotPermitted")
+	if !assert.Eventually(t,
+		helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
+			metav1.Condition{
+				Type:   "ResolvedRefs",
+				Status: "False",
+				Reason: "RefNotPermitted",
+			},
+		),
+		waitDuration, tickDuration,
+	) {
+		t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
+	}
+
+	rg := gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      uuid.NewString(),
+		},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group),
+					Kind:      "HTTPRoute",
+					Namespace: gatewayv1beta1.Namespace(nsRoute.Name),
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: nsRoute.Name,
-					Name:      uuid.NewString(),
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{
+					Group: "",
+					Kind:  "Service",
 				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Name:      gatewayv1beta1.ObjectName(gw.Name),
-							Namespace: lo.ToPtr(gatewayv1beta1.Namespace(ns.Name)),
-						}},
-					},
-					Rules: []gatewayv1beta1.HTTPRouteRule{{
-						BackendRefs: builder.NewHTTPBackendRef("backend-1").WithNamespace(ns.Name).ToSlice(),
-					}},
-				},
-			}
-			require.NoError(t, client.Create(ctx, &route))
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &rg))
+	t.Logf("verifying that HTTPRoute gets accepted by HTTPRouteReconciler after relevant ReferenceGrant gets created")
+	if !assert.Eventually(t,
+		helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
+			metav1.Condition{
+				Type:   "ResolvedRefs",
+				Status: "True",
+				Reason: "ResolvedRefs",
+			},
+			metav1.Condition{
+				Type:   "Accepted",
+				Status: "True",
+				Reason: "Accepted",
+			},
+			// Programmed condition requires a bit more work with mocks.
+			// It's set only when KubernetesObjectReports are enabled in the underlying
+			// dataplane client and then it relies on what's returned by
+			// dataplane client in KubernetesObjectConfigurationStatus().
+			// This can be done but it's not the main focus of this test.
+			// Related: https://github.com/Kong/kubernetes-ingress-controller/issues/3793
+		),
+		waitDuration, tickDuration,
+	) {
+		t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
+	}
 
-			nn := types.NamespacedName{
-				Namespace: route.GetNamespace(),
-				Name:      route.GetName(),
-			}
+	require.NoError(t, client.Delete(ctx, &rg))
+	t.Logf("verifying that HTTPRoute gets its ResolvedRefs condition to Status False and Reason RefNotPermitted when relevant ReferenceGrant gets deleted")
 
-			t.Logf("verifying that HTTPRoute has ResolvedRefs set to Status False and Reason RefNotPermitted")
-			if !assert.Eventually(t,
-				helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
-					metav1.Condition{
-						Type:   "ResolvedRefs",
-						Status: "False",
-						Reason: "RefNotPermitted",
-					},
-				),
-				waitDuration, tickDuration,
-			) {
-				t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
-			}
-
-			rg := gatewayv1beta1.ReferenceGrant{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.Name,
-					Name:      uuid.NewString(),
-				},
-				Spec: gatewayv1beta1.ReferenceGrantSpec{
-					From: []gatewayv1beta1.ReferenceGrantFrom{
-						{
-							Group:     gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group),
-							Kind:      "HTTPRoute",
-							Namespace: gatewayv1beta1.Namespace(nsRoute.Name),
-						},
-					},
-					To: []gatewayv1beta1.ReferenceGrantTo{
-						{
-							Group: "",
-							Kind:  "Service",
-						},
-					},
-				},
-			}
-			require.NoError(t, client.Create(ctx, &rg))
-			if tc.reconciler.EnableReferenceGrant {
-				t.Logf("verifying that HTTPRoute gets accepted by HTTPRouteReconciler after relevant ReferenceGrant gets created")
-				if !assert.Eventually(t,
-					helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
-						metav1.Condition{
-							Type:   "ResolvedRefs",
-							Status: "True",
-							Reason: "ResolvedRefs",
-						},
-						metav1.Condition{
-							Type:   "Accepted",
-							Status: "True",
-							Reason: "Accepted",
-						},
-						// Programmed condition requires a bit more work with mocks.
-						// It's set only when KubernetesObjectReports are enabled in the underlying
-						// dataplane client and then it relies on what's returned by
-						// dataplane client in KubernetesObjectConfigurationStatus().
-						// This can be done but it's not the main focus of this test.
-						// Related: https://github.com/Kong/kubernetes-ingress-controller/issues/3793
-					),
-					waitDuration, tickDuration,
-				) {
-					t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
-				}
-			} else {
-				t.Logf("verifying that HTTPRoute's status doesn't change after relevant ReferenceGrant gets created")
-
-				if !assert.Eventually(t,
-					helpers.HTTPRouteEventuallyNotContainsConditions(ctx, t, client, nn,
-						metav1.Condition{
-							Type:   "ResolvedRefs",
-							Status: "True",
-							Reason: "ResolvedRefs",
-						},
-						metav1.Condition{
-							Type:   "Accepted",
-							Status: "True",
-							Reason: "Accepted",
-						},
-					),
-					waitDuration, tickDuration,
-				) {
-					t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
-				}
-			}
-
-			require.NoError(t, client.Delete(ctx, &rg))
-			t.Logf("verifying that HTTPRoute gets its ResolvedRefs condition to Status False and Reason RefNotPermitted when relevant ReferenceGrant gets deleted")
-
-			if !assert.Eventually(t,
-				helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
-					metav1.Condition{
-						Type:   "ResolvedRefs",
-						Status: "False",
-						Reason: "RefNotPermitted",
-					},
-				),
-				waitDuration, tickDuration,
-			) {
-				t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
-			}
-		})
+	if !assert.Eventually(t,
+		helpers.HTTPRouteEventuallyContainsConditions(ctx, t, client, nn,
+			metav1.Condition{
+				Type:   "ResolvedRefs",
+				Status: "False",
+				Reason: "RefNotPermitted",
+			},
+		),
+		waitDuration, tickDuration,
+	) {
+		t.Fatal(printHTTPRoutesConditions(ctx, client, nn))
 	}
 }
 

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -324,7 +324,7 @@ func setupControllers(
 		// ---------------------------------------------------------------------------
 		{
 			Enabled: featureGates[featuregates.GatewayFeature],
-			Controller: &crds.DynamicController{
+			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.Log.WithName("controllers").WithName("Dynamic/gatewayv1beta1"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
@@ -372,7 +372,7 @@ func setupControllers(
 		// ---------------------------------------------------------------------------
 		{
 			Enabled: featureGates[featuregates.GatewayAlphaFeature],
-			Controller: &crds.DynamicController{
+			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.Log.WithName("controllers").WithName("Dynamic/gatewayv1alpha2"),
 				CacheSyncTimeout: c.CacheSyncTimeout,

--- a/internal/manager/scheme/scheme.go
+++ b/internal/manager/scheme/scheme.go
@@ -1,6 +1,7 @@
 package scheme
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -17,6 +18,10 @@ import (
 // those that were enabled via the feature flags.
 func Get(fg map[string]bool) (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
+
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `crds.DynamicController` that ensures that RequiredCRDs are installed in the cluster and only then sets up all of its Controllers that depend on them. In case the CRDs are not installed at start-up time, DynamicController will set up a watch for CustomResourceDefinition and will dynamically set up its Controllers once it detects that all RequiredCRDs are already in place.

It's used for both the beta and alpha parts of the Gateway API.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3029.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
