### PR TITLE
feat: Consumer Group can be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Adding a new version? You'll need three changes:
 ### Added
 
 - **WIP** Introduce `KongConsumerGroup` CRD (supported by Kong Enterprise only)
-  [#4325](https://github.com/Kong/kubernetes-ingress-controller/pull/4325)
+  [#4325](https://github.com/Kong/kubernetes-ingress-controller/pull/4325), [#4387](https://github.com/Kong/kubernetes-ingress-controller/pull/4387)
 - The ResponseHeaderModifier Gateway API filter is now supported and translated
   to the proper set of Kong plugins.
   [#4350](https://github.com/Kong/kubernetes-ingress-controller/pull/4350)

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -104,6 +104,14 @@ func ToDeckContent(
 			PluginString(content.Plugins[j])) > 0
 	})
 
+	for _, cg := range k8sState.ConsumerGroups {
+		consumerGroup := file.FConsumerGroupObject{ConsumerGroup: cg.ConsumerGroup}
+		content.ConsumerGroups = append(content.ConsumerGroups, consumerGroup)
+	}
+	sort.SliceStable(content.ConsumerGroups, func(i, j int) bool {
+		return strings.Compare(*content.ConsumerGroups[i].Name, *content.ConsumerGroups[j].Name) > 0
+	})
+
 	for _, u := range k8sState.Upstreams {
 		fillUpstream(&u.Upstream)
 		upstream := file.FUpstream{Upstream: u.Upstream}

--- a/internal/dataplane/kongstate/consumergroup.go
+++ b/internal/dataplane/kongstate/consumergroup.go
@@ -1,0 +1,8 @@
+package kongstate
+
+import "github.com/kong/go-kong/kong"
+
+// ConsumerGroup holds a Kong Consumer.
+type ConsumerGroup struct {
+	kong.ConsumerGroup
+}

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -238,6 +238,9 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 		p.registerSuccessfullyParsedObject(pl.K8sParent)
 	}
 
+	// process consumer groups
+	result.FillConsumerGroups(p.logger, p.storer)
+
 	// generate Certificates and SNIs
 	ingressCerts := p.getCerts(ingressRules.SecretNameToSNIs)
 	gatewayCerts := p.getGatewayCerts()

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -58,6 +58,7 @@ type FakeObjects struct {
 	KongClusterPlugins             []*configurationv1.KongClusterPlugin
 	KongIngresses                  []*configurationv1.KongIngress
 	KongConsumers                  []*configurationv1.KongConsumer
+	KongConsumerGroups             []*configurationv1beta1.KongConsumerGroup
 
 	KnativeIngresses []*knative.Ingress
 }
@@ -179,6 +180,13 @@ func NewFakeStore(
 			return nil, err
 		}
 	}
