### PR TITLE
chore(release): bump K8s & Istio versions for 2.10 release

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -72,7 +72,7 @@ jobs:
         name: Set Kind versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.14\", \"1.25.10\", \"1.26.5\", \"1.27.2\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.13\", \"1.25.9\", \"1.26.4\", \"1.27.2\"]" >> $GITHUB_OUTPUT
           else
             echo "kind-versions=[\"1.27.2\"]" >> $GITHUB_OUTPUT
           fi
@@ -225,11 +225,11 @@ jobs:
           # K8s v1.27.2 is not officially supported by Istio v1.17.2, but we want to test it anyway.
           - kubernetes-version: 'v1.27.2'
             istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.26.5'
+          - kubernetes-version: 'v1.26.4'
             istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.25.10'
+          - kubernetes-version: 'v1.25.9'
             istio-version: 'v1.16.5'
-          - kubernetes-version: 'v1.25.10'
+          - kubernetes-version: 'v1.25.9'
             istio-version: 'v1.15.7'
     steps:
       - name: Download built image artifact

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -72,11 +72,10 @@ jobs:
         name: Set Kind versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.7\", \"1.25.8\", \"1.26.3\", \"1.27.1\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.14\", \"1.25.10\", \"1.26.5\", \"1.27.2\"]" >> $GITHUB_OUTPUT
           else
-            echo "kind-versions=[\"1.27.1\"]" >> $GITHUB_OUTPUT
-          fi 
-
+            echo "kind-versions=[\"1.27.2\"]" >> $GITHUB_OUTPUT
+          fi
   kind:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
@@ -223,14 +222,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kubernetes-version: 'v1.26.0'
-            istio-version: 'v1.17.1'
-          - kubernetes-version: 'v1.25.3'
-            istio-version: 'v1.17.1'
-          - kubernetes-version: 'v1.25.3'
-            istio-version: 'v1.16.3'
-          - kubernetes-version: 'v1.25.3'
-            istio-version: 'v1.15.6'
+          # K8s v1.27.2 is not officially supported by Istio v1.17.2, but we want to test it anyway.
+          - kubernetes-version: 'v1.27.2'
+            istio-version: 'v1.17.2'
+          - kubernetes-version: 'v1.26.5'
+            istio-version: 'v1.17.2'
+          - kubernetes-version: 'v1.25.10'
+            istio-version: 'v1.16.5'
+          - kubernetes-version: 'v1.25.10'
+            istio-version: 'v1.15.7'
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,9 +135,9 @@ jobs:
         kubernetes-version:
           - 'v1.22.15'
           - 'v1.23.13'
-          - 'v1.24.14'
-          - 'v1.25.10'
-          - 'v1.26.5'
+          - 'v1.24.13'
+          - 'v1.25.9'
+          - 'v1.26.4'
           - 'v1.27.2'
     steps:
       - name: checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
           Depending on the value, a production release will be published to GitHub or not.
             - In case of prerelease tags (e.g. v1.2.3-alpha.1) it will build-push the images (only standard tags,
               i.e., v1.2.3-alpha.1), test them and publish a GitHub prerelease (labeled as non-production ready).
-            - In other cases (e.g. v1.2.3) it will build-push the images (standard and supplemental tags, 
+            - In other cases (e.g. v1.2.3) it will build-push the images (standard and supplemental tags,
               i.e., v1.2.3 and v1.2), test them and publish a production Github release.
         required: true
       latest:
@@ -135,9 +135,10 @@ jobs:
         kubernetes-version:
           - 'v1.22.15'
           - 'v1.23.13'
-          - 'v1.24.7'
-          - 'v1.25.3'
-          - 'v1.26.0'
+          - 'v1.24.14'
+          - 'v1.25.10'
+          - 'v1.26.5'
+          - 'v1.27.2'
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -183,9 +184,9 @@ jobs:
 
           - [Docker Image](https://hub.docker.com/repository/docker/kong/kubernetes-ingress-controller)
           - [Get started](https://github.com/Kong/kubernetes-ingress-controller#get-started)
-          
+
           #### Links:
-          
+
           - [Changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#${{ steps.semver_parser.outputs.major }}${{ steps.semver_parser.outputs.minor }}${{ steps.semver_parser.outputs.patch }})
 
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

K8s versions
<img width="1013" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/9593424/74f3d945-9e8a-4dac-9092-9cedd05eff6a">

Below versions are not yet available as [kindest:node](https://hub.docker.com/r/kindest/node) thus for them older are used
- `1.26.5`    -> `1.26.4`
- `1.25.10`  -> `1.25.9`
- `1.24.14`  -> `1.24.13`

Istio versions
<img width="904" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/9593424/d311f177-d634-4827-bec1-ffc109531cbc">

You can see that `K8s 1.27` is not specified, but we'll test with it anyway.

The newest versions are
<img width="624" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/9593424/cdb6244a-2806-466b-9ba0-8fdd99937f56">

<img width="769" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/9593424/c526b648-b736-498f-a01d-4c255127a306">

<img width="608" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/9593424/3c5dc291-6955-40eb-848f-48c2d1941cca">



**Related issue**:

https://github.com/Kong/kubernetes-ingress-controller/issues/4098

**Notes for reviewer**:

Tests with label `ci-run/e2e` have been run too
