### PR TITLE
chore(ci): make running gke/konnect cleanup separately possible

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -14,16 +14,29 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: setup golang
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-
       - name: cleanup orphaned test clusters
-        run: go run ./hack/cleanup
+        run: go run ./hack/cleanup gcloud
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+
+  konnect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
+      - name: cleanup orphaned test clusters
+        run: go run ./hack/cleanup konnect
+        env:
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -12,6 +12,12 @@
 // A runtime group is considered orphaned when all conditions are satisfied:
 // 1. It has a label `created_in_tests` with value `true`.
 // 2. It was created more than 1h ago.
+//
+// Usage: `go run ./hack/cleanup [mode]`
+// Where `mode` is one of:
+// - `all` (default): clean up both GKE clusters and Konnect runtime groups
+// - `gke`: clean up only GKE clusters
+// - `konnect`: clean up only Konnect runtime groups
 package main
 
 import (
@@ -25,6 +31,10 @@ import (
 
 const (
 	konnectAccessTokenVar = "TEST_KONG_KONNECT_ACCESS_TOKEN" //nolint:gosec
+
+	cleanupModeAll     = "all"
+	cleanupModeGKE     = "gke"
+	cleanupModeKonnect = "konnect"
 )
 
 var (
@@ -36,29 +46,94 @@ var (
 )
 
 func main() {
-	validateVars()
+	mode, err := getCleanupMode()
+	if err != nil {
+		log.Errorf("error getting cleanup mode: %v\n", err)
+		os.Exit(1)
+	}
 
+	if err := validateVars(mode); err != nil {
+		log.Errorf("error validating vars: %v\n", err)
+		os.Exit(1)
+	}
+
+	cleanupFuncs := resolveCleanupFuncs(mode)
 	ctx := context.Background()
-	if err := cleanupGKEClusters(ctx); err != nil {
-		log.Errorf("error cleaning up GKE clusters: %v\n", err)
-		os.Exit(1)
-	}
-
-	if err := cleanupKonnectRuntimeGroups(ctx); err != nil {
-		log.Errorf("error cleaning up Konnect runtime groups: %v\n", err)
-		os.Exit(1)
+	for _, f := range cleanupFuncs {
+		if err := f(ctx); err != nil {
+			log.Errorf("error running cleanup function: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 
-func validateVars() {
-	mustNotBeEmpty(gke.GKECredsVar, gkeCreds)
-	mustNotBeEmpty(gke.GKEProjectVar, gkeProject)
-	mustNotBeEmpty(gke.GKELocationVar, gkeLocation)
-	mustNotBeEmpty(konnectAccessTokenVar, konnectAccessToken)
+func getCleanupMode() (string, error) {
+	if len(os.Args) < 2 {
+		return cleanupModeAll, nil
+	}
+
+	switch os.Args[1] {
+	case cleanupModeGKE:
+	case cleanupModeKonnect:
+	default:
+		return "", fmt.Errorf("invalid cleanup mode: %s", os.Args[1])
+	}
+
+	return os.Args[1], nil
 }
 
-func mustNotBeEmpty(name, value string) {
+func resolveCleanupFuncs(mode string) []func(context.Context) error {
+	switch mode {
+	case cleanupModeGKE:
+		return []func(context.Context) error{
+			cleanupGKEClusters,
+		}
+	case cleanupModeKonnect:
+		return []func(context.Context) error{
+			cleanupKonnectRuntimeGroups,
+		}
+	default:
+		return []func(context.Context) error{
+			cleanupGKEClusters,
+			cleanupKonnectRuntimeGroups,
+		}
+	}
+}
+
+func validateVars(mode string) error {
+	switch mode {
+	case cleanupModeGKE:
+		return validateGKEVars()
+	case cleanupModeKonnect:
+		return validateKonnectVars()
+	default:
+		if err := validateGKEVars(); err != nil {
+			return err
+		}
+		if err := validateKonnectVars(); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func validateKonnectVars() error {
+	return notEmpty(konnectAccessTokenVar, konnectAccessToken)
+}
+
+func validateGKEVars() error {
+	if err := notEmpty(gke.GKECredsVar, gkeCreds); err != nil {
+		return err
+	}
+	if err := notEmpty(gke.GKEProjectVar, gkeProject); err != nil {
+		return err
+	}
+	return notEmpty(gke.GKELocationVar, gkeLocation)
+}
+
+func notEmpty(name, value string) error {
 	if value == "" {
-		panic(fmt.Sprintf("%s was empty", name))
+		return fmt.Errorf("%s was empty", name)
 	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes it possible to run the cleanup script in  `gke`, `konnect`, or `all` mode. Also splits the cleanup job into two separate jobs for `gke` and `konnect`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


