### PR TITLE
refactor: use controllers.DataPlane interface instead of concrete *dataplane.KongClient

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -390,6 +390,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
@@ -420,7 +421,7 @@ type {{.PackageAlias}}{{.Kind}}Reconciler struct {
 
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
-	DataplaneClient *dataplane.KongClient
+	DataplaneClient controllers.DataPlane
 	CacheSyncTimeout time.Duration
 {{- if .CapableOfStatusUpdates }}
 

--- a/internal/controllers/configuration/object_references.go
+++ b/internal/controllers/configuration/object_references.go
@@ -9,8 +9,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
@@ -19,7 +19,7 @@ import (
 // currently it only updates reference records to secrets, since we wanted to limit cache size of secrets:
 // https://github.com/Kong/kubernetes-ingress-controller/issues/2868
 func updateReferredObjects(
-	ctx context.Context, client client.Client, refIndexers ctrlref.CacheIndexers, dataplaneClient *dataplane.KongClient, obj client.Object,
+	ctx context.Context, client client.Client, refIndexers ctrlref.CacheIndexers, dataplaneClient controllers.DataPlane, obj client.Object,
 ) error {
 	referredSecretNameMap := make(map[k8stypes.NamespacedName]struct{})
 	var referredSecretList []k8stypes.NamespacedName

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
@@ -36,7 +36,7 @@ type CoreV1SecretReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	ReferenceIndexers ctrlref.CacheIndexers

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
@@ -59,7 +60,7 @@ type CoreV1ServiceReconciler struct {
 
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
-	DataplaneClient   *dataplane.KongClient
+	DataplaneClient   controllers.DataPlane
 	CacheSyncTimeout  time.Duration
 	ReferenceIndexers ctrlref.CacheIndexers
 }
@@ -157,7 +158,7 @@ type DiscoveryV1EndpointSliceReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -233,7 +234,7 @@ type NetV1IngressReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
@@ -428,7 +429,7 @@ type NetV1IngressClassReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -504,7 +505,7 @@ type KongV1KongIngressReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -581,7 +582,7 @@ type KongV1KongPluginReconciler struct {
 
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
-	DataplaneClient   *dataplane.KongClient
+	DataplaneClient   controllers.DataPlane
 	CacheSyncTimeout  time.Duration
 	ReferenceIndexers ctrlref.CacheIndexers
 }
@@ -679,7 +680,7 @@ type KongV1KongClusterPluginReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	IngressClassName           string
@@ -833,7 +834,7 @@ type KongV1KongConsumerReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	IngressClassName           string
@@ -987,7 +988,7 @@ type KongV1Beta1KongConsumerGroupReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	IngressClassName           string
@@ -1141,7 +1142,7 @@ type KongV1Beta1TCPIngressReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
@@ -1336,7 +1337,7 @@ type KongV1Beta1UDPIngressReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
@@ -1510,7 +1511,7 @@ type KongV1Alpha1IngressClassParametersReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 

--- a/internal/controllers/dataplane.go
+++ b/internal/controllers/dataplane.go
@@ -10,21 +10,20 @@ import (
 )
 
 // DataPlane is a common interface that is used by reconcilers to interact
-// with the dataplane.
-//
-// TODO: This can probably be used in other reconcilers as well.
-// Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/3794
+// with the Kong dataplane.
 type DataPlane interface {
 	DataPlaneClient
 
 	Listeners(ctx context.Context) ([]kong.ProxyListener, []kong.StreamListener, error)
 	AreKubernetesObjectReportsEnabled() bool
 	KubernetesObjectConfigurationStatus(obj client.Object) k8sobj.ConfigurationStatus
+	KubernetesObjectIsConfigured(obj client.Object) bool
 }
 
 // DataPlaneClient is a common client interface that is used by reconcilers to interact
-// with the dataplane to perform CRUD operations on provided objects.
+// with the Kong dataplane to perform CRUD operations on provided objects.
 type DataPlaneClient interface {
 	UpdateObject(obj client.Object) error
 	DeleteObject(obj client.Object) error
+	ObjectExists(obj client.Object) (bool, error)
 }

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -24,7 +24,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
@@ -40,7 +40,7 @@ type GRPCRouteReconciler struct {
 
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
-	DataplaneClient *dataplane.KongClient
+	DataplaneClient controllers.DataPlane
 	StatusQueue     *status.Queue
 	// If EnableReferenceGrant is true, we will check for ReferenceGrant if backend in another
 	// namespace is in backendRefs.

--- a/internal/controllers/gateway/referencegrant_controller.go
+++ b/internal/controllers/gateway/referencegrant_controller.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 )
 
 // ReferenceGrantReconciler reconciles a ReferenceGrant object.
@@ -39,7 +39,7 @@ type ReferenceGrantReconciler struct {
 	client.Client
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
-	DataplaneClient *dataplane.KongClient
+	DataplaneClient controllers.DataPlane
 
 	CacheSyncTimeout time.Duration
 }

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -24,7 +24,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
@@ -40,7 +40,7 @@ type TCPRouteReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 }

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -24,7 +24,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
@@ -40,7 +40,7 @@ type TLSRouteReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 }

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -24,7 +24,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	k8sobj "github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
@@ -40,7 +40,7 @@ type UDPRouteReconciler struct {
 
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	DataplaneClient  *dataplane.KongClient
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 }

--- a/internal/controllers/knative/knative.go
+++ b/internal/controllers/knative/knative.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/reference"
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
@@ -39,7 +40,7 @@ type Knativev1alpha1IngressReconciler struct {
 
 	Log             logr.Logger
 	Scheme          *runtime.Scheme
-	DataplaneClient *dataplane.KongClient
+	DataplaneClient controllers.DataPlane
 
 	DataplaneAddressFinder *dataplane.AddressFinder
 	StatusQueue            *status.Queue

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -363,6 +363,8 @@ func (c *KongClient) KubernetesObjectIsConfigured(obj client.Object) bool {
 	return c.kubernetesObjectReportsFilter.Get(obj) == k8sobj.ConfigurationStatusSucceeded
 }
 
+// KubernetesObjectConfigurationStatus reports the status of applying provided object's
+// configuration to the data-plane.
 func (c *KongClient) KubernetesObjectConfigurationStatus(obj client.Object) k8sobj.ConfigurationStatus {
 	c.kubernetesObjectReportLock.RLock()
 	defer c.kubernetesObjectReportLock.RUnlock()

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -11,6 +11,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/crds"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
@@ -59,7 +60,7 @@ func (c *ControllerDef) MaybeSetupWithManager(mgr ctrl.Manager) error {
 
 func setupControllers(
 	mgr manager.Manager,
-	dataplaneClient *dataplane.KongClient,
+	dataplaneClient controllers.DataPlane,
 	dataplaneAddressFinder *dataplane.AddressFinder,
 	udpDataplaneAddressFinder *dataplane.AddressFinder,
 	kubernetesStatusQueue *status.Queue,

--- a/test/mocks/dataplane.go
+++ b/test/mocks/dataplane.go
@@ -26,6 +26,15 @@ func (d Dataplane) DeleteObject(_ client.Object) error {
 	return nil
 }
 
+func (d Dataplane) ObjectExists(obj client.Object) (bool, error) {
+	_, exists := d.ObjectsStatuses[obj.GetNamespace()][obj.GetName()]
+	return exists, nil
+}
+
+func (d Dataplane) Listeners(context.Context) ([]kong.ProxyListener, []kong.StreamListener, error) {
+	return nil, nil, nil
+}
+
 func (d Dataplane) AreKubernetesObjectReportsEnabled() bool {
 	return d.KubernetesObjectReportsEnabled
 }
@@ -34,6 +43,6 @@ func (d Dataplane) KubernetesObjectConfigurationStatus(obj client.Object) k8sobj
 	return d.ObjectsStatuses[obj.GetNamespace()][obj.GetName()]
 }
 
-func (d Dataplane) Listeners(context.Context) ([]kong.ProxyListener, []kong.StreamListener, error) {
-	return nil, nil, nil
+func (d Dataplane) KubernetesObjectIsConfigured(obj client.Object) bool {
+	return d.ObjectsStatuses[obj.GetNamespace()][obj.GetName()] == k8sobj.ConfigurationStatusSucceeded
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR decouples controllers from concrete `*dataplane.KongClient` in favor of using interface `controllers.DataPlane.`. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

closes https://github.com/Kong/kubernetes-ingress-controller/issues/3794

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The interface has to be extended to fit all use cases.

The only usage of concrete `*dataplane.KongClient` is left in 

https://github.com/Kong/kubernetes-ingress-controller/blob/70df8f674b77741e5f9a77cd42c995db5106a0f2/internal/manager/run.go#L326-L367

that is ok, otherwise, interface would have to be extended with the method
```go
SetConfigStatusNotifier(clients.ConfigStatusNotifier)
```
that is only used in the above function. It would pollute the interface.

<!-- Here you can add any open questions or notes that you might have for reviewers -->


