### PR TITLE
tests: transform TestMissingCRDsDontCrashTheControler into envtest

### DIFF
--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -34,12 +34,6 @@ const (
 - op: replace
   path: /spec/template/spec/containers/0/livenessProbe/failureThreshold
   value: %[3]d`
-
-	addControllerEnvPatch = `- op: add
-  path: "/spec/template/spec/containers/0/env/-"
-  value:
-    name: %s
-    value: "%s"`
 )
 
 // patchControllerImage replaces the kong/kubernetes-ingress-controller image with the provided image and tag,
@@ -118,29 +112,6 @@ func patchLivenessProbes(baseManifestReader io.Reader, deployment k8stypes.Names
 						},
 						Name:      deployment.Name,
 						Namespace: deployment.Namespace,
-					},
-				},
-			},
-		},
-	}
-	return kubectl.GetKustomizedManifest(kustomization, baseManifestReader)
-}
-
-// addControllerEnv adds an environment variable to ingress-controller container.
-func addControllerEnv(baseManifestReader io.Reader, envName, value string) (io.Reader, error) {
-	kustomization := types.Kustomization{
-		Patches: []types.Patch{
-			{
-				Patch: fmt.Sprintf(addControllerEnvPatch, envName, value),
-				Target: &types.Selector{
-					ResId: resid.ResId{
-						Gvk: resid.Gvk{
-							Group:   "apps",
-							Version: "v1",
-							Kind:    "Deployment",
-						},
-						Name:      controllerDeploymentName,
-						Namespace: "kong",
 					},
 				},
 			},

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -26,12 +26,10 @@ import (
 func TestMissingCRDsDontCrashTheManager(t *testing.T) {
 	emptyScheme := runtime.NewScheme()
 	envcfg := Setup(t, emptyScheme)
-	ctrlClient := NewControllerClient(t, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	gw := deployGateway(ctx, t, ctrlClient)
-	loggerHook := runManagerWithConfig(ctx, t, envcfg, gw, func(cfg *manager.Config) {
+	loggerHook := RunManager(ctx, t, envcfg, func(cfg *manager.Config) {
 		// Reducing controllers' cache synchronisation timeout in order to trigger the possible sync timeout quicker.
 		// It's a regression test for https://github.com/Kong/gateway-operator/issues/326.
 		cfg.CacheSyncTimeout = time.Millisecond * 500
@@ -86,5 +84,5 @@ func TestMissingCRDsDontCrashTheManager(t *testing.T) {
 			}
 		}
 		return true
-	}, time.Minute, time.Millisecond)
+	}, time.Minute, time.Millisecond*500)
 }

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -1,0 +1,90 @@
+//go:build envtest
+
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+)
+
+// TestMissingCRDsDontCrashTheManager ensures that in case of missing CRDs installation in the cluster, specific
+// controllers are disabled, this fact is properly logged, and the manager does not crash.
+func TestMissingCRDsDontCrashTheManager(t *testing.T) {
+	emptyScheme := runtime.NewScheme()
+	envcfg := Setup(t, emptyScheme)
+	ctrlClient := NewControllerClient(t, envcfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	gw := deployGateway(ctx, t, ctrlClient)
+	loggerHook := runManagerWithConfig(ctx, t, envcfg, gw, func(cfg *manager.Config) {
+		// Reducing controllers' cache synchronisation timeout in order to trigger the possible sync timeout quicker.
+		// It's a regression test for https://github.com/Kong/gateway-operator/issues/326.
+		cfg.CacheSyncTimeout = time.Millisecond * 500
+	})
+
+	require.Eventually(t, func() bool {
+		gvrs := []schema.GroupVersionResource{
+			{
+				Group:    kongv1beta1.GroupVersion.Group,
+				Version:  kongv1beta1.GroupVersion.Version,
+				Resource: "udpingresses",
+			},
+			{
+				Group:    kongv1beta1.GroupVersion.Group,
+				Version:  kongv1beta1.GroupVersion.Version,
+				Resource: "tcpingresses",
+			},
+			{
+				Group:    kongv1.GroupVersion.Group,
+				Version:  kongv1.GroupVersion.Version,
+				Resource: "kongingresses",
+			},
+			{
+				Group:    kongv1alpha1.GroupVersion.Group,
+				Version:  kongv1alpha1.GroupVersion.Version,
+				Resource: "ingressclassparameterses",
+			},
+			{
+				Group:    kongv1.GroupVersion.Group,
+				Version:  kongv1.GroupVersion.Version,
+				Resource: "kongplugins",
+			},
+			{
+				Group:    kongv1.GroupVersion.Group,
+				Version:  kongv1.GroupVersion.Version,
+				Resource: "kongconsumers",
+			},
+			{
+				Group:    kongv1.GroupVersion.Group,
+				Version:  kongv1.GroupVersion.Version,
+				Resource: "kongclusterplugins",
+			},
+		}
+
+		for _, gvr := range gvrs {
+			expectedLog := fmt.Sprintf("Disabling controller for Group=%s, Resource=%s due to missing CRD", gvr.GroupVersion(), gvr.Resource)
+			if !lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
+				return strings.Contains(entry.Message, expectedLog)
+			}) {
+				t.Logf("expected log not found: %s", expectedLog)
+				return false
+			}
+		}
+		return true
+	}, time.Minute, time.Millisecond)
+}

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -7,25 +7,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bombsimon/logrusr/v2"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
-	"github.com/samber/mo"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 )
 
@@ -36,7 +29,7 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	gw := deployGateway(ctx, t, ctrlClient)
-	runManagerWithConfig(ctx, t, envcfg, gw, func(cfg *manager.Config) {
+	RunManager(ctx, t, envcfg, WithPublishService(gw.Namespace), WithGatewayFeatureEnabled, func(cfg *manager.Config) {
 		// Enable status updates and change the queue's buffer size to 0 to
 		// ensure that the status update notifications do not block the
 		// sync loop despite the fact that the status update queue is full.
@@ -114,43 +107,6 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 	t.Cleanup(func() { _ = ctrlClient.Delete(ctx, &httpRoute) })
 }
 
-const publishSvcName = "publish-svc"
-
-// runManagerWithConfig runs the manager in a goroutine using configuration modified by modifyCfgFn.
-// It also sets up configuration parameters that are required for the Gateway API to work as expected.
-func runManagerWithConfig(
-	ctx context.Context,
-	t *testing.T,
-	envcfg *rest.Config,
-	gw gatewayv1beta1.Gateway,
-	modifyCfgFn func(cfg *manager.Config),
-) (loggerHook *test.Hook) {
-	cfg := ConfigForEnvConfig(t, envcfg)
-
-	cfg.PublishStatusAddress = []string{"127.0.0.1"}
-	cfg.PublishService = mo.Some(k8stypes.NamespacedName{
-		Name:      publishSvcName,
-		Namespace: gw.Namespace,
-	})
-	cfg.FeatureGates[featuregates.GatewayFeature] = true
-	cfg.FeatureGates[featuregates.GatewayAlphaFeature] = true
-
-	if modifyCfgFn != nil {
-		modifyCfgFn(&cfg)
-	}
-
-	logrusLogger, loggerHook := test.NewNullLogger()
-	logger := logrusr.New(logrusLogger)
-	ctrl.SetLogger(logger)
-
-	go func() {
-		err := manager.Run(ctx, &cfg, util.ConfigDumpDiagnostic{}, logrusLogger)
-		require.NoError(t, err)
-	}()
-
-	return loggerHook
-}
-
 // deployGateway deploys a Gateway, GatewayClass, and publish Service for use in tests.
 func deployGateway(ctx context.Context, t *testing.T, client client.Client) gatewayv1beta1.Gateway {
 	ns := CreateNamespace(ctx, t, client)
@@ -158,7 +114,7 @@ func deployGateway(ctx context.Context, t *testing.T, client client.Client) gate
 	publishSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns.Name,
-			Name:      publishSvcName,
+			Name:      PublishServiceName,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{


### PR DESCRIPTION
**What this PR does / why we need it**:

Spotted this test when doing another refactor in E2E tests and noticed it should be easily convertible to an envtest.
