### PR TITLE
refactor: use gojson to marshal config for SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@ Adding a new version? You'll need three changes:
   all involved Services, not just Services whose annotation does not match the
   first observed value, as that value is not necessarily the desired value.
   [#4171](https://github.com/Kong/kubernetes-ingress-controller/pull/4171)
+- Use [`gojson`][gojson] for marshalling JSON when generating SHA for config.
+  This should yield some performance benefits during config preparation and
+  sending stage (we've observed around 35% reduced time in config marshalling
+  time but be aware that your mileage may vary).
+  [#4222](https://github.com/Kong/kubernetes-ingress-controller/pull/4222)
+
+[gojson]: https://github.com/goccy/go-json
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/deepmap/oapi-codegen v1.13.0
 	github.com/go-logr/logr v1.2.4
+	github.com/goccy/go-json v0.10.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jpillora/backoff v1.0.0
@@ -60,7 +61,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-containerregistry v0.13.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -2,9 +2,9 @@ package deckgen
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 
+	gojson "github.com/goccy/go-json"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 )
@@ -12,7 +12,7 @@ import (
 // GenerateSHA generates a SHA256 checksum of targetContent, with the purpose
 // of change detection.
 func GenerateSHA(targetContent *file.Content) ([]byte, error) {
-	jsonConfig, err := json.Marshal(targetContent)
+	jsonConfig, err := gojson.Marshal(targetContent)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling Kong declarative configuration to JSON: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use [`gojson`](https://github.com/goccy/go-json) to marshal config to JSON to get config SHA.

This speeds up the marshalling of config to JSON by about 35%, using roughly the same amount of memory and the same amount of memory allocations.

Results (run locally):

```
$ benchstat /tmp/old /tmp/new
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen
                      │  /tmp/old   │              /tmp/new               │
                      │   sec/op    │   sec/op     vs base                │
DeckgenGenerateSHA-10   31.32µ ± 0%   20.25µ ± 1%  -35.36% (p=0.000 n=10)

                      │   /tmp/old   │              /tmp/new               │
                      │     B/op     │     B/op      vs base               │
DeckgenGenerateSHA-10   10.95Ki ± 0%   10.87Ki ± 0%  -0.70% (p=0.000 n=10)

                      │  /tmp/old  │            /tmp/new            │
                      │ allocs/op  │ allocs/op   vs base            │
DeckgenGenerateSHA-10   12.00 ± 0%   12.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

Results can be observed at https://kong.github.io/kubernetes-ingress-controller/dev/bench/ for https://github.com/Kong/kubernetes-ingress-controller/commit/2501474b2cf5eeb4104531811a4b3396c89de588 or at https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5377294841

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
