### PR TITLE
refactor(tests): use constants for referencing images and ports

### DIFF
--- a/test/consts.go
+++ b/test/consts.go
@@ -5,11 +5,17 @@ const (
 	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/kong/httpbin
 	HTTPBinImage = "kong/httpbin:0.1.0"
+	HTTPBinPort  = 80
 
-	// TCPEchoImage echoes TCP text sent to it after printing out basic information about its environment, e.g.
+	// EchoImage works with TCP, UDP, HTTP and responses with basic information about its environment and echo
+	// read more about it here: http://github.com/kong/go-echo
+	// e.g.
 	// Welcome, you are connected to node kind-control-plane.
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.
 	// In namespace foo.
 	// With IP address 10.244.0.13.
-	TCPEchoImage = "kong/go-echo:0.3.0"
+	EchoImage    = "kong/go-echo:0.3.0"
+	EchoTCPPort  = 1025
+	EchoUDPPort  = 1026
+	EchoHTTPPort = 1027
 )

--- a/test/consts.go
+++ b/test/consts.go
@@ -7,13 +7,13 @@ const (
 	HTTPBinImage = "kong/httpbin:0.1.0"
 	HTTPBinPort  = 80
 
-	// EchoImage works with TCP, UDP, HTTP and responses with basic information about its environment and echo
-	// read more about it here: http://github.com/kong/go-echo
-	// e.g.
+	// EchoImage works with TCP, UDP, HTTP and responds with basic information about its environment and echo
+	// Sample response:
 	// Welcome, you are connected to node kind-control-plane.
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.
 	// In namespace foo.
 	// With IP address 10.244.0.13.
+	// Read more about it here: http://github.com/kong/go-echo
 	EchoImage    = "kong/go-echo:0.3.0"
 	EchoTCPPort  = 1025
 	EchoUDPPort  = 1026

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -407,7 +407,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	for i, container := range proxyDeployment.Spec.Template.Spec.Containers {
 		if container.Name == proxyContainerName {
 			proxyDeployment.Spec.Template.Spec.Containers[i].Env = append(proxyDeployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "KONG_STREAM_LISTEN", Value: fmt.Sprintf("0.0.0.0:%d", tcpListnerPort)})
+				corev1.EnvVar{Name: "KONG_STREAM_LISTEN", Value: fmt.Sprintf("0.0.0.0:%d", tcpListenerPort)})
 		}
 	}
 	_, err = env.Cluster().Client().AppsV1().Deployments(namespace).Update(ctx, proxyDeployment, metav1.UpdateOptions{})
@@ -419,8 +419,8 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	proxyService.Spec.Ports = append(proxyService.Spec.Ports, corev1.ServicePort{
 		Name:       "stream-tcp",
 		Protocol:   corev1.ProtocolTCP,
-		Port:       tcpListnerPort,
-		TargetPort: intstr.FromInt(tcpListnerPort),
+		Port:       tcpListenerPort,
+		TargetPort: intstr.FromInt(tcpListenerPort),
 	})
 	_, err = env.Cluster().Client().CoreV1().Services(namespace).Update(ctx, proxyService, metav1.UpdateOptions{})
 	require.NoError(t, err)
