### PR TITLE
refactor(tests): make TestTLSRouteEssentials easier to follow

### DIFF
--- a/test/consts.go
+++ b/test/consts.go
@@ -7,7 +7,7 @@ const (
 	HTTPBinImage = "kong/httpbin:0.1.0"
 	HTTPBinPort  = 80
 
-	// EchoImage works with TCP, UDP, HTTP and responds with basic information about its environment and echo
+	// EchoImage works with TCP, UDP, HTTP, TLS and responds with basic information about its environment and echo
 	// Sample response:
 	// Welcome, you are connected to node kind-control-plane.
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

During working on https://github.com/Kong/kubernetes-ingress-controller/pull/4088, I spotted `TestTLSRouteEssentials` that relies on the usage of `TLS_PORT` env variable to configure `go-echo` (it's easy to overlook when you just skim through it). This PR makes it easier to follow for newbies in the codebase.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
