### PR TITLE
[Backport release/2.10.x] chore(ci): do not run e2e tests triggered by label on GKE clusters

### DIFF
--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -41,11 +41,16 @@ jobs:
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.inputs.pr-number }}
+      RUN_GKE: ${{ inputs.run-gke }}
     steps:
       - uses: actions/checkout@v3
       - run: |
-          gh pr comment ${PR_NUMBER} --body \
-            "E2E (targeted) tests were started at ${URL}"
+          if [ "${RUN_GKE}" == "true" ]; then
+            MSG="E2E (targeted) tests with KIND-based and GKE-based clusters were started at ${URL}"
+          else
+            MSG="E2E (targeted) tests with KIND-based clusters were started at ${URL}"
+          fi
+          gh pr comment ${PR_NUMBER} --body "${MSG}"
       # Remove the 'ci/run-e2e' label from the PR to prevent the `e2e_trigger_via_label.yaml`
       # workflow from running the `e2e_targeted.yaml` again.
       - run: gh pr edit ${PR_NUMBER} --remove-label ci/run-e2e

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -18,9 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    # Do not run e2e tests on GKE-based clusters for specific PR, because currently
+    # there is no way to use an image built from PR's code for those tests.
+    # https://github.com/Kong/kubernetes-testing-framework/issues/587
     - run: |
         gh workflow run ${WORKFLOW} --ref ${BRANCH} \
-          -f run-gke=true \
+          -f run-gke=false \
           -f run-istio=true \
           -f all-supported-k8s-versions=true \
           -f pr-number=${PR_NUMBER}


### PR DESCRIPTION
Backports #4235