@@ -492,7 +492,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	kongDeployment := getManifestDeployments(dblessPath).ControllerNN
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -71,8 +71,7 @@ const (
 	namespace        = "kong"
 	adminServiceName = "kong-admin-lb"
 
-	tcpEchoPort    = 1025
-	tcpListnerPort = 8888
+	tcpListenerPort = 8888
 
 	// controllerDeploymentName is the name of the controller deployment in all manifests variants.
 	controllerDeploymentName = "ingress-kong"
@@ -326,7 +325,7 @@ func deployIngress(ctx context.Context, t *testing.T, env environments.Environme
 	c, err := clientset.NewForConfig(env.Cluster().Config())
 	assert.NoError(t, err)
 	t.Log("deploying an HTTP service to test the ingress controller and proxy")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -125,7 +125,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("creating a mesh enabled http deployment")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/expressionrouter/generate_test.go
+++ b/test/expressionrouter/generate_test.go
@@ -92,7 +92,7 @@ func TestExpressionRouterGenerateRoutes(t *testing.T) {
 
 	t.Log("deploying HTTP container deployment to test generating expression routes")
 	// TODO: use another HTTP server image that can return 200 on any path
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/config_error_event_test.go
+++ b/test/integration/config_error_event_test.go
@@ -38,7 +38,7 @@ func TestConfigErrorEventGeneration(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -34,7 +34,7 @@ func TestConsumerCredential(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -524,7 +524,7 @@ func TestGatewayFilters(t *testing.T) {
 	client := env.Cluster().Client()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deploymentTemplate := generators.NewDeploymentForContainer(container)
 	deployment, err := client.AppsV1().Deployments(ns.Name).Create(ctx, deploymentTemplate, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -58,7 +58,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -331,7 +331,7 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container1 := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container1 := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment1 := generators.NewDeploymentForContainer(container1)
 	deployment1, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment1, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -523,7 +523,7 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -142,7 +142,7 @@ func TestHTTPSRedirect(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("creating an HTTP container via deployment to test redirect functionality")
-	container := generators.NewContainer("alsohttpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("alsohttpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	opts := metav1.CreateOptions{}
 	_, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, opts)
@@ -212,7 +212,7 @@ func TestHTTPSIngress(t *testing.T) {
 	}
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -79,7 +79,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 	}
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 	}
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -49,7 +49,7 @@ func TestIngressEssentials(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -213,7 +213,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestIngressNamespaces(t *testing.T) {
 	t.Logf("using testing namespace %s", ns.Name)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -509,7 +509,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -628,7 +628,7 @@ func TestIngressRegexPrefix(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -791,7 +791,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -997,7 +997,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -1095,7 +1095,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 	client := env.Cluster().Client()
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].Name = "http"
 	deployment, err := client.AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -24,6 +24,7 @@ import (
 	kservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	kservingclientsetv "knative.dev/serving/pkg/client/clientset/versioned"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
@@ -71,10 +72,10 @@ func TestKnativeIngress(t *testing.T) {
 						PodSpec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Image: "kong/httpbin:0.1.0",
+									Image: test.HTTPBinImage,
 									Ports: []corev1.ContainerPort{
 										{
-											ContainerPort: 80,
+											ContainerPort: test.HTTPBinPort,
 										},
 									},
 								},

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -36,7 +36,7 @@ func TestKongIngressEssentials(t *testing.T) {
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	testName := "minking"
-	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, test.HTTPBinImage, 80))
+	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, test.HTTPBinImage, test.HTTPBinPort))
 	_, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -39,7 +39,7 @@ func TestPluginEssentials(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestPluginOrdering(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -56,7 +56,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, test.HTTPBinImage, 80))
+	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, test.HTTPBinImage, test.HTTPBinPort))
 	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(deployment)
@@ -167,7 +167,7 @@ func TestTCPIngressTLS(t *testing.T) {
 	for _, i := range testServiceSuffixes {
 		localTestName := fmt.Sprintf(testName, i)
 		t.Log("deploying a minimal TCP container deployment to test Ingress routes")
-		container := generators.NewContainer(localTestName, test.TCPEchoImage, tcpEchoPort)
+		container := generators.NewContainer(localTestName, test.EchoImage, test.EchoTCPPort)
 		// go-echo sends a "Running on Pod POD_NAME." immediately on connecting
 		container.Env = []corev1.EnvVar{
 			{
@@ -204,7 +204,7 @@ func TestTCPIngressTLS(t *testing.T) {
 					Port: 8899,
 					Backend: kongv1beta1.IngressBackend{
 						ServiceName: testServices[testServiceSuffixes[0]].Name,
-						ServicePort: tcpEchoPort,
+						ServicePort: test.EchoTCPPort,
 					},
 				},
 				{
@@ -212,7 +212,7 @@ func TestTCPIngressTLS(t *testing.T) {
 					Port: 8899,
 					Backend: kongv1beta1.IngressBackend{
 						ServiceName: testServices[testServiceSuffixes[1]].Name,
-						ServicePort: tcpEchoPort,
+						ServicePort: test.EchoTCPPort,
 					},
 				},
 			},
@@ -237,7 +237,7 @@ func TestTCPIngressTLS(t *testing.T) {
 					Port: 8899,
 					Backend: kongv1beta1.IngressBackend{
 						ServiceName: testServices[testServiceSuffixes[2]].Name,
-						ServicePort: tcpEchoPort,
+						ServicePort: test.EchoTCPPort,
 					},
 				},
 			},

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
-const (
-	tcpEchoPort = 1025
-)
-
 func TestTCPRouteEssentials(t *testing.T) {
 	skipTestForExpressionRouter(t)
 	ctx := context.Background()
@@ -70,7 +66,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("creating a tcpecho pod to test TCPRoute traffic routing")
-	container1 := generators.NewContainer("tcpecho-1", test.TCPEchoImage, tcpEchoPort)
+	container1 := generators.NewContainer("tcpecho-1", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID1 := uuid.NewString()
 	container1.Env = []corev1.EnvVar{
@@ -85,7 +81,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	cleaner.Add(deployment1)
 
 	t.Log("creating an additional tcpecho pod to test TCPRoute multiple backendRef loadbalancing")
-	container2 := generators.NewContainer("tcpecho-2", test.TCPEchoImage, tcpEchoPort)
+	container2 := generators.NewContainer("tcpecho-2", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID2 := uuid.NewString()
 	container2.Env = []corev1.EnvVar{
@@ -110,7 +106,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ktfkong.DefaultTCPServicePort,
-		TargetPort: intstr.FromInt(tcpEchoPort),
+		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service1, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service1, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -127,7 +123,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ktfkong.DefaultTCPServicePort,
-		TargetPort: intstr.FromInt(tcpEchoPort),
+		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service2, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service2, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -456,7 +452,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("creating a tcpecho pod to test TCPRoute traffic routing")
-	container1 := generators.NewContainer("tcpecho-1", test.TCPEchoImage, tcpEchoPort)
+	container1 := generators.NewContainer("tcpecho-1", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID1 := uuid.NewString()
 	container1.Env = []corev1.EnvVar{
@@ -471,7 +467,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(deployment1)
 
 	t.Log("creating an additional tcpecho pod to test TCPRoute multiple backendRef loadbalancing")
-	container2 := generators.NewContainer("tcpecho-2", test.TCPEchoImage, tcpEchoPort)
+	container2 := generators.NewContainer("tcpecho-2", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID2 := uuid.NewString()
 	container2.Env = []corev1.EnvVar{
@@ -496,7 +492,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ktfkong.DefaultTCPServicePort,
-		TargetPort: intstr.FromInt(tcpEchoPort),
+		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service1, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service1, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -508,7 +504,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
 		Port:       ktfkong.DefaultTCPServicePort,
-		TargetPort: intstr.FromInt(tcpEchoPort),
+		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service2, err = env.Cluster().Client().CoreV1().Services(otherNs.Name).Create(ctx, service2, metav1.CreateOptions{})
 	assert.NoError(t, err)

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -166,7 +166,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 
 	t.Log("creating a tcpecho pod to test TLSRoute traffic routing")
 
-	container := generators.NewContainer("tcpecho-1", test.TCPEchoImage, tcpEchoPort)
+	container := generators.NewContainer("tcpecho-1", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID := uuid.NewString()
 	container.Env = []corev1.EnvVar{
@@ -181,7 +181,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	cleaner.Add(deployment)
 
 	t.Log("creating an additional tcpecho pod to test TLSRoute multiple backendRef loadbalancing")
-	container2 := generators.NewContainer("tcpecho-2", test.TCPEchoImage, tcpEchoPort)
+	container2 := generators.NewContainer("tcpecho-2", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID2 := uuid.NewString()
 	container2.Env = []corev1.EnvVar{
@@ -207,7 +207,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(service2)
 
-	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
+	backendPort := gatewayv1alpha2.PortNumber(test.EchoTCPPort)
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsRoute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -587,7 +587,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(grant)
 
 	t.Log("creating a tcpecho pod to test TLSRoute traffic routing")
-	container := generators.NewContainer("tcpecho", test.TCPEchoImage, tcpEchoPort)
+	container := generators.NewContainer("tcpecho", test.EchoImage, test.EchoTCPPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID := uuid.NewString()
 	container.Env = []corev1.EnvVar{
@@ -607,7 +607,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(service)
 
-	backendPort := gatewayv1alpha2.PortNumber(tcpEchoPort)
+	backendPort := gatewayv1alpha2.PortNumber(test.EchoTCPPort)
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsroute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -762,7 +762,7 @@ func TestTLSRoutePassthrough(t *testing.T) {
 	cleaner.Add(gateway)
 
 	t.Log("creating a tcpecho pod to test TLSRoute traffic routing")
-	container := generators.NewContainer("tcpecho", test.TCPEchoImage, tlsEchoPort)
+	container := generators.NewContainer("tcpecho", test.EchoImage, tlsEchoPort)
 	// go-echo sends a "Running on Pod <UUID>." immediately on connecting
 	testUUID := uuid.NewString()
 	container.Env = []corev1.EnvVar{

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -103,7 +103,7 @@ func TestTranslationFailures(t *testing.T) {
 				require.NoError(t, err)
 				cleaner.Add(gateway)
 
-				container := generators.NewContainer("httpbin", test.HTTPBinImage, 80)
+				container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 				deployment := generators.NewDeploymentForContainer(container)
 				deployment, err = env.Cluster().Client().AppsV1().Deployments(ns).Create(ctx, deployment, metav1.CreateOptions{})
 				require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Initial refactor - do not use magic strings and numbers to refer images and their ports used in tests.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This is a part of implementing e2e tests that verifies proper handling of EndpointSlices https://github.com/Kong/kubernetes-ingress-controller/issues/4026
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

This is the part of implementing strategy proposed in this one too big PR https://github.com/Kong/kubernetes-ingress-controller/pull/4084.

In `test/integration/tlsroute_test.go:765` const `tlsEchoPort` and its usage is a little bit mysterious to me. I backchannelled it to the author to gain more understanding (and maybe handle in different PR).

Labelled with `ci/run-e2e` to be sure, result has to be examined.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
