### PR TITLE
[Backport release/2.10.x] Backport #4238 to 2.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
+ - [2.10.2](#2102)
  - [2.10.1](#2101)
  - [2.10.0](#2100)
  - [2.9.3](#293)
@@ -67,6 +68,16 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [2.10.2]
+
+> Release date: TBD
+
+### Fixed
+
+- Translator of `GRPCRoute` generates paths without leading `~` when running
+  with Kong gateway with version below 3.0.
+  [#4238](https://github.com/Kong/kubernetes-ingress-controller/pull/4238)
 
 ## [2.10.1]
 

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
@@ -1,0 +1,42 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.0
+  name: grpcroute.default.grpcbin.0
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    name: grpcroute.default.grpcbin.0.0
+    path_handling: v0
+    paths:
+    - ~/grpcbin.GRPCBin/DummyUnary
+    protocols:
+    - grpc
+    - grpcs
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.0
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/in.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GRPCRoute
+metadata:
+  name: grpcbin
+  namespace: default
+spec:
+  parentRefs:
+  - name: kong
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: grpcbin
+      port: 443
+    matches:
+    - method:
+        service: "grpcbin.GRPCBin"
+        method: "DummyUnary"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpcbin
+  namespace: default
+  labels:
+    app: grpcbin
+spec:
+  ports:
+  - name: grpc
+    port: 443
+    targetPort: 9001
+  selector:
+    app: grpcbin

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
@@ -1,0 +1,42 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.0
+  name: grpcroute.default.grpcbin.0
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    name: grpcroute.default.grpcbin.0.0
+    path_handling: v0
+    paths:
+    - /grpcbin.GRPCBin/DummyUnary
+    protocols:
+    - grpc
+    - grpcs
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.0
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  RegexPathPrefix: false

--- a/internal/dataplane/parser/translate_grpcroute.go
+++ b/internal/dataplane/parser/translate_grpcroute.go
@@ -62,7 +62,7 @@ func (p *Parser) ingressRulesFromGRPCRoute(result *ingressRules, grpcroute *gate
 		if p.featureFlags.ExpressionRoutes {
 			routes = translators.GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute, ruleNumber)
 		} else {
-			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber)
+			routes = translators.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber, p.featureFlags.RegexPathPrefix)
 		}
 
 		// create a service and attach the routes to it

--- a/internal/dataplane/parser/translators/grpcroute_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_test.go
@@ -47,12 +47,13 @@ func makeTestGRPCRoute(
 
 func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 	testCases := []struct {
-		name           string
-		objectName     string
-		annotations    map[string]string
-		hostnames      []string
-		rule           gatewayv1alpha2.GRPCRouteRule
-		expectedRoutes []kongstate.Route
+		name               string
+		objectName         string
+		annotations        map[string]string
+		hostnames          []string
+		rule               gatewayv1alpha2.GRPCRouteRule
+		prependRegexPrefix bool
+		expectedRoutes     []kongstate.Route
 	}{
 		{
 			name:        "single match without hostname",
@@ -74,6 +75,7 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 					},
 				},
 			},
+			prependRegexPrefix: true,
 			expectedRoutes: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
@@ -108,6 +110,7 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 					},
 				},
 			},
+			prependRegexPrefix: true,
 			expectedRoutes: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
@@ -156,6 +159,7 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 					},
 				},
 			},
+			prependRegexPrefix: true,
 			expectedRoutes: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
@@ -190,13 +194,81 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "multiple matches with hostname, prependRegexPrefix off",
+			objectName:  "multiple-matches-with-hostname",
+			annotations: map[string]string{},
+			hostnames:   []string{"foo.com", "*.foo.com"},
+			rule: gatewayv1alpha2.GRPCRouteRule{
+				Matches: []gatewayv1alpha2.GRPCRouteMatch{
+					{
+						Method: &gatewayv1alpha2.GRPCMethodMatch{
+							Service: nil,
+							Method:  lo.ToPtr("method0"),
+						},
+						Headers: []gatewayv1alpha2.GRPCHeaderMatch{
+							{
+								Name:  "Version",
+								Value: "2",
+							},
+							{
+								Name:  "Client",
+								Value: "kong-test",
+							},
+						},
+					},
+					{
+						Method: &gatewayv1alpha2.GRPCMethodMatch{
+							Type:    lo.ToPtr(gatewayv1alpha2.GRPCMethodMatchRegularExpression),
+							Service: lo.ToPtr("v[012]"),
+						},
+					},
+				},
+			},
+			prependRegexPrefix: false,
+			expectedRoutes: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:             "multiple-matches-with-hostname",
+						Namespace:        "default",
+						Annotations:      map[string]string{},
+						GroupVersionKind: grpcRouteGVK,
+					},
+					Route: kong.Route{
+						Name:      kong.String("grpcroute.default.multiple-matches-with-hostname.0.0"),
+						Protocols: kong.StringSlice("grpc", "grpcs"),
+						Paths:     kong.StringSlice("/.+/method0"),
+						Hosts:     kong.StringSlice("foo.com", "*.foo.com"),
+						Headers: map[string][]string{
+							"Version": {"2"},
+							"Client":  {"kong-test"},
+						},
+					},
+				},
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:             "multiple-matches-with-hostname",
+						Namespace:        "default",
+						Annotations:      map[string]string{},
+						GroupVersionKind: grpcRouteGVK,
+					},
+					Route: kong.Route{
+						Name:      kong.String("grpcroute.default.multiple-matches-with-hostname.0.1"),
+						Protocols: kong.StringSlice("grpc", "grpcs"),
+						Paths:     kong.StringSlice("/v[012]/.+"),
+						Hosts:     kong.StringSlice("foo.com", "*.foo.com"),
+						Headers:   map[string][]string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayv1alpha2.GRPCRouteRule{tc.rule})
-			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0)
+			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, tc.prependRegexPrefix)
 			require.Equal(t, tc.expectedRoutes, routes)
 		})
 	}


### PR DESCRIPTION
** Original PR info *** 
* fix: do not prepend ~ before regex paths for Kong < 3.0

* add tests for translating grpcroute

* add CHANGELOG

(cherry picked from commit 1b59a9bbeedeace8a1d3f800ec26681493b2fa6d)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

manual backport of fixing translator of `GRPCRoute` #4238  to 2.10.x.
fixed conflicts on `CHANGELOG.md` .

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
