### PR TITLE
tests: fix flaky TestAgent

### DIFF
--- a/internal/adminapi/backoff_strategy_konnect.go
+++ b/internal/adminapi/backoff_strategy_konnect.go
@@ -26,10 +26,6 @@ type Clock interface {
 	Now() time.Time
 }
 
-type SystemClock struct{}
-
-func (SystemClock) Now() time.Time { return time.Now() }
-
 // KonnectBackoffStrategy keeps track of Konnect config push backoffs.
 //
 // It takes into account:

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -11,6 +11,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/clock"
 )
 
 // Client is a wrapper around raw *kong.Client. It's advised to pass this wrapper across the codebase, and
@@ -61,7 +62,7 @@ func NewKonnectClient(c *kong.Client, runtimeGroup string) *KonnectClient {
 			konnectRuntimeGroup: runtimeGroup,
 			pluginSchemaStore:   util.NewPluginSchemaStore(c),
 		},
-		backoffStrategy: NewKonnectBackoffStrategy(SystemClock{}),
+		backoffStrategy: NewKonnectBackoffStrategy(clock.System{}),
 	}
 }
 

--- a/internal/license/agent.go
+++ b/internal/license/agent.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/clock"
 )
 
 const (
@@ -52,6 +53,20 @@ func WithPollingPeriod(regularPollingPeriod time.Duration) AgentOpt {
 	}
 }
 
