### PR TITLE
refactor: don't use kong version singleton

### DIFF
--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -3,6 +3,7 @@ package kongstate
 import (
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
@@ -66,7 +67,7 @@ func (c *Consumer) SanitizedCopy() *Consumer {
 	}
 }
 
-func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags []*string) error {
+func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags []*string, kongVersion semver.Version) error {
 	switch credType {
 	case "key-auth", "keyauth_credential":
 		cred, err := NewKeyAuth(credConfig)
@@ -111,7 +112,7 @@ func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags [
 		cred.Tags = tags
 		c.ACLGroups = append(c.ACLGroups, cred)
 	case "mtls-auth":
-		if !versions.GetKongVersion().MajorMinorPatchOnly().GTE(versions.MTLSCredentialVersionCutoff) {
+		if !kongVersion.GTE(versions.MTLSCredentialVersionCutoff) {
 			return fmt.Errorf("controller cannot support mtls-auth below version %v", versions.MTLSCredentialVersionCutoff)
 		}
 		cred, err := NewMTLSAuth(credConfig)

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -130,7 +130,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 				continue
 			}
 			credTags := util.GenerateTagsForObject(secret)
-			err = c.SetCredential(credType, credConfig, credTags)
+			err = c.SetCredential(credType, credConfig, credTags, ks.Version)
 			if err != nil {
 				log.WithError(err).Errorf("failed to provision credential")
 				continue

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -79,7 +80,7 @@ type FeatureFlags struct {
 func NewFeatureFlags(
 	logger logrus.FieldLogger,
 	featureGates featuregates.FeatureGates,
-	kongVersion versions.KongVersion,
+	kongVersion semver.Version,
 	routerFlavor string,
 	updateStatusFlag bool,
 ) FeatureFlags {
@@ -94,7 +95,7 @@ func NewFeatureFlags(
 	return FeatureFlags{
 		ReportConfiguredKubernetesObjects: updateStatusFlag,
 		CombinedServiceRoutes:             combinedRoutesEnabled,
-		RegexPathPrefix:                   kongVersion.MajorMinorOnly().GTE(versions.ExplicitRegexPathVersionCutoff),
+		RegexPathPrefix:                   kongVersion.GTE(versions.ExplicitRegexPathVersionCutoff),
 		ExpressionRoutes:                  expressionRoutesEnabled,
 		CombinedServices:                  combinedRoutesEnabled && featureGates.Enabled(featuregates.CombinedServicesFeature),
 		FillIDs:                           featureGates.Enabled(featuregates.FillIDsFeature),
@@ -134,6 +135,7 @@ type Parser struct {
 	storer        store.Storer
 	licenseGetter LicenseGetter
 	featureFlags  FeatureFlags
+	kongVersion   semver.Version
 
 	failuresCollector      *failures.ResourceFailuresCollector
 	parsedObjectsCollector *ObjectsCollector
@@ -145,6 +147,7 @@ func NewParser(
 	logger logrus.FieldLogger,
 	storer store.Storer,
 	featureFlags FeatureFlags,
+	kongVersion semver.Version,
 ) (*Parser, error) {
 	failuresCollector, err := failures.NewResourceFailuresCollector(logger)
 	if err != nil {
@@ -163,6 +166,7 @@ func NewParser(
 		featureFlags:           featureFlags,
 		failuresCollector:      failuresCollector,
 		parsedObjectsCollector: parsedObjectsCollector,
+		kongVersion:            kongVersion,
 	}, nil
 }
 

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -28,7 +29,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
@@ -5197,7 +5197,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		name string
 
 		featureGates     map[string]bool
-		kongVersion      versions.KongVersion
+		kongVersion      semver.Version
 		routerFlavor     string
 		updateStatusFlag bool
 
@@ -5259,7 +5259,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		},
 		{
 			name:        "kong version >= 3.0 enables regex path prefix",
-			kongVersion: versions.KongVersion{Major: 3, Minor: 0},
+			kongVersion: semver.Version{Major: 3, Minor: 0},
 			expectedFeatureFlags: FeatureFlags{
 				RegexPathPrefix: true,
 			},
@@ -5315,9 +5315,17 @@ func TestNewFeatureFlags(t *testing.T) {
 }
 
 func mustNewParser(t *testing.T, storer store.Storer) *Parser {
-	p, err := NewParser(logrus.New(), storer, FeatureFlags{
-		FillIDs: true, // We'll assume this is true for all tests.
-	})
+	const testKongVersion = "3.2.0"
+
+	v, err := semver.Parse(testKongVersion)
+	require.NoError(t, err)
+
+	p, err := NewParser(logrus.New(), storer,
+		FeatureFlags{
+			FillIDs: true, // We'll assume this is true for all tests.
+		},
+		v,
+	)
 	require.NoError(t, err)
 	return p
 }

--- a/internal/dataplane/sendconfig/inmemory_test.go
+++ b/internal/dataplane/sendconfig/inmemory_test.go
@@ -1,0 +1,48 @@
+package sendconfig
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_shouldUseFlattenedErrors(t *testing.T) {
+	testcases := []struct {
+		version  string
+		expected bool
+	}{
+		{
+			version:  "3.1.0",
+			expected: false,
+		},
+		{
+			version:  "3.1.9",
+			expected: false,
+		},
+		{
+			version:  "3.2.0",
+			expected: true,
+		},
+		{
+			version:  "3.2.1",
+			expected: true,
+		},
+		{
+			version:  "3.5.0",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.version, func(t *testing.T) {
+			v, err := semver.Parse(tc.version)
+			require.NoError(t, err)
+			if tc.expected {
+				require.True(t, shouldUseFlattenedErrors(v))
+			} else {
+				require.False(t, shouldUseFlattenedErrors(v))
+			}
+		})
+	}
+}

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -113,5 +113,9 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(client UpdateClient
 		)
 	}
 
-	return NewUpdateStrategyInMemory(adminAPIClient, r.log)
+	return NewUpdateStrategyInMemory(
+		adminAPIClient,
+		r.log,
+		r.config.Version,
+	)
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -92,7 +92,6 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	}
 
 	kongSemVersion := semver.Version{Major: v.Major(), Minor: v.Minor(), Patch: v.Patch()}
-	versions.SetKongVersion(kongSemVersion)
 
 	kongConfig := sendconfig.Config{
 		Version:               kongSemVersion,
@@ -102,7 +101,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		SkipCACertificates:    c.SkipCACertificates,
 		EnableReverseSync:     c.EnableReverseSync,
 		ExpressionRoutes:      featureGates.Enabled(featuregates.ExpressionRoutesFeature),
-		DeckFileFormatVersion: versions.DeckFileFormat(versions.GetKongVersion()),
+		DeckFileFormatVersion: versions.DeckFileFormat(kongSemVersion),
 	}
 	kongConfig.Init(ctx, setupLog, initialKongClients)
 
@@ -142,7 +141,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	parserFeatureFlags := parser.NewFeatureFlags(
 		deprecatedLogger,
 		featureGates,
-		versions.GetKongVersion(),
+		kongSemVersion,
 		routerFlavor,
 		c.UpdateStatus,
 	)
@@ -151,6 +150,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		deprecatedLogger,
 		store.New(cache, c.IngressClassName, deprecatedLogger),
 		parserFeatureFlags,
+		kongSemVersion,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create parser: %w", err)

--- a/internal/versions/deck.go
+++ b/internal/versions/deck.go
@@ -1,7 +1,10 @@
 package versions
 
-func DeckFileFormat(kongVersion KongVersion) string {
-	if kongVersion.MajorMinorOnly().GTE(ExplicitRegexPathVersionCutoff) {
+import "github.com/blang/semver/v4"
+
+// DeckFileFormat returns Deck file format based on Kong version.
+func DeckFileFormat(kongVersion semver.Version) string {
+	if kongVersion.GTE(ExplicitRegexPathVersionCutoff) {
 		return "3.0"
 	}
 	return "1.1"

--- a/internal/versions/deck_test.go
+++ b/internal/versions/deck_test.go
@@ -3,6 +3,7 @@ package versions_test
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
@@ -10,17 +11,17 @@ import (
 
 func TestDeckFileFormat(t *testing.T) {
 	t.Run("Kong version >= 3.0", func(t *testing.T) {
-		actualDeckFormat := versions.DeckFileFormat(versions.KongVersion{Major: 3, Minor: 0})
+		actualDeckFormat := versions.DeckFileFormat(semver.Version{Major: 3, Minor: 0})
 		require.Equal(t, "3.0", actualDeckFormat)
 	})
 
 	t.Run("Kong version >= 3.0 - other than 3.0", func(t *testing.T) {
-		actualDeckFormat := versions.DeckFileFormat(versions.KongVersion{Major: 3, Minor: 5})
+		actualDeckFormat := versions.DeckFileFormat(semver.Version{Major: 3, Minor: 5})
 		require.Equal(t, "3.0", actualDeckFormat)
 	})
 
 	t.Run("Kong version < 3.0", func(t *testing.T) {
-		actualDeckFormat := versions.DeckFileFormat(versions.KongVersion{Major: 2, Minor: 9})
+		actualDeckFormat := versions.DeckFileFormat(semver.Version{Major: 2, Minor: 9})
 		require.Equal(t, "1.1", actualDeckFormat)
 	})
 }

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -1,8 +1,6 @@
 package versions
 
 import (
-	"sync"
-
 	"github.com/blang/semver/v4"
 )
 
@@ -11,9 +9,8 @@ var (
 	// matches.
 	RegexHeaderVersionCutoff = semver.Version{Major: 2, Minor: 8}
 
-	// ExplicitRegexPathVersionCutoff is the Kong version prior to the addition of explicit "~" prefixes in regular
-	// expression paths.
-	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3}
+	// ExplicitRegexPathVersionCutoff is the lowest Kong version adding the explicit "~" prefixes in regular expression paths.
+	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 
 	// PluginOrderingVersionCutoff is the Kong version prior to the addition of plugin ordering.
 	PluginOrderingVersionCutoff = semver.Version{Major: 3}
@@ -22,56 +19,9 @@ var (
 	// because the original version of the mTLS credential was not compatible with KIC.
 	MTLSCredentialVersionCutoff = semver.Version{Major: 2, Minor: 3, Patch: 2}
 
-	// FlattenedErrorCutoff is the Kong version prior to the addition of flattened errors.
-	FlattenedErrorCutoff = semver.Version{Major: 3, Minor: 1}
+	// FlattenedErrorCutoff is the lowest Kong version with support for flattened errors.
+	FlattenedErrorCutoff = semver.Version{Major: 3, Minor: 2}
+
+	// TLSPassthroughCutoff is the lowest Kong version with support for TLS passthrough.
+	TLSPassthroughCutoff = semver.Version{Major: 2, Minor: 7}
 )
-
-var (
-	// kongVersion holds the Kong version singleton. If never initialized (during some tests), it defaults to the
-	// lowest possible version.
-	kongVersion = KongVersion(semver.MustParse("0.0.0"))
-
-	kongVersionOnce sync.Once
-
-	kongVersionLock sync.RWMutex
-)
-
-// KongVersion is a Kong version.
-type KongVersion semver.Version
-
-// SetKongVersion sets the Kong version. It can only be used once. Repeated calls will not update the Kong
-// version.
-func SetKongVersion(version semver.Version) {
-	kongVersionOnce.Do(func() {
-		kongVersionLock.Lock()
-		defer kongVersionLock.Unlock()
-		kongVersion = KongVersion(version)
-	})
-}
-
-// GetKongVersion retrieves the Kong version. If the version is not set, it returns the lowest possible version.
-func GetKongVersion() KongVersion {
-	kongVersionLock.RLock()
-	defer kongVersionLock.RUnlock()
-	return kongVersion
-}
-
-// Full returns a complete Kong version as a semver.Version.
-func (v KongVersion) Full() semver.Version {
-	return semver.Version(v)
-}
-
-// MajorOnly returns a semver.Version with a KongVersion's major version only.
-func (v KongVersion) MajorOnly() semver.Version {
-	return semver.Version{Major: v.Major}
-}
-
-// MajorMinorOnly returns a semver.Version with a KongVersion's major and minor versions only.
-func (v KongVersion) MajorMinorOnly() semver.Version {
-	return semver.Version{Major: v.Major, Minor: v.Minor}
-}
-
-// MajorMinorPatchOnly returns a semver.Version with a KongVersion's major, minor, and patch versions only.
-func (v KongVersion) MajorMinorPatchOnly() semver.Version {
-	return semver.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
-}

--- a/test/integration/config_error_event_test.go
+++ b/test/integration/config_error_event_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
@@ -20,20 +21,17 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 func TestConfigErrorEventGeneration(t *testing.T) {
+	// This test is NOT parallel.
+	// The broken configuration prevents all updates and will break unrelated tests
+
 	skipTestForExpressionRouter(t)
-	// this test is NOT parallel. the broken configuration prevents all updates and will break unrelated tests
-	if testenv.DBMode() != "off" {
-		t.Skip("config errors are only supported on DB-less mode")
-	}
-	if versions.GetKongVersion().MajorMinorOnly().LTE(versions.FlattenedErrorCutoff) {
-		t.Skipf("kong version is %s < 3.2, skipping testing config error parsing", versions.GetKongVersion().MajorMinorOnly().String())
-	} else {
-		t.Logf("kong version is %s >= 3.2, testing config error parsing", versions.GetKongVersion().MajorMinorOnly().String())
-	}
+
+	RunWhenKongDBMode(t, "off", "config errors are only supported on DB-less mode")
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.FlattenedErrorCutoff))
+
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -25,9 +25,7 @@ import (
 )
 
 func TestIngressRegexMatchPath(t *testing.T) {
-	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
-	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff), "regex prefixes are only relevant for Kong 3.0+")
 
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)
@@ -148,9 +146,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 }
 
 func TestIngressRegexMatchHeader(t *testing.T) {
-	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
-	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff), "regex prefixes are only relevant for Kong 3.0+")
 
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -483,13 +483,7 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 // parallel: parts of the test may add this route _without_ the prefix, and the 3.x router really hates this and will
 // stop working altogether.
 func TestIngressClassRegexToggle(t *testing.T) {
-	// the manager runs in a goroutine and may not have pulled the version before this test starts
-	require.Eventually(t, func() bool {
-		return !versions.GetKongVersion().Full().EQ(semver.MustParse("0.0.0"))
-	}, time.Minute, time.Second)
-	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
-	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff), "regex prefixes are only relevant for Kong 3.0+")
 
 	// skip the test if the cluster does not support namespaced ingress class parameter (<=1.21).
 	// since 1.21 is End of Life now.
@@ -620,9 +614,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 }
 
 func TestIngressRegexPrefix(t *testing.T) {
-	if v := versions.GetKongVersion(); !v.MajorOnly().GTE(versions.ExplicitRegexPathVersionCutoff) {
-		t.Skipf("regex prefixes are only relevant for Kong 3.0+, detected: %s", v.Full())
-	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff), "regex prefixes are only relevant for Kong 3.0+")
 
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -10,9 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
@@ -29,7 +27,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 func TestPluginEssentials(t *testing.T) {
@@ -162,18 +159,8 @@ func TestPluginEssentials(t *testing.T) {
 func TestPluginOrdering(t *testing.T) {
 	t.Parallel()
 
-	// the manager runs in a goroutine and may not have pulled the version before this test starts
-	require.Eventually(t, func() bool {
-		return !versions.GetKongVersion().Full().EQ(semver.MustParse("0.0.0"))
-	}, time.Minute, time.Second)
-
-	{
-		v := versions.GetKongVersion()
-		enterprise := testenv.KongEnterpriseEnabled()
-		if !v.MajorOnly().GTE(versions.PluginOrderingVersionCutoff) || !enterprise {
-			t.Skipf("plugin ordering requires Kong Enterprise 3.0+, detected: %s (enterprise: %v)", v.Full(), enterprise)
-		}
-	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.PluginOrderingVersionCutoff))
+	RunWhenKongEnterprise(t)
 
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -303,15 +303,10 @@ func TestTCPIngressTLS(t *testing.T) {
 }
 
 func TestTCPIngressTLSPassthrough(t *testing.T) {
-	skipTestForExpressionRouter(t)
-	version, err := helpers.GetKongVersion(proxyAdminURL, consts.KongTestPassword)
-	if err != nil {
-		t.Logf("attempting TLS passthrough test despite unknown kong version: %v", err)
-	} else if version.LT(semver.MustParse("2.7.0")) {
-		t.Skipf("kong version %s below minimum TLS passthrough version", version)
-	}
-
 	t.Parallel()
+	skipTestForExpressionRouter(t)
+
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.TLSPassthroughCutoff))
 
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -1,0 +1,91 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+func RunWhenKongVersion(t *testing.T, vRangeStr string, msg ...any) {
+	t.Helper()
+
+	vRange, err := kong.NewRange(vRangeStr)
+	require.NoError(t, err)
+
+	version := eventuallyGetKongVersion(t, proxyAdminURL)
+
+	// We could parse version, clear the rc/alpha/beta suffixes and then compare
+	// it but it seems unnecessary since gateway dev pre release images coming from
+	// kong/kong-gateway-dev report the final version through Admin API anyway.
+	// So when running 3.3.0.0-rc.3 we'll get 3.3.0.0.
+
+	if !vRange(version) {
+		if len(msg) > 0 {
+			t.Log(msg...)
+		}
+		t.Skipf("skipping because Kong version %q is not within test's range %q: ", version, vRangeStr)
+	}
+}
+
+func RunWhenKongDBMode(t *testing.T, dbmode string, msg ...any) {
+	t.Helper()
+
+	actual := eventuallyGetKongDBMode(t, proxyAdminURL)
+
+	if actual != dbmode {
+		if len(msg) > 0 {
+			t.Log(msg...)
+		}
+		t.Skipf("skipping because Kong dbmode %q is different than requested %q", actual, dbmode)
+	}
+}
+
+func RunWhenKongEnterprise(t *testing.T) {
+	t.Helper()
+
+	version := eventuallyGetKongVersion(t, proxyAdminURL)
+
+	if !version.IsKongGatewayEnterprise() {
+		t.Skipf("skipping because Kong is not running as Enterprise, detected version %q", version)
+	}
+}
+
+func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
+	t.Helper()
+
+	var (
+		err     error
+		version kong.Version
+	)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		version, err = helpers.GetKongVersion(adminURL, consts.KongTestPassword)
+		assert.NoError(t, err)
+	}, time.Minute, time.Second)
+	return version
+}
+
+func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) string {
+	t.Helper()
+
+	var (
+		err    error
+		dbmode string
+	)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		dbmode, err = helpers.GetKongDBMode(adminURL, consts.KongTestPassword)
+		assert.NoError(t, err)
+	}, time.Minute, time.Second)
+	return dbmode
+}

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -8,44 +8,88 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 )
 
 // GetKongVersion returns kong version using the provided Admin API URL.
