### PR TITLE
feat(konnect): account for config sync failures in reported node status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,11 +114,15 @@ Adding a new version? You'll need three changes:
   during the start-up phase. From now on, they will be dynamically started in runtime
   once their installation is detected, making restarting the process unnecessary.
   [#3996](https://github.com/Kong/kubernetes-ingress-controller/pull/3996)
-- Disable translation of unspported kubernetes objects when translating to
-  expression based routes is enabled (`ExpressionRoutes` feature enabled AND 
+- Disable translation of unsupported Kubernetes objects when translating to
+  expression based routes is enabled (`ExpressionRoutes` feature enabled AND
   kong using router flavor `expressions`), and generate a translation failure
   event attached to each of the unsupported objects.
   [#4022](https://github.com/Kong/kubernetes-ingress-controller/pull/4022)
+- Controller's configuration synchronization status reported to Konnect's Node API
+  now accounts for potential failures in synchronizing configuration with Konnect's
+  Runtime Group Admin API.
+  [#4029](https://github.com/Kong/kubernetes-ingress-controller/pull/4029)
 
 ### Changed
 

--- a/internal/clients/config_status_test.go
+++ b/internal/clients/config_status_test.go
@@ -1,4 +1,4 @@
-package clients
+package clients_test
 
 import (
 	"context"
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 )
 
 func TestChannelConfigNotifier(t *testing.T) {
 	logger := testr.New(t)
-	n := NewChannelConfigNotifier(logger)
+	n := clients.NewChannelConfigNotifier(logger)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -18,7 +21,7 @@ func TestChannelConfigNotifier(t *testing.T) {
 
 	// Call NotifyConfigStatus 5 times to make sure that the method is non-blocking.
 	for i := 0; i < 5; i++ {
-		n.NotifyConfigStatus(ctx, ConfigStatusOK)
+		n.NotifyConfigStatus(ctx, clients.ConfigStatusOK)
 	}
 
 	for i := 0; i < 5; i++ {
@@ -27,5 +30,73 @@ func TestChannelConfigNotifier(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("timed out waiting for config status i=%d", i)
 		}
+	}
+}
+
+func TestCalculateConfigStatus(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		gatewayFailure      bool
+		konnectFailure      bool
+		translationFailures bool
+
+		expectedConfigStatus clients.ConfigStatus
+	}{
+		{
+			name:                 "success",
+			expectedConfigStatus: clients.ConfigStatusOK,
+		},
+		{
+			name:                 "gateway failure",
+			gatewayFailure:       true,
+			expectedConfigStatus: clients.ConfigStatusApplyFailed,
+		},
+		{
+			name:                 "translation failures",
+			translationFailures:  true,
+			expectedConfigStatus: clients.ConfigStatusTranslationErrorHappened,
+		},
+		{
+			name:                 "konnect failure",
+			konnectFailure:       true,
+			expectedConfigStatus: clients.ConfigStatusOKKonnectApplyFailed,
+		},
+		{
+			name:                 "both gateway and konnect failure",
+			gatewayFailure:       true,
+			konnectFailure:       true,
+			expectedConfigStatus: clients.ConfigStatusApplyFailedKonnectApplyFailed,
+		},
+		{
+			name:                 "translation failures and konnect failure",
+			translationFailures:  true,
+			konnectFailure:       true,
+			expectedConfigStatus: clients.ConfigStatusTranslationErrorHappenedKonnectApplyFailed,
+		},
+		{
+			name:                 "gateway failure with translation failures",
+			gatewayFailure:       true,
+			translationFailures:  true,
+			expectedConfigStatus: clients.ConfigStatusApplyFailed,
+		},
+		{
+			name:                 "both gateway and konnect failure with translation failures",
+			gatewayFailure:       true,
+			konnectFailure:       true,
+			translationFailures:  true,
+			expectedConfigStatus: clients.ConfigStatusApplyFailedKonnectApplyFailed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := clients.CalculateConfigStatus(clients.CalculateConfigStatusInput{
+				GatewaysFailed:              tc.gatewayFailure,
+				KonnectFailed:               tc.konnectFailure,
+				TranslationFailuresOccurred: tc.translationFailures,
+			})
+			require.Equal(t, tc.expectedConfigStatus, result)
+		})
 	}
 }

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -240,8 +240,6 @@ func (m mockConfigurationChangeDetector) HasConfigurationChanged(
 }
 
 func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx                = context.Background()
 		testKonnectClient  = mustSampleKonnectClient(t)
@@ -409,8 +407,6 @@ func (p *mockKongConfigBuilder) returnTranslationFailures(enabled bool) {
 }
 
 func TestKongClientUpdate_ConfigStatusIsAlwaysNotified(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx               = context.Background()
 		testKonnectClient = mustSampleKonnectClient(t)
@@ -525,7 +521,8 @@ func newFakeEventsRecorder() *record.FakeRecorder {
 
 	// Ingest events to unblock writing side.
 	go func() {
-		for range eventRecorder.Events {
+		for {
+			<-eventRecorder.Events
 		}
 	}()
 

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
@@ -164,11 +165,15 @@ func (f *mockUpdateStrategyResolver) ResolveUpdateStrategy(c sendconfig.UpdateCl
 }
 
 // returnErrorOnUpdate will cause the mockUpdateStrategy with a given Admin API URL to return an error on Update().
-func (f *mockUpdateStrategyResolver) returnErrorOnUpdate(url string) {
+func (f *mockUpdateStrategyResolver) returnErrorOnUpdate(url string, shouldReturnErr bool) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	f.shouldReturnErrorOnUpdate[url] = struct{}{}
+	if shouldReturnErr {
+		f.shouldReturnErrorOnUpdate[url] = struct{}{}
+	} else {
+		delete(f.shouldReturnErrorOnUpdate, url)
+	}
 }
 
 // updateCalledForURLCallback returns a function that will be called when the mockUpdateStrategy is called.
@@ -234,15 +239,7 @@ func (m mockConfigurationChangeDetector) HasConfigurationChanged(
 	return m.hasConfigurationChanged, nil
 }
 
-type noopKongConfigBuilder struct{}
-
-func (p noopKongConfigBuilder) BuildKongConfig() parser.KongConfigBuildingResult {
-	return parser.KongConfigBuildingResult{
-		KongState: &kongstate.KongState{},
-	}
-}
-
-func TestKongClientUpdate_AllExpectedClientsAreCalled(t *testing.T) {
+func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -315,12 +312,13 @@ func TestKongClientUpdate_AllExpectedClientsAreCalled(t *testing.T) {
 			}
 			updateStrategyResolver := newMockUpdateStrategyResolver(t)
 			for _, url := range tc.errorOnUpdateForURLs {
-				updateStrategyResolver.returnErrorOnUpdate(url)
+				updateStrategyResolver.returnErrorOnUpdate(url, true)
 			}
 			// always return true for HasConfigurationChanged to trigger an update
 			configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
+			configBuilder := newMockKongConfigBuilder()
 
-			kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector)
+			kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder)
 
 			err := kongClient.Update(ctx)
 			if tc.expectError {
@@ -347,8 +345,9 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 
 	// no change in config, we'll expect no update to be called
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: false}
+	configBuilder := newMockKongConfigBuilder()
 
-	kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector)
+	kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder)
 
 	ctx := context.Background()
 	err := kongClient.Update(ctx)
@@ -357,19 +356,150 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 	updateStrategyResolver.assertNoUpdateCalled()
 }
 
+type mockConfigStatusQueue struct {
+	wasNotified bool
+}
+
+func newMockConfigStatusQueue() *mockConfigStatusQueue {
+	return &mockConfigStatusQueue{}
+}
+
+func (m *mockConfigStatusQueue) NotifyConfigStatus(context.Context, clients.ConfigStatus) {
+	m.wasNotified = true
+}
+
+func (m *mockConfigStatusQueue) WasNotified() bool {
+	return m.wasNotified
+}
+
+type mockKongConfigBuilder struct {
+	translationFailuresToReturn []failures.ResourceFailure
+}
+
+func newMockKongConfigBuilder() *mockKongConfigBuilder {
+	return &mockKongConfigBuilder{}
+}
+
+func (p *mockKongConfigBuilder) BuildKongConfig() parser.KongConfigBuildingResult {
+	return parser.KongConfigBuildingResult{
+		KongState:           &kongstate.KongState{},
+		TranslationFailures: p.translationFailuresToReturn,
+	}
+}
+
+func (p *mockKongConfigBuilder) returnTranslationFailures(enabled bool) {
+	if enabled {
+		// Return some mocked translation failures.
+		p.translationFailuresToReturn = []failures.ResourceFailure{
+			lo.Must(failures.NewResourceFailure("some reason", &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+			},
+			)),
+		}
+	} else {
+		p.translationFailuresToReturn = nil
+	}
+}
+
+func TestKongClientUpdate_ConfigStatusIsAlwaysNotified(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx               = context.Background()
+		testKonnectClient = mustSampleKonnectClient(t)
+		testGatewayClient = mustSampleGatewayClient(t)
+
+		clientsProvider = mockGatewayClientsProvider{
+			gatewayClients: []*adminapi.Client{testGatewayClient},
+			konnectClient:  testKonnectClient,
+		}
+
+		updateStrategyResolver = newMockUpdateStrategyResolver(t)
+		configChangeDetector   = mockConfigurationChangeDetector{hasConfigurationChanged: true}
+		configBuilder          = newMockKongConfigBuilder()
+		kongClient             = setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder)
+	)
+
+	testCases := []struct {
+		name                string
+		gatewayFailure      bool
+		konnectFailure      bool
+		translationFailures bool
+	}{
+		{
+			name:                "success",
+			gatewayFailure:      false,
+			konnectFailure:      false,
+			translationFailures: false,
+		},
+		{
+			name:                "gateway failure",
+			gatewayFailure:      true,
+			konnectFailure:      false,
+			translationFailures: false,
+		},
+		{
+			name:                "translation failures",
+			gatewayFailure:      false,
+			konnectFailure:      false,
+			translationFailures: true,
+		},
+		{
+			name:                "konnect failure",
+			gatewayFailure:      false,
+			konnectFailure:      true,
+			translationFailures: false,
+		},
+		{
+			name:                "both gateway and konnect failure",
+			gatewayFailure:      true,
+			konnectFailure:      true,
+			translationFailures: false,
+		},
+		{
+			name:                "translation failures and konnect failure",
+			gatewayFailure:      false,
+			konnectFailure:      true,
+			translationFailures: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the status queue. We want to make sure that the status is always notified.
+			statusQueue := newMockConfigStatusQueue()
+			kongClient.SetConfigStatusNotifier(statusQueue)
+
+			updateStrategyResolver.returnErrorOnUpdate(testGatewayClient.BaseRootURL(), tc.gatewayFailure)
+			updateStrategyResolver.returnErrorOnUpdate(testKonnectClient.BaseRootURL(), tc.konnectFailure)
+			configBuilder.returnTranslationFailures(tc.translationFailures)
+
+			_ = kongClient.Update(ctx)
+			require.True(t, statusQueue.WasNotified())
+		})
+	}
+}
+
 // setupTestKongClient creates a KongClient with mocked dependencies.
 func setupTestKongClient(
 	t *testing.T,
 	updateStrategyResolver *mockUpdateStrategyResolver,
 	clientsProvider mockGatewayClientsProvider,
 	configChangeDetector sendconfig.ConfigurationChangeDetector,
+	configBuilder *mockKongConfigBuilder,
 ) *dataplane.KongClient {
 	logger := logrus.New()
 	timeout := time.Second
 	ingressClass := "kong"
 	diagnostic := util.ConfigDumpDiagnostic{}
 	config := sendconfig.Config{}
-	eventRecorder := record.NewFakeRecorder(0)
 	dbMode := "off"
 
 	kongClient, err := dataplane.NewKongClient(
@@ -378,16 +508,28 @@ func setupTestKongClient(
 		ingressClass,
 		diagnostic,
 		config,
-		eventRecorder,
+		newFakeEventsRecorder(),
 		dbMode,
 		clientsProvider,
 		updateStrategyResolver,
 		configChangeDetector,
-		noopKongConfigBuilder{},
+		configBuilder,
 		store.NewCacheStores(),
 	)
 	require.NoError(t, err)
 	return kongClient
+}
+
+func newFakeEventsRecorder() *record.FakeRecorder {
+	eventRecorder := record.NewFakeRecorder(0)
+
+	// Ingest events to unblock writing side.
+	go func() {
+		for range eventRecorder.Events {
+		}
+	}()
+
+	return eventRecorder
 }
 
 func mustSampleGatewayClient(t *testing.T) *adminapi.Client {

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -2,6 +2,7 @@ package konnect_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -379,5 +380,84 @@ func TestNodeAgent_StartDoesntReturnUntilContextGetsCancelled(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected the agent to return after the context was cancelled")
 	case <-agentReturned:
+	}
+}
+
+func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testing.T) {
+	nodeClient := newMockNodeClient(nil)
+	configStatusQueue := newMockConfigStatusNotifier()
+	gatewayClientsChangesNotifier := newMockGatewayClientsNotifier()
+
+	nodeAgent := konnect.NewNodeAgent(
+		testHostname,
+		testKicVersion,
+		konnect.DefaultRefreshNodePeriod,
+		logr.Discard(),
+		nodeClient,
+		configStatusQueue,
+		newMockGatewayInstanceGetter(nil),
+		gatewayClientsChangesNotifier,
+		newMockManagerInstanceIDProvider(uuid.New()),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	agentReturned := make(chan struct{})
+	go func() {
+		require.NoError(t, nodeAgent.Start(ctx))
+		close(agentReturned)
+	}()
+
+	testCases := []struct {
+		notifiedConfigStatus    clients.ConfigStatus
+		expectedControllerState nodes.IngressControllerState
+	}{
+		{
+			notifiedConfigStatus:    clients.ConfigStatusOK,
+			expectedControllerState: nodes.IngressControllerStateOperational,
+		},
+		{
+			notifiedConfigStatus:    clients.ConfigStatusTranslationErrorHappened,
+			expectedControllerState: nodes.IngressControllerStatePartialConfigFail,
+		},
+		{
+			notifiedConfigStatus:    clients.ConfigStatusApplyFailed,
+			expectedControllerState: nodes.IngressControllerStateInoperable,
+		},
+		{
+			notifiedConfigStatus:    clients.ConfigStatusOKKonnectApplyFailed,
+			expectedControllerState: nodes.IngressControllerStateOperationalKonnectOutOfSync,
+		},
+		{
+			notifiedConfigStatus:    clients.ConfigStatusTranslationErrorHappenedKonnectApplyFailed,
+			expectedControllerState: nodes.IngressControllerStatePartialConfigFailKonnectOutOfSync,
+		},
+		{
+			notifiedConfigStatus:    clients.ConfigStatusApplyFailedKonnectApplyFailed,
+			expectedControllerState: nodes.IngressControllerStateInoperableKonnectOutOfSync,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc.notifiedConfigStatus), func(t *testing.T) {
+			configStatusQueue.NotifyConfigStatus(ctx, tc.notifiedConfigStatus)
+
+			require.Eventually(t, func() bool {
+				controllerNode, ok := lo.Find(nodeClient.MustAllNodes(), func(n *nodes.NodeItem) bool {
+					return n.Type == nodes.NodeTypeIngressController
+				})
+				if !ok {
+					t.Log("controller node not found")
+					return false
+				}
+
+				if controllerNode.Status != string(tc.expectedControllerState) {
+					t.Logf("expected controller node status to be %q, got %q", tc.expectedControllerState, controllerNode.Status)
+					return false
+				}
+
+				return true
+			}, time.Second, time.Millisecond*10)
+		})
 	}
 }

