### PR TITLE
Cherry-pick the _validate Kong image (targeted)_ workflow to `release/2.9.x`

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -1,14 +1,35 @@
 name: integration tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      kong-container-repo:
+        type: string
+        default: "kong/kong"
+        required: false
+      kong-container-tag:
+        type: string
+        # TODO: Consider changing to "kong:latest"
+        # See https://github.com/Kong/kubernetes-testing-framework/issues/542
+        default: "3.2"
+        required: false
+      kong-enteprise-container-repo:
+        type: string
+        default: "kong/kong-gateway"
+        required: false
+      kong-enterprise-container-tag:
+        type: string
+        # TODO: Consider changing to "kong/kong-gateway:latest"
+        # See https://github.com/Kong/kubernetes-testing-framework/issues/542
+        default: "3.2"
+        required: false
 
 jobs:
   integration-tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     env:
-      KONG_CLUSTER_VERSION: 'v1.26.0'
+      KONG_CLUSTER_VERSION: 'v1.27.1'
       TEST_KONG_ROUTER_FLAVOR: 'traditional'
     strategy:
       fail-fast: false
@@ -43,19 +64,13 @@ jobs:
 
       - name: Set image of Kong
         id: set_kong_image
-        # TODO: We need a systematic approach to this. Either:
-        # - leave this here and bump every GW release
-        # - remove this and rely on bumping GW image in ktf
-        # - rely on a mechanism in ktf that will always, by default return the newest
-        #   Gateway tag.
-        # Related issue: https://github.com/Kong/kubernetes-testing-framework/issues/542
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
-            echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2.1.0" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-container-tag }}" >> $GITHUB_ENV
           else
-            echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2.1" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
           fi
 
       - name: checkout repository

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -66,11 +66,11 @@ jobs:
         id: set_kong_image
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
-            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
           else
-            echo "TEST_KONG_IMAGE=${{ github.event.inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ github.event.inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_IMAGE=${{ inputs.kong-container-repo }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${{ inputs.kong-container-tag }}" >> $GITHUB_ENV
           fi
 
       - name: checkout repository

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -13,7 +13,7 @@ on:
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
         default: "3.2"
         required: false
-      kong-enteprise-container-repo:
+      kong-enterprise-container-repo:
         type: string
         default: "kong/kong-gateway"
         required: false

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
-      # URL is the current's workflow run URL.
+      # URL is the current workflow's run URL.
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.inputs.pr-number }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -1,0 +1,68 @@
+name: "validate Kong image (targeted)"
+run-name: "validate Kong ${{ format('{0}:{1}', github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-repo:
+        description: Kong Gateway Docker image to test with (repository).
+        type: string
+        required: true
+        default: "kong/kong-gateway"
+      kong-image-tag:
+        description: Kong Gateway Docker image to test with (tag).
+        type: string
+        required: true
+        default: "latest"
+      e2e-controller-image-repo:
+        description: KIC Docker image for E2E tests (repository).
+        type: string
+        required: true
+        default: "kong/kubernetes-ingress-controller"
+      e2e-controller-image-tag:
+        description: KIC Docker image for E2E tests (tag).
+        type: string
+        required: true
+        default: "latest"
+      issue-number:
+        description: Issue number to post a comment in. If empty, no comment is posted.
+        type: string
+        required: false
+
+jobs:
+  post-comment-in-issue:
+    if: ${{ github.event.inputs.issue-number != '' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      # URL is the current workflow's run URL.
+      # Sadly this is not readily available in github's context.
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ISSUE_NUMBER: ${{ github.event.inputs.issue-number }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          gh issue comment ${ISSUE_NUMBER} --body \
+            "Kong Gateway validation tests were started at ${URL} with the following parameters: ${{ toJSON(github.event.inputs) }}"
+
+  run-e2e-tests:
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_e2e_tests.yaml
+    secrets: inherit
+    with:
+      kic-image: ${{ format('{0}:{1}', github.event.inputs.e2e-controller-image-repo, github.event.inputs.e2e-controller-image-tag) }}
+      kong-image: ${{ format('{0}:{1}', github.event.inputs.kong-image-repo, github.event.inputs.kong-image-tag) }}
+      load-local-image: false
+      run-gke: true
+      run-istio: true
+      all-supported-k8s-versions: true
+
+  run-integration-tests:
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_integration_tests.yaml
+    secrets: inherit
+    with:
+      kong-container-repo: $ {{ github.event.inputs.kong-container-repo }}
+      kong-container-tag: $ {{ github.event.inputs.kong-container-tag }}
+      kong-enterprise-container-repo: $ {{ github.event.inputs.kong-container-repo }}
+      kong-enterprise-container-tag: $ {{ github.event.inputs.kong-container-tag }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       kong-image-repo:
-        description: Kong Gateway Docker image to test with (repository).
+        description: Kong Gateway Docker image to test with (repository). Must be an EE variant.
         type: string
         required: true
         default: "kong/kong-gateway"
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           gh issue comment ${ISSUE_NUMBER} --body \
-            'Kong Gateway validation tests were started at ${URL} with the following parameters:
+            'Kong Gateway validation tests were started at ${{ env.URL }} with the following parameters:
             ```json
             ${{ toJSON(github.event.inputs) }}
             ```
@@ -66,7 +66,10 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yaml
     secrets: inherit
     with:
-      kong-container-repo: $ {{ github.event.inputs.kong-container-repo }}
-      kong-container-tag: $ {{ github.event.inputs.kong-container-tag }}
-      kong-enterprise-container-repo: $ {{ github.event.inputs.kong-container-repo }}
-      kong-enterprise-container-tag: $ {{ github.event.inputs.kong-container-tag }}
+      kong-container-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-container-tag: ${{ github.event.inputs.kong-image-tag }}
+      # We're passing the same image twice, because the integration tests need to know the image
+      # for Enterprise variant of tests separately.
+      # That makes this workflow usable only for Enterprise images.
+      kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
+      kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -43,7 +43,11 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           gh issue comment ${ISSUE_NUMBER} --body \
-            "Kong Gateway validation tests were started at ${URL} with the following parameters: ${{ toJSON(github.event.inputs) }}"
+            'Kong Gateway validation tests were started at ${URL} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '
 
   run-e2e-tests:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
This PR cherry-picks #4028 #4030 #4031 #4032 into `release/2.9.x` to make it possible to run the "validate Kong image (targeted)" workflow for a stable KIC 2.9.x.

The command to run a workflow is
```shell
gh workflow run "validate Kong image (targeted)" \
  -R kong/kubernetes-ingress-controller \
  --ref release/2.9.x \
  -f kong-image-repo=kong/kong-gateway \
  -f kong-image-tag=x.x.x.x-alpine \ # FILL THIS IN, example value: 2.8.4.1-alpine
  -f e2e-controller-image-repo=kong/kubernetes-ingress-controller \
  -f e2e-controller-image-tag=x.x.x \ # FILL THIS IN, example value: 2.9.3
  -f issue-number=XXXX # FILL THIS IN
```