### PR TITLE
PoC: assign priorities to routes translated from HTTPRoutes

### DIFF
--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -246,6 +246,7 @@ func SplitHTTPRoute(httproute *gatewayv1beta1.HTTPRoute) []*gatewayv1beta1.HTTPR
 		for _, hostname := range httproute.Spec.Hostnames {
 			hostNamedRoute := httproute.DeepCopy()
 			hostNamedRoute.Spec.Hostnames = []gatewayv1beta1.Hostname{hostname}
+			hostnamedRoutes = append(hostnamedRoutes, hostNamedRoute)
 		}
 	}
 
@@ -432,6 +433,7 @@ func KongExpressionRouteFromHTTPRouteWithPriority(
 			PreserveHost: kong.Bool(true),
 			Tags:         tags,
 		},
+		Ingress:          util.FromK8sObject(httproute),
 		ExpressionRoutes: true,
 	}
 

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -1,7 +1,9 @@
 package translators
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kong/go-kong/kong"
@@ -226,4 +228,247 @@ func matchersFromParentHTTPRoute(hostnames []string, metaAnnotations map[string]
 		ret = append(ret, sniMatcher)
 	}
 	return ret
+}
+
+const (
+	InternalRuleIndexAnnotationKey  = "internal-rule-index"
+	InternalMatchIndexAnnotationKey = "internal-match-index"
+)
+
+// SplitHTTPRoute split HTTPRoutes into HTTPRoutes with at most one hostname, and at most one rule
+// with exactly one match. It will split one rule with multiple hostnames and multiple matches
+// to one hostname and one match per each HTTPRoute.
+func SplitHTTPRoute(httproute *gatewayv1beta1.HTTPRoute) []*gatewayv1beta1.HTTPRoute {
+	hostnamedRoutes := []*gatewayv1beta1.HTTPRoute{}
+	if len(httproute.Spec.Hostnames) == 0 {
+		hostnamedRoutes = append(hostnamedRoutes, httproute.DeepCopy())
+	} else {
+		for _, hostname := range httproute.Spec.Hostnames {
+			hostNamedRoute := httproute.DeepCopy()
+			hostNamedRoute.Spec.Hostnames = []gatewayv1beta1.Hostname{hostname}
+		}
+	}
+
+	newHTTPRoutes := []*gatewayv1beta1.HTTPRoute{}
+	for _, route := range hostnamedRoutes {
+		for i, rule := range route.Spec.Rules {
+			for j, match := range rule.Matches {
+				splittedRoute := route.DeepCopy()
+				splittedRoute.Spec.Rules = []gatewayv1beta1.HTTPRouteRule{
+					{
+						Matches:     []gatewayv1beta1.HTTPRouteMatch{match},
+						Filters:     rule.Filters,
+						BackendRefs: rule.BackendRefs,
+					},
+				}
+				if splittedRoute.Annotations == nil {
+					splittedRoute.Annotations = map[string]string{}
+				}
+				splittedRoute.Annotations[InternalRuleIndexAnnotationKey] = strconv.Itoa(i)
+				splittedRoute.Annotations[InternalMatchIndexAnnotationKey] = strconv.Itoa(j)
+				newHTTPRoutes = append(newHTTPRoutes, splittedRoute)
+			}
+		}
+	}
+
+	return newHTTPRoutes
+}
+
+type SplittedHTTPRouteToKongRoutePriority struct {
+	HTTPRoute *gatewayv1beta1.HTTPRoute
+	Priority  int
+}
+
+// AssignPrioritiesToHTTPRoutes sets priorities to splitted HTTPRoutes.
+func AssignPrioritiesToHTTPRoutes(httproutes []*gatewayv1beta1.HTTPRoute) []SplittedHTTPRouteToKongRoutePriority {
+	const (
+		// PreciseHostnameShiftBits assigns bit 51 for marking if the hostname is non-wildcard.
+		PreciseHostnameShiftBits = 51
+		// HostnameLengthShiftBits assigns bits 43-50 for the length of hostname.
+		HostnameLengthShiftBits = 43
+		// ExactPathShiftBits assigns bit 42 to mark if the match is exact path match.
+		ExactPathShiftBits = 42
+		// RegularExpressionPathShiftBits assigns bit 41 to mark if the match is regex path match.
+		RegularExpressionPathShiftBits = 41
+		// PathLengthShiftBits assigns bits 31-40 to path length. (max length = 1024, but must start with /)
+		PathLengthShiftBits = 31
+		// HeaderNumberShiftBits assign bits 26-30 to number of headers. (max number of headers = 16)
+		HeaderNumberShiftBits = 26
+		// MethodMatchShiftBits assigns bit 25 to mark if method is specified.
+		MethodMatchShiftBits = 25
+		// QueryParamNumberShiftBits makes bits 20-24 used for number of query params (max number of query params = 16)
+		QueryParamNumberShiftBits = 20
+		// bits 0-19 are used for relative order of creation timestamp, namespace/name, and internal order of rules and matches.
+	)
+
+	priorityToHTTPRoutes := map[int][]*gatewayv1beta1.HTTPRoute{}
+	for _, httproute := range httproutes {
+		anns := httproute.Annotations
+		if anns == nil || anns[InternalRuleIndexAnnotationKey] == "" || anns[InternalMatchIndexAnnotationKey] == "" {
+			continue
+		}
+
+		var priority int
+		// assign priority bits for hostname.
+		if len(httproute.Spec.Hostnames) > 0 {
+			hostname := httproute.Spec.Hostnames[0]
+			priority += len(hostname) << HostnameLengthShiftBits
+			if !strings.HasPrefix(string(hostname), "*") {
+				priority += (1 << PreciseHostnameShiftBits)
+			}
+		}
+
+		if len(httproute.Spec.Rules) > 0 && len(httproute.Spec.Rules[0].Matches) > 0 {
+			match := httproute.Spec.Rules[0].Matches[0]
+			if match.Path != nil {
+				switch *match.Path.Type { //nolint: exhaustive
+				case gatewayv1beta1.PathMatchExact:
+					priority += (1 << ExactPathShiftBits)
+				case gatewayv1beta1.PathMatchRegularExpression:
+					priority += (1 << RegularExpressionPathShiftBits)
+				}
+
+				if match.Path.Value != nil && len(*match.Path.Value) > 0 {
+					pathLength := len(*match.Path.Value) - 1
+					priority += pathLength << PathLengthShiftBits
+				}
+
+				if len(match.Headers) > 0 {
+					headerNumber := len(match.Headers)
+					priority += headerNumber << HeaderNumberShiftBits
+				}
+
+				if match.Method != nil && len(*match.Method) > 0 {
+					priority += (1 << MethodMatchShiftBits)
+				}
+
+				if len(match.QueryParams) > 0 {
+					queryParamNumber := len(match.QueryParams)
+					priority += queryParamNumber << QueryParamNumberShiftBits
+				}
+
+				priorityToHTTPRoutes[priority] = append(priorityToHTTPRoutes[priority], httproute)
+			}
+		}
+	}
+
+	httpRoutesToPriorities := make([]SplittedHTTPRouteToKongRoutePriority, 0, len(httproutes))
+	for priority, routes := range priorityToHTTPRoutes {
+		if len(routes) == 1 {
+			httpRoutesToPriorities = append(httpRoutesToPriorities, SplittedHTTPRouteToKongRoutePriority{
+				HTTPRoute: routes[0],
+				Priority:  priority + ((1 << 20) - 1),
+			})
+			continue
+		}
+
+		sort.Slice(routes, func(i, j int) bool {
+			// compare by creation timestamp.
+			if !routes[i].CreationTimestamp.Equal(&routes[j].CreationTimestamp) {
+				return routes[i].CreationTimestamp.Before(&routes[j].CreationTimestamp)
+			}
+			// compare by namespace.
+			if routes[i].Namespace != routes[j].Namespace {
+				return routes[i].Namespace < routes[j].Namespace
+			}
+			// compare by name.
+			if routes[i].Name != routes[j].Name {
+				return routes[i].Name < routes[j].Name
+			}
+			// compare by internal rule order.
+			ruleIndexi, _ := strconv.Atoi(routes[i].Annotations[InternalRuleIndexAnnotationKey])
+			ruleIndexj, _ := strconv.Atoi(routes[j].Annotations[InternalRuleIndexAnnotationKey])
+			if ruleIndexi != ruleIndexj {
+				return ruleIndexi < ruleIndexj
+			}
+			// compare by match order.
+			matchIndexi, _ := strconv.Atoi(routes[i].Annotations[InternalMatchIndexAnnotationKey])
+			matchIndexj, _ := strconv.Atoi(routes[j].Annotations[InternalMatchIndexAnnotationKey])
+			if matchIndexi != matchIndexj {
+				return matchIndexi < matchIndexj
+			}
+			return i < j
+		})
+
+		relativeOrderPriority := ((1 << 20) - 1)
+		for i, route := range routes {
+			httpRoutesToPriorities = append(httpRoutesToPriorities, SplittedHTTPRouteToKongRoutePriority{
+				HTTPRoute: route,
+				Priority:  priority + relativeOrderPriority - i,
+			})
+		}
+	}
+
+	return httpRoutesToPriorities
+}
+
+// getHTTPRouteHostnamesAsSliceOfStrings translates the hostnames defined in an
+// HTTPRoute specification into a []*string slice, which is the type required by translating to matchers
+// in expression based routes.
+func getHTTPRouteHostnamesAsSliceOfStrings(httproute *gatewayv1beta1.HTTPRoute) []string {
+	return lo.Map(httproute.Spec.Hostnames, func(h gatewayv1beta1.Hostname, _ int) string {
+		return string(h)
+	})
+}
+
+// KongExpressionRouteFromHTTPRouteWithPriority translates splitted HTTPRoute into expression
+// based kong route with assigned priority.
+// the HTTPRoute should have at most one hostname, and at most one rule having exactly one match.
+func KongExpressionRouteFromHTTPRouteWithPriority(
+	httpRouteWithPriority SplittedHTTPRouteToKongRoutePriority,
+) kongstate.Route {
+	httproute := httpRouteWithPriority.HTTPRoute
+	tags := util.GenerateTagsForObject(httproute)
+	routeName := fmt.Sprintf("httproute.%s.%s.%s.%s",
+		httproute.Namespace,
+		httproute.Name,
+		httproute.Annotations[InternalRuleIndexAnnotationKey],
+		httproute.Annotations[InternalMatchIndexAnnotationKey],
+	)
+
+	r := kongstate.Route{
+		Route: kong.Route{
+			Name:         kong.String(routeName),
+			PreserveHost: kong.Bool(true),
+			Tags:         tags,
+		},
+		ExpressionRoutes: true,
+	}
+
+	hostnames := getHTTPRouteHostnamesAsSliceOfStrings(httproute)
+	matchers := matchersFromParentHTTPRoute(hostnames, httproute.Annotations)
+
+	if len(httproute.Spec.Rules) > 0 && len(httproute.Spec.Rules[0].Matches) > 0 {
+		matchers = append(matchers, generateMatcherFromHTTPRouteMatch(httproute.Spec.Rules[0].Matches[0]))
+	}
+	atc.ApplyExpression(&r.Route, atc.And(matchers...), httpRouteWithPriority.Priority)
+
+	// translate filters in the rule.
+	if len(httproute.Spec.Rules) > 0 {
+		rule := httproute.Spec.Rules[0]
+		path := ""
+		// since we have at most one match per rule, we do not need to generate request redirect for each match.
+		if len(rule.Matches) > 0 {
+			match := rule.Matches[0]
+			if match.Path != nil && match.Path.Value != nil {
+				path = *match.Path.Value
+			}
+		}
+
+		plugins := GeneratePluginsFromHTTPRouteFilters(rule.Filters, path, tags)
+		r.Plugins = plugins
+	}
+
+	return r
+}
+
+func KongServiceNameFromHTTPRouteWithPriority(
+	httpRouteWithPriority SplittedHTTPRouteToKongRoutePriority,
+) string {
+	httproute := httpRouteWithPriority.HTTPRoute
+	return fmt.Sprintf("httproute.%s.%s.%s",
+		httproute.Namespace,
+		httproute.Name,
+		httproute.Annotations[InternalRuleIndexAnnotationKey],
+	)
 }

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -165,6 +165,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	helpers.EventuallyGETPath(t, proxyURL, "3/exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 	helpers.EventuallyGETPath(t, proxyURL, "3/exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
 
+	t.Log("verifying for configuration of plugins")
 	require.Eventually(t, func() bool {
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "test-http-route-essentials"), nil)
 		if err != nil {

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -589,7 +589,7 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	// testGetByHost tries to get the test path with specified host in request,
 	// and returns true if 200 returned.
 	testGetByHost := func(t *testing.T, host string) bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL, "/test-http-route-filter-hosts", nil)
+		req := helpers.MustHTTPRequest(t, "GET", proxyURL, "test-http-route-filter-hosts", nil)
 		req.Host = host
 		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

PoC of assigning priorities to expression based routes translated from `HTTPRoute`s. 
It assigns bits to fields with fixed maximum length in the following way:
- Highest (bit 51): precise (non-wildcard) hostname
- bit 50~43(8 bits): length of hostname (max = 253)
- bit 42: exact path match
- bit 41: regex path match (REVIEW: should we use the 2 bits as 00 = no path, 01 = prefix path, 10 = regex path, 11 = exact path to distinguish between no path and prefix path?)
- bits 40-31(10 bits): path length. (max length = 1024 but must start with `/`; could we use number if path segments instead? (`/` = 1, `/a` = 2, `/a/b` = 3, etc; but cannot assign proper number for regex))
- bits 30-26(5 bits): number of headers in match (max = 16)
- bit 25: method in match is set
- bits 24-20 (5 bits): number of query params
- bits 19-0: when the higher bits are the same, relative order of sorting by:
  - earlier creation timestamp
  - alphabetical order of namespace/name 
  - internal rule index
  - internal match index 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
