### PR TITLE
test(e2e): fix retry on create konnect RG

### DIFF
--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -29,6 +29,12 @@ var (
 	// be created in tests. It can be either `gke` or `kind`.
 	// It's not used when KONG_TEST_CLUSTER is set.
 	clusterProvider = os.Getenv("KONG_TEST_CLUSTER_PROVIDER")
+
+	// githubServerURL, githubRepo, githubRunID are used to locate the run of github wokflow.
+	// See: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+	githubServerURL = os.Getenv("GITHUB_SERVER_URL")
+	githubRepo      = os.Getenv("GITHUB_REPOSITORY")
+	githubRunID     = os.Getenv("GITHUB_RUN_ID")
 )
 
 // shouldLoadImages tells whether the controller and kong images should be loaded into the cluster.

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -234,7 +234,7 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 		// list other RGs also created in the previous code for situations
 		// that RG created, but we timed out on getting the response.
 		// This prevents RG leaks.
-		listRgResp, err := rgClient.ListRuntimeGroupsWithResponse(ctx, nil)
+		listRgResp, err := rgClient.ListRuntimeGroupsWithResponse(ctx, &rg.ListRuntimeGroupsParams{})
 		assert.NoError(t, err, "failed to list runtime groups")
 		assert.Equalf(t, http.StatusOK, listRgResp.StatusCode(), "failed to list runtime groups: code %d, body %s",
 			listRgResp.StatusCode(), string(listRgResp.Body))

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -195,64 +195,6 @@ func generateTestKonnectRuntimeGroupDescription(t *testing.T) string {
 	return desc
 }
 
-// deleteRuntimeGroupsCreatedInTest returns a function that deletes RGs created in test
-// to be used in the retry procedure.
-func deleteRuntimeGroupsCreatedInTest(
-	ctx context.Context,
-	rgClient rg.ClientWithResponses,
-	t *testing.T, createTimeStamp time.Time, testUUID string,
-) func() error {
-	t.Helper()
-	// rgNumberLimit is the maximum runtime groups in the test account
-	rgNumberLimit := 100
-	createTimeStampStr := fmt.Sprintf("%d", createTimeStamp.Unix())
-
-	return func() error {
-		// list all RGs before we can list RGs by labels.
-		listRgResp, err := rgClient.ListRuntimeGroupsWithResponse(ctx, &rg.ListRuntimeGroupsParams{
-			PageSize: lo.ToPtr(rgNumberLimit),
-		})
-		if err != nil {
-			t.Logf("failed to list runtime groups: %v", err)
-			return err
-		}
-		if listRgResp.StatusCode() != http.StatusOK {
-			t.Logf("failed to list runtime groups: code %d, body %s",
-				listRgResp.StatusCode(), string(listRgResp.Body))
-			return fmt.Errorf("non-OK status code: %d", listRgResp.StatusCode())
-		}
-		if listRgResp.JSON200.Data == nil {
-			t.Logf("failed to list runtime groups: no data in body")
-			return errors.New("no data in response body")
-		}
-
-		rgs := *listRgResp.JSON200.Data
-
-		var deleteRgErrors []error
-		for _, rg := range rgs {
-			if rg.Labels == nil || *rg.Labels == nil {
-				continue
-			}
-			labels := *rg.Labels
-			// find the RGs created in the test by labels, and delete them.
-			if labels["created_in_tests"] == "true" &&
-				labels["create_test_timestamp"] == createTimeStampStr &&
-				labels["create_test_uuid"] == testUUID &&
-				rg.Id != nil {
-				deleteRgID := *rg.Id
-
-				t.Logf("deleting runtime group %s created in test %s", deleteRgID, t.Name())
-				_, deleteErr := rgClient.DeleteRuntimeGroupWithResponse(ctx, deleteRgID)
-				if deleteErr != nil {
-					t.Logf("failed to delete runtime group %s: %v", deleteRgID, err)
-					deleteRgErrors = append(deleteRgErrors, deleteErr)
-				}
-			}
-		}
-		return errors.Join(deleteRgErrors...)
-	}
-}
-
 // createTestRuntimeGroup creates a runtime group to be used in tests. It returns the created runtime group's ID.
 // It also sets up a cleanup function for it to be deleted.
 func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
@@ -265,19 +207,14 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 		}),
 	)
 	require.NoError(t, err)
-	createTimeStamp := time.Now()
-	createTestUUID := uuid.NewString()
 
 	var rgID uuid.UUID
-
 	createRgErr := retry.Do(func() error {
 		rgName := uuid.NewString()
 		createRgResp, err := rgClient.CreateRuntimeGroupWithResponse(ctx, rg.CreateRuntimeGroupRequest{
 			Description: lo.ToPtr(generateTestKonnectRuntimeGroupDescription(t)),
 			Labels: &rg.Labels{
-				"created_in_tests":      "true",
-				"create_test_timestamp": fmt.Sprintf("%d", createTimeStamp.Unix()),
-				"create_test_uuid":      createTestUUID,
+				"created_in_tests": "true",
 			},
 			Name:        rgName,
 			ClusterType: rg.ClusterTypeKubernetesIngressController,
@@ -295,7 +232,6 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 		rgID = *createRgResp.JSON201.Id
 		return nil
 	}, retry.Attempts(5), retry.Delay(time.Second))
-
 	require.NoError(t, createRgErr)
 
 	t.Cleanup(func() {
@@ -313,19 +249,6 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 			retry.Attempts(5), retry.Delay(time.Second),
 		)
 		assert.NoErrorf(t, err, "failed to delete runtime group %s used in the test", rgID.String())
-
-		// list other RGs also created in the previous code for situations
-		// that RG created, but we timed out on getting the response.
-		// This prevents RG leaks.
-		t.Logf("deleting other runtime groups created in the test")
-		err = retry.Do(
-			deleteRuntimeGroupsCreatedInTest(
-				ctx, *rgClient,
-				t, createTimeStamp, createTestUUID,
-			),
-			retry.Attempts(5), retry.Delay(time.Second),
-		)
-		assert.NoError(t, err, "failed to list and delete other runtime groups created in the test")
 	})
 
 	t.Logf("created test Konnect Runtime Group: %q", rgID.String())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

current retry logic on creating test konnect RGs will fail when the RG is created, but the request timed out to get response. This caused e2e test cases fail when creating RGs on the situations above.

This PR checks for existence of RG with specified name before sending the creation request. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4193 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
