### PR TITLE
feat: use /status/ready as readiness probe of gateway for gateway discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ Adding a new version? You'll need three changes:
   KIC restarts, it is now able to fetch the last good configuration from a running
   proxy instance and store it in its internal cache.
   [#4265](https://github.com/Kong/kubernetes-ingress-controller/pull/4265)
+- Gateway Discovery feature was adapted to handle Gateways that are not ready yet
+  in terms of accepting data-plane traffic, but are ready to accept configuration
+  updates. The controller will now send configuration to such Gateways and will 
+  actively monitor their readiness for accepting configuration updates.
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
 
 ### Changed
 
@@ -132,6 +137,10 @@ Adding a new version? You'll need three changes:
   sending stage (we've observed around 35% reduced time in config marshalling
   time but be aware that your mileage may vary).
   [#4222](https://github.com/Kong/kubernetes-ingress-controller/pull/4222)
+- Changed the Gateway's readiness probe in all-in-one manifests from `/status`
+  to `/status/ready`. Gateways will be considered ready only after an initial
+  configuration is applied by the controller.
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
 
 [gojson]: https://github.com/goccy/go-json
 [httproute-specification]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ Adding a new version? You'll need three changes:
   [#4265](https://github.com/Kong/kubernetes-ingress-controller/pull/4265)
 - Gateway Discovery feature was adapted to handle Gateways that are not ready yet
   in terms of accepting data-plane traffic, but are ready to accept configuration
-  updates. The controller will now send configuration to such Gateways and will 
+  updates. The controller will now send configuration to such Gateways and will
   actively monitor their readiness for accepting configuration updates.
   [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
 

--- a/config/variants/multi-gw/base/gateway_deployment.yaml
+++ b/config/variants/multi-gw/base/gateway_deployment.yaml
@@ -99,7 +99,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -2108,7 +2108,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2113,7 +2113,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -2123,7 +2123,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -2123,7 +2123,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -2108,7 +2108,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status
+            path: /status/ready
             port: 8100
             scheme: HTTP
           initialDelaySeconds: 5

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -95,6 +95,12 @@ func (c *Client) NodeID(ctx context.Context) (string, error) {
 	return nodeID, nil
 }
 
+// IsReady returns nil if the Admin API is ready to serve requests.
+func (c *Client) IsReady(ctx context.Context) error {
+	_, err := c.adminAPIClient.Status(ctx)
+	return err
+}
+
 // GetKongVersion returns version of the kong gateway.
 func (c *Client) GetKongVersion(ctx context.Context) (string, error) {
 	if c.isKonnect {

--- a/internal/adminapi/endpoints.go
+++ b/internal/adminapi/endpoints.go
@@ -122,7 +122,7 @@ func (d *Discoverer) AdminAPIsFromEndpointSlice(
 		}
 
 		for _, e := range endpoints.Endpoints {
-			if e.Conditions.Ready == nil || !*e.Conditions.Ready {
+			if e.Conditions.Terminating != nil && *e.Conditions.Terminating {
 				continue
 			}
 

--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -167,7 +167,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			dnsStrategy: cfgtypes.ServiceScopedPodDNSStrategy,
 		},
 		{
-			name: "not ready endpoints are not returned",
+			name: "not ready endpoints are returned",
 			endpoints: discoveryv1.EndpointSlice{
 				ObjectMeta:  endpointsSliceObjectMeta,
 				AddressType: discoveryv1.AddressTypeIPv4,
@@ -183,12 +183,18 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 				},
 				Ports: builder.NewEndpointPort(8444).WithName("admin").IntoSlice(),
 			},
-			portNames:   sets.New("admin"),
-			want:        sets.New[DiscoveredAdminAPI](),
+			portNames: sets.New("admin"),
+			want: sets.New[DiscoveredAdminAPI](
+				DiscoveredAdminAPI{
+					Address: "https://10.0.0.1:8444",
+					PodRef: k8stypes.NamespacedName{
+						Name: "pod-1", Namespace: namespaceName,
+					},
+				}),
 			dnsStrategy: cfgtypes.IPDNSStrategy,
 		},
 		{
-			name: "not ready and terminating endpoints are not returned",
+			name: "ready and terminating endpoints are not returned",
 			endpoints: discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
@@ -199,7 +205,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 					{
 						Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
 						Conditions: discoveryv1.EndpointConditions{
-							Ready:       lo.ToPtr(false),
+							Ready:       lo.ToPtr(true),
 							Terminating: lo.ToPtr(true),
 						},
 						TargetRef: testPodReference(namespaceName, "pod-1"),
@@ -237,7 +243,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 						Addresses: []string{"10.0.2.1"},
 						Conditions: discoveryv1.EndpointConditions{
 							Ready:       lo.ToPtr(false),
-							Terminating: lo.ToPtr(false),
+							Terminating: lo.ToPtr(true),
 						},
 						TargetRef: testPodReference(namespaceName, "pod-3"),
 					},
@@ -289,7 +295,7 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 						Addresses: []string{"10.0.2.1"},
 						Conditions: discoveryv1.EndpointConditions{
 							Ready:       lo.ToPtr(false),
-							Terminating: lo.ToPtr(false),
+							Terminating: lo.ToPtr(true),
 						},
 						TargetRef: testPodReference(namespaceName, "pod-3"),
 					},
@@ -551,7 +557,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 									Addresses: []string{"8.0.0.1"},
 									Conditions: discoveryv1.EndpointConditions{
 										Ready:       lo.ToPtr(false),
-										Terminating: lo.ToPtr(false),
+										Terminating: lo.ToPtr(true),
 									},
 									TargetRef: testPodReference(namespaceName, "pod-3"),
 								},
@@ -637,7 +643,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 			dnsStrategy: cfgtypes.IPDNSStrategy,
 		},
 		{
-			name: "not Ready Endpoints are not matched",
+			name: "terminating Endpoints are not matched",
 			service: k8stypes.NamespacedName{
 				Namespace: namespaceName,
 				Name:      serviceName,
@@ -652,7 +658,8 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 								{
 									Addresses: []string{"7.0.0.1"},
 									Conditions: discoveryv1.EndpointConditions{
-										Ready: lo.ToPtr(false),
+										Ready:       lo.ToPtr(false),
+										Terminating: lo.ToPtr(true),
 									},
 									TargetRef: testPodReference(namespaceName, "pod-1"),
 								},

--- a/internal/clients/config_status_test.go
+++ b/internal/clients/config_status_test.go
@@ -5,15 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr/testr"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 )
 
 func TestChannelConfigNotifier(t *testing.T) {
-	logger := testr.New(t)
-	n := clients.NewChannelConfigNotifier(logger)
+	n := clients.NewChannelConfigNotifier(logr.Discard())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -121,7 +121,7 @@ func TestClientAddressesNotifications(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
-	manager.RunNotifyLoop()
+	manager.Run()
 	<-manager.Running()
 
 	defer testClientFactoryWithExpected.AssertExpectedCalls()
@@ -186,7 +186,7 @@ func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
 	manager, err := NewAdminAPIClientsManager(ctx, logger, []*adminapi.Client{testClient}, cf)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
-	manager.RunNotifyLoop()
+	manager.Run()
 	<-manager.Running()
 
 	clients := manager.GatewayClients()
@@ -282,7 +282,7 @@ func TestAdminAPIClientsManager_NotRunningNotifyLoop(t *testing.T) {
 
 	select {
 	case <-m.Running():
-		t.Error("expected manager to not run without explicitly running it with RunNotifyLoop method")
+		t.Error("expected manager to not run without explicitly running it with Run method")
 	case <-time.After(time.Millisecond * 100):
 	}
 }
@@ -322,7 +322,7 @@ func TestAdminAPIClientsManager_GatewayClientsFromNotificationsAreExpectedToHave
 		cf,
 	)
 	require.NoError(t, err)
-	m.RunNotifyLoop()
+	m.Run()
 
 	m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("http://10.0.0.1:8080")})
 
@@ -360,7 +360,7 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 		require.Falsef(t, ok, "expected no subscription to be created because no notification loop is running")
 	})
 
-	m.RunNotifyLoop()
+	m.Run()
 
 	t.Run("when notification loop is running subscription should be created", func(t *testing.T) {
 		ch, ok := m.SubscribeToGatewayClientsChanges()
@@ -437,7 +437,7 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	defer cancel()
 	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
 	require.NoError(t, err)
-	m.RunNotifyLoop()
+	m.Run()
 
 	var receivedNotificationsCount atomic.Uint32
 	ch, ok := m.SubscribeToGatewayClientsChanges()
@@ -493,7 +493,7 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 	defer cancel()
 	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
 	require.NoError(t, err)
-	m.RunNotifyLoop()
+	m.Run()
 
 	var receivedNotificationsCount atomic.Uint32
 	ch, ok := m.SubscribeToGatewayClientsChanges()

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -1,270 +1,130 @@
-package clients
+package clients_test
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 )
 
-// clientFactoryWithExpected implements ClientFactory interface and can be used
-// in tests to assert which clients have been created and signal failure if:
-// - client for an unexpected address gets created
-// - client which already got created was tried to be created second time.
-type clientFactoryWithExpected struct {
-	expected map[string]bool
-	t        *testing.T
+type mockReadinessChecker struct {
+	nextResult clients.ReadinessCheckResult
+	lock       sync.RWMutex
 }
 
-func (cf clientFactoryWithExpected) CreateAdminAPIClient(_ context.Context, adminAPI adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
-	address := adminAPI.Address
-	stillExpecting, ok := cf.expected[address]
-	if !ok {
-		cf.t.Errorf("got %s which was unexpected", address)
-		return nil, fmt.Errorf("got %s which was unexpected", address)
-	}
-	if !stillExpecting {
-		cf.t.Errorf("got %s more than once", address)
-		return nil, fmt.Errorf("got %s more than once", address)
-	}
-	cf.expected[address] = false
-
-	return adminapi.NewTestClient(address)
+func (m *mockReadinessChecker) CheckReadiness(
+	context.Context,
+	[]clients.AlreadyCreatedClient,
+	[]adminapi.DiscoveredAdminAPI,
+) clients.ReadinessCheckResult {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.nextResult
 }
 
-func (cf clientFactoryWithExpected) AssertExpectedCalls() {
-	for _, addr := range cf.ExpectedCallsLeft() {
-		cf.t.Errorf("%s client expected to be called, but wasn't", addr)
-	}
+func (m *mockReadinessChecker) LetChecksReturn(result clients.ReadinessCheckResult) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.nextResult = result
 }
 
-func (cf clientFactoryWithExpected) ExpectedCallsLeft() []string {
-	var notCalled []string
-	for addr, stillExpected := range cf.expected {
-		if stillExpected {
-			notCalled = append(notCalled, addr)
-		}
-	}
-	return notCalled
+func intoTurnedReady(urls ...string) []*adminapi.Client {
+	return lo.Map(urls, func(url string, _ int) *adminapi.Client {
+		return lo.Must(adminapi.NewTestClient(url))
+	})
 }
 
-type alwaysSuccessClientFactory struct{}
-
-func (a alwaysSuccessClientFactory) CreateAdminAPIClient(
-	_ context.Context,
-	adminAPI adminapi.DiscoveredAdminAPI,
-) (*adminapi.Client, error) {
-	return adminapi.NewTestClient(adminAPI.Address)
+func intoTurnedPending(urls ...string) []adminapi.DiscoveredAdminAPI {
+	return lo.Map(urls, func(url string, _ int) adminapi.DiscoveredAdminAPI {
+		return testDiscoveredAdminAPI(url)
+	})
 }
 
-func TestClientAddressesNotifications(t *testing.T) {
-	var (
-		logger      = logrus.New()
-		expected    = map[string]bool{}
-		serverCalls int32
-	)
-
-	const numberOfServers = 2
-
-	createTestServer := func() *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// This test server serves as kong Admin API checking that we only get
-			// as many calls as new clients requests.
-			// That said: when we have 1 manager with url1 and we receive a notification
-			// with url1 and url2 we should only create the second manager with
-			// url2 and leave the existing one (for url1) in place and reuse it.
-
-			atomic.AddInt32(&serverCalls, 1)
-			n := int(atomic.LoadInt32(&serverCalls))
-
-			if n > numberOfServers {
-				t.Errorf("clients should only call out to the server %d times, but we received %d requests",
-					numberOfServers, n,
-				)
-			}
-		}))
-	}
-
-	srv := createTestServer()
-	defer srv.Close()
-	expected[srv.URL] = true
-
-	srv2 := createTestServer()
-	defer srv2.Close()
-	expected[srv2.URL] = true
-
-	testClientFactoryWithExpected := clientFactoryWithExpected{
-		expected: expected,
-		t:        t,
-	}
+func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	initialClient, err := adminapi.NewTestClient("localhost:8083")
+	logger := logrus.New()
+	readinessChecker := &mockReadinessChecker{}
+	initialClient, err := adminapi.NewTestClient("https://localhost:8083")
 	require.NoError(t, err)
-	manager, err := NewAdminAPIClientsManager(
+	manager, err := clients.NewAdminAPIClientsManager(
 		ctx,
 		logger,
 		[]*adminapi.Client{initialClient},
-		testClientFactoryWithExpected,
+		readinessChecker,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 	manager.Run()
 	<-manager.Running()
 
-	defer testClientFactoryWithExpected.AssertExpectedCalls()
-
-	requireClientsCountEventually := func(t *testing.T, c *AdminAPIClientsManager, addresses []string, args ...any) {
+	requireClientsMatchEventually := func(t *testing.T, c *clients.AdminAPIClientsManager, addresses []string, args ...any) {
 		require.Eventually(t, func() bool {
 			clientAddresses := lo.Map(c.GatewayClients(), func(cl *adminapi.Client, _ int) string {
 				return cl.BaseRootURL()
 			})
 			return slices.Equal(addresses, clientAddresses)
-		}, time.Second, time.Millisecond, args...,
-		)
+		}, time.Second, time.Millisecond, args...)
 	}
 
-	requireClientsCountEventually(t, manager, []string{"localhost:8083"},
+	requireClientsMatchEventually(t, manager, []string{initialClient.BaseRootURL()},
 		"initially there should be the initial client")
 
-	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(srv.URL)})
-	requireClientsCountEventually(t, manager, []string{srv.URL},
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
+	requireClientsMatchEventually(t, manager, []string{testURL1},
 		"after notifying about a new address we should get 1 client eventually")
 
-	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(srv.URL)})
-	requireClientsCountEventually(t, manager, []string{srv.URL},
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
+	requireClientsMatchEventually(t, manager, []string{testURL1},
 		"after notifying the same address there's no update in clients")
 
-	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(srv.URL), testDiscoveredAdminAPI(srv2.URL)})
-	requireClientsCountEventually(t, manager, []string{srv.URL, srv2.URL},
-		"after notifying new address set including the old already existing one we get both the old and the new")
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1), testDiscoveredAdminAPI(testURL2)})
+	requireClientsMatchEventually(t, manager, []string{testURL1},
+		"after notifying new address set including the old already existing one but new one not yet ready we get just the old one")
 
