### PR TITLE
poc: assign priorities of routes translated from ingresses

### DIFF
--- a/internal/dataplane/parser/translators/ingress_atc.go
+++ b/internal/dataplane/parser/translators/ingress_atc.go
@@ -112,7 +112,8 @@ func (m *ingressTranslationMeta) translateIntoKongExpressionRoute() *kongstate.R
 		routeMatcher.And(sniMatcher)
 	}
 
-	atc.ApplyExpression(&route.Route, routeMatcher, NormalIngressExpressionPriority)
+	priority := calculateExpressionRoutePriority(m.paths, pathRegexPrefix, m.ingressHost, ingressAnnotations)
+	atc.ApplyExpression(&route.Route, routeMatcher, priority)
 	return route
 }
 
@@ -237,4 +238,148 @@ func sniMatcherFromSNIs(snis []string) atc.Matcher {
 		matchers = append(matchers, atc.NewPredicateTLSSNI(atc.OpEqual, sni))
 	}
 	return atc.Or(matchers...)
+}
+
+// calculateExpressionRoutePriority calculates the priority of the generated route.
+// It basically follows the calculating method used in Kong's traditional compatible router:
+//   - First, sort by number of fields specified (methods, hosts, headers, paths, snis)
+//   - Then, if both routes have hosts, the routes having only plain(non-wildcard) hosts has
+//     higher priority than routes having at least one wildcard host
+//   - Then, sort by numer of different headers (maximum header count = 255).
+//   - Then, paths with regex match has higher priority than prefix match.
+//   - Then, sort by regex_priority field (not supported in KIC with expression routes).
+//   - At last, sort by maximum length of paths in the route.
+func calculateExpressionRoutePriority(
+	paths []netv1.HTTPIngressPath,
+	regexPathPrefix string,
+	ingressHost string,
+	ingressAnnotations map[string]string,
+) int {
+	matchFields := 0
+	plainHost := false
+	headerCount := 0
+	maxPathLength := 0
+	hasRegexPath := false
+
+	// add 1 to matchFields if path is non-empty.
+	if len(paths) > 0 {
+		matchFields++
+	}
+	for _, path := range paths {
+		// TODO: in non-combined translator, we assigned different regex priorities to different type of path:
+		// exact = 300, prefix = 200, implementationSpecific = 100.
+		// We may add additional weights on path types.
+		if path.PathType == nil {
+			continue
+		}
+		// since we will generate regex path for exact and prefix matches in traditional routes,
+		// we should consider them as using regex path.
+		var pathLength int
+		switch *path.PathType {
+		case netv1.PathTypeExact:
+			hasRegexPath = true
+			// trim all leading '/'s and calculate the length by '/'+ trimmed path.
+			// for example: len("/foo") = 4; len("/foo/") = 5; len("//foo") = 4.
+			relative := strings.TrimLeft(path.Path, "/")
+			pathLength = 1 + len(relative)
+		case netv1.PathTypePrefix:
+			hasRegexPath = true
+			// trim all leading and trailing '/' s and calculate the length by '/' + trimmed path + '/' (except that len("/")=1)
+			// for example: len("/foo") = 5; len("/foo/") = 5; len("//foo/bar") = len("/foo/bar//") = 9.
+			base := strings.Trim(path.Path, "/")
+			if base == "" {
+				pathLength = 1
+			} else {
+				pathLength = 2 + len(base)
+			}
+		case netv1.PathTypeImplementationSpecific:
+			if regexPathPrefix != "" && strings.HasPrefix(path.Path, regexPathPrefix) {
+				// regex path match, calculate the length by length of regex part.
+				hasRegexPath = true
+				regex := strings.TrimPrefix(path.Path, path.Path)
+				pathLength = len(regex)
+			} else {
+				// non-regex path.
+				pathLength = len(path.Path)
+			}
+		}
+		if pathLength > maxPathLength {
+			maxPathLength = pathLength
+		}
+	}
+
+	hosts := []string{}
+	if ingressHost != "" {
+		hosts = append(hosts, ingressHost)
+	}
+	hostAliases, _ := annotations.ExtractHostAliases(ingressAnnotations)
+	hosts = append(hosts, hostAliases...)
+	if len(hosts) > 0 {
+		matchFields++
+		plainHost = true
+	}
+
+	for _, host := range hosts {
+		if strings.HasPrefix(host, "*") {
+			plainHost = false
+			break
+		}
+	}
+
+	headers, exist := annotations.ExtractHeaders(ingressAnnotations)
+	if exist {
+		matchFields++
+		headerCount = len(headers)
+	}
+
+	methods := annotations.ExtractMethods(ingressAnnotations)
+	if len(methods) > 0 {
+		matchFields++
+	}
+
+	snis, exist := annotations.ExtractSNIs(ingressAnnotations)
+	if exist && len(snis) > 0 {
+		matchFields++
+	}
+
+	// combine priority into numbers. route.priority in admin API could only use the lowest 52 bits
+	// because the numbers in JSON is parsed into double precision floating number by Kong.
+	const (
+		// lowest 16 bits (0~15) for max path length
+		// regexPathShiftBits uses the 16th bit for marking if regex match on path exists.
+		regexPathShiftBits = 16
+		// bits 17~31 are preserved.
+
+		// plainHostShiftBits uses the 32nd bit for marking if ALL hosts are non-wildcard.
+		plainHostShiftBits = 32
+		// headerNumberShiftBits makes bits 33~40 used for number of headers.
+		headerNumberShiftBits = 33
+		// matchFieldsShiftBits uses bits 41 and over (41~43 since there are at most 5 fields).
+		matchFieldsShiftBits = 41
+
+		headerNumberLimit = 255
+		pathLengthLimit   = (1 << 16) - 1
+	)
+
+	var priority int
+	// add max path length.
+	if maxPathLength > pathLengthLimit {
+		maxPathLength = pathLengthLimit
+	}
+	priority += maxPathLength
+	// add regex path mark.
+	if hasRegexPath {
+		priority += (1 << regexPathShiftBits)
+	}
+	// add plain host mark.
+	if plainHost {
+		priority += (1 << plainHostShiftBits)
+	}
+	if headerCount > headerNumberLimit {
+		headerCount = headerNumberLimit
+	}
+	priority += (headerCount << headerNumberShiftBits)
+	priority += (matchFields << matchFieldsShiftBits)
+
+	return priority
 }

--- a/internal/dataplane/parser/translators/ingress_atc_test.go
+++ b/internal/dataplane/parser/translators/ingress_atc_test.go
@@ -73,7 +73,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
 							Expression:        kong.String(`(http.host == "konghq.com") && ((http.path == "/api") || (http.path ^= "/api/")) && ((net.protocol == "http") || (net.protocol == "https"))`),
-							Priority:          kong.Int(NormalIngressExpressionPriority),
+							Priority:          kong.Int((2 << 41) + (1 << 32) + (1 << 16) + 5),
 							PreserveHost:      kong.Bool(true),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
@@ -145,7 +145,7 @@ func TestTranslateIngressATC(t *testing.T) {
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
 							Expression:        kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/") && ((net.protocol == "http") || (net.protocol == "https"))`),
-							Priority:          kong.Int(NormalIngressExpressionPriority),
+							Priority:          kong.Int((2 << 41) + (1 << 32) + (5)),
 							PreserveHost:      kong.Bool(true),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

PoC for assigning priorities to routes translated from `Ingress`es. Basically it follows the rules used in `traditional_compatible` router of Kong, the only difference is `regex_priority` field is removed here.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

part of #3958 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
