### PR TITLE
feat: make NewKongClientForWorkspace first verify status + tests

### DIFF
--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -1,0 +1,38 @@
+package adminapi_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
+)
+
+func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
+	factory := adminapi.NewClientFactoryForWorkspace("workspace", adminapi.HTTPClientOpts{}, "")
+
+	adminAPIHandler := mocks.NewAdminAPIHandler(t)
+	adminAPIServer := httptest.NewServer(adminAPIHandler)
+	t.Cleanup(func() { adminAPIServer.Close() })
+
+	client, err := factory.CreateAdminAPIClient(context.Background(), adminapi.DiscoveredAdminAPI{
+		Address: adminAPIServer.URL,
+		PodRef: k8stypes.NamespacedName{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	ref, ok := client.PodReference()
+	require.True(t, ok, "expected pod reference to be attached to the client")
+	require.Equal(t, k8stypes.NamespacedName{
+		Namespace: "namespace",
+		Name:      "name",
+	}, ref)
+}

--- a/test/envtest/adminapimock.go
+++ b/test/envtest/adminapimock.go
@@ -1,64 +1,19 @@
 package envtest
 
 import (
-	"io"
-	"net/http"
 	"net/http/httptest"
 	"testing"
-)
 
-const dblessConfig = `{
-	"version": "3.3.0",
-	"configuration": {
-		"database": "off",
-		"router_flavor": "traditional",
-		"role": "traditional",
-		"proxy_listeners": [
-			{
-				"backlog=%d+": false,
-				"ipv6only=on": false,
-				"ipv6only=off": false,
-				"ssl": false,
-				"so_keepalive=off": false,
-				"so_keepalive=%w*:%w*:%d*": false,
-				"listener": "0.0.0.0:8000",
-				"bind": false,
-				"port": 8000,
-				"deferred": false,
-				"so_keepalive=on": false,
-				"http2": false,
-				"proxy_protocol": false,
-				"ip": "0.0.0.0",
-				"reuseport": false
-			}
-		]
-	}
-}`
+	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
+)
 
 // StartAdminAPIServerMock starts a mock Kong Admin API server.
 // Server's .Close() method will be called during test's cleanup.
 func StartAdminAPIServerMock(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		t.Logf("Admin API config: %s %s %s", r.Method, r.URL, string(body))
-	})
-	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		if _, err := w.Write([]byte(dblessConfig)); err != nil {
-			w.WriteHeader(500)
-			return
-		}
-	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if _, err := w.Write([]byte(dblessConfig)); err != nil {
-			w.WriteHeader(500)
-			return
-		}
-	})
-
-	s := httptest.NewServer(mux)
+	handler := mocks.NewAdminAPIHandler(t)
+	s := httptest.NewServer(handler)
 	t.Cleanup(func() {
 		s.Close()
 	})

--- a/test/mocks/admin_api_handler.go
+++ b/test/mocks/admin_api_handler.go
@@ -51,17 +51,17 @@ type AdminAPIHandler struct {
 	workspaceWasCreated atomic.Bool
 }
 
-type AdminAPIHandlerOpt func(srv *AdminAPIHandler)
+type AdminAPIHandlerOpt func(h *AdminAPIHandler)
 
 func WithWorkspaceExists(exists bool) AdminAPIHandlerOpt {
-	return func(srv *AdminAPIHandler) {
-		srv.workspaceExists = exists
+	return func(h *AdminAPIHandler) {
+		h.workspaceExists = exists
 	}
 }
 
 func WithReady(ready bool) AdminAPIHandlerOpt {
-	return func(srv *AdminAPIHandler) {
-		srv.ready = ready
+	return func(h *AdminAPIHandler) {
+		h.ready = ready
 	}
 }
 

--- a/test/mocks/admin_api_handler.go
+++ b/test/mocks/admin_api_handler.go
@@ -1,0 +1,149 @@
+package mocks
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+)
+
+const defaultDBLessStatusResponse = `{
+	"version": "3.3.0",
+	"configuration": {
+		"database": "off",
+		"router_flavor": "traditional",
+		"role": "traditional",
+		"proxy_listeners": [
+			{
+				"backlog=%d+": false,
+				"ipv6only=on": false,
+				"ipv6only=off": false,
+				"ssl": false,
+				"so_keepalive=off": false,
+				"so_keepalive=%w*:%w*:%d*": false,
+				"listener": "0.0.0.0:8000",
+				"bind": false,
+				"port": 8000,
+				"deferred": false,
+				"so_keepalive=on": false,
+				"http2": false,
+				"proxy_protocol": false,
+				"ip": "0.0.0.0",
+				"reuseport": false
+			}
+		]
+	}
+}`
+
+// AdminAPIHandler is a mock implementation of the Admin API. It only implements the endpoints that are
+// required for the tests.
+type AdminAPIHandler struct {
+	mux *http.ServeMux
+	t   *testing.T
+
+	// ready is a flag that indicates whether the server should return a 200 OK or a 503 Service Unavailable.
+	// It's set to true by default.
+	ready bool
+
+	// workspaceExists makes `/workspace/workspaces/:id` return 200 when true, or 404 otherwise.
+	workspaceExists bool
+
+	// workspaceWasCreated is set to true when a workspace `POST /workspaces` was called.
+	workspaceWasCreated atomic.Bool
+}
+
+type AdminAPIHandlerOpt func(srv *AdminAPIHandler)
+
+func WithWorkspaceExists(exists bool) AdminAPIHandlerOpt {
+	return func(srv *AdminAPIHandler) {
+		srv.workspaceExists = exists
+	}
+}
+
+func WithReady(ready bool) AdminAPIHandlerOpt {
+	return func(srv *AdminAPIHandler) {
+		srv.ready = ready
+	}
+}
+
+func NewAdminAPIHandler(t *testing.T, opts ...AdminAPIHandlerOpt) *AdminAPIHandler {
+	h := &AdminAPIHandler{
+		t:     t,
+		ready: true,
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(defaultDBLessStatusResponse))
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if !h.ready {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			} else {
+				_, _ = w.Write([]byte(defaultDBLessStatusResponse))
+			}
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
+	mux.HandleFunc("/workspace/workspaces/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if h.workspaceExists {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
+	mux.HandleFunc("/workspaces", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			if !h.workspaceExists {
+				h.workspaceWasCreated.Store(true)
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"id": "workspace"}`))
+			} else {
+				t.Errorf("unexpected workspace creation")
+			}
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
+	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"version": "3.3.0"}`))
+			return
+		}
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
+	h.mux = mux
+	return h
+}
+
+func (m *AdminAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.t.Logf("AdminAPIHandler received request: %s %s", r.Method, r.URL)
+	m.mux.ServeHTTP(w, r)
+}
+
+func (m *AdminAPIHandler) WasWorkspaceCreated() bool {
+	return m.workspaceWasCreated.Load()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `NewKongClientForWorkspace` verify the status before calling other endpoints. Returns a new `KongClientNotReadyError` when the client is not ready yet. It gives callers a context of whether it makes sense to retry while awaiting for readiness (will be used in the next PRs for #3499).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It's part of #3499. Changelog entry will be added in the final PR swapping the readiness endpoint.

