### PR TITLE
chore(ci): make release e2e tests run in parallel jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         run: make verify.versions
 
   build-push-images:
-#    environment: 'Docker Push'
+    environment: 'Docker Push'
     needs: verify-manifest-tag
     runs-on: ubuntu-latest
     steps:
@@ -61,76 +61,76 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-#      - name: Parse semver string
-#        id: semver_parser
-#        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-#        with:
-#          input_string: ${{ github.event.inputs.tag }}
-#          version_extractor_regex: 'v(.*)$'
-#      - name: Add standard tags
-#        run: |
-#          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
-#          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
-#          echo 'EOF' >> $GITHUB_ENV
-#      - name: Add major.minor tag
-#        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
-#        run: |
-#          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
-#          echo "" >> $GITHUB_ENV
-#          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
-#          echo 'EOF' >> $GITHUB_ENV
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v2
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v2
-#      - name: Cache Docker layers
-#        uses: actions/cache@v3
-#        with:
-#          path: /tmp/.buildx-cache
-#          key: ${{ runner.os }}-buildx-${{ github.sha }}
-#          restore-keys: |
-#            ${{ runner.os }}-buildx-
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKER_USERNAME }}
-#          password: ${{ secrets.DOCKER_TOKEN }}
-#      - name: Docker meta
-#        id: meta
-#        uses: docker/metadata-action@v4.6.0
-#        with:
-#          images: kong/kubernetes-ingress-controller
-#          flavor: |
-#            latest=${{ github.event.inputs.latest == 'true' }}
-#          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
-#      - name: Build binary
-#        id: docker_build_binary
-#        uses: docker/build-push-action@v4
-#        with:
-#          push: false
-#          file: Dockerfile
-#          cache-from: type=local,src=/tmp/.buildx-cache
-#          cache-to: type=local,dest=/tmp/.buildx-cache
-#          target: builder
-#          platforms: linux/amd64, linux/arm64
-#          build-args: |
-#            TAG=${{ steps.meta.outputs.version }}
-#            COMMIT=${{ github.sha }}
-#            REPO_INFO=https://github.com/${{ github.repository }}.git
-#      - name: Build and push distroless image to DockerHub
-#        id: docker_build
-#        uses: docker/build-push-action@v4
-#        with:
-#          push: true
-#          file: Dockerfile
-#          tags: ${{ steps.meta.outputs.tags }}
-#          cache-from: type=local,src=/tmp/.buildx-cache
-#          target: distroless
-#          platforms: linux/amd64, linux/arm64
-#          build-args: |
-#            TAG=${{ steps.meta.outputs.version }}
-#            COMMIT=${{ github.sha }}
-#            REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: Parse semver string
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        with:
+          input_string: ${{ github.event.inputs.tag }}
+          version_extractor_regex: 'v(.*)$'
+      - name: Add standard tags
+        run: |
+          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
+          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Add major.minor tag
+        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
+        run: |
+          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4.6.0
+        with:
+          images: kong/kubernetes-ingress-controller
+          flavor: |
+            latest=${{ github.event.inputs.latest == 'true' }}
+          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
+      - name: Build binary
+        id: docker_build_binary
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          target: builder
+          platforms: linux/amd64, linux/arm64
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: Build and push distroless image to DockerHub
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          target: distroless
+          platforms: linux/amd64, linux/arm64
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git
 
   test-e2e:
     needs: [verify-manifest-tag, build-push-images]
@@ -139,48 +139,48 @@ jobs:
     with:
       kic-image: kong/kubernetes-ingress-controller:${{ needs.verify-manifest-tag.outputs.fullversion_tag }}
       all-supported-k8s-versions: true
