### PR TITLE
fix: fix incorrect .Is() method on update skipped due to backoff error (#4213)

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -437,7 +437,7 @@ func (c *KongClient) maybeSendOutToKonnectClient(ctx context.Context, s *kongsta
 		// In case of an error, we only log it since we don't want the Konnect to affect the basic functionality
 		// of the controller.
 
-		if errors.Is(err, sendconfig.ErrUpdateSkippedDueToBackoffStrategy{}) {
+		if errors.As(err, &sendconfig.UpdateSkippedDueToBackoffStrategyError{}) {
 			c.logger.WithError(err).Warn("Skipped pushing configuration to Konnect")
 		} else {
 			c.logger.WithError(err).Warn("Failed pushing configuration to Konnect")

--- a/internal/dataplane/sendconfig/backoff_strategy.go
+++ b/internal/dataplane/sendconfig/backoff_strategy.go
@@ -2,7 +2,6 @@ package sendconfig
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -11,20 +10,16 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 )
 
-type ErrUpdateSkippedDueToBackoffStrategy struct {
+type UpdateSkippedDueToBackoffStrategyError struct {
 	explanation string
 }
 
-func NewErrUpdateSkippedDueToBackoffStrategy(explanation string) ErrUpdateSkippedDueToBackoffStrategy {
-	return ErrUpdateSkippedDueToBackoffStrategy{explanation: explanation}
+func NewUpdateSkippedDueToBackoffStrategyError(explanation string) UpdateSkippedDueToBackoffStrategyError {
+	return UpdateSkippedDueToBackoffStrategyError{explanation: explanation}
 }
 
-func (e ErrUpdateSkippedDueToBackoffStrategy) Error() string {
+func (e UpdateSkippedDueToBackoffStrategyError) Error() string {
 	return fmt.Sprintf("update skipped due to a backoff strategy not being satisfied: %s", e.explanation)
-}
-
-func (e ErrUpdateSkippedDueToBackoffStrategy) Is(err error) bool {
-	return errors.Is(err, ErrUpdateSkippedDueToBackoffStrategy{})
 }
 
 // UpdateStrategyWithBackoff decorates any UpdateStrategy to respect a passed adminapi.UpdateBackoffStrategy.
@@ -57,7 +52,7 @@ func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent Con
 	resourceErrorsParseErr error,
 ) {
 	if canUpdate, whyNot := s.backoffStrategy.CanUpdate(targetContent.Hash); !canUpdate {
-		return NewErrUpdateSkippedDueToBackoffStrategy(whyNot), nil, nil
+		return NewUpdateSkippedDueToBackoffStrategyError(whyNot), nil, nil
 	}
 
 	err, resourceErrors, resourceErrorsParseErr = s.decorated.Update(ctx, targetContent)

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -82,7 +82,7 @@ func PerformUpdate(
 	metricsProtocol := updateStrategy.MetricsProtocol()
 	if err != nil {
 		// Not pushing metrics in case it's an update skip due to a backoff.
-		if errors.Is(err, ErrUpdateSkippedDueToBackoffStrategy{}) {
+		if errors.As(err, &UpdateSkippedDueToBackoffStrategyError{}) {
 			return nil, []failures.ResourceFailure{}, err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backporting #4213 

No changelog entry. We'll add it in `main` when we release 2.10.1.