### PR TITLE
fix: fix incorrect .Is() method on update skipped due to backoff error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ Adding a new version? You'll need three changes:
   first observed value, as that value is not necessarily the desired value.
   [#4171](https://github.com/Kong/kubernetes-ingress-controller/pull/4171)
 
+### Fixed
+
+- Fix KIC crash which occurred when invalid config was applied in DB mode.
+  [#4213](https://github.com/Kong/kubernetes-ingress-controller/pull/4213)
+
 ## [2.10.0]
 
 > Release date: 2023-06-02

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -439,7 +439,7 @@ func (c *KongClient) maybeSendOutToKonnectClient(ctx context.Context, s *kongsta
 		// In case of an error, we only log it since we don't want the Konnect to affect the basic functionality
 		// of the controller.
 
-		if errors.Is(err, sendconfig.ErrUpdateSkippedDueToBackoffStrategy{}) {
+		if errors.As(err, &sendconfig.UpdateSkippedDueToBackoffStrategyError{}) {
 			c.logger.WithError(err).Warn("Skipped pushing configuration to Konnect")
 		} else {
 			c.logger.WithError(err).Warn("Failed pushing configuration to Konnect")

--- a/internal/dataplane/sendconfig/backoff_strategy.go
+++ b/internal/dataplane/sendconfig/backoff_strategy.go
@@ -2,7 +2,6 @@ package sendconfig
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -11,20 +10,16 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 )
 
-type ErrUpdateSkippedDueToBackoffStrategy struct {
+type UpdateSkippedDueToBackoffStrategyError struct {
 	explanation string
 }
 
-func NewErrUpdateSkippedDueToBackoffStrategy(explanation string) ErrUpdateSkippedDueToBackoffStrategy {
-	return ErrUpdateSkippedDueToBackoffStrategy{explanation: explanation}
+func NewUpdateSkippedDueToBackoffStrategyError(explanation string) UpdateSkippedDueToBackoffStrategyError {
+	return UpdateSkippedDueToBackoffStrategyError{explanation: explanation}
 }
 
-func (e ErrUpdateSkippedDueToBackoffStrategy) Error() string {
+func (e UpdateSkippedDueToBackoffStrategyError) Error() string {
 	return fmt.Sprintf("update skipped due to a backoff strategy not being satisfied: %s", e.explanation)
-}
-
-func (e ErrUpdateSkippedDueToBackoffStrategy) Is(err error) bool {
-	return errors.Is(err, ErrUpdateSkippedDueToBackoffStrategy{})
 }
 
 // UpdateStrategyWithBackoff decorates any UpdateStrategy to respect a passed adminapi.UpdateBackoffStrategy.
@@ -57,7 +52,7 @@ func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent Con
 	resourceErrorsParseErr error,
 ) {
 	if canUpdate, whyNot := s.backoffStrategy.CanUpdate(targetContent.Hash); !canUpdate {
-		return NewErrUpdateSkippedDueToBackoffStrategy(whyNot), nil, nil
+		return NewUpdateSkippedDueToBackoffStrategyError(whyNot), nil, nil
 	}
 
 	err, resourceErrors, resourceErrorsParseErr = s.decorated.Update(ctx, targetContent)

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -82,7 +82,7 @@ func PerformUpdate(
 	metricsProtocol := updateStrategy.MetricsProtocol()
 	if err != nil {
 		// Not pushing metrics in case it's an update skip due to a backoff.
-		if errors.Is(err, ErrUpdateSkippedDueToBackoffStrategy{}) {
+		if errors.As(err, &UpdateSkippedDueToBackoffStrategyError{}) {
 			return nil, []failures.ResourceFailure{}, err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where KIC crash due to a stack overflow when a broken config is applied in dbmode.

The problematic piece was:

```
func (e ErrUpdateSkippedDueToBackoffStrategy) Is(err error) bool {
	return errors.Is(err, ErrUpdateSkippedDueToBackoffStrategy{})
}
```

which didn't work as intended. `.Is()` is meant to compare errors, as in compare their values, not types.

Where this was called we intended to check the type of an error, not it's value.

The stack overflow is prevent by removing the `.Is()` method from `UpdateSkippedDueToBackoffStrategyError` as it's not needed now.

The test that failed due to a stack overflow before this change was introduced and passes now:

```
	skippedErr := sendconfig.NewUpdateSkippedDueToBackoffStrategyError("reason")

	t.Run("errors.Is()", func(t *testing.T) {
		assert.False(t,
			errors.Is(skippedErr, deckerrors.ConfigConflictError{
				Err: sendconfig.NewUpdateSkippedDueToBackoffStrategyError("different reason"),
			}),
			"shouldn't panic when using errors.Is() with NewUpdateSkippedDueToBackoffStrategyError",
		)
	})
```

**Which issue this PR fixes**:

Fixes: #4212

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
