### PR TITLE
tests: make upgrade tests more robust

### DIFF
--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -96,7 +96,14 @@ func TestKonnectLicenseActivation(t *testing.T) {
 
 	t.Log("disabling license management")
 	kubeconfig := getTemporaryKubeconfig(t, env)
-	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", controllerContainerName, "CONTROLLER_KONNECT_LICENSING_ENABLED", ""))
+	require.NoError(t, setEnv(setEnvParams{
+		kubeCfgPath:   kubeconfig,
+		namespace:     namespace,
+		target:        fmt.Sprintf("deployment/%s", controllerDeploymentName),
+		containerName: controllerContainerName,
+		variableName:  "CONTROLLER_KONNECT_LICENSING_ENABLED",
+		value:         "",
+	}))
 
 	t.Log("restarting proxy")
 	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "rollout", "-n", "kong", "restart", "deployment", "proxy-kong")
@@ -116,7 +123,14 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	}, adminAPIWait, time.Second)
 
 	t.Log("re-enabling license management")
-	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", controllerContainerName, "CONTROLLER_KONNECT_LICENSING_ENABLED", "true"))
+	require.NoError(t, setEnv(setEnvParams{
+		kubeCfgPath:   kubeconfig,
+		namespace:     namespace,
+		target:        fmt.Sprintf("deployment/%s", controllerDeploymentName),
+		containerName: controllerContainerName,
+		variableName:  "CONTROLLER_KONNECT_LICENSING_ENABLED",
+		value:         "true",
+	}))
 
 	t.Log("confirming that the license is set")
 	assert.Eventually(t, func() bool {

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -96,7 +96,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 
 	t.Log("disabling license management")
 	kubeconfig := getTemporaryKubeconfig(t, env)
-	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", "CONTROLLER_KONNECT_LICENSING_ENABLED", ""))
+	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", controllerContainerName, "CONTROLLER_KONNECT_LICENSING_ENABLED", ""))
 
 	t.Log("restarting proxy")
 	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "rollout", "-n", "kong", "restart", "deployment", "proxy-kong")
@@ -116,7 +116,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	}, adminAPIWait, time.Second)
 
 	t.Log("re-enabling license management")
