### PR TITLE
keep Gateway's `AttachedRoutes` field up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,9 @@ Adding a new version? You'll need three changes:
   - `service`: will make KIC build addresses using the following template:
     `pod-ip-address.service-name.my-namespace.svc`.
     This is known to not work on GKE becuase it uses `kube-dns` instead of coredns.
+- Gateway's `AttachedRoutes` fields get updated with the number of routes referencing
+  and using each listener.
+  [#4052](https://github.com/Kong/kubernetes-ingress-controller/pull/4052)
 
 ### Changed
 

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -133,7 +133,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// if a HTTPRoute gets accepted by a Gateway, we need to make sure to trigger
 	// reconciliation on the gateway, as we need to update the number of attachedRoutes.
 	if err := c.Watch(
-		&source.Kind{Type: &gatewayv1beta1.HTTPRoute{}},
+		source.Kind(mgr.GetCache(), &gatewayv1beta1.HTTPRoute{}),
 		handler.EnqueueRequestsFromMapFunc(r.listGatewaysForHTTPRoute),
 	); err != nil {
 		return err
@@ -276,7 +276,7 @@ func (r *GatewayReconciler) listGatewaysForService(ctx context.Context, svc clie
 }
 
 // listGatewaysForHTTPRoute retrieves all the gateways referenced as parents by the HTTPRoute.
-func (r *GatewayReconciler) listGatewaysForHTTPRoute(obj client.Object) []reconcile.Request {
+func (r *GatewayReconciler) listGatewaysForHTTPRoute(_ context.Context, obj client.Object) []reconcile.Request {
 	httpRoute, ok := obj.(*gatewayv1beta1.HTTPRoute)
 	if !ok {
 		r.Log.Error(

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -243,7 +243,7 @@ func getListenerStatus(
 
 	// TODO we should check transition time rather than always nowing, which we do throughout the below
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/2556
-	for _, listener := range gateway.Spec.Listeners {
+	for listenerIndex, listener := range gateway.Spec.Listeners {
 		var hostname Hostname
 		if listener.Hostname != nil {
 			hostname = *listener.Hostname
@@ -292,7 +292,7 @@ func getListenerStatus(
 			}
 		}
 
-		attachedRoutes, err := getAttachedRoutesForListener(ctx, client, listener, *gateway)
+		attachedRoutes, err := getAttachedRoutesForListener(ctx, client, *gateway, listenerIndex)
 		if err != nil {
 			return nil, err
 		}
@@ -698,7 +698,7 @@ func routeAcceptedByGateways(routeNamespace string, parentStatuses []RouteParent
 //
 // NOTE: At this point we take into account HTTPRoutes only, as they are the
 // only routes in beta.
-func getAttachedRoutesForListener(ctx context.Context, client client.Client, listener gatewayv1beta1.Listener, gateway gatewayv1beta1.Gateway) (int32, error) {
+func getAttachedRoutesForListener(ctx context.Context, client client.Client, gateway gatewayv1beta1.Gateway, listenerIndex int) (int32, error) {
 	httpRouteList := gatewayv1beta1.HTTPRouteList{}
 	if err := client.List(ctx, &httpRouteList); err != nil {
 		return 0, err
@@ -722,8 +722,8 @@ func getAttachedRoutesForListener(ctx context.Context, client client.Client, lis
 				ctx,
 				client,
 				&route,
-				listener,
 				gateway,
+				listenerIndex,
 				parentRef,
 			)
 			if err != nil {

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -693,8 +693,10 @@ func routeAcceptedByGateways(routeNamespace string, parentStatuses []RouteParent
 	return gateways
 }
 
-// Get all the HTTPRoutes and update the listeners' attachedRoutes field.
-// At this point we take into account HTTPRoutes only, as they are the
+// getAttachedRoutesForListener returns the number of all the routes that are attached
+// to the provided Gateway.
+//
+// NOTE: At this point we take into account HTTPRoutes only, as they are the
 // only routes in beta.
 func getAttachedRoutesForListener(ctx context.Context, client client.Client, listener gatewayv1beta1.Listener, gateway gatewayv1beta1.Gateway) (int32, error) {
 	httpRouteList := gatewayv1beta1.HTTPRouteList{}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -897,3 +897,51 @@ func isParentRefEqualToParent[
 
 	return true
 }
+
+func isRouteAcceptedByListener[T types.RouteT](ctx context.Context,
+	mgrc client.Client,
+	route T,
+	listener gatewayv1beta1.Listener,
+	gateway gatewayv1beta1.Gateway,
+	parentRef gatewayv1beta1.ParentReference,
+) (bool, error) {
+	// Check if the route matches listener's AllowedRoutes.
+	if ok, err := routeMatchesListenerAllowedRoutes(ctx, mgrc, route, listener, gateway.Namespace, parentRef.Namespace); err != nil {
+		return false, fmt.Errorf("failed matching listener %s to a route %s for gateway %s: %w",
+			listener.Name, route.GetName(), gateway.Name, err,
+		)
+	} else if !ok {
+		return false, nil
+	}
+
+	// Check the listeners statuses:
+	// - Check if a listener status exists with a matching type (via SupportedKinds).
+	// - Check if it matches the requested listener by name (if specified).
+	// - And finally check if that listeners is marked as Ready.
+	if err := existsMatchingReadyListenerInStatus(route, listener, gateway.Status.Listeners); err != nil {
+		// return no error here, as we don't care of the reason why this check failed.
+		return false, nil //nolint:nilerr
+	}
+
+	// Check if listener name matches.
+	if parentRef.SectionName != nil && *parentRef.SectionName != "" && *parentRef.SectionName != listener.Name {
+		return false, nil
+	}
+
+	// Perform the port matching as described in GEP-957.
+	if parentRef.Port != nil && *parentRef.Port != listener.Port {
+		// This ParentRef has a port specified and it's different
+		// than current listener's port.
+		return false, nil
+	}
+
+	if !routeTypeMatchesListenerType(route, listener) {
+		return false, nil
+	}
+
+	if !routeHostnamesIntersectsWithListenerHostname(route, listener) {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -898,6 +898,8 @@ func isParentRefEqualToParent[
 	return true
 }
 
+// isRouteAcceptedByListener checks the given route is accepted by the
+// gateway's listener specified by a proper parentReference.
 func isRouteAcceptedByListener[T types.RouteT](ctx context.Context,
 	mgrc client.Client,
 	route T,

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -901,11 +901,12 @@ func isParentRefEqualToParent[
 func isRouteAcceptedByListener[T types.RouteT](ctx context.Context,
 	mgrc client.Client,
 	route T,
-	listener gatewayv1beta1.Listener,
 	gateway gatewayv1beta1.Gateway,
+	listenerIndex int,
 	parentRef gatewayv1beta1.ParentReference,
 ) (bool, error) {
 	// Check if the route matches listener's AllowedRoutes.
+	listener := gateway.Spec.Listeners[listenerIndex]
 	if ok, err := routeMatchesListenerAllowedRoutes(ctx, mgrc, route, listener, gateway.Namespace, parentRef.Namespace); err != nil {
 		return false, fmt.Errorf("failed matching listener %s to a route %s for gateway %s: %w",
 			listener.Name, route.GetName(), gateway.Name, err,

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -2236,7 +2236,6 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			var (
 				ctx       = context.Background()
 				namespace = &corev1.Namespace{

--- a/internal/util/builder/allowedroutes.go
+++ b/internal/util/builder/allowedroutes.go
@@ -1,6 +1,9 @@
 package builder
 
-import gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
 
 func NewAllowedRoutesFromSameNamespaces() *gatewayv1beta1.AllowedRoutes {
 	return &gatewayv1beta1.AllowedRoutes{
@@ -11,5 +14,11 @@ func NewAllowedRoutesFromSameNamespaces() *gatewayv1beta1.AllowedRoutes {
 func NewAllowedRoutesFromAllNamespaces() *gatewayv1beta1.AllowedRoutes {
 	return &gatewayv1beta1.AllowedRoutes{
 		Namespaces: NewRouteNamespaces().FromAll().Build(),
+	}
+}
+
+func NewAllowedRoutesFromSelectorNamespace(selector *metav1.LabelSelector) *gatewayv1beta1.AllowedRoutes {
+	return &gatewayv1beta1.AllowedRoutes{
+		Namespaces: NewRouteNamespaces().FromSelector(selector).Build(),
 	}
 }

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -182,6 +183,20 @@ func httpRouteAcceptedConditionMatches(t *testing.T, c *gatewayclient.Clientset,
 	}
 
 	return false
+}
+
+func ListenersHaveNAttachedRoutesCallback(t *testing.T, c *gatewayclient.Clientset, namespace, gatewayName string, attachedRoutesByListener map[string]int32) func() bool {
+	return func() bool {
+		gateway, err := c.GatewayV1beta1().Gateways(namespace).Get(context.Background(), gatewayName, metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		for _, listenerStatus := range gateway.Status.Listeners {
+			if attachedRoutesByListener[string(listenerStatus.Name)] != listenerStatus.AttachedRoutes {
+				return false
+			}
+		}
+		return true
+	}
 }
 
 // GetGatewayIsLinkedCallback returns a callback that checks if the specific Route (HTTP, TCP, TLS, or UDP)

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -185,6 +185,9 @@ func httpRouteAcceptedConditionMatches(t *testing.T, c *gatewayclient.Clientset,
 	return false
 }
 
+// ListenersHaveNAttachedRoutesCallback checks that every listener has a given number of attachedRoutes.
+// The attachedRoutesByListener parameter contains the number of expected acceptedRoutes for
+// each listener's name.
 func ListenersHaveNAttachedRoutesCallback(t *testing.T, c *gatewayclient.Clientset, namespace, gatewayName string, attachedRoutesByListener map[string]int32) func() bool {
 	return func() bool {
 		gateway, err := c.GatewayV1beta1().Gateways(namespace).Get(context.Background(), gatewayName, metav1.GetOptions{})

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,12 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	gatewayName := uuid.NewString()
 	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayv1beta1.Gateway) {
 		gw.Name = gatewayName
+		// add a UDP listener to check the HTTPRoute does not get attached to it.
+		gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1beta1.Listener{
+			Name:     "udp",
+			Protocol: gatewayv1beta1.UDPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(ktfkong.DefaultUDPServicePort),
+		})
 	})
 	require.NoError(t, err)
 	cleaner.Add(gateway)
@@ -192,6 +199,16 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		helpers.EventuallyGETPath(t, proxyURL, "", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
 	}
 
+	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True'")
+	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, true, gatewayv1beta1.RouteReasonAccepted), statusWait, waitTick)
+
+	t.Log("verifying that the Gateway listener have the proper attachedRoutes")
+	require.Eventually(t, ListenersHaveNAttachedRoutesCallback(t, gatewayClient, ns.Name, gatewayName, map[string]int32{
+		"http":  1,
+		"https": 1,
+		"udp":   0,
+	}), statusWait, waitTick)
+
 	t.Log("removing the parentrefs from the HTTPRoute")
 	oldParentRefs := httpRoute.Spec.ParentRefs
 	require.Eventually(t, func() bool {
@@ -289,9 +306,6 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	t.Log("putting the GatewayClass back")
 	_, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
-
-	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True' before specifying a port not existent in Gateway")
-	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, true, gatewayv1beta1.RouteReasonAccepted), statusWait, waitTick)
 
 	// Set the Port in ParentRef which does not have a matching listener in Gateway.
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

We need to update and keep up to date the `Gateway`'s `AttachedRoutes` field, with the actual number of routes accepted by it.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #3120 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