-#
-#  publish-release:
-#    runs-on: ubuntu-latest
-#    needs: [build-push-images, test-e2e]
-#    steps:
-#    - name: Parse semver string
-#      id: semver_parser
-#      uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-#      with:
-#        input_string: ${{ github.event.inputs.tag }}
-#        version_extractor_regex: 'v(.*)$'
-#    - uses: ncipollo/release-action@v1
-#      with:
-#        body: |
-#          #### Download Kong Ingress Controller ${{ steps.semver_parser.outputs.fullversion }}:
-#
-#          - [Docker Image](https://hub.docker.com/repository/docker/kong/kubernetes-ingress-controller)
-#          - [Get started](https://github.com/Kong/kubernetes-ingress-controller#get-started)
-#
-#          #### Links:
-#
-#          - [Changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#${{ steps.semver_parser.outputs.major }}${{ steps.semver_parser.outputs.minor }}${{ steps.semver_parser.outputs.patch }})
-#
-#        token: ${{ secrets.GITHUB_TOKEN }}
-#        tag: ${{ github.event.inputs.tag }}
-#        commit: ${{ github.sha }}
-#        # When prerelease part of the input tag is not empty, make it a prerelease.
-#        # The release will be labeled as non-production ready in GitHub.
-#        prerelease: ${{ steps.semver_parser.outputs.prerelease != '' }}
-#
-#  update-latest-branch:
-#    runs-on: ubuntu-latest
-#    if: github.event.inputs.latest == 'true'
-#    needs:
-#    - publish-release
-#    steps:
-#    - name: checkout repository
-#      uses: actions/checkout@v3
-#      with:
-#        fetch-depth: 0
-#    - name: update 'latest' branch
-#      run: |
-#        git checkout latest
-#        git reset --hard v${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
-#        git push latest
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [build-push-images, test-e2e]
+    steps:
+    - name: Parse semver string
+      id: semver_parser
+      uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+      with:
+        input_string: ${{ github.event.inputs.tag }}
+        version_extractor_regex: 'v(.*)$'
+    - uses: ncipollo/release-action@v1
+      with:
+        body: |
+          #### Download Kong Ingress Controller ${{ steps.semver_parser.outputs.fullversion }}:
+
+          - [Docker Image](https://hub.docker.com/repository/docker/kong/kubernetes-ingress-controller)
+          - [Get started](https://github.com/Kong/kubernetes-ingress-controller#get-started)
+
+          #### Links:
+
+          - [Changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#${{ steps.semver_parser.outputs.major }}${{ steps.semver_parser.outputs.minor }}${{ steps.semver_parser.outputs.patch }})
+
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.event.inputs.tag }}
+        commit: ${{ github.sha }}
+        # When prerelease part of the input tag is not empty, make it a prerelease.
+        # The release will be labeled as non-production ready in GitHub.
+        prerelease: ${{ steps.semver_parser.outputs.prerelease != '' }}
+
+  update-latest-branch:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.latest == 'true'
+    needs:
+    - publish-release
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: update 'latest' branch
+      run: |
+        git checkout latest
+        git reset --hard v${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+        git push latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ on:
 jobs:
   verify-manifest-tag:
     runs-on: ubuntu-latest
+    outputs:
+      fullversion_tag: ${{ steps.semver_parser.outputs.fullversion }}
     steps:
       - uses: mukunku/tag-exists-action@v1.2.0
         id: check-tag
@@ -51,7 +53,7 @@ jobs:
         run: make verify.versions
 
   build-push-images:
-    environment: 'Docker Push'
+#    environment: 'Docker Push'
     needs: verify-manifest-tag
     runs-on: ubuntu-latest
     steps:
@@ -59,158 +61,126 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Parse semver string
-        id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-        with:
-          input_string: ${{ github.event.inputs.tag }}
-          version_extractor_regex: 'v(.*)$'
-      - name: Add standard tags
-        run: |
-          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Add major.minor tag
-        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
-        run: |
-          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4.6.0
-        with:
-          images: kong/kubernetes-ingress-controller
-          flavor: |
-            latest=${{ github.event.inputs.latest == 'true' }}
-          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
-      - name: Build binary
-        id: docker_build_binary
-        uses: docker/build-push-action@v4
-        with:
-          push: false
-          file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: builder
-          platforms: linux/amd64, linux/arm64
-          build-args: |
-            TAG=${{ steps.meta.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
-      - name: Build and push distroless image to DockerHub
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          file: Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          target: distroless
-          platforms: linux/amd64, linux/arm64
-          build-args: |
-            TAG=${{ steps.meta.outputs.version }}
-            COMMIT=${{ github.sha }}
-            REPO_INFO=https://github.com/${{ github.repository }}.git
+#      - name: Parse semver string
+#        id: semver_parser
+#        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+#        with:
+#          input_string: ${{ github.event.inputs.tag }}
+#          version_extractor_regex: 'v(.*)$'
+#      - name: Add standard tags
+#        run: |
+#          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
+#          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
+#          echo 'EOF' >> $GITHUB_ENV
+#      - name: Add major.minor tag
+#        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
+#        run: |
+#          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
+#          echo "" >> $GITHUB_ENV
+#          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
+#          echo 'EOF' >> $GITHUB_ENV
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v2
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v2
+#      - name: Cache Docker layers
+#        uses: actions/cache@v3
+#        with:
+#          path: /tmp/.buildx-cache
+#          key: ${{ runner.os }}-buildx-${{ github.sha }}
+#          restore-keys: |
+#            ${{ runner.os }}-buildx-
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_TOKEN }}
+#      - name: Docker meta
+#        id: meta
+#        uses: docker/metadata-action@v4.6.0
+#        with:
+#          images: kong/kubernetes-ingress-controller
+#          flavor: |
+#            latest=${{ github.event.inputs.latest == 'true' }}
+#          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
+#      - name: Build binary
+#        id: docker_build_binary
+#        uses: docker/build-push-action@v4
+#        with:
+#          push: false
+#          file: Dockerfile
+#          cache-from: type=local,src=/tmp/.buildx-cache
+#          cache-to: type=local,dest=/tmp/.buildx-cache
+#          target: builder
+#          platforms: linux/amd64, linux/arm64
+#          build-args: |
+#            TAG=${{ steps.meta.outputs.version }}
+#            COMMIT=${{ github.sha }}
+#            REPO_INFO=https://github.com/${{ github.repository }}.git
+#      - name: Build and push distroless image to DockerHub
+#        id: docker_build
+#        uses: docker/build-push-action@v4
+#        with:
+#          push: true
+#          file: Dockerfile
+#          tags: ${{ steps.meta.outputs.tags }}
+#          cache-from: type=local,src=/tmp/.buildx-cache
+#          target: distroless
+#          platforms: linux/amd64, linux/arm64
+#          build-args: |
+#            TAG=${{ steps.meta.outputs.version }}
+#            COMMIT=${{ github.sha }}
+#            REPO_INFO=https://github.com/${{ github.repository }}.git
+
   test-e2e:
-    runs-on: ubuntu-latest
-    needs: build-push-images
-    strategy:
-      fail-fast: true
-      matrix:
-        kubernetes-version:
-          - 'v1.22.17'
-          - 'v1.23.17'
-          - 'v1.24.15'
-          - 'v1.25.11'
-          - 'v1.26.6'
-          - 'v1.27.3'
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: setup golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
-      - uses: Kong/kong-license@master
-        id: license
-        with:
-          password: ${{ secrets.PULP_PASSWORD }}
-      - name: Parse semver string
-        id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-        with:
-          input_string: ${{ github.event.inputs.tag }}
-          version_extractor_regex: 'v(.*)$'
-      - name: e2e - ${{ matrix.kubernetes-version }}
-        run: make test.e2e
-        env:
-          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/kubernetes-ingress-controller:${{ steps.semver_parser.outputs.fullversion }}"
-          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-          NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
-          # multiple kind clusters within a single job, so only 1 is allowed at a time.
-
-  publish-release:
-    runs-on: ubuntu-latest
-    needs: [build-push-images, test-e2e]
-    steps:
-    - name: Parse semver string
-      id: semver_parser
-      uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-      with:
-        input_string: ${{ github.event.inputs.tag }}
-        version_extractor_regex: 'v(.*)$'
-    - uses: ncipollo/release-action@v1
-      with:
-        body: |
-          #### Download Kong Ingress Controller ${{ steps.semver_parser.outputs.fullversion }}:
-
-          - [Docker Image](https://hub.docker.com/repository/docker/kong/kubernetes-ingress-controller)
-          - [Get started](https://github.com/Kong/kubernetes-ingress-controller#get-started)
-
-          #### Links:
-
-          - [Changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#${{ steps.semver_parser.outputs.major }}${{ steps.semver_parser.outputs.minor }}${{ steps.semver_parser.outputs.patch }})
-
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.event.inputs.tag }}
-        commit: ${{ github.sha }}
-        # When prerelease part of the input tag is not empty, make it a prerelease.
-        # The release will be labeled as non-production ready in GitHub.
-        prerelease: ${{ steps.semver_parser.outputs.prerelease != '' }}
-
-  update-latest-branch:
-    runs-on: ubuntu-latest
-    if: github.event.inputs.latest == 'true'
-    needs:
-    - publish-release
-    steps:
-    - name: checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: update 'latest' branch
-      run: |
-        git checkout latest
-        git reset --hard v${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
-        git push latest
+    needs: [verify-manifest-tag, build-push-images]
+    uses: ./.github/workflows/_e2e_tests.yaml
+    secrets: inherit
+    with:
+      kic-image: kong/kubernetes-ingress-controller:${{ needs.verify-manifest-tag.outputs.fullversion_tag }}
+      all-supported-k8s-versions: true
+#
+#  publish-release:
+#    runs-on: ubuntu-latest
+#    needs: [build-push-images, test-e2e]
+#    steps:
+#    - name: Parse semver string
+#      id: semver_parser
+#      uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+#      with:
+#        input_string: ${{ github.event.inputs.tag }}
+#        version_extractor_regex: 'v(.*)$'
+#    - uses: ncipollo/release-action@v1
+#      with:
+#        body: |
+#          #### Download Kong Ingress Controller ${{ steps.semver_parser.outputs.fullversion }}:
+#
+#          - [Docker Image](https://hub.docker.com/repository/docker/kong/kubernetes-ingress-controller)
+#          - [Get started](https://github.com/Kong/kubernetes-ingress-controller#get-started)
+#
+#          #### Links:
+#
+#          - [Changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#${{ steps.semver_parser.outputs.major }}${{ steps.semver_parser.outputs.minor }}${{ steps.semver_parser.outputs.patch }})
+#
+#        token: ${{ secrets.GITHUB_TOKEN }}
+#        tag: ${{ github.event.inputs.tag }}
+#        commit: ${{ github.sha }}
+#        # When prerelease part of the input tag is not empty, make it a prerelease.
+#        # The release will be labeled as non-production ready in GitHub.
+#        prerelease: ${{ steps.semver_parser.outputs.prerelease != '' }}
+#
+#  update-latest-branch:
+#    runs-on: ubuntu-latest
+#    if: github.event.inputs.latest == 'true'
+#    needs:
+#    - publish-release
+#    steps:
+#    - name: checkout repository
+#      uses: actions/checkout@v3
+#      with:
+#        fetch-depth: 0
+#    - name: update 'latest' branch
+#      run: |
+#        git checkout latest
+#        git reset --hard v${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+#        git push latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses the reusable workflow to enable running E2Es in `release.yaml` workflow in parallel jobs. This should reduce the release workflow time from ~1-2h to ~30min. 

Tested in workflow run (with publishing jobs commented-out ): https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5545392883/jobs/10124268023

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

As part of #4329.