### PR TITLE
feat(parser) error for all inconsistent services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Adding a new version? You'll need three changes:
 - Log message `no active endpoints` is now logged at debug instead of
   warning level.
   [#4161](https://github.com/Kong/kubernetes-ingress-controller/pull/4161)
+- Events and logs for inconsistent multi-Service backend annotations now list
+  all involved Services, not just Services whose annotation does not match the
+  first observed value, as that value is not necessarily the desired value.
+  [#4171](https://github.com/Kong/kubernetes-ingress-controller/pull/4171)
 
 ## [2.10.0]
 

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -487,6 +487,8 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			expected: false,
 			expectedLogEntries: []string{
 				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 			},
 		},
 		{
@@ -528,6 +530,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			},
 			expected: false,
 			expectedLogEntries: []string{
+				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 				"Service has inconsistent konghq.com/foo annotation and is used in multi-Service backend",
 			},
@@ -649,7 +652,11 @@ func TestPopulateServices(t *testing.T) {
 			require.NoError(t, err)
 			servicesToBeSkipped := ingressRules.populateServices(logrus.New(), fakeStore, failuresCollector)
 			require.Equal(t, tc.serviceNamesToSkip, servicesToBeSkipped)
-			require.Len(t, failuresCollector.PopResourceFailures(), len(servicesToBeSkipped), "expecting as many translation failures as services to skip")
+			expectedErrorCount := 0
+			for s := range tc.serviceNamesToSkip {
+				expectedErrorCount += len(tc.serviceNamesToServices[s].Backends)
+			}
+			require.Len(t, failuresCollector.PopResourceFailures(), expectedErrorCount, "expecting as many translation failures as backends of services to skip")
 		})
 	}
 }

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -652,11 +652,6 @@ func TestPopulateServices(t *testing.T) {
 			require.NoError(t, err)
 			servicesToBeSkipped := ingressRules.populateServices(logrus.New(), fakeStore, failuresCollector)
 			require.Equal(t, tc.serviceNamesToSkip, servicesToBeSkipped)
-			expectedErrorCount := 0
-			for s := range tc.serviceNamesToSkip {
-				expectedErrorCount += len(tc.serviceNamesToServices[s].Backends)
-			}
-			require.Len(t, failuresCollector.PopResourceFailures(), expectedErrorCount, "expecting as many translation failures as backends of services to skip")
 		})
 	}
 }

--- a/internal/dataplane/parser/ingressrules_test.go
+++ b/internal/dataplane/parser/ingressrules_test.go
@@ -540,7 +540,7 @@ func TestDoK8sServicesMatchAnnotations(t *testing.T) {
 			logger, loggerHook := test.NewNullLogger()
 			failuresCollector, err := failures.NewResourceFailuresCollector(logger)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, servicesAllUseTheSameKongAnnotations(tt.services, tt.annotations, failuresCollector, ""))
+			assert.Equal(t, tt.expected, collectInconsistentAnnotations(tt.services, tt.annotations, failuresCollector, ""))
 			assert.Len(t, failuresCollector.PopResourceFailures(), len(tt.expectedLogEntries), "expecting as many translation failures as log entries")
 			for i := range tt.expectedLogEntries {
 				assert.Contains(t, loggerHook.AllEntries()[i].Message, tt.expectedLogEntries[i])

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -128,11 +128,10 @@ func TestTranslationFailures(t *testing.T) {
 				require.NoError(t, err)
 				cleaner.Add(httpRoute)
 
-				// TODO broken
 				return expectedTranslationFailure{
 					// expect event for service2 as it doesn't have annotations that service1 has
 					causingObjects: []client.Object{service2},
-					reasonContains: "All Services in a multi-Service backend must have matching Kong annotations.",
+					reasonContains: "This annotation must have the same value across all Services in the backend.",
 				}
 			},
 		},

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -128,11 +128,11 @@ func TestTranslationFailures(t *testing.T) {
 				require.NoError(t, err)
 				cleaner.Add(httpRoute)
 
+				// TODO broken
 				return expectedTranslationFailure{
 					// expect event for service2 as it doesn't have annotations that service1 has
 					causingObjects: []client.Object{service2},
-					reasonContains: "All Services in a multi-Service backend must have matching Kong annotations. " +
-						"Review the associated route resource and align annotations in its multi-Service backends.",
+					reasonContains: "All Services in a multi-Service backend must have matching Kong annotations.",
 				}
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Emit errors for every Service in a multi-Service backend when an annotation is inconsistent.

Previously, the parser would arbitrarily choose one annotation value as the correct value and only log errors for Services with a different value. There was no basis for choosing this as the correct value, it was just the first observed value, and there was no indication which Service was the source of the value. Logging for each informs users of the complete set of Services.

Shortens the log to remove the "review the Route" string, as we're now listing all Services of interest.

**Which issue this PR fixes**:

Fix #3032

**Special notes for your reviewer**:

The original request in #3032 was already addressed by a previous change. We were already including Service information in these logs after we converted it to a translation error. However, we would only log Services with the "incorrect" value when there was no basis for choosing the "correct" value--it was just the first one we saw in the loop.

Users need to review all involved Services to select a correct value based on external information, so we want to include all of them.

I initially adjusted the check in TestPopulateServices rather than removing it, but on further review it looks like we shouldn't be  checking error count there, only that the service is indeed skipped. Error count should instead be checked for tests of individual skip reasons (it is). Left as a separate commit for comparison to the initial fix.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
