### PR TITLE
fix: do not prepend ~ before regex paths for Kong < 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ Adding a new version? You'll need three changes:
   time but be aware that your mileage may vary).
   [#4222](https://github.com/Kong/kubernetes-ingress-controller/pull/4222)
 
+### Fixed
+
+- Translator of `GRPCRoute` generates paths without leading `~` when running
+  with Kong gateway with version below 3.0.
+  [#4238](https://github.com/Kong/kubernetes-ingress-controller/pull/4238)
+
 [gojson]: https://github.com/goccy/go-json
 
 ## [2.10.1]

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
@@ -1,0 +1,42 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.0
+  name: grpcroute.default.grpcbin.0
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    name: grpcroute.default.grpcbin.0.0
+    path_handling: v0
+    paths:
+    - ~/grpcbin.GRPCBin/DummyUnary
+    protocols:
+    - grpc
+    - grpcs
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.0
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/in.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GRPCRoute
+metadata:
+  name: grpcbin
+  namespace: default
+spec:
+  parentRefs:
+  - name: kong
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: grpcbin
+      port: 443
+    matches:
+    - method:
+        service: "grpcbin.GRPCBin"
+        method: "DummyUnary"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpcbin
+  namespace: default
+  labels:
+    app: grpcbin
+spec:
+  ports:
+  - name: grpc
+    port: 443
+    targetPort: 9001
+  selector:
+    app: grpcbin

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
@@ -1,0 +1,42 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.0
+  name: grpcroute.default.grpcbin.0
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    name: grpcroute.default.grpcbin.0.0
+    path_handling: v0
+    paths:
+    - /grpcbin.GRPCBin/DummyUnary
+    protocols:
+    - grpc
+    - grpcs
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.0
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  RegexPathPrefix: false

--- a/internal/dataplane/parser/translate_grpcroute.go
+++ b/internal/dataplane/parser/translate_grpcroute.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -63,8 +62,7 @@ func (p *Parser) ingressRulesFromGRPCRoute(result *ingressRules, grpcroute *gate
 		if p.featureFlags.ExpressionRoutes {
 			routes = translators.GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute, ruleNumber)
 		} else {
-			prependRegexPrefix := p.kongVersion.GTE(versions.ExplicitRegexPathVersionCutoff)
-			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber, prependRegexPrefix)
+			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber, p.featureFlags.RegexPathPrefix)
 		}
 
 		// create a service and attach the routes to it

--- a/internal/dataplane/parser/translate_grpcroute.go
+++ b/internal/dataplane/parser/translate_grpcroute.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -62,7 +63,8 @@ func (p *Parser) ingressRulesFromGRPCRoute(result *ingressRules, grpcroute *gate
 		if p.featureFlags.ExpressionRoutes {
 			routes = translators.GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute, ruleNumber)
 		} else {
-			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber)
+			prependRegexPrefix := p.kongVersion.GTE(versions.ExplicitRegexPathVersionCutoff)
+			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber, prependRegexPrefix)
 		}
 
 		// create a service and attach the routes to it

--- a/internal/dataplane/parser/translators/grpcroute_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_test.go
@@ -196,7 +196,7 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayv1alpha2.GRPCRouteRule{tc.rule})
-			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0)
+			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, true)
 			require.Equal(t, tc.expectedRoutes, routes)
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Do not add `~` prefix on paths generated from GRPCRoutes if kong version < 3.0 to generate correct Kong config.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4237 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Question: Do we need to backport it to 2.10/2.9?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR 
