### PR TITLE
[Backport release/2.9.x] fix: make status queue not block when no sub exists (#4267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ Adding a new version? You'll need three changes:
   together with the related manifest resources (`configmaps` and `leases`) might
   become mixed up when the manifest is unmarshalled.
   [#3932](https://github.com/Kong/kubernetes-ingress-controller/pull/3932)
+- Fixed a bug where the controller sync loop would get stuck when a number of
+  updates for one of Gateway API resources kinds (`HTTPRoute`, `TCPRoute`,
+  `UDPRoute`, `TLSRoute`) exceeded 8192. This was caused by the fact that
+  the controller was using a fixed-size buffer to store updates for each
+  resource kind and there were no consumers for the updates. The sending side
+  was blocked after a buffer got full, resulting in a deadlock.
+  [#4267](https://github.com/Kong/kubernetes-ingress-controller/pull/4267)
 
 ## [2.9.3]
 

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
 )
 
 // -----------------------------------------------------------------------------
@@ -39,6 +41,7 @@ type GRPCRouteReconciler struct {
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
 	DataplaneClient *dataplane.KongClient
+	StatusQueue     *status.Queue
 	// If EnableReferenceGrant is true, we will check for ReferenceGrant if backend in another
 	// namespace is in backendRefs.
 	// If it is false, referencing backend in different namespace will be rejected.
@@ -85,6 +88,19 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.listGRPCRoutesForGateway),
 	); err != nil {
 		return err
+	}
+
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    "GRPCRoute",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
 	}
 
 	// because of the additional burden of having to manage reference data-plane

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
 )
 
 // -----------------------------------------------------------------------------
@@ -40,6 +42,7 @@ type TCPRouteReconciler struct {
 	Scheme           *runtime.Scheme
 	DataplaneClient  *dataplane.KongClient
 	CacheSyncTimeout time.Duration
+	StatusQueue      *status.Queue
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -81,6 +84,19 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForGateway),
 	); err != nil {
 		return err
+	}
+
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    "TCPRoute",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
 	}
 
 	// because of the additional burden of having to manage reference data-plane

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
 )
 
 // -----------------------------------------------------------------------------
@@ -40,6 +42,7 @@ type TLSRouteReconciler struct {
 	Scheme           *runtime.Scheme
 	DataplaneClient  *dataplane.KongClient
 	CacheSyncTimeout time.Duration
+	StatusQueue      *status.Queue
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -81,6 +84,19 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForGateway),
 	); err != nil {
 		return err
+	}
+
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    "TLSRoute",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
 	}
 
 	// because of the additional burden of having to manage reference data-plane

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
 )
 
 // -----------------------------------------------------------------------------
@@ -40,6 +42,7 @@ type UDPRouteReconciler struct {
 	Scheme           *runtime.Scheme
 	DataplaneClient  *dataplane.KongClient
 	CacheSyncTimeout time.Duration
+	StatusQueue      *status.Queue
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -81,6 +84,19 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForGateway),
 	); err != nil {
 		return err
+	}
+
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    "TCPRoute",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
 	}
 
 	// because of the additional burden of having to manage reference data-plane

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -401,6 +401,7 @@ func setupControllers(
 				DataplaneClient:      dataplaneClient,
 				EnableReferenceGrant: referenceGrantsEnabled,
 				CacheSyncTimeout:     c.CacheSyncTimeout,
+				StatusQueue:          kubernetesStatusQueue,
 			},
 		},
 		// ---------------------------------------------------------------------------
@@ -431,6 +432,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				CacheSyncTimeout: c.CacheSyncTimeout,
+				StatusQueue:      kubernetesStatusQueue,
 			},
 		},
 		{
@@ -448,6 +450,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				CacheSyncTimeout: c.CacheSyncTimeout,
+				StatusQueue:      kubernetesStatusQueue,
 			},
 		},
 		{
@@ -465,6 +468,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				CacheSyncTimeout: c.CacheSyncTimeout,
+				StatusQueue:      kubernetesStatusQueue,
 			},
 		},
 		{
@@ -482,6 +486,7 @@ func setupControllers(
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
 				CacheSyncTimeout: c.CacheSyncTimeout,
+				StatusQueue:      kubernetesStatusQueue,
 			},
 		},
 	}

