### PR TITLE
chore: relax uniform Gateway version check

### DIFF
--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -160,13 +160,7 @@ func (kr Root) Key(skipCACerts bool) string {
 		return ""
 	}
 
-	v := kong.VersionFromInfo(kr)
-	_, err = kong.ParseSemanticVersion(v)
-	if err != nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%s:%s", dbMode, v)
+	return dbMode
 }
 
 func validateRootFunc(skipCACerts bool) func(Root, int) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the potential lockup situation where KIC is being restarted and provided Admin API addresses (or discovered via Gateway Discovery) have different versions (potential upgrade scenario).

Up until now the KIC would detect this as non homogenous versions and report an error (which would eventually prevent it from getting ready.

This PR relaxes that check by only enforcing the same DB setting detect in Gateways' config on startup.

**Which issue this PR fixes**:

Closes #4085 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
