### PR TITLE
chore(konnect): improve logging

### DIFF
--- a/internal/adminapi/backoff_strategy_konnect.go
+++ b/internal/adminapi/backoff_strategy_konnect.go
@@ -2,6 +2,7 @@ package adminapi
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
@@ -158,7 +159,7 @@ func (s *KonnectBackoffStrategy) whyCannotUpdate(
 	if isTheSameFaultyConfig {
 		reasons = append(reasons, fmt.Sprintf(
 			"config has to be changed: %q hash has already failed to be pushed with a client error",
-			string(s.lastFailedConfigHash),
+			hex.EncodeToString(s.lastFailedConfigHash),
 		))
 	}
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -436,9 +436,9 @@ func (c *KongClient) maybeSendOutToKonnectClient(ctx context.Context, s *kongsta
 
 		if errors.Is(err, sendconfig.ErrUpdateSkippedDueToBackoffStrategy{}) {
 			c.logger.WithError(err).Warn("Skipped pushing configuration to Konnect")
+		} else {
+			c.logger.WithError(err).Warn("Failed pushing configuration to Konnect")
 		}
-
-		c.logger.WithError(err).Warn("Failed pushing configuration to Konnect")
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not log `{Failed, Skipped} pushing configuration to Konnect` one after another, print hex encoded config hash.


