### PR TITLE
feat: disable expression routes mode when ExpressionRoutes is on but CombinedRoutes is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,9 @@ Adding a new version? You'll need three changes:
   now accounts for potential failures in synchronizing configuration with Konnect's
   Runtime Group Admin API.
   [#4029](https://github.com/Kong/kubernetes-ingress-controller/pull/4029)
+- Disable translation to expression routes when feature gate `ExpressionRoutes`
+  is enabled but feature gate `CombinedRoutes` is not enabled.
+  [#4057](https://github.com/Kong/kubernetes-ingress-controller/pull/4057)
 
 ### Changed
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -83,17 +83,10 @@ func NewFeatureFlags(
 		logger.Info("combined routes mode has been enabled")
 	}
 
-	expressionRoutesEnabled := false
-	if featureGates.Enabled(featuregates.ExpressionRoutesFeature) {
-		if routerFlavor == kongRouterFlavorExpressions {
-			expressionRoutesEnabled = true
-			logger.Info("expression routes mode has been enabled")
-		} else {
-			logger.Infof("ExpressionRoutes feature gate enabled, but Gateway run with %q router flavor, using this instead", routerFlavor)
-		}
-	}
-
 	combinedRoutesEnabled := featureGates.Enabled(featuregates.CombinedRoutesFeature)
+
+	expressionRoutesEnabled := shouldEnableParserExpressionRoutes(logger, featureGates, routerFlavor)
+
 	return FeatureFlags{
 		ReportConfiguredKubernetesObjects: updateStatusFlag,
 		CombinedServiceRoutes:             combinedRoutesEnabled,
@@ -101,6 +94,26 @@ func NewFeatureFlags(
 		ExpressionRoutes:                  expressionRoutesEnabled,
 		CombinedServices:                  combinedRoutesEnabled && featureGates.Enabled(featuregates.CombinedServicesFeature),
 	}
+}
+
+func shouldEnableParserExpressionRoutes(
+	logger logrus.FieldLogger,
+	featureGates featuregates.FeatureGates,
+	routerFlavor string,
+) bool {
+	if !featureGates.Enabled(featuregates.ExpressionRoutesFeature) {
+		return false
+	}
+	if !featureGates.Enabled(featuregates.CombinedRoutesFeature) {
+		logger.Info("ExpressionRoutes feature gate is enabled but CombinedRoutes feature gate is disabled, do not enable expression routes")
+		return false
+	}
+	if routerFlavor != kongRouterFlavorExpressions {
+		logger.Infof("ExpressionRoutes feature gate enabled, but Gateway run with %q router flavor, using this instead", routerFlavor)
+		return false
+	}
+	logger.Info("expression routes mode has been enabled")
+	return true
 }
 
 // LicenseGetter is an interface for getting the Kong Enterprise license.

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -109,10 +109,10 @@ func shouldEnableParserExpressionRoutes(
 		return false
 	}
 	if routerFlavor != kongRouterFlavorExpressions {
-		logger.Infof("ExpressionRoutes feature gate enabled, but Gateway run with %q router flavor, using this instead", routerFlavor)
+		logger.Infof("ExpressionRoutes feature gate enabled but Gateway is running with %q router flavor, using that instead", routerFlavor)
 		return false
 	}
-	logger.Info("expression routes mode has been enabled")
+	logger.Info("expression routes mode enabled")
 	return true
 }
 

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5259,7 +5259,7 @@ func TestNewFeatureFlags(t *testing.T) {
 				CombinedServiceRoutes: true,
 				ExpressionRoutes:      true,
 			},
-			expectInfoLog: "expression routes mode has been enabled",
+			expectInfoLog: "expression routes mode enabled",
 		},
 		{
 			name: "expression routes feature gate enabled and router flavor does not match",
@@ -5271,7 +5271,7 @@ func TestNewFeatureFlags(t *testing.T) {
 			expectedFeatureFlags: FeatureFlags{
 				CombinedServiceRoutes: true,
 			},
-			expectInfoLog: "ExpressionRoutes feature gate enabled, but Gateway run with \"any_other_router_mode\" router flavor, using this instead",
+			expectInfoLog: "ExpressionRoutes feature gate enabled but Gateway is running with \"any_other_router_mode\" router flavor, using that instead",
 		},
 		{
 			name: "expression routes feature gate enabled and combined routes disabled",

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5251,22 +5251,36 @@ func TestNewFeatureFlags(t *testing.T) {
 		{
 			name: "expression routes feature gate enabled and router flavor matches",
 			featureGates: map[string]bool{
+				featuregates.CombinedRoutesFeature:   true,
 				featuregates.ExpressionRoutesFeature: true,
 			},
 			routerFlavor: kongRouterFlavorExpressions,
 			expectedFeatureFlags: FeatureFlags{
-				ExpressionRoutes: true,
+				CombinedServiceRoutes: true,
+				ExpressionRoutes:      true,
 			},
 			expectInfoLog: "expression routes mode has been enabled",
 		},
 		{
 			name: "expression routes feature gate enabled and router flavor does not match",
 			featureGates: map[string]bool{
+				featuregates.CombinedRoutesFeature:   true,
 				featuregates.ExpressionRoutesFeature: true,
 			},
-			routerFlavor:         "any_other_router_mode",
+			routerFlavor: "any_other_router_mode",
+			expectedFeatureFlags: FeatureFlags{
+				CombinedServiceRoutes: true,
+			},
+			expectInfoLog: "ExpressionRoutes feature gate enabled, but Gateway run with \"any_other_router_mode\" router flavor, using this instead",
+		},
+		{
+			name: "expression routes feature gate enabled and combined routes disabled",
+			featureGates: map[string]bool{
+				featuregates.ExpressionRoutesFeature: true,
+			},
+			routerFlavor:         kongRouterFlavorExpressions,
 			expectedFeatureFlags: FeatureFlags{},
-			expectInfoLog:        "ExpressionRoutes feature gate enabled, but Gateway run with \"any_other_router_mode\" router flavor, using this instead",
+			expectInfoLog:        "ExpressionRoutes feature gate is enabled but CombinedRoutes feature gate is disabled, do not enable expression routes",
 		},
 		{
 			name: "combined routes feature gate enabled",


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Since we did not implement the translator for ingresses and httproutes to expression based routes, we disable expression routes mode of parser when `ExpressionRoutes` is enabled but `CombinedRoutes` is disabled.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4043 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
