### PR TITLE
feat: all-in-one manifests migrations job improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ Adding a new version? You'll need three changes:
 - Gateway's `AttachedRoutes` fields get updated with the number of routes referencing
   and using each listener.
   [#4052](https://github.com/Kong/kubernetes-ingress-controller/pull/4052)
+- `all-in-one-postgres.yaml` and `all-in-one-postgres-enterprise.yaml` manifests'
+  migrations job now works properly when running against an already bootstrapped
+  database, allowing upgrades from one version of Kong Gateway to another without
+  tearing down the database.
+  [#4116](https://github.com/Kong/kubernetes-ingress-controller/pull/4116)
 
 ### Changed
 

--- a/config/variants/postgres/migration.yaml
+++ b/config/variants/postgres/migration.yaml
@@ -28,5 +28,5 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        command: [ "/bin/bash", "-c", "kong migrations bootstrap" ]
+        command: [ "/bin/bash", "-c", "kong migrations bootstrap && kong migrations up && kong migrations finish" ]
       restartPolicy: OnFailure

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1923,7 +1923,7 @@ spec:
       - command:
         - /bin/bash
         - -c
-        - kong migrations bootstrap
+        - kong migrations bootstrap && kong migrations up && kong migrations finish
         env:
         - name: KONG_LICENSE_DATA
           valueFrom:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1860,7 +1860,7 @@ spec:
       - command:
         - /bin/bash
         - -c
-        - kong migrations bootstrap
+        - kong migrations bootstrap && kong migrations up && kong migrations finish
         env:
         - name: KONG_PG_PASSWORD
           value: kong


### PR DESCRIPTION
**What this PR does / why we need it**:

`kong migrations bootstrap` alone works fine when installing a fresh instance of KIC with DB-backed Kong. It doesn't work though when we'd like to upgrade and keep the DB state between the upgrades, because it only bootstraps a fresh database - when there is one already in existence, it just returns. 

This PR aims to solve this issue by adding additional commands to the migrations job: `kong migrations up && kong migrations finish` which will make the job detect new migrations that need to be run after the upgrade and finish them. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It was discovered when writing E2E tests for https://github.com/Kong/kubernetes-ingress-controller/issues/4025.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
