### PR TITLE
chore(release): bump KIC version in manifests

### DIFF
--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '3.3'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.10.0'
+  newTag: '2.10.1'

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -1668,7 +1668,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1668,7 +1668,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -1683,7 +1683,7 @@ spec:
         envFrom:
         - configMapRef:
             name: konnect-config
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -1683,7 +1683,7 @@ spec:
         envFrom:
         - configMapRef:
             name: konnect-config
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -1716,7 +1716,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1668,7 +1668,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1790,7 +1790,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1734,7 +1734,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.10.0
+        image: kong/kubernetes-ingress-controller:2.10.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps KIC version to 2.10.1 in all-in-one manifests.

**Which issue this PR fixes**:

Part of #4227 