### PR TITLE
[release/2.5.x] fix(ci): make tests run for PRs on all branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,12 +3,13 @@ name: tests
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
   push:
     branches:
       - 'main'
+      - 'release/[0-9]+.[0-9]+.x'
     tags:
-      - '*'
+      - '**'
   workflow_dispatch: {}
 
 jobs:
@@ -271,6 +272,25 @@ jobs:
 
     - name: run conformance tests
       run: make test.conformance
+
+  # We need this step to fail the workflow if any of the previous steps failed or were cancelled.
+  # It allows to use this particular job as a required check for PRs.
+  # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
+  passed:
+    runs-on: ubuntu-latest
+    needs:
+      - "lint"
+      - "unit-tests"
+      - "integration-tests-dbless"
+      - "integration-tests-postgres"
+      - "integration-tests-enterprise-postgres"
+      - "integration-tests-feature-gates"
+    if: always()
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "Some jobs failed or were cancelled."
+          exit 1
 
   coverage:
     environment: "Configure ci"


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes PR tests run on all branches like in https://github.com/Kong/kubernetes-ingress-controller/pull/4223.