-func GetKongVersion(proxyAdminURL *url.URL, kongTestPassword string) (semver.Version, error) {
+func GetKongVersion(proxyAdminURL *url.URL, kongTestPassword string) (kong.Version, error) {
 	if override := os.Getenv("TEST_KONG_VERSION_OVERRIDE"); len(override) > 0 {
-		version, err := kong.ParseSemanticVersion(override)
+		_, err := kong.ParseSemanticVersion(override)
 		if err != nil {
-			return semver.Version{}, err
+			return kong.Version{}, err
 		}
-		return semver.Version{Major: version.Major(), Minor: version.Minor(), Patch: version.Patch()}, nil
+		return kong.NewVersion(override)
 	}
 
 	req, err := http.NewRequest("GET", proxyAdminURL.String(), nil)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed creating request for %s: %w", proxyAdminURL, err)
+		return kong.Version{}, fmt.Errorf("failed creating request for %s: %w", proxyAdminURL, err)
 	}
 	req.Header.Set("kong-admin-token", kongTestPassword)
 	resp, err := DefaultHTTPClient().Do(req)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed issuing HTTP request for %s: %w", proxyAdminURL, err)
+		return kong.Version{}, fmt.Errorf("failed issuing HTTP request for %s: %w", proxyAdminURL, err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed reading response body from %s: %w", proxyAdminURL, err)
+		return kong.Version{}, fmt.Errorf("failed reading response body from %s: %w", proxyAdminURL, err)
 	}
 	var jsonResp map[string]interface{}
 	err = json.Unmarshal(body, &jsonResp)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed parsing response body from %s: %w", proxyAdminURL, err)
+		return kong.Version{}, fmt.Errorf("failed parsing response body from %s: %w", proxyAdminURL, err)
 	}
 
 	m := kong.VersionFromInfo(jsonResp)
 	version, err := kong.ParseSemanticVersion(m)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed parsing kong (URL: %s) semver from body: %s: %w", proxyAdminURL, m, err)
