### PR TITLE
tests(integration): more visibililty into customized kong images

### DIFF
--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -29,11 +29,10 @@ func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
 			WithProxyAdminServiceTypeLoadBalancer()
 	}
 
-	if image, tag := testenv.KongImage(), testenv.KongTag(); image != "" {
-		if tag == "" {
-			return nil, nil, fmt.Errorf("TEST_KONG_IMAGE requires TEST_KONG_TAG")
-		}
+	if image, tag := testenv.KongImage(), testenv.KongTag(); image != "" && tag != "" {
 		kongbuilder = kongbuilder.WithProxyImage(image, tag)
+	} else if tag != "" || image != "" {
+		return nil, nil, fmt.Errorf("when specifying TEST_KONG_IMAGE or TEST_KONG_TAG, both need to be provided")
 	}
 
 	if user, pass := testenv.KongPullUsername(), testenv.KongPullPassword(); user != "" || pass != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will make the custom kong image and tag (specified by the [relevant env variables](https://github.com/Kong/kubernetes-ingress-controller/blob/7ba7e2c15be2696433b6f75a3ad6a1c933aa1d79/test/internal/testenv/testenv.go#L28-L36): `TEST_KONG_IMAGE` and `TEST_KONG_TAG`) visible during integration tests execution.

It also adds a log, printing a version as retrieved from the Admin API when Kong is up and running. This should help (hopefully) catch issues like [this](https://github.com/Kong/kubernetes-ingress-controller/issues/4013#issuecomment-1552998225) faster.