### PR TITLE
chore(release) date changelog and generate manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1832,7 +1832,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
-[2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.5.1
+[2.5.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.2...v2.5.0
 [2.4.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.0...v2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 ## [2.5.1]
 
-> Release date: TBD
+> Release date: 2023-07-13
 
 #### Fixed
 
@@ -1832,6 +1832,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.2...v2.5.0
 [2.4.2]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/kong/kubernetes-ingress-controller/compare/v2.4.0...v2.4.1

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -7,4 +7,4 @@ images:
   newTag: '2.8'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '2.5.0'
+  newTag: '2.5.1'

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1541,7 +1541,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.5.0
+        image: kong/kubernetes-ingress-controller:2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -1536,7 +1536,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.5.0
+        image: kong/kubernetes-ingress-controller:2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -1610,7 +1610,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.5.0
+        image: kong/kubernetes-ingress-controller:2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -1554,7 +1554,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:2.5.0
+        image: kong/kubernetes-ingress-controller:2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the 2.5.1 release.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

The checklist has items that appear not valid for LTS/backport releases:

- It doesn't look like we should update the Kubernetes/Istio versions. Unclear if we're going to target newer Kubernetes versions than the release originally supported. 2.5.1 does not include changes to do so AFAIK, so I've left those as-is.
- Kong versions have been left as-is.
- FOSSA should be updated for this, but isn't letting me select `release/2.5.x` in the branch dropdown--or _any_ branches other than main, for that matter. The cron job that we have only applies to main. Changing that needs to be PRed to main rather than here.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
