### PR TITLE
chore(ci): unify import aliases and introduce forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
   - errorlint
   - exhaustive
   - exportloopref
+  - forbidigo
   - gci
   - godot
   - gofmt
@@ -64,17 +65,30 @@ linters-settings:
       alias: appsv1
     - pkg: k8s.io/api/admission/v1
       alias: admissionv1
+    - pkg: k8s.io/api/admissionregistration/v1
+      alias: admregv1
+    - pkg: k8s.io/api/discovery/v1
+      alias: discoveryv1
     - pkg: k8s.io/api/networking/v1
       alias: netv1
-    - pkg: k8s.io/api/networking/v1beta1
-      alias: netv1beta1
 
+    - pkg: k8s.io/apimachinery/pkg/types
+      alias: k8stypes
+    - pkg: k8s.io/apimachinery/pkg/util/validation
+      alias: utilvalidation      
+    - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+      alias: apiextensionsv1
     - pkg: k8s.io/apimachinery/pkg/api/errors
       alias: apierrors
     - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       alias: metav1
     - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
       alias: gateway${1}
+  forbidigo:
+    exclude_godoc_examples: false
+    forbid:
+      - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
+      - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'
   gomodguard:
     blocked:
       modules:

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -366,7 +366,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -484,7 +484,7 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) listClassless(obj client.Object) 
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -546,7 +546,7 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) Reconcile(ctx context.Context, re
 {{if .AcceptsIngressClassNameAnnotation}}
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
@@ -26,7 +26,7 @@ type Client struct {
 	lastConfigSHA       []byte
 
 	// podRef (optional) describes the Pod that the Client communicates with.
-	podRef *types.NamespacedName
+	podRef *k8stypes.NamespacedName
 }
 
 // NewClient creates an Admin API client that is to be used with a regular Admin API exposed by Kong Gateways.
@@ -159,16 +159,16 @@ func (c *Client) LastConfigSHA() []byte {
 
 // AttachPodReference allows attaching a Pod reference to the client. Should be used in case we know what Pod the client
 // will communicate with (e.g. when the gateway service discovery is used).
-func (c *Client) AttachPodReference(podNN types.NamespacedName) {
+func (c *Client) AttachPodReference(podNN k8stypes.NamespacedName) {
 	c.podRef = &podNN
 }
 
 // PodReference returns an optional reference to the Pod the client communicates with.
-func (c *Client) PodReference() (types.NamespacedName, bool) {
+func (c *Client) PodReference() (k8stypes.NamespacedName, bool) {
 	if c.podRef != nil {
 		return *c.podRef, true
 	}
-	return types.NamespacedName{}, false
+	return k8stypes.NamespacedName{}, false
 }
 
 type ClientFactory struct {

--- a/internal/adminapi/endpoints.go
+++ b/internal/adminapi/endpoints.go
@@ -7,7 +7,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,7 +15,7 @@ import (
 // DiscoveredAdminAPI represents an Admin API discovered from a Kubernetes Service.
 type DiscoveredAdminAPI struct {
 	Address string
-	PodRef  types.NamespacedName
+	PodRef  k8stypes.NamespacedName
 }
 
 // GetAdminAPIsForService performs an endpoint lookup, using provided kubeClient
@@ -24,7 +24,7 @@ type DiscoveredAdminAPI struct {
 func GetAdminAPIsForService(
 	ctx context.Context,
 	kubeClient client.Client,
-	service types.NamespacedName,
+	service k8stypes.NamespacedName,
 	portNames sets.Set[string],
 ) (sets.Set[DiscoveredAdminAPI], error) {
 	const (
@@ -87,7 +87,7 @@ func AdminAPIsFromEndpointSlice(endpoints discoveryv1.EndpointSlice, portNames s
 			if e.TargetRef == nil || e.TargetRef.Kind != "Pod" {
 				continue
 			}
-			podNN := types.NamespacedName{
+			podNN := k8stypes.NamespacedName{
 				Name:      e.TargetRef.Name,
 				Namespace: e.TargetRef.Namespace,
 			}

--- a/internal/adminapi/endpoints_envtest_test.go
+++ b/internal/adminapi/endpoints_envtest_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +61,7 @@ func TestGetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(
 			var (
 				ns          = envtest.CreateNamespace(ctx, t, client)
 				serviceName = uuid.NewString()
-				service     = types.NamespacedName{
+				service     = k8stypes.NamespacedName{
 					Namespace: ns.Name,
 					Name:      serviceName,
 				}

--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -52,7 +52,7 @@ func TestAddressesFromEndpointSlice(t *testing.T) {
 			},
 			portNames: sets.New("admin"),
 			want: sets.New(
-				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: k8stypes.NamespacedName{
 					Name: "pod-1", Namespace: "ns",
 				}},
 			),
@@ -150,11 +150,11 @@ func TestAddressesFromEndpointSlice(t *testing.T) {
 			},
 			portNames: sets.New("admin"),
 			want: sets.New(
-				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-1",
 				}},
-				DiscoveredAdminAPI{Address: "https://10.0.1.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.1.1:8444", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-2",
 				}},
@@ -252,11 +252,11 @@ func TestAddressesFromEndpointSlice(t *testing.T) {
 			},
 			portNames: sets.New("admin", "admin-tls"),
 			want: sets.New(
-				DiscoveredAdminAPI{Address: "https://10.0.0.1:8443", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.0.1:8443", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-1",
 				}},
-				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-1",
 				}},
@@ -337,14 +337,14 @@ func TestGetAdminAPIsForService(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		service types.NamespacedName
+		service k8stypes.NamespacedName
 		objects []client.ObjectList
 		want    sets.Set[DiscoveredAdminAPI]
 		wantErr bool
 	}{
 		{
 			name: "basic",
-			service: types.NamespacedName{
+			service: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      serviceName,
 			},
@@ -423,11 +423,11 @@ func TestGetAdminAPIsForService(t *testing.T) {
 				},
 			},
 			want: sets.New(
-				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://10.0.0.1:8444", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-1",
 				}},
-				DiscoveredAdminAPI{Address: "https://9.0.0.1:8444", PodRef: types.NamespacedName{
+				DiscoveredAdminAPI{Address: "https://9.0.0.1:8444", PodRef: k8stypes.NamespacedName{
 					Namespace: "ns",
 					Name:      "pod-2",
 				}},
@@ -435,7 +435,7 @@ func TestGetAdminAPIsForService(t *testing.T) {
 		},
 		{
 			name: "ports not matching the specified port names are not taken into account",
-			service: types.NamespacedName{
+			service: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      serviceName,
 			},
@@ -469,7 +469,7 @@ func TestGetAdminAPIsForService(t *testing.T) {
 		},
 		{
 			name: "Endpoints without a TargetRef are not matched",
-			service: types.NamespacedName{
+			service: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      serviceName,
 			},
@@ -502,7 +502,7 @@ func TestGetAdminAPIsForService(t *testing.T) {
 		},
 		{
 			name: "not Ready Endpoints are not matched",
-			service: types.NamespacedName{
+			service: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      serviceName,
 			},

--- a/internal/admission/response_builder.go
+++ b/internal/admission/response_builder.go
@@ -3,17 +3,17 @@ package admission
 import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 type ResponseBuilder struct {
-	uid      types.UID
+	uid      k8stypes.UID
 	message  string
 	allowed  bool
 	warnings []string
 }
 
-func NewResponseBuilder(uid types.UID) *ResponseBuilder {
+func NewResponseBuilder(uid k8stypes.UID) *ResponseBuilder {
 	return &ResponseBuilder{uid: uid}
 }
 

--- a/internal/admission/response_builder_test.go
+++ b/internal/admission/response_builder_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/admission"
 )
 
 func TestResponseBuilder(t *testing.T) {
-	someUID := types.UID("f0c595d0-09f5-4dca-95b7-80869e250068")
+	someUID := k8stypes.UID("f0c595d0-09f5-4dca-95b7-80869e250068")
 	testCases := []struct {
 		name             string
 		modifyBuilderFn  func(b *admission.ResponseBuilder)

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 )
@@ -447,6 +447,6 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 func testDiscoveredAdminAPI(address string) adminapi.DiscoveredAdminAPI {
 	return adminapi.DiscoveredAdminAPI{
 		Address: address,
-		PodRef:  types.NamespacedName{Name: "pod-1", Namespace: "ns"},
+		PodRef:  k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns"},
 	}
 }

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -9,7 +9,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +29,7 @@ type KongAdminAPIServiceReconciler struct {
 	client.Client
 
 	// ServiceNN is the service NamespacedName to watch EndpointSlices for.
-	ServiceNN types.NamespacedName
+	ServiceNN k8stypes.NamespacedName
 	// PortNames is the set of port names that Admin API Service ports will be
 	// matched against.
 	PortNames        sets.Set[string]
@@ -42,7 +42,7 @@ type KongAdminAPIServiceReconciler struct {
 	Cache DiscoveredAdminAPIsCache
 }
 
-type DiscoveredAdminAPIsCache map[types.NamespacedName]sets.Set[adminapi.DiscoveredAdminAPI]
+type DiscoveredAdminAPIsCache map[k8stypes.NamespacedName]sets.Set[adminapi.DiscoveredAdminAPI]
 
 type EndpointsNotifier interface {
 	Notify(adminAPIs []adminapi.DiscoveredAdminAPI)

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -18,7 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -70,7 +70,7 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kong-admin",
 			Namespace: ns.Name,
-			UID:       types.UID(uuid.NewString()),
+			UID:       k8stypes.UID(uuid.NewString()),
 		},
 	}
 
@@ -78,7 +78,7 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 	require.NoError(t,
 		(&configuration.KongAdminAPIServiceReconciler{
 			Client: mgr.GetClient(),
-			ServiceNN: types.NamespacedName{
+			ServiceNN: k8stypes.NamespacedName{
 				Name:      adminService.Name,
 				Namespace: adminService.Namespace,
 			},
@@ -178,14 +178,14 @@ func TestKongAdminAPIController(t *testing.T) {
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.1:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.2:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
@@ -255,7 +255,7 @@ func TestKongAdminAPIController(t *testing.T) {
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.2:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
@@ -375,28 +375,28 @@ func TestKongAdminAPIController(t *testing.T) {
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.1:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.2:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.10:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.20:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
@@ -466,14 +466,14 @@ func TestKongAdminAPIController(t *testing.T) {
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.1:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.2:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
@@ -487,21 +487,21 @@ func TestKongAdminAPIController(t *testing.T) {
 			endpoints.Endpoints[i].Conditions.Ready = lo.ToPtr(false)
 		}
 		require.NoError(t, client.Update(ctx, &endpoints, &ctrlclient.UpdateOptions{}))
-		require.NoError(t, client.Get(ctx, types.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))
+		require.NoError(t, client.Get(ctx, k8stypes.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))
 		assert.Eventually(t, func() bool { return len(n.LastNotified()) == 0 }, 3*time.Second, time.Millisecond)
 
 		// Update 1 endpoint so that that it's Ready.
 		endpoints.Endpoints[0].Conditions.Ready = lo.ToPtr(true)
 
 		require.NoError(t, client.Update(ctx, &endpoints, &ctrlclient.UpdateOptions{}))
-		require.NoError(t, client.Get(ctx, types.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))
+		require.NoError(t, client.Get(ctx, k8stypes.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))
 		assert.Eventually(t, func() bool { return len(n.LastNotified()) == 1 }, 3*time.Second, time.Millisecond)
 
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.1:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
@@ -571,14 +571,14 @@ func TestKongAdminAPIController(t *testing.T) {
 			[]adminapi.DiscoveredAdminAPI{
 				{
 					Address: "https://10.0.0.1:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
 					Address: "https://10.0.0.2:8080",
-					PodRef: types.NamespacedName{
+					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},

--- a/internal/controllers/configuration/object_references.go
+++ b/internal/controllers/configuration/object_references.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -21,8 +21,8 @@ import (
 func updateReferredObjects(
 	ctx context.Context, client client.Client, refIndexers ctrlref.CacheIndexers, dataplaneClient *dataplane.KongClient, obj client.Object,
 ) error {
-	referredSecretNameMap := make(map[types.NamespacedName]struct{})
-	var referredSecretList []types.NamespacedName
+	referredSecretNameMap := make(map[k8stypes.NamespacedName]struct{})
+	var referredSecretList []k8stypes.NamespacedName
 	switch obj := obj.(type) {
 	// functions update***ReferredSecrets first list the secrets referred by object,
 	// then call UpdateReferencesToSecret to store reference records between the object and referred secrets,
@@ -47,15 +47,15 @@ func updateReferredObjects(
 	return ctrlref.UpdateReferencesToSecret(ctx, client, refIndexers, dataplaneClient, obj, referredSecretNameMap)
 }
 
-func listCoreV1ServiceReferredSecrets(service *corev1.Service) []types.NamespacedName {
+func listCoreV1ServiceReferredSecrets(service *corev1.Service) []k8stypes.NamespacedName {
 	if service.Annotations == nil {
 		return nil
 	}
 
-	referredSecretNames := make([]types.NamespacedName, 0, 1)
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, 1)
 	secretName := annotations.ExtractClientCertificate(service.Annotations)
 	if secretName != "" {
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: service.Namespace,
 			Name:      secretName,
 		}
@@ -65,13 +65,13 @@ func listCoreV1ServiceReferredSecrets(service *corev1.Service) []types.Namespace
 	return referredSecretNames
 }
 
-func listNetV1IngressReferredSecrets(ingress *netv1.Ingress) []types.NamespacedName {
-	referredSecretNames := make([]types.NamespacedName, 0, len(ingress.Spec.TLS))
+func listNetV1IngressReferredSecrets(ingress *netv1.Ingress) []k8stypes.NamespacedName {
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, len(ingress.Spec.TLS))
 	for _, tls := range ingress.Spec.TLS {
 		if tls.SecretName == "" {
 			continue
 		}
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: ingress.Namespace,
 			Name:      tls.SecretName,
 		}
@@ -80,10 +80,10 @@ func listNetV1IngressReferredSecrets(ingress *netv1.Ingress) []types.NamespacedN
 	return referredSecretNames
 }
 
-func listKongPluginReferredSecrets(plugin *kongv1.KongPlugin) []types.NamespacedName {
-	referredSecretNames := make([]types.NamespacedName, 0, 1)
+func listKongPluginReferredSecrets(plugin *kongv1.KongPlugin) []k8stypes.NamespacedName {
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, 1)
 	if plugin.ConfigFrom != nil {
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: plugin.Namespace,
 			Name:      plugin.ConfigFrom.SecretValue.Secret,
 		}
@@ -92,10 +92,10 @@ func listKongPluginReferredSecrets(plugin *kongv1.KongPlugin) []types.Namespaced
 	return referredSecretNames
 }
 
-func listKongClusterPluginReferredSecrets(plugin *kongv1.KongClusterPlugin) []types.NamespacedName {
-	referredSecretNames := make([]types.NamespacedName, 0, 1)
+func listKongClusterPluginReferredSecrets(plugin *kongv1.KongClusterPlugin) []k8stypes.NamespacedName {
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, 1)
 	if plugin.ConfigFrom != nil {
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: plugin.ConfigFrom.SecretValue.Namespace,
 			Name:      plugin.ConfigFrom.SecretValue.Secret,
 		}
@@ -104,10 +104,10 @@ func listKongClusterPluginReferredSecrets(plugin *kongv1.KongClusterPlugin) []ty
 	return referredSecretNames
 }
 
-func listKongConsumerReferredSecrets(consumer *kongv1.KongConsumer) []types.NamespacedName {
-	referredSecretNames := make([]types.NamespacedName, 0, len(consumer.Credentials))
+func listKongConsumerReferredSecrets(consumer *kongv1.KongConsumer) []k8stypes.NamespacedName {
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, len(consumer.Credentials))
 	for _, secretName := range consumer.Credentials {
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: consumer.Namespace,
 			Name:      secretName,
 		}
@@ -116,13 +116,13 @@ func listKongConsumerReferredSecrets(consumer *kongv1.KongConsumer) []types.Name
 	return referredSecretNames
 }
 
-func listTCPIngressReferredSecrets(tcpIngress *kongv1beta1.TCPIngress) []types.NamespacedName {
-	referredSecretNames := make([]types.NamespacedName, 0, len(tcpIngress.Spec.TLS))
+func listTCPIngressReferredSecrets(tcpIngress *kongv1beta1.TCPIngress) []k8stypes.NamespacedName {
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, len(tcpIngress.Spec.TLS))
 	for _, tls := range tcpIngress.Spec.TLS {
 		if tls.SecretName == "" {
 			continue
 		}
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: tcpIngress.Namespace,
 			Name:      tls.SecretName,
 		}

--- a/internal/controllers/configuration/object_references_test.go
+++ b/internal/controllers/configuration/object_references_test.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
@@ -18,7 +18,7 @@ func TestListCoreV1ServiceReferredSecrets(t *testing.T) {
 		name          string
 		service       *corev1.Service
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "service_has_no_annotations",
@@ -55,7 +55,7 @@ func TestListCoreV1ServiceReferredSecrets(t *testing.T) {
 				},
 			},
 			secretNum:     1,
-			refSecretName: types.NamespacedName{Namespace: "ns1", Name: "secret1"},
+			refSecretName: k8stypes.NamespacedName{Namespace: "ns1", Name: "secret1"},
 		},
 	}
 
@@ -76,7 +76,7 @@ func TestListIngressReferredSecrets(t *testing.T) {
 		name          string
 		ingress       *netv1.Ingress
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "ingress_has_no_tls_should_refer_no_secrets",
@@ -102,7 +102,7 @@ func TestListIngressReferredSecrets(t *testing.T) {
 				},
 			},
 			secretNum:     1,
-			refSecretName: types.NamespacedName{Namespace: "ns", Name: "secret1"},
+			refSecretName: k8stypes.NamespacedName{Namespace: "ns", Name: "secret1"},
 		},
 		{
 			name: "ingress_has_tls_without_secretName_should_refer_no_secrets",
@@ -138,7 +138,7 @@ func TestListKongPluginReferredSecrets(t *testing.T) {
 		name          string
 		plugin        *kongv1.KongPlugin
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "kong_plugin_refer_no_secrets",
@@ -165,7 +165,7 @@ func TestListKongPluginReferredSecrets(t *testing.T) {
 				},
 			},
 			secretNum: 1,
-			refSecretName: types.NamespacedName{
+			refSecretName: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      "secret1",
 			},
@@ -188,7 +188,7 @@ func TestListKongClusterPluginReferredSecrets(t *testing.T) {
 		name          string
 		plugin        *kongv1.KongClusterPlugin
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "kong_cluster_plugin_refer_no_secrets",
@@ -214,7 +214,7 @@ func TestListKongClusterPluginReferredSecrets(t *testing.T) {
 				},
 			},
 			secretNum: 1,
-			refSecretName: types.NamespacedName{
+			refSecretName: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      "secret1",
 			},
@@ -237,7 +237,7 @@ func TestListKongConsumerReferredSecrets(t *testing.T) {
 		name          string
 		consumer      *kongv1.KongConsumer
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "consumer_refer_no_secrets",
@@ -259,7 +259,7 @@ func TestListKongConsumerReferredSecrets(t *testing.T) {
 				Credentials: []string{"secret1", "secret2"},
 			},
 			secretNum: 2,
-			refSecretName: types.NamespacedName{
+			refSecretName: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      "secret1",
 			},
@@ -282,7 +282,7 @@ func TestListTCPIngressReferredSecrets(t *testing.T) {
 		name          string
 		tcpIngress    *kongv1beta1.TCPIngress
 		secretNum     int
-		refSecretName types.NamespacedName
+		refSecretName k8stypes.NamespacedName
 	}{
 		{
 			name: "tcp_ingress_refer_no_secrets",
@@ -309,7 +309,7 @@ func TestListTCPIngressReferredSecrets(t *testing.T) {
 				},
 			},
 			secretNum: 1,
-			refSecretName: types.NamespacedName{
+			refSecretName: k8stypes.NamespacedName{
 				Namespace: "ns",
 				Name:      "secret1",
 			},

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -30,7 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -298,7 +298,7 @@ func (r *NetV1IngressReconciler) listClassless(obj client.Object) []reconcile.Re
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -357,7 +357,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
@@ -728,7 +728,7 @@ func (r *KongV1KongClusterPluginReconciler) listClassless(obj client.Object) []r
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -787,7 +787,7 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
@@ -882,7 +882,7 @@ func (r *KongV1KongConsumerReconciler) listClassless(obj client.Object) []reconc
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -941,7 +941,7 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
@@ -1052,7 +1052,7 @@ func (r *KongV1Beta1TCPIngressReconciler) listClassless(obj client.Object) []rec
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -1111,7 +1111,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
@@ -1246,7 +1246,7 @@ func (r *KongV1Beta1UDPIngressReconciler) listClassless(obj client.Object) []rec
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -1295,7 +1295,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -60,8 +60,8 @@ type GatewayReconciler struct { //nolint:revive
 
 	ReferenceIndexers ctrlref.CacheIndexers
 
-	PublishServiceRef    types.NamespacedName
-	PublishServiceUDPRef mo.Option[types.NamespacedName]
+	PublishServiceRef    k8stypes.NamespacedName
+	PublishServiceUDPRef mo.Option[k8stypes.NamespacedName]
 
 	// If enableReferenceGrant is true, controller will watch ReferenceGrants
 	// to invalidate or allow cross-namespace TLSConfigs in gateways.
@@ -227,7 +227,7 @@ func (r *GatewayReconciler) listReferenceGrantsForGateway(obj client.Object) []r
 				from.Kind == gatewayv1alpha2.Kind("Gateway") &&
 				from.Group == gatewayv1alpha2.Group("gateway.networking.k8s.io") {
 				recs = append(recs, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: gateway.Namespace,
 						Name:      gateway.Name,
 					},
@@ -250,13 +250,13 @@ func (r *GatewayReconciler) listGatewaysForService(svc client.Object) (recs []re
 	}
 	for _, gateway := range gateways.Items {
 		gatewayClass := &gatewayv1beta1.GatewayClass{}
-		if err := r.Client.Get(context.Background(), types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
+		if err := r.Client.Get(context.Background(), k8stypes.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
 			r.Log.Error(err, "failed to retrieve gateway class in watch predicates", "gatewayclass", gateway.Spec.GatewayClassName)
 			return
 		}
 		if isGatewayClassControlledAndUnmanaged(gatewayClass) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: gateway.Namespace,
 					Name:      gateway.Name,
 				},
@@ -579,7 +579,7 @@ func (r *GatewayReconciler) determineServiceForGateway(ctx context.Context, ref 
 	// provided to the controller manager via flags when operating on unmanaged gateways. This constraint may
 	// be loosened in later iterations if there is need.
 
-	var name types.NamespacedName
+	var name k8stypes.NamespacedName
 	switch {
 	case ref == r.PublishServiceRef.String():
 		name = r.PublishServiceRef

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -286,19 +286,19 @@ func TestReconcileGatewaysIfClassMatches(t *testing.T) {
 	t.Log("verifying reconciliation results")
 	expected := []reconcile.Request{
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: k8stypes.NamespacedName{
 				Name:      "sanfrancisco",
 				Namespace: "california",
 			},
 		},
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: k8stypes.NamespacedName{
 				Name:      "sandiego",
 				Namespace: "california",
 			},
 		},
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: k8stypes.NamespacedName{
 				Name:      "losangelos",
 				Namespace: "california",
 			},

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -104,7 +104,7 @@ func reconcileGatewaysIfClassMatches(gatewayClass client.Object, gateways []Gate
 	for _, gateway := range gateways {
 		if string(gateway.Spec.GatewayClassName) == gatewayClass.GetName() {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: gateway.Namespace,
 					Name:      gateway.Name,
 				},
@@ -115,8 +115,8 @@ func reconcileGatewaysIfClassMatches(gatewayClass client.Object, gateways []Gate
 }
 
 // list namespaced names of secrets referred by the gateway.
-func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[types.NamespacedName]struct{} {
-	nsNames := make(map[types.NamespacedName]struct{})
+func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[k8stypes.NamespacedName]struct{} {
+	nsNames := make(map[k8stypes.NamespacedName]struct{})
 
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.TLS == nil {
@@ -137,7 +137,7 @@ func listSecretNamesReferredByGateway(gateway *gatewayv1beta1.Gateway) map[types
 				refNamespace = string(*certRef.Namespace)
 			}
 
-			nsNames[types.NamespacedName{
+			nsNames[k8stypes.NamespacedName{
 				Namespace: refNamespace,
 				Name:      string(certRef.Name),
 			}] = struct{}{}
@@ -284,7 +284,7 @@ func getListenerStatus(
 				if certRef.Namespace != nil {
 					secretNamespace = string(*certRef.Namespace)
 				}
-				if err := client.Get(ctx, types.NamespacedName{Namespace: secretNamespace, Name: string(certRef.Name)}, secret); err != nil {
+				if err := client.Get(ctx, k8stypes.NamespacedName{Namespace: secretNamespace, Name: string(certRef.Name)}, secret); err != nil {
 					if !apierrors.IsNotFound(err) {
 						return nil, err
 					}

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -162,7 +162,7 @@ func (r *GRPCRouteReconciler) listGRPCRoutesForGatewayClass(obj client.Object) [
 			if gatewaysForNamespace, ok := gateways[namespace]; ok {
 				if _, ok := gatewaysForNamespace[string(parentRef.Name)]; ok {
 					queue = append(queue, reconcile.Request{
-						NamespacedName: types.NamespacedName{
+						NamespacedName: k8stypes.NamespacedName{
 							Namespace: grpcroute.Namespace,
 							Name:      grpcroute.Name,
 						},
@@ -218,7 +218,7 @@ func (r *GRPCRouteReconciler) listGRPCRoutesForGateway(obj client.Object) []reco
 			}
 			if namespace == gw.Namespace && string(parentRef.Name) == gw.Name {
 				queue = append(queue, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: grpcroute.Namespace,
 						Name:      grpcroute.Name,
 					},

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -150,7 +150,7 @@ func (r *HTTPRouteReconciler) listReferenceGrantsForHTTPRoute(obj client.Object)
 				from.Kind == ("HTTPRoute") &&
 				from.Group == ("gateway.networking.k8s.io") {
 				recs = append(recs, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: gateway.Namespace,
 						Name:      gateway.Name,
 					},
@@ -234,7 +234,7 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForGatewayClass(obj client.Object) [
 			if gatewaysForNamespace, ok := gateways[namespace]; ok {
 				if _, ok := gatewaysForNamespace[string(parentRef.Name)]; ok {
 					queue = append(queue, reconcile.Request{
-						NamespacedName: types.NamespacedName{
+						NamespacedName: k8stypes.NamespacedName{
 							Namespace: httproute.Namespace,
 							Name:      httproute.Name,
 						},
@@ -290,7 +290,7 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForGateway(obj client.Object) []reco
 			}
 			if namespace == gw.Namespace && string(parentRef.Name) == gw.Name {
 				queue = append(queue, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: httproute.Namespace,
 						Name:      httproute.Name,
 					},
@@ -669,7 +669,7 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 			// Check if all the objects referenced actually exist
 			// Only services are currently supported as BackendRef objects
 			service := &corev1.Service{}
-			err := r.Client.Get(ctx, types.NamespacedName{Namespace: backendNamespace, Name: string(backendRef.Name)}, service)
+			err := r.Client.Get(ctx, k8stypes.NamespacedName{Namespace: backendNamespace, Name: string(backendRef.Name)}, service)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					return "", err

--- a/internal/controllers/gateway/httproute_controller_envtest_test.go
+++ b/internal/controllers/gateway/httproute_controller_envtest_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -202,7 +202,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 	}
 	require.NoError(t, client.Create(ctx, &route))
 
-	nn := types.NamespacedName{
+	nn := k8stypes.NamespacedName{
 		Namespace: route.GetNamespace(),
 		Name:      route.GetName(),
 	}
@@ -285,7 +285,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 	}
 }
 
-func printHTTPRoutesConditions(ctx context.Context, client ctrlclient.Client, nn types.NamespacedName) string {
+func printHTTPRoutesConditions(ctx context.Context, client ctrlclient.Client, nn k8stypes.NamespacedName) string {
 	var route gateway.HTTPRoute
 	err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: nn.Namespace, Name: nn.Name}, &route)
 	if err != nil {

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -1206,7 +1206,7 @@ func Test_getSupportedGatewayForRoute(t *testing.T) {
 }
 
 func Test_ensureParentsProgrammedCondition(t *testing.T) {
-	createGateway := func(nn types.NamespacedName) *Gateway {
+	createGateway := func(nn k8stypes.NamespacedName) *Gateway {
 		return &Gateway{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: gatewayv1beta1.GroupVersion.String(),
@@ -1215,7 +1215,7 @@ func Test_ensureParentsProgrammedCondition(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nn.Name,
 				Namespace: nn.Namespace,
-				UID:       types.UID(uuid.NewString()),
+				UID:       k8stypes.UID(uuid.NewString()),
 			},
 			Spec: gatewayv1beta1.GatewaySpec{
 				GatewayClassName: "test-gatewayclass",
@@ -1249,12 +1249,12 @@ func Test_ensureParentsProgrammedCondition(t *testing.T) {
 	}
 
 	t.Run("HTTPRoute", func(t *testing.T) {
-		gatewayNN1 := types.NamespacedName{
+		gatewayNN1 := k8stypes.NamespacedName{
 			Namespace: "test-namespace",
 			Name:      "test-gateway",
 		}
 		gateway1 := createGateway(gatewayNN1)
-		gatewayNN2 := types.NamespacedName{
+		gatewayNN2 := k8stypes.NamespacedName{
 			Namespace: "test-namespace",
 			Name:      "test-gateway-2",
 		}

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -158,7 +158,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGatewayClass(obj client.Object) []r
 			if gatewaysForNamespace, ok := gateways[namespace]; ok {
 				if _, ok := gatewaysForNamespace[string(parentRef.Name)]; ok {
 					queue = append(queue, reconcile.Request{
-						NamespacedName: types.NamespacedName{
+						NamespacedName: k8stypes.NamespacedName{
 							Namespace: tcproute.Namespace,
 							Name:      tcproute.Name,
 						},
@@ -214,7 +214,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGateway(obj client.Object) []reconc
 			}
 			if namespace == gw.Namespace && string(parentRef.Name) == gw.Name {
 				queue = append(queue, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: tcproute.Namespace,
 						Name:      tcproute.Name,
 					},

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -158,7 +158,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGatewayClass(obj client.Object) []r
 			if gatewaysForNamespace, ok := gateways[namespace]; ok {
 				if _, ok := gatewaysForNamespace[string(parentRef.Name)]; ok {
 					queue = append(queue, reconcile.Request{
-						NamespacedName: types.NamespacedName{
+						NamespacedName: k8stypes.NamespacedName{
 							Namespace: tlsroute.Namespace,
 							Name:      tlsroute.Name,
 						},
@@ -214,7 +214,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGateway(obj client.Object) []reconc
 			}
 			if namespace == gw.Namespace && string(parentRef.Name) == gw.Name {
 				queue = append(queue, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: tlsroute.Namespace,
 						Name:      tlsroute.Name,
 					},

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -158,7 +158,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGatewayClass(obj client.Object) []r
 			if gatewaysForNamespace, ok := gateways[namespace]; ok {
 				if _, ok := gatewaysForNamespace[string(parentRef.Name)]; ok {
 					queue = append(queue, reconcile.Request{
-						NamespacedName: types.NamespacedName{
+						NamespacedName: k8stypes.NamespacedName{
 							Namespace: udproute.Namespace,
 							Name:      udproute.Name,
 						},
@@ -214,7 +214,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGateway(obj client.Object) []reconc
 			}
 			if namespace == gw.Namespace && string(parentRef.Name) == gw.Name {
 				queue = append(queue, reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8stypes.NamespacedName{
 						Namespace: udproute.Namespace,
 						Name:      udproute.Name,
 					},

--- a/internal/controllers/knative/knative.go
+++ b/internal/controllers/knative/knative.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	knativev1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	knativeApis "knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -105,7 +105,7 @@ func (r *Knativev1alpha1IngressReconciler) listClassless(_ client.Object) []reco
 	for i, resource := range resourceList.Items {
 		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
 			recs = append(recs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: k8stypes.NamespacedName{
 					Namespace: resource.Namespace,
 					Name:      resource.Name,
 				},
@@ -162,7 +162,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 
 	class := new(netv1.IngressClass)
 	if !r.DisableIngressClassLookups {
-		if err := r.Get(ctx, types.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
 			// we log this without taking action to support legacy configurations that only set ingressClassName or
 			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
 			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
@@ -177,13 +177,13 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	// update reference records for secrets referred by the ingress
-	referredSecretNames := make(map[types.NamespacedName]struct{}, len(obj.Spec.TLS))
+	referredSecretNames := make(map[k8stypes.NamespacedName]struct{}, len(obj.Spec.TLS))
 	for _, tls := range obj.Spec.TLS {
 		secretNamespace := tls.SecretNamespace
 		if tls.SecretNamespace != "" {
 			secretNamespace = tls.SecretNamespace
 		}
-		nsName := types.NamespacedName{
+		nsName := k8stypes.NamespacedName{
 			Namespace: secretNamespace,
 			Name:      tls.SecretName,
 		}

--- a/internal/controllers/reference/reference.go
+++ b/internal/controllers/reference/reference.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
@@ -23,7 +23,7 @@ const (
 func UpdateReferencesToSecret(
 	ctx context.Context,
 	c client.Client, indexers CacheIndexers, dataplaneClient *dataplane.KongClient,
-	referrer client.Object, referencedSecretNameMap map[types.NamespacedName]struct{},
+	referrer client.Object, referencedSecretNameMap map[k8stypes.NamespacedName]struct{},
 ) error {
 	for nsName := range referencedSecretNameMap {
 		secret := &corev1.Secret{
@@ -61,7 +61,7 @@ func UpdateReferencesToSecret(
 func removeOutdatedReferencesToSecret(
 	ctx context.Context,
 	indexers CacheIndexers, c client.Client, dataplaneClient *dataplane.KongClient,
-	referrer client.Object, referredSecretNameMap map[types.NamespacedName]struct{},
+	referrer client.Object, referredSecretNameMap map[k8stypes.NamespacedName]struct{},
 ) error {
 	referents, err := indexers.ListReferredObjects(referrer)
 	if err != nil {
@@ -71,7 +71,7 @@ func removeOutdatedReferencesToSecret(
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		// delete the reference record if the secret is not referred by the service.
 		if gvk.Group == corev1.GroupName && gvk.Version == VersionV1 && gvk.Kind == KindSecret {
-			namespacedName := types.NamespacedName{
+			namespacedName := k8stypes.NamespacedName{
 				Namespace: obj.GetNamespace(),
 				Name:      obj.GetName(),
 			}

--- a/internal/dataplane/parser/ingressrules.go
+++ b/internal/dataplane/parser/ingressrules.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -219,13 +219,13 @@ func (m SecretNameToSNIs) merge(o SecretNameToSNIs) {
 
 type SNIs struct {
 	// parents are objects that the SNIs are inherited from
-	parents map[types.UID]client.Object
+	parents map[k8stypes.UID]client.Object
 	hosts   []string
 }
 
 func newSNIs() *SNIs {
 	return &SNIs{
-		parents: map[types.UID]client.Object{},
+		parents: map[k8stypes.UID]client.Object{},
 	}
 }
 

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -18,7 +18,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
 
@@ -463,7 +463,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			objects.Secrets = []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+						UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 						Name:      "conf-secret",
 						Namespace: "default",
 					},
@@ -570,7 +570,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			objects.Secrets = []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+						UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 						Name:      "conf-secret",
 						Namespace: "default",
 					},
@@ -674,7 +674,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			objects.Secrets = []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+						UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 						Name:      "conf-secret",
 						Namespace: "default",
 					},
@@ -705,7 +705,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 		objects.Secrets = []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 					Name:      "conf-secret",
 					Namespace: "default",
 				},
@@ -827,7 +827,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			objects.Secrets = []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+						UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 						Name:      "conf-secret",
 						Namespace: "default",
 					},
@@ -1080,7 +1080,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		secrets := []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 					Name:      "secret1",
 					Namespace: "default",
 				},
@@ -4984,7 +4984,7 @@ func TestCertificate(t *testing.T) {
 		secrets := []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 					Name:      "secret1",
 					Namespace: "ns1",
 				},
@@ -4995,7 +4995,7 @@ func TestCertificate(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("6392jz73-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("6392jz73-180b-4702-a91f-61351a33c6e4"),
 					Name:      "secret1",
 					Namespace: "ns2",
 				},
@@ -5006,7 +5006,7 @@ func TestCertificate(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("72x2j56k-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("72x2j56k-180b-4702-a91f-61351a33c6e4"),
 					Name:      "secret1",
 					Namespace: "ns3",
 				},
@@ -5101,7 +5101,7 @@ func TestCertificate(t *testing.T) {
 		secrets := []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+					UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 					Name:      "secret",
 					Namespace: "ns1",
 				},

--- a/internal/dataplane/parser/translate_secrets.go
+++ b/internal/dataplane/parser/translate_secrets.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
@@ -77,7 +77,7 @@ func toKongCACertificate(certSecret *corev1.Secret, secretID string) (kong.CACer
 }
 
 func getPluginsAssociatedWithCACertSecret(secretID string, storer store.Storer) []client.Object {
-	refersToSecret := func(pluginConfig v1.JSON) bool {
+	refersToSecret := func(pluginConfig apiextensionsv1.JSON) bool {
 		cfg := struct {
 			CACertificates []string `json:"ca_certificates,omitempty"`
 		}{}

--- a/internal/dataplane/parser/translate_secrets_test.go
+++ b/internal/dataplane/parser/translate_secrets_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -20,7 +20,7 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Config: v1.JSON{
+			Config: apiextensionsv1.JSON{
 				Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, secretID)),
 			},
 		}
@@ -31,7 +31,7 @@ func TestGetPluginsAssociatedWithCACertSecret(t *testing.T) {
 				Name:        name,
 				Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 			},
-			Config: v1.JSON{
+			Config: apiextensionsv1.JSON{
 				Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, secretID)),
 			},
 		}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/samber/mo"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -21,7 +21,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 )
 
-type OptionalNamespacedName = mo.Option[types.NamespacedName]
+type OptionalNamespacedName = mo.Option[k8stypes.NamespacedName]
 
 // Type override to be used with OptionalNamespacedName variables to override their type name printed in the help text.
 var nnTypeNameOverride = WithTypeNameOverride[OptionalNamespacedName]("namespacedName")

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/samber/mo"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 )
@@ -27,7 +27,7 @@ func namespacedNameFromFlagValue(flagValue string) (OptionalNamespacedName, erro
 		return OptionalNamespacedName{}, errors.New("name cannot be empty")
 	}
 
-	return mo.Some(types.NamespacedName{
+	return mo.Some(k8stypes.NamespacedName{
 		Namespace: parts[0],
 		Name:      parts[1],
 	}), nil

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
@@ -48,7 +48,7 @@ func TestConfigValidatedVars(t *testing.T) {
 				ExtractValueFn: func(c manager.Config) any {
 					return c.PublishService
 				},
-				ExpectedValue: mo.Some(types.NamespacedName{Namespace: "namespace", Name: "servicename"}),
+				ExpectedValue: mo.Some(k8stypes.NamespacedName{Namespace: "namespace", Name: "servicename"}),
 			},
 			{
 				Input:                 "servicename",
@@ -61,7 +61,7 @@ func TestConfigValidatedVars(t *testing.T) {
 				ExtractValueFn: func(c manager.Config) any {
 					return c.KongAdminSvc
 				},
-				ExpectedValue: mo.Some(types.NamespacedName{Namespace: "namespace", Name: "servicename"}),
+				ExpectedValue: mo.Some(k8stypes.NamespacedName{Namespace: "namespace", Name: "servicename"}),
 			},
 			{
 				Input:                 "namespace/",
@@ -100,7 +100,7 @@ func TestConfigValidate(t *testing.T) {
 	t.Run("konnect", func(t *testing.T) {
 		validEnabled := func() *manager.Config {
 			return &manager.Config{
-				KongAdminSvc: mo.Some(types.NamespacedName{Name: "admin-svc", Namespace: "ns"}),
+				KongAdminSvc: mo.Some(k8stypes.NamespacedName{Name: "admin-svc", Namespace: "ns"}),
 				Konnect: adminapi.KonnectConfig{
 					ConfigSynchronizationEnabled: true,
 					RuntimeGroupID:               "fbd3036f-0f1c-4e98-b71c-d4cd61213f90",
@@ -271,7 +271,7 @@ func TestConfigValidateGatewayDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &manager.Config{}
 			if tc.gatewayDiscovery {
-				c.KongAdminSvc = mo.Some(types.NamespacedName{Name: "admin-svc", Namespace: "ns"})
+				c.KongAdminSvc = mo.Some(k8stypes.NamespacedName{Name: "admin-svc", Namespace: "ns"})
 			}
 			err := c.ValidateGatewayDiscovery(tc.dbMode)
 			if !tc.expectError {

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kong/deck/cprint"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -225,7 +225,7 @@ func buildDataplaneAddressFinder(mgrc client.Client, publishStatusAddress []stri
 	return nil, errors.New("no publish status address or publish service were provided")
 }
 
-func generateAddressFinderGetter(mgrc client.Client, publishServiceNn types.NamespacedName) func(context.Context) ([]string, error) {
+func generateAddressFinderGetter(mgrc client.Client, publishServiceNn k8stypes.NamespacedName) func(context.Context) ([]string, error) {
 	return func(ctx context.Context) ([]string, error) {
 		svc := new(corev1.Service)
 		if err := mgrc.Get(ctx, publishServiceNn, svc); err != nil {
@@ -288,7 +288,7 @@ func (c *Config) adminAPIClients(ctx context.Context, logger logr.Logger) ([]*ad
 }
 
 type NoAvailableEndpointsError struct {
-	serviceNN types.NamespacedName
+	serviceNN k8stypes.NamespacedName
 }
 
 func (e NoAvailableEndpointsError) Error() string {

--- a/internal/manager/telemetry/manager.go
+++ b/internal/manager/telemetry/manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kong/kubernetes-telemetry/pkg/telemetry"
 	"github.com/kong/kubernetes-telemetry/pkg/types"
 	"github.com/sirupsen/logrus"
-	apitypes "k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -36,7 +36,7 @@ type Payload = types.ProviderReport
 type ReportValues struct {
 	FeatureGates                   map[string]bool
 	MeshDetection                  bool
-	PublishServiceNN               apitypes.NamespacedName
+	PublishServiceNN               k8stypes.NamespacedName
 	KonnectSyncEnabled             bool
 	GatewayServiceDiscoveryEnabled bool
 }

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -18,7 +18,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	apitypes "k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	testdynclient "k8s.io/client-go/dynamic/fake"
@@ -44,11 +44,11 @@ func TestCreateManager(t *testing.T) {
 			"gateway": true,
 			"knative": false,
 		}
-		publishService = apitypes.NamespacedName{
+		publishService = k8stypes.NamespacedName{
 			Namespace: "kong",
 			Name:      "kong-proxy",
 		}
-		pod = apitypes.NamespacedName{
+		pod = k8stypes.NamespacedName{
 			Namespace: "kong",
 			Name:      "kong-ingress-controller",
 		}
@@ -255,7 +255,7 @@ func prepareScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
-func prepareObjects(pod apitypes.NamespacedName) []runtime.Object {
+func prepareObjects(pod k8stypes.NamespacedName) []runtime.Object {
 	setRandomUUIDName := func(o client.Object) runtime.Object {
 		o.SetName(uuid.NewString())
 		return o

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -26,7 +26,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -80,13 +80,13 @@ func GetNodeIPOrName(ctx context.Context, kubeClient clientset.Interface, name s
 }
 
 // GetPodNN returns NamespacedName of pod that this process is running in.
-func GetPodNN() (types.NamespacedName, error) {
-	nn := types.NamespacedName{
+func GetPodNN() (k8stypes.NamespacedName, error) {
+	nn := k8stypes.NamespacedName{
 		Namespace: os.Getenv("POD_NAMESPACE"),
 		Name:      os.Getenv("POD_NAME"),
 	}
 	if nn.Name == "" || nn.Namespace == "" {
-		return types.NamespacedName{},
+		return k8stypes.NamespacedName{},
 			fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
 	}
 

--- a/internal/util/kubernetes/object/set.go
+++ b/internal/util/kubernetes/object/set.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,27 +25,27 @@ const (
 // ConfigurationStatusSet is a de-duplicate set to store the configure status
 // (succeeded, failed, unknown) of kubernetes objects.
 type ConfigurationStatusSet struct {
-	store map[gvk]map[types.NamespacedName]objectConfigurationStatus
+	store map[gvk]map[k8stypes.NamespacedName]objectConfigurationStatus
 }
 
 func NewConfigurationStatusSet() *ConfigurationStatusSet {
 	return &ConfigurationStatusSet{
-		store: map[gvk]map[types.NamespacedName]objectConfigurationStatus{},
+		store: map[gvk]map[k8stypes.NamespacedName]objectConfigurationStatus{},
 	}
 }
 
 func (s *ConfigurationStatusSet) Insert(obj client.Object, succeeded bool) {
 	if s.store == nil {
-		s.store = make(map[gvk]map[types.NamespacedName]objectConfigurationStatus)
+		s.store = make(map[gvk]map[k8stypes.NamespacedName]objectConfigurationStatus)
 	}
 
 	objGVK := gvk(obj.GetObjectKind().GroupVersionKind().String())
-	nsName := types.NamespacedName{
+	nsName := k8stypes.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}
 	if s.store[objGVK] == nil {
-		s.store[objGVK] = make(map[types.NamespacedName]objectConfigurationStatus)
+		s.store[objGVK] = make(map[k8stypes.NamespacedName]objectConfigurationStatus)
 	}
 	s.store[objGVK][nsName] = objectConfigurationStatus{
 		generation: obj.GetGeneration(),
@@ -59,7 +59,7 @@ func (s *ConfigurationStatusSet) Get(obj client.Object) ConfigurationStatus {
 	}
 
 	objGVK := gvk(obj.GetObjectKind().GroupVersionKind().String())
-	nsName := types.NamespacedName{
+	nsName := k8stypes.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -21,7 +21,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 )
@@ -359,7 +359,7 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	ensureAllProxyReplicasAreConfigured(ctx, t, env, deployments.ProxyNN)
 }
 
-func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env environments.Environment, proxyDeploymentNN types.NamespacedName) {
+func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env environments.Environment, proxyDeploymentNN k8stypes.NamespacedName) {
 	pods, err := listPodsByLabels(ctx, env, proxyDeploymentNN.Namespace, map[string]string{"app": proxyDeploymentNN.Name})
 	require.NoError(t, err)
 

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 // TestKongRouterCompatibility verifies that KIC behaves consistently with Kong routers
@@ -46,7 +46,7 @@ func setGatewayRouterFlavor(
 	ctx context.Context,
 	t *testing.T,
 	cluster clusters.Cluster,
-	proxyDeploymentNN types.NamespacedName,
+	proxyDeploymentNN k8stypes.NamespacedName,
 	flavor string,
 ) {
 	// Since we cannot replace env vars in kustomize, here we update the deployment to set KONG_ROUTER_FLAVOR to traditional_compatible.
@@ -69,7 +69,7 @@ func ensureGatewayDeployedWithRouterFlavor(
 	ctx context.Context,
 	t *testing.T,
 	env environments.Environment,
-	proxyDeploymentNN types.NamespacedName,
+	proxyDeploymentNN k8stypes.NamespacedName,
 	expectedFlavor string,
 ) {
 	labelsForDeployment := metav1.ListOptions{

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -38,7 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -265,8 +265,8 @@ func deployKong(ctx context.Context, t *testing.T, env environments.Environment,
 
 // Deployments represent the deployments that are deployed by the all-in-one manifests.
 type Deployments struct {
-	ProxyNN      types.NamespacedName
-	ControllerNN types.NamespacedName
+	ProxyNN      k8stypes.NamespacedName
+	ControllerNN k8stypes.NamespacedName
 }
 
 // GetProxy gets the proxy deployment from the cluster.
@@ -290,11 +290,11 @@ func (d Deployments) GetController(ctx context.Context, t *testing.T, env enviro
 func getManifestDeployments(manifestPath string) Deployments {
 	proxyDeploymentName := getProxyDeploymentName(manifestPath)
 	return Deployments{
-		ProxyNN: types.NamespacedName{
+		ProxyNN: k8stypes.NamespacedName{
 			Namespace: namespace,
 			Name:      proxyDeploymentName,
 		},
-		ControllerNN: types.NamespacedName{
+		ControllerNN: k8stypes.NamespacedName{
 			Namespace: namespace,
 			Name:      controllerDeploymentName,
 		},
@@ -755,7 +755,7 @@ func listPodsByLabels(
 }
 
 // scaleDeployment scales the deployment to the given number of replicas and waits for the replicas to be ready.
-func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environment, deployment types.NamespacedName, replicas int32) {
+func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environment, deployment k8stypes.NamespacedName, replicas int32) {
 	t.Helper()
 
 	scale := &autoscalingv1.Scale{

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -30,7 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect"
@@ -92,7 +92,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	manifest := getTestManifest(t, manifestFile)
 	deployKong(ctx, t, env, manifest)
 
-	exposeAdminAPI(ctx, t, env, types.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
+	exposeAdminAPI(ctx, t, env, k8stypes.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
 
 	t.Log("disabling license management")
 	kubeconfig := getTemporaryKubeconfig(t, env)
@@ -393,7 +393,7 @@ func requireAllProxyReplicasIDsConsistentWithKonnect(
 	ctx context.Context,
 	t *testing.T,
 	env environment.Environment,
-	proxyDeploymentNN types.NamespacedName,
+	proxyDeploymentNN k8stypes.NamespacedName,
 	rg, cert, key string,
 ) {
 	pods, err := listPodsByLabels(ctx, env, proxyDeploymentNN.Namespace, map[string]string{"app": proxyDeploymentNN.Name})

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 )
@@ -58,7 +58,7 @@ func generateAdminPasswordSecret() (string, *corev1.Secret, error) {
 // exposeAdminAPI will override the KONG_ADMIN_LISTEN for the cluster's proxy to expose the
 // Admin API via a service. Some deployments only expose this on localhost by default as there's
 // no authentication, so note that this is only for testing environment purposes.
-func exposeAdminAPI(ctx context.Context, t *testing.T, env environments.Environment, proxyDeployment types.NamespacedName) {
+func exposeAdminAPI(ctx context.Context, t *testing.T, env environments.Environment, proxyDeployment k8stypes.NamespacedName) {
 	t.Log("updating the proxy container KONG_ADMIN_LISTEN to expose the admin api")
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(proxyDeployment.Namespace).Get(ctx, proxyDeployment.Name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func isPodReady(pod corev1.Pod) bool {
 }
 
 // ensureNoneOfDeploymentPodsHasCrashed ensures that none of the pods of a deployment has crashed.
-func ensureNoneOfDeploymentPodsHasCrashed(ctx context.Context, t *testing.T, env environments.Environment, deploymentNN types.NamespacedName) {
+func ensureNoneOfDeploymentPodsHasCrashed(ctx context.Context, t *testing.T, env environments.Environment, deploymentNN k8stypes.NamespacedName) {
 	t.Logf("ensuring none of %s deployment pods has crashed", deploymentNN.String())
 	pods, err := listPodsByLabels(ctx, env, deploymentNN.Namespace, map[string]string{"app": deploymentNN.Name})
 	require.NoError(t, err)

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -46,45 +46,45 @@ func Setup(t *testing.T, scheme *runtime.Scheme) *rest.Config {
 	require.NoError(t, err)
 
 	t.Logf("waiting for Gateway API CRDs to be available...")
-	require.NoError(t, envtest.WaitForCRDs(cfg, []*v1.CustomResourceDefinition{
+	require.NoError(t, envtest.WaitForCRDs(cfg, []*apiextensionsv1.CustomResourceDefinition{
 		{
-			Spec: v1.CustomResourceDefinitionSpec{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: gatewayv1beta1.GroupVersion.Group,
-				Versions: []v1.CustomResourceDefinitionVersion{
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 					{
 						Name:   gatewayv1beta1.GroupVersion.Version,
 						Served: true,
 					},
 				},
-				Names: v1.CustomResourceDefinitionNames{
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
 					Plural: "gateways",
 				},
 			},
 		},
 		{
-			Spec: v1.CustomResourceDefinitionSpec{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: gatewayv1beta1.GroupVersion.Group,
-				Versions: []v1.CustomResourceDefinitionVersion{
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 					{
 						Name:   gatewayv1beta1.GroupVersion.Version,
 						Served: true,
 					},
 				},
-				Names: v1.CustomResourceDefinitionNames{
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
 					Plural: "httproutes",
 				},
 			},
 		},
 		{
-			Spec: v1.CustomResourceDefinitionSpec{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: gatewayv1beta1.GroupVersion.Group,
-				Versions: []v1.CustomResourceDefinitionVersion{
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 					{
 						Name:   gatewayv1beta1.GroupVersion.Version,
 						Served: true,
 					},
 				},
-				Names: v1.CustomResourceDefinitionNames{
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
 					Plural: "referencegrants",
 				},
 			},

--- a/test/helpers/conditions.go
+++ b/test/helpers/conditions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/net"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,7 +25,7 @@ import (
 // used with assert.Eventually or require.Eventually in order to check - via the
 // provided client - that the HTTPRoute with the NamespacedName as provided in
 // the arguments, does indeed contain the provied conditions in the status.
-func HTTPRouteEventuallyContainsConditions(ctx context.Context, t *testing.T, client ctrlclient.Client, nn types.NamespacedName, conds ...metav1.Condition) func() bool {
+func HTTPRouteEventuallyContainsConditions(ctx context.Context, t *testing.T, client ctrlclient.Client, nn k8stypes.NamespacedName, conds ...metav1.Condition) func() bool {
 	return func() bool {
 		t.Helper()
 
@@ -65,7 +65,7 @@ func HTTPRouteEventuallyContainsConditions(ctx context.Context, t *testing.T, cl
 	}
 }
 
-func HTTPRouteEventuallyNotContainsConditions(ctx context.Context, t *testing.T, client ctrlclient.Client, nn types.NamespacedName, conds ...metav1.Condition) func() bool {
+func HTTPRouteEventuallyNotContainsConditions(ctx context.Context, t *testing.T, client ctrlclient.Client, nn k8stypes.NamespacedName, conds ...metav1.Condition) func() bool {
 	return func() bool {
 		t.Helper()
 

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -14,7 +14,7 @@ import (
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -98,7 +98,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 			}
 
 			if len(tt.patch) > 0 {
-				_, gotUpdateErr := gatewayClient.GatewayV1beta1().Gateways(ns.Name).Patch(ctx, tt.createdGW.Name, types.MergePatchType, tt.patch, metav1.PatchOptions{})
+				_, gotUpdateErr := gatewayClient.GatewayV1beta1().Gateways(ns.Name).Patch(ctx, tt.createdGW.Name, k8stypes.MergePatchType, tt.patch, metav1.PatchOptions{})
 				if tt.wantPatchErr {
 					require.Error(t, gotUpdateErr)
 					require.Contains(t, gotUpdateErr.Error(), tt.wantPatchErrSubstring)

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -244,7 +244,7 @@ func TestHTTPSIngress(t *testing.T) {
 	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
+				UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e4"),
 				Name:      "secret1",
 				Namespace: ns.Name,
 			},
@@ -255,7 +255,7 @@ func TestHTTPSIngress(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e5"),
+				UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e5"),
 				Name:      "secret2",
 				Namespace: ns.Name,
 			},

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -119,7 +119,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e8"),
+				UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e8"),
 				Name:      tlsSecretName,
 				Namespace: ns.Name,
 			},
@@ -492,7 +492,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:       types.UID("7428fb98-180b-4702-a91f-61351a33c6e8"),
+				UID:       k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e8"),
 				Name:      tlsSecretName,
 				Namespace: ns.Name,
 			},
@@ -503,7 +503,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  types.UID("7428fb98-180b-4702-a91f-61351a33c6e9"),
+				UID:  k8stypes.UID("7428fb98-180b-4702-a91f-61351a33c6e9"),
 				Name: "secret2",
 			},
 			Data: map[string][]byte{

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -352,7 +352,7 @@ func pluginUsingInvalidCACert(ns string) *kongv1.KongPlugin {
 				annotations.IngressClassKey: consts.IngressClass,
 			},
 		},
-		Config:     v1.JSON{Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, invalidCASecretID))},
+		Config:     apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"ca_certificates": ["%s"]}`, invalidCASecretID))},
 		PluginName: "mtls-auth",
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- unify how `k8s.io/*` packages are imported (with standardised aliases)
- introduce [forbidgo](https://golangci-lint.run/usage/linters/#forbidigo) to prevent using old `CoreV1 Endpoints`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Introducing and configuring `fobidgo` is a nice to have for issue https://github.com/Kong/kubernetes-ingress-controller/issues/3916.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

CI will pass after merging PR https://github.com/Kong/kubernetes-ingress-controller/pull/3997 that gets rid of `CoreV1 Endpoints`

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
