### PR TITLE
feat: add stub upstream when config is empty in dbless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@ Adding a new version? You'll need three changes:
   method is adopted to keep the compatibility with traditional router on
   maximum effort.
   [#4240](https://github.com/Kong/kubernetes-ingress-controller/pull/4240)
+- When a translated Kong configuration is empty in DB-less mode, the controller
+  will now send the configuration with a single empty `Upstream`. This is to make
+  Gateways using `/status/ready` as their health check ready after receiving the
+  initial configuration (even if it's empty).
+  [#4316](https://github.com/Kong/kubernetes-ingress-controller/pull/4316)
 
 ### Changed
 

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	gojson "github.com/goccy/go-json"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 )
@@ -105,4 +106,18 @@ func PluginString(plugin file.FPlugin) string {
 		result += *plugin.Service.ID
 	}
 	return result
+}
+
+// IsContentEmpty returns true if the content is considered empty.
+// This ignores meta fields like FormatVersion and Info.
+func IsContentEmpty(content *file.Content) bool {
+	return cmp.Equal(content, &file.Content{},
+		cmp.FilterPath(
+			func(p cmp.Path) bool {
+				path := p.String()
+				return path == "FormatVersion" || path == "Info"
+			},
+			cmp.Ignore(),
+		),
+	)
 }

--- a/internal/dataplane/deckgen/generate_test.go
+++ b/internal/dataplane/deckgen/generate_test.go
@@ -1,0 +1,68 @@
+package deckgen_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kong/deck/file"
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+)
+
+func TestToDeckContent(t *testing.T) {
+	defaultTestParams := func() deckgen.GenerateDeckContentParams {
+		return deckgen.GenerateDeckContentParams{
+			FormatVersion: "3.0",
+		}
+	}
+	modifiedDefaultTestParams := func(fn func(p *deckgen.GenerateDeckContentParams)) deckgen.GenerateDeckContentParams {
+		p := defaultTestParams()
+		fn(&p)
+		return p
+	}
+
+	testCases := []struct {
+		name     string
+		params   deckgen.GenerateDeckContentParams
+		input    *kongstate.KongState
+		expected *file.Content
+	}{
+		{
+			name:   "empty",
+			params: defaultTestParams(),
+			input:  &kongstate.KongState{},
+			expected: &file.Content{
+				FormatVersion: "3.0",
+			},
+		},
+		{
+			name: "empty, generate stub entity",
+			params: modifiedDefaultTestParams(func(p *deckgen.GenerateDeckContentParams) {
+				p.AppendStubEntityWhenConfigEmpty = true
+			}),
+			input: &kongstate.KongState{},
+			expected: &file.Content{
+				FormatVersion: "3.0",
+				Upstreams: []file.FUpstream{
+					{
+						Upstream: kong.Upstream{
+							Name: lo.ToPtr(deckgen.StubUpstreamName),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := deckgen.ToDeckContent(context.Background(), logrus.New(), tc.input, tc.params)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/dataplane/sendconfig/config_change_detector.go
+++ b/internal/dataplane/sendconfig/config_change_detector.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
 	"github.com/sirupsen/logrus"
 )
 
@@ -75,15 +75,7 @@ func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
 	// Kong instance has no configuration, we should push despite the oldSHA and newSHA being equal...
 	if hasNoConfiguration {
 		// ... unless we're trying to push an empty config in such case skip.
-		if cmp.Equal(targetConfig, &file.Content{},
-			cmp.FilterPath(
-				func(p cmp.Path) bool {
-					path := p.String()
-					return path == "FormatVersion" || path == "Info"
-				},
-				cmp.Ignore(),
-			),
-		) {
+		if deckgen.IsContentEmpty(targetConfig) {
 			return false, nil
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When a translated configuration is empty, the controller adds an empty `Upstream` named `kong` to a Kong configuration. It will happen for Gateways in DB-less mode only.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3499.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
