### PR TITLE
tests: delete migrations job before upgrade in e2e test

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -71,7 +71,6 @@ nodes:
 `
 	validationWebhookName = "kong-validation-webhook"
 	kongNamespace         = "kong"
-	admissionScriptPath   = "../../hack/deploy-admission-controller.sh"
 )
 
 // openssl req -new -x509 -nodes -newkey ec:<(openssl ecparam -name secp384r1) -keyout cert.key -out cert.crt -days 3650 -subj '/CN=first.example/'

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -81,6 +81,9 @@ const (
 
 	// proxyContainerName is the name of the proxy container in all manifests variants.
 	proxyContainerName = "proxy"
+
+	// migrationsJobName is the name of the migrations job in postgres manifests variant.
+	migrationsJobName = "kong-migrations"
 )
 
 // setupE2ETest builds a testing environment for the E2E test. It also sets up the environment's teardown and test


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent failures caused by not being allowed to update jobs' spec when upgrading with `kubectl apply -f` to a newer version of all-in-one manifests, delete the job just before the upgrade. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #4097.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

We agreed to use `generateName`, but unfortunately it's not supported by Kustomize (see the issue: https://github.com/kubernetes-sigs/kustomize/issues/641). I also tried going with using Kustomize's `replacements` to use the deployment's image tag to append a version-dependent suffix to the migration job's name, but it didn't work either due to deployment not being rendered at that stage yet. I decided to not spend more time on it and just go with a simple delete in the test.

