### PR TITLE
Support plugin instance name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ Adding a new version? You'll need three changes:
 
 - The `CombinedServices` feature gate is now enabled by default.
   [#4138](https://github.com/Kong/kubernetes-ingress-controller/pull/4138)
+- Plugin CRDs now support the `instance_name` field introduced in Kong 3.1.
+  [#4174](https://github.com/Kong/kubernetes-ingress-controller/pull/4174)
 
 ### Changed
 

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -88,6 +88,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -84,6 +84,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -144,6 +144,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -716,6 +721,11 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
+          instance_name:
+            description: InstanceName is an optional custom name to identify an instance
+              of the plugin. This is useful when running the same plugin in multiple
+              contexts, for example, on multiple services.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -36,6 +36,7 @@ KongClusterPlugin is the Schema for the kongclusterplugins API.
 | `run_on` _string_ | RunOn configures the plugin to run on the first or the second or both nodes in case of a service mesh deployment. |
 | `protocols` _[KongProtocol](#kongprotocol) array_ | Protocols configures plugin to run on requests received on specific protocols. |
 | `ordering` _PluginOrdering_ | Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise. `<phase>` is a request processing phase (for example, `access` or `body_filter`) and `<plugin>` is the name of the plugin that will run before or after the KongPlugin. For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]` will create a rate limiting plugin that limits requests _before_ they are authenticated. |
+| `instance_name` _string_ | InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the same plugin in multiple contexts, for example, on multiple services. |
 
 
 
@@ -101,6 +102,7 @@ KongPlugin is the Schema for the kongplugins API.
 | `run_on` _string_ | RunOn configures the plugin to run on the first or the second or both nodes in case of a service mesh deployment. |
 | `protocols` _[KongProtocol](#kongprotocol) array_ | Protocols configures plugin to run on requests received on specific protocols. |
 | `ordering` _[PluginOrdering](#pluginordering)_ | Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise. `<phase>` is a request processing phase (for example, `access` or `body_filter`) and `<plugin>` is the name of the plugin that will run before or after the KongPlugin. For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]` will create a rate limiting plugin that limits requests _before_ they are authenticated. |
+| `instance_name` _string_ | InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the same plugin in multiple contexts, for example, on multiple services. |
 
 
 

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -141,11 +141,12 @@ func kongPluginFromK8SClusterPlugin(
 		Name:   k8sPlugin.PluginName,
 		Config: config,
 
-		RunOn:     k8sPlugin.RunOn,
-		Ordering:  k8sPlugin.Ordering,
-		Disabled:  k8sPlugin.Disabled,
-		Protocols: protocolsToStrings(k8sPlugin.Protocols),
-		Tags:      util.GenerateTagsForObject(&k8sPlugin),
+		RunOn:        k8sPlugin.RunOn,
+		Ordering:     k8sPlugin.Ordering,
+		InstanceName: k8sPlugin.InstanceName,
+		Disabled:     k8sPlugin.Disabled,
+		Protocols:    protocolsToStrings(k8sPlugin.Protocols),
+		Tags:         util.GenerateTagsForObject(&k8sPlugin),
 	}.toKongPlugin()
 	return kongPlugin, nil
 }
@@ -194,11 +195,12 @@ func kongPluginFromK8SPlugin(
 		Name:   k8sPlugin.PluginName,
 		Config: config,
 
-		RunOn:     k8sPlugin.RunOn,
-		Ordering:  k8sPlugin.Ordering,
-		Disabled:  k8sPlugin.Disabled,
-		Protocols: protocolsToStrings(k8sPlugin.Protocols),
-		Tags:      util.GenerateTagsForObject(&k8sPlugin),
+		RunOn:        k8sPlugin.RunOn,
+		Ordering:     k8sPlugin.Ordering,
+		InstanceName: k8sPlugin.InstanceName,
+		Disabled:     k8sPlugin.Disabled,
+		Protocols:    protocolsToStrings(k8sPlugin.Protocols),
+		Tags:         util.GenerateTagsForObject(&k8sPlugin),
 	}.toKongPlugin()
 	return kongPlugin, nil
 }
