### PR TITLE
chore(ci): fix notifications for failures of e2e nightly tests

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -46,7 +46,7 @@ jobs:
       - test-reports
     steps:
       - name: Notify on Slack for failures of e2e tests run automatically at night
-        if: failure() && github.event_name == 'schedule'
+        if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
         uses: 8398a7/action-slack@v3
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Notification was not sent for the last [e2e tests (nightly)](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5035826541), because `needs` condition is evaluated to [false for skipped jobs too](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs), and there was no overwrite of it in  in `if`. Now the job executes always after jobs required by `needs` and evaluate `if` anything previously failed to fire an alert on Slack. This is the approach inspired by [this snippet](https://github.com/benjamin-bergia/github-workflow-patterns/blob/master/.github/workflows/ignore-skipped.yml).
 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes notifications introduced in PR https://github.com/Kong/kubernetes-ingress-controller/pull/4023
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