+		return kong.Version{}, fmt.Errorf("failed parsing kong (URL: %s) semver from body: %s: %w", proxyAdminURL, m, err)
 	}
-	return semver.Version{Major: version.Major(), Minor: version.Minor(), Patch: version.Patch()}, nil
+	return version, nil
+}
+
+// GetKongDBMode returns kong dbmode using the provided Admin API URL.
+func GetKongDBMode(proxyAdminURL *url.URL, kongTestPassword string) (string, error) {
+	req, err := http.NewRequest("GET", proxyAdminURL.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating request for %s: %w", proxyAdminURL, err)
+	}
+	req.Header.Set("kong-admin-token", kongTestPassword)
+	resp, err := DefaultHTTPClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed issuing HTTP request for %s: %w", proxyAdminURL, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed reading response body from %s: %w", proxyAdminURL, err)
+	}
+
+	var jsonResp map[string]interface{}
+	if err = json.Unmarshal(body, &jsonResp); err != nil {
+		return "", fmt.Errorf("failed parsing response body from %s: %w", proxyAdminURL, err)
+	}
+
+	rootConfig, ok := jsonResp["configuration"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf(
+			"unexpected root configuration type %T for kong (URL: %s)",
+			jsonResp["configuration"], proxyAdminURL,
+		)
+	}
+
+	db, ok := rootConfig["database"]
+	if !ok {
+		return "", fmt.Errorf("missing 'database' key in kong's (URL: %s) configuration", proxyAdminURL)
+	}
+
+	dbStr, ok := db.(string)
+	if !ok {
+		return "", fmt.Errorf(
+			"'database' key is of unexpected type - %T - in kong's (URL: %s) configuration, value: %v",
+			db, proxyAdminURL, db,
+		)
+	}
+	return dbStr, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the usage of kong version singleton. In its place we use kong's version explicitly where needed. Additionally this adds several test helpers which run tests conditionally based on the kong version as from Kong Admin API.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The only place that parser takes Kong Version into account it for Gateway API http regex header matching:

https://github.com/Kong/kubernetes-ingress-controller/blob/1af68ca36af74ae6c60be20c63b0badc9ddf13ae/internal/dataplane/parser/translate_utils.go#L36-L40

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
