### PR TITLE
chore(ci): fix notifications for failures of e2e nightly tests

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -44,9 +44,9 @@ jobs:
       - e2e-tests
       - e2e-tests-unreleased-kong
       - test-reports
+    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
     steps:
       - name: Notify on Slack for failures of e2e tests run automatically at night
-        if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
         uses: 8398a7/action-slack@v3
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It should fix notifications introduced in #4023 and adjusted in #4053. Mistake was simple - condition on the level of a step instead of a job (so it skipped always the whole job). Now it should work as expected


