### PR TITLE
chore(features) enable CombinedServices by default

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -41,7 +41,7 @@ jobs:
             test: postgres
           - name: feature-gates
             test: dbless
-            feature_gates: "GatewayAlpha=true,CombinedRoutes=false"
+            feature_gates: "GatewayAlpha=true,CombinedRoutes=false,CombinedServices=false"
           - name: dbless-knative
             test: dbless.knative
           - name: postgres-knative
@@ -59,11 +59,6 @@ jobs:
             test: dbless
             feature_gates: "ExpressionRoutes=true,GatewayAlpha=true"
             router-flavor: "expressions"
-          # TODO: remove this once CombinedServices is enabled by default.
-          # https://github.com/Kong/kubernetes-ingress-controller/issues/3979
-          - name: dbless-combined-services
-            test: dbless
-            feature_gates: "GatewayAlpha=true,CombinedServices=true"
           - name: dbless-fill-ids
             test: dbless
             feature_gates: "GatewayAlpha=true,FillIDs=true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+### Added
+
+- The `CombinedServices` feature gate is now enabled by default.
+  [#4138](https://github.com/Kong/kubernetes-ingress-controller/pull/4138)
+
 ## [2.10.0]
 
 > Release date: 2023-06-02

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -57,11 +57,14 @@ Features that reach GA and over time become stable will be removed from this tab
 | Feature          | Default | Stage | Since   | Until |
 |------------------|---------|-------|---------|-------|
 | Knative          | `false` | Alpha | 0.8.0   | TBD   |
-| Gateway          | `true`  | Beta  | 2.2.0   | TBD   |
+| Gateway          | `false` | Alpha | 2.2.0   | TBD   |
+| Gateway          | `true`  | Beta  | 2.6.0   | TBD   |
+| CombinedRoutes   | `false` | Alpha | 2.4.0   | TBD   |
 | CombinedRoutes   | `true`  | Beta  | 2.8.0   | TBD   |
 | GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
 | ExpressionRoutes | `false` | Alpha | 2.10.0  | TBD   |
-| CombinedServices | `true`  | Beta  | 2.10.0  | TBD   |
+| CombinedServices | `false` | Alpha | 2.10.0  | TBD   |
+| CombinedServices | `true`  | Beta  | 2.11.0  | TBD   |
 | FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -61,7 +61,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | CombinedRoutes   | `true`  | Beta  | 2.8.0   | TBD   |
 | GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
 | ExpressionRoutes | `false` | Alpha | 2.10.0  | TBD   |
-| CombinedServices | `false` | Alpha | 2.10.0  | TBD   |
+| CombinedServices | `true`  | Beta  | 2.10.0  | TBD   |
 | FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -81,7 +81,7 @@ func GetFeatureGatesDefaults() map[string]bool {
 		GatewayAlphaFeature:     false,
 		CombinedRoutesFeature:   true,
 		ExpressionRoutesFeature: false,
-		CombinedServicesFeature: false,
+		CombinedServicesFeature: true,
 		FillIDsFeature:          false,
 	}
 }

--- a/internal/manager/telemetry/telemetry_test.go
+++ b/internal/manager/telemetry/telemetry_test.go
@@ -353,7 +353,7 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"signal=kic-ping;"+
 			"db=off;"+
 			"feature-combinedroutes=true;"+
-			"feature-combinedservices=false;"+
+			"feature-combinedservices=true;"+
 			"feature-expressionroutes=false;"+
 			"feature-fillids=false;"+
 			"feature-gateway-service-discovery=false;"+


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables CombinedServices by default and updates test matrix to reflect this.

**Which issue this PR fixes**:

Fix #3979

**Special notes for your reviewer**:

See https://github.com/Kong/kubernetes-ingress-controller/issues/3979#issuecomment-1577388487. It looks like we meant to do this for 2.11, but the original issue only requests part of this change.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
