### PR TITLE
chore(ci): add code block when posting comment in validate kong issue

### DIFF
--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -43,7 +43,11 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           gh issue comment ${ISSUE_NUMBER} --body \
-            "Kong Gateway validation tests were started at ${URL} with the following parameters: ${{ toJSON(github.event.inputs) }}"
+            'Kong Gateway validation tests were started at ${URL} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '
 
   run-e2e-tests:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the parameters printed e.g. in https://github.com/Kong/kubernetes-ingress-controller/issues/4013#issuecomment-1551889541 to be wrapped in a code block

Example how it might look like: https://github.com/pmalek/test/issues/1#issuecomment-1551918124