### PR TITLE
fix(konnect): update nodes status only when it actually changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ Adding a new version? You'll need three changes:
   time but be aware that your mileage may vary).
   [#4222](https://github.com/Kong/kubernetes-ingress-controller/pull/4222)
 
+### Fixed
+
+- Nodes in Konnect Runtime Groups API are not updated every 3s anymore.
+  This was caused by a bug in `NodeAgent` that was sending the updates
+  despite the fact that the configuration status was not changed.
+  [#4324](https://github.com/Kong/kubernetes-ingress-controller/pull/4324)
+
 [gojson]: https://github.com/goccy/go-json
 
 ## [2.10.2]

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -59,6 +59,15 @@ func (cf clientFactoryWithExpected) ExpectedCallsLeft() []string {
 	return notCalled
 }
 
+type alwaysSuccessClientFactory struct{}
+
+func (a alwaysSuccessClientFactory) CreateAdminAPIClient(
+	_ context.Context,
+	adminAPI adminapi.DiscoveredAdminAPI,
+) (*adminapi.Client, error) {
+	return adminapi.NewTestClient(adminAPI.Address)
+}
+
 func TestClientAddressesNotifications(t *testing.T) {
 	var (
 		logger      = logrus.New()
@@ -195,8 +204,16 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		cf.expected = map[string]bool{"localhost:8080": true, "localhost:8081": true}
 		// there are 2 addresses contained in the notification of which 2 are new
 		// and client creator should be called exactly 2 times
-		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080"), testDiscoveredAdminAPI("localhost:8081")})
+		clients := []adminapi.DiscoveredAdminAPI{
+			testDiscoveredAdminAPI("localhost:8080"),
+			testDiscoveredAdminAPI("localhost:8081"),
+		}
+		changed := manager.adjustGatewayClients(clients)
+		require.True(t, changed)
 		requireNoExpectedCallsLeftEventually(t)
+
+		changed = manager.adjustGatewayClients(clients)
+		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
 	})
 
 	t.Run("1 addresses, no new client", func(t *testing.T) {
@@ -204,8 +221,13 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		cf.expected = map[string]bool{}
 		// there is address contained in the notification but a client for that
 		// address already exists, client creator should not be called
-		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080")})
+		clients := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080")}
+		changed := manager.adjustGatewayClients(clients)
+		require.True(t, changed)
 		requireNoExpectedCallsLeftEventually(t)
+
+		changed = manager.adjustGatewayClients(clients)
+		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
 	})
 
 	t.Run("2 addresses, 1 new client", func(t *testing.T) {
@@ -213,8 +235,16 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		cf.expected = map[string]bool{"localhost:8081": true}
 		// there are 2 addresses contained in the notification but only 1 is new
 		// hence the client creator should be called only once
-		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080"), testDiscoveredAdminAPI("localhost:8081")})
+		clients := []adminapi.DiscoveredAdminAPI{
+			testDiscoveredAdminAPI("localhost:8080"),
+			testDiscoveredAdminAPI("localhost:8081"),
+		}
+		changed := manager.adjustGatewayClients(clients)
+		require.True(t, changed)
 		requireNoExpectedCallsLeftEventually(t)
+
+		changed = manager.adjustGatewayClients(clients)
+		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
 	})
 
 	t.Run("0 addresses", func(t *testing.T) {
@@ -222,8 +252,12 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 		cf.expected = map[string]bool{}
 		// there are 0 addresses contained in the notification hence the client
 		// creator should not be called
-		manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI(nil))
+		changed := manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI(nil))
+		require.True(t, changed)
 		requireNoExpectedCallsLeftEventually(t)
+
+		changed = manager.adjustGatewayClients(nil)
+		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
 	})
 }
 
@@ -395,9 +429,7 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	t.Parallel()
 
