### PR TITLE
tests: separate envtest directory and makefile target

### DIFF
--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -1,0 +1,36 @@
+name: envtest tests
+
+on:
+  workflow_call: {}
+
+jobs:
+  envtest-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
+
+      - name: run envtest tests
+        run: make test.envtest
+        env:
+          GOTESTSUM_JUNITFILE: envtest-tests.xml
+
+      - name: collect test coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.envtest.out
+
+      - name: collect test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-report
+          path: envtest-tests.xml

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -29,7 +29,7 @@ jobs:
           path: coverage.envtest.out
 
       - name: collect test report
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: tests-report

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -97,6 +97,7 @@ jobs:
     needs:
       - should-run-with-secrets
       - unit-tests
+      - envtest-tests
       - integration-tests
       - conformance-tests
     if: ${{ always() && needs.should-run-with-secrets.outputs.result == 'true' }}

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -55,6 +55,10 @@ jobs:
     uses: ./.github/workflows/_unit_tests.yaml
     secrets: inherit
 
+  envtest-tests:
+    uses: ./.github/workflows/_envtest_tests.yaml
+    secrets: inherit
+
   integration-tests:
     needs: should-run-with-secrets
     if: ${{ needs.should-run-with-secrets.outputs.result == 'true' }}
@@ -78,6 +82,7 @@ jobs:
       - tools
       - linters
       - unit-tests
+      - envtest-tests
       - integration-tests
       - conformance-tests
       - build-docker-image

--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,20 @@ test.unit.pretty:
 test.golden.update:
 	@go test -v -run TestParser_GoldenTests ./internal/dataplane/parser -update
 
+.PHONY: test.envtest
+.ONESHELL: test.envtest
+test.envtest: gotestsum setup-envtest
+	$(SETUP_ENVTEST) use
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
+		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
+		$(GOTESTSUM) -- \
+		-race $(GOTESTFLAGS) \
+		-tags envtest \
+		-covermode=atomic \
+		-coverpkg=$(PKG_LIST) \
+		-coverprofile=coverage.envtest.out \
+		./test/envtest/...
+
 .PHONY: _check.container.environment
 _check.container.environment:
 	@./scripts/check-container-environment.sh

--- a/TESTING.md
+++ b/TESTING.md
@@ -96,7 +96,7 @@ export KUBEBUILDER_ASSETS='/Users/username/Library/Application Support/io.kubebu
 and use that to manually run the tests:
 
 ```
-$ eval `./bin/setup-envtest use -p env`
+$ eval $(./bin/setup-envtest use -p env)
 $ go test -v -count 1 -tags envtest ./pkg/to/test
 ...
 ```

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -237,6 +237,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -515,6 +515,12 @@ spec:
                       concurrency:
                         minimum: 1
                         type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
                       healthy:
                         description: Healthy configures thresholds and HTTP status
                           codes to mark targets healthy for an upstream.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/kong/deck v1.21.0
+	github.com/kong/deck v1.22.0
 	github.com/kong/go-kong v0.43.0
 	github.com/kong/kubernetes-telemetry v0.0.5
 	github.com/kong/kubernetes-testing-framework v0.31.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/deck v1.21.0
-	github.com/kong/go-kong v0.42.0
+	github.com/kong/go-kong v0.43.0
 	github.com/kong/kubernetes-telemetry v0.0.5
 	github.com/kong/kubernetes-testing-framework v0.31.0
 	github.com/lithammer/dedent v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kong/deck v1.21.0 h1:L/vs4WvA5n5d3nqMiBxgxzb0xxqaCD8G2uCzzO+VwxI=
 github.com/kong/deck v1.21.0/go.mod h1:4ifsbs8AcrvTSdQG4snxaaKiSGEv6l4eyeHOMoOlv+Y=
