### PR TITLE
chore(logs): `no active endpoints` is logged at debug instead of warning level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ Adding a new version? You'll need three changes:
 - The `CombinedServices` feature gate is now enabled by default.
   [#4138](https://github.com/Kong/kubernetes-ingress-controller/pull/4138)
 
+### Changed
+
+- Log message `no active endpoints` is now logged at debug instead of
+  warning level.
+  [#4161](https://github.com/Kong/kubernetes-ingress-controller/pull/4161)
+
 ## [2.10.0]
 
 > Release date: 2023-06-02

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -708,7 +708,7 @@ func getServiceEndpoints(
 		endpoints = append(endpoints, newEndpoints...)
 	}
 	if len(endpoints) == 0 {
-		log.Warningf("no active endpoints")
+		log.Debugf("no active endpoints")
 	}
 
 	return targetsForEndpoints(endpoints)


### PR DESCRIPTION
**What this PR does / why we need it**:

The message `no active endpoints` is logged often at least once during normal operation due to eventual consistency of the whole K8s ecosystem.
```log
2023-06-12T12:51:30.065792925Z stderr F time="2023-06-12T12:51:30Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.7:8444"
2023-06-12T12:51:30.070302425Z stderr F time="2023-06-12T12:51:30Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.6:8444"
2023-06-12T12:51:30.877209092Z stderr F time="2023-06-12T12:51:30Z" level=info msg="successfully synced configuration to Konnect" update_strategy="WithBackoff(DBMode)" url="https://us.kic.api.konghq.tech/kic/api/runtime_groups/ea93254c-5c46-4b2d-b43f-cebf606fc51f"
2023-06-12T12:51:38.937834596Z stderr F time="2023-06-12T12:51:38Z" level=warning msg="no active endpoints" service_name=echo service_namespace=default service_port="&ServicePort{Name:,Protocol:TCP,Port:1027,TargetPort:{0 1027 },NodePort:0,AppProtocol:nil,}"
2023-06-12T12:51:38.937851304Z stderr F time="2023-06-12T12:51:38Z" level=info msg="no targets could be found for kubernetes service default/echo" service_name=default.echo.echo.1027
2023-06-12T12:51:38.937866596Z stderr F time="2023-06-12T12:51:38Z" level=info msg="no targets found to create upstream" service_name=default.echo.echo.1027
2023-06-12T12:51:39.084362096Z stderr F time="2023-06-12T12:51:39Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.7:8444"
2023-06-12T12:51:39.090115638Z stderr F time="2023-06-12T12:51:39Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.6:8444"
2023-06-12T12:51:40.342402221Z stderr F time="2023-06-12T12:51:40Z" level=info msg="successfully synced configuration to Konnect" update_strategy="WithBackoff(DBMode)" url="https://us.kic.api.konghq.tech/kic/api/runtime_groups/ea93254c-5c46-4b2d-b43f-cebf606fc51f"
2023-06-12T12:51:42.061711514Z stderr F time="2023-06-12T12:51:42Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.6:8444"
2023-06-12T12:51:42.062431264Z stderr F time="2023-06-12T12:51:42Z" level=info msg="successfully synced configuration to Kong" update_strategy=InMemory url="https://10.244.0.7:8444"
```

Showing it in logs at a warning level may be misleading for end users. Since it's normal behavior. This PR changes the logging level to debug for this message.