-	cf := &clientFactoryWithExpected{t: t, expected: map[string]bool{
-		"http://10.0.0.1:8080": true,
-	}}
+	cf := alwaysSuccessClientFactory{}
 	testClient, err := adminapi.NewTestClient("http://10.0.0.1:8080")
 	require.NoError(t, err)
 
@@ -419,7 +451,7 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 			case <-ch:
 				// Call GatewayClients() here to make sure that we can access the clients safely
 				// from the subscriber goroutine without causing a deadlock in the notify loop.
-				require.Len(t, m.GatewayClients(), 1, "expected to get 1 client")
+				_ = m.GatewayClients()
 				receivedNotificationsCount.Add(1)
 			case <-ctx.Done():
 				return
@@ -428,21 +460,89 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	}()
 
 	// Run multiple notifiers in parallel to make sure that Notify is safe for concurrent use.
+	clients := []adminapi.DiscoveredAdminAPI{
+		testDiscoveredAdminAPI("http://10.0.0.1:8080"),
+	}
 	for i := 0; i < 10; i++ {
+		i := i
 		go func() {
-			m.Notify([]adminapi.DiscoveredAdminAPI{
-				testDiscoveredAdminAPI("http://10.0.0.1:8080"),
-			})
+			// Notify with different clients' sets to trigger notifications as changes are required for them to happen.
+			if i%2 == 0 {
+				m.Notify(clients)
+			} else {
+				m.Notify(nil)
+			}
 		}()
 	}
 
 	require.Eventually(t, func() bool {
-		if count := receivedNotificationsCount.Load(); count != 10 {
-			t.Logf("Received %d notifications, expected 10, waiting...", count)
+		if count := receivedNotificationsCount.Load(); count < 2 {
+			t.Logf("Received %d notifications, expected at least 2, waiting...", count)
 			return false
 		}
 		return true
-	}, time.Second, time.Millisecond, "expected to receive 10 notifications")
+	}, time.Second, time.Millisecond, "expected to receive at least 2 notifications")
+}
+
+func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(t *testing.T) {
+	cf := alwaysSuccessClientFactory{}
+	testClient, err := adminapi.NewTestClient("http://10.0.0.1:8080")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
+	require.NoError(t, err)
+	m.RunNotifyLoop()
+
+	var receivedNotificationsCount atomic.Uint32
+	ch, ok := m.SubscribeToGatewayClientsChanges()
+	require.NotNil(t, ch)
+	require.True(t, ok)
+
+	// Run subscriber worker in a separate goroutine to consume notifications.
+	go func() {
+		for {
+			select {
+			case <-ch:
+				receivedNotificationsCount.Add(1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	firstClientsSet := []adminapi.DiscoveredAdminAPI{
+		testDiscoveredAdminAPI("http://10.0.0.1:8080"),
+	}
+	secondClientsSet := []adminapi.DiscoveredAdminAPI{
+		testDiscoveredAdminAPI("http://10.0.0.2:8080"),
+	}
+	notificationsCountEventuallyEquals := func(expectedCount int) {
+		require.Eventually(t, func() bool {
+			if count := receivedNotificationsCount.Load(); count != uint32(expectedCount) {
+				t.Logf("Received %d notifications, expected %d, waiting...", count, expectedCount)
+				return false
+			}
+			return true
+		}, time.Second, time.Millisecond, "expected to receive %d notifications", expectedCount)
+	}
+
+	// Notify the first set of clients and make sure that the subscriber doesn't get notified as it was initial state.
+	m.Notify(firstClientsSet)
+	notificationsCountEventuallyEquals(0)
+
+	// Notify an empty set of clients and make sure that the subscriber get notified.
+	m.Notify(nil)
+	notificationsCountEventuallyEquals(1)
+
+	// Notify an empty set again and make sure that the subscriber doesn't get notified as the state didn't change.
+	m.Notify(nil)
+	notificationsCountEventuallyEquals(1)
+
+	// Notify the second set of clients and make sure that the subscriber gets notified.
+	m.Notify(secondClientsSet)
+	notificationsCountEventuallyEquals(2)
 }
 
 func testDiscoveredAdminAPI(address string) adminapi.DiscoveredAdminAPI {

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -373,19 +373,26 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 }
 
 type mockConfigStatusQueue struct {
-	wasNotified bool
+	notifications []clients.ConfigStatus
+	lock          sync.RWMutex
 }
 
 func newMockConfigStatusQueue() *mockConfigStatusQueue {
 	return &mockConfigStatusQueue{}
 }
 
-func (m *mockConfigStatusQueue) NotifyConfigStatus(context.Context, clients.ConfigStatus) {
-	m.wasNotified = true
+func (m *mockConfigStatusQueue) NotifyConfigStatus(_ context.Context, status clients.ConfigStatus) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.notifications = append(m.notifications, status)
 }
 
-func (m *mockConfigStatusQueue) WasNotified() bool {
-	return m.wasNotified
+func (m *mockConfigStatusQueue) Notifications() []clients.ConfigStatus {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	copied := make([]clients.ConfigStatus, len(m.notifications))
+	copy(copied, m.notifications)
+	return copied
 }
 
 type mockKongConfigBuilder struct {
@@ -427,7 +434,7 @@ func (p *mockKongConfigBuilder) returnTranslationFailures(enabled bool) {
 	}
 }
 
-func TestKongClientUpdate_ConfigStatusIsAlwaysNotified(t *testing.T) {
+func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 	var (
 		ctx               = context.Background()
 		testKonnectClient = mustSampleKonnectClient(t)
@@ -449,42 +456,49 @@ func TestKongClientUpdate_ConfigStatusIsAlwaysNotified(t *testing.T) {
 		gatewayFailure      bool
 		konnectFailure      bool
 		translationFailures bool
+		expectedStatus      clients.ConfigStatus
 	}{
 		{
 			name:                "success",
 			gatewayFailure:      false,
 			konnectFailure:      false,
 			translationFailures: false,
+			expectedStatus:      clients.ConfigStatusOK,
 		},
 		{
 			name:                "gateway failure",
 			gatewayFailure:      true,
 			konnectFailure:      false,
 			translationFailures: false,
+			expectedStatus:      clients.ConfigStatusApplyFailed,
 		},
 		{
 			name:                "translation failures",
 			gatewayFailure:      false,
 			konnectFailure:      false,
 			translationFailures: true,
+			expectedStatus:      clients.ConfigStatusTranslationErrorHappened,
 		},
 		{
 			name:                "konnect failure",
 			gatewayFailure:      false,
 			konnectFailure:      true,
 			translationFailures: false,
+			expectedStatus:      clients.ConfigStatusOKKonnectApplyFailed,
 		},
 		{
 			name:                "both gateway and konnect failure",
 			gatewayFailure:      true,
 			konnectFailure:      true,
 			translationFailures: false,
+			expectedStatus:      clients.ConfigStatusApplyFailedKonnectApplyFailed,
 		},
 		{
 			name:                "translation failures and konnect failure",
 			gatewayFailure:      false,
 			konnectFailure:      true,
 			translationFailures: true,
+			expectedStatus:      clients.ConfigStatusTranslationErrorHappenedKonnectApplyFailed,
 		},
 	}
 
@@ -499,7 +513,13 @@ func TestKongClientUpdate_ConfigStatusIsAlwaysNotified(t *testing.T) {
 			configBuilder.returnTranslationFailures(tc.translationFailures)
 
 			_ = kongClient.Update(ctx)
-			require.True(t, statusQueue.WasNotified())
+			notifications := statusQueue.Notifications()
+			require.Len(t, notifications, 1)
+			require.Equal(t, tc.expectedStatus, notifications[0])
+
+			_ = kongClient.Update(ctx)
+			notifications = statusQueue.Notifications()
+			require.Len(t, notifications, 1, "no new notification should be sent if the status hasn't changed")
 		})
 	}
 }

--- a/internal/konnect/mock_node_api_test.go
+++ b/internal/konnect/mock_node_api_test.go
@@ -3,6 +3,7 @@ package konnect_test
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -15,6 +16,7 @@ type mockNodeClient struct {
 	nodes                    map[string]*nodes.NodeItem
 	returnErrorFromListNodes bool
 	wasListAllNodesCalled    bool
+	nodeUpdatesCount         atomic.Int32
 	lock                     sync.RWMutex
 }
 
@@ -69,6 +71,7 @@ func (m *mockNodeClient) ListAllNodes(_ context.Context) ([]*nodes.NodeItem, err
 func (m *mockNodeClient) upsertNode(node *nodes.NodeItem) *nodes.NodeItem {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+	m.nodeUpdatesCount.Add(1)
 
 	if node.ID == "" {
 		node.ID = uuid.New().String()
@@ -95,4 +98,8 @@ func (m *mockNodeClient) ReturnErrorFromListAllNodes(v bool) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.returnErrorFromListNodes = v
+}
+
+func (m *mockNodeClient) NodesUpdatesCount() int {
+	return int(m.nodeUpdatesCount.Load())
 }

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/nodes"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
 )
 
 const (
@@ -417,6 +418,7 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 		},
 	}
 
+	expectedNodesUpdatesCount := 0
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc.notifiedConfigStatus), func(t *testing.T) {
 			configStatusQueue.Notify(tc.notifiedConfigStatus)
@@ -437,8 +439,114 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 
 				return true
 			}, time.Second, time.Millisecond)
+
+			expectedNodesUpdatesCount++
+			require.Equal(t, expectedNodesUpdatesCount, nodeClient.NodesUpdatesCount(), "expected only one more node update")
 		})
 	}
