### PR TITLE
chore(build): get rid of obsolete Go build tags

### DIFF
--- a/internal/adminapi/endpoints_envtest_test.go
+++ b/internal/adminapi/endpoints_envtest_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package adminapi_test
 

--- a/internal/cmd/fips/main.go
+++ b/internal/cmd/fips/main.go
@@ -1,5 +1,4 @@
 //go:build fips
-// +build fips
 
 package main
 

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package configuration_test
 

--- a/internal/metrics/metrics_envtest_test.go
+++ b/internal/metrics/metrics_envtest_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package metrics_test
 

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -1,5 +1,4 @@
 //go:build conformance_tests
-// +build conformance_tests
 
 package conformance
 

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -1,5 +1,4 @@
 //go:build conformance_tests
-// +build conformance_tests
 
 package conformance
 

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 package e2e
 

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 package e2e
 

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 package e2e
 

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 // The file is used for putting functions related to gateway APIs.
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests || istio_tests
-// +build e2e_tests istio_tests
 
 package e2e
 

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -1,5 +1,4 @@
 //go:build istio_tests
-// +build istio_tests
 
 package e2e
 

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 package e2e
 

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests || istio_tests
-// +build e2e_tests istio_tests
 
 package e2e
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests || istio_tests
-// +build e2e_tests istio_tests
 
 package e2e
 

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package envtest
 

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package envtest
 

--- a/test/envtest/manager_debugendpoints_test.go
+++ b/test/envtest/manager_debugendpoints_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package envtest
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -1,5 +1,4 @@
 //go:build envtest
-// +build envtest
 
 package envtest
 

--- a/test/expressionrouter/generate_test.go
+++ b/test/expressionrouter/generate_test.go
@@ -1,5 +1,4 @@
 //go:build expression_router_tests
-// +build expression_router_tests
 
 package expressionrouter
 

--- a/test/expressionrouter/helpers_test.go
+++ b/test/expressionrouter/helpers_test.go
@@ -1,5 +1,4 @@
 //go:build expression_router_tests
-// +build expression_router_tests
 
 package expressionrouter
 

--- a/test/expressionrouter/suite_test.go
+++ b/test/expressionrouter/suite_test.go
@@ -1,5 +1,4 @@
 //go:build expression_router_tests
-// +build expression_router_tests
 
 package expressionrouter
 

--- a/test/integration/addons_knative_test.go
+++ b/test/integration/addons_knative_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests && knative
-// +build integration_tests,knative
 
 package integration
 

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests && !knative
-// +build integration_tests,!knative
 
 package integration
 

--- a/test/integration/config_error_event_test.go
+++ b/test/integration/config_error_event_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/crd_validations_test.go
+++ b/test/integration/crd_validations_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/grpcroute_test.go
+++ b/test/integration/grpcroute_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests && knative
-// +build integration_tests,knative
 
 package integration
 

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/internal/cmd/generate-gateway-api-consts/main.go
+++ b/test/internal/cmd/generate-gateway-api-consts/main.go
@@ -1,5 +1,4 @@
 //go:build generate_gateway_api_consts
-// +build generate_gateway_api_consts
 
 package main
 

--- a/test/internal/testenv/feature_gates.go
+++ b/test/internal/testenv/feature_gates.go
@@ -1,5 +1,4 @@
 //go:build !knative
-// +build !knative
 
 package testenv
 

--- a/test/internal/testenv/feature_gates_knative.go
+++ b/test/internal/testenv/feature_gates_knative.go
@@ -1,5 +1,4 @@
 //go:build knative
-// +build knative
 
 package testenv
 

--- a/third_party/client-gen.go
+++ b/third_party/client-gen.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/controller-gen.go
+++ b/third_party/controller-gen.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/crd-ref-docs.go
+++ b/third_party/crd-ref-docs.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/dlv.go
+++ b/third_party/dlv.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/go-junit-report.go
+++ b/third_party/go-junit-report.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/golangci-lint.go
+++ b/third_party/golangci-lint.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/gotestsum.go
+++ b/third_party/gotestsum.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/kustomize.go
+++ b/third_party/kustomize.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/setup-envtest.go
+++ b/third_party/setup-envtest.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/third_party/skaffold.go
+++ b/third_party/skaffold.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package skaffold
 

--- a/third_party/staticcheck.go
+++ b/third_party/staticcheck.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since Go 1.18 the new directive `//go:build` is now preferred and the toolchain will actively remove old directives; as mentioned in Go 1.18 release notes:

> In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod files.

KIC  specifies in `go.mod` Go version `1.20`.
 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It's part of the https://github.com/Kong/team-k8s/issues/286

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Files generated by `controller-gen`:

- `pkg/apis/configuration/v1/zz_generated.deepcopy.go`
- `pkg/apis/configuration/v1alpha1/zz_generated.deepcopy.go`
- `pkg/apis/configuration/v1beta1/zz_generated.deepcopy.go`

still include obsolete build tag. Issue has been created https://github.com/kubernetes-sigs/controller-tools/issues/826
