### PR TITLE
POC httproute priorities

### DIFF
--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -737,7 +737,7 @@ func hasHostnames(httpRoute gatewayv1beta1.HTTPRoute) bool {
 }
 
 func hasWildcardHostname(httpRoute gatewayv1beta1.HTTPRoute) bool {
-	return len(httpRoute.Spec.Hostnames) > 0 && strings.HasSuffix(string(httpRoute.Spec.Hostnames[0]), ".*")
+	return len(httpRoute.Spec.Hostnames) > 0 && strings.HasPrefix(string(httpRoute.Spec.Hostnames[0]), "*.")
 }
 
 func httpRouteNamespacedName(route gatewayv1beta1.HTTPRoute) string {

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -1264,75 +1264,78 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 						},
 					},
 				},
-				// {
-				// 	ObjectMeta: metav1.ObjectMeta{
-				// 		Name:      "httproute-2",
-				// 		Namespace: corev1.NamespaceDefault,
-				// 	},
-				// 	Spec: gatewayv1beta1.HTTPRouteSpec{
-				// 		Hostnames: []gatewayv1beta1.Hostname{
-				// 			"foo.bar.com",
-				// 		},
-				// 		CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
-				// 		Rules: []gatewayv1beta1.HTTPRouteRule{
-				// 			{
-				// 				Matches: []gatewayv1beta1.HTTPRouteMatch{
-				// 					builder.NewHTTPRouteMatch().WithPathExact("/a/b/c").Build(),
-				// 					builder.NewHTTPRouteMatch().WithPathExact("/foo/bar").Build(),
-				// 				},
-				// 				BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-				// 					builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-				// 				},
-				// 			},
-				// 			{
-				// 				Matches: []gatewayv1beta1.HTTPRouteMatch{
-				// 					builder.NewHTTPRouteMatch().WithPathPrefix("/d/e/f").Build(),
-				// 				},
-				// 				BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-				// 					builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-				// 				},
-				// 			},
-				// 		},
-				// 	},
-				// },
-				// {
-				// 	ObjectMeta: metav1.ObjectMeta{
-				// 		Name:      "httproute-3",
-				// 		Namespace: corev1.NamespaceDefault,
-				// 	},
-				// 	Spec: gatewayv1beta1.HTTPRouteSpec{
-				// 		Hostnames: []gatewayv1beta1.Hostname{
-				// 			"foo.com",
-				// 			"bar.net",
-				// 		},
-				// 		CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
-				// 		Rules: []gatewayv1beta1.HTTPRouteRule{
-				// 			{
-				// 				Matches: []gatewayv1beta1.HTTPRouteMatch{
-				// 					builder.NewHTTPRouteMatch().WithPathExact("/a/b").Build(),
-				// 					builder.NewHTTPRouteMatch().WithHeader("name", "value").Build(),
-				// 				},
-				// 				BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-				// 					builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-				// 				},
-				// 			},
-				// 			{
-				// 				Matches: []gatewayv1beta1.HTTPRouteMatch{
-				// 					builder.NewHTTPRouteMatch().WithHeader("name", "value").Build(),
-				// 				},
-				// 				BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-				// 					builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
-				// 				},
-				// 			},
-				// 		},
-				// 	},
-				// },
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httproute-2",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						Hostnames: []gatewayv1beta1.Hostname{
+							"foo.bar.com",
+						},
+						CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathExact("/a/b/c").Build(),
+									builder.NewHTTPRouteMatch().WithPathExact("/foo/bar").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathPrefix("/d/e/f").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httproute-3",
+						Namespace: corev1.NamespaceDefault,
+					},
+					Spec: gatewayv1beta1.HTTPRouteSpec{
+						Hostnames: []gatewayv1beta1.Hostname{
+							"foo.com",
+							"bar.net",
+						},
+						CommonRouteSpec: commonRouteSpecMock("fake-gateway"),
+						Rules: []gatewayv1beta1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathExact("/a/b").Build(),
+									builder.NewHTTPRouteMatch().WithHeader("name", "value").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+							{
+								Matches: []gatewayv1beta1.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithHeader("fake", "header").Build(),
+									builder.NewHTTPRouteMatch().WithHeader("fake-2", "header").Build(),
+								},
+								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
 			},
 			expected: func(routes []*gatewayv1beta1.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
 					ServiceNameToParent: map[string]client.Object{
 						"httproute.default.httproute-1": routes[0],
+						"httproute.default.httproute-2": routes[1],
+						"httproute.default.httproute-3": routes[2],
 					},
 					ServiceNameToServices: map[string]kongstate.Service{
 						"httproute.default.httproute-1": {
@@ -1420,6 +1423,175 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 								},
 							},
 						},
