### PR TITLE
refactor: make telemetry related variables const again

### DIFF
--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -120,6 +120,11 @@ type Config struct {
 	Konnect adminapi.KonnectConfig
 
 	flagSet *pflag.FlagSet
+
+	// Override default telemetry settings (e.g. for testing). They aren't exposed in the CLI.
+	SplunkEndpoint                   string
+	SplunkEndpointInsecureSkipVerify bool
+	TelemetryPeriod                  time.Duration
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -267,12 +267,17 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 			ctx,
 			kubeconfig,
 			clientsManager,
-			telemetry.ReportValues{
-				PublishServiceNN:               c.PublishService.OrEmpty(),
-				FeatureGates:                   featureGates,
-				MeshDetection:                  len(c.WatchNamespaces) == 0,
-				KonnectSyncEnabled:             c.Konnect.ConfigSynchronizationEnabled,
-				GatewayServiceDiscoveryEnabled: c.KongAdminSvc.IsPresent(),
+			telemetry.ReportConfig{
+				SplunkEndpoint:                   c.SplunkEndpoint,
+				SplunkEndpointInsecureSkipVerify: c.SplunkEndpointInsecureSkipVerify,
+				TelemetryPeriod:                  c.TelemetryPeriod,
+				ReportValues: telemetry.ReportValues{
+					PublishServiceNN:               c.PublishService.OrEmpty(),
+					FeatureGates:                   featureGates,
+					MeshDetection:                  len(c.WatchNamespaces) == 0,
+					KonnectSyncEnabled:             c.Konnect.ConfigSynchronizationEnabled,
+					GatewayServiceDiscoveryEnabled: c.KongAdminSvc.IsPresent(),
+				},
 			},
 			instanceIDProvider,
 		)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

No more overriding package global variables for testing telemetry

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

closes https://github.com/Kong/kubernetes-ingress-controller/issues/4119
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

