### PR TITLE
tests: propagate exit code from makefile targets using pipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 # Some sensible Make defaults: https://tech.davis-hansson.com/p/make/
 SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
 
 # ------------------------------------------------------------------------------
 # Configuration - Repository
@@ -305,8 +306,8 @@ test.conformance: go-junit-report
 		-race $(GOTESTFLAGS) \
 		-timeout $(INTEGRATION_TEST_TIMEOUT) \
 		-parallel $(NCPU) \
-		./test/conformance |
-	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -set-exit-code --parser gotest
+		./test/conformance | \
+	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -parser gotest
 
 .PHONY: test.integration
 test.integration: test.integration.dbless test.integration.postgres test.integration.cp
@@ -363,7 +364,7 @@ _test.integration: _check.container.environment go-junit-report
 		-coverpkg=$(PKG_LIST) \
 		-coverprofile=$(COVERAGE_OUT) \
 		./test/integration | \
-	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -set-exit-code --parser gotest
+	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -parser gotest
 
 .PHONY: test.integration.dbless.knative
 test.integration.dbless.knative:


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason, despite the `-set-exit-code` flag, the `go-junit-report` fails to propagate the error once the tests fail to compile. 

Adding `.SHELLFLAGS := -eu -o pipefail -c` to the Makefile will make all targets using pipes propagate errors as expected.

Sample run that should fail the GH workflow but the exit code was 0 for integration tests (reason for this PR): https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5089899978/jobs/9148069971

**Note**: I have no idea why `.SHELLFLAGS` doesn't work for me on Mac, but it seems it works as expected on GH runners: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5091603544/jobs/9151854177.
