### PR TITLE
feat: attach translation failure events to unsupported objects when ExpressionRoutes enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,11 @@ Adding a new version? You'll need three changes:
   during the start-up phase. From now on, they will be dynamically started in runtime
   once their installation is detected, making restarting the process unnecessary.
   [#3996](https://github.com/Kong/kubernetes-ingress-controller/pull/3996)
+- Disable translation of unspported kubernetes objects when translating to
+  expression based routes is enabled (`ExpressionRoutes` feature enabled AND 
+  kong using router flavor `expressions`), and generate a translation failure
+  event attached to each of the unsupported objects.
+  [#4022](https://github.com/Kong/kubernetes-ingress-controller/pull/4022)
 
 ### Changed
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -584,6 +584,18 @@ func (p *Parser) getCerts(secretsToSNIs SecretNameToSNIs) []certWrapper {
 	return certs
 }
 
+func (p *Parser) registerResourceFailureNotSupportedForExpressionRoutes(obj client.Object) {
+	if p.featureFlags.ExpressionRoutes {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		p.failuresCollector.PushResourceFailure(
+			fmt.Sprintf(
+				"resource kind %s/%s.%s not supported when expression routes enabled",
+				gvk.Group, gvk.Version, gvk.Kind,
+			), obj,
+		)
+	}
+}
+
 func mergeCerts(log logrus.FieldLogger, certLists ...[]certWrapper) []kongstate.Certificate {
 	snisSeen := make(map[string]string)
 	certsSeen := make(map[string]certWrapper)

--- a/internal/dataplane/parser/translate_failures_test.go
+++ b/internal/dataplane/parser/translate_failures_test.go
@@ -1,0 +1,199 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knative "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+)
+
+// This file contains unit test functions to test translation failures genreated by parser.
+
+func TestTranslationFailureUnsupportedObjectsExpressionRoutes(t *testing.T) {
+	testCases := []struct {
+		name           string
+		objects        store.FakeObjects
+		causingObjects []client.Object
+	}{
+		{
+			name: "knative.Ingresses are not supported",
+			objects: store.FakeObjects{
+				KnativeIngresses: []*knative.Ingress{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Ingress",
+							APIVersion: knative.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "knative-ing-1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								annotations.KnativeIngressClassKey: annotations.DefaultIngressClass,
+							},
+						},
+						Spec: knative.IngressSpec{},
+					},
+				},
+			},
+			causingObjects: []client.Object{
+				&knative.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "knative-ing-1",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+		{
+			name: "TCPIngresses and UDPIngresses are not supported",
+			objects: store.FakeObjects{
+				TCPIngresses: []*kongv1beta1.TCPIngress{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "TCPIngress",
+							APIVersion: kongv1beta1.GroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tcpingress-1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								annotations.IngressClassKey: annotations.DefaultIngressClass,
+							},
+						},
+					},
+				},
+				UDPIngresses: []*kongv1beta1.UDPIngress{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "UDPIngress",
+							APIVersion: kongv1beta1.GroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "udpingress-1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								annotations.IngressClassKey: annotations.DefaultIngressClass,
+							},
+						},
+					},
+				},
+			},
+			causingObjects: []client.Object{
+				&kongv1beta1.TCPIngress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tcpingress-1",
+						Namespace: "default",
+					},
+				},
+				&kongv1beta1.UDPIngress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "udpingress-1",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+		{
+			name: "TCPRoutes, UDPRoutes and TLSRoutes in gateway APIs are not supported",
+			objects: store.FakeObjects{
+				TCPRoutes: []*gatewayv1alpha2.TCPRoute{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "TCPRoute",
+							APIVersion: gatewayv1alpha2.GroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tcproute-1",
+							Namespace: "default",
+						},
+					},
+				},
+				UDPRoutes: []*gatewayv1alpha2.UDPRoute{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "UDPRoute",
+							APIVersion: gatewayv1alpha2.GroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "udproute-1",
+							Namespace: "default",
+						},
+					},
+				},
+				TLSRoutes: []*gatewayv1alpha2.TLSRoute{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "TLSRoute",
+							APIVersion: gatewayv1alpha2.GroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tlsroute-1",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			causingObjects: []client.Object{
+				&gatewayv1alpha2.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tcproute-1",
+						Namespace: "default",
+					},
+				},
+				&gatewayv1alpha2.UDPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "udproute-1",
+						Namespace: "default",
+					},
+				},
+				&gatewayv1alpha2.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tlsroute-1",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			storer, err := store.NewFakeStore(tc.objects)
+			require.NoError(t, err)
+
+			parser := mustNewParser(t, storer)
+			parser.featureFlags.ExpressionRoutes = true
+
+			result := parser.BuildKongConfig()
+			t.Log(result.TranslationFailures)
+			for _, object := range tc.causingObjects {
+				require.True(t, lo.ContainsBy(result.TranslationFailures, func(f failures.ResourceFailure) bool {
+					msg := f.Message()
+					if !strings.Contains(msg, "not supported when expression routes enabled") {
+						return false
+					}
+
+					causingObjects := f.CausingObjects()
+					if len(causingObjects) != 1 {
+						return false
+					}
+					causingObject := causingObjects[0]
+					return object.GetNamespace() == causingObject.GetNamespace() &&
+						object.GetName() == causingObject.GetName()
+				}))
+			}
+		})
+
+	}
+}

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -44,6 +44,11 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 	secretToSNIs := newSecretNameToSNIs()
 
 	for _, ingress := range ingressList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(ingress)
