### PR TITLE
chore(ci): Notify on Slack for failures of e2e tests run at night

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -37,3 +37,20 @@ jobs:
     secrets: inherit
     with:
       coverage: false # E2E tests do not generate coverage reports
+
+  notify-on-slack:
+    runs-on: ubuntu-latest
+    needs:
+      - e2e-tests
+      - e2e-tests-unreleased-kong
+      - test-reports
+    steps:
+      - name: Notify on Slack for failures of e2e tests run automatically at night
+        if: failure() && github.event_name == 'schedule'
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow
+          text: 'E2E tests failed for nightly run, please check why.'


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines 
https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

k8s-maintainers wants to be notified about  failures of e2e tests run automatically at night on a dedicated Slack channel
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Special notes for your reviewer**:

I decided not to send notifications in case running those tests manually to avoid unnecessary spamming of a dedicated channel.
The true verification of it will be when we get or do not get a notification in case of failure 🙃  
<!-- Here you can add any open questions or notes that you might have for reviewers -->

