### PR TITLE
feat: Gateway Discovery produce DNS names instead of IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,9 @@ Adding a new version? You'll need three changes:
   [#3998](https://github.com/Kong/kubernetes-ingress-controller/pull/3998)
   [#3980](https://github.com/Kong/kubernetes-ingress-controller/pull/3980)
   [#3977](https://github.com/Kong/kubernetes-ingress-controller/pull/3977)
-  
+- Gateway Discovery now produces DNS names instead of IP addresses
+  [#4044](https://github.com/Kong/kubernetes-ingress-controller/pull/4044)
+
 ### Fixed
 
 - Fix paging in `GetAdminAPIsForService` which might have caused the controller

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -5,6 +5,7 @@ package configuration_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -177,14 +178,14 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.1:8080",
+					Address: fmt.Sprintf("https://10-0-0-1.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.2:8080",
+					Address: fmt.Sprintf("https://10-0-0-2.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
@@ -254,7 +255,7 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.2:8080",
+					Address: fmt.Sprintf("https://10-0-0-2.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
@@ -374,28 +375,28 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.1:8080",
+					Address: fmt.Sprintf("https://10-0-0-1.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.2:8080",
+					Address: fmt.Sprintf("https://10-0-0-2.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.10:8080",
+					Address: fmt.Sprintf("https://10-0-0-10.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.20:8080",
+					Address: fmt.Sprintf("https://10-0-0-20.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
@@ -465,14 +466,14 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.1:8080",
+					Address: fmt.Sprintf("https://10-0-0-1.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.2:8080",
+					Address: fmt.Sprintf("https://10-0-0-2.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
@@ -500,7 +501,7 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.1:8080",
+					Address: fmt.Sprintf("https://10-0-0-1.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
@@ -570,14 +571,14 @@ func TestKongAdminAPIController(t *testing.T) {
 		assert.ElementsMatch(t,
 			[]adminapi.DiscoveredAdminAPI{
 				{
-					Address: "https://10.0.0.1:8080",
+					Address: fmt.Sprintf("https://10-0-0-1.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,
 					},
 				},
 				{
-					Address: "https://10.0.0.2:8080",
+					Address: fmt.Sprintf("https://10-0-0-2.%s.%s.svc:8080", adminService.Name, adminService.Namespace),
 					PodRef: k8stypes.NamespacedName{
 						Namespace: adminPod.Namespace,
 						Name:      adminPod.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the implementation Gateway Discovery in a way that it now produces DNS names instead of IP address of Kong's pods.

There are 2 formats that this implementation can use:

- `pod-ip-address.service-name.my-namespace.svc` - when a Kong's `EndpointSlice` that we're trying to convert into an address (that will be used for sending the configuration) contains an owner reference of type `Service` then we use that reference to build the DNS name
- `pod-ip-address.my-namespace.pod` when that `Service` owner reference is missing

Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/

**Which issue this PR fixes**:

Closes: #3934 

**Special notes for your reviewer**:

This will be required for Kong Gateway Operator to use TLS verification.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
