### PR TITLE
test(conformance): enable expression router

### DIFF
--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -50,7 +50,7 @@ func TestGatewayConformance(t *testing.T) {
 		"--dump-config",
 		"--log-level=trace",
 		"--debug-log-reduce-redundancy",
-		fmt.Sprintf("--feature-gates=%s", consts.DefaultFeatureGates),
+		fmt.Sprintf("--feature-gates=%s", consts.ConformanceTestsFeatureGates),
 		"--anonymous-reports=false",
 	}
 
@@ -83,10 +83,6 @@ func TestGatewayConformance(t *testing.T) {
 		ExemptFeatures:             exemptFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,
 		SkipTests: []string{
-			// disabling after being re-enabled by https://github.com/Kong/kubernetes-ingress-controller/pull/4296
-			// it is consistently failing and needs to be investigated.
-			tests.HTTPRouteHeaderMatching.ShortName,
-
 			// extended conformance
 			// https://github.com/Kong/kubernetes-ingress-controller/issues/4166
 			// requires an 8080 listener, which our manually-built test gateway does not have

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -57,7 +57,8 @@ func TestMain(m *testing.M) {
 	globalDeprecatedLogger = deprecatedLogger
 	globalLogger = logger
 
-	kongAddon := kong.NewBuilder().WithControllerDisabled().WithProxyAdminServiceTypeLoadBalancer().Build()
+	// In order to pass conformance tests, the expression router is required.
+	kongAddon := kong.NewBuilder().WithControllerDisabled().WithProxyEnvVar("router_flavor", "expressions").WithProxyAdminServiceTypeLoadBalancer().Build()
 	builder := environments.NewBuilder().WithAddons(metallb.New(), kongAddon)
 	useExistingClusterIfPresent(builder)
 

--- a/test/consts/feature_gates.go
+++ b/test/consts/feature_gates.go
@@ -6,4 +6,8 @@ const (
 	// that are innocuous, or otherwise don't actually get triggered unless the
 	// user takes further action.
 	DefaultFeatureGates = "GatewayAlpha=true"
+
+	// ConformanceTestsFeatureGates is the set of feature gates to be used when running
+	// conformance tests.
+	ConformanceTestsFeatureGates = "GatewayAlpha=true,ExpressionRoutes=true"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Enable the expression router when running conformance tests and enable again `HTTPRouteHeaderMatching` test.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
