### PR TITLE
[backport] chore(release): add 2.10.1 entry to the changelog (#4228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
+ - [2.10.1](#2101)
  - [2.10.0](#2100)
  - [2.9.3](#293)
  - [2.9.2](#292)
@@ -67,7 +68,22 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
-## Unreleased
+## [2.10.1]
+
+> Release date: 2023-06-27
+
+### Added
+
+- `--konnect-initial-license-polling-period` and `--konnect-license-polling-period`
+  CLI flags were added to allow configuring periods at which KIC polls license
+  from Konnect. The initial period will be used until a valid license is retrieved.
+  The default values are 1m and 12h respectively.
+  [#4178](https://github.com/Kong/kubernetes-ingress-controller/pull/4178)
+
+### Fixed
+
+- Fix KIC crash which occurred when invalid config was applied in DB mode.
+  [#4213](https://github.com/Kong/kubernetes-ingress-controller/pull/4213)
 
 ## [2.10.0]
 
@@ -2501,6 +2517,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.10.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.3...v2.10.0
 [2.9.3]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.2...v2.9.3
 [2.9.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.9.1...v2.9.2


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #4228 to `release/2.10.x` branch. 

