### PR TITLE
Update golden and test hint

### DIFF
--- a/internal/dataplane/parser/golden_test.go
+++ b/internal/dataplane/parser/golden_test.go
@@ -280,8 +280,7 @@ func runParserGoldenTest(t *testing.T, tc parserGoldenTestCase) {
 
 		require.Equalf(t, string(goldenB), string(resultB),
 			"Golden file %s does not match the result. \n"+
-				"If you are sure the result is correct, run the test "+
-				"with the -update-golden flag to update the golden file: \n"+
+				"If you are sure the result is correct, update the golden file: \n"+
 				"$ %s", tc.goldenFile, commandToRegenerateGoldenFile)
 		t.Logf("Successfully compared result to golden file %s", tc.goldenFile)
 	}

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.8000.svc
-  name: foo-namespace.foo.foo-svc.8000
+  name: foo-namespace.foo-svc.8000
   path: /
   port: 80
   protocol: http
@@ -38,7 +38,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.http.svc
-  name: foo-namespace.regex-prefix.foo-svc.http
+  name: foo-namespace.foo-svc.http
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/regex-path-prefix-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/regex-path-prefix-off_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.regex-prefix.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -69,7 +69,7 @@ certificates:
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc
-  name: bar-namespace.ing-with-tls.foo-svc.80
+  name: bar-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http
@@ -30,21 +30,6 @@ services:
     - k8s-kind:Ingress
     - k8s-group:networking.k8s.io
     - k8s-version:v1
-  tags:
-  - k8s-name:foo-svc
-  - k8s-namespace:foo-namespace
-  - k8s-kind:Service
-  - k8s-version:v1
-  write_timeout: 60000
-- connect_timeout: 60000
-  host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo-2.foo-svc.80
-  path: /
-  port: 80
-  protocol: http
-  read_timeout: 60000
-  retries: 5
-  routes:
   - hosts:
     - example.com
     https_redirect_status_code: 426

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: cert-manager-solver-pod.foo-namespace.80.svc
-  name: foo-namespace.foo.cert-manager-solver-pod.80
+  name: foo-namespace.cert-manager-solver-pod.80
   path: /
   port: 80
   protocol: http

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
-  name: foo-namespace.foo.foo-svc.80
+  name: foo-namespace.foo-svc.80
   path: /
   port: 80
   protocol: http


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates golden following https://github.com/Kong/kubernetes-ingress-controller/pull/4138

Removes the mysterious `-update-golden` flag that exists only in the comment mentioning it (and very much does not work when passed to `go test` or what have you.

**Which issue this PR fixes**:

Broken tests in main.