### PR TITLE
refactor: extract adminapi.Discoverer and add tests

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -186,10 +186,15 @@ func NewClientFactoryForWorkspace(workspace string, httpClientOpts HTTPClientOpt
 	}
 }
 
-func (cf ClientFactory) CreateAdminAPIClient(ctx context.Context, address string) (*Client, error) {
+func (cf ClientFactory) CreateAdminAPIClient(ctx context.Context, discoveredAdminAPI DiscoveredAdminAPI) (*Client, error) {
 	httpclient, err := MakeHTTPClient(&cf.httpClientOpts, cf.adminToken)
 	if err != nil {
 		return nil, err
 	}
-	return NewKongClientForWorkspace(ctx, address, cf.workspace, httpclient)
+	cl, err := NewKongClientForWorkspace(ctx, discoveredAdminAPI.Address, cf.workspace, httpclient)
+	if err != nil {
+		return nil, err
+	}
+	cl.AttachPodReference(discoveredAdminAPI.PodRef)
+	return cl, nil
 }

--- a/internal/adminapi/endpoints_envtest_test.go
+++ b/internal/adminapi/endpoints_envtest_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 )
 
-func TestGetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(t *testing.T) {
+func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(t *testing.T) {
 	t.Parallel()
 
 	cfg := envtest.Setup(t, scheme.Scheme)
@@ -87,7 +87,10 @@ func TestGetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(
 				}
 			}
 
-			got, err := adminapi.GetAdminAPIsForService(ctx, client, service, sets.New("admin"), cfgtypes.IPDNSStrategy)
+			discoverer, err := adminapi.NewDiscoverer(sets.New("admin"), cfgtypes.IPDNSStrategy)
+			require.NoError(t, err)
+
+			got, err := discoverer.GetAdminAPIsForService(ctx, client, service)
 			require.NoError(t, err)
 			require.Len(t, got, tc.subnetD*tc.subnetC, "GetAdminAPIsForService should return all valid addresses")
 		})

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ClientFactory interface {
-	CreateAdminAPIClient(ctx context.Context, address string) (*adminapi.Client, error)
+	CreateAdminAPIClient(ctx context.Context, address adminapi.DiscoveredAdminAPI) (*adminapi.Client, error)
 }
 
 // AdminAPIClientsManager keeps track of current Admin API clients of Gateways that we should configure.