@@ -282,11 +284,12 @@ type plugin struct {
 	Name   string
 	Config kong.Configuration
 
-	RunOn     string
-	Ordering  *kong.PluginOrdering
-	Disabled  bool
-	Protocols []string
-	Tags      []*string
+	RunOn        string
+	Ordering     *kong.PluginOrdering
+	InstanceName string
+	Disabled     bool
+	Protocols    []string
+	Tags         []*string
 }
 
 func (p plugin) toKongPlugin() kong.Plugin {
@@ -304,6 +307,9 @@ func (p plugin) toKongPlugin() kong.Plugin {
 	result.Ordering = p.Ordering
 	if len(p.Protocols) > 0 {
 		result.Protocols = kong.StringSlice(p.Protocols...)
+	}
+	if p.InstanceName != "" {
+		result.InstanceName = kong.String(p.InstanceName)
 	}
 	return result
 }

--- a/internal/dataplane/kongstate/util_test.go
+++ b/internal/dataplane/kongstate/util_test.go
@@ -48,8 +48,9 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 			name: "basic configuration",
 			args: args{
 				plugin: configurationv1.KongClusterPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
-					PluginName: "correlation-id",
+					Protocols:    []configurationv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
@@ -60,7 +61,8 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 				Config: kong.Configuration{
 					"header_name": "foo",
 				},
-				Protocols: kong.StringSlice("http"),
+				Protocols:    kong.StringSlice("http"),
+				InstanceName: kong.String("example"),
 			},
 			wantErr: false,
 		},
@@ -182,8 +184,9 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 			name: "basic configuration",
 			args: args{
 				plugin: configurationv1.KongPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
-					PluginName: "correlation-id",
+					Protocols:    []configurationv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
@@ -194,7 +197,8 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 				Config: kong.Configuration{
 					"header_name": "foo",
 				},
-				Protocols: kong.StringSlice("http"),
+				Protocols:    kong.StringSlice("http"),
+				InstanceName: kong.String("example"),
 			},
 			wantErr: false,
 		},

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -80,6 +80,10 @@ type KongClusterPlugin struct {
 	// For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
 	// will create a rate limiting plugin that limits requests _before_ they are authenticated.
 	Ordering *kong.PluginOrdering `json:"ordering,omitempty"`
+
+	// InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+	// same plugin in multiple contexts, for example, on multiple services.
+	InstanceName string `json:"instance_name,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -80,6 +80,10 @@ type KongPlugin struct {
 	// For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
 	// will create a rate limiting plugin that limits requests _before_ they are authenticated.
 	Ordering *kong.PluginOrdering `json:"ordering,omitempty"`
+
+	// InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+	// same plugin in multiple contexts, for example, on multiple services.
+	InstanceName string `json:"instance_name,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds instance_name to the plugin CRDs and translation functions.

**Which issue this PR fixes**:

Fix #4140 

**Special notes for your reviewer**:

No library bumps; this was already added to go-kong and deck earlier.

Basic validation past the units:

```
16:26:49-0700 esenin $ grep -A6 KongPlugin /tmp/instance.yaml
kind: KongPlugin
metadata:
  name: kong-id
config:
  header_name: kong-id
plugin: correlation-id
instance_name: grapes
16:26:55-0700 esenin $ kubectl apply -f /tmp/instance.yaml   
service/httpbin unchanged
deployment.apps/httpbin unchanged
ingress.networking.k8s.io/httpbin unchanged
kongplugin.configuration.konghq.com/kong-id unchanged
16:26:57-0700 esenin $ grep instance_name /tmp/all-in-one-dbless.yaml -A2                                
          instance_name:
            description: InstanceName is an optional custom name to identify an instance
              of the plugin. This is useful when running the same plugin in multiple
--
          instance_name:
            description: InstanceName is an optional custom name to identify an instance
              of the plugin. This is useful when running the same plugin in multiple
16:27:13-0700 esenin $ kubectl get kongplugins.configuration.konghq.com kong-id -oyaml | grep -i instance
instance_name: grapes  
      {"apiVersion":"configuration.konghq.com/v1","config":{"header_name":"kong-id"},"instance_name":"grapes","kind":"KongPlugin","metadata":{"annotations":{},"name":"kong-id","namespace":"default"},"plugin":"correlation-id"}
16:27:22-0700 esenin $ curl -ks https://localhost:8999/plugins | jq .data[0].instance_name
"grapes"
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
