### PR TITLE
feat: add FillIDs feature gate

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -64,6 +64,12 @@ jobs:
           - name: dbless-combined-services
             test: dbless
             feature_gates: "GatewayAlpha=true,CombinedServices=true"
+          - name: dbless-fill-ids
+            test: dbless
+            feature_gates: "GatewayAlpha=true,FillIDs=true"
+          - name: postgres-fill-ids
+            test: postgres
+            feature_gates: "GatewayAlpha=true,FillIDs=true"
 
     steps:
       - uses: Kong/kong-license@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,19 @@ Adding a new version? You'll need three changes:
   [#3832](https://github.com/Kong/kubernetes-ingress-controller/pull/3832)
 - Added license agent for Konnect-managed instances.
   [#3883](https://github.com/Kong/kubernetes-ingress-controller/pull/3883)
-- `Service`, `Route` and `Consumer` Kong entities now get assigned deterministic
+- `Service`, `Route`, and `Consumer` Kong entities now get assigned deterministic
   IDs based on their unique properties (name, username, etc.) instead of random
   UUIDs.
+  After the upgrade to 2.10.0, the controller will re-create all the existing
+  entities (Services, Routes, and Consumers) with the new IDs. That can
+  potentially lead to temporary downtime between the deletion of the old entities
+  and the creation of the new ones.
+  Users might want to disable the feature if their existing DB-backed setup
+  consists of a huge amount of entities for which the recreation can take
+  significant time. It is possible to opt out of this behavior by setting
+  `FillIDs` feature gate to `false`.
   [#3933](https://github.com/Kong/kubernetes-ingress-controller/pull/3933)
+  [#4075](https://github.com/Kong/kubernetes-ingress-controller/pull/4075)
 - Added translator to translate ingresses under `networking.k8s.io/v1` to
   expression based Kong routes. The translator is enabled when feature gate
   `ExpressionRoutes` is turned on and the managed Kong gateway runs in router

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,17 +77,21 @@ Adding a new version? You'll need three changes:
   [#3832](https://github.com/Kong/kubernetes-ingress-controller/pull/3832)
 - Added license agent for Konnect-managed instances.
   [#3883](https://github.com/Kong/kubernetes-ingress-controller/pull/3883)
-- `Service`, `Route`, and `Consumer` Kong entities now get assigned deterministic
-  IDs based on their unique properties (name, username, etc.) instead of random
-  UUIDs.
-  After the upgrade to 2.10.0, the controller will re-create all the existing
-  entities (Services, Routes, and Consumers) with the new IDs. That can
+- `Service`, `Route`, and `Consumer` Kong entities now can get assigned
+  deterministic IDs based on their unique properties (name, username, etc.)
+  instead of random UUIDs. To enable this feature, set `FillIDs` feature gate
+  to `true`.
+  It's going to be useful in cases where stable IDs are needed across multiple
+  Kong Gateways managed by KIC (e.g. for the integration with Konnect and
+  reporting metrics that later can be aggregated across multiple instances based
+  on the entity's ID).
+  When `FillIDs` will be enabled, the controller will re-create all the existing
+  entities (Services, Routes, and Consumers) with the new IDs assigned. That can
   potentially lead to temporary downtime between the deletion of the old entities
   and the creation of the new ones.
-  Users might want to disable the feature if their existing DB-backed setup
-  consists of a huge amount of entities for which the recreation can take
-  significant time. It is possible to opt out of this behavior by setting
-  `FillIDs` feature gate to `false`.
+  Users should be cautious about enabling the feature if their existing DB-backed
+  setup consists of a huge amount of entities for which the recreation can take
+  significant time.
   [#3933](https://github.com/Kong/kubernetes-ingress-controller/pull/3933)
   [#4075](https://github.com/Kong/kubernetes-ingress-controller/pull/4075)
 - Added translator to translate ingresses under `networking.k8s.io/v1` to

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -62,7 +62,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
 | ExpressionRoutes | `false` | Alpha | 2.10.0  | TBD   |
 | CombinedServices | `false` | Alpha | 2.10.0  | TBD   |
-| FillIDs          | `true`  | Beta  | 2.10.0  | 3.0.0 |
+| FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -62,6 +62,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
 | ExpressionRoutes | `false` | Alpha | 2.10.0  | TBD   |
 | CombinedServices | `false` | Alpha | 2.10.0  | TBD   |
+| FillIDs          | `true`  | Beta  | 2.10.0  | 3.0.0 |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5351,7 +5351,7 @@ func TestNewFeatureFlags(t *testing.T) {
 
 func mustNewParser(t *testing.T, storer store.Storer) *Parser {
 	p, err := NewParser(logrus.New(), storer, FeatureFlags{
-		FillIDs: featuregates.GetFeatureGatesDefaults()[featuregates.FillIDsFeature],
+		FillIDs: true, // We'll assume this is true for all tests.
 	})
 	require.NoError(t, err)
 	return p

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5321,6 +5321,15 @@ func TestNewFeatureFlags(t *testing.T) {
 				CombinedServices:      false,
 			},
 		},
+		{
+			name: "fill ids enabled",
+			featureGates: map[string]bool{
+				featuregates.FillIDsFeature: true,
+			},
+			expectedFeatureFlags: FeatureFlags{
+				FillIDs: true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -5341,7 +5350,9 @@ func TestNewFeatureFlags(t *testing.T) {
 }
 
 func mustNewParser(t *testing.T, storer store.Storer) *Parser {
-	p, err := NewParser(logrus.New(), storer, FeatureFlags{})
+	p, err := NewParser(logrus.New(), storer, FeatureFlags{
+		FillIDs: featuregates.GetFeatureGatesDefaults()[featuregates.FillIDsFeature],
+	})
 	require.NoError(t, err)
 	return p
 }

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -37,6 +37,10 @@ const (
 	// a Kubernetes Service is referenced by multiple netv1.Ingresses. It's effective only when CombinedRoutesFeature is enabled.
 	CombinedServicesFeature = "CombinedServices"
 
+	// FillIDsFeature is the name of the feature-gate that makes KIC fill in the ID fields of Kong entities (Services,
+	// Routes, and Consumers). It ensures that IDs remain stable across restarts of the controller.
+	FillIDsFeature = "FillIDs"
+
 	// DocsURL provides a link to the documentation for feature gates in the KIC repository.
 	DocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
 )
@@ -78,5 +82,6 @@ func GetFeatureGatesDefaults() map[string]bool {
 		CombinedRoutesFeature:   true,
 		ExpressionRoutesFeature: false,
 		CombinedServicesFeature: false,
+		FillIDsFeature:          true,
 	}
 }

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -82,6 +82,6 @@ func GetFeatureGatesDefaults() map[string]bool {
 		CombinedRoutesFeature:   true,
 		ExpressionRoutesFeature: false,
 		CombinedServicesFeature: false,
-		FillIDsFeature:          true,
+		FillIDsFeature:          false,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a default-off `FillIDs` feature gate to allow opting in for the https://github.com/Kong/kubernetes-ingress-controller/issues/3906.

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4074



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