+type Ticker interface {
+	Stop()
+	Channel() <-chan time.Time
+	Reset(d time.Duration)
+}
+
+// WithTicker sets the ticker in Agent. This is useful for testing.
+// Ticker doesn't define the period, it defines the implementation of ticking.
+func WithTicker(t Ticker) AgentOpt {
+	return func(a *Agent) {
+		a.ticker = t
+	}
+}
+
 // NewAgent creates a new license agent that retrieves a license from the given url once every given period.
 func NewAgent(
 	konnectLicenseClient KonnectLicenseClient,
@@ -63,6 +78,9 @@ func NewAgent(
 		konnectLicenseClient: konnectLicenseClient,
 		initialPollingPeriod: DefaultInitialPollingPeriod,
 		regularPollingPeriod: DefaultPollingPeriod,
+		// Note: the ticker defined the implementation of ticking, not the period.
+		ticker:    clock.NewTicker(),
+		startedCh: make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -78,6 +96,8 @@ type Agent struct {
 	konnectLicenseClient KonnectLicenseClient
 	initialPollingPeriod time.Duration
 	regularPollingPeriod time.Duration
+	ticker               Ticker
+	startedCh            chan struct{}
 
 	// cachedLicense is the current license retrieved from upstream. It's optional because we may not have retrieved a
 	// license yet.
@@ -122,21 +142,28 @@ func (a *Agent) GetLicense() mo.Option[kong.License] {
 	return mo.None[kong.License]()
 }
 
+// Started returns a channel which will be closed when the Agent has started.
+func (a *Agent) Started() <-chan struct{} {
+	return a.startedCh
+}
+
 // runPollingLoop updates the license on a regular period until the context is cancelled.
 // It will run at a faster period initially, and then switch to the regular period once a license is retrieved.
 func (a *Agent) runPollingLoop(ctx context.Context) error {
-	ticker := time.NewTicker(a.resolvePollingPeriod())
-	defer ticker.Stop()
+	a.ticker.Reset(a.initialPollingPeriod)
+	defer a.ticker.Stop()
 
+	ch := a.ticker.Channel()
+	close(a.startedCh)
 	for {
 		select {
-		case <-ticker.C:
+		case <-ch:
 			a.logger.V(util.DebugLevel).Info("retrieving license from external service")
 			if err := a.reconcileLicenseWithKonnect(ctx); err != nil {
 				a.logger.Error(err, "could not reconcile license with Konnect")
 			}
 			// Reset the ticker to run with the expected period which may change after we receive the license.
-			ticker.Reset(a.resolvePollingPeriod())
+			a.ticker.Reset(a.resolvePollingPeriod())
 		case <-ctx.Done():
 			a.logger.Info("context done, shutting down license agent")
 			return ctx.Err()

--- a/internal/license/agent.go
+++ b/internal/license/agent.go
@@ -78,7 +78,7 @@ func NewAgent(
 		konnectLicenseClient: konnectLicenseClient,
 		initialPollingPeriod: DefaultInitialPollingPeriod,
 		regularPollingPeriod: DefaultPollingPeriod,
-		// Note: the ticker defined the implementation of ticking, not the period.
+		// Note: the ticker defines the implementation of ticking, not the period.
 		ticker:    clock.NewTicker(),
 		startedCh: make(chan struct{}),
 	}

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -130,10 +130,8 @@ func TestAgent(t *testing.T) {
 		)
 
 		startTime := time.Now()
-		go func() {
-			err := a.Start(ctx)
-			require.NoError(t, err)
-		}()
+		go a.Start(ctx)
+
 		select {
 		case <-a.Started():
 		case <-time.After(time.Second):

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -116,7 +116,6 @@ func TestAgent(t *testing.T) {
 		upstreamClient.ReturnError(errors.New("something went wrong on a backend"))
 
 		const (
-			// Set the initial polling period to a very short duration to ensure that the agent retries quickly.
 			initialPollingPeriod = time.Minute * 3
 			regularPollingPeriod = time.Minute * 20
 			allowedDelta         = time.Second

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -100,10 +100,7 @@ func TestAgent(t *testing.T) {
 	t.Run("initial license is retrieved", func(t *testing.T) {
 		upstreamClient := newMockKonnectLicenseClient(mo.Some(expectedLicense), clock.System{})
 		a := license.NewAgent(upstreamClient, logr.Discard())
-		go func() {
-			err := a.Start(ctx)
-			require.NoError(t, err)
-		}()
+		go a.Start(ctx) //nolint:errcheck
 		expectLicenseToMatchEventually(t, a, expectedLicense.Payload)
 	})
 
@@ -130,7 +127,7 @@ func TestAgent(t *testing.T) {
 		)
 
 		startTime := time.Now()
-		go a.Start(ctx)
+		go a.Start(ctx) //nolint:errcheck
 
 		select {
 		case <-a.Started():

--- a/internal/util/clock/clock.go
+++ b/internal/util/clock/clock.go
@@ -1,0 +1,7 @@
+package clock
+
+import "time"
+
+type System struct{}
+
+func (System) Now() time.Time { return time.Now() }

--- a/internal/util/clock/ticker.go
+++ b/internal/util/clock/ticker.go
@@ -2,9 +2,18 @@ package clock
 
 import "time"
 
+const (
+	// This is irrelevant for the ticker, but we need to pass something to NewTicker.
+	// The reason for this is that the ticker is used in the license agent, which
+	// uses a non trivial logic to determine the polling period based on the state
+	// of license retrieval.
+	// This might be changed in the future if it doesn't fit the future needs.
+	initialTickerDuration = 1000 * time.Hour
+)
+
 func NewTicker() *TimeTicker {
 	return &TimeTicker{
-		ticker: time.NewTicker(1000 * time.Hour),
+		ticker: time.NewTicker(initialTickerDuration),
 	}
 }
 

--- a/internal/util/clock/ticker.go
+++ b/internal/util/clock/ticker.go
@@ -1,0 +1,25 @@
+package clock
+
+import "time"
+
+func NewTicker() *TimeTicker {
+	return &TimeTicker{
+		ticker: time.NewTicker(1000 * time.Hour),
+	}
+}
+
+type TimeTicker struct {
+	ticker *time.Ticker
+}
+
+func (t *TimeTicker) Stop() {
+	t.ticker.Stop()
+}
+
+func (t *TimeTicker) Channel() <-chan time.Time {
+	return t.ticker.C
+}
+
+func (t *TimeTicker) Reset(d time.Duration) {
+	t.ticker.Reset(d)
+}

--- a/test/mocks/ticker.go
+++ b/test/mocks/ticker.go
@@ -49,8 +49,8 @@ func (t *Ticker) Channel() <-chan time.Time {
 }
 
 func (t *Ticker) Now() time.Time {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 	return t.time
 }
 

--- a/test/mocks/ticker.go
+++ b/test/mocks/ticker.go
@@ -1,0 +1,78 @@
+package mocks
+
+import (
+	"sync"
+	"time"
+)
+
+func NewTicker() *Ticker {
+	now := time.Now()
+
+	ticker := &Ticker{
+		sigTime:  make(chan time.Time),
+		sigClose: make(chan struct{}, 1),
+		sigAdd:   make(chan time.Duration),
+		sigReset: make(chan time.Duration),
+		d:        1000 * time.Hour,
+		ch:       make(chan time.Time, 1),
+		time:     now,
+		lastTick: now,
+	}
+
+	return ticker
+}
+
+type Ticker struct {
+	lock     sync.RWMutex
+	sigTime  chan time.Time
+	sigClose chan struct{}
+	sigReset chan time.Duration
+	sigAdd   chan time.Duration
+	d        time.Duration
+	ch       chan time.Time
+	time     time.Time
+	lastTick time.Time
+}
+
+func (t *Ticker) Stop() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	close(t.sigTime)
+	close(t.sigAdd)
+	close(t.sigReset)
+	close(t.sigClose)
+}
+
+func (t *Ticker) Channel() <-chan time.Time {
+	return t.ch
+}
+
+func (t *Ticker) Now() time.Time {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.time
+}
+
+func (t *Ticker) Reset(d time.Duration) {
+	now := time.Now()
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.lastTick = now
+	t.time = now
+	t.d = d
+}
+
+func (t *Ticker) Add(d time.Duration) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.time = t.time.Add(d)
+
+	if t.time.Compare(t.lastTick.Add(t.d)) >= 0 {
+		t.ch <- t.time
+		t.lastTick = t.time
+	}
+}

--- a/test/mocks/ticker_test.go
+++ b/test/mocks/ticker_test.go
@@ -1,0 +1,89 @@
+package mocks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTicker(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		ticker := NewTicker()
+		ch := ticker.Channel()
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+
+		ticker.Reset(time.Hour)
+
+		t.Log("adding second should not tick when ticker has an interval of 1 hour")
+		ticker.Add(time.Second)
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+
+		t.Log("adding 40 minutes should not tick when ticker has an interval of 1 hour")
+		ticker.Add(40 * time.Minute)
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+
+		t.Log("adding 40 minutes should tick when 40 minutes already passed and ticker has an interval of 1 hour")
+		ticker.Add(40 * time.Minute)
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			require.FailNow(t, "expected a tick to happen but it didn't")
+		}
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		ticker := NewTicker()
+		ch := ticker.Channel()
+
+		t.Log("reseting ticker to 3 hour interval")
+		ticker.Reset(3 * time.Hour)
+		t.Log("adding second should not tick when ticker has an interval of 3 hours")
+		ticker.Add(time.Second)
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+
+		t.Log("adding an hour should not tick when ticker has an interval of 3 hour")
+		ticker.Add(time.Hour)
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+
+		t.Log("adding 2 hours should tick when ticker has an interval of 3 hour")
+		ticker.Add(2 * time.Hour)
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			require.FailNow(t, "expected a tick to happen but it didn't")
+		}
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		ticker := NewTicker()
+		ch := ticker.Channel()
+		ticker.Stop()
+
+		select {
+		case <-ch:
+			require.FailNow(t, "unexpected tick")
+		default:
+		}
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a `Ticker` interface within the license agent and uses that to mock time 🕐 .

This should help us fix #4200.

**Which issue this PR fixes**:

Fixes #4200.

