### PR TITLE
ci: add auto issue close and comment to validate kong image workflow

### DIFF
--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -25,7 +25,7 @@ on:
         required: true
         default: "latest"
       issue-number:
-        description: Issue number to post a comment in. If empty, no comment is posted.
+        description: Issue number to comment in, and close in case of success. Can be none.
         type: string
         required: false
 

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -30,7 +30,7 @@ on:
         required: false
 
 jobs:
-  post-comment-in-issue:
+  startup-issue-comment:
     if: ${{ github.event.inputs.issue-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -73,3 +73,24 @@ jobs:
       # That makes this workflow usable only for Enterprise images.
       kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
       kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}
+
+  on-success-close-issue:
+    needs:
+    - startup-issue-comment
+    - run-e2e-tests
+    - run-integration-tests
+    if: ${{ github.event.inputs.issue-number != '' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ISSUE_NUMBER: ${{ github.event.inputs.issue-number }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          gh issue close ${ISSUE_NUMBER} --comment \
+            'Kong Gateway validation tests **PASSED** at ${{ env.URL }} with the following parameters:
+            ```json
+            ${{ toJSON(github.event.inputs) }}
+            ```
+            '


### PR DESCRIPTION
Expand #4028

A "validate Kong image (targeted)" workflow run, before this PR:
- on startup, creates an issue comment.

After this PR:
- the same as before, and additionally:
- on __successful__ completion
  - creates another issue comment
  - closes the issue.