+	consumerGroupStore := cache.NewStore(keyFunc)
+	for _, c := range objects.KongConsumerGroups {
+		err := consumerGroupStore.Add(c)
+		if err != nil {
+			return nil, err
+		}
+	}
 	kongPluginsStore := cache.NewStore(keyFunc)
 	for _, p := range objects.KongPlugins {
 		err := kongPluginsStore.Add(p)
@@ -220,6 +228,7 @@ func NewFakeStore(
 			Plugin:                         kongPluginsStore,
 			ClusterPlugin:                  kongClusterPluginsStore,
 			Consumer:                       consumerStore,
+			ConsumerGroup:                  consumerGroupStore,
 			KongIngress:                    kongIngressStore,
 			IngressClassParametersV1alpha1: IngressClassParametersV1alpha1Store,
 			KnativeIngress:                 knativeIngressStore,
@@ -258,6 +267,7 @@ func (objects FakeObjects) MarshalToYAML() ([]byte, error) {
 		reflect.TypeOf(&configurationv1.KongClusterPlugin{}):            configurationv1.SchemeGroupVersion.WithKind("KongClusterPlugin"),
 		reflect.TypeOf(&configurationv1.KongIngress{}):                  configurationv1.SchemeGroupVersion.WithKind("KongIngress"),
 		reflect.TypeOf(&configurationv1.KongConsumer{}):                 configurationv1.SchemeGroupVersion.WithKind("KongConsumer"),
+		reflect.TypeOf(&configurationv1beta1.KongConsumerGroup{}):       configurationv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"),
 	}
 
 	out := &bytes.Buffer{}
@@ -299,6 +309,7 @@ func (objects FakeObjects) MarshalToYAML() ([]byte, error) {
 	allObjects = append(allObjects, lo.ToAnySlice(objects.KongClusterPlugins)...)
 	allObjects = append(allObjects, lo.ToAnySlice(objects.KongIngresses)...)
 	allObjects = append(allObjects, lo.ToAnySlice(objects.KongConsumers)...)
+	allObjects = append(allObjects, lo.ToAnySlice(objects.KongConsumerGroups)...)
 
 	for _, obj := range allObjects {
 		if err := fillGVKAndAppendToBuffer(obj.(runtime.Object)); err != nil {

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -485,6 +485,35 @@ func TestFakeStoreConsumer(t *testing.T) {
 	assert.True(errors.As(err, &ErrNotFound{}))
 }
 
+func TestFakeStoreConsumerGroup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	consumerGroups := []*configurationv1beta1.KongConsumerGroup{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+		},
+	}
+	store, err := NewFakeStore(FakeObjects{KongConsumerGroups: consumerGroups})
+	require.Nil(err)
+	require.NotNil(store)
+	assert.Len(store.ListKongConsumerGroups(), 1)
+	c, err := store.GetKongConsumerGroup("default", "foo")
+	assert.Nil(err)
+	assert.NotNil(c)
+
+	c, err = store.GetKongConsumerGroup("default", "does-not-exist")
+	assert.Nil(c)
+	assert.NotNil(err)
+	assert.True(errors.As(err, &ErrNotFound{}))
+}
+
 func TestFakeStorePlugins(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,7 @@ import (
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
@@ -76,6 +77,7 @@ type Storer interface {
 	GetKongPlugin(namespace, name string) (*kongv1.KongPlugin, error)
 	GetKongClusterPlugin(name string) (*kongv1.KongClusterPlugin, error)
 	GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, error)
+	GetKongConsumerGroup(namespace, name string) (*kongv1beta1.KongConsumerGroup, error)
 	GetIngressClassName() string
 	GetIngressClassV1(name string) (*netv1.IngressClass, error)
 	GetIngressClassParametersV1Alpha1(ingressClass *netv1.IngressClass) (*kongv1alpha1.IngressClassParameters, error)
@@ -99,6 +101,7 @@ type Storer interface {
 	ListKongPlugins() []*kongv1.KongPlugin
 	ListKongClusterPlugins() []*kongv1.KongClusterPlugin
 	ListKongConsumers() []*kongv1.KongConsumer
+	ListKongConsumerGroups() []*kongv1beta1.KongConsumerGroup
 	ListCACerts() ([]*corev1.Secret, error)
 }
 
@@ -143,6 +146,7 @@ type CacheStores struct {
 	Plugin                         cache.Store
 	ClusterPlugin                  cache.Store
 	Consumer                       cache.Store
+	ConsumerGroup                  cache.Store
 	KongIngress                    cache.Store
 	TCPIngress                     cache.Store
 	UDPIngress                     cache.Store
@@ -175,6 +179,7 @@ func NewCacheStores() CacheStores {
 		Plugin:                         cache.NewStore(keyFunc),
 		ClusterPlugin:                  cache.NewStore(clusterResourceKeyFunc),
 		Consumer:                       cache.NewStore(keyFunc),
+		ConsumerGroup:                  cache.NewStore(keyFunc),
 		KongIngress:                    cache.NewStore(keyFunc),
 		TCPIngress:                     cache.NewStore(keyFunc),
 		UDPIngress:                     cache.NewStore(keyFunc),
@@ -273,6 +278,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.ClusterPlugin.Get(obj)
 	case *kongv1.KongConsumer:
 		return c.Consumer.Get(obj)
+	case *kongv1beta1.KongConsumerGroup:
+		return c.ConsumerGroup.Get(obj)
 	case *kongv1.KongIngress:
 		return c.KongIngress.Get(obj)
 	case *kongv1beta1.TCPIngress:
@@ -336,6 +343,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.ClusterPlugin.Add(obj)
 	case *kongv1.KongConsumer:
 		return c.Consumer.Add(obj)
+	case *kongv1beta1.KongConsumerGroup:
+		return c.ConsumerGroup.Add(obj)
 	case *kongv1.KongIngress:
 		return c.KongIngress.Add(obj)
 	case *kongv1beta1.TCPIngress:
@@ -400,6 +409,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.ClusterPlugin.Delete(obj)
 	case *kongv1.KongConsumer:
 		return c.Consumer.Delete(obj)
+	case *kongv1beta1.KongConsumerGroup:
+		return c.ConsumerGroup.Delete(obj)
 	case *kongv1.KongIngress:
 		return c.KongIngress.Delete(obj)
 	case *kongv1beta1.TCPIngress:
@@ -804,6 +815,19 @@ func (s Store) GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, er
 	return p.(*kongv1.KongConsumer), nil
 }
 
+// GetKongConsumerGroup returns the 'name' KongConsumerGroup resource in namespace.
+func (s Store) GetKongConsumerGroup(namespace, name string) (*configurationv1beta1.KongConsumerGroup, error) {
+	key := fmt.Sprintf("%v/%v", namespace, name)
+	p, exists, err := s.stores.ConsumerGroup.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, ErrNotFound{fmt.Sprintf("KongConsumerGroup %v not found", key)}
+	}
+	return p.(*configurationv1beta1.KongConsumerGroup), nil
+}
+
 func (s Store) GetIngressClassName() string {
 	return s.ingressClass
 }
@@ -888,6 +912,20 @@ func (s Store) ListKongConsumers() []*kongv1.KongConsumer {
 	}
 
 	return consumers
+}
+
+// ListKongConsumerGroups returns all KongConsumerGroups filtered by the ingress.class
+// annotation.
+func (s Store) ListKongConsumerGroups() []*kongv1beta1.KongConsumerGroup {
+	var consumerGroups []*kongv1beta1.KongConsumerGroup
+	for _, item := range s.stores.ConsumerGroup.List() {
+		c, ok := item.(*kongv1beta1.KongConsumerGroup)
+		if ok && s.isValidIngressClass(&c.ObjectMeta, annotations.IngressClassKey, s.getIngressClassHandling()) {
+			consumerGroups = append(consumerGroups, c)
+		}
+	}
+
+	return consumerGroups
 }
 
 // ListGlobalKongPlugins returns all KongPlugin resources
@@ -1066,6 +1104,8 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 		return &kongv1.KongClusterPlugin{}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongConsumer"):
 		return &kongv1.KongConsumer{}, nil
+	case kongv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"):
+		return &kongv1beta1.KongConsumerGroup{}, nil
 	case kongv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"):
 		return &kongv1alpha1.IngressClassParameters{}, nil
 	// ----------------------------------------------------------------------------

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,7 +44,6 @@ import (
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
@@ -816,7 +815,7 @@ func (s Store) GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, er
 }
 
 // GetKongConsumerGroup returns the 'name' KongConsumerGroup resource in namespace.
-func (s Store) GetKongConsumerGroup(namespace, name string) (*configurationv1beta1.KongConsumerGroup, error) {
+func (s Store) GetKongConsumerGroup(namespace, name string) (*kongv1beta1.KongConsumerGroup, error) {
 	key := fmt.Sprintf("%v/%v", namespace, name)
 	p, exists, err := s.stores.ConsumerGroup.GetByKey(key)
 	if err != nil {
@@ -825,7 +824,7 @@ func (s Store) GetKongConsumerGroup(namespace, name string) (*configurationv1bet
 	if !exists {
 		return nil, ErrNotFound{fmt.Sprintf("KongConsumerGroup %v not found", key)}
 	}
-	return p.(*configurationv1beta1.KongConsumerGroup), nil
+	return p.(*kongv1beta1.KongConsumerGroup), nil
 }
 
 func (s Store) GetIngressClassName() string {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -15,6 +15,11 @@ var (
 	// PluginOrderingVersionCutoff is the Kong version prior to the addition of plugin ordering.
 	PluginOrderingVersionCutoff = semver.Version{Major: 3}
 
+	// ConsumerGroupsVersionCutoff is the Kong version prior to the addition of Consumer Groups as first class citizens.
+	// TODO: Change to 3.4 once it's released. For now let's assume it's 3.3 (some features work), but for the full
+	// support it should be 3.4 (unreleased yet).
+	ConsumerGroupsVersionCutoff = semver.Version{Major: 3, Minor: 3}
+
 	// MTLSCredentialVersionCutoff is the minimum Kong version that support mTLS credentials. This is a patch version
 	// because the original version of the mTLS credential was not compatible with KIC.
 	MTLSCredentialVersionCutoff = semver.Version{Major: 2, Minor: 3, Patch: 2}

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -1,0 +1,89 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
+)
+
+func TestConsumerGroup(t *testing.T) {
+	t.Parallel()
+
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ConsumerGroupsVersionCutoff))
+	RunWhenKongEnterprise(t)
+
+	ctx := context.Background()
+	ns, cleaner := helpers.Setup(ctx, t, env)
+
+	c, err := clientset.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
+	const consumerGroupName = "test-consumer-group"
+	t.Logf("configuring Consumer Group: %q", consumerGroupName)
+	cg, err := c.ConfigurationV1beta1().KongConsumerGroups(ns.Name).Create(
+		ctx,
+		&kongv1beta1.KongConsumerGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      consumerGroupName,
+				Namespace: ns.Name,
+				Annotations: map[string]string{
+					annotations.IngressClassKey: consts.IngressClass,
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+	cleaner.Add(cg)
+
+	t.Logf("validating that Consumer Group: %q was successfully configured", consumerGroupName)
+	require.Eventually(t, func() bool {
+		cgPath := fmt.Sprintf("/consumer_groups/%s", consumerGroupName)
+		var headers map[string]string
+		if testenv.DBMode() != testenv.DBModeOff {
+			cgPath = fmt.Sprintf("/%s/consumer_groups/%s", consts.KongTestWorkspace, consumerGroupName)
+			headers = map[string]string{
+				"Kong-Admin-Token": consts.KongTestPassword,
+			}
+		}
+		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyAdminURL, cgPath, headers)
+		resp, err := helpers.DefaultHTTPClient().Do(req)
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", resp.Request.URL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Logf("WARNING: error while reading response from %s: %v", resp.Request.URL, err)
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			return true
+		case http.StatusForbidden:
+			t.Logf(
+				"WARNING: it seems Kong Gateway Enterprise hasn't got a valid license passed - from: %s received: %s with body: %s",
+				resp.Request.URL, resp.Status, body,
+			)
+			return false
+		default:
+			t.Logf("WARNING: from: %s received unexpected: %s with body: %s", resp.Request.URL, resp.Status, body)
+			return false
+		}
+	}, ingressWait, waitTick)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

In https://github.com/Kong/kubernetes-ingress-controller/pull/4325 Consumer Group CRD and the boilerplate controller has been introduced. This PR continues that effort - applied Consumer Group will be configured in Kong Gateway. Validation webhook, adding Consumers, and scoping Plugins will be introduced in the next PRs.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This is a part of #3728 and closes https://github.com/Kong/kubernetes-ingress-controller/issues/4358
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The introduced integration test `TestConsumerGroup` will evolve in the future to cover all features of it e.g. adding Consumers to Consumer Group. Since Consumer Group doesn't do anything useful yet for now check directly in Gateway if it was created. Later it will be replaced with a proper testing scenario.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