-	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", "CONTROLLER_KONNECT_LICENSING_ENABLED", "true"))
+	require.NoError(t, setEnv(kubeconfig, "kong", "deployment/ingress-kong", controllerContainerName, "CONTROLLER_KONNECT_LICENSING_ENABLED", "true"))
 
 	t.Log("confirming that the license is set")
 	assert.Eventually(t, func() bool {

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -111,15 +111,14 @@ func testManifestsUpgrade(
 	if featureGates := testParams.controllerFeatureGates; featureGates != "" {
 		t.Logf("setting environment variables for controller feature gates: %s", featureGates)
 		kubeconfig := getTemporaryKubeconfig(t, env)
-		err = setEnv(
-			kubeconfig,
-			namespace,
-			fmt.Sprintf("deployment/%s", controllerDeploymentName),
-			controllerContainerName,
-			"CONTROLLER_FEATURE_GATES",
-			featureGates,
-		)
-		require.NoError(t, err)
+		require.NoError(t, setEnv(setEnvParams{
+			kubeCfgPath:   kubeconfig,
+			namespace:     namespace,
+			target:        fmt.Sprintf("deployment/%s", controllerDeploymentName),
+			containerName: controllerContainerName,
+			variableName:  "CONTROLLER_FEATURE_GATES",
+			value:         featureGates,
+		}))
 		waitForDeploymentRollout(ctx, t, env, namespace, controllerDeploymentName)
 	}
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -116,7 +116,7 @@ func testManifestsUpgrade(
 			namespace,
 			fmt.Sprintf("deployment/%s", controllerDeploymentName),
 			controllerContainerName,
-			"KONG_CONTROLLER_FEATURE_GATES",
+			"CONTROLLER_FEATURE_GATES",
 			featureGates,
 		)
 		require.NoError(t, err)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -111,7 +111,14 @@ func testManifestsUpgrade(
 	if featureGates := testParams.controllerFeatureGates; featureGates != "" {
 		t.Logf("setting environment variables for controller feature gates: %s", featureGates)
 		kubeconfig := getTemporaryKubeconfig(t, env)
-		err = setEnv(kubeconfig, namespace, fmt.Sprintf("deployment/%s", controllerDeploymentName), "KONG_CONTROLLER_FEATURE_GATES", featureGates)
+		err = setEnv(
+			kubeconfig,
+			namespace,
+			fmt.Sprintf("deployment/%s", controllerDeploymentName),
+			controllerContainerName,
+			"KONG_CONTROLLER_FEATURE_GATES",
+			featureGates,
+		)
 		require.NoError(t, err)
 		waitForDeploymentRollout(ctx, t, env, namespace, controllerDeploymentName)
 	}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
@@ -27,59 +28,101 @@ const (
 )
 
 func TestDeployAndUpgradeAllInOneDBLESS(t *testing.T) {
-	fromManifestURL := fmt.Sprintf(dblessURLTemplate, upgradeTestFromTag)
-	toManifestPath := dblessPath
-	testManifestsUpgrade(t, fromManifestURL, toManifestPath, nil)
+	testManifestsUpgrade(t, manifestsUpgradeTestParams{
+		fromManifestURL: fmt.Sprintf(dblessURLTemplate, upgradeTestFromTag),
+		toManifestPath:  dblessPath,
+	})
 }
 
 func TestDeployAndUpgradeAllInOnePostgres(t *testing.T) {
-	fromManifestURL := fmt.Sprintf(postgresURLTemplate, upgradeTestFromTag)
-	toManifestPath := postgresPath
-
-	// Injecting a beforeUpgradeHook to delete the old migrations job before the upgrade. This is necessary because it's
-	// not allowed to modify the existing job's spec.
-	beforeUpgradeHook := func(ctx context.Context, t *testing.T, env environments.Environment) {
-		err := env.Cluster().Client().BatchV1().Jobs(namespace).Delete(ctx, migrationsJobName, metav1.DeleteOptions{
-			PropagationPolicy: lo.ToPtr(metav1.DeletePropagationBackground),
-		})
-		require.NoError(t, err, "failed to delete old migrations job before upgrade")
-	}
-	testManifestsUpgrade(t, fromManifestURL, toManifestPath, beforeUpgradeHook)
+	testManifestsUpgrade(t, manifestsUpgradeTestParams{
+		fromManifestURL:   fmt.Sprintf(postgresURLTemplate, upgradeTestFromTag),
+		toManifestPath:    postgresPath,
+		beforeUpgradeHook: postgresBeforeUpgradeHook,
+	})
 }
 
-// beforeUpgradeFn is a function that is run before the upgrade to clean up any resources that may interfere with the upgrade.
+func TestDeployAndUpgradeAllInOnePostgres_FeatureGates(t *testing.T) {
+	testManifestsUpgrade(t, manifestsUpgradeTestParams{
+		fromManifestURL:   fmt.Sprintf(postgresURLTemplate, upgradeTestFromTag),
+		toManifestPath:    postgresPath,
+		beforeUpgradeHook: postgresBeforeUpgradeHook,
+		// We want to test that nothing breaks when enabling FillIDs feature gate to prevent regressions like
+		// https://github.com/Kong/kubernetes-ingress-controller/issues/4025.
+		// In 2.10.0 this is disabled by default, so we need a separate test for this.
+		// TODO: remove this test when FillIDs is enabled by default.
+		controllerFeatureGates: "FillIDs=true",
+	})
+}
+
+func postgresBeforeUpgradeHook(ctx context.Context, t *testing.T, env environments.Environment) {
+	// Injecting a beforeUpgradeHook to delete the old migrations job before the upgrade. This is necessary because it's
+	// not allowed to modify the existing job's spec.
+	err := env.Cluster().Client().BatchV1().Jobs(namespace).Delete(ctx, migrationsJobName, metav1.DeleteOptions{
+		PropagationPolicy: lo.ToPtr(metav1.DeletePropagationBackground),
+	})
+	require.NoError(t, err, "failed to delete old migrations job before upgrade")
+}
+
 type beforeUpgradeFn func(ctx context.Context, t *testing.T, env environments.Environment)
+
+type manifestsUpgradeTestParams struct {
+	// fromManifestURL is the URL to the manifest to deploy before the upgrade.
+	fromManifestURL string
+
+	// toManifestPath is the path to the manifest to deploy after the upgrade.
+	toManifestPath string
+
+	// beforeUpgradeHook is a function that is run before the upgrade to clean up any resources that may interfere with the upgrade.
+	beforeUpgradeHook beforeUpgradeFn
+
+	// controllerFeatureGates contains feature gates to enable on the controller during the upgrade (e.g. "FillID=true").
+	controllerFeatureGates string
+}
 
 func testManifestsUpgrade(
 	t *testing.T,
-	fromManifestURL string,
-	toManifestPath string,
-	beforeUpgradeHook beforeUpgradeFn,
+	testParams manifestsUpgradeTestParams,
 ) {
-	t.Parallel()
-
 	httpClient := helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())
-	oldManifest, err := httpClient.Get(fromManifestURL)
+	oldManifest, err := httpClient.Get(testParams.fromManifestURL)
 	require.NoError(t, err)
 	defer oldManifest.Body.Close()
 
 	t.Log("configuring upgrade manifests test")
 	ctx, env := setupE2ETest(t)
 
-	t.Logf("deploying previous kong manifests: %s", fromManifestURL)
+	t.Logf("deploying previous kong manifests: %s", testParams.fromManifestURL)
 	deployKong(ctx, t, env, oldManifest.Body)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
-	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+	ingress := deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
-	if beforeUpgradeHook != nil {
+	if hook := testParams.beforeUpgradeHook; hook != nil {
 		t.Log("running before upgrade hook")
-		beforeUpgradeHook(ctx, t, env)
+		hook(ctx, t, env)
 	}
 
-	t.Logf("deploying target version of kong manifests: %s", toManifestPath)
-	manifest := getTestManifest(t, toManifestPath)
+	t.Logf("deploying target version of kong manifests: %s", testParams.toManifestPath)
+	manifest := getTestManifest(t, testParams.toManifestPath)
+
+	if featureGates := testParams.controllerFeatureGates; featureGates != "" {
+		t.Logf("setting environment variables for controller feature gates: %s", featureGates)
+		manifest, err = addControllerEnv(manifest, "KONG_CONTROLLER_FEATURE_GATES", featureGates)
+		require.NoError(t, err)
+	}
+
 	deployKong(ctx, t, env, manifest)
-	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
+
+	// Add a new rule to the ingress to verify that the ingress controller is still functional after the upgrade
+	// and is able to configure new Kong routes.
+	newRule := ingress.Spec.Rules[0].DeepCopy()
+	const newPath = "/echo-new"
+	newRule.HTTP.Paths[0].Path = newPath
+	ingress.Spec.Rules = append(ingress.Spec.Rules, *newRule)
+	_, err = env.Cluster().Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Update(ctx, ingress, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	verifyIngressWithEchoBackendsPath(ctx, t, env, numberOfEchoBackends, newPath)
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -423,14 +423,32 @@ func ensureNoneOfDeploymentPodsHasCrashed(ctx context.Context, t *testing.T, env
 	}
 }
 
-func setEnv(kubecfg, namespace, target, containerName, variable, value string) error {
+type setEnvParams struct {
+	kubeCfgPath   string
+	namespace     string
+	target        string // e.g. deployment/name or pod/name
+	containerName string
+	variableName  string
+	value         string
+}
+
+func setEnv(p setEnvParams) error {
 	var envvar string
-	if value == "" {
-		envvar = fmt.Sprintf("%s-", variable)
+	if p.value == "" {
+		envvar = fmt.Sprintf("%s-", p.variableName)
 	} else {
-		envvar = fmt.Sprintf("%s=%s", variable, value)
+		envvar = fmt.Sprintf("%s=%s", p.variableName, p.value)
 	}
-	cmd := exec.Command("kubectl", "--kubeconfig", kubecfg, "set", "env", "-n", namespace, "-c", containerName, target, envvar)
+	//nolint:gosec
+	cmd := exec.Command(
+		"kubectl",
+		"--kubeconfig", p.kubeCfgPath,
+		"set", "env",
+		"-n", p.namespace,
+		"-c", p.containerName,
+		p.target,
+		envvar,
+	)
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -423,14 +423,14 @@ func ensureNoneOfDeploymentPodsHasCrashed(ctx context.Context, t *testing.T, env
 	}
 }
 
-func setEnv(kubecfg, namespace, target, variable, value string) error {
+func setEnv(kubecfg, namespace, target, containerName, variable, value string) error {
 	var envvar string
 	if value == "" {
 		envvar = fmt.Sprintf("%s-", variable)
 	} else {
 		envvar = fmt.Sprintf("%s=%s", variable, value)
 	}
-	cmd := exec.Command("kubectl", "--kubeconfig", kubecfg, "set", "env", "-n", namespace, target, envvar)
+	cmd := exec.Command("kubectl", "--kubeconfig", kubecfg, "set", "env", "-n", namespace, "-c", containerName, target, envvar)
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
**What this PR does / why we need it**:

It introduces two main changes to the upgrade tests that should make them more reliable:
1. Ensure that after the controller deployment is upgraded, we actually wait until all new replicas are rolled out and become ready so that we're sure that we're testing against the new version.
2. Add a new path to the Ingress after the upgrade is done and test against it to make sure that the new configuration is processed correctly (without that we were only verifying that the old Kong Gateway instance was configured, but it could be the configuration pushed by the old controller).

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5142252037/jobs/9255887769 test failure proves that if we set the feature gate `FillIDs=true`, the upgrade will fail. To fix that we will [bump deck version to v1.21.0](https://github.com/Kong/kubernetes-ingress-controller/pull/4113) which will make the test pass. 

**Which issue this PR fixes**:

Noticed when working on https://github.com/Kong/kubernetes-ingress-controller/issues/4025.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