+}
+
+func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnlyWhenItChanges(t *testing.T) {
+	nodeClient := newMockNodeClient(nil)
+	configStatusQueue := newMockConfigStatusNotifier()
+	gatewayClientsChangesNotifier := newMockGatewayClientsNotifier()
+
+	nodeAgent := konnect.NewNodeAgent(
+		testHostname,
+		testKicVersion,
+		konnect.DefaultRefreshNodePeriod,
+		logr.Discard(),
+		nodeClient,
+		configStatusQueue,
+		newMockGatewayInstanceGetter(nil),
+		gatewayClientsChangesNotifier,
+		newMockManagerInstanceIDProvider(uuid.New()),
+	)
+
+	runAgent(t, nodeAgent)
+
+	// We'll use these two to toggle between when we want to trigger an update.
+	statusOne := clients.ConfigStatusOK
+	statusTwo := clients.ConfigStatusTranslationErrorHappened
+
+	nodesUpdatesCountEventuallyEquals := func(count int) {
+		require.Eventually(t, func() bool {
+			return nodeClient.NodesUpdatesCount() == count
+		}, time.Second, time.Millisecond)
+	}
+
+	// Notify the first status and wait for the node to be updated.
+	configStatusQueue.Notify(statusOne)
+	nodesUpdatesCountEventuallyEquals(1)
+
+	// Notify the same status again and ensure that the node wasn't updated.
+	configStatusQueue.Notify(statusOne)
+	nodesUpdatesCountEventuallyEquals(1)
+
+	// Notify the second status and ensure that the node was updated.
+	configStatusQueue.Notify(statusTwo)
+	nodesUpdatesCountEventuallyEquals(2)
+
+	// Notify the same status again and ensure that the node wasn't updated.
+	configStatusQueue.Notify(statusTwo)
+	nodesUpdatesCountEventuallyEquals(2)
+}
+
+func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
+	nodeClient := newMockNodeClient(nil)
+	configStatusQueue := newMockConfigStatusNotifier()
+	gatewayClientsChangesNotifier := newMockGatewayClientsNotifier()
+
+	ticker := mocks.NewTicker()
+	const halfOfRefreshPeriod = konnect.DefaultRefreshNodePeriod / 2
+	nodeAgent := konnect.NewNodeAgent(
+		testHostname,
+		testKicVersion,
+		konnect.DefaultRefreshNodePeriod,
+		logr.Discard(),
+		nodeClient,
+		configStatusQueue,
+		newMockGatewayInstanceGetter(nil),
+		gatewayClientsChangesNotifier,
+		newMockManagerInstanceIDProvider(uuid.New()),
+		konnect.WithRefreshTicker(ticker),
+	)
+
+	runAgent(t, nodeAgent)
+
+	t.Run("config status notification", func(t *testing.T) {
+		// Let half of the period pass.
+		ticker.Add(halfOfRefreshPeriod)
+
+		// Trigger update with config status notification.
+		configStatusQueue.Notify(clients.ConfigStatusApplyFailed)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Nanosecond)
+
+		// Let another half of the period pass - no update should be triggered yet because of the notification.
+		ticker.Add(halfOfRefreshPeriod)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Nanosecond)
+
+		// Trigger update with ticker.
+		ticker.Add(halfOfRefreshPeriod)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 2 }, time.Second, time.Nanosecond)
+	})
+
+	t.Run("gateway clients changes notification", func(t *testing.T) {
+		// Let half of the period pass.
+		ticker.Add(halfOfRefreshPeriod)
+
+		// Trigger update with gateway clients change notification.
+		gatewayClientsChangesNotifier.Notify()
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Nanosecond)
+
+		// Let another half of the period pass - no update should be triggered yet because of the notification.
+		ticker.Add(halfOfRefreshPeriod)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Nanosecond)
+
+		// Trigger update with ticker.
+		ticker.Add(halfOfRefreshPeriod)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 4 }, time.Second, time.Nanosecond)
+	})
 }
 
 // runAgent runs the agent in a goroutine and cancels the context after the test is done, ensuring that the agent

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -520,15 +520,15 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 
 		// Trigger update with config status notification.
 		configStatusQueue.Notify(clients.ConfigStatusApplyFailed)
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Microsecond)
 
 		// Let another half of the period pass - no update should be triggered yet because of the notification.
 		ticker.Add(halfOfRefreshPeriod)
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 1 }, time.Second, time.Microsecond)
 
 		// Trigger update with ticker.
 		ticker.Add(halfOfRefreshPeriod)
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 2 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 2 }, time.Second, time.Microsecond)
 	})
 
 	t.Run("gateway clients changes notification", func(t *testing.T) {
@@ -537,15 +537,15 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 
 		// Trigger update with gateway clients change notification.
 		gatewayClientsChangesNotifier.Notify()
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Microsecond)
 
 		// Let another half of the period pass - no update should be triggered yet because of the notification.
 		ticker.Add(halfOfRefreshPeriod)
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 3 }, time.Second, time.Microsecond)
 
 		// Trigger update with ticker.
 		ticker.Add(halfOfRefreshPeriod)
-		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 4 }, time.Second, time.Nanosecond)
+		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() != 4 }, time.Second, time.Microsecond)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes sure that:

- `NodeAgent` calls Konnect APIs only when the config status actually changes (enforce that on both ends of the notification channel - in `NodeAgent` and in `KongClient`). **This was an actual reason for KIC updating nodes every 3s**.
- `NodeAgent` calls Konnect APIs only when a set of Gateway clients actually changes (enforce that on `ClientsManager` side)

Also improves debug logging to make it visible when the calls are made.

After this change, `NodeAgent` will call Konnect APIs in the following cases:
- configuration status has changed,
- gateways' clients have changed (Gateway deployment scaling, Pod eviction, etc.),
- every 30s.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #4322.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
