### PR TITLE
chore(release): bump test dependencies

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -72,9 +72,9 @@ jobs:
         name: Set Kind versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.13\", \"1.25.9\", \"1.26.4\", \"1.27.2\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.22\", \"1.23\", \"1.24\", \"1.25\", \"1.26\", \"1.27\"]" >> $GITHUB_OUTPUT
           else
-            echo "kind-versions=[\"1.27.2\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.27\"]" >> $GITHUB_OUTPUT
           fi
   kind:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.25.5'
+          - 'v1.25'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: checkout repository
@@ -222,15 +222,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # K8s v1.27.2 is not officially supported by Istio v1.17.2, but we want to test it anyway.
-          - kubernetes-version: 'v1.27.2'
-            istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.26.4'
-            istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.25.9'
-            istio-version: 'v1.16.5'
-          - kubernetes-version: 'v1.25.9'
-            istio-version: 'v1.15.7'
+          - kubernetes-version: 'v1.27'
+            istio-version: 'v1.18'
+          - kubernetes-version: 'v1.26'
+            istio-version: 'v1.17'
+          - kubernetes-version: 'v1.25'
+            istio-version: 'v1.16'
+          - kubernetes-version: 'v1.25'
+            istio-version: 'v1.15'
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     env:
-      KONG_CLUSTER_VERSION: 'v1.27.1'
+      KONG_CLUSTER_VERSION: 'v1.27'
       TEST_KONG_ROUTER_FLAVOR: 'traditional'
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,12 +133,12 @@ jobs:
       fail-fast: true
       matrix:
         kubernetes-version:
-          - 'v1.22.15'
-          - 'v1.23.13'
-          - 'v1.24.13'
-          - 'v1.25.9'
-          - 'v1.26.4'
-          - 'v1.27.2'
+          - 'v1.22'
+          - 'v1.23'
+          - 'v1.24'
+          - 'v1.25'
+          - 'v1.26'
+          - 'v1.27'
     steps:
       - name: checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump test dependencies for 2.10.1 release.

**Which issue this PR fixes**:

Part of #4227.