### PR TITLE
CI workflow for Gateway validation

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -78,7 +78,7 @@ jobs:
             echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-container-repo }}" >> $GITHUB_ENV
             echo "TEST_KONG_TAG=${{ github.event.inputs.kong-container-tag }}" >> $GITHUB_ENV
           else
-            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise--container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
             echo "TEST_KONG_TAG=${{ github.event.inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -1,7 +1,28 @@
 name: integration tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      kong-container-repo:
+        type: string
+        default: "kong/kong"
+        required: false
+      kong-container-tag:
+        type: string
+        # TODO: Consider changing to "kong:latest"
+        # See https://github.com/Kong/kubernetes-testing-framework/issues/542
+        default: "3.2"
+        required: false
+      kong-enteprise-container-repo:
+        type: string
+        default: "kong/kong-gateway"
+        required: false
+      kong-enterprise-container-tag:
+        type: string
+        # TODO: Consider changing to "kong/kong-gateway:latest"
+        # See https://github.com/Kong/kubernetes-testing-framework/issues/542
+        default: "3.2"
+        required: false
 
 jobs:
   integration-tests:
@@ -52,19 +73,13 @@ jobs:
 
       - name: Set image of Kong
         id: set_kong_image
-        # TODO: We need a systematic approach to this. Either:
-        # - leave this here and bump every GW release
-        # - remove this and rely on bumping GW image in ktf
-        # - rely on a mechanism in ktf that will always, by default return the newest
-        #   Gateway tag.
-        # Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
-            echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-container-tag }}" >> $GITHUB_ENV
           else
-            echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise--container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
           fi
 
       - name: checkout repository

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
-      # URL is the current's workflow run URL.
+      # URL is the current workflow's run URL.
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.inputs.pr-number }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           gh issue comment ${ISSUE_NUMBER} --body \
-            "Kong Gateway validation tests were started at ${URL}"
+            "Kong Gateway validation tests were started at ${URL} with the following parameters: ${{ toJSON(github.event.inputs) }}"
 
   run-e2e-tests:
     if: ${{ !cancelled() }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -1,0 +1,68 @@
+name: "validate a Kong version (targeted)"
+run-name: "validate Kong ${{ format('{0}:{1}', github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-repo:
+        description: Kong Gateway Docker image to test with (repository).
+        type: string
+        required: true
+        default: "kong/kong-gateway"
+      kong-image-tag:
+        description: Kong Gateway Docker image to test with (tag).
+        type: string
+        required: true
+        default: "latest"
+      e2e-controller-image-repo:
+        description: KIC Docker image for E2E tests (repository).
+        type: string
+        required: true
+        default: "kong/kubernetes-ingress-controller"
+      e2e-controller-image-tag:
+        description: KIC Docker image for E2E tests (tag).
+        type: string
+        required: true
+        default: "latest"
+      issue-number:
+        description: Issue number to post a comment in. If empty, no comment is posted.
+        type: string
+        required: false
+
+jobs:
+  post-comment-in-issue:
+    if: ${{ github.event.inputs.issue-number != '' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      # URL is the current workflow's run URL.
+      # Sadly this is not readily available in github's context.
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ISSUE_NUMBER: ${{ github.event.inputs.issue-number }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          gh issue comment ${ISSUE_NUMBER} --body \
+            "Kong Gateway validation tests were started at ${URL}"
+
+  run-e2e-tests:
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_e2e_tests.yaml
+    secrets: inherit
+    with:
+      kic-image: ${{ format('{0}:{1}', github.event.inputs.e2e-controller-image-repo, github.event.inputs.e2e-controller-image-tag) }}
+      kong-image: ${{ format('{0}:{1}', github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}
+      load-local-image: false
+      run-gke: true
+      run-istio: true
+      all-supported-k8s-versions: true
+
+  run-integration-tests:
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_integration_tests.yaml
+    secrets: inherit
+    with:
+      kong-container-repo: $ {{ github.event.inputs.kong-container-repo }}
+      kong-container-tag: $ {{ github.event.inputs.kong-container-tag }}
+      kong-enterprise-container-repo: $ {{ github.event.inputs.kong-container-repo }}
+      kong-enterprise-container-tag: $ {{ github.event.inputs.kong-container-tag }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -1,4 +1,4 @@
-name: "validate a Kong version (targeted)"
+name: "validate Kong image (targeted)"
 run-name: "validate Kong ${{ format('{0}:{1}', github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}"
 
 on:


### PR DESCRIPTION
Resolves #4018.

This PR does two things (please review commit by commit):
- refactors the integration tests reusable workflow (`_integration_tests.yaml`) so that the caller can override the "non-enterprise tests" and the "enterprise tests" container images. This is intended to be a non-breaking interface-compatible change.
- adds a workflow that runs the reusable E2E and integration tests workflows. It is intentionally opinionated so as to leave no ambiguity about the desired level of validation.