### PR TITLE
chore(ci): cleanup orphaned Konnect RGs and roles in cleanup job

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,8 +21,9 @@ jobs:
           go-version: '^1.20'
 
       - name: cleanup orphaned test clusters
-        run: go run hack/cleanup_gke_clusters.go
+        run: go run hack/cleanup
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}

--- a/hack/cleanup/gke_clusters.go
+++ b/hack/cleanup/gke_clusters.go
@@ -1,25 +1,14 @@
-// This script cleans up all GKE clusters that could be potentially
-// orphaned by our tests (e.g. unexpected crash that didn't allow
-// a test's teardown to be completed correctly). It's meant to be
-// installed as a cronjob and run repeatedly throughout the day to
-// catch any orphaned clusters: however tests should be trying to
-// delete the clusters they create themselves.
-//
-// A cluster is considered orphaned when all conditions are satisfied:
-// 1. Its name begins with a predefined prefix (`gke-e2e-`).
-// 2. It was created more than 1h ago.
 package main
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	container "cloud.google.com/go/container/apiv1"
 	"cloud.google.com/go/container/apiv1/containerpb"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"google.golang.org/api/option"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test/e2e"
@@ -27,51 +16,33 @@ import (
 
 const timeUntilClusterOrphaned = time.Hour
 
-var (
-	gkeCreds    = os.Getenv(gke.GKECredsVar)
-	gkeProject  = os.Getenv(gke.GKEProjectVar)
-	gkeLocation = os.Getenv(gke.GKELocationVar)
-)
-
-func main() {
-	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
-	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
-	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)
-
+func cleanupGKEClusters(ctx context.Context) error {
 	var creds map[string]string
 	if err := json.Unmarshal([]byte(gkeCreds), &creds); err != nil {
-		fmt.Fprintf(os.Stderr, "invalid credentials: %s\n", err)
-		os.Exit(10)
-	}
-
-	if len(os.Args) < 1 {
-		fmt.Fprintln(os.Stdout, "Usage: cleanup all | <list of cluster names...>")
-		os.Exit(1)
+		return fmt.Errorf("invalid credentials: %w", err)
 	}
 
 	credsOpt := option.WithCredentialsJSON([]byte(gkeCreds))
-	mgrc, err := container.NewClusterManagerClient(context.Background(), credsOpt)
+	mgrc, err := container.NewClusterManagerClient(ctx, credsOpt)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create cluster manager client: %s", err)
-		os.Exit(2)
+		return fmt.Errorf("failed to create cluster manager client: %w", err)
 	}
 	defer mgrc.Close()
 
-	clusterNames, err := findOrphanedClusters(context.Background(), mgrc)
+	clusterNames, err := findOrphanedClusters(ctx, mgrc)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not find orphaned clusters: %s", err)
-		os.Exit(2)
+		return fmt.Errorf("could not find orphaned clusters: %w", err)
 	}
 
 	if len(clusterNames) < 1 {
-		fmt.Println("INFO: no clusters to clean up")
-		os.Exit(0)
+		log.Info("no clusters to clean up")
+		return nil
 	}
 
 	var errs []error
 	for _, clusterName := range clusterNames {
-		fmt.Printf("INFO: cleaning up cluster %s\n", clusterName)
-		err := deleteCluster(context.Background(), mgrc, gkeProject, gkeLocation, clusterName)
+		log.Infof("cleaning up cluster %s\n", clusterName)
+		err := deleteCluster(ctx, mgrc, gkeProject, gkeLocation, clusterName)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -79,15 +50,10 @@ func main() {
 	}
 
 	if len(errs) > 0 {
-		fmt.Fprintf(os.Stderr, "failed to cleanup all clusters: %v\n", errs)
-		os.Exit(3)
+		return fmt.Errorf("failed to cleanup all clusters: %w", errors.Join(errs...))
 	}
-}
 
