### PR TITLE
perf(config_validation): make regex a global variable and avoid `[]byte` conversion

### DIFF
--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -13,6 +13,9 @@ import (
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v2/internal/manager/config/types"
 )
 
+// https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463
+var gatewayAPIControllerNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
+
 // *FromFlagValue functions are used to validate single flag values and set those in Config.
 // They're meant to be used together with ValidatedValue[T] type.
 
@@ -35,9 +38,7 @@ func namespacedNameFromFlagValue(flagValue string) (OptionalNamespacedName, erro
 }
 
 func gatewayAPIControllerNameFromFlagValue(flagValue string) (string, error) {
-	// https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463
-	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
-	if !re.MatchString(flagValue) {
+	if !gatewayAPIControllerNameRegex.MatchString(flagValue) {
 		return "", errors.New("the expected format is example.com/controller-name")
 	}
 	return flagValue, nil

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -37,7 +37,7 @@ func namespacedNameFromFlagValue(flagValue string) (OptionalNamespacedName, erro
 func gatewayAPIControllerNameFromFlagValue(flagValue string) (string, error) {
 	// https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463
 	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
-	if !re.Match([]byte(flagValue)) {
+	if !re.MatchString(flagValue) {
 		return "", errors.New("the expected format is example.com/controller-name")
 	}
 	return flagValue, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

We can use `(*regexp.Regexp).MatchString` to avoid an unnecessary byte slice conversion and reduce allocation.

Benchmark code using `(*regexp.Regexp).MatchString`:
```go
func matchString(flagValue string) (string, error) {
	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
	if !re.MatchString(flagValue) {
		return "", errors.New("the expected format is example.com/controller-name")
	}
	return flagValue, nil
}

func match(flagValue string) (string, error) {
	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)
	if !re.Match([]byte(flagValue)) {
		return "", errors.New("the expected format is example.com/controller-name")
	}
	return flagValue, nil
}

func BenchmarkGatewayAPIControllerNameFromFlagValueMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		matchString("example.com/controller-name")
	}
}
func BenchmarkGatewayAPIControllerNameFromFlagValueMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		match("example.com/controller-name")
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/kong/kubernetes-ingress-controller/v2/internal/manager
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkGatewayAPIControllerNameFromFlagValueMatchString-16    	   52533	     26469 ns/op	    9781 B/op	      78 allocs/op
BenchmarkGatewayAPIControllerNameFromFlagValueMatch-16          	   43731	     27882 ns/op	    9845 B/op	      79 allocs/op
```

---

Benchmark code using `(*regexp.Regexp).MatchString` and global regex:
```go
var gatewayAPIControllerNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`)

func matchString(flagValue string) (string, error) {
	if !gatewayAPIControllerNameRegex.MatchString(flagValue) {
		return "", errors.New("the expected format is example.com/controller-name")
	}
	return flagValue, nil
}

func match(flagValue string) (string, error) {
	if !gatewayAPIControllerNameRegex.Match([]byte(flagValue)) {
		return "", errors.New("the expected format is example.com/controller-name")
	}
	return flagValue, nil
}

func BenchmarkGatewayAPIControllerNameFromFlagValueMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		matchString("example.com/controller-name")
	}
}
func BenchmarkGatewayAPIControllerNameFromFlagValueMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		match("example.com/controller-name")
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/kong/kubernetes-ingress-controller/v2/internal/manager
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkGatewayAPIControllerNameFromFlagValueMatchString-16    	 2052745	       557.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkGatewayAPIControllerNameFromFlagValueMatch-16          	  920378	      1233 ns/op	      32 B/op	       1 allocs/op
```

**Which issue this PR fixes**:

**Special notes for your reviewer**:


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