+						"httproute.default.httproute-3": {
+							Service: kong.Service{
+								ConnectTimeout: kong.Int(60000),
+								Host:           kong.String("httproute.default.httproute-3"),
+								Name:           kong.String("httproute.default.httproute-3"),
+								Protocol:       kong.String("http"),
+								ReadTimeout:    kong.Int(60000),
+								Retries:        kong.Int(5),
+								WriteTimeout:   kong.Int(60000),
+							},
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+							},
+							Namespace: "default",
+							Parent:    routes[0],
+							Routes: []kongstate.Route{
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-3.4.0"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(4),
+										Hosts:        kong.StringSlice("bar.net"),
+										Headers:      map[string][]string{"name": {"value"}},
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-3"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[3]),
+								},
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-3.5.0"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(4),
+										Hosts:        kong.StringSlice("bar.net"),
+										Headers:      map[string][]string{"name": {"value"}},
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-3"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[3]),
+								},
+								{
+									Route: kong.Route{
+										Name: kong.String("httproute.default.httproute-1.3.0"),
+										Paths: []*string{
+											kong.String("~/foo/bar$"),
+										},
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(3),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-1"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+								},
+							},
+						},
+						"httproute.default.httproute-2": {
+							Service: kong.Service{
+								ConnectTimeout: kong.Int(60000),
+								Host:           kong.String("httproute.default.httproute-2"),
+								Name:           kong.String("httproute.default.httproute-2"),
+								Protocol:       kong.String("http"),
+								ReadTimeout:    kong.Int(60000),
+								Retries:        kong.Int(5),
+								WriteTimeout:   kong.Int(60000),
+							},
+							Backends: kongstate.ServiceBackends{
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+							},
+							Namespace: "default",
+							Parent:    routes[1],
+							Routes: []kongstate.Route{
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-2.4.0"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(4),
+										Hosts:        kong.StringSlice("foo.bar.com"),
+										Paths:        kong.StringSlice("~/d/e/f$", "/d/e/f/"),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-2"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[1]),
+								},
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-2.5.0"),
+										Hosts:        kong.StringSlice("foo.bar.com"),
+										Paths:        kong.StringSlice("~/a/b/c$"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(5),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-2"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[1]),
+								},
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-2.6.0"),
+										Hosts:        kong.StringSlice("foo.bar.com"),
+										Paths:        kong.StringSlice("~/foo/bar$"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(6),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-2"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[1]),
+								},
+							},
+						},
 					},
 				}
 			},
@@ -1445,10 +1617,11 @@ func TestPoc(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			result := newIngressRules()
 
-			newRoutes := mergeAllRoutesIntoSeparateRules(tt.routes)
+			newRoutes := splitHTTPRouteRules(tt.routes)
 			sortHTTPRoutes(newRoutes)
+			indexedHTTPRoutes := indexHTTPRoutes(tt.routes)
 
-			err := parser.ingressRulesFromHTTPRoute(&result, newRoutes)
+			err := parser.ingressRulesFromHTTPRoute(&result, newRoutes, indexedHTTPRoutes)
 			assert.NoError(t, err)
 
 			expected := tt.expected(tt.routes)

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -1318,8 +1318,7 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 							},
 							{
 								Matches: []gatewayv1beta1.HTTPRouteMatch{
-									builder.NewHTTPRouteMatch().WithHeader("fake", "header").Build(),
-									builder.NewHTTPRouteMatch().WithHeader("fake-2", "header").Build(),
+									builder.NewHTTPRouteMatch().WithHeader("fake", "header").WithHeader("fake-2", "header-2").Build(),
 								},
 								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
 									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
@@ -1437,7 +1436,7 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
 							},
 							Namespace: "default",
