### PR TITLE
chore(.gitignore): ignore macOS specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ TODO
 
 # user specific dlv config
 .config/dlv
+
+# OS specific
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines 
https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

When directory is opened on `macOS` with finder, file `.DS_Store` is created. Ignore it and other `macOS` specific files in version control.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

