### PR TITLE
chore(ci): make github release latest only when asked for

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,6 +198,7 @@ jobs:
         # When prerelease part of the input tag is not empty, make it a prerelease.
         # The release will be labeled as non-production ready in GitHub.
         prerelease: ${{ steps.semver_parser.outputs.prerelease != '' }}
+        makeLatest: ${{ github.event.inputs.latest == 'true' }}
 
   update-latest-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason when releasing 2.5.1, https://github.com/ncipollo/release-action marked it as `latest` in GH releases. I had to manually assign the label to `2.10.3` again. This PR makes this setting explicit using the input we already have in place.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4330.