-func mustNotBeEmpty(name, value string) {
-	if value == "" {
-		panic(fmt.Sprintf("%s was empty", name))
-	}
+	return nil
 }
 
 func deleteCluster(ctx context.Context, mgrc *container.ClusterManagerClient, project, location, name string) error {
@@ -124,7 +90,7 @@ func findOrphanedClusters(ctx context.Context, mgrc *container.ClusterManagerCli
 			if time.Now().UTC().After(orphanTime) {
 				orphanedClusterNames = append(orphanedClusterNames, cluster.Name)
 			} else {
-				fmt.Printf("INFO: cluster %s skipped (built in the last %s)\n", cluster.Name, timeUntilClusterOrphaned)
+				log.Infof("cluster %s skipped (built in the last %s)\n", cluster.Name, timeUntilClusterOrphaned)
 			}
 		}
 	}

--- a/hack/cleanup/konnect_runtime_groups.go
+++ b/hack/cleanup/konnect_runtime_groups.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/samber/lo"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/roles"
+	rg "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroups"
+)
+
+const (
+	konnectRuntimeGroupsBaseURL     = "https://us.kic.api.konghq.tech/v2"
+	konnectRuntimeGroupsLimit       = 100
+	konnectRolesBaseURL             = "https://global.api.konghq.tech/v2"
+	createdInTestsRuntimeGroupLabel = "created_in_tests"
+	timeUntilRuntimeGroupOrphaned   = time.Hour
+)
+
+// cleanupKonnectRuntimeGroups deletes orphaned runtime groups created by the tests and their roles.
+func cleanupKonnectRuntimeGroups(ctx context.Context) error {
+	rgClient, err := rg.NewClientWithResponses(konnectRuntimeGroupsBaseURL, rg.WithRequestEditorFn(
+		func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
+			return nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create runtime groups client: %w", err)
+	}
+
+	orphanedRGs, err := findOrphanedRuntimeGroups(ctx, rgClient)
+	if err != nil {
+		return fmt.Errorf("failed to find orphaned runtime groups: %w", err)
+	}
+	if err := deleteRuntimeGroups(ctx, orphanedRGs, rgClient); err != nil {
+		return fmt.Errorf("failed to delete runtime groups: %w", err)
+	}
+
+	// We have to manually delete roles created for the runtime group because Konnect doesn't do it automatically.
+	// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
+	// because of a performance issue when there's too many roles for the account
+	// (see https://konghq.atlassian.net/browse/TPS-1319).
+	//
+	// We can drop this once the automated cleanup is implemented on Konnect side:
+	// https://konghq.atlassian.net/browse/TPS-1453.
+	rolesClient := roles.NewClient(&http.Client{}, konnectRolesBaseURL, konnectAccessToken)
+	rolesToDelete, err := findOrphanedRolesToDelete(ctx, orphanedRGs, rolesClient)
+	if err != nil {
+		return fmt.Errorf("failed to list runtime group roles to delete: %w", err)
+	}
+	if err := deleteRoles(ctx, rolesToDelete, rolesClient); err != nil {
+		return fmt.Errorf("failed to delete runtime group roles: %w", err)
+	}
+
+	return nil
+}
+
+// findOrphanedRuntimeGroups finds runtime groups that were created by the tests and are older than timeUntilRuntimeGroupOrphaned.
+func findOrphanedRuntimeGroups(ctx context.Context, c *rg.ClientWithResponses) ([]types.UUID, error) {
+	response, err := c.ListRuntimeGroupsWithResponse(ctx, &rg.ListRuntimeGroupsParams{
+		PageSize: lo.ToPtr(konnectRuntimeGroupsLimit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list runtime groups: %w", err)
+	}
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("failed to list runtime groups, status: %s, body: %s", response.Status(), string(response.Body))
+	}
+	if response.JSON200 == nil || response.JSON200.Data == nil {
+		return nil, fmt.Errorf("no data in the response, status: %s, body: %s", response.Status(), string(response.Body))
+	}
+
+	var orphanedRuntimeGroups []types.UUID
+	for _, runtimeGroup := range *response.JSON200.Data {
+		if runtimeGroup.Labels == nil || (*runtimeGroup.Labels)[createdInTestsRuntimeGroupLabel] != "true" {
+			log.Infof("runtime group %s was not created by the tests, skipping\n", *runtimeGroup.Name)
+			continue
+		}
+		if runtimeGroup.CreatedAt == nil {
+			log.Infof("runtime group %s has no creation timestamp, skipping\n", *runtimeGroup.Name)
+			continue
+		}
+		orphanedAfter := (*runtimeGroup.CreatedAt).Add(timeUntilRuntimeGroupOrphaned)
+		if !time.Now().After(orphanedAfter) {
+			log.Infof("runtime group %s is not old enough to be considered orphaned, created at %s, skipping\n", *runtimeGroup.Name, *runtimeGroup.CreatedAt)
+			continue
+		}
+		orphanedRuntimeGroups = append(orphanedRuntimeGroups, *runtimeGroup.Id)
+	}
+	return orphanedRuntimeGroups, nil
+}
+
+// deleteRuntimeGroups deletes runtime groups by their IDs.
+func deleteRuntimeGroups(ctx context.Context, rgsIDs []types.UUID, c *rg.ClientWithResponses) error {
+	if len(rgsIDs) < 1 {
+		log.Info("no runtime groups to clean up")
+		return nil
+	}
+
+	var errs []error
+	for _, rgID := range rgsIDs {
+		log.Infof("deleting runtime group %s\n", rgID)
+		if _, err := c.DeleteRuntimeGroupWithResponse(ctx, rgID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete runtime group %s: %w", rgID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// findOrphanedRolesToDelete gets a list of roles that belong to the orphaned runtime groups.
+func findOrphanedRolesToDelete(ctx context.Context, orphanedRGsIDs []types.UUID, rolesClient *roles.Client) ([]string, error) {
+	if len(orphanedRGsIDs) < 1 {
+		log.Info("no runtime groups to clean up, skipping listing roles")
+		return nil, nil
+	}
+
+	existingRoles, err := rolesClient.ListRuntimeGroupsRoles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list runtime group roles: %w", err)
+	}
+
+	var rolesIDsToDelete []string
+	for _, role := range existingRoles {
+		belongsToOrphanedRuntimeGroup := lo.ContainsBy(orphanedRGsIDs, func(rgID types.UUID) bool {
+			return rgID.String() == role.EntityID
+		})
+		if !belongsToOrphanedRuntimeGroup {
+			log.Infof("role %s is not assigned to an orphaned runtime group, skipping\n", role.ID)
+			continue
+		}
+		rolesIDsToDelete = append(rolesIDsToDelete, role.ID)
+	}
+	return rolesIDsToDelete, nil
+}
+
+// deleteRoles deletes roles by their IDs.
+func deleteRoles(ctx context.Context, rolesIDsToDelete []string, rolesClient *roles.Client) error {
+	if len(rolesIDsToDelete) == 0 {
+		log.Info("no roles to delete")
+		return nil
+	}
+
+	var errs []error
+	for _, roleID := range rolesIDsToDelete {
+		log.Infof("deleting role %s\n", roleID)
+		if err := rolesClient.DeleteRole(ctx, roleID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete role %s: %w", roleID, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -1,0 +1,64 @@
+// This script cleans up orphaned GKE clusters and Konnect runtime
+// groups that were created by the e2e tests (caued by e.g. unexpected
+// crash that didn't allow a test's teardown to be completed correctly).
+// It's meant to be installed as a cronjob and run repeatedly throughout
+// the day to catch any orphaned resources: however tests should be trying to
+// delete the resources they create themselves.
+//
+// A cluster is considered orphaned when all conditions are satisfied:
+// 1. Its name begins with a predefined prefix (`gke-e2e-`).
+// 2. It was created more than 1h ago.
+//
+// A runtime group is considered orphaned when all conditions are satisfied:
+// 1. It has a label `created_in_tests` with value `true`.
+// 2. It was created more than 1h ago.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	konnectAccessTokenVar = "TEST_KONG_KONNECT_ACCESS_TOKEN" //nolint:gosec
+)
+
+var (
+	gkeCreds           = os.Getenv(gke.GKECredsVar)
+	gkeProject         = os.Getenv(gke.GKEProjectVar)
+	gkeLocation        = os.Getenv(gke.GKELocationVar)
+	konnectAccessToken = os.Getenv(konnectAccessTokenVar)
+	log                = logrus.New()
+)
+
+func main() {
+	validateVars()
+
+	ctx := context.Background()
+	if err := cleanupGKEClusters(ctx); err != nil {
+		log.Errorf("error cleaning up GKE clusters: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := cleanupKonnectRuntimeGroups(ctx); err != nil {
+		log.Errorf("error cleaning up Konnect runtime groups: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func validateVars() {
+	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
+	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
+	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)
+	mustNotBeEmpty(konnectAccessTokenVar, konnectAccessToken)
+}
+
+func mustNotBeEmpty(name, value string) {
+	if value == "" {
+		panic(fmt.Sprintf("%s was empty", name))
+	}
+}

--- a/internal/konnect/roles/client.go
+++ b/internal/konnect/roles/client.go
@@ -1,0 +1,164 @@
+package roles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	konnectUsersMeURL            = "/users/me"
+	konnectUsersAssignedRolesURL = "/users/%s/assigned-roles?filter%%5Bentity_type_name%%5D=Runtime+Groups"
+	konnectAssignedRoleURL       = "/users/%s/assigned-roles/%s"
+)
+
+type Client struct {
+	httpClient          *http.Client
+	personalAccessToken string
+	currentUserID       string
+	baseURL             string
+}
+
+type Role struct {
+	// ID is the role ID.
+	ID string
+
+	// EntityID is the ID of the entity the role is assigned to (e.g. Runtime Group).
+	EntityID string
+}
+
+func NewRole(id, entityID string) (Role, error) {
+	if id == "" {
+		return Role{}, fmt.Errorf("role ID is required")
+	}
+	if entityID == "" {
+		return Role{}, fmt.Errorf("entity ID is required")
+	}
+	return Role{
+		ID:       id,
+		EntityID: entityID,
+	}, nil
+}
+
+func NewClient(httpClient *http.Client, baseURL string, personalAccessToken string) *Client {
+	return &Client{
+		baseURL:             baseURL,
+		httpClient:          httpClient,
+		personalAccessToken: personalAccessToken,
+	}
+}
+
+// ListRuntimeGroupsRoles lists all roles assigned to the current user for Runtime Groups.
+func (c *Client) ListRuntimeGroupsRoles(ctx context.Context) ([]Role, error) {
+	currentUserID, err := c.getCurrentUserID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user ID: %w", err)
+	}
+
+	listRolesURL := fmt.Sprintf(konnectUsersAssignedRolesURL, currentUserID)
+	req, err := c.newRequestWithAuth(ctx, http.MethodGet, listRolesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list roles: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list roles, status: %s", resp.Status)
+	}
+
+	var rolesResponse struct {
+		Data []struct {
+			ID       string `json:"id"`
+			EntityID string `json:"entity_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rolesResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode roles response: %w", err)
+	}
+
+	var roles []Role
+	for _, role := range rolesResponse.Data {
+		r, err := NewRole(role.ID, role.EntityID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create role: %w", err)
+		}
+		roles = append(roles, r)
+	}
+
+	return roles, nil
+}
+
+// DeleteRole deletes a role assigned to the current user.
+func (c *Client) DeleteRole(ctx context.Context, roleID string) error {
+	currentUserID, err := c.getCurrentUserID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current user ID: %w", err)
+	}
+
+	deleteRoleURL := fmt.Sprintf(konnectAssignedRoleURL, currentUserID, roleID)
+	req, err := c.newRequestWithAuth(ctx, http.MethodDelete, deleteRoleURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete role %s: %w", roleID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to delete role %s, status: %s", roleID, resp.Status)
+	}
+
+	return nil
+}
+
+func (c *Client) getCurrentUserID(ctx context.Context) (string, error) {
+	// It's already cached, no need to make a request.
+	if c.currentUserID != "" {
+		return c.currentUserID, nil
+	}
+
+	meRequest, err := c.newRequestWithAuth(ctx, http.MethodGet, konnectUsersMeURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	meResponse, err := c.httpClient.Do(meRequest)
+	if err != nil {
+		return "", fmt.Errorf("failed to get current user: %w", err)
+	}
+	defer meResponse.Body.Close()
+	if meResponse.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get current user, status: %s", meResponse.Status)
+	}
+
+	var meResponseData struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(meResponse.Body).Decode(&meResponseData); err != nil {
+		return "", fmt.Errorf("failed to decode current user response: %w", err)
+	}
+
+	if meResponseData.ID == "" {
+		return "", fmt.Errorf("failed to get current user, empty id")
+	}
+
+	c.currentUserID = meResponseData.ID
+	return meResponseData.ID, nil
+}
+
+func (c *Client) newRequestWithAuth(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.personalAccessToken)
+	return req, nil
+}

--- a/internal/konnect/roles/client_test.go
+++ b/internal/konnect/roles/client_test.go
@@ -1,0 +1,99 @@
+package roles_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/roles"
+)
+
+const (
+	currentUserID = "515d12f2-aab2-42b3-a093-6ad793c0c7ab"
+	testToken     = "test-token"
+)
+
+func newMockRolesServer(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+
+	requireToken := func(r *http.Request) {
+		token := r.Header.Get("Authorization")
+		require.Equal(t, "Bearer "+testToken, token)
+	}
+
+	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
+		requireToken(r)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`
+		{
+		   "id": "515d12f2-aab2-42b3-a093-6ad793c0c7ab",
+		   "email": "team-k8s+konnect-testing-2@konghq.com",
+		   "full_name": "Kubernetes Team",
+		   "preferred_name": "",
+		   "active": true,
+		   "created_at": "2023-06-26T12:16:08Z",
+		   "updated_at": "2023-06-26T12:16:28Z"
+		}`))
+	})
+
+	mux.HandleFunc("/users/"+currentUserID+"/assigned-roles/", func(w http.ResponseWriter, r *http.Request) {
+		requireToken(r)
+
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`
+		{
+		   "meta": {
+		       "page": {
+		           "number": 1,
+		           "size": 10,
+		           "total": 2
+		       }
+		   },
+		   "data": [
+		       {
+		           "id": "24ac168d-4ffb-46ec-8dd6-5a26b5ec6f0b",
+		           "role_name": "Admin",
+		           "entity_region": "us",
+		           "entity_type_name": "Runtime Groups",
+		           "entity_id": "e3f155ec-1786-4017-98d0-b0a0f5e179c3"
+		       },
+		       {
+		           "id": "7edaf68b-8f07-4827-b540-fce06e45429e",
+		           "role_name": "Admin",
+		           "entity_region": "us",
+		           "entity_type_name": "Runtime Groups",
+		           "entity_id": "c486f518-9fc8-461f-af0a-2bc85b70e492"
+		       }
+		   ]
+		}`))
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestRolesClient(t *testing.T) {
+	ctx := context.Background()
+	server := newMockRolesServer(t)
+	c := roles.NewClient(&http.Client{}, server.URL, testToken)
+
+	rgRoles, err := c.ListRuntimeGroupsRoles(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rgRoles))
+	role := rgRoles[0]
+	require.Equal(t, "24ac168d-4ffb-46ec-8dd6-5a26b5ec6f0b", role.ID)
+	require.Equal(t, "e3f155ec-1786-4017-98d0-b0a0f5e179c3", role.EntityID)
+
+	err = c.DeleteRole(ctx, "24ac168d-4ffb-46ec-8dd6-5a26b5ec6f0b")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the cleanup workflow by adding a step in the script removing orphaned Konnect runtime groups and roles created for them (to ensure we do not hit the issue with degraded performance and unreliable APIs when we have too many orphaned roles). Also adds the roles removal step to the cleanup function in E2E tests.

**Which issue this PR fixes**:

Fix #4225.
