### PR TITLE
fix(ci): fix kong image override

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -117,6 +117,16 @@ jobs:
         with:
           password: ${{ secrets.PULP_PASSWORD }}
 
+      # We need to pull the Gateway image locally if loading local image was specified.
+      # This is a "workaround" of the fact that we bind the env variable - responsible for
+      # indicating whether we'd like to load the images - for both controller
+      # and gateway. Hence when that's set to true we try to load the Gateway
+      # image which is available in the external container image registry but not
+      # locally and that fails.
+      - name: Pull Gateway image for tests
+        if: ${{ inputs.kong-image != '' && inputs.load-local-image }}
+        run: docker pull ${{ inputs.kong-image }}
+
       - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
@@ -124,7 +134,7 @@ jobs:
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ inputs.kic-image }}
           TEST_KONG_LOAD_IMAGES: ${{ inputs.load-local-image }}
-          TEST_KONG_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
+          TEST_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           GOTESTSUM_JUNITFILE: "e2e-${{ matrix.test }}${{ matrix.kubernetes-version }}-tests.xml"
@@ -181,7 +191,7 @@ jobs:
           # TODO: Once we have a way to load images into GKE, we can use the local image.
           # KTF issue that should enable it: https://github.com/Kong/kubernetes-testing-framework/issues/587
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
-          TEST_KONG_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
+          TEST_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
@@ -255,7 +265,7 @@ jobs:
         env:
           TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ inputs.kic-image }}
           TEST_KONG_LOAD_IMAGES: ${{ inputs.load-local-image }}
-          TEST_KONG_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
+          TEST_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           ISTIO_VERSION: ${{ matrix.istio-version }}

--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -20,7 +20,13 @@ jobs:
     secrets: inherit
     with:
       kic-image: kong/nightly-ingress-controller:nightly
-      kong-image: kong/kong:amd64-latest
+      # TODO: Previously we've used kong/kong:amd64-latest but that image reports
+      # its version (through AdminAPI / endpoint) as SHA instead of a semver.
+      # This breaks KIC's Admin root configuration verification on startup.
+      # To unblock this, we're switching to kong/kong-gateway-dev:nightly because
+      # it reports the next release to be released as semver in the version field.
+      # ref: https://github.com/Kong/kubernetes-ingress-controller/issues/4014
+      kong-image: kong/kong-gateway-dev:nightly
       all-supported-k8s-versions: false
       run-gke: false
       run-istio: false

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -96,7 +96,7 @@ jobs:
     with:
       kic-image: ${{ needs.choose-image.outputs.image }}
       load-local-image: ${{ inputs.controller-image == '' }}
-      kong-image: kong/kong:amd64-latest
+      kong-image: kong/kong-gateway-dev:nightly
       # these do not honor the inputs, as this job is intended to be a minimal
       # test against unreleased kong images, with the main run covering the
       # other test conditions


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to fix the Gateway version override in e2e tests that used an incorrect env variable: `TEST_KONG_KONG_IMAGE_OVERRIDE` instead of `TEST_KONG_IMAGE_OVERRIDE`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

~Currently blocked by #4014 because we cannot run with Gateway versions that report SHA in Admin API `/` response's: `.version` field.~

The above was mitigated by using `kong/kong-gateway-dev:nightly` instead which includes a semver (well not a semver but a 4 segment version instead of SHA which is parsable by `go-kong`'s `kong.ParseSemanticVersion`)


