### PR TITLE
tests: verify all deployments are ready after installation

### DIFF
--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -24,8 +24,8 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 
 	t.Log("deploying kong components with traditional Kong router")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
-	proxyDeploymentNN := getManifestDeployments(dblessPath).ProxyNN
+	deployments := ManifestDeploy{Path: manifest}.Run(ctx, t, env)
+	proxyDeploymentNN := deployments.ProxyNN
 	ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, "traditional")
 
 	t.Log("running ingress tests to verify that KIC with traditonal Kong router works")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -167,7 +167,7 @@ func TestWebhookUpdate(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
+	ManifestDeploy{Path: manifest}.Run(ctx, t, env)
 
 	firstCertificate := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -284,8 +284,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
-	deployments := getManifestDeployments(dblessPath)
+	deployments := ManifestDeploy{Path: manifest}.Run(ctx, t, env)
 	controllerDeploymentNN := deployments.ControllerNN
 	controllerDeploymentListOptions := metav1.ListOptions{
 		LabelSelector: "app=" + controllerDeploymentNN.Name,
@@ -436,7 +435,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
+	ManifestDeploy{Path: manifest}.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
@@ -483,8 +482,8 @@ func TestDefaultIngressClass(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
-	kongDeployment := getManifestDeployments(dblessPath).ControllerNN
+	deployments := ManifestDeploy{Path: manifest}.Run(ctx, t, env)
+	kongDeployment := deployments.ControllerNN
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	retry "github.com/avast/retry-go/v4"
+	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
 	gokong "github.com/kong/go-kong/kong"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
@@ -93,10 +93,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
 	manifestFile := "../../deploy/single/all-in-one-dbless-konnect-enterprise.yaml"
-	t.Logf("deploying %s manifest file", manifestFile)
-
-	manifest := getTestManifest(t, manifestFile)
-	deployKong(ctx, t, env, manifest)
+	ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 
 	exposeAdminAPI(ctx, t, env, k8stypes.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
 
@@ -181,9 +178,7 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	const manifestFile = "../../deploy/single/all-in-one-dbless-konnect.yaml"
 	t.Logf("deploying %s manifest file", manifestFile)
 
-	manifest := getTestManifest(t, manifestFile)
-	deployKong(ctx, t, env, manifest)
-	return getManifestDeployments(manifestFile)
+	return ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 }
 
 func generateTestKonnectRuntimeGroupDescription(t *testing.T) string {

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -22,8 +22,7 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifest := getDBLessTestManifestByControllerImageEnv(t)
-	deployKong(ctx, t, env, manifest)
-	deployments := getManifestDeployments(dblessPath)
+	deployments := ManifestDeploy{Path: manifest}.Run(ctx, t, env)
 
 	t.Log("adding Kuma mesh")
 	require.NoError(t, kuma.EnableMeshForNamespace(ctx, env.Cluster(), "kong"))
@@ -50,9 +49,7 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, kuma.New())
 
 	t.Log("deploying kong components")
-	manifest := getTestManifest(t, postgresPath)
-	deployKong(ctx, t, env, manifest)
-	deployments := getManifestDeployments(postgresPath)
+	deployments := ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -108,6 +108,7 @@ func exposeAdminAPI(ctx context.Context, t *testing.T, env environments.Environm
 
 // getTestManifest gets a manifest io.Reader, applying optional patches to the base manifest provided.
 // In case of any failure while patching, the base manifest is returned.
+// If skipTestPatches is true, no patches are applied (useful when untouched manifest is needed, e.g. in upgrade tests).
 func getTestManifest(t *testing.T, baseManifestPath string, skipTestPatches bool) io.Reader {
 	t.Helper()
 
@@ -496,7 +497,7 @@ func setEnv(p setEnvParams) error {
 // dumpToTempFile dumps the contents of the reader to a temporary file and returns the path to the file.
 func dumpToTempFile(t *testing.T, reader io.Reader) string {
 	t.Helper()
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	defer file.Close()
 	_, err = io.Copy(file, reader)


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes E2E tests more restrictive about deployments' readiness before proceeding with configuring any resources. It's to ensure that both Gateway and KIC deployments are ready in a default idle state after installation. This is the behavior we want to preserve while implementing #3499.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3499.
