### PR TITLE
fix(ci): fix release workflow updating release branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,12 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Parse semver string
+      id: semver_parser
+      uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+      with:
+        input_string: ${{ github.event.inputs.tag }}
+        version_extractor_regex: 'v(.*)$'
     - name: update 'latest' branch
       run: |
         git checkout latest


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes release workflow which updates the `latest` branch.

To avoid situations like in: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5656958959/job/15327633006 we need to parse the tag to get semver components which we use `git reset --hard ...`