--- a/internal/util/builder/httproutematch.go
+++ b/internal/util/builder/httproutematch.go
@@ -22,6 +22,10 @@ func (b *HTTPRouteMatchBuilder) Build() gatewayv1beta1.HTTPRouteMatch {
 	return b.httpRouteMatch
 }
 
+func (b *HTTPRouteMatchBuilder) ToSlice() []gatewayv1beta1.HTTPRouteMatch {
+	return []gatewayv1beta1.HTTPRouteMatch{b.Build()}
+}
+
 func (b *HTTPRouteMatchBuilder) WithPathPrefix(pathPrefix string) *HTTPRouteMatchBuilder {
 	return b.WithPathType(&pathPrefix, pathMatchTypePtr(gatewayv1beta1.PathMatchPathPrefix))
 }

--- a/internal/util/kubernetes/object/status/queue.go
+++ b/internal/util/kubernetes/object/status/queue.go
@@ -8,18 +8,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-// ----------------------------------------------------------------------------
-// Queue - Vars & Consts
-// ----------------------------------------------------------------------------
-
-// defaultBufferSize indicates the buffer size of the underlying channels that
+// DefaultBufferSize indicates the buffer size of the underlying channels that
 // will be created for object kinds by default. This literally equates to the
 // number of Kubernetes objects which can be in the queue at a single time.
-const defaultBufferSize = 8192
-
-// ----------------------------------------------------------------------------
-// Queue - Public Types
-// ----------------------------------------------------------------------------
+const DefaultBufferSize = 8192
 
 // Queue provides a pub/sub queue with channels for individual Kubernetes
 // objects, the purpose of which is to submit GenericEvents for those objects
@@ -27,26 +19,50 @@ const defaultBufferSize = 8192
 // the dataplane so that its status can be updated (for instance, with IP
 // address information in the case of Ingress resources).
 type Queue struct {
-	lock     sync.RWMutex
-	channels map[string]chan event.GenericEvent
+	// subscriptionBufferSize indicates the buffer size of the underlying channels
+	// that will be created for object kinds' subscriptions.
+	subscriptionBufferSize int
+
+	// subscriptions indexed by the string representation of the object GVK.
+	subscriptions map[string]chan event.GenericEvent
+
+	// lock protects the subscriptions map.
+	lock sync.RWMutex
+}
+
+// QueueOption provides a functional option for configuring a Queue object.
+type QueueOption func(*Queue)
+
+// WithBufferSize sets the buffer size of the underlying channels that will be
+// created for object kinds.
+func WithBufferSize(size int) QueueOption {
+	return func(q *Queue) {
+		q.subscriptionBufferSize = size
+	}
 }
 
 // NewQueue provides a new Queue object which can be used to
 // publish status update events or subscribe to those events.
