### PR TITLE
chore(ci): ensure nightly image is built in nightly e2e

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -6,7 +6,14 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  ensure-nightly-image-was-built:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if image built this night exists
+        run: docker pull kong/nightly-ingress-controller:$(date +%Y-%m-%d)
+
   e2e-tests:
+    needs: ensure-nightly-image-was-built
     uses: ./.github/workflows/_e2e_tests.yaml
     secrets: inherit
     with:
@@ -16,6 +23,7 @@ jobs:
       run-istio: true
 
   e2e-tests-unreleased-kong:
+    needs: ensure-nightly-image-was-built
     uses: ./.github/workflows/_e2e_tests.yaml
     secrets: inherit
     with:
@@ -41,6 +49,7 @@ jobs:
   notify-on-slack:
     runs-on: ubuntu-latest
     needs:
+      - ensure-nightly-image-was-built
       - e2e-tests
       - e2e-tests-unreleased-kong
       - test-reports


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that a nightly image for a current day exists in the nightly e2e workflow.

CI run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5413037620/jobs/9838008102

**Which issue this PR fixes**:

To avoid situations like #4251. 
