### PR TITLE
chore(ci): fix gke cleanup

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: '^1.20'
       - name: cleanup orphaned test clusters
-        run: go run ./hack/cleanup gcloud
+        run: go run ./hack/cleanup gke
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use proper `gke` `./hack/cleanup` script's argument.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5413757425/jobs/9839795934
