### PR TITLE
tests: add RetryableHTTPClient util function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.4 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/nodes"
 	rg "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroups"
 	rgc "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroupsconfig"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 const (
@@ -175,6 +176,7 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
 			return nil
 		}),
+		rg.WithHTTPClient(helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())),
 	)
 	require.NoError(t, err)
 
@@ -208,6 +210,7 @@ func createClientCertificate(ctx context.Context, t *testing.T, rgID string) (ce
 			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
 			return nil
 		}),
+		rgc.WithHTTPClient(helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())),
 	)
 	require.NoError(t, err)
 

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +20,14 @@ func DefaultHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 10 * time.Second,
 	}
+}
+
+// RetryableHTTPClient wraps a client with retry logic. That should be used when calling external services that might
+// temporarily fail (e.g. Konnect APIs), and we don't want them to affect the test results.
+func RetryableHTTPClient(base *http.Client) *http.Client {
+	retryable := retryablehttp.NewClient()
+	retryable.HTTPClient = base
+	return retryable.StandardClient()
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `helpers.RetryableHTTPClient` that can be used for calling external services that might temporarily fail, and we do not want them to affect tests results.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

