### PR TITLE
chore(ci): mark as failure notifications from e2e nightly tests

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -51,6 +51,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          status: ${{ job.status }}
+          # Since notify-on-slack is triggered on failure (if statement), we can hardcode this.
+          status: failure
           fields: repo,message,commit,author,action,eventName,ref,workflow
           text: 'E2E tests failed for nightly run, please check why.'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Message on Slack does not use a template (red color, etc.) for failure events, because to the field status current
`${{ job.status }}` is assigned that is always `success`. The whole job is triggered on `failue` of previous jobs (the `if` statement ensures it), so it should be hardcoded to `failure`. 

