### PR TITLE
chore: remove outdated debug skaffold profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,7 @@ debug: install _ensure-namespace
 debug.connect:
 	XDG_CONFIG_HOME="$(PROJECT_DIR)/.config" $(DLV) connect localhost:40000
 
-SKAFFOLD_DEBUG_PROFILE ?= debug
+SKAFFOLD_DEBUG_PROFILE ?= debug_multi_gw
 
 # This will port-forward 40000 from KIC's debugger to localhost. Connect to that
 # port with debugger/IDE of your choice

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -42,21 +42,6 @@ profiles:
           TAG: ${{ .TAG }}
           COMMIT: ${{ .COMMIT }}
           REPO_INFO: ${{ .REPO_INFO }}
-- name: debug
-  manifests:
-    kustomize:
-      paths:
-      - config/debug/base
-  build:
-    artifacts:
-    - image: kic-placeholder
-      docker:
-        dockerfile: Dockerfile.debug
-        target: debug
-        buildArgs:
-          TAG: ${{ .TAG }}
-          COMMIT: ${{ .COMMIT }}
-          REPO_INFO: ${{ .REPO_INFO }}
 - name: multi_gw
   manifests:
     kustomize:


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove outdated `debug` skaffold profile and make `debug_multi_gw` a default one for `make debug.skaffold`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
