### PR TITLE
[Backport release/2.9.x] ci: run PR checks on PRs against all branches (#4223)

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           if [ "${{ matrix.enterprise }}" == "true" ]; then
             echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=3.2.1.0" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=3.2.2.3" >> $GITHUB_ENV
           else
             echo "TEST_KONG_IMAGE=kong/kong" >> $GITHUB_ENV
             echo "TEST_KONG_TAG=3.2.1" >> $GITHUB_ENV

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -10,12 +10,13 @@ concurrency:
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
   push:
     branches:
       - 'main'
+      - 'release/[0-9]+.[0-9]+.x'
     tags:
-      - '*'
+      - '**'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

This backports #4223 to 2.9.x release branch so that CI tests can run there and fulfil a required `passed` check.
