### PR TITLE
tests: align E2E to dynamic handling of GW API CRDs

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -690,16 +690,6 @@ func TestMissingCRDsDontCrashTheController(t *testing.T) {
 				Version:  kongv1.GroupVersion.Version,
 				Resource: "kongclusterplugins",
 			},
-			{
-				Group:    gatewayv1beta1.GroupVersion.Group,
-				Version:  gatewayv1beta1.GroupVersion.Version,
-				Resource: "gateways",
-			},
-			{
-				Group:    gatewayv1beta1.GroupVersion.Group,
-				Version:  gatewayv1beta1.GroupVersion.Version,
-				Resource: "httproutes",
-			},
 		}
 
 		for _, gvr := range gvrs {


### PR DESCRIPTION
**What this PR does / why we need it**:

Missing `Gateway` and `HTTPRoute` will no longer output the log that was expected in the `TestMissingCRDsDontCrashTheController` as they are using now the `DynamicCRDController` that was introduced in https://github.com/Kong/kubernetes-ingress-controller/pull/3996.
