### PR TITLE
chore(ci): remove redundant vet and fmt commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ For a GitHub issue describing a problem/feature request:
 
 For a closed issue, one can verify which released versions contain the fix/enhancement by navigating into the merge commit of each attached PR, where GitHub lists tags/branches that contain the merge commit.
 Thus:
+
 - if the list includes a release tag: the fix/enhancement is included in that release tag.
 - if the list includes `next` but no release tags: the fix/enhancement will come in the nearest minor release.
 - if the list includes `main` but no release tags: the fix/enhancement will come in the nearest patch release.
@@ -121,7 +122,6 @@ Make sure you're [generally familiar with Kubernetes Controllers as a concept, a
 
 [ctrl]:https://kubernetes.io/docs/concepts/architecture/controller/
 [kapi]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/
-[kubebuilder]:https://kubebuilder.io/
 [kbquick]:https://kubebuilder.io/quick-start.html
 [kbctrl]:https://kubebuilder.io/cronjob-tutorial/controller-overview.html
 
@@ -155,6 +155,7 @@ go run -tags gcp ./internal/cmd/main.go \
 ```
 
 If you are using Kind we can leverage [extraPortMapping config](https://kind.sigs.k8s.io/docs/user/ingress/)
+
 ```shell
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
@@ -189,13 +190,13 @@ or push an image to a remote repository.
 ### Build a raw server binary
 
 ```console
-$ make build
+make build
 ```
 
 ### Build a local container image
 
 ```console
-$ TAG=DEV REGISTRY=docker.example.com/registry make container
+TAG=DEV REGISTRY=docker.example.com/registry make container
 ```
 
 Note: this will use the Docker daemon
@@ -215,7 +216,7 @@ in your Deployment specs.
 ### Push the container image to a remote repository
 
 ```console
-$ docker push docker.example.com/registry/kong-ingress-controller:DEV
+docker push docker.example.com/registry/kong-ingress-controller:DEV
 ```
 
 Note: replace `docker.example.com/registry` with your registry URL.
@@ -225,24 +226,34 @@ Note: replace `docker.example.com/registry` with your registry URL.
 There are several ways to deploy Kong Ingress Controller onto a cluster.
 Please check the [deployment guide](https://docs.konghq.com/kubernetes-ingress-controller/latest/deployment/overview/).
 
+## Linting
+
+You can lint the codebase by running:
+
+```console
+make lint
+```
+
+passing the above is required by CI.
+
 ## Testing
 
 You can run the unit tests by running:
 
 ```console
-$ make test
+make test
 ```
 
 For integration tests run:
 
 ```console
-$ make test.integration
+make test.integration
 ```
 
 And for E2E tests run:
 
 ```console
-$ make test.e2e
+make test.e2e
 ```
 
 Note that the `integration` and `e2e` tests require a local container runtime
@@ -259,8 +270,8 @@ Our images are hosted on
 An example release might look like:
 
 ```shell
-$ export TAG=42
-$ make release
+export TAG=42
+make release
 ```
 
 Please follow these guidelines to cut a release:

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ clean:
 	@rm -f coverage*.out
 
 .PHONY: build
-build: generate lint _build
+build: generate _build
 
 .PHONY: build.fips
 build.fips: generate lint _build.fips

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ clean:
 	@rm -f coverage*.out
 
 .PHONY: build
-build: generate fmt vet lint _build
+build: generate lint _build
 
 .PHONY: build.fips
-build.fips: generate fmt vet lint _build.fips
+build.fips: generate lint _build.fips
 
 .PHONY: _build
 _build:
@@ -149,10 +149,6 @@ _build.template.debug:
 .PHONY: fmt
 fmt:
 	go fmt ./...
-
-.PHONY: vet
-vet:
-	go vet ./...
 
 .PHONY: lint
 lint: verify.tidy golangci-lint staticcheck
@@ -514,7 +510,7 @@ debug: install _ensure-namespace
 # > Otherwise, they are located in $HOME/.config/dlv on Linux and $HOME/.dlv on other systems.
 #
 # ref: https://github.com/go-delve/delve/blob/master/Documentation/cli/README.md#configuration-and-command-history
-# 
+#
 # This sets the XDG_CONFIG_HOME to this project's subdirectory so that project
 # specific substitution paths can be isolated to this project only and not shared
 # across projects under $HOME or common XDG_CONFIG_HOME.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Direct usage of 
- [fmt](https://github.com/Kong/kubernetes-ingress-controller/blob/7f4ab1902f113b3864095b9042ba56c0ee216660/Makefile#L149-L151)
- [vet](https://github.com/Kong/kubernetes-ingress-controller/blob/31b1ba2fe4cb5f37119e0ab299743b07e04e1098/Makefile#L153-L155)

is redundant, since we have [lint](https://github.com/Kong/kubernetes-ingress-controller/blob/7f4ab1902f113b3864095b9042ba56c0ee216660/Makefile#L157-L159) that invokes golangci-lint with configuration that includes [govet](https://github.com/Kong/kubernetes-ingress-controller/blob/7f4ab1902f113b3864095b9042ba56c0ee216660/.golangci.yaml#L34) (it uses [stdlib vet](https://pkg.go.dev/cmd/vet)) & [gofmt](https://github.com/Kong/kubernetes-ingress-controller/blob/7f4ab1902f113b3864095b9042ba56c0ee216660/.golangci.yaml#L28) (it uses [stdlib gofmt](https://pkg.go.dev/cmd/gofmt)) according to [docs](https://golangci-lint.run/usage/linters/).

By getting rid of that duplications, we save couple of seconds and simplify `Makefile`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Special notes for your reviewer**:

Target `fmt` is used by [generate](https://github.com/Kong/kubernetes-ingress-controller/blob/b63b9ca05fe1f58b058a189638c664f3b003a6aa/Makefile#L214-L215) to properly format autogenerated files. Since golangci-lint do not check autogenerated files it forces proper formatting of file created with [hack/generators/controllers/networking/main.go](https://github.com/Kong/kubernetes-ingress-controller/blob/ccafa7ca9da7fb52ba959c2ebbc0974e22497b5b/hack/generators/controllers/networking/main.go). So only redundant invocations are removed.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

