### PR TITLE
chore(deps): bump go-echo to 0.3.0 everywhere

### DIFF
--- a/examples/gateway-tcproute.yaml
+++ b/examples/gateway-tcproute.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: tcpecho
-        image: kong/go-echo:0.1.0
+        image: kong/go-echo:0.3.0
         ports:
         - containerPort: 1025
         env:

--- a/examples/gateway-tlsroute.yaml
+++ b/examples/gateway-tlsroute.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: tcpecho
-        image: kong/go-echo:0.1.0
+        image: kong/go-echo:0.3.0
         ports:
         - containerPort: 1025
         env:

--- a/test/consts.go
+++ b/test/consts.go
@@ -11,5 +11,5 @@ const (
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.
 	// In namespace foo.
 	// With IP address 10.244.0.13.
-	TCPEchoImage = "kong/go-echo:0.2.0"
+	TCPEchoImage = "kong/go-echo:0.3.0"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Use the newest image of `kong/go-echo` everywhere in KIC

