### PR TITLE
feat(ci): add benchmarking code

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,38 @@
+name: Go Benchmarks
+on:
+  push:
+    branches:
+    - '*'
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Go benchmarks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+
+    - name: Run benchmark
+      run: make bench | tee bench.out
+
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Go Benchmark
+        tool: 'go'
+        output-file-path: bench.out
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '150%'
+        alert-comment-cc-users: '@Kong/k8s-maintainers'
+        comment-always: false
+        comment-on-alert: true
+
+        # Enable Job Summary for PRs
+        summary-always: true
+        fail-on-alert: true

--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,11 @@ E2E_TEST_RUN ?= ""
 KONG_CONTROLLER_FEATURE_GATES ?= GatewayAlpha=true
 GOTESTSUM_FORMAT ?= standard-verbose
 KONG_CLUSTER_VERSION ?= v1.27.1
-JUNIT_REPORT ?= /dev/null	
+JUNIT_REPORT ?= /dev/null
+
+.PHONY: bench
+bench:
+	@go test -count 1 -bench=. -benchmem -run=^$$ ./internal/...
 
 .PHONY: test
 test: test.unit

--- a/internal/dataplane/deckgen/deckgen_test.go
+++ b/internal/dataplane/deckgen/deckgen_test.go
@@ -1,0 +1,294 @@
+package deckgen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kong/deck/file"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkDeckgenGenerateSHA(b *testing.B) {
+	var targetContent file.Content
+	require.NoError(b, json.Unmarshal([]byte(configJSON), &targetContent))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		bb, err := GenerateSHA(&targetContent)
+		require.NoError(b, err)
+		_ = bb
+	}
+}
+
+const configJSON = `{
+	"_format_version": "3.0",
+	"_info": {
+		"select_tags": [
+			"managed-by-ingress-controller"
+		],
+		"defaults": {}
+	},
+	"services": [
+		{
+			"connect_timeout": 60000,
+			"host": "httproute.default.httproute-testing.0",
+			"name": "httproute.default.httproute-testing.0",
+			"protocol": "http",
+			"read_timeout": 60000,
+			"retries": 5,
+			"write_timeout": 60000,
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"routes": [
+				{
+					"name": "httproute.default.httproute-testing.0.0",
+					"paths": [
+						"/httproute-testing"
+					],
+					"path_handling": "v0",
+					"preserve_host": true,
+					"protocols": [
+						"http",
+						"https"
+					],
+					"strip_path": true,
+					"tags": [
+						"k8s-name:httproute-testing",
+						"k8s-namespace:default",
+						"k8s-kind:HTTPRoute",
+						"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+						"k8s-group:gateway.networking.k8s.io",
+						"k8s-version:v1beta1"
+					],
+					"https_redirect_status_code": 426
+				}
+			]
+		},
+		{
+			"connect_timeout": 60000,
+			"host": "httproute.default.httproute-testing.1",
+			"name": "httproute.default.httproute-testing.1",
+			"protocol": "http",
+			"read_timeout": 60000,
+			"retries": 5,
+			"write_timeout": 60000,
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"routes": [
+				{
+					"name": "httproute.default.httproute-testing.1.0",
+					"paths": [
+						"/httproute-testing"
+					],
+					"path_handling": "v0",
+					"preserve_host": true,
+					"protocols": [
+						"http",
+						"https"
+					],
+					"strip_path": true,
+					"tags": [
+						"k8s-name:httproute-testing",
+						"k8s-namespace:default",
+						"k8s-kind:HTTPRoute",
+						"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+						"k8s-group:gateway.networking.k8s.io",
+						"k8s-version:v1beta1"
+					],
+					"https_redirect_status_code": 426
+				}
+			]
+		},
+		{
+			"connect_timeout": 60000,
+			"host": "httproute.default.httproute-testing.2",
+			"name": "httproute.default.httproute-testing.2",
+			"protocol": "http",
+			"read_timeout": 60000,
+			"retries": 5,
+			"write_timeout": 60000,
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"routes": [
+				{
+					"name": "httproute.default.httproute-testing.2.0",
+					"paths": [
+						"/httproute-testing"
+					],
+					"path_handling": "v0",
+					"preserve_host": true,
+					"protocols": [
+						"http",
+						"https"
+					],
+					"strip_path": true,
+					"tags": [
+						"k8s-name:httproute-testing",
+						"k8s-namespace:default",
+						"k8s-kind:HTTPRoute",
+						"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+						"k8s-group:gateway.networking.k8s.io",
+						"k8s-version:v1beta1"
+					],
+					"https_redirect_status_code": 426
+				}
+			]
+		},
+		{
+			"connect_timeout": 60000,
+			"host": "httproute.default.httproute-testing.3",
+			"name": "httproute.default.httproute-testing.3",
+			"protocol": "http",
+			"read_timeout": 60000,
+			"retries": 5,
+			"write_timeout": 60000,
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"routes": [
+				{
+					"name": "httproute.default.httproute-testing.3.0",
+					"paths": [
+						"/httproute-testing"
+					],
+					"path_handling": "v0",
+					"preserve_host": true,
+					"protocols": [
+						"http",
+						"https"
+					],
+					"strip_path": true,
+					"tags": [
+						"k8s-name:httproute-testing",
+						"k8s-namespace:default",
+						"k8s-kind:HTTPRoute",
+						"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+						"k8s-group:gateway.networking.k8s.io",
+						"k8s-version:v1beta1"
+					],
+					"https_redirect_status_code": 426
+				}
+			]
+		},
+		{
+			"connect_timeout": 60000,
+			"host": "httproute.default.httproute-testing.4",
+			"name": "httproute.default.httproute-testing.4",
+			"protocol": "http",
+			"read_timeout": 60000,
+			"retries": 5,
+			"write_timeout": 60000,
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"routes": [
+				{
+					"name": "httproute.default.httproute-testing.4.0",
+					"paths": [
+						"/httproute-testing"
+					],
+					"path_handling": "v0",
+					"preserve_host": true,
+					"protocols": [
+						"http",
+						"https"
+					],
+					"strip_path": true,
+					"tags": [
+						"k8s-name:httproute-testing",
+						"k8s-namespace:default",
+						"k8s-kind:HTTPRoute",
+						"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+						"k8s-group:gateway.networking.k8s.io",
+						"k8s-version:v1beta1"
+					],
+					"https_redirect_status_code": 426
+				}
+			]
+		}
+	],
+	"upstreams": [
+		{
+			"name": "httproute.default.httproute-testing.0",
+			"algorithm": "round-robin",
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"targets": [
+				{
+					"target": "10.244.0.11:80",
+					"weight": 75
+				}
+			]
+		},
+		{
+			"name": "httproute.default.httproute-testing.1",
+			"algorithm": "round-robin",
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"targets": [
+				{
+					"target": "10.244.0.11:80",
+					"weight": 75
+				}
+			]
+		},
+		{
+			"name": "httproute.default.httproute-testing.2",
+			"algorithm": "round-robin",
+			"tags": [
+				"k8s-name:httproute-testing",
+				"k8s-namespace:default",
+				"k8s-kind:HTTPRoute",
+				"k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3",
+				"k8s-group:gateway.networking.k8s.io",
+				"k8s-version:v1beta1"
+			],
+			"targets": [
+				{
+					"target": "10.244.0.11:80",
+					"weight": 75
+				}
+			]
+		}
+	]
+}`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds benchmarking code using https://github.com/benchmark-action/github-action-benchmark.

The [CI workflow](https://github.com/Kong/kubernetes-ingress-controller/blob/214773b81c9c2c2df925b6da313429034944f97c/.github/workflows/benchmarks.yaml)  will run all benchmark in the codebase and save the results in gh-pages so that they are available for developers to see the trend and results.

This workflow will also issue a comment in case it detect a regression by a certain threshold (currently set to 150%). 

Form the action README:

> Percentage value like "150%". It is a ratio indicating how worse the current benchmark result is. For example, if we now get 150 ns/iter and previously got 100 ns/iter, it gets 150% worse.

---

The chart (1 for now since there's only 1 benchmark) is available at https://kong.github.io/kubernetes-ingress-controller/dev/bench/

---

A possible alternative to use could be https://gobenchdata.bobheadxi.dev/ which puts each package benchmarks onto one plot and have 3 separate plots for ns/op, allocations/op and memory_allocated/op


