### PR TITLE
chore: update ingress examples and test code using deprecated `kubernetes.io/ingress.class` annotation to use `spec.ingressClassName` instead

### DIFF
--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -46,9 +46,9 @@ kind: Ingress
 metadata:
   name: httpbin-ingress
   annotations:
-    httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
+    konghq.com/strip-path: "true"
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/default_golden.yaml
@@ -1,0 +1,46 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    path_handling: v0
+    paths:
+    - /
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/in.yaml
@@ -4,8 +4,9 @@ kind: Ingress
 metadata:
   name: foo
   namespace: foo-namespace
+  annotations:
+    kubernetes.io/ingress.class: kong
 spec:
-  ingressClassName: kong
   rules:
   - host: example.com
     http:
@@ -20,8 +21,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo-svc
   namespace: foo-namespace
 spec:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/in.yaml
@@ -2,11 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo
   namespace: foo-namespace
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/in.yaml
@@ -2,11 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo
   namespace: foo-namespace
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/in.yaml
@@ -2,11 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo
   namespace: foo-namespace
 spec:
+  ingressClassName: kong
   rules:
     - host: example.com
       http:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/in.yaml
@@ -2,11 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo
   namespace: foo-namespace
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/in.yaml
@@ -2,11 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: kong
   name: foo
   namespace: foo-namespace
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -39,10 +39,8 @@ kind: Ingress
 metadata:
   name: httpbin-ingress
   namespace: default
-  annotations:
-    httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -240,7 +240,7 @@ func TestIngressExample(t *testing.T) {
 	t.Logf("applying yaml manifest %s", ingressExampleManifests)
 	b, err := os.ReadFile(ingressExampleManifests)
 	require.NoError(t, err)
-	manifests := replaceIngressClassInManifests(string(b))
+	manifests := replaceIngressClassSpecFieldInManifests(string(b))
 	require.NoError(t, clusters.ApplyManifestByYAML(ctx, env.Cluster(), manifests))
 	cleaner.AddManifest(string(b))
 
@@ -298,7 +298,7 @@ func TestUDPIngressExample(t *testing.T) {
 	t.Logf("applying yaml manifest %s", udpingressExampleManifests)
 	b, err := os.ReadFile(udpingressExampleManifests)
 	require.NoError(t, err)
-	manifests := replaceIngressClassInManifests(string(b))
+	manifests := replaceIngressClassAnnotationInManifests(string(b))
 	require.NoError(t, clusters.ApplyManifestByYAML(ctx, env.Cluster(), manifests))
 	cleaner.AddManifest(string(b))
 
@@ -316,6 +316,10 @@ func TestUDPIngressExample(t *testing.T) {
 	}, ingressWait, waitTick)
 }
 
-func replaceIngressClassInManifests(manifests string) string {
+func replaceIngressClassAnnotationInManifests(manifests string) string {
 	return strings.ReplaceAll(manifests, `kubernetes.io/ingress.class: "kong"`, fmt.Sprintf(`kubernetes.io/ingress.class: "%s"`, consts.IngressClass))
+}
+
+func replaceIngressClassSpecFieldInManifests(manifests string) string {
+	return strings.ReplaceAll(manifests, `ingressClassName: kong`, fmt.Sprintf(`ingressClassName: %s`, consts.IngressClass))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we're now supporting only Ingress v1 let's get rid of the references and usages of deprecated `kubernetes.io/ingress.class` annotation.

As per kubernetes docs:

> Deprecated annotation
> Before the IngressClass resource and ingressClassName field were added in Kubernetes 1.18, Ingress classes were specified with a kubernetes.io/ingress.class annotation on the Ingress. This annotation was never formally defined, but was widely supported by Ingress controllers.

> The newer ingressClassName field on Ingresses is a replacement for that annotation, but is not a direct equivalent. While the annotation was generally used to reference the name of the Ingress controller that should implement the Ingress, the field is a reference to an IngressClass resource that contains additional Ingress configuration, including the name of the Ingress controller.

This PR updates ingress example manifest and some test code. At the same time adding an explicit parser test to ensure we still support the annotation (as the decision about its deprecation hasn't been made).

Thanks to this PR, the examplar `examples/ingress.yaml` manifest won't yield:

```
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

warning anymore.
