### PR TITLE
chore: remove redundant // +optional for CRDs' fields

### DIFF
--- a/pkg/apis/configuration/v1beta1/ingress_rules.go
+++ b/pkg/apis/configuration/v1beta1/ingress_rules.go
@@ -32,7 +32,6 @@ type IngressRule struct {
 	// If a Host is specified, the protocol must be TLS over TCP.
 	// A plain-text TCP request cannot be routed based on Host. It can only
 	// be routed based on Port.
-	// +optional
 	Host string `json:"host,omitempty"`
 
 	// Port is the port on which to accept TCP or TLS over TCP sessions and

--- a/pkg/apis/configuration/v1beta1/tcpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/tcpingress_types.go
@@ -60,7 +60,6 @@ type TCPIngressSpec struct {
 	// used for HTTP Ingress rules as well. Once can define the mapping in
 	// this resource or the original Ingress resource, both have the same
 	// effect.
-	// +optional
 	TLS []IngressTLS `json:"tls,omitempty"`
 }
 
@@ -70,17 +69,14 @@ type IngressTLS struct {
 	// this list must match the name/s used in the tlsSecret. Defaults to the
 	// wildcard host setting for the loadbalancer controller fulfilling this
 	// Ingress, if left unspecified.
-	// +optional
 	Hosts []string `json:"hosts,omitempty"`
 	// SecretName is the name of the secret used to terminate SSL traffic.
-	// +optional
 	SecretName string `json:"secretName,omitempty"`
 }
 
 // TCPIngressStatus defines the observed state of TCPIngress.
 type TCPIngressStatus struct {
 	// LoadBalancer contains the current status of the load-balancer.
-	// +optional
 	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
 }
 

--- a/pkg/apis/configuration/v1beta1/udpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/udpingress_types.go
@@ -63,6 +63,5 @@ type UDPIngressSpec struct {
 // UDPIngressStatus defines the observed state of UDPIngress.
 type UDPIngressStatus struct {
 	// LoadBalancer contains the current status of the load-balancer.
-	// +optional
 	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR removes redundant `// +optional` comment for fields in CRDs, check [the docs](https://book.kubebuilder.io/reference/markers.html?highlight=omitempty#difference-between--optional-and--kubebuildervalidationoptional). Moreover nothing is regenerated after this change thus this comment is ineffectual for our code. 

