### PR TITLE
test(e2e): use legacy manifest and skip tests for KIC version < 2.9

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -36,11 +36,6 @@ import (
 // ensure that things are up and running.
 // -----------------------------------------------------------------------------
 
-const (
-	dblessLegacyPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
-	dblessPath       = "../../deploy/single/all-in-one-dbless.yaml"
-)
-
 func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 	t.Log("configuring all-in-one-dbless-legacy.yaml manifest test")
 	t.Parallel()

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -72,6 +72,7 @@ func TestDeployAllInOneDBLESSLegacy(t *testing.T) {
 const entDBLESSPath = "../../deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml"
 
 func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
+	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	t.Log("configuring all-in-one-dbless-k4k8s-enterprise.yaml manifest test")
 	if os.Getenv(kong.LicenseDataEnvVar) == "" {
 		t.Skipf("no license available to test enterprise: %s was not provided", kong.LicenseDataEnvVar)
@@ -290,6 +291,7 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 }
 
 func TestDeployAllInOneDBLESS(t *testing.T) {
+	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	t.Parallel()
 
 	const (

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -24,7 +24,7 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 	cluster := env.Cluster()
 
 	t.Log("deploying kong components with traditional Kong router")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 	proxyDeploymentNN := getManifestDeployments(dblessPath).ProxyNN
 	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -171,7 +171,7 @@ func TestWebhookUpdate(t *testing.T) {
 	}()
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 
 	firstCertificate := &corev1.Secret{
@@ -288,7 +288,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 	deployments := getManifestDeployments(dblessPath)
 	controllerDeploymentNN := deployments.ControllerNN
@@ -440,7 +440,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
@@ -487,7 +487,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 	kongDeployment := getManifestDeployments(dblessPath).ControllerNN
 
@@ -594,7 +594,7 @@ func TestMissingCRDsDontCrashTheController(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 
 	manifest = stripCRDs(t, manifest)
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -53,6 +53,7 @@ var konnectAccessToken = os.Getenv("TEST_KONG_KONNECT_ACCESS_TOKEN")
 
 func TestKonnectConfigPush(t *testing.T) {
 	t.Parallel()
+	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	skipIfMissingRequiredKonnectEnvVariables(t)
 
 	ctx, env := setupE2ETest(t)
@@ -78,6 +79,7 @@ func TestKonnectConfigPush(t *testing.T) {
 
 func TestKonnectLicenseActivation(t *testing.T) {
 	t.Parallel()
+	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	skipIfMissingRequiredKonnectEnvVariables(t)
 
 	ctx, env := setupE2ETest(t)
@@ -132,7 +134,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	t.Parallel()
 	skipIfMissingRequiredKonnectEnvVariables(t)
-
+	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	ctx, env := setupE2ETest(t)
 
 	rgID := createTestRuntimeGroup(ctx, t)

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -19,7 +19,7 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, kuma.New())
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, dblessPath)
+	manifest := getDBLessTestManifestByControllerImageEnv(t)
 	deployKong(ctx, t, env, manifest)
 	deployments := getManifestDeployments(dblessPath)
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -35,6 +35,9 @@ const (
 	// adminPasswordSecretName is the name of the secret which will house the admin
 	// API admin password.
 	adminPasswordSecretName = "kong-enterprise-superuser-password"
+
+	dblessLegacyPath = "../../deploy/single/all-in-one-dbless-legacy.yaml"
+	dblessPath       = "../../deploy/single/all-in-one-dbless.yaml"
 )
 
 // gatewayDiscoveryMinimalVersion is the minimal version of KIC that enables gateway discovery.

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -192,9 +192,10 @@ func skipTestIfControllerVersionBelow(t *testing.T, minVersion semver.Version) {
 	}
 }
 
-// getDBLessTestManifestByControllerImageEnv gets the proper manifest of dbless deployment by
-// specified image for Kong ingress controller. Since KIC does not support gateway discovery in
-// versions below 2.9, we neet to use the legacy manifest for the versions.
+// getDBLessTestManifestByControllerImageEnv gets the proper manifest for dbless deployment.
+// It takes into account the TEST_KONG_CONTROLLER_IMAGE_OVERRIDE environment variable.
+// This is needed because KIC does not support Gateway Discovery in versions below 2.9,
+// and hence we need to use the legacy manifest for those versions.
 func getDBLessTestManifestByControllerImageEnv(t *testing.T) io.Reader {
 	t.Helper()
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -178,7 +178,11 @@ func skipTestIfControllerVersionBelow(t *testing.T, minVersion semver.Version) {
 		return
 	}
 	v, err := extractVersionFromImage(controllerImageOverride)
-	require.NoError(t, err)
+	// assume using latest version if failed to extract version from image tag.
+	if err != nil {
+		t.Logf("could not extract version from controller image: %v, assume using the latest version", err)
+		return
+	}
 	if v.LE(minVersion) {
 		t.Skipf("skipped the test because version of KIC %s is below the minimum version %s",
 			v.String(), minVersion.String())
@@ -197,7 +201,11 @@ func getDBLessTestManifestByControllerImageEnv(t *testing.T) io.Reader {
 	}
 
 	v, err := extractVersionFromImage(controllerImageOverride)
-	require.NoError(t, err)
+	// assume using latest version if failed to extract version from image tag.
+	if err != nil {
+		t.Logf("could not extract version from controller image: %v, assume using the latest version", err)
+		return getTestManifest(t, dblessPath)
+	}
 	// If KIC version is lower than the minimum version that enables gateway discovery, use the legacy manifest.
 	if v.LE(gatewayDiscoveryMinimalVersion) {
 		return getTestManifest(t, dblessLegacyPath)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

The default dbless manifest uses gateway discovery by specifying `CONTROLLER_ADMIN_SVC`, which is not supported by KIC with versions below 2.9. This PR adds check for overriding KIC image and use the legacy manifest if KIC version < 2.9.
This PR also adds a helper function to skip tests if KIC version below a certain version.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4069 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
