### PR TITLE
chore(release): improve issue template for release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -20,9 +20,9 @@ body:
   attributes:
     label: "**For all releases** Github Workflow Test Matrix Checkup"
     options:
-      - label: Check the testing workflow ([.github/workflows/test.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/test.yaml)) and ensure that all matrix versions ([.github/workflows/e2e.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/e2e.yaml) and [.github/workflows/release.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/release.yaml))  are up to date for various component releases. If there have been any new releases (major, minor or patch) of those components since the latest version seen in that configuration make sure the new versions get added before proceeding with the release. Remove any versions that are no longer supported by the environment provider.
+      - label: Check the testing workflow ([.github/workflows/_integration_tests.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/_integration_tests.yaml)) and ensure that all matrix versions ([.github/workflows/_e2e_tests.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/_e2e_tests.yaml) (for both K8s and Istio with K8s matrix) and [.github/workflows/release.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/release.yaml))  are up to date for various component releases. If there have been any new releases (major, minor or patch) of those components since the latest version seen in that configuration make sure the new versions get added before proceeding with the release. Remove any versions that are no longer supported by the environment provider.
       - label: Kubernetes (via [KIND](https://hub.docker.com/r/kindest/node/tags) and the latest image available when creating a new rapid channel cluster from the GKE new cluster wizard)
-      - label: Istio (via [Istio's releases page](https://github.com/istio/istio/releases))
+      - label: Istio (via [Istio's releases page](https://istio.io/latest/news/releases))
 - type: checkboxes
   id: gateway_version
   attributes:
@@ -30,7 +30,7 @@ body:
     options:
       - label: "Note: it might be possible that the latest Gateway version is not compatible with KIC and code changes are required. In such case, a decision whether to release with no compliance with the latest Gateway version should be made on a team level."
       - label: Check the latest minor Kong Gateway release in [Kong releases](https://github.com/Kong/kong/releases).
-      - label: Make sure the image tag in `config/image/enterprise/kustomization.yaml`, `config/image/oss/kustomization.yaml`, and `config/variants/enterprise/kustomization.yaml` is updated accordingly.
+      - label: Make sure the image tag in [config/image/enterprise/kustomization.yaml](/Kong/kubernetes-ingress-controller/blob/main/config/image/enterprise/kustomization.yaml) and [config/image/oss/kustomization.yaml](/Kong/kubernetes-ingress-controller/blob/main/config/image/oss/kustomization.yaml) is updated accordingly.
       - label: Run `make manifests` to regenerate manifests using the modified kustomizations and open a PR with the changes (similarly to [this PR](https://github.com/Kong/kubernetes-ingress-controller/pull/3288)).
 - type: checkboxes
   id: release_branch
@@ -82,18 +82,3 @@ body:
   attributes:
     label: Release Troubleshooting
     value: The [Release Troubleshooting guide](https://github.com/Kong/kubernetes-ingress-controller/blob/main/RELEASE.md#release-troubleshooting) covers strategies for dealing with a release that has failed.
-- type: textarea
-  id: release_trouble_shooting
-  attributes:
-    label: Manual Docker image build
-    value: If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually
-- type: checkboxes
-  id: release_manual_docker_build
-  attributes:
-    label: Steps
-    options:
-      - label: Check out your release tag.
-      - label: Run `make container`. Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.
-      - label: Add additional tags for your container (e.g. `docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2.0; docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2`)
-      - label: Create a temporary token for the `kongbot` user (see 1Password) and log in using it.
-      - label: Push each of your tags (e.g. `docker push kong/kubernetes-ingress-controller:1.2.0-alpine`)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,23 +6,13 @@ Fill out the issue title and release type, create the issue, and proceed through
 
 # Release Troubleshooting
 
-## Manual Docker image build
-
-If the "Build and push development images" Github action is not appropriate for your release, or is not operating properly, you can build and push Docker images manually:
-
-- Check out your release tag.
-- Run `make container`. Note that you can set the `TAG` environment variable if you need to override the current tag in Makefile.
-- Add additional tags for your container (e.g. `docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2.0; docker tag kong/kubernetes-ingress-controller:1.2.0-alpine kong/kubernetes-ingress-controller:1.2`)
-- Create a temporary token for the `kongbot` user (see 1Password) and log in using it.
-- Push each of your tags (e.g. `docker push kong/kubernetes-ingress-controller:1.2.0-alpine`)
-
 ## GKE test failures
 
-If GKE test clusters are not successfully starting, you can review their Pod logs from the Kubernetes Engine section of https://console.cloud.google.com/
+If GKE test clusters are not successfully starting, you can review their Pod logs from the Kubernetes Engine section of <https://console.cloud.google.com/>
 
 You can run GKE tests locally by [creating a service account and token](https://cloud.google.com/docs/authentication/getting-started) and running, for example:
 
-```
+```sh
 KUBERNETES_MAJOR_VERSION=1 KUBERNETES_MINOR_VERSION=21 GOOGLE_APPLICATION_CREDENTIALS=`cat /tmp/credentials.json` GOOGLE_PROJECT='<project name>' GOOGLE_LOCATION=us-central1 hack/e2e/dlv-tests.sh
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR improves our issue template for releases, update obsolete information and fix broken links.

**Which issue this PR fixes**:

It resolves below bullet points from https://github.com/Kong/kubernetes-ingress-controller/issues/4120

- broken links
    - [.github/workflows/test.yaml](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/test.yaml)
    - [.github/workflows/e2e.yaml](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/e2e.yaml)
- for istio is easier to check latest versions here https://istio.io/latest/news/releases than go through GH releases
- make references to files clickable
    - config/image/enterprise/kustomization.yaml
    - config/image/oss/kustomization.yaml
    - config/variants/enterprise/kustomization.yaml (it seems redundant, because it doesn't contain any version)
- steps from **Steps** are no longer up to date, policy for obtaining credentials has changed
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

I decided to remove **Steps** entirely because team-k8s no longer can obtain credentials for Docker Hub. Furthermore, in the [release workflow](https://github.com/Kong/kubernetes-ingress-controller/blob/677187e61569252896557d414203b3db7117d96b/.github/workflows/release.yaml#L51-L129), different way is used than described which may lead to disparity. Described method seems not to take into account building images for all supported architectures and pushing them to registry. I'm open to creating an issue for writing and testing the proper manual method if you consider need.


