### PR TITLE
feat(expression router): assign priorities of routes translated from ingresses

### DIFF
--- a/internal/dataplane/parser/translators/ingress_atc.go
+++ b/internal/dataplane/parser/translators/ingress_atc.go
@@ -26,12 +26,18 @@ var (
 	validHosts = regexp.MustCompile(`^(\*\.)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*?(\.\*)?$`)
 )
 
-var (
+const (
+	// Priorities for exact path match, prefix path match, and implementation specific path match.
+	// The numbers are chosen arbitrarily to keep exact > prefix > implementation specific
+	// and have intervals between them.
 	ExactPathMatchPriority                  = 256 * 3
 	PrefixPathMatchPriority                 = 256 * 2
 	ImplementationSpecificPathMatchPriority = 256
-	NormalIngressExpressionPriority         = 1
-	IngressDefaultBackendPriority           = 0
+	// NormalIngressExpressionPriority is for default priority of route translated from ingress rules.
+	NormalIngressExpressionPriority = 1
+	// IngressDefaultBackendPriority is the priority of route translated from default backends of ingresses
+	// should be less than NormalIngressExpressionPriority.
+	IngressDefaultBackendPriority = 0
 )
 
 func (m *ingressTranslationMeta) translateIntoKongExpressionRoute() *kongstate.Route {

--- a/internal/dataplane/parser/translators/ingress_atc_test.go
+++ b/internal/dataplane/parser/translators/ingress_atc_test.go
@@ -73,7 +73,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
 							Expression:        kong.String(`(http.host == "konghq.com") && ((http.path == "/api") || (http.path ^= "/api/")) && ((net.protocol == "http") || (net.protocol == "https"))`),
-							Priority:          kong.Int(NormalIngressExpressionPriority),
+							Priority:          kong.Int(PrefixPathMatchPriority),
 							PreserveHost:      kong.Bool(true),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
@@ -145,7 +145,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
 							Expression:        kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/") && ((net.protocol == "http") || (net.protocol == "https"))`),
-							Priority:          kong.Int(NormalIngressExpressionPriority),
+							Priority:          kong.Int(ImplementationSpecificPathMatchPriority),
 							PreserveHost:      kong.Bool(true),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Assign priorities to routes translated from ingresses by types of `IngressPath`. 
Follow the rule `Exact` > `Preifx` > `ImplementationSpecific` mode.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

part of #3958.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Undecided point:
- Do we need to generate separated routes and assign different priorities to the routes translated from different types of paths?
- Do we need to consider hosts and headers, as in `HTTPRoute`?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
