### PR TITLE
chore: add grpcroute to changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,9 +124,9 @@ Adding a new version? You'll need three changes:
   [#4238](https://github.com/Kong/kubernetes-ingress-controller/pull/4238)
 - Fixed a bug where the controller sync loop would get stuck when a number of
   updates for one of Gateway API resources kinds (`HTTPRoute`, `TCPRoute`,
-  `UDPRoute`, `TLSRoute`) exceeded 8192. This was caused by the fact that
-  the controller was using a fixed-size buffer to store updates for each
-  resource kind and there were no consumers for the updates. The sending side
+  `UDPRoute`, `TLSRoute`, `GRPCRoute`) exceeded 8192. This was caused by the
+  fact that the controller was using a fixed-size buffer to store updates for
+  each resource kind and there were no consumers for the updates. The sending
   was blocked after a buffer got full, resulting in a deadlock.
   [#4267](https://github.com/Kong/kubernetes-ingress-controller/pull/4267)
 


### PR DESCRIPTION
`GRPCRoute` was missed to be included in the changelog entry for https://github.com/Kong/kubernetes-ingress-controller/pull/4267.
