### PR TITLE
tests: add UT ensuring synchronizer.IsReady is not blocking

### DIFF
--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -88,8 +88,6 @@ func NewSynchronizer(logger logrus.FieldLogger, client Client, opts ...Synchroni
 		opt(synchronizer)
 	}
 
-	synchronizer.dbMode = client.DBMode()
-
 	return synchronizer, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a unit test ensuring that `Synchronizer.IsReady` call is not blocking when `dataplaneClient`'s calls are blocked.

It covers a [bug](https://github.com/Kong/kubernetes-ingress-controller/issues/3876) that was fixed as a side-effect of https://github.com/Kong/kubernetes-ingress-controller/pull/3267. It's effectively fixed since 2.8.0 release.

