### PR TITLE
refactor: remove version from KongState

### DIFF
--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -24,7 +24,6 @@ type KongState struct {
 	Licenses       []kong.License
 	Plugins        []Plugin
 	Consumers      []Consumer
-	Version        semver.Version
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
@@ -49,7 +48,7 @@ func (ks *KongState) SanitizedCopy() *KongState {
 	}
 }
 
-func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store.Storer) {
+func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store.Storer, kongVersion semver.Version) {
 	consumerIndex := make(map[string]Consumer)
 
 	// build consumer index
@@ -130,7 +129,7 @@ func (ks *KongState) FillConsumersAndCredentials(log logrus.FieldLogger, s store
 				continue
 			}
 			credTags := util.GenerateTagsForObject(secret)
-			err = c.SetCredential(credType, credConfig, credTags, ks.Version)
+			err = c.SetCredential(credType, credConfig, credTags, kongVersion)
 			if err != nil {
 				log.WithError(err).Errorf("failed to provision credential")
 				continue

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -380,14 +380,11 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				},
 			},
 		}},
-		Version: semver.MustParse("2.3.2"),
 	}
 
 	t.Run("parses consumer and credential from store into state", func(t *testing.T) {
-		state := KongState{
-			Version: semver.MustParse("2.3.2"),
-		}
-		state.FillConsumersAndCredentials(logrus.New(), store)
+		state := KongState{}
+		state.FillConsumersAndCredentials(logrus.New(), store, semver.MustParse("2.3.2"))
 		assert.Equal(t, want.Consumers[0].Consumer.Username, state.Consumers[0].Consumer.Username)
 		assert.Equal(t, want.Consumers[0].Consumer.CustomID, state.Consumers[0].Consumer.CustomID)
 		assert.Equal(t, want.Consumers[0].KeyAuths[0].Key, state.Consumers[0].KeyAuths[0].Key)

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -226,7 +226,7 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 	result.FillOverrides(p.logger, p.storer)
 
 	// generate consumers and credentials
-	result.FillConsumersAndCredentials(p.logger, p.storer)
+	result.FillConsumersAndCredentials(p.logger, p.storer, p.kongVersion)
 
 	// process annotation plugins
 	result.FillPlugins(p.logger, p.storer)


### PR DESCRIPTION
**What this PR does / why we need it**:

As `KongState` represents all entities translated from Kubernetes resources, `Version` field doesn't match to be there. It appears it's quite easily removable. 