### PR TITLE
chore: bump test dependencies

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -72,9 +72,9 @@ jobs:
         name: Set Kind versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.22.15\", \"1.23.13\", \"1.24.13\", \"1.25.9\", \"1.26.4\", \"1.27.2\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.22.17\", \"1.23.17\", \"1.24.15\", \"1.25.11\", \"1.26.6\", \"1.27.3\"]" >> $GITHUB_OUTPUT
           else
-            echo "kind-versions=[\"1.27.2\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.27.3\"]" >> $GITHUB_OUTPUT
           fi
   kind:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 'v1.25.5'
+          - 'v1.26.5'
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: checkout repository
@@ -222,15 +222,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # K8s v1.27.2 is not officially supported by Istio v1.17.2, but we want to test it anyway.
-          - kubernetes-version: 'v1.27.2'
-            istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.26.4'
-            istio-version: 'v1.17.2'
-          - kubernetes-version: 'v1.25.9'
-            istio-version: 'v1.16.5'
-          - kubernetes-version: 'v1.25.9'
-            istio-version: 'v1.15.7'
+          - kubernetes-version: 'v1.27.3'
+            istio-version: 'v1.18'
+          - kubernetes-version: 'v1.26.6'
+            istio-version: 'v1.17'
+          - kubernetes-version: 'v1.25.11'
+            istio-version: 'v1.16'
+          - kubernetes-version: 'v1.25.11'
+            istio-version: 'v1.15'
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     env:
-      KONG_CLUSTER_VERSION: 'v1.27.1'
+      KONG_CLUSTER_VERSION: 'v1.27.3'
       TEST_KONG_ROUTER_FLAVOR: 'traditional'
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,12 +134,12 @@ jobs:
       fail-fast: true
       matrix:
         kubernetes-version:
-          - 'v1.22.15'
-          - 'v1.23.13'
-          - 'v1.24.13'
-          - 'v1.25.9'
-          - 'v1.26.4'
-          - 'v1.27.2'
+          - 'v1.22.17'
+          - 'v1.23.17'
+          - 'v1.24.15'
+          - 'v1.25.11'
+          - 'v1.26.6'
+          - 'v1.27.3'
     steps:
       - name: checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps:
- Istio to v1.18 (which now officially supports K8s v1.27) 
- Kind's patch versions
- GKE version to v1.26.5 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4227.