-	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(srv.URL), testDiscoveredAdminAPI(srv2.URL)})
-	requireClientsCountEventually(t, manager, []string{srv.URL, srv2.URL},
-		"notifying again with the same set of URLs should not change the existing URLs")
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1), testDiscoveredAdminAPI(testURL2)})
+	requireClientsMatchEventually(t, manager, []string{testURL1, testURL2},
+		"after notifying new address set including the old already existing one and new one turning ready we get both the old and the new")
 
-	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(srv.URL)})
-	requireClientsCountEventually(t, manager, []string{srv.URL},
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1), testDiscoveredAdminAPI(testURL2)})
+	requireClientsMatchEventually(t, manager, []string{testURL1, testURL2},
+		"after notifying again with the same set of URLs should not change the existing URLs")
+
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedPending: intoTurnedPending(testURL2)})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1), testDiscoveredAdminAPI(testURL2)})
+	requireClientsMatchEventually(t, manager, []string{testURL1},
+		"after notifying the same address set with one turning pending, we get only one client")
+
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{})
+	manager.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
+	requireClientsMatchEventually(t, manager, []string{testURL1},
 		"notifying again with just one URL should decrease the set of URLs to just this one")
 
 	manager.Notify([]adminapi.DiscoveredAdminAPI{})
-	requireClientsCountEventually(t, manager, []string{})
-
-	// We could test here notifying about srv.URL and srv2.URL again but there's
-	// no data structure in the manager that could notify us about a removal of
-	// a manager which we could use here.
+	requireClientsMatchEventually(t, manager, []string{})
 
 	cancel()
 	require.NotPanics(t, func() { manager.Notify([]adminapi.DiscoveredAdminAPI{}) }, "notifying about new clients after manager has been shut down shouldn't panic")
 }
 