+			continue
+		}
+
 		regexPrefix := translators.ControllerPathRegexPrefix
 		if prefix, ok := ingress.ObjectMeta.Annotations[annotations.AnnotationPrefix+annotations.RegexPrefixKey]; ok {
 			regexPrefix = prefix

--- a/internal/dataplane/parser/translate_kong_l4.go
+++ b/internal/dataplane/parser/translate_kong_l4.go
@@ -26,6 +26,11 @@ func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
 	})
 
 	for _, ingress := range ingressList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(ingress)
+			continue
+		}
+
 		ingressSpec := ingress.Spec
 
 		result.SecretNameToSNIs.addFromIngressV1TLS(tcpIngressToNetworkingTLS(ingressSpec.TLS), ingress)
@@ -101,6 +106,11 @@ func (p *Parser) ingressRulesFromUDPIngressV1beta1() ingressRules {
 	})
 
 	for _, ingress := range ingressList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(ingress)
+			continue
+		}
+
 		ingressSpec := ingress.Spec
 
 		var objectSuccessfullyParsed bool

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -25,6 +25,11 @@ func (p *Parser) ingressRulesFromTCPRoutes() ingressRules {
 
 	var errs []error
 	for _, tcproute := range tcpRouteList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(tcproute)
+			continue
+		}
+
 		if err := p.ingressRulesFromTCPRoute(&result, tcproute); err != nil {
 			err = fmt.Errorf("TCPRoute %s/%s can't be routed: %w", tcproute.Namespace, tcproute.Name, err)
 			errs = append(errs, err)

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -29,6 +29,11 @@ func (p *Parser) ingressRulesFromTLSRoutes() ingressRules {
 
 	var errs []error
 	for _, tlsroute := range tlsRouteList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(tlsroute)
+			continue
+		}
+
 		if err := p.ingressRulesFromTLSRoute(&result, tlsroute); err != nil {
 			err = fmt.Errorf("TLSRoute %s/%s can't be routed: %w", tlsroute.Namespace, tlsroute.Name, err)
 			errs = append(errs, err)

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -25,6 +25,11 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 
 	var errs []error
 	for _, udproute := range udpRouteList {
+		if p.featureFlags.ExpressionRoutes {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(udproute)
+			continue
+		}
+
 		if err := p.ingressRulesFromUDPRoute(&result, udproute); err != nil {
 			err = fmt.Errorf("UDPRoute %s/%s can't be routed: %w", udproute.Namespace, udproute.Name, err)
 			errs = append(errs, err)

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -12,16 +12,13 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
-	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -30,12 +27,10 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 const testTranslationFailuresObjectsPrefix = "translation-failures-"
@@ -463,117 +458,5 @@ func validService() *corev1.Service {
 				},
 			},
 		},
-	}
-}
-
-func TestTranslationFailuresUnsupportedObjectsWithExpressionRoutes(t *testing.T) {
-	if testenv.KongRouterFlavor() != kongRouterFlavorExpressions {
-		t.Skip("only run with expression route enabled")
-	}
-
-	ctx := context.Background()
-	gatewayName := testutils.RandomName(testTranslationFailuresObjectsPrefix)
-	testCases := []struct {
-		name   string
-		object client.Object
-	}{
-		{
-			name: "1-TCPIngresses are not supported",
-			object: &kongv1beta1.TCPIngress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tcpingress-1",
-					Annotations: map[string]string{
-						annotations.IngressClassKey: consts.IngressClass,
-					},
-				},
-				Spec: kongv1beta1.TCPIngressSpec{},
-			},
-		},
-		{
-			name: "2-TCPRoutes are not supported",
-			object: &gatewayv1alpha2.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tcproute-1",
-				},
-				Spec: gatewayv1alpha2.TCPRouteSpec{
-					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayv1alpha2.ParentReference{{
-							Name: gatewayv1alpha2.ObjectName(gatewayName),
-						}},
-					},
-					Rules: []gatewayv1alpha2.TCPRouteRule{{
-						BackendRefs: []gatewayv1alpha2.BackendRef{{
-							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-								Name: gatewayv1alpha2.ObjectName("service1"),
-								Port: lo.ToPtr(gatewayv1alpha2.PortNumber(8899)),
-							},
-						}},
-					}},
-				},
-			},
-		},
-	}
-
-	c, err := client.New(env.Cluster().Config(), client.Options{})
-	require.NoError(t, err)
-	err = gatewayv1alpha2.AddToScheme(c.Scheme())
-	require.NoError(t, err)
-	err = kongv1beta1.AddToScheme(c.Scheme())
-	require.NoError(t, err)
-
-	for _, tc := range testCases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			ns, cleaner := helpers.Setup(ctx, t, env)
-			nsClient := client.NewNamespacedClient(c, ns.Name)
-
-			gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
-			require.NoError(t, err)
-
-			gatewayClassName := testutils.RandomName(testTranslationFailuresObjectsPrefix)
-			gwc, err := DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
-			require.NoError(t, err)
-			cleaner.Add(gwc)
-
-			gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
-				gw.Name = gatewayName
-				gw.Spec.Listeners = []gatewayv1beta1.Listener{{
-					Name:     "tcp",
-					Protocol: gatewayv1beta1.TCPProtocolType,
-					Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultTCPServicePort),
-				}}
-			})
-			require.NoError(t, err)
-			cleaner.Add(gateway)
-
-			err = nsClient.Create(ctx, tc.object)
-			require.NoError(t, err)
-			cleaner.Add(tc.object)
-
-			require.Eventually(t, func() bool {
-				events, err := env.Cluster().Client().CoreV1().Events(ns.GetName()).List(ctx, metav1.ListOptions{
-					FieldSelector: fmt.Sprintf(
-						"reason=%s,type=%s,involvedObject.name=%s",
-						dataplane.KongConfigurationTranslationFailedEventReason,
-						corev1.EventTypeWarning,
-						tc.object.GetName(),
-					),
-				})
-				require.NoError(t, err)
-
-				if len(events.Items) == 0 {
-					return false
-				}
-
-				for _, event := range events.Items {
-					if strings.Contains(event.Message, "not supported when expression routes enabled") {
-						return true
-					}
-				}
-
-				return false
-			}, time.Minute, time.Second)
-		})
 	}
 }

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -516,8 +516,10 @@ func TestTranslationFailuresUnsupportedObjectsWithExpressionRoutes(t *testing.T)
 
 	c, err := client.New(env.Cluster().Config(), client.Options{})
 	require.NoError(t, err)
-	gatewayv1alpha2.AddToScheme(c.Scheme())
-	kongv1beta1.AddToScheme(c.Scheme())
+	err = gatewayv1alpha2.AddToScheme(c.Scheme())
+	require.NoError(t, err)
+	err = kongv1beta1.AddToScheme(c.Scheme())
+	require.NoError(t, err)
 
 	for _, tc := range testCases {
 		tc := tc
@@ -572,7 +574,6 @@ func TestTranslationFailuresUnsupportedObjectsWithExpressionRoutes(t *testing.T)
 
 				return false
 			}, time.Minute, time.Second)
-
 		})
 	}
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When expression router is enabled, we disable translation of the following unsupported objects:
- `knative.Ingress`
- `TCPIngress`
- `UDPIngress`
- `TCPRoute`
- `UDPRoute`
- `TLSRoute`

And generate a translation failure event to each of the objects.
Also, this PR adds an integration test to verify it.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #4000 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
