### PR TITLE
chore(docs): remove bit.ly link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Setting up Kong for Kubernetes is as simple as:
 
 ```shell
 # using YAMLs
-$ kubectl apply -f https://bit.ly/k4k8s
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/latest/deploy/single/all-in-one-dbless.yaml
 
 # or using Helm
 $ helm repo add kong https://charts.konghq.com


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove last bit.ly link from README.md and replace it with github links that's based on `latest` branch that points to latest release tag.