-func TestClientAdjustInternalClientsAfterNotification(t *testing.T) {
-	var (
-		ctx    = context.Background()
-		logger = logrus.New()
-	)
-
-	cf := &clientFactoryWithExpected{
-		t: t,
-	}
-
-	// Initial client is expected to be replaced later on.
-	testClient, err := adminapi.NewTestClient("localhost:8083")
-	require.NoError(t, err)
-	manager, err := NewAdminAPIClientsManager(ctx, logger, []*adminapi.Client{testClient}, cf)
-	require.NoError(t, err)
-	require.NotNil(t, manager)
-	manager.Run()
-	<-manager.Running()
-
-	clients := manager.GatewayClients()
-	require.Len(t, clients, 1)
-	require.Equal(t, "localhost:8083", clients[0].BaseRootURL())
-
-	requireNoExpectedCallsLeftEventually := func(t *testing.T) {
-		require.Eventually(t, func() bool {
-			return len(cf.ExpectedCallsLeft()) == 0
-		}, time.Second, time.Millisecond)
-	}
-
-	t.Run("2 new clients", func(t *testing.T) {
-		// Change expected addresses
-		cf.expected = map[string]bool{"localhost:8080": true, "localhost:8081": true}
-		// there are 2 addresses contained in the notification of which 2 are new
-		// and client creator should be called exactly 2 times
-		clients := []adminapi.DiscoveredAdminAPI{
-			testDiscoveredAdminAPI("localhost:8080"),
-			testDiscoveredAdminAPI("localhost:8081"),
-		}
-		changed := manager.adjustGatewayClients(clients)
-		require.True(t, changed)
-		requireNoExpectedCallsLeftEventually(t)
-
-		changed = manager.adjustGatewayClients(clients)
-		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
-	})
-
-	t.Run("1 addresses, no new client", func(t *testing.T) {
-		// Change expected addresses
-		cf.expected = map[string]bool{}
-		// there is address contained in the notification but a client for that
-		// address already exists, client creator should not be called
-		clients := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("localhost:8080")}
-		changed := manager.adjustGatewayClients(clients)
-		require.True(t, changed)
-		requireNoExpectedCallsLeftEventually(t)
-
-		changed = manager.adjustGatewayClients(clients)
-		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
-	})
-
-	t.Run("2 addresses, 1 new client", func(t *testing.T) {
-		// Change expected addresses
-		cf.expected = map[string]bool{"localhost:8081": true}
-		// there are 2 addresses contained in the notification but only 1 is new
-		// hence the client creator should be called only once
-		clients := []adminapi.DiscoveredAdminAPI{
-			testDiscoveredAdminAPI("localhost:8080"),
-			testDiscoveredAdminAPI("localhost:8081"),
-		}
-		changed := manager.adjustGatewayClients(clients)
-		require.True(t, changed)
-		requireNoExpectedCallsLeftEventually(t)
-
-		changed = manager.adjustGatewayClients(clients)
-		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
-	})
-
-	t.Run("0 addresses", func(t *testing.T) {
-		// Change expected addresses
-		cf.expected = map[string]bool{}
-		// there are 0 addresses contained in the notification hence the client
-		// creator should not be called
-		changed := manager.adjustGatewayClients([]adminapi.DiscoveredAdminAPI(nil))
-		require.True(t, changed)
-		requireNoExpectedCallsLeftEventually(t)
-
-		changed = manager.adjustGatewayClients(nil)
-		require.False(t, changed, "adjusting clients with the same set of addresses should not change anything")
-	})
-}
-
 func TestNewAdminAPIClientsManager_NoInitialClientsDisallowed(t *testing.T) {
-	cf := &clientFactoryWithExpected{t: t}
-	_, err := NewAdminAPIClientsManager(context.Background(), logrus.New(), nil, cf)
-	require.Error(t, err)
+	_, err := clients.NewAdminAPIClientsManager(context.Background(), logrus.New(), nil, &mockReadinessChecker{})
+	require.ErrorContains(t, err, "at least one initial client must be provided")
 }
 
 func TestAdminAPIClientsManager_NotRunningNotifyLoop(t *testing.T) {
@@ -272,11 +132,11 @@ func TestAdminAPIClientsManager_NotRunningNotifyLoop(t *testing.T) {
 
 	testClient, err := adminapi.NewTestClient("localhost:8080")
 	require.NoError(t, err)
-	m, err := NewAdminAPIClientsManager(
+	m, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
 		logrus.New(),
 		[]*adminapi.Client{testClient},
-		&clientFactoryWithExpected{t: t},
+		&mockReadinessChecker{},
 	)
 	require.NoError(t, err)
 
@@ -292,11 +152,11 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 
 	testClient, err := adminapi.NewTestClient("localhost:8080")
 	require.NoError(t, err)
-	m, err := NewAdminAPIClientsManager(
+	m, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
 		logrus.New(),
 		[]*adminapi.Client{testClient},
-		&clientFactoryWithExpected{t: t},
+		&mockReadinessChecker{},
 	)
 	require.NoError(t, err)
 	require.Len(t, m.GatewayClients(), 1, "expecting one initial client")
@@ -309,49 +169,15 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 	require.Equal(t, konnectTestClient, m.KonnectClient(), "konnect client should be returned from KonnectClient")
 }
 
-func TestAdminAPIClientsManager_GatewayClientsFromNotificationsAreExpectedToHavePodRef(t *testing.T) {
-	t.Parallel()
-
-	cf := &clientFactoryWithExpected{t: t, expected: map[string]bool{"http://10.0.0.1:8080": true}}
-	testClient, err := adminapi.NewTestClient("http://localhost:8080")
-	require.NoError(t, err)
-	m, err := NewAdminAPIClientsManager(
-		context.Background(),
-		logrus.New(),
-		[]*adminapi.Client{testClient},
-		cf,
-	)
-	require.NoError(t, err)
-	m.Run()
-
-	m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("http://10.0.0.1:8080")})
-
-	require.Eventually(t, func() bool {
-		gwClients := m.GatewayClients()
-		if len(gwClients) != 1 {
-			t.Log("there's no gateway clients...")
-			return false
-		}
-		_, ok := gwClients[0].PodReference()
-		if !ok {
-			t.Log("there's no pod reference attached")
-		}
-		return ok
-	}, time.Second, time.Millisecond)
-}
-
 func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 	t.Parallel()
 