-github.com/kong/go-kong v0.42.0 h1:N0Rth32eGq6S5x33Txu+Gv9ZJ3gG5noffDjqezwutfA=
-github.com/kong/go-kong v0.42.0/go.mod h1:YUq7A3gcwk+9Z1ajwzVY2HnSyL/IKq/TJHsJDqT8hJM=
+github.com/kong/go-kong v0.43.0 h1:+PUA6iMOH4JSOoy9AGBiQnBzWjyBYZwrT/RbKmAD+R4=
+github.com/kong/go-kong v0.43.0/go.mod h1:jOLA875EFgEZ1phzwRgmm/p34pWh0gg4p8FTC0QuF6w=
 github.com/kong/kubernetes-telemetry v0.0.5 h1:FCJx1ShFXbqNb2K6N9FE3MZKwCkp8CEVAJuej5+1S9U=
 github.com/kong/kubernetes-telemetry v0.0.5/go.mod h1:FrAXjZHEPSAEL4aUXnNOpPoRiA68VJvwgN8dfG/qF60=
 github.com/kong/kubernetes-testing-framework v0.31.0 h1:3MTlUeiD/jV3ArdZWfRLidi7kchg19HI222dXQHwasw=

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/kong/deck v1.21.0 h1:L/vs4WvA5n5d3nqMiBxgxzb0xxqaCD8G2uCzzO+VwxI=
-github.com/kong/deck v1.21.0/go.mod h1:4ifsbs8AcrvTSdQG4snxaaKiSGEv6l4eyeHOMoOlv+Y=
+github.com/kong/deck v1.22.0 h1:oTNS5DCAb3uw1D8rKyqyxKvpwmUo8uTW8G13FJuirTY=
+github.com/kong/deck v1.22.0/go.mod h1:yRIuXWxu4ZsKqpBq1XFrzgc6cjPkwjLG3Np5kPsyyB0=
 github.com/kong/go-kong v0.43.0 h1:+PUA6iMOH4JSOoy9AGBiQnBzWjyBYZwrT/RbKmAD+R4=
 github.com/kong/go-kong v0.43.0/go.mod h1:jOLA875EFgEZ1phzwRgmm/p34pWh0gg4p8FTC0QuF6w=
 github.com/kong/kubernetes-telemetry v0.0.5 h1:FCJx1ShFXbqNb2K6N9FE3MZKwCkp8CEVAJuej5+1S9U=

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -9,11 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
+
+func init() {
+	if err := gatewayv1beta1.Install(scheme.Scheme); err != nil {
+		panic(err)
+	}
+}
 
 func TestGetListenerSupportedRouteKinds(t *testing.T) {
 	testCases := []struct {

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -1,7 +1,7 @@
 //go:build envtest
 // +build envtest
 
-package gateway_test
+package envtest
 
 import (
 	"context"
@@ -24,8 +24,8 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/mocks"
 )
 
 func init() {
@@ -42,7 +42,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		tickDuration = 100 * time.Millisecond
 	)
 
-	cfg := envtest.Setup(t, scheme.Scheme)
+	cfg := Setup(t, scheme.Scheme)
 	var client ctrlclient.Client
 	{
 		var err error
@@ -54,15 +54,15 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 
 	reconciler := &gateway.HTTPRouteReconciler{
 		Client:          client,
-		DataplaneClient: gateway.DataplaneMock{},
+		DataplaneClient: mocks.Dataplane{},
 	}
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ns := envtest.CreateNamespace(ctx, t, client)
-	nsRoute := envtest.CreateNamespace(ctx, t, client)
+	ns := CreateNamespace(ctx, t, client)
+	nsRoute := CreateNamespace(ctx, t, client)
 
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -81,7 +81,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		},
 	}
 	require.NoError(t, client.Create(ctx, &svc))
-	envtest.StartReconciler(ctx, t, client.Scheme(), cfg, reconciler)
+	StartReconciler(ctx, t, client.Scheme(), cfg, reconciler)
 
 	gwc := gatewayv1beta1.GatewayClass{
 		Spec: gatewayv1beta1.GatewayClassSpec{

--- a/test/envtest/manager_debugendpoints_test.go
+++ b/test/envtest/manager_debugendpoints_test.go
@@ -1,7 +1,7 @@
 //go:build envtest
 // +build envtest
 
-package rootcmd_test
+package envtest
 
 import (
 	"context"
@@ -17,7 +17,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 )
 
 func TestDebugEndpoints(t *testing.T) {
@@ -28,8 +27,8 @@ func TestDebugEndpoints(t *testing.T) {
 		tickTime = 10 * time.Millisecond
 	)
 
-	envcfg := envtest.Setup(t, scheme.Scheme)
-	cfg := envtest.ConfigForEnvConfig(t, envcfg)
+	envcfg := Setup(t, scheme.Scheme)
+	cfg := ConfigForEnvConfig(t, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/internal/mocks/dataplane.go
+++ b/test/internal/mocks/dataplane.go
@@ -1,4 +1,4 @@
-package gateway
+package mocks
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -6,7 +6,7 @@ import (
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 )
 
-type DataplaneMock struct {
+type Dataplane struct {
 	KubernetesObjectReportsEnabled bool
 	// Mapping namespace to name to status
 	// Note: this will come in useful when implementing
@@ -15,18 +15,18 @@ type DataplaneMock struct {
 	ObjectsStatuses map[string]map[string]k8sobj.ConfigurationStatus
 }
 
-func (d DataplaneMock) UpdateObject(_ client.Object) error {
+func (d Dataplane) UpdateObject(_ client.Object) error {
 	return nil
 }
 
-func (d DataplaneMock) DeleteObject(_ client.Object) error {
+func (d Dataplane) DeleteObject(_ client.Object) error {
 	return nil
 }
 
-func (d DataplaneMock) AreKubernetesObjectReportsEnabled() bool {
+func (d Dataplane) AreKubernetesObjectReportsEnabled() bool {
 	return d.KubernetesObjectReportsEnabled
 }
 
-func (d DataplaneMock) KubernetesObjectConfigurationStatus(obj client.Object) k8sobj.ConfigurationStatus {
+func (d Dataplane) KubernetesObjectConfigurationStatus(obj client.Object) k8sobj.ConfigurationStatus {
 	return d.ObjectsStatuses[obj.GetNamespace()][obj.GetName()]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR continues the effort to document testing practices and expand with explicitly documenting as per #4099.

This also adds:

- separate `test.envtest` `Makefile` target
- related CI job which runs it

**Which issue this PR fixes**:

Related: #4099

**Special notes for your reviewer**:

This PR moves some tests to `test/envtest/` but not all of them. This might be done if we agree to pursue this route.

