### PR TITLE
chore(deps) update to GWAPI 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ Adding a new version? You'll need three changes:
 
 - The `CombinedServices` feature gate is now enabled by default.
   [#4138](https://github.com/Kong/kubernetes-ingress-controller/pull/4138)
+- Gateway resources no longer use the _Ready_ condition following changes to
+  the upstream Gateway API specification in version 0.7.
+  [#4142](https://github.com/Kong/kubernetes-ingress-controller/pull/4142)
 
 ### Changed
 

--- a/examples/gateway-grpcroute.yaml
+++ b/examples/gateway-grpcroute.yaml
@@ -81,3 +81,7 @@ spec:
   - backendRefs:
     - name: grpcbin
       port: 443
+    matches:
+    - method:
+        service: "grpcbin.GRPCBin"
+        method: "DummyUnary"

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,6 @@ module github.com/kong/kubernetes-ingress-controller/v2
 
 go 1.20
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/2953
-exclude (
-	sigs.k8s.io/gateway-api v0.6.2
-	sigs.k8s.io/gateway-api v0.7.0
-	sigs.k8s.io/gateway-api v0.7.1
-)
-
 require (
 	cloud.google.com/go/container v1.21.0
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	knative.dev/networking v0.0.0-20230504184058-77975a12b2ee
 	knative.dev/pkg v0.0.0-20230502134655-db8a35330281
 	sigs.k8s.io/controller-runtime v0.15.0
-	sigs.k8s.io/gateway-api v0.6.1
+	sigs.k8s.io/gateway-api v0.7.1
 	sigs.k8s.io/kustomize/api v0.13.4
 	sigs.k8s.io/kustomize/kyaml v0.14.2
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,8 @@ knative.dev/serving v0.37.2/go.mod h1:v0Xbfp7olb0Gljm5l4qNuLsIf8/2p1rIt/mphxvx1z
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/controller-runtime v0.15.0 h1:ML+5Adt3qZnMSYxZ7gAverBLNPSMQEibtzAgp0UPojU=
 sigs.k8s.io/controller-runtime v0.15.0/go.mod h1:7ngYvp1MLT+9GeZ+6lH3LOlcHkp/+tzA/fmHa4iq9kk=
-sigs.k8s.io/gateway-api v0.6.1 h1:d/nIkhtbU0zVoFsriKi8lXwBYKNopz3EGeSwDqxeTRs=
-sigs.k8s.io/gateway-api v0.6.1/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
+sigs.k8s.io/gateway-api v0.7.1 h1:Tts2jeepVkPA5rVG/iO+S43s9n7Vp7jCDhZDQYtPigQ=
+sigs.k8s.io/gateway-api v0.7.1/go.mod h1:Xv0+ZMxX0lu1nSSDIIPEfbVztgNZ+3cfiYrJsa2Ooso=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.19.0 h1:ZSUh6/kpab6fiowT6EqL4k8xSbedI2NWxyuUOtoPFe4=

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -782,24 +782,15 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 // -----------------------------------------------------------------------------
 
 // updateAddressesAndListenersStatus updates a unmanaged gateway's status with new addresses and listeners.
-// If the addresses and listeners provided are the same as what exists, it is assumed that reconciliation is complete and a Ready condition is posted.
+// If the addresses and listeners provided are the same as what exists, it is assumed that reconciliation is complete and a Programmed condition is posted.
 func (r *GatewayReconciler) updateAddressesAndListenersStatus(
 	ctx context.Context,
 	gateway *gatewayv1beta1.Gateway,
 	listenerStatuses []gatewayv1beta1.ListenerStatus,
 ) (bool, error) {
-	if !isGatewayReady(gateway) {
+	if !isGatewayProgrammed(gateway) {
 		gateway.Status.Listeners = listenerStatuses
 		gateway.Status.Addresses = gateway.Spec.Addresses
-		readyCondition := metav1.Condition{
-			Type:               string(gatewayv1beta1.GatewayConditionReady),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: gateway.Generation,
-			LastTransitionTime: metav1.Now(),
-			Reason:             string(gatewayv1beta1.GatewayReasonReady),
-			Message:            "addresses and listeners for the Gateway resource were successfully updated",
-		}
-		setGatewayCondition(gateway, readyCondition)
 		programmedCondition := metav1.Condition{
 			Type:               string(gatewayv1beta1.GatewayConditionProgrammed),
 			Status:             metav1.ConditionTrue,

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -16,48 +16,48 @@ import (
 )
 
 func TestReadyConditionExistsForObservedGeneration(t *testing.T) {
-	t.Log("checking ready condition for currently ready gateway")
-	currentlyReadyGateway := &gatewayv1beta1.Gateway{
+	t.Log("checking programmed condition for currently ready gateway")
+	currentlyProgrammedGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 1,
 		},
 		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
-				Type:               string(gatewayv1beta1.GatewayConditionReady),
+				Type:               string(gatewayv1beta1.GatewayConditionProgrammed),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: 1,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1beta1.GatewayReasonReady),
+				Reason:             string(gatewayv1beta1.GatewayReasonProgrammed),
 			}},
 		},
 	}
-	assert.True(t, isGatewayReady(currentlyReadyGateway))
+	assert.True(t, isGatewayProgrammed(currentlyProgrammedGateway))
 
-	t.Log("checking ready condition for previously ready gateway that has since been updated")
-	previouslyReadyGateway := &gatewayv1beta1.Gateway{
+	t.Log("checking programmed condition for previously programmed gateway that has since been updated")
+	previouslyProgrammedGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 2,
 		},
 		Status: gatewayv1beta1.GatewayStatus{
 			Conditions: []metav1.Condition{{
-				Type:               string(gatewayv1beta1.GatewayConditionReady),
+				Type:               string(gatewayv1beta1.GatewayConditionProgrammed),
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: 1,
 				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1beta1.GatewayReasonReady),
+				Reason:             string(gatewayv1beta1.GatewayReasonProgrammed),
 			}},
 		},
 	}
-	assert.False(t, isGatewayReady(previouslyReadyGateway))
+	assert.False(t, isGatewayProgrammed(previouslyProgrammedGateway))
 
-	t.Log("checking ready condition for a gateway which has never been ready")
-	neverBeenReadyGateway := &gatewayv1beta1.Gateway{
+	t.Log("checking programmed condition for a gateway which has never been ready")
+	neverBeenProgrammedGateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 10,
 		},
 		Status: gatewayv1beta1.GatewayStatus{},
 	}
