### PR TITLE
chore: bump gateway to 3.3

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         # TODO: Consider changing to "kong:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.2"
+        default: "3.3"
         required: false
       kong-enterprise-container-repo:
         type: string
@@ -21,7 +21,7 @@ on:
         type: string
         # TODO: Consider changing to "kong/kong-gateway:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.2"
+        default: "3.3"
         required: false
 
 jobs:

--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.2'
+  newTag: '3.3'
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.2'
+  newTag: '3.3'

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.2'
+  newTag: '3.3'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
   newTag: '2.9.3'

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -1769,7 +1769,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1774,7 +1774,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -1784,7 +1784,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1784,7 +1784,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.2
+        image: kong:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -1660,7 +1660,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.2
+        image: kong:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1769,7 +1769,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.2
+        image: kong:3.3
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1723,7 +1723,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         lifecycle:
           preStop:
             exec:
@@ -1842,7 +1842,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -1941,7 +1941,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
@@ -1956,7 +1956,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.2
+        image: kong/kong-gateway:3.3
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1678,7 +1678,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.2
+        image: kong:3.3
         lifecycle:
           preStop:
             exec:
@@ -1779,7 +1779,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:3.2
+        image: kong:3.3
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -1868,7 +1868,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.2
+        image: kong:3.3
         name: kong-migrations
       initContainers:
       - command:
@@ -1881,7 +1881,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.2
+        image: kong:3.3
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump default Gateway image to be used in tests and manifests from 3.2 to 3.3.
