### PR TITLE
fix(ci): access inputs in integration tests workflow correctly

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -75,11 +75,11 @@ jobs:
         id: set_kong_image
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
-            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
           else
-            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ inputs.kong-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ inputs.kong-container-tag }}" >> $GITHUB_ENV
           fi
 
       - name: checkout repository

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       kong-image-repo:
-        description: Kong Gateway Docker image to test with (repository).
+        description: Kong Gateway Docker image to test with (repository). Must be an EE variant.
         type: string
         required: true
         default: "kong/kong-gateway"
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           gh issue comment ${ISSUE_NUMBER} --body \
-            'Kong Gateway validation tests were started at ${URL} with the following parameters:
+            'Kong Gateway validation tests were started at ${{ env.URL }} with the following parameters:
             ```json
             ${{ toJSON(github.event.inputs) }}
             ```
@@ -66,7 +66,10 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yaml
     secrets: inherit
     with:
-      kong-container-repo: $ {{ github.event.inputs.kong-container-repo }}
-      kong-container-tag: $ {{ github.event.inputs.kong-container-tag }}
-      kong-enterprise-container-repo: $ {{ github.event.inputs.kong-container-repo }}
-      kong-enterprise-container-tag: $ {{ github.event.inputs.kong-container-tag }}
+      kong-container-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-container-tag: ${{ github.event.inputs.kong-image-tag }}
+      # We're passing the same image twice, because the integration tests need to know the image
+      # for Enterprise variant of tests separately.
+      # That makes this workflow usable only for Enterprise images.
+      kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that the latest test run of the validate kong image workflow hasn't set the expected Kong image for integration tests: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5007227425/jobs/8973545997 

```
  if [ "" == "true" ]; then
    echo "TEST_KONG_IMAGE=" >> $GITHUB_ENV
    echo "TEST_KONG_TAG=" >> $GITHUB_ENV
  else
    echo "TEST_KONG_IMAGE=" >> $GITHUB_ENV
    echo "TEST_KONG_TAG=" >> $GITHUB_ENV
  fi
```

This PR aims to solve this issue by referring to inputs correctly. 

Also:
-  adds a comment explaining why we set the same image for enterprise and regular images when we pass inputs to `_integration_tests.yaml` in `validate_kong_image.yaml` as I found this confusing when reading it.
- fixes the URL to workflow embedded in the comment