-	assert.False(t, isGatewayReady(neverBeenReadyGateway))
+	assert.False(t, isGatewayProgrammed(neverBeenProgrammedGateway))
 }
 
 func TestSetGatewayCondtion(t *testing.T) {

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -60,8 +60,8 @@ func isGatewayScheduled(gateway *Gateway) bool {
 	)
 }
 
-// isGatewayProgrammed returns boolean whether the ready condition exists
-// for the given gateway object if it matches the currently known generation of that object.
+// isGatewayProgrammed returns boolean whether the Programmed condition exists
+// for the given Gateway object and if it matches the currently known generation of that object.
 func isGatewayProgrammed(gateway *Gateway) bool {
 	return util.CheckCondition(
 		gateway.Status.Conditions,

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -409,12 +409,11 @@ func getListenerStatus(
 					Reason:             string(gatewayv1beta1.ListenerReasonResolvedRefs),
 				},
 				metav1.Condition{
-					Type:               string(gatewayv1beta1.ListenerConditionReady),
+					Type:               string(gatewayv1beta1.ListenerConditionAccepted),
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: gateway.Generation,
 					LastTransitionTime: metav1.Now(),
-					Reason:             string(gatewayv1beta1.ListenerReasonReady),
-					Message:            "the listener is ready and available for routing",
+					Reason:             string(gatewayv1beta1.ListenerReasonAccepted),
 				},
 				metav1.Condition{
 					Type:               string(gatewayv1beta1.ListenerConditionProgrammed),
@@ -425,18 +424,8 @@ func getListenerStatus(
 				},
 			)
 		} else {
-			// any conditions we added above will prevent the Listener from becoming ready
-			// unsure if we want to add the ready=false condition on a per-failure basis or use this else to just mark
-			// it generic unready if we hit anything bad. do any failure conditions block readiness? do we care about
-			// having distinct ready false messages, assuming we have more descriptive messages in the other conditions?
-			status.Conditions = append(status.Conditions, metav1.Condition{
-				Type:               string(gatewayv1beta1.ListenerConditionReady),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: gateway.Generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             string(gatewayv1beta1.ListenerReasonInvalid),
-				Message:            "the listener is not ready and cannot route requests",
-			},
+			// any conditions we added above will prevent the Listener from becoming programmed
+			status.Conditions = append(status.Conditions,
 				metav1.Condition{
 					Type:               string(gatewayv1beta1.ListenerConditionProgrammed),
 					Status:             metav1.ConditionFalse,
@@ -481,7 +470,7 @@ func getListenerStatus(
 			for _, cond := range statuses[listener.Name].Conditions {
 				// shut up linter, there's a default
 				switch gatewayv1alpha2.ListenerConditionType(cond.Type) { //nolint:exhaustive
-				case gatewayv1beta1.ListenerConditionReady, gatewayv1beta1.ListenerConditionConflicted:
+				case gatewayv1beta1.ListenerConditionProgrammed, gatewayv1beta1.ListenerConditionConflicted:
 					continue
 				default:
 					newConditions = append(newConditions, cond)
@@ -496,12 +485,11 @@ func getListenerStatus(
 					Reason:             conflictReason,
 				},
 				metav1.Condition{
-					Type:               string(gatewayv1beta1.ListenerConditionReady),
+					Type:               string(gatewayv1beta1.ListenerConditionProgrammed),
 					Status:             metav1.ConditionFalse,
 					ObservedGeneration: gateway.Generation,
 					LastTransitionTime: metav1.Now(),
-					Reason:             string(gatewayv1beta1.ListenerReasonReady),
-					Message:            "the listener is not ready and cannot route requests",
+					Reason:             string(gatewayv1beta1.ListenerReasonInvalid),
 				},
 			)
 		}

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -60,13 +60,13 @@ func isGatewayScheduled(gateway *Gateway) bool {
 	)
 }
 
-// isGatewayReady returns boolean whether the ready condition exists
+// isGatewayProgrammed returns boolean whether the ready condition exists
 // for the given gateway object if it matches the currently known generation of that object.
-func isGatewayReady(gateway *Gateway) bool {
+func isGatewayProgrammed(gateway *Gateway) bool {
 	return util.CheckCondition(
 		gateway.Status.Conditions,
-		util.ConditionType(gatewayv1beta1.GatewayConditionReady),
-		util.ConditionReason(gatewayv1beta1.GatewayReasonReady),
+		util.ConditionType(gatewayv1beta1.GatewayConditionProgrammed),
+		util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed),
 		metav1.ConditionTrue,
 		gateway.Generation,
 	)

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -310,7 +310,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, grpcroute, "checking if the grpcroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayReady(gateway.gateway) {
+		if !isGatewayProgrammed(gateway.gateway) {
 			debug(log, grpcroute, "gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -382,7 +382,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, httproute, "checking if the httproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayReady(gateway.gateway) {
+		if !isGatewayProgrammed(gateway.gateway) {
 			debug(log, httproute, "gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -465,10 +465,10 @@ func routeMatchesListenerAllowedRoutes[T types.RouteT](
 }
 
 var (
-	errUnsupportedRouteKind             = errors.New("unsupported route kind")
-	errUnmatchedListenerName            = errors.New("unmatched listener name")
-	errNoReadyConditionFoundForListener = errors.New("no Ready condition found for listener")
-	errListenerNotReadyYet              = errors.New("listener not ready yet")
+	errUnsupportedRouteKind  = errors.New("unsupported route kind")
+	errUnmatchedListenerName = errors.New("unmatched listener name")
+	errListenerNotProgrammed = errors.New("no Programmed condition found for listener")
+	errListenerNotReadyYet   = errors.New("listener not ready yet")
 )
 
 // existsMatchingReadyListenerInStatus checks if:
@@ -515,12 +515,12 @@ func existsMatchingReadyListenerInStatus[T types.RouteT](route T, listener Liste
 		return errUnsupportedRouteKind // Listener(s) found but none with matching supported kinds.
 	}
 
-	// ... and verify if it's ready.
+	// ... and verify if it's programmed.
 	lReadyCond, ok := lo.Find(listenerStatus.Conditions, func(c metav1.Condition) bool {
-		return c.Type == string(gatewayv1beta1.ListenerConditionReady)
+		return c.Type == string(gatewayv1beta1.ListenerConditionProgrammed)
 	})
 	if !ok {
-		return errNoReadyConditionFoundForListener
+		return errListenerNotProgrammed
 	}
 	if lReadyCond.Status != "True" {
 		return errListenerNotReadyYet // Listener is not ready yet.

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -306,7 +306,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 							Name: "http",
 							Conditions: []metav1.Condition{
 								{
-									Type:   "Ready",
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -606,7 +606,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 							Name: "tcp",
 							Conditions: []metav1.Condition{
 								{
-									Type:   "Ready",
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -813,7 +813,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 							Name: "udp",
 							Conditions: []metav1.Condition{
 								{
-									Type:   "Ready",
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -1005,7 +1005,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 							Name: "tls",
 							Conditions: []metav1.Condition{
 								{
-									Type:   "Ready",
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -1227,7 +1227,7 @@ func TestEnsureParentsProgrammedCondition(t *testing.T) {
 						Name: "http-1",
 						Conditions: []metav1.Condition{
 							{
-								Type:   "Ready",
+								Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 								Status: metav1.ConditionTrue,
 							},
 						},
@@ -1237,7 +1237,7 @@ func TestEnsureParentsProgrammedCondition(t *testing.T) {
 						Name: "http-2",
 						Conditions: []metav1.Condition{
 							{
-								Type:   "Ready",
+								Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 								Status: metav1.ConditionTrue,
 							},
 						},
@@ -1888,7 +1888,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -1946,7 +1946,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -2000,7 +2000,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionFalse,
 								},
 							},
@@ -2054,7 +2054,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -2110,7 +2110,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -2164,7 +2164,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},
@@ -2222,7 +2222,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 							},
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(gatewayv1beta1.ListenerConditionReady),
+									Type:   string(gatewayv1beta1.ListenerConditionProgrammed),
 									Status: metav1.ConditionTrue,
 								},
 							},

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -306,7 +306,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tcproute, "checking if the tcproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayReady(gateway.gateway) {
+		if !isGatewayProgrammed(gateway.gateway) {
 			debug(log, tcproute, "gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -306,7 +306,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tlsroute, "checking if the tlsroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayReady(gateway.gateway) {
+		if !isGatewayProgrammed(gateway.gateway) {
 			debug(log, tlsroute, "gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -306,7 +306,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, udproute, "checking if the udproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayReady(gateway.gateway) {
+		if !isGatewayProgrammed(gateway.gateway) {
 			debug(log, udproute, "gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -507,11 +507,11 @@ func (p *Parser) getGatewayCerts() []certWrapper {
 				continue
 			}
 
-			// Check if listener is marked as ready
+			// Check if listener is marked as programmed
 			if !util.CheckCondition(
 				status.Conditions,
-				util.ConditionType(gatewayv1beta1.ListenerConditionReady),
-				util.ConditionReason(gatewayv1beta1.ListenerReasonReady),
+				util.ConditionType(gatewayv1beta1.ListenerConditionProgrammed),
+				util.ConditionReason(gatewayv1beta1.ListenerReasonProgrammed),
 				metav1.ConditionTrue,
 				gateway.Generation,
 			) {

--- a/internal/dataplane/parser/translators/httproute.go
+++ b/internal/dataplane/parser/translators/httproute.go
@@ -294,10 +294,10 @@ func (m httpRouteMatchMeta) getKey() string {
 	seenQueryParams := make(map[string]struct{})
 	queryParams := make([]gatewayv1beta1.HTTPQueryParamMatch, 0, len(m.Match.QueryParams))
 	for _, queryParam := range m.Match.QueryParams {
-		if _, ok := seenQueryParams[queryParam.Name]; ok {
+		if _, ok := seenQueryParams[string(queryParam.Name)]; ok {
 			continue
 		}
-		seenQueryParams[queryParam.Name] = struct{}{}
+		seenQueryParams[string(queryParam.Name)] = struct{}{}
 		queryParams = append(queryParams, queryParam)
 	}
 

--- a/internal/util/builder/httproutematch.go
+++ b/internal/util/builder/httproutematch.go
@@ -45,7 +45,7 @@ func (b *HTTPRouteMatchBuilder) WithPathType(pathValuePtr *string, pathTypePtr *
 
 func (b *HTTPRouteMatchBuilder) WithQueryParam(name, value string) *HTTPRouteMatchBuilder {
 	b.httpRouteMatch.QueryParams = append(b.httpRouteMatch.QueryParams, gatewayv1beta1.HTTPQueryParamMatch{
-		Name:  name,
+		Name:  gatewayv1beta1.HTTPHeaderName(name),
 		Value: value,
 	})
 	return b

--- a/internal/util/conditions.go
+++ b/internal/util/conditions.go
@@ -2,10 +2,10 @@ package util
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// ConditionType can be any condition type, e.g. `gatewayv1beta1.GatewayConditionReady`.
+// ConditionType can be any condition type, e.g. `gatewayv1beta1.GatewayConditionProgrammed`.
 type ConditionType string
 
-// ConditionReason can be any condition reason, e.g. `gatewayv1beta1.GatewayReasonReady`.
+// ConditionReason can be any condition reason, e.g. `gatewayv1beta1.GatewayReasonProgrammed`.
 type ConditionReason string
 
 // CheckCondition tells if there's a condition matching the given type, reason, and status in conditions.

--- a/internal/util/conditions_test.go
+++ b/internal/util/conditions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCheckCondition(t *testing.T) {
-	expectedType := util.ConditionType(gatewayv1beta1.ListenerConditionReady)
+	expectedType := util.ConditionType(gatewayv1beta1.ListenerConditionProgrammed)
 	expectedReason := util.ConditionReason(gatewayv1beta1.GatewayReasonAccepted)
 	expectedStatus := metav1.ConditionTrue
 	generation := int64(1)
@@ -102,7 +102,7 @@ func TestCheckCondition(t *testing.T) {
 }
 
 func TestCheckCondition_observed_generations_lower_than_actual_are_ignored(t *testing.T) {
-	expectedType := util.ConditionType(gatewayv1beta1.ListenerConditionReady)
+	expectedType := util.ConditionType(gatewayv1beta1.ListenerConditionProgrammed)
 	expectedReason := util.ConditionReason(gatewayv1beta1.GatewayReasonAccepted)
 	expectedStatus := metav1.ConditionTrue
 	givenConditions := []metav1.Condition{

--- a/internal/util/conditions_test.go
+++ b/internal/util/conditions_test.go
@@ -25,7 +25,7 @@ func TestCheckCondition(t *testing.T) {
 	}
 
 	otherType := util.ConditionType(gatewayv1beta1.ListenerConditionConflicted)
-	otherReason := util.ConditionReason(gatewayv1beta1.GatewayReasonReady)
+	otherReason := util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed)
 	otherStatus := metav1.ConditionFalse
 
 	testCases := []struct {

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -3,8 +3,8 @@
 package consts
 
 const (
-	GatewayAPIVersion                   = "v0.6.1"
-	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v0.6.1"
-	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1"
-	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.6.1"
+	GatewayAPIVersion                   = "v0.7.1"
+	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v0.7.1"
+	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1"
+	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.7.1"
 )

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -78,14 +78,14 @@ func verifyGateway(ctx context.Context, t *testing.T, env environments.Environme
 	gc, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
-	t.Log("verifying that the gateway receives a final ready condition once reconciliation completes")
+	t.Log("verifying that the gateway receives a final programmed condition once reconciliation completes")
 	require.Eventually(t, func() bool {
 		gw, err = gc.GatewayV1beta1().Gateways(corev1.NamespaceDefault).Get(ctx, gw.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		if ready := util.CheckCondition(
 			gw.Status.Conditions,
-			util.ConditionType(gatewayv1beta1.GatewayConditionReady),
-			util.ConditionReason(gatewayv1beta1.GatewayReasonReady),
+			util.ConditionType(gatewayv1beta1.GatewayConditionProgrammed),
+			util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed),
 			metav1.ConditionTrue,
 			gw.Generation,
 		); ready {

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -130,9 +130,9 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		},
 		Conditions: []metav1.Condition{
 			{
-				Type:               "Ready",
+				Type:               "Programmed",
 				Status:             metav1.ConditionTrue,
-				Reason:             "Ready",
+				Reason:             "Programmed",
 				LastTransitionTime: metav1.Now(),
 				ObservedGeneration: gw.Generation,
 			},
@@ -140,13 +140,6 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 				Type:               "Accepted",
 				Status:             metav1.ConditionTrue,
 				Reason:             "Accepted",
-				LastTransitionTime: metav1.Now(),
-				ObservedGeneration: gw.Generation,
-			},
-			{
-				Type:               "Programmed",
-				Status:             metav1.ConditionTrue,
-				Reason:             "Programmed",
 				LastTransitionTime: metav1.Now(),
 				ObservedGeneration: gw.Generation,
 			},
@@ -162,9 +155,9 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 						LastTransitionTime: metav1.Now(),
 					},
 					{
-						Type:               "Ready",
+						Type:               "Programmed",
 						Status:             metav1.ConditionTrue,
-						Reason:             "Ready",
+						Reason:             "Programmed",
 						LastTransitionTime: metav1.Now(),
 					},
 				},

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -120,8 +120,8 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 		for _, lstatus := range gw.Status.Listeners {
 			if listenerReady := util.CheckCondition(
 				lstatus.Conditions,
-				util.ConditionType(gatewayv1beta1.ListenerConditionReady),
-				util.ConditionReason(gatewayv1beta1.ListenerReasonReady),
+				util.ConditionType(gatewayv1beta1.ListenerConditionProgrammed),
+				util.ConditionReason(gatewayv1beta1.ListenerReasonProgrammed),
 				metav1.ConditionTrue,
 				gw.Generation,
 			); !listenerReady {
@@ -200,7 +200,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 					if condition.Type == string(gatewayv1beta1.ListenerConditionConflicted) && condition.Status == metav1.ConditionTrue {
 						badudpConflicted = (condition.Reason == string(gatewayv1beta1.ListenerReasonProtocolConflict))
 					}
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						badudpReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
@@ -213,7 +213,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 						// precedence
 						badhttpConflicted = (condition.Reason == string(gatewayv1beta1.ListenerReasonProtocolConflict))
 					}
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						badhttpReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
@@ -223,7 +223,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 					if condition.Type == string(gatewayv1beta1.ListenerConditionConflicted) {
 						httpConflicted = (condition.Status == metav1.ConditionTrue)
 					}
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httpReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
@@ -261,7 +261,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 					if condition.Type == string(gatewayv1beta1.ListenerConditionConflicted) && condition.Status == metav1.ConditionTrue {
 						httpAlphaConflicted = (condition.Reason == string(gatewayv1beta1.ListenerReasonHostnameConflict))
 					}
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httpAlphaReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
@@ -271,7 +271,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 					if condition.Type == string(gatewayv1beta1.ListenerConditionConflicted) && condition.Status == metav1.ConditionTrue {
 						httpBravoConflicted = (condition.Reason == string(gatewayv1beta1.ListenerReasonHostnameConflict))
 					}
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httpBravoReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
@@ -328,28 +328,28 @@ func TestGatewayListenerConflicts(t *testing.T) {
 		for _, lstatus := range gw.Status.Listeners {
 			if lstatus.Name == "http" {
 				for _, condition := range lstatus.Conditions {
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httpReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
 			}
 			if lstatus.Name == "tls" {
 				for _, condition := range lstatus.Conditions {
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						tlsReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
 			}
 			if lstatus.Name == "https" {
 				for _, condition := range lstatus.Conditions {
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httpsReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}
 			}
 			if lstatus.Name == "httphost" {
 				for _, condition := range lstatus.Conditions {
-					if condition.Type == string(gatewayv1beta1.ListenerConditionReady) {
+					if condition.Type == string(gatewayv1beta1.ListenerConditionProgrammed) {
 						httphostReady = (condition.Status == metav1.ConditionTrue)
 					}
 				}

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -99,21 +99,21 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 		return len(gw.Status.Listeners) == len(gw.Spec.Listeners) && len(gw.Status.Addresses) == len(gw.Spec.Addresses)
 	}, gatewayUpdateWaitTime, time.Second)
 
-	t.Log("verifying that the gateway receives a final ready condition once reconciliation completes")
+	t.Log("verifying that the gateway receives a final programmed condition once reconciliation completes")
 	require.Eventually(t, func() bool {
 		gw, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		ready := util.CheckCondition(
 			gw.Status.Conditions,
-			util.ConditionType(gatewayv1beta1.GatewayConditionReady),
-			util.ConditionReason(gatewayv1beta1.GatewayReasonReady),
+			util.ConditionType(gatewayv1beta1.GatewayConditionProgrammed),
+			util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed),
 			metav1.ConditionTrue,
 			gw.Generation,
 		)
 		return ready
 	}, gatewayUpdateWaitTime, time.Second)
 
-	t.Log("verifying that the gateway listeners reach the ready condition")
+	t.Log("verifying that the gateway listeners reach the programmed condition")
 	require.Eventually(t, func() bool {
 		gw, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gw.Name, metav1.GetOptions{})
 		require.NoError(t, err)
@@ -151,15 +151,15 @@ func TestGatewayListenerConflicts(t *testing.T) {
 	err = gatewayHealthCheck(ctx, gatewayClient, gateway.Name, ns.Name)
 	require.NoError(t, err)
 
-	t.Log("verifying that the gateway listeners reach the ready condition")
+	t.Log("verifying that the gateway listeners reach the programmed condition")
 	require.Eventually(t, func() bool {
 		gw, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, defaultGatewayName, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, lstatus := range gw.Status.Listeners {
 			ready := util.CheckCondition(
 				lstatus.Conditions,
-				util.ConditionType(gatewayv1beta1.GatewayConditionReady),
-				util.ConditionReason(gatewayv1beta1.GatewayReasonReady),
+				util.ConditionType(gatewayv1beta1.GatewayConditionProgrammed),
+				util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed),
 				metav1.ConditionTrue,
 				gw.Generation,
 			)
@@ -427,7 +427,7 @@ func TestUnmanagedGatewayClass(t *testing.T) {
 		gateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, cond := range gateway.Status.Conditions {
-			if cond.Reason == string(gatewayv1beta1.GatewayReasonReady) {
+			if cond.Reason == string(gatewayv1beta1.GatewayReasonProgrammed) {
 				return true
 			}
 		}
@@ -478,8 +478,8 @@ func TestManagedGatewayClass(t *testing.T) {
 		gateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, cond := range gateway.Status.Conditions {
-			if cond.Type == string(gatewayv1beta1.GatewayConditionReady) {
-				require.Equal(t, cond.Status, metav1.ConditionFalse)
+			if cond.Type == string(gatewayv1beta1.GatewayConditionProgrammed) {
+				require.Equal(t, cond.Status, metav1.ConditionUnknown)
 			}
 		}
 	})

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -385,10 +385,8 @@ func TestUnmanagedGatewayControllerSupport(t *testing.T) {
 	for timeout.After(time.Now()) {
 		unsupportedGateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, unsupportedGateway.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Len(t, unsupportedGateway.Status.Conditions, 1)
-		//lint:ignore SA1019 the default upstream reason is still NotReconciled https://github.com/kubernetes-sigs/gateway-api/pull/1701
-		//nolint:staticcheck
-		require.Equal(t, string(gatewayv1beta1.GatewayReasonNotReconciled), unsupportedGateway.Status.Conditions[0].Reason)
+		require.Len(t, unsupportedGateway.Status.Conditions, 2)
+		require.Equal(t, string(gatewayv1beta1.GatewayReasonPending), unsupportedGateway.Status.Conditions[0].Reason)
 	}
 }
 
@@ -415,10 +413,8 @@ func TestUnmanagedGatewayClass(t *testing.T) {
 	for timeout.After(time.Now()) {
 		gateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Len(t, gateway.Status.Conditions, 1)
-		//lint:ignore SA1019 the default upstream reason is still NotReconciled https://github.com/kubernetes-sigs/gateway-api/pull/1701
-		//nolint:staticcheck
-		require.Equal(t, string(gatewayv1beta1.GatewayReasonNotReconciled), gateway.Status.Conditions[0].Reason)
+		require.Len(t, gateway.Status.Conditions, 2)
+		require.Equal(t, string(gatewayv1beta1.GatewayReasonPending), gateway.Status.Conditions[0].Reason)
 	}
 
 	t.Log("deploying the missing gatewayclass to the test cluster")
@@ -462,10 +458,8 @@ func TestManagedGatewayClass(t *testing.T) {
 	for timeout.After(time.Now()) {
 		gateway, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, gateway.Name, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Len(t, gateway.Status.Conditions, 1)
-		//lint:ignore SA1019 the default upstream reason is still NotReconciled https://github.com/kubernetes-sigs/gateway-api/pull/1701
-		//nolint:staticcheck
-		require.Equal(t, string(gatewayv1beta1.GatewayReasonNotReconciled), gateway.Status.Conditions[0].Reason)
+		require.Len(t, gateway.Status.Conditions, 2)
+		require.Equal(t, string(gatewayv1beta1.GatewayReasonPending), gateway.Status.Conditions[0].Reason)
 	}
 
 	t.Log("deploying a missing managed gatewayclass to the test cluster")

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -134,8 +134,8 @@ func gatewayHealthCheck(ctx context.Context, client *gatewayclient.Clientset, ga
 				exitOnErr(ctx, err)
 				ok := util.CheckCondition(
 					gw.Status.Conditions,
-					util.ConditionType(gatewayv1beta1.GatewayConditionReady),
-					util.ConditionReason(gatewayv1beta1.GatewayReasonReady),
+					util.ConditionType(gatewayv1beta1.GatewayConditionProgrammed),
+					util.ConditionReason(gatewayv1beta1.GatewayReasonProgrammed),
 					metav1.ConditionTrue,
 					gw.Generation,
 				)


### PR DESCRIPTION
**What this PR does / why we need it**:

GWAPI upgrades and a conformance fix.

**Which issue this PR fixes**:

Fix #3726
Fix #2953
Fix #3990 

**Special notes for your reviewer**:

https://github.com/kubernetes-sigs/gateway-api/pull/1888 and https://github.com/kubernetes-sigs/gateway-api/issues/1832#issuecomment-1483974578 change expectations around statuses. This PR includes changes that adhere to the 0.7.1 conformance test informed by these changes, but it's possible we missed something not covered in conformance. GWAPI doesn't really provide an expected state flowchart for statuses (we have to go off individual condition descriptions in the API docs), which makes it a bit difficult to determine if our state changes are truly correct absent conformance tests.

Changes to conformance suite covered in:

https://github.com/Kong/kubernetes-ingress-controller/issues/4166
https://github.com/Kong/kubernetes-ingress-controller/issues/4165
https://github.com/Kong/kubernetes-ingress-controller/issues/4164

Also skips mesh stuff but no issue for that as I assume we have no intention to implement that for Kong-based products.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