-							Parent:    routes[0],
+							Parent:    routes[2],
 							Routes: []kongstate.Route{
 								{
 									Route: kong.Route{
@@ -1459,14 +1458,14 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 											kong.String("k8s-version:v1beta1"),
 										},
 									},
-									Ingress: k8sObjectInfoOfHTTPRoute(routes[3]),
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
 								},
 								{
 									Route: kong.Route{
 										Name:         kong.String("httproute.default.httproute-3.5.0"),
 										PreserveHost: kong.Bool(true),
-										Priority:     kong.Int(4),
-										Hosts:        kong.StringSlice("bar.net"),
+										Priority:     kong.Int(5),
+										Hosts:        kong.StringSlice("foo.com"),
 										Headers:      map[string][]string{"name": {"value"}},
 										Protocols: []*string{
 											kong.String("http"),
@@ -1481,30 +1480,101 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 											kong.String("k8s-version:v1beta1"),
 										},
 									},
-									Ingress: k8sObjectInfoOfHTTPRoute(routes[3]),
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
 								},
 								{
 									Route: kong.Route{
-										Name: kong.String("httproute.default.httproute-1.3.0"),
-										Paths: []*string{
-											kong.String("~/foo/bar$"),
+										Name:  kong.String("httproute.default.httproute-3.6.0"),
+										Hosts: kong.StringSlice("bar.net"),
+										Headers: map[string][]string{
+											"fake":   {"header"},
+											"fake-2": {"header-2"},
 										},
 										PreserveHost: kong.Bool(true),
-										Priority:     kong.Int(3),
+										Priority:     kong.Int(6),
 										Protocols: []*string{
 											kong.String("http"),
 											kong.String("https"),
 										},
 										StripPath: lo.ToPtr(false),
 										Tags: []*string{
-											kong.String("k8s-name:httproute-1"),
+											kong.String("k8s-name:httproute-3"),
 											kong.String("k8s-namespace:default"),
 											kong.String("k8s-kind:HTTPRoute"),
 											kong.String("k8s-group:gateway.networking.k8s.io"),
 											kong.String("k8s-version:v1beta1"),
 										},
 									},
-									Ingress: k8sObjectInfoOfHTTPRoute(routes[0]),
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
+								},
+								{
+									Route: kong.Route{
+										Name:  kong.String("httproute.default.httproute-3.7.0"),
+										Hosts: kong.StringSlice("foo.com"),
+										Headers: map[string][]string{
+											"fake":   {"header"},
+											"fake-2": {"header-2"},
+										},
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(7),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-3"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
+								},
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-3.8.0"),
+										Hosts:        kong.StringSlice("bar.net"),
+										Paths:        kong.StringSlice("~/a/b$"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(8),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-3"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
+								},
+								{
+									Route: kong.Route{
+										Name:         kong.String("httproute.default.httproute-3.9.0"),
+										Hosts:        kong.StringSlice("foo.com"),
+										Paths:        kong.StringSlice("~/a/b$"),
+										PreserveHost: kong.Bool(true),
+										Priority:     kong.Int(9),
+										Protocols: []*string{
+											kong.String("http"),
+											kong.String("https"),
+										},
+										StripPath: lo.ToPtr(false),
+										Tags: []*string{
+											kong.String("k8s-name:httproute-3"),
+											kong.String("k8s-namespace:default"),
+											kong.String("k8s-kind:HTTPRoute"),
+											kong.String("k8s-group:gateway.networking.k8s.io"),
+											kong.String("k8s-version:v1beta1"),
+										},
+									},
+									Ingress: k8sObjectInfoOfHTTPRoute(routes[2]),
 								},
 							},
 						},