@@ -231,7 +231,7 @@ func (c *AdminAPIClientsManager) adjustGatewayClients(discoveredAdminAPIs []admi
 	}
 
 	for _, adminAPI := range toAdd {
-		client, err := c.adminAPIClientFactory.CreateAdminAPIClient(c.ctx, adminAPI.Address)
+		client, err := c.adminAPIClientFactory.CreateAdminAPIClient(c.ctx, adminAPI)
 		if err != nil {
 			c.logger.WithError(err).Errorf("failed to create a client for %s", adminAPI)
 			continue

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -27,7 +27,8 @@ type clientFactoryWithExpected struct {
 	t        *testing.T
 }
 
-func (cf clientFactoryWithExpected) CreateAdminAPIClient(_ context.Context, address string) (*adminapi.Client, error) {
+func (cf clientFactoryWithExpected) CreateAdminAPIClient(_ context.Context, adminAPI adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
+	address := adminAPI.Address
 	stillExpecting, ok := cf.expected[address]
 	if !ok {
 		cf.t.Errorf("got %s which was unexpected", address)

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -38,13 +38,20 @@ type KongAdminAPIServiceReconciler struct {
 	EndpointsNotifier EndpointsNotifier
 
 	Cache               DiscoveredAdminAPIsCache
-	AdminAPIsDiscoverer *adminapi.Discoverer
+	AdminAPIsDiscoverer AdminAPIsDiscoverer
 }
 
 type DiscoveredAdminAPIsCache map[k8stypes.NamespacedName]sets.Set[adminapi.DiscoveredAdminAPI]
 
 type EndpointsNotifier interface {
 	Notify(adminAPIs []adminapi.DiscoveredAdminAPI)
+}
+
+type AdminAPIsDiscoverer interface {
+	AdminAPIsFromEndpointSlice(discoveryv1.EndpointSlice) (
+		sets.Set[adminapi.DiscoveredAdminAPI],
+		error,
+	)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -77,6 +77,10 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 	}
 
 	n = &notifier{t: t}
+
+	adminAPIsDiscoverer, err := adminapi.NewDiscoverer(sets.New("admin"), types.ServiceScopedPodDNSStrategy)
+	require.NoError(t, err)
+
 	require.NoError(t,
 		(&configuration.KongAdminAPIServiceReconciler{
 			Client: mgr.GetClient(),
@@ -84,10 +88,9 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 				Name:      adminService.Name,
 				Namespace: adminService.Namespace,
 			},
-			PortNames:         sets.New("admin"),
-			EndpointsNotifier: n,
-			Log:               mgr.GetLogger(),
-			DNSStrategy:       types.ServiceScopedPodDNSStrategy,
+			EndpointsNotifier:   n,
+			Log:                 mgr.GetLogger(),
+			AdminAPIsDiscoverer: adminAPIsDiscoverer,
 		}).SetupWithManager(mgr),
 	)
 	// This wait group makes it so that we wait for manager to exit.

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	KongAdminURLs               []string
 	KongAdminSvc                OptionalNamespacedName
 	GatewayDiscoveryDNSStrategy cfgtypes.DNSStrategy
-	KondAdminSvcPortNames       []string
+	KongAdminSvcPortNames       []string
 	ProxySyncSeconds            float32
 	InitCacheSyncDuration       time.Duration
 	ProxyTimeoutSeconds         float32
@@ -172,7 +172,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 			`More than 1 URL can be provided, in such case the flag should be used multiple times or a corresponding env variable should use comma delimited addresses.`)
 	flagSet.Var(flags.NewValidatedValue(&c.KongAdminSvc, namespacedNameFromFlagValue, nnTypeNameOverride), "kong-admin-svc",
 		`Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery.`)
-	flagSet.StringSliceVar(&c.KondAdminSvcPortNames, "kong-admin-svc-port-names", []string{"admin", "admin-tls", "kong-admin", "kong-admin-tls"},
+	flagSet.StringSliceVar(&c.KongAdminSvcPortNames, "kong-admin-svc-port-names", []string{"admin", "admin-tls", "kong-admin", "kong-admin-tls"},
 		"Names of ports on Kong Admin API service to take into account when doing gateway discovery.")
 	flagSet.Var(flags.NewValidatedValue(&c.GatewayDiscoveryDNSStrategy, dnsStrategyFromFlagValue, flags.WithDefault(cfgtypes.IPDNSStrategy), flags.WithTypeNameOverride[cfgtypes.DNSStrategy]("dns-strategy")),
 		"gateway-discovery-dns-strategy", "DNS strategy to use when creating Gateway's Admin API addresses. One of: ip, service, pod.")

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -11,7 +11,6 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/crds"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
@@ -67,7 +66,7 @@ func setupControllers(
 	c *Config,
 	featureGates map[string]bool,
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
-	adminAPIsDiscoverer *adminapi.Discoverer,
+	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
 ) ([]ControllerDef, error) {
 	restMapper := mgr.GetClient().RESTMapper()
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -66,8 +67,20 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	healthServer.setHealthzCheck(healthz.Ping)
 	healthServer.Start(ctx, c.ProbeAddr, setupLog.WithName("health-check"))
 
+	adminAPIsDiscoverer, err := adminapi.NewDiscoverer(sets.New(c.KongAdminSvcPortNames...), c.GatewayDiscoveryDNSStrategy)
+	if err != nil {
+		return fmt.Errorf("failed to create admin apis discoverer: %w", err)
+	}
+
+	adminAPIClientsFactory := adminapi.NewClientFactoryForWorkspace(c.KongWorkspace, c.KongAdminAPIConfig, c.KongAdminToken)
+
 	setupLog.Info("getting the kong admin api client configuration")
-	initialKongClients, err := c.adminAPIClients(ctx, setupLog.WithName("initialize-kong-clients"))
+	initialKongClients, err := c.adminAPIClients(
+		ctx,
+		setupLog.WithName("initialize-kong-clients"),
+		adminAPIsDiscoverer,
+		adminAPIClientsFactory,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to build kong api client(s): %w", err)
 	}
@@ -123,7 +136,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		ctx,
 		deprecatedLogger,
 		initialKongClients,
-		adminapi.NewClientFactoryForWorkspace(c.KongWorkspace, c.KongAdminAPIConfig, c.KongAdminToken),
+		adminAPIClientsFactory,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create AdminAPIClientsManager: %w", err)
@@ -199,8 +212,17 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	}
 
 	setupLog.Info("Starting Enabled Controllers")
-	controllers, err := setupControllers(mgr, dataplaneClient,
-		dataplaneAddressFinder, udpDataplaneAddressFinder, kubernetesStatusQueue, c, featureGates, clientsManager)
+	controllers, err := setupControllers(
+		mgr,
+		dataplaneClient,
+		dataplaneAddressFinder,
+		udpDataplaneAddressFinder,
+		kubernetesStatusQueue,
+		c,
+		featureGates,
+		clientsManager,
+		adminAPIsDiscoverer,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to setup controller as expected %w", err)
 	}

--- a/internal/manager/setup_test.go
+++ b/internal/manager/setup_test.go
@@ -1,0 +1,156 @@
+package manager_test
+
+import (
+	"context"
+	errors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+)
+
+type mockAdminAPIDiscoverer struct {
+	apis                              sets.Set[adminapi.DiscoveredAdminAPI]
+	err                               error
+	getAdminAPIsForServiceCalledTimes atomic.Int32
+}
+
+func (m *mockAdminAPIDiscoverer) GetAdminAPIsForService(_ context.Context, _ client.Client, _ k8stypes.NamespacedName) (sets.Set[adminapi.DiscoveredAdminAPI], error) {
+	m.getAdminAPIsForServiceCalledTimes.Add(1)
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.apis, nil
+}
+
+func (m *mockAdminAPIDiscoverer) GetAdminAPIsForServiceCalledTimes() int {
+	return int(m.getAdminAPIsForServiceCalledTimes.Load())
+}
+
+type mockAdminAPIClientFactory struct {
+	errs map[string]error // map from address to error
+}
+
+func newMockAdminAPIClientFactory(errs map[string]error) *mockAdminAPIClientFactory {
+	if errs == nil {
+		errs = make(map[string]error)
+	}
+	return &mockAdminAPIClientFactory{
+		errs: errs,
+	}
+}
+
+func (m *mockAdminAPIClientFactory) CreateAdminAPIClient(_ context.Context, api adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
+	err, ok := m.errs[api.Address]
+	if !ok {
+		return adminapi.NewTestClient(api.Address)
+	}
+	return nil, err
+}
+
+func TestAdminAPIClientFromServiceDiscovery(t *testing.T) {
+	log := logr.Discard()
+	adminAPISvcNN := k8stypes.NamespacedName{Name: "admin-api", Namespace: "kong"}
+	kubeClient := fake.NewClientBuilder().Build()
+	genericErr := errors.New("some generic error")
+	someDiscoveredAPI := func(address string) adminapi.DiscoveredAdminAPI {
+		return adminapi.DiscoveredAdminAPI{
+			Address: address,
+			PodRef: k8stypes.NamespacedName{
+				Namespace: "kong",
+				Name:      "pod",
+			},
+		}
+	}
+	testCases := []struct {
+		name           string
+		discoveredAPIs sets.Set[adminapi.DiscoveredAdminAPI]
+		discovererErr  error
+		factoryErrs    map[string]error // Map from address to error.
+		cancelContext  bool             // If true, will cancel the context after GetAdminAPIsForService is called 2 times.
+
+		expectedClientsCount int
+		expectedErr          error
+	}{
+		{
+			name: "no errors and one admin api",
+			discoveredAPIs: sets.New(
+				someDiscoveredAPI("https://localhost:8444"),
+			),
+			expectedClientsCount: 1,
+		},
+		{
+			name: "no errors and two apis",
+			discoveredAPIs: sets.New(
+				someDiscoveredAPI("https://localhost:8444"),
+				someDiscoveredAPI("https://localhost:8445"),
+			),
+			expectedClientsCount: 2,
+		},
+		{
+			name: "two apis one error",
+			discoveredAPIs: sets.New(
+				someDiscoveredAPI("https://localhost:8444"),
+				someDiscoveredAPI("https://localhost:8445"),
+			),
+			factoryErrs: map[string]error{
+				"https://localhost:8445": genericErr,
+			},
+			expectedErr: genericErr,
+		},
+		{
+			name:          "no admin apis waits forever",
+			cancelContext: true,
+			expectedErr:   context.Canceled,
+		},
+		{
+			name:          "any discoverer error aborts",
+			discovererErr: genericErr,
+			expectedErr:   genericErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			discoverer := &mockAdminAPIDiscoverer{apis: tc.discoveredAPIs, err: tc.discovererErr}
+			factory := newMockAdminAPIClientFactory(tc.factoryErrs)
+
+			// If cancelContext is true, we will cancel the context after GetAdminAPIsForService is called >= 2 times.
+			// This will mean that the retry loop is running. By cancelling the context we can ensure it will exit and
+			// return the expected error.
+			if tc.cancelContext {
+				go func() {
+					if assert.Eventually(t, func() bool {
+						return discoverer.GetAdminAPIsForServiceCalledTimes() >= 2
+					}, time.Second, time.Millisecond) {
+						t.Log("cancelling context, GetAdminAPIsForService called >= 2 times")
+						cancel()
+					}
+				}()
+			} else {
+				defer cancel()
+			}
+
+			retryEveryMs := retry.Delay(time.Millisecond) // For testing purposes, we want to retry as fast as possible.
+			clients, err := manager.AdminAPIClientFromServiceDiscovery(ctx, log, adminAPISvcNN, kubeClient, discoverer, factory, retryEveryMs)
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, clients, tc.expectedClientsCount)
+		})
+	}
+}

--- a/test/mocks/admin_api_client_factory.go
+++ b/test/mocks/admin_api_client_factory.go
@@ -1,0 +1,29 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+)
+
+// AdminAPIClientFactory is a mock implementation of adminapi.ClientFactory.
+type AdminAPIClientFactory struct {
+	errorsToReturn map[string]error // map from address to error
+}
+
+func NewAdminAPIClientFactory(errorsToReturn map[string]error) *AdminAPIClientFactory {
+	if errorsToReturn == nil {
+		errorsToReturn = make(map[string]error)
+	}
+	return &AdminAPIClientFactory{
+		errorsToReturn: errorsToReturn,
+	}
+}
+
+func (m *AdminAPIClientFactory) CreateAdminAPIClient(_ context.Context, api adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
+	err, ok := m.errorsToReturn[api.Address]
+	if !ok {
+		return adminapi.NewTestClient(api.Address)
+	}
+	return nil, err
+}

--- a/test/mocks/admin_api_discoverer.go
+++ b/test/mocks/admin_api_discoverer.go
@@ -1,0 +1,59 @@
+package mocks
+
+import (
+	"context"
+	"sync/atomic"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+)
+
+// AdminAPIDiscoverer is a mock implementation of adminapi.Discoverer.
+type AdminAPIDiscoverer struct {
+	apisToReturn sets.Set[adminapi.DiscoveredAdminAPI]
+	errToReturn  error
+
+	getAdminAPIsForServiceCalledTimes     atomic.Int32
+	adminAPIsFromEndpointSliceCalledTimes atomic.Int32
+}
+
+func NewAdminAPIDiscoverer(apisToReturn sets.Set[adminapi.DiscoveredAdminAPI], errToReturn error) *AdminAPIDiscoverer {
+	return &AdminAPIDiscoverer{
+		apisToReturn: apisToReturn,
+		errToReturn:  errToReturn,
+	}
+}
+
+func (m *AdminAPIDiscoverer) GetAdminAPIsForService(context.Context, client.Client, k8stypes.NamespacedName) (
+	sets.Set[adminapi.DiscoveredAdminAPI],
+	error,
+) {
+	m.getAdminAPIsForServiceCalledTimes.Add(1)
+	if m.errToReturn != nil {
+		return nil, m.errToReturn
+	}
+	return m.apisToReturn, nil
+}
+
+func (m *AdminAPIDiscoverer) AdminAPIsFromEndpointSlice(discoveryv1.EndpointSlice) (
+	sets.Set[adminapi.DiscoveredAdminAPI],
+	error,
+) {
+	m.adminAPIsFromEndpointSliceCalledTimes.Add(1)
+	if m.errToReturn != nil {
+		return nil, m.errToReturn
+	}
+	return m.apisToReturn, nil
+}
+
+func (m *AdminAPIDiscoverer) GetAdminAPIsForServiceCalledTimes() int {
+	return int(m.getAdminAPIsForServiceCalledTimes.Load())
+}
+
+func (m *AdminAPIDiscoverer) AdminAPIsFromEndpointSliceCalledTimes() int {
+	return int(m.adminAPIsFromEndpointSliceCalledTimes.Load())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts `adminapi.Discoverer` and thanks to that, covers `AdminAPIClientFromServiceDiscovery` with unit tests.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Refactor required for https://github.com/Kong/kubernetes-ingress-controller/issues/3499.