-	cf := &clientFactoryWithExpected{t: t, expected: map[string]bool{
-		"http://10.0.0.1:8080": true,
-		"http://10.0.0.2:8080": true,
-	}}
+	readinessChecker := &mockReadinessChecker{}
 	testClient, err := adminapi.NewTestClient("http://localhost:8080")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
+	m, err := clients.NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
 
 	t.Run("no notify loop running should return false when subscribing", func(t *testing.T) {
@@ -367,9 +193,10 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 		require.NotNil(t, ch)
 		require.True(t, ok)
 
+		readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1, testURL2)})
 		m.Notify([]adminapi.DiscoveredAdminAPI{
-			testDiscoveredAdminAPI("http://10.0.0.1:8080"),
-			testDiscoveredAdminAPI("http://10.0.0.2:8080"),
+			testDiscoveredAdminAPI(testURL1),
+			testDiscoveredAdminAPI(testURL2),
 		})
 
 		select {
@@ -389,7 +216,8 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 		require.NotNil(t, sub2)
 		require.True(t, ok)
 
-		m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("http://10.0.0.1:8080")})
+		readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedPending: intoTurnedPending(testURL2)})
+		m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
 
 		select {
 		case <-sub2:
@@ -429,13 +257,14 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	t.Parallel()
 
-	cf := alwaysSuccessClientFactory{}
-	testClient, err := adminapi.NewTestClient("http://10.0.0.1:8080")
+	readinessChecker := &mockReadinessChecker{}
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
+	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
+	m, err := clients.NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
 	m.Run()
 
@@ -451,7 +280,7 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 			case <-ch:
 				// Call GatewayClients() here to make sure that we can access the clients safely
 				// from the subscriber goroutine without causing a deadlock in the notify loop.
-				require.Len(t, m.GatewayClients(), 1, "expected to get 1 client")
+				_ = m.GatewayClients()
 				receivedNotificationsCount.Add(1)
 			case <-ctx.Done():
 				return
@@ -459,19 +288,16 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 		}
 	}()
 
-	// Run multiple notifiers in parallel to make sure that Notify is safe for concurrent use.
-	// We'll use two sets of clients interchangeably to cause an actual change that results in a notification.
-	oddClients := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("http://10.0.0.1:8080")}
-	evenClients := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI("http://10.0.0.2:8080")}
 	for i := 0; i < 10; i++ {
 		i := i
 		go func() {
-			// Notify with even or odd clients interchangeably depending on the iteration to trigger a change.
+			// Swap between ready and pending interchangeably depending on the iteration to trigger a change.
 			if pickEven := i%2 == 0; pickEven {
-				m.Notify(evenClients)
+				readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
 			} else {
-				m.Notify(oddClients)
+				readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedPending: intoTurnedPending(testURL1)})
 			}
+			m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
 		}()
 	}
 
@@ -485,13 +311,13 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(t *testing.T) {
-	cf := alwaysSuccessClientFactory{}
-	testClient, err := adminapi.NewTestClient("http://10.0.0.1:8080")
+	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 
+	readinessChecker := &mockReadinessChecker{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m, err := NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, cf)
+	m, err := clients.NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
 	m.Run()
 
@@ -513,10 +339,10 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 	}()
 
 	firstClientsSet := []adminapi.DiscoveredAdminAPI{
-		testDiscoveredAdminAPI("http://10.0.0.1:8080"),
+		testDiscoveredAdminAPI(testURL1),
 	}
 	secondClientsSet := []adminapi.DiscoveredAdminAPI{
-		testDiscoveredAdminAPI("http://10.0.0.2:8080"),
+		testDiscoveredAdminAPI(testURL2),
 	}
 	notificationsCountEventuallyEquals := func(expectedCount int) {
 		require.Eventually(t, func() bool {
@@ -540,7 +366,12 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 	m.Notify(nil)
 	notificationsCountEventuallyEquals(1)
 
-	// Notify the second set of clients and make sure that the subscriber gets notified.
+	// Notify the second set of clients without making the new one ready and make sure that the subscriber gets no notification.
+	m.Notify(secondClientsSet)
+	notificationsCountEventuallyEquals(1)
+
+	// Notify the second set of clients and make sure that the subscriber gets notified after the new one becomes ready.
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
 	m.Notify(secondClientsSet)
 	notificationsCountEventuallyEquals(2)
 }

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -3,32 +3,51 @@ package clients_test
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
+	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
 )
+
+type readinessCheckCall struct {
+	AlreadyCreatedURLs []string
+	PendingURLs        []string
+}
 
 type mockReadinessChecker struct {
 	nextResult clients.ReadinessCheckResult
+	lastCall   mo.Option[readinessCheckCall]
+	callsCount int
 	lock       sync.RWMutex
 }
 
 func (m *mockReadinessChecker) CheckReadiness(
-	context.Context,
-	[]clients.AlreadyCreatedClient,
-	[]adminapi.DiscoveredAdminAPI,
+	_ context.Context,
+	alreadyCreatedClients []clients.AlreadyCreatedClient,
+	pendingClients []adminapi.DiscoveredAdminAPI,
 ) clients.ReadinessCheckResult {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.callsCount++
+	m.lastCall = mo.Some(readinessCheckCall{
+		AlreadyCreatedURLs: lo.Map(alreadyCreatedClients, func(c clients.AlreadyCreatedClient, _ int) string {
+			return c.BaseRootURL()
+		}),
+		PendingURLs: lo.Map(pendingClients, func(c adminapi.DiscoveredAdminAPI, _ int) string {
+			return c.Address
+		}),
+	})
 	return m.nextResult
 }
 
@@ -36,6 +55,21 @@ func (m *mockReadinessChecker) LetChecksReturn(result clients.ReadinessCheckResu
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.nextResult = result
+}
+
+func (m *mockReadinessChecker) LastCall() (readinessCheckCall, bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if call, ok := m.lastCall.Get(); ok {
+		return call, true
+	}
+	return readinessCheckCall{}, false
+}
+
+func (m *mockReadinessChecker) CallsCount() int {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.callsCount
 }
 
 func intoTurnedReady(urls ...string) []*adminapi.Client {
@@ -255,8 +289,6 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
-	t.Parallel()
-
 	readinessChecker := &mockReadinessChecker{}
 	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
 	testClient, err := adminapi.NewTestClient(testURL1)
@@ -268,49 +300,30 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	require.NoError(t, err)
 	m.Run()
 
-	var receivedNotificationsCount atomic.Uint32
-	ch, ok := m.SubscribeToGatewayClientsChanges()
-	require.NotNil(t, ch)
-	require.True(t, ok)
-
-	// Run subscriber worker in a separate goroutine to consume notifications.
+	// Run a goroutine that will call GatewayClients() every millisecond.
 	go func() {
 		for {
 			select {
-			case <-ch:
-				// Call GatewayClients() here to make sure that we can access the clients safely
-				// from the subscriber goroutine without causing a deadlock in the notify loop.
+			case <-time.Tick(time.Millisecond):
 				_ = m.GatewayClients()
-				receivedNotificationsCount.Add(1)
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
 
-	for i := 0; i < 10; i++ {
-		i := i
-		go func() {
-			// Swap between ready and pending interchangeably depending on the iteration to trigger a change.
-			if pickEven := i%2 == 0; pickEven {
-				readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
-			} else {
-				readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedPending: intoTurnedPending(testURL1)})
-			}
-			m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
-		}()
-	}
+	go func() {
+		for i := 0; i < 100; i++ {
+			go m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)})
+		}
+	}()
 
 	require.Eventually(t, func() bool {
-		if count := receivedNotificationsCount.Load(); count < 2 {
-			t.Logf("Received %d notifications, expected at least 2, waiting...", count)
-			return false
-		}
-		return true
-	}, time.Second, time.Millisecond, "expected to receive at least 2 notifications")
+		return readinessChecker.CallsCount() == 100
+	}, time.Second, time.Millisecond)
 }
 