@@ -1526,9 +1596,9 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 							Routes: []kongstate.Route{
 								{
 									Route: kong.Route{
-										Name:         kong.String("httproute.default.httproute-2.4.0"),
+										Name:         kong.String("httproute.default.httproute-2.10.0"),
 										PreserveHost: kong.Bool(true),
-										Priority:     kong.Int(4),
+										Priority:     kong.Int(10),
 										Hosts:        kong.StringSlice("foo.bar.com"),
 										Paths:        kong.StringSlice("~/d/e/f$", "/d/e/f/"),
 										Protocols: []*string{
@@ -1548,11 +1618,11 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 								},
 								{
 									Route: kong.Route{
-										Name:         kong.String("httproute.default.httproute-2.5.0"),
+										Name:         kong.String("httproute.default.httproute-2.11.0"),
 										Hosts:        kong.StringSlice("foo.bar.com"),
 										Paths:        kong.StringSlice("~/a/b/c$"),
 										PreserveHost: kong.Bool(true),
-										Priority:     kong.Int(5),
+										Priority:     kong.Int(11),
 										Protocols: []*string{
 											kong.String("http"),
 											kong.String("https"),
@@ -1570,11 +1640,11 @@ func pocTestCases() []testCaseIngressRulesFromHTTPRoutes {
 								},
 								{
 									Route: kong.Route{
-										Name:         kong.String("httproute.default.httproute-2.6.0"),
+										Name:         kong.String("httproute.default.httproute-2.12.0"),
 										Hosts:        kong.StringSlice("foo.bar.com"),
 										Paths:        kong.StringSlice("~/foo/bar$"),
 										PreserveHost: kong.Bool(true),
-										Priority:     kong.Int(6),
+										Priority:     kong.Int(12),
 										Protocols: []*string{
 											kong.String("http"),
 											kong.String("https"),

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -78,6 +78,7 @@ func generateKongServiceFromBackendRefWithName(
 	rules *ingressRules,
 	serviceName string,
 	route client.Object,
+	parentRoute client.Object,
 	protocol string,
 	backendRefs ...gatewayv1beta1.BackendRef,
 ) (kongstate.Service, error) {
@@ -114,7 +115,7 @@ func generateKongServiceFromBackendRefWithName(
 			},
 			Namespace: route.GetNamespace(),
 			Backends:  backends,
-			Parent:    route,
+			Parent:    parentRoute,
 		}
 	}
 
@@ -158,6 +159,7 @@ func generateKongServiceFromBackendRefWithRuleNumber(
 		storer,
 		rules,
 		serviceName,
+		route,
 		route,
 		protocol,
 		backendRefs...,

--- a/internal/util/builder/httproutematch.go
+++ b/internal/util/builder/httproutematch.go
@@ -60,9 +60,11 @@ func (b *HTTPRouteMatchBuilder) WithMethod(method gatewayv1beta1.HTTPMethod) *HT
 }
 
 func (b *HTTPRouteMatchBuilder) WithHeader(name, value string) *HTTPRouteMatchBuilder {
+	t := gatewayv1beta1.HeaderMatchType(gatewayv1beta1.HeaderMatchExact)
 	b.httpRouteMatch.Headers = append(b.httpRouteMatch.Headers, gatewayv1beta1.HTTPHeaderMatch{
 		Name:  gatewayv1beta1.HTTPHeaderName(name),
 		Value: value,
+		Type:  &t,
 	})
 	return b
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

> NOTE: **This PR is to be intended as a POC and will not be merged.**

> NOTE_2: all the code lines commented in this PR are workarounds to compile the code and execute the new test. They are not to be intended as a proposal for the actual implementation

**What this PR does / why we need it**:

This is a poc for setting priorities to all the HTTPRouteMatches, even when coming from different `HTTPRoutes`.

To do so, the following has been implemented:
1. all the HTTPRoutesMatches have been isolated along with each hostname for each HTTPRoutes and have been like if they were unique `HTTPRoutes`
2. all the `HTTPRoutes` created in the step above are sorted according to the Gateway API specification (pasted below)
3. the HTTPRoutes are inversely iterated and an increasing priority is assigned to them.

A omni-comprehensive test has been added to verify and showcase how the logic works.

### Gateway API specification:

```go
	// In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
	// overlapping wildcard matching and exact matching hostnames), precedence must
	// be given to rules from the HTTPRoute with the largest number of:
	//
	// * Characters in a matching non-wildcard hostname.
	// * Characters in a matching hostname.
	//
	// If ties exist across multiple Routes, the matching precedence rules for
	// HTTPRouteMatches takes over.
        // ...
	// Proxy or Load Balancer routing configuration generated from HTTPRoutes
	// MUST prioritize matches based on the following criteria, continuing on
	// ties. Across all rules specified on applicable Routes, precedence must be
	// given to the match with the largest number of:
	//
	// * Characters in a matching "Exact" path match
	// * Characters in a matching "Prefix" path match
	// * Header matches.
	// * Query param matches.
	//
	// Note: The precedence of RegularExpression path matches are implementation-specific.
	//
	// If ties still exist across multiple Routes, matching precedence MUST be
	// determined in order of the following criteria, continuing on ties:
	//
	// * The oldest Route based on creation timestamp.
	// * The Route appearing first in alphabetical order by
	//   "{namespace}/{name}".
	//
	// If ties still exist within an HTTPRoute, matching precedence MUST be granted
	// to the FIRST matching rule (in list order) with a match meeting the above
	// criteria.
```

~This implementation takes into account all the above rules but the hostname wildcard one and the latest related to the precedence within `HTTPRoutes`. They are just additional sorting rules that will be taken into account and implemented if the POC is accepted.~

All the specification rules have been implemented.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
