### PR TITLE
fix(ci): workflow param name typo

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -13,7 +13,7 @@ on:
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
         default: "3.2"
         required: false
-      kong-enteprise-container-repo:
+      kong-enterprise-container-repo:
         type: string
         default: "kong/kong-gateway"
         required: false


### PR DESCRIPTION
follow-up to #4028

fixes the misspelled `kong-enterprise-container-repo` param name :grimacing: