### PR TITLE
feat(tests): verify routing to every backend in e2e tests

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -59,14 +59,14 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	pod := podList.Items[0]
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Log("killing Kong process to simulate a crash and container restart")
 	killKong(ctx, t, env, &pod)
 
 	t.Log("confirming that routes are restored after crash")
-	verifyIngress(ctx, t, env)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }
 
 const entDBLESSPath = "../../deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml"
@@ -98,8 +98,8 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 	exposeAdminAPI(ctx, t, env, deployments.ProxyNN)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Log("verifying enterprise mode was enabled properly")
 	verifyEnterprise(ctx, t, env, adminPassword)
@@ -120,8 +120,8 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	verifyPostgres(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }
 
 func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
@@ -138,8 +138,8 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	verifyPostgres(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Log("verifying that kong pods deployed properly and gathering a sample pod")
 	forDeployment := metav1.ListOptions{
@@ -278,8 +278,8 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	verifyPostgres(ctx, t, env)
 
 	t.Log("running ingress tests to verify ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Log("exposing the admin api so that enterprise features can be verified")
 	exposeAdminAPI(ctx, t, env, deployments.ProxyNN)
@@ -306,8 +306,8 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	deployments := getManifestDeployments(manifestFilePath)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 	ensureAllProxyReplicasAreConfigured(ctx, t, env, deployments.ProxyNN)
 
 	t.Log("scale proxy to 0 replicas")
@@ -356,7 +356,7 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 			kongClient, err := gokong.NewClient(lo.ToPtr(address), client)
 			require.NoError(t, err)
 
-			requireIngressConfiguredInAdminAPIEventually(ctx, t, kongClient)
+			verifyIngressWithEchoBackendsInAdminAPI(ctx, t, kongClient, numberOfEchoBackends)
 			t.Logf("proxy pod %s/%s: got the config", pod.Namespace, pod.Name)
 		}()
 	}

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -30,8 +30,8 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional")
 
 	t.Log("running ingress tests to verify that KIC with traditonal Kong router works")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	setGatewayRouterFlavor(ctx, t, cluster, proxyDeploymentNN, "traditional_compatible")
 
@@ -39,7 +39,7 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional_compatible")
 
 	t.Log("running ingress tests to verify that KIC with traditonal_compatible Kong router works")
-	verifyIngress(ctx, t, env)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }
 
 func setGatewayRouterFlavor(

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -444,8 +444,8 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	deployKong(ctx, t, env, manifest)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	// ensure that Gateways with no addresses come online and start ingesting routes
 	t.Logf("deploying Gateway APIs CRDs from %s", consts.GatewayExperimentalCRDsKustomizeURL)

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -64,12 +64,12 @@ func TestKonnectConfigPush(t *testing.T) {
 	deployments := deployAllInOneKonnectManifest(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Log("ensuring ingress resources are correctly populated in Konnect Runtime Group's Admin API")
 	konnectAdminAPIClient := createKonnectAdminAPIClient(t, rgID, cert, key)
-	requireIngressConfiguredInAdminAPIEventually(ctx, t, konnectAdminAPIClient.AdminAPIClient())
+	verifyIngressWithEchoBackendsInAdminAPI(ctx, t, konnectAdminAPIClient.AdminAPIClient(), numberOfEchoBackends)
 
 	t.Log("ensuring KIC nodes and controlled kong gateway nodes are present in konnect runtime group")
 	requireKonnectNodesConsistentWithK8s(ctx, t, env, deployments, rgID, cert, key)
@@ -145,8 +145,8 @@ func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	deployAllInOneKonnectManifest(ctx, t, env)
 
 	t.Log("running ingress tests to verify misconfiguration doesn't affect basic ingress functionality")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }
 
 func skipIfMissingRequiredKonnectEnvVariables(t *testing.T) {

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -4,11 +4,14 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kuma"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -36,33 +39,9 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	scaleDeployment(ctx, t, env, deployments.ControllerNN, 2)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-
-	// use retry.RetryOnConflict to update service, to avoid conflicts from different source.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if service.ObjectMeta.Annotations == nil {
-			service.ObjectMeta.Annotations = map[string]string{}
-		}
-		service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
-		_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
-		return err
-	})
-	require.NoError(t, err,
-		// dump the status of service if the error happens on updating service.
-		func() string {
-			service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
-			if err != nil {
-				return fmt.Sprintf("failed to dump service, error %v", err)
-			}
-			return fmt.Sprintf("current status of service: %#v", service)
-		}(),
-	)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyKuma(ctx, t, env)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }
 
 func TestDeployAllInOnePostgresKuma(t *testing.T) {
@@ -89,31 +68,38 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	scaleDeployment(ctx, t, env, deployments.ControllerNN, 2)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	// use retry.RetryOnConflict to update service, to avoid conflicts from different source.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyKuma(ctx, t, env)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+}
 
-		if service.ObjectMeta.Annotations == nil {
-			service.ObjectMeta.Annotations = map[string]string{}
-		}
-		service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
-		_, err = env.Cluster().Client().CoreV1().Services("default").Update(ctx, service, metav1.UpdateOptions{})
-		return err
-	})
+func verifyKuma(ctx context.Context, t *testing.T, env environments.Environment) {
+	svcClient := env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault)
+	const svcName = "echo"
+	// Use retry.RetryOnConflict to update service, to avoid conflicts from different source.
+	err := retry.RetryOnConflict(retry.DefaultRetry,
+		func() error {
+			service, err := svcClient.Get(ctx, svcName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if service.ObjectMeta.Annotations == nil {
+				service.ObjectMeta.Annotations = map[string]string{}
+			}
+			service.ObjectMeta.Annotations["ingress.kubernetes.io/service-upstream"] = "true"
+			_, err = svcClient.Update(ctx, service, metav1.UpdateOptions{})
+			return err
+		},
+	)
 	require.NoError(t, err,
 		// dump the status of service if the error happens on updating service.
 		func() string {
-			service, err := env.Cluster().Client().CoreV1().Services("default").Get(ctx, "httpbin", metav1.GetOptions{})
+			service, err := svcClient.Get(ctx, svcName, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Sprintf("failed to dump service, error %v", err)
 			}
 			return fmt.Sprintf("current status of service: %#v", service)
 		}(),
 	)
-
-	verifyIngress(ctx, t, env)
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -49,11 +49,11 @@ func testManifestsUpgrade(t *testing.T, fromManifestURL string, toManifestPath s
 	deployKong(ctx, t, env, oldManifest.Body)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngress(ctx, t, env)
-	verifyIngress(ctx, t, env)
+	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
 	t.Logf("deploying target version of kong manifests: %s", toManifestPath)
 	manifest := getTestManifest(t, toManifestPath)
 	deployKong(ctx, t, env, manifest)
-	verifyIngress(ctx, t, env)
+	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR proposes enhanced approach for testing KIC e2e tests
- Kind clusters have configuration `--max-endpoints-per-slice 2` to make possible to test KIC against Services with multiple EndpointSlices (introduced in #4091)
- basic Ingress deployment and its verification is enhanced to ensure that traffic is routed to every backend by Kong gateway (IPs are in many multiple EndpointSlices)

Rationale - the proper discovery of IP addresses of all backends and setting routings in Kong gateway are the core feature of KIC, thus it should be covered with tests that verify it. Having K8s Kind cluster with such config and enhanced tests allows ensure that KIC with Kong gateway do it properly.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

closes #4026, it's the last from the series of PRs #4088, #4091 - all of them surpass to big initial PR https://github.com/Kong/kubernetes-ingress-controller/pull/4084 which presented the approach 
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

- I've tested it locally in the loop for the test `TestDeployAllInOneDBLESSLegacy$` and I haven't observed flakiness
- Measured time of this test (locally) after the change is around `100s` the same as before
- I run e2e tests for this PR by adding label `ci/run-e2e`
- Maybe there are other places with should be tested in terms of dealing with multiple `EndpointSlice`s? Let's create separate issues for them.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
