### PR TITLE
chore(ci): replace deprecated buildpulse GH Action

### DIFF
--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload test results to BuildPulse for flaky test detection
         if: ${{ !cancelled() }}
-        uses: Workshop64/buildpulse-action@43cb4e7429b9a6d8f882d188062573b7c937de14
+        uses: buildpulse/buildpulse-action@v0.11.0
         with:
           account: 962416
           repository: 127765544


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

GH action [Workshop64/buildpulse-action](https://github.com/BuildPulseLLC/buildpulse-action) is effectively deprecated, has been moved to [buildpulse/buildpulse-action](https://github.com/buildpulse/buildpulse-action), hence this is the recommended way of using it.