-func NewQueue() *Queue {
-	return &Queue{
-		channels: make(map[string]chan event.GenericEvent),
+func NewQueue(opts ...QueueOption) *Queue {
+	q := &Queue{
+		subscriptionBufferSize: DefaultBufferSize,
+		subscriptions:          make(map[string]chan event.GenericEvent),
 	}
+	for _, opt := range opts {
+		opt(q)
+	}
+	return q
 }
-
-// ----------------------------------------------------------------------------
-// Queue - Public Methods
-// ----------------------------------------------------------------------------
 
 // Publish emits a GenericEvent for the provided objects that indicates to
 // subscribers that the status of that object needs to be updated.
+// It's a no-op if there are no subscriptions for the object kind.
 func (q *Queue) Publish(obj client.Object) {
-	ch := q.getChanForKind(obj.GetObjectKind().GroupVersionKind())
+	ch, ok := q.getSubscriptionForKind(obj.GetObjectKind().GroupVersionKind())
+	if !ok {
+		// There's no subscriber for this object kind - nothing to do.
+		return
+	}
 	ch <- event.GenericEvent{Object: obj}
 }
 
@@ -59,20 +75,28 @@ func (q *Queue) Publish(obj client.Object) {
 // be duplicated and each subscriber will receive events on a first come first
 // serve basis.
 func (q *Queue) Subscribe(gvk schema.GroupVersionKind) chan event.GenericEvent {
-	return q.getChanForKind(gvk)
+	return q.getOrCreateSubscriptionForKind(gvk)
 }
 
-// ----------------------------------------------------------------------------
-// Queue - Private Methods
-// ----------------------------------------------------------------------------
-
-func (q *Queue) getChanForKind(gvk schema.GroupVersionKind) chan event.GenericEvent {
+// getOrCreateSubscriptionForKind returns the subscription channel for the provided object GVK.
+// If the channel does not exist, it will be created.
+func (q *Queue) getOrCreateSubscriptionForKind(gvk schema.GroupVersionKind) chan event.GenericEvent {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	ch, ok := q.channels[gvk.String()]
-	if !ok { // if there's no channel built for this kind yet, make it
-		ch = make(chan event.GenericEvent, defaultBufferSize)
-		q.channels[gvk.String()] = ch
+	ch, ok := q.subscriptions[gvk.String()]
+	if !ok {
+		// If there's no channel built for this kind yet, make it.
+		ch = make(chan event.GenericEvent, q.subscriptionBufferSize)
+		q.subscriptions[gvk.String()] = ch
 	}
 	return ch
+}
+
+// getSubscriptionForKind returns the subscription channel for the provided object GVK.
+// The second return value indicates whether the channel exists.
+func (q *Queue) getSubscriptionForKind(gvk schema.GroupVersionKind) (chan event.GenericEvent, bool) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	ch, ok := q.subscriptions[gvk.String()]
+	return ch, ok
 }

--- a/internal/util/kubernetes/object/status/queue_test.go
+++ b/internal/util/kubernetes/object/status/queue_test.go
@@ -2,8 +2,10 @@ package status
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +18,6 @@ import (
 func TestQueue(t *testing.T) {
 	t.Log("creating a status queue")
 	q := NewQueue()
-	assert.Len(t, q.channels, 0, "no channels should be created by default")
 
 	t.Log("generating Kubernetes objects to emit events for the queue")
 	ing1 := &netv1.Ingress{
@@ -52,13 +53,13 @@ func TestQueue(t *testing.T) {
 
 	t.Log("verifying that events can be subscribed to for new object kinds")
 	ingCH := q.Subscribe(ing1.GroupVersionKind())
-	assert.Len(t, q.channels, 1, "internally a single channel should be created for the object kind")
-	t.Logf("%+v", q.channels)
+	assert.Len(t, q.subscriptions, 1, "internally a single channel should be created for the object kind")
+	t.Logf("%+v", q.subscriptions)
 	assert.Len(t, ingCH, 0, "the underlying channel should be empty")
 
 	t.Log("verifying an object can have an event published for it")
 	q.Publish(ing1)
-	assert.Len(t, q.channels, 1, "a channel was already created for the consumer: no more should be created")
+	assert.Len(t, q.subscriptions, 1, "a channel was already created for the consumer: no more should be created")
 	assert.Len(t, ingCH, 1, "the underlying channel should now contain one event")
 
 	t.Log("verifying a published event can be consumed by the consumer")
@@ -67,15 +68,15 @@ func TestQueue(t *testing.T) {
 
 	t.Log("verifying publishing different named objects for kinds that have already been seen")
 	q.Publish(ing2)
-	assert.Len(t, q.channels, 1, "a channel was already created for the object kind: no more should be created")
+	assert.Len(t, q.subscriptions, 1, "a channel was already created for the object kind: no more should be created")
 	assert.Len(t, ingCH, 1, "the underlying channel should now contain one event")
 
 	t.Log("verifying that objects of new kinds can be published into the queue")
-	q.Publish(tcp)
-	q.Publish(udp)
 	tcpCH := q.Subscribe(tcp.GroupVersionKind())
 	udpCH := q.Subscribe(udp.GroupVersionKind())
-	assert.Len(t, q.channels, 3, "2 new channels should have been created for the two new object kinds")
+	q.Publish(tcp)
+	q.Publish(udp)
+	assert.Len(t, q.subscriptions, 3, "2 new channels should have been created for the two new object kinds")
 	assert.Len(t, ingCH, 1, "the underlying channel should contain 1 event")
 	assert.Len(t, tcpCH, 1, "the underlying channel should contain 1 event")
 	assert.Len(t, udpCH, 1, "the underlying channel should contain 1 event")
@@ -93,7 +94,7 @@ func TestQueue(t *testing.T) {
 	q.Publish(udp)
 	q.Publish(udp)
 	q.Publish(udp)
-	assert.Len(t, q.channels, 3)
+	assert.Len(t, q.subscriptions, 3)
 	assert.Len(t, ingCH, 4)
 	assert.Len(t, tcpCH, 5)
 	assert.Len(t, udpCH, 6)
@@ -108,7 +109,7 @@ func TestQueue(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		assert.Equal(t, event.GenericEvent{Object: udp}, <-udpCH)
 	}
-	assert.Len(t, q.channels, 3)
+	assert.Len(t, q.subscriptions, 3)
 	assert.Len(t, ingCH, 0)
 	assert.Len(t, tcpCH, 0)
 	assert.Len(t, udpCH, 0)
@@ -133,3 +134,79 @@ var (
 		Kind:    "UDPIngress",
 	}
 )
+
+func TestQueuePublish(t *testing.T) {
+	const testBufferSize = 1
+	testObj := &netv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: corev1.NamespaceDefault,
+			Name:      "ingress-test-1",
+		},
+	}
+
+	// shouldCompleteAlmostImmediately is a helper function that runs a given action
+	// in a goroutine and verifies that it completes within a second.
+	shouldCompleteAlmostImmediately := func(t *testing.T, action func()) {
+		done := make(chan struct{})
+		go func() {
+			action()
+			close(done)
+		}()
+		select {
+		case <-done:
+			return
+		case <-time.After(1 * time.Second):
+			t.Fatal("action did not complete in time")
+		}
+	}
+
+	t.Run("does not block when no subscription exists", func(t *testing.T) {
+		q := NewQueue(WithBufferSize(testBufferSize))
+
+		shouldCompleteAlmostImmediately(t, func() {
+			// Publish more events than the buffer size and expect no block.
+			for i := 0; i < testBufferSize+1; i++ {
+				q.Publish(testObj)
+			}
+		})
+	})
+
+	t.Run("blocks when subscription exists and buffer is full", func(t *testing.T) {
+		q := NewQueue(WithBufferSize(testBufferSize))
+		sub := q.Subscribe(testObj.GroupVersionKind())
+
+		shouldCompleteAlmostImmediately(t, func() {
+			// Publish exactly the number of events that fit in the buffer. Expect no block.
+			// This is to ensure that the buffer is full.
+			for i := 0; i < testBufferSize; i++ {
+				q.Publish(testObj)
+			}
+		})
+
+		require.Len(t, sub, testBufferSize, "the channel should be full")
+
+		published := make(chan struct{})
+		go func() {
+			q.Publish(testObj)
+			close(published)
+		}()
+
+		select {
+		case <-published:
+			t.Fatal("the Publish goroutine should be blocked")
+		case <-sub:
+			// Consume one event from the channel to unblock the Publish goroutine.
+		}
+
+		select {
+		case <-time.After(1 * time.Second):
+			t.Fatal("the Publish goroutine should have completed, timeout")
+		case <-published:
+		}
+		require.Len(t, sub, testBufferSize, "the channel should be full again")
+	})
+}


### PR DESCRIPTION

**What this PR does / why we need it**:

Backports #4267 to release/2.9.x. Doesn't port an envtest due to discrepancies in setup code and controller-runtime version. 
