### PR TITLE
ci: run PR checks on PRs against all branches

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -2,7 +2,7 @@ name: Go Benchmarks
 on:
   push:
     branches:
-    - '*'
+    - '**'
 
 permissions:
   contents: write

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -10,12 +10,13 @@ concurrency:
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
   push:
     branches:
       - 'main'
+      - 'release/[0-9]+.[0-9]+.x'
     tags:
-      - '*'
+      - '**'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

This should fix #4221 since github uses path like matching using `*` and `**` and `release/N.M.x` branches do contain a `/`.

Additionally add a regex filter to run PR checks against pushes on release branches.

**Which issue this PR fixes**:

Fixes #4221.
