### PR TITLE
tests: make upgrade tests run, add one for postgres

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -39,7 +39,6 @@ import (
 const (
 	dblessLegacyPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
 	dblessPath       = "../../deploy/single/all-in-one-dbless.yaml"
-	dblessURL        = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%v.%v.x/deploy/single/all-in-one-dbless.yaml"
 )
 
 func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
@@ -67,36 +66,6 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	killKong(ctx, t, env, &pod)
 
 	t.Log("confirming that routes are restored after crash")
-	verifyIngress(ctx, t, env)
-}
-
-func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
-	curTag, err := getCurrentGitTag("")
-	require.NoError(t, err)
-	preTag, err := getPreviousGitTag("", curTag)
-	require.NoError(t, err)
-	if curTag.Patch != 0 || len(curTag.Pre) > 0 {
-		t.Skipf("%v not a new minor version, skipping upgrade test", curTag)
-	}
-	oldManifest, err := http.Get(fmt.Sprintf(dblessURL, preTag.Major, preTag.Minor))
-	require.NoError(t, err)
-	defer oldManifest.Body.Close()
-
-	t.Log("configuring all-in-one-dbless.yaml manifest test")
-	t.Parallel()
-	ctx, env := setupE2ETest(t)
-
-	t.Logf("deploying previous version %s kong manifest", preTag)
-	deployKong(ctx, t, env, oldManifest.Body)
-
-	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
-
-	t.Logf("deploying current version %s kong manifest", curTag)
-
-	manifest := getTestManifest(t, dblessPath)
-	deployKong(ctx, t, env, manifest)
 	verifyIngress(ctx, t, env)
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,59 @@
+//go:build e2e_tests
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+const (
+	// upgradeTestFromTag is the tag of the previous version of the controller to upgrade from.
+	upgradeTestFromTag = "v2.9.3"
+
+	// dblessURLTemplate is the template of the URL to the all-in-one-dbless.yaml manifest with a placeholder for the tag.
+	dblessURLTemplate = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%s/deploy/single/all-in-one-dbless.yaml"
+
+	// 	postgresURLTemplate is the template of the URL to the all-in-one-postgres.yaml manifest with a placeholder for the tag.
+	postgresURLTemplate = "https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/%s/deploy/single/all-in-one-postgres.yaml"
+)
+
+func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
+	fromManifestURL := fmt.Sprintf(dblessURLTemplate, upgradeTestFromTag)
+	toManifestPath := dblessPath
+	testManifestsUpgrade(t, fromManifestURL, toManifestPath)
+}
+
+func TestDeployAndUpgradeAllInOnePostgres(t *testing.T) {
+	fromManifestURL := fmt.Sprintf(postgresURLTemplate, upgradeTestFromTag)
+	toManifestPath := postgresPath
+	testManifestsUpgrade(t, fromManifestURL, toManifestPath)
+}
+
+func testManifestsUpgrade(t *testing.T, fromManifestURL string, toManifestPath string) {
+	t.Parallel()
+
+	httpClient := helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())
+	oldManifest, err := httpClient.Get(fromManifestURL)
+	require.NoError(t, err)
+	defer oldManifest.Body.Close()
+
+	t.Log("configuring upgrade manifests test")
+	ctx, env := setupE2ETest(t)
+
+	t.Logf("deploying previous kong manifests: %s", fromManifestURL)
+	deployKong(ctx, t, env, oldManifest.Body)
+
+	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
+	deployIngress(ctx, t, env)
+	verifyIngress(ctx, t, env)
+
+	t.Logf("deploying target version of kong manifests: %s", toManifestPath)
+	manifest := getTestManifest(t, toManifestPath)
+	deployKong(ctx, t, env, manifest)
+	verifyIngress(ctx, t, env)
+}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -12,13 +12,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/phayes/freeport"
@@ -197,43 +195,6 @@ func patchControllerImageFromEnv(t *testing.T, manifestReader io.Reader) (io.Rea
 
 	t.Log("controller image override undefined, using defaults")
 	return manifestReader, nil
-}
-
-func getCurrentGitTag(path string) (semver.Version, error) {
-	cmd := exec.Command("git", "describe", "--tags")
-	cmd.Dir = path
-	tagBytes, err := cmd.Output()
-	if err != nil {
-		return semver.Version{}, fmt.Errorf("%q command failed: %w", cmd.String(), err)
-	}
-	tag, err := semver.ParseTolerant(string(tagBytes))
-	if err != nil {
-		return semver.Version{}, err
-	}
-	return tag, nil
-}
-
-func getPreviousGitTag(path string, cur semver.Version) (semver.Version, error) {
-	var tags []semver.Version
-	cmd := exec.Command("git", "tag")
-	cmd.Dir = path
-	tagsBytes, err := cmd.Output()
-	if err != nil {
-		return semver.Version{}, err
-	}
-	foo := strings.Split(string(tagsBytes), "\n")
-	for _, tag := range foo {
-		ver, err := semver.ParseTolerant(tag)
-		if err == nil {
-			tags = append(tags, ver)
-		}
-	}
-	sort.Slice(tags, func(i, j int) bool { return tags[i].LT(tags[j]) })
-	curIndex := sort.Search(len(tags), func(i int) bool { return tags[i].EQ(cur) })
-	if curIndex == 0 {
-		return tags[curIndex], nil
-	}
-	return tags[curIndex-1], nil
 }
 
 // getKongProxyIP takes a Service with Kong proxy ports and returns and its IP, or fails the test if it cannot.


### PR DESCRIPTION
**What this PR does / why we need it**:

In the current setup, the existing upgrade test for DB-less manifests is never executed (sample runs of [e2e nightly](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5041834863/jobs/9041892003) and [e2e targeted](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5025607446/jobs/9013457853)).

This PR aims to fix this by explicitly setting the version of the manifest we'd like to test upgrading from. It also adds one more test case for all-in-one-postgres manifests.