--- a/internal/konnect/nodes/types.go
+++ b/internal/konnect/nodes/types.go
@@ -50,11 +50,14 @@ type CompatibilityStatus struct {
 type IngressControllerState string
 
 const (
-	IngressControllerStateUnspecified       IngressControllerState = "INGRESS_CONTROLLER_STATE_UNSPECIFIED"
-	IngressControllerStateOperational       IngressControllerState = "INGRESS_CONTROLLER_STATE_OPERATIONAL"
-	IngressControllerStatePartialConfigFail IngressControllerState = "INGRESS_CONTROLLER_STATE_PARTIAL_CONFIG_FAIL"
-	IngressControllerStateInoperable        IngressControllerState = "INGRESS_CONTROLLER_STATE_INOPERABLE"
-	IngressControllerStateUnknown           IngressControllerState = "INGRESS_CONTROLLER_STATE_UNKNOWN"
+	IngressControllerStateUnspecified                       IngressControllerState = "INGRESS_CONTROLLER_STATE_UNSPECIFIED"
+	IngressControllerStateOperational                       IngressControllerState = "INGRESS_CONTROLLER_STATE_OPERATIONAL"
+	IngressControllerStatePartialConfigFail                 IngressControllerState = "INGRESS_CONTROLLER_STATE_PARTIAL_CONFIG_FAIL"
+	IngressControllerStateInoperable                        IngressControllerState = "INGRESS_CONTROLLER_STATE_INOPERABLE"
+	IngressControllerStateOperationalKonnectOutOfSync       IngressControllerState = "INGRESS_CONTROLLER_STATE_OPERATIONAL_KONNECT_OUT_OF_SYNC"
+	IngressControllerStatePartialConfigFailKonnectOutOfSync IngressControllerState = "INGRESS_CONTROLLER_STATE_PARTIAL_CONFIG_FAIL_KONNECT_OUT_OF_SYNC"
+	IngressControllerStateInoperableKonnectOutOfSync        IngressControllerState = "INGRESS_CONTROLLER_STATE_INOPERABLE_KONNECT_OUT_OF_SYNC"
+	IngressControllerStateUnknown                           IngressControllerState = "INGRESS_CONTROLLER_STATE_UNKNOWN"
 )
 
 type CreateNodeRequest struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

It extends the config sync status reported to Konnect's Node API with values that take into account failures of syncing configuration with Konnect RG, effectively extending it with three new values (on the API surface level):

- `INGRESS_CONTROLLER_STATE_OPERATIONAL_KONNECT_OUT_OF_SYNC`
- `INGRESS_CONTROLLER_STATE_PARTIAL_CONFIG_FAIL_KONNECT_OUT_OF_SYNC`
- `INGRESS_CONTROLLER_STATE_INOPERABLE_KONNECT_OUT_OF_SYNC`

There's no strict contract for allowed values on the API level, however, there's an implicit contract between KIC and Konnect UI that directly consumes the `Node` object, therefore we're keeping the old values unchanged to make them backward-compatible.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Internal reference: [K8-67](https://konghq.atlassian.net/browse/K8-67).

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR


[K8-67]: https://konghq.atlassian.net/browse/K8-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