-func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(t *testing.T) {
+func TestAdminAPIClientsManager_GatewayClientsChanges(t *testing.T) {
 	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 
@@ -319,7 +332,9 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 	defer cancel()
 	m, err := clients.NewAdminAPIClientsManager(ctx, logrus.New(), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
+
 	m.Run()
+	<-m.Running()
 
 	var receivedNotificationsCount atomic.Uint32
 	ch, ok := m.SubscribeToGatewayClientsChanges()
@@ -338,12 +353,8 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 		}
 	}()
 
-	firstClientsSet := []adminapi.DiscoveredAdminAPI{
-		testDiscoveredAdminAPI(testURL1),
-	}
-	secondClientsSet := []adminapi.DiscoveredAdminAPI{
-		testDiscoveredAdminAPI(testURL2),
-	}
+	firstClientsSet := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1)}
+	secondClientsSet := []adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL2)}
 	notificationsCountEventuallyEquals := func(expectedCount int) {
 		require.Eventually(t, func() bool {
 			if count := receivedNotificationsCount.Load(); count != uint32(expectedCount) {
@@ -353,27 +364,120 @@ func TestAdminAPIClientsManager_NotifiesSubscribersOnlyWhenGatewayClientsChange(
 			return true
 		}, time.Second, time.Millisecond, "expected to receive %d notifications", expectedCount)
 	}
+	requireLastReadinessCheckCall := func(expected readinessCheckCall) {
+		call, ok := readinessChecker.LastCall()
+		require.True(t, ok, "expected call to readiness checker")
+		require.Equal(t, expected, call)
+	}
 
 	// Notify the first set of clients and make sure that the subscriber doesn't get notified as it was initial state.
 	m.Notify(firstClientsSet)
 	notificationsCountEventuallyEquals(0)
+	require.Equal(t, 1, readinessChecker.CallsCount(), "expected readiness check on non-empty set of clients")
+	requireLastReadinessCheckCall(readinessCheckCall{
+		AlreadyCreatedURLs: []string{testURL1},
+		PendingURLs:        []string{},
+	})
 
 	// Notify an empty set of clients and make sure that the subscriber get notified.
 	m.Notify(nil)
 	notificationsCountEventuallyEquals(1)
+	require.Equal(t, 1, readinessChecker.CallsCount(), "no readiness check should be performed when notifying an empty set")
 
 	// Notify an empty set again and make sure that the subscriber doesn't get notified as the state didn't change.
 	m.Notify(nil)
 	notificationsCountEventuallyEquals(1)
+	require.Equal(t, 1, readinessChecker.CallsCount(), "no readiness check should be performed when notifying an empty set")
 
 	// Notify the second set of clients without making the new one ready and make sure that the subscriber gets no notification.
 	m.Notify(secondClientsSet)
 	notificationsCountEventuallyEquals(1)
+	requireLastReadinessCheckCall(readinessCheckCall{
+		AlreadyCreatedURLs: []string{},
+		PendingURLs:        []string{testURL2},
+	})
+	require.Equal(t, 2, readinessChecker.CallsCount(), "expected readiness check on non-empty set of clients")
 
 	// Notify the second set of clients and make sure that the subscriber gets notified after the new one becomes ready.
 	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
 	m.Notify(secondClientsSet)
 	notificationsCountEventuallyEquals(2)
+	requireLastReadinessCheckCall(readinessCheckCall{
+		AlreadyCreatedURLs: []string{},
+		PendingURLs:        []string{testURL2},
+	})
+	require.Equal(t, 3, readinessChecker.CallsCount(), "expected readiness check on non-empty set of clients")
+
+	m.Notify([]adminapi.DiscoveredAdminAPI{firstClientsSet[0], secondClientsSet[0]})
+	notificationsCountEventuallyEquals(3)
+	requireLastReadinessCheckCall(readinessCheckCall{
+		AlreadyCreatedURLs: []string{testURL2},
+		PendingURLs:        []string{testURL1},
+	})
+	require.Equal(t, 4, readinessChecker.CallsCount(), "expected readiness check on non-empty set of clients")
+}
+
+func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
+	testClient, err := adminapi.NewTestClient(testURL1)
+	require.NoError(t, err)
+
+	readinessTicker := mocks.NewTicker()
+	readinessChecker := &mockReadinessChecker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m, err := clients.NewAdminAPIClientsManager(
+		ctx,
+		logrus.New(),
+		[]*adminapi.Client{testClient},
+		readinessChecker,
+		clients.WithReadinessReconciliationTicker(readinessTicker),
+	)
+	require.NoError(t, err)
+	m.Run()
+	<-m.Running()
+
+	readinessCheckCallEventuallyMatches := func(expected readinessCheckCall) {
+		require.Eventually(t, func() bool {
+			lastCall, wasCalledAtAll := readinessChecker.LastCall()
+			if !wasCalledAtAll {
+				t.Log("Readiness checker was not called yet, waiting...")
+				return false
+			}
+			if diff := cmp.Diff(expected, lastCall); diff != "" {
+				t.Logf("Readiness checker was called with unexpected arguments: %s", diff)
+				return false
+			}
+			return true
+		}, time.Second, time.Millisecond)
+	}
+
+	// Trigger the first readiness check.
+	readinessTicker.Add(clients.DefaultReadinessReconciliationInterval)
+	readinessCheckCallEventuallyMatches(readinessCheckCall{
+		AlreadyCreatedURLs: []string{testURL1},
+		PendingURLs:        []string{},
+	})
+	require.Equal(t, 1, readinessChecker.CallsCount())
+
+	// Notify with a new client and check the readiness check call was made as expected.
+	m.Notify([]adminapi.DiscoveredAdminAPI{testDiscoveredAdminAPI(testURL1), testDiscoveredAdminAPI(testURL2)})
+	readinessCheckCallEventuallyMatches(readinessCheckCall{
+		AlreadyCreatedURLs: []string{testURL1},
+		PendingURLs:        []string{testURL2},
+	})
+	require.Equal(t, 2, readinessChecker.CallsCount())
+
+	// Trigger a next readiness check which will make testURL2 ready.
+	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
+	readinessTicker.Add(clients.DefaultReadinessReconciliationInterval)
+	readinessCheckCallEventuallyMatches(readinessCheckCall{
+		AlreadyCreatedURLs: []string{testURL1},
+		PendingURLs:        []string{testURL2},
+	})
+	require.Equal(t, 3, readinessChecker.CallsCount())
+	require.True(t, lo.ContainsBy(m.GatewayClients(), func(c *adminapi.Client) bool {
+		return c.BaseRootURL() == testURL2
+	}), "expected to find the new client in the manager's clients list after it became ready")
 }
 
 func testDiscoveredAdminAPI(address string) adminapi.DiscoveredAdminAPI {

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ReadinessCheckTimeout = time.Second
+	readinessCheckTimeout = time.Second
 )
 
 // ReadinessCheckResult represents the result of a readiness check.
@@ -95,7 +95,7 @@ func (c DefaultReadinessChecker) checkPendingClient(
 			Debugf("checking readiness of pending client for %q", pendingClient.Address)
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, ReadinessCheckTimeout)
+	ctx, cancel := context.WithTimeout(ctx, readinessCheckTimeout)
 	defer cancel()
 	client, err := c.factory.CreateAdminAPIClient(ctx, pendingClient)
 	if err != nil {
@@ -134,7 +134,7 @@ func (c DefaultReadinessChecker) checkAlreadyCreatedClient(ctx context.Context, 
 			Debugf("checking readiness of already created client for %q", client.BaseRootURL())
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, ReadinessCheckTimeout)
+	ctx, cancel := context.WithTimeout(ctx, readinessCheckTimeout)
 	defer cancel()
 	if err := client.IsReady(ctx); err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -3,21 +3,34 @@ package clients
 import (
 	"context"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/sirupsen/logrus"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 )
 
+// ReadinessCheckResult represents the result of a readiness check.
 type ReadinessCheckResult struct {
-	ClientsTurnedReady   []*adminapi.Client
+	// ClientsTurnedReady are the clients that were pending and are now ready to be used.
+	ClientsTurnedReady []*adminapi.Client
+	// ClientsTurnedPending are the clients that were ready and are now pending to be created.
 	ClientsTurnedPending []adminapi.DiscoveredAdminAPI
 }
 
+// HasChanges returns true if there are any changes in the readiness check result.
+// When no changes are present, it means that the readiness check haven't successfully created any pending client
+// nor detected any already created client that became not ready.
 func (r ReadinessCheckResult) HasChanges() bool {
 	return len(r.ClientsTurnedReady) > 0 || len(r.ClientsTurnedPending) > 0
 }
 
+// ReadinessChecker is responsible for checking the readiness of Admin API clients.
 type ReadinessChecker interface {
+	// CheckReadiness checks readiness of the provided clients:
+	// - alreadyCreatedClients are the clients that have already been created. The readiness of these clients will be
+	//   checked by their IsReady() method.
+	// - pendingClients are the clients that have not been created yet and are pending to be created. The readiness of
+	//   these clients will be checked by trying to create them.
 	CheckReadiness(
 		ctx context.Context,
 		alreadyCreatedClients []AlreadyCreatedClient,
@@ -25,6 +38,7 @@ type ReadinessChecker interface {
 	) ReadinessCheckResult
 }
 
+// AlreadyCreatedClient represents an Admin API client that has already been created.
 type AlreadyCreatedClient interface {
 	IsReady(context.Context) error
 	PodReference() (k8stypes.NamespacedName, bool)
@@ -50,10 +64,11 @@ func (c DefaultReadinessChecker) CheckReadiness(
 ) ReadinessCheckResult {
 	return ReadinessCheckResult{
 		ClientsTurnedReady:   c.checkPendingGatewayClients(ctx, pendingClients),
-		ClientsTurnedPending: c.checkActiveGatewayClients(ctx, readyClients),
+		ClientsTurnedPending: c.checkAlreadyExistingClients(ctx, readyClients),
 	}
 }
 
+// checkPendingGatewayClients checks if the pending clients are ready to be used and returns the ones that are.
 func (c DefaultReadinessChecker) checkPendingGatewayClients(ctx context.Context, lastPending []adminapi.DiscoveredAdminAPI) (turnedReady []*adminapi.Client) {
 	for _, adminAPI := range lastPending {
 		// We indirectly check readiness of the client by trying to create it. If it succeeds then it means that
@@ -70,9 +85,11 @@ func (c DefaultReadinessChecker) checkPendingGatewayClients(ctx context.Context,
 	return turnedReady
 }
 
-func (c DefaultReadinessChecker) checkActiveGatewayClients(ctx context.Context, lastActive []AlreadyCreatedClient) (turnedPending []adminapi.DiscoveredAdminAPI) {
+// checkAlreadyExistingClients checks if the already existing clients are still ready to be used and returns the ones
+// that are not.
+func (c DefaultReadinessChecker) checkAlreadyExistingClients(ctx context.Context, lastActive []AlreadyCreatedClient) (turnedPending []adminapi.DiscoveredAdminAPI) {
 	for _, client := range lastActive {
-		// For active clients we check readiness by calling the Status endpoint.
+		// For ready clients we check readiness by calling the Status endpoint.
 		if err := client.IsReady(ctx); err != nil {
 			// Despite the error reason we still want to keep the client in the pending list to retry later.
 			c.logger.WithError(err).Debugf("active client for %q is not ready, moving to pending", client.BaseRootURL())

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -1,0 +1,72 @@
+package clients
+
+import (
+	"context"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/sirupsen/logrus"
+)
+
+type ReadinessCheckResult struct {
+	TurnedReady   []*adminapi.Client
+	TurnedPending []adminapi.DiscoveredAdminAPI
+}
+
+type ReadinessChecker interface {
+	CheckReadiness(
+		ctx context.Context,
+		lastReadyClients []*adminapi.Client,
+		lastPendingClients []adminapi.DiscoveredAdminAPI,
+	) ReadinessCheckResult
+}
+
+type DefaultReadinessChecker struct {
+	factory ClientFactory
+	logger  logrus.FieldLogger
+}
+
+func (c DefaultReadinessChecker) CheckReadiness(
+	ctx context.Context,
+	lastReadyClients []*adminapi.Client,
+	lastPendingClients []adminapi.DiscoveredAdminAPI,
+) ReadinessCheckResult {
+	return ReadinessCheckResult{
+		TurnedReady:   c.checkPendingGatewayClients(ctx, lastPendingClients),
+		TurnedPending: c.checkActiveGatewayClients(ctx, lastReadyClients),
+	}
+}
+
+func (c DefaultReadinessChecker) checkPendingGatewayClients(ctx context.Context, lastPending []adminapi.DiscoveredAdminAPI) (turnedReady []*adminapi.Client) {
+	for _, adminAPI := range lastPending {
+		client, err := c.factory.CreateAdminAPIClient(ctx, adminAPI)
+		if err != nil {
+			// Despite the error reason we still want to keep the client in the pending list to retry later.
+			c.logger.WithError(err).Debugf("pending client for %q is not ready yet", adminAPI.Address)
+			continue
+		}
+
+		turnedReady = append(turnedReady, client)
+	}
+	return turnedReady
+}
+
+func (c DefaultReadinessChecker) checkActiveGatewayClients(ctx context.Context, lastActive []*adminapi.Client) (turnedPending []adminapi.DiscoveredAdminAPI) {
+	for _, client := range lastActive {
+		_, err := client.AdminAPIClient().Status(ctx)
+		if err != nil {
+			// Despite the error reason we still want to keep the client in the pending list to retry later.
+			c.logger.WithError(err).Debugf("active client for %q is not ready, moving to pending", client.BaseRootURL())
+
+			podRef, ok := client.PodReference()
+			if !ok {
+				// This should never happen, but if it does, we want to log it.
+				c.logger.Errorf("failed to get PodReference for client %q", client.BaseRootURL())
+			}
+			turnedPending = append(turnedPending, adminapi.DiscoveredAdminAPI{
+				Address: client.BaseRootURL(),
+				PodRef:  podRef,
+			})
+		}
+	}
+	return turnedPending
+}

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -196,7 +196,7 @@ func TestDefaultReadinessChecker(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			factory := newMockClientFactory(t, tc.pendingClientsReadiness)
-			checker := clients.NewDefaultReadinessChecker(factory, logrus.New())
+			checker := clients.NewDefaultReadinessChecker(factory, logr.Discard())
 			result := checker.CheckReadiness(context.Background(), tc.alreadyCreatedClients, tc.pendingClients)
 
 			turnedPending := lo.Map(result.ClientsTurnedPending, func(c adminapi.DiscoveredAdminAPI, _ int) string { return c.Address })

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -1,0 +1,178 @@
+package clients_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	testURL1 = "http://localhost:8001"
+	testURL2 = "http://localhost:8002"
+)
+
+var (
+	testPodRef = k8stypes.NamespacedName{
+		Namespace: "default",
+		Name:      "mock",
+	}
+)
+
+type mockClientFactory struct {
+	ready      map[string]bool // Maps address to readiness.
+	callsCount map[string]int  // Maps address to number of CreateAdminAPIClient calls.
+	t          *testing.T
+}
+
+func newMockClientFactory(t *testing.T, ready map[string]bool) mockClientFactory {
+	return mockClientFactory{
+		ready:      ready,
+		callsCount: map[string]int{},
+		t:          t,
+	}
+}
+
+func (cf mockClientFactory) CreateAdminAPIClient(_ context.Context, adminAPI adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
+	address := adminAPI.Address
+
+	cf.callsCount[address]++
+
+	ready, ok := cf.ready[address]
+	if !ok {
+		cf.t.Errorf("unexpected client creation for %s", address)
+	}
+	if !ok || !ready {
+		return nil, fmt.Errorf("client for %s is not ready", address)
+	}
+
+	return adminapi.NewTestClient(address)
+}
+
+type mockAlreadyCreatedClient struct {
+	url     string
+	isReady bool
+}
+
+func (m mockAlreadyCreatedClient) IsReady(context.Context) error {
+	if !m.isReady {
+		return errors.New("not ready")
+	}
+	return nil
+}
+
+func (m mockAlreadyCreatedClient) PodReference() (k8stypes.NamespacedName, bool) {
+	return testPodRef, true
+}
+
+func (m mockAlreadyCreatedClient) BaseRootURL() string {
+	return m.url
+}
+
+func TestDefaultReadinessChecker(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		alreadyCreatedClients   []clients.AlreadyCreatedClient
+		pendingClients          []adminapi.DiscoveredAdminAPI
+		pendingClientsReadiness map[string]bool
+
+		expectedTurnedReady   []string
+		expectedTurnedPending []string
+	}{
+		{
+			name: "ready turning pending",
+			alreadyCreatedClients: []clients.AlreadyCreatedClient{
+				mockAlreadyCreatedClient{
+					url:     testURL1,
+					isReady: false,
+				},
+			},
+			expectedTurnedPending: []string{testURL1},
+		},
+		{
+			name: "pending turning ready",
+			pendingClients: []adminapi.DiscoveredAdminAPI{
+				{
+					Address: testURL1,
+					PodRef:  testPodRef,
+				},
+			},
+			pendingClientsReadiness: map[string]bool{
+				testURL1: true,
+			},
+			expectedTurnedReady: []string{testURL1},
+		},
+		{
+			name: "ready turning pending, pending turning ready at once",
+			alreadyCreatedClients: []clients.AlreadyCreatedClient{
+				mockAlreadyCreatedClient{
+					url:     testURL1,
+					isReady: false,
+				},
+			},
+			pendingClients: []adminapi.DiscoveredAdminAPI{
+				{
+					Address: testURL2,
+					PodRef:  testPodRef,
+				},
+			},
+			pendingClientsReadiness: map[string]bool{
+				testURL2: true,
+			},
+			expectedTurnedReady:   []string{testURL2},
+			expectedTurnedPending: []string{testURL1},
+		},
+		{
+			name: "no changes",
+			alreadyCreatedClients: []clients.AlreadyCreatedClient{
+				mockAlreadyCreatedClient{
+					url:     testURL1,
+					isReady: true,
+				},
+			},
+			pendingClients: []adminapi.DiscoveredAdminAPI{
+				{
+					Address: testURL2,
+					PodRef:  testPodRef,
+				},
+			},
+			pendingClientsReadiness: map[string]bool{
+				testURL2: false,
+			},
+			expectedTurnedReady:   nil,
+			expectedTurnedPending: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := newMockClientFactory(t, tc.pendingClientsReadiness)
+			checker := clients.NewDefaultReadinessChecker(factory, logrus.New())
+			result := checker.CheckReadiness(context.Background(), tc.alreadyCreatedClients, tc.pendingClients)
+
+			turnedPending := lo.Map(result.ClientsTurnedPending, func(c adminapi.DiscoveredAdminAPI, _ int) string { return c.Address })
+			turnedReady := lo.Map(result.ClientsTurnedReady, func(c *adminapi.Client, _ int) string { return c.BaseRootURL() })
+
+			require.ElementsMatch(t, tc.expectedTurnedReady, turnedReady)
+			require.ElementsMatch(t, tc.expectedTurnedPending, turnedPending)
+
+			// For every pending client turning ready we expect exactly one call to CreateAdminAPIClient.
+			for _, url := range tc.pendingClients {
+				require.Equal(t, 1, factory.callsCount[url.Address])
+			}
+
+			// For every already created client we expect no calls to CreateAdminAPIClient.
+			for _, url := range tc.alreadyCreatedClients {
+				require.Zero(t, factory.callsCount[url.BaseRootURL()])
+			}
+		})
+	}
+}

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 )
 
 const (
@@ -19,12 +20,10 @@ const (
 	testURL2 = "http://localhost:8002"
 )
 
-var (
-	testPodRef = k8stypes.NamespacedName{
-		Namespace: "default",
-		Name:      "mock",
-	}
-)
+var testPodRef = k8stypes.NamespacedName{
+	Namespace: "default",
+	Name:      "mock",
+}
 
 type mockClientFactory struct {
 	ready      map[string]bool // Maps address to readiness.

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -166,8 +166,9 @@ func (r *KongAdminAPIServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 
 func (r *KongAdminAPIServiceReconciler) notify() {
 	discovered := flattenDiscoveredAdminAPIs(r.Cache)
+	addresses := lo.Map(discovered, func(d adminapi.DiscoveredAdminAPI, _ int) string { return d.Address })
 	r.Log.V(util.DebugLevel).
-		Info("notifying about newly detected Admin APIs", "admin_apis", discovered)
+		Info("notifying about newly detected Admin APIs", "admin_apis", addresses)
 	r.EndpointsNotifier.Notify(discovered)
 }
 

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -192,7 +192,7 @@ func TestKongAdminAPIController(t *testing.T) {
 		)
 	})
 
-	t.Run("not Ready Endpoints are not matched", func(t *testing.T) {
+	t.Run("terminating Endpoints are not matched", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
@@ -218,7 +218,7 @@ func TestKongAdminAPIController(t *testing.T) {
 				{
 					Addresses: []string{"10.0.0.1"},
 					Conditions: discoveryv1.EndpointConditions{
-						Ready: lo.ToPtr(false),
+						Terminating: lo.ToPtr(true),
 					},
 					TargetRef: &corev1.ObjectReference{
 						Kind:      "Pod",
@@ -459,16 +459,16 @@ func TestKongAdminAPIController(t *testing.T) {
 			n.LastNotified(),
 		)
 
-		// Update all endpoints so that they are not Ready.
+		// Update all endpoints so that they are Terminating.
 		for i := range endpoints.Endpoints {
-			endpoints.Endpoints[i].Conditions.Ready = lo.ToPtr(false)
+			endpoints.Endpoints[i].Conditions.Terminating = lo.ToPtr(true)
 		}
 		require.NoError(t, client.Update(ctx, &endpoints, &ctrlclient.UpdateOptions{}))
 		require.NoError(t, client.Get(ctx, k8stypes.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))
 		assert.Eventually(t, func() bool { return len(n.LastNotified()) == 0 }, 3*time.Second, time.Millisecond)
 
-		// Update 1 endpoint so that that it's Ready.
-		endpoints.Endpoints[0].Conditions.Ready = lo.ToPtr(true)
+		// Update 1 endpoint so that it's not Terminating.
+		endpoints.Endpoints[0].Conditions.Terminating = nil
 
 		require.NoError(t, client.Update(ctx, &endpoints, &ctrlclient.UpdateOptions{}))
 		require.NoError(t, client.Get(ctx, k8stypes.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, &endpoints, &ctrlclient.GetOptions{}))

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -134,18 +134,19 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	setupLog.Info("Initializing Dataplane Client")
 	eventRecorder := mgr.GetEventRecorderFor(KongClientEventRecorderComponentName)
 
+	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, deprecatedLogger)
 	clientsManager, err := clients.NewAdminAPIClientsManager(
 		ctx,
 		deprecatedLogger,
 		initialKongClients,
-		adminAPIClientsFactory,
+		readinessChecker,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create AdminAPIClientsManager: %w", err)
 	}
 	if c.KongAdminSvc.IsPresent() {
-		setupLog.Info("Running AdminAPIClientsManager notify loop")
-		clientsManager.RunNotifyLoop()
+		setupLog.Info("Running AdminAPIClientsManager loop")
+		clientsManager.Run()
 	}
 
 	setupLog.Info("Starting Admission Server")

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -134,7 +134,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	setupLog.Info("Initializing Dataplane Client")
 	eventRecorder := mgr.GetEventRecorderFor(KongClientEventRecorderComponentName)
 
-	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, deprecatedLogger)
+	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, setupLog.WithName("readiness-checker"))
 	clientsManager, err := clients.NewAdminAPIClientsManager(
 		ctx,
 		deprecatedLogger,

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -28,13 +28,8 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	require.NoError(t, kuma.EnableMeshForNamespace(ctx, env.Cluster(), "kong"))
 	require.NoError(t, kuma.EnableMeshForNamespace(ctx, env.Cluster(), "default"))
 
-	// scale to force a restart of pods and trigger mesh injection (we can't annotate the Kong namespace in advance,
-	// it gets clobbered by deployKong()). is there a "rollout restart" in client-go? who knows!
-	scaleDeployment(ctx, t, env, deployments.ProxyNN, 0)
-	scaleDeployment(ctx, t, env, deployments.ControllerNN, 0)
-
-	scaleDeployment(ctx, t, env, deployments.ProxyNN, 2)
-	scaleDeployment(ctx, t, env, deployments.ControllerNN, 2)
+	// Restart Kong pods to trigger mesh injection.
+	deployments.Restart(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -110,8 +110,9 @@ func testManifestsUpgrade(
 
 	t.Logf("deploying target version of kong manifests: %s", testParams.toManifestPath)
 	deployments := ManifestDeploy{
-		Path:            testParams.toManifestPath,
-		SkipTestPatches: true,
+		Path: testParams.toManifestPath,
+		// Do not skip test patches - we want to verify that upgrade works with an image override in target manifest.
+		SkipTestPatches: false,
 	}.Run(ctx, t, env)
 
 	if featureGates := testParams.controllerFeatureGates; featureGates != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the Gateway's Pod readiness probe from `/status` to `/status/ready`. `/status/ready` returns 200 after receiving the first non-empty configuration. That allows to make Gateway pods to serve proxy traffic only after they're initially configured by KIC.

In KIC's Gateway discovery, instead of relying on `EndpointSlices` `Endpoints`' being ready, we use the discovered endpoints despite their readiness (we only discard terminating ones) and verify their readiness on our own with the use of the Admin API's `/status` in the `ReadinessChecker`. It requires running a periodic readiness reconciliation loop to check whether the endpoints that were ready should be moved to the pending list and vice versa.

Fundamental changes that were made in this PR:

- `KongAdminAPIServiceReconciler` watches Admin API service endpoints and pushes all but terminating ones to the `AdminAPIClientsManager` (via `Notify` method)
- `AdminAPIClientsManager` accepts the discovered endpoints and verifies their readiness with use of a new `ReadinessChecker` first:
  - if they're not ready - they're kept on a pending list
  - if they're ready - they're kept on an active list (that is used to return `GatewayClients()` to the upper layers)
- `AdminAPIClientsManager` is responsible for running a readiness reconciliation loop in which it uses `ReadinessChecker` to verify if: 
  - the clients kept on the active list became not ready; if yes, move them to the pending list
  - the clients kept on the pending list became ready; if yes, move them to the active list

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3499.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
