### PR TITLE
chore: mark file docs/api-reference.md as autogenerated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 **/zz_generated*.go linguist-generated=true
 pkg/clientset/** linguist-generated=true
 deploy/single/** linguist-generated=true
+docs/api-reference.md linguist-generated=true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since
https://github.com/Kong/kubernetes-ingress-controller/blob/399eef2002a6dfa7fa758d214ec6df54924e1de8/docs/api-reference.md#L1
it should be added to `.gitattributes` too.

