### PR TITLE
test: trim prefix / of path and suffix / of proxy URL in MustHTTPRequest

### DIFF
--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -37,7 +37,11 @@ func RetryableHTTPClient(base *http.Client) *http.Client {
 // MustHTTPRequest creates a request with provided parameters and it fails the
 // test that it was called in when request creation fails.
 func MustHTTPRequest(t *testing.T, method string, proxyURL *url.URL, path string, headers map[string]string) *http.Request {
-	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", proxyURL, path), nil)
+	proxyURLStr := proxyURL.String()
+	// trim suffix '/'s of proxy URL and prefix '/'s of path to avoid duplicate /s
+	proxyURLStr = strings.TrimRight(proxyURLStr, "/")
+	path = strings.TrimLeft(path, "/")
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", proxyURLStr, path), nil)
 	require.NoError(t, err)
 	for header, value := range headers {
 		req.Header.Set(header, value)

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -37,11 +37,10 @@ func RetryableHTTPClient(base *http.Client) *http.Client {
 // MustHTTPRequest creates a request with provided parameters and it fails the
 // test that it was called in when request creation fails.
 func MustHTTPRequest(t *testing.T, method string, proxyURL *url.URL, path string, headers map[string]string) *http.Request {
-	proxyURLStr := proxyURL.String()
 	// trim suffix '/'s of proxy URL and prefix '/'s of path to avoid duplicate /s
-	proxyURLStr = strings.TrimRight(proxyURLStr, "/")
+	host := strings.TrimRight(proxyURL.String(), "/")
 	path = strings.TrimLeft(path, "/")
-	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", proxyURLStr, path), nil)
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", host, path), nil)
 	require.NoError(t, err)
 	for header, value := range headers {
 		req.Header.Set(header, value)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Trim trailing `/` s of proxy URL and leading `/` s of path before concatenate the URL to avoid duplicate `/` s .
like: `http://kong.proxy/` + `/foo` -> `http://kong.proxy/foo`


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
