### PR TITLE
test: add common name to SANs in certificate used in TestHTTPSIngress

### DIFF
--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -138,11 +138,11 @@ func TestHTTPSIngress(t *testing.T) {
 
 	t.Log("configuring secrets")
 	fooExampleTLSCert, fooExampleTLSKey := certificate.GenerateSelfSignedCertPEMFormat(t,
-		certificate.WithCommonName("secure-foo-bar"), certificate.WithDNSNames("foo.example"),
+		certificate.WithCommonName("secure-foo-bar"), certificate.WithDNSNames("secure-foo-bar", "foo.example"),
 	)
 	require.NoError(t, err)
 	barExampleTLSCert, barExampleTLSKey := certificate.GenerateSelfSignedCertPEMFormat(t,
-		certificate.WithCommonName("foo.com"), certificate.WithDNSNames("bar.example"),
+		certificate.WithCommonName("foo.com"), certificate.WithDNSNames("foo.com", "bar.example"),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

The validation on `kong/kong-gateway-dev:2.8.4.2-rc2`  still fails on integration test `TestHTTPSIngress` . 
The PR adds the common name to SANs in the certificates used, after that, the case passes. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
