### PR TITLE
feat: populate Programmed condition for KongConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,9 +128,9 @@ Adding a new version? You'll need three changes:
   actively monitor their readiness for accepting configuration updates.
   [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
 - `KongConsumer` CRD was extended with `Status.Conditions` field. It will now
-  contain the `Programmed` condition describing whether an object was successfully 
+  contain the `Programmed` condition describing whether an object was successfully
   translated into Kong entities and sent to Kong.
-  [#4409](https://github.com/Kong/kubernetes-ingress-controller/pull/4409 
+  [#4409](https://github.com/Kong/kubernetes-ingress-controller/pull/4409
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ Adding a new version? You'll need three changes:
   updates. The controller will now send configuration to such Gateways and will
   actively monitor their readiness for accepting configuration updates.
   [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
+- `KongConsumer` CRD was extended with `Status.Conditions` field. It will now
+  contain the `Programmed` condition describing whether an object was successfully 
+  translated into Kong entities and sent to Kong.
+  [#4409](https://github.com/Kong/kubernetes-ingress-controller/pull/4409 
 
 ### Changed
 

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -59,6 +59,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -125,7 +133,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -400,6 +400,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongConsumer.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -466,7 +474,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
           username:
             description: Username is a Kong cluster-unique username of the consumer.

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+)
+
+const (
+	// ProgrammedConditionTrueMessage is the message for the programmed condition when it is True.
+	ProgrammedConditionTrueMessage = "Object was successfully configured in Kong."
+
+	// ProgrammedConditionFalseInvalidMessage is the message for the programmed condition when it is False with reason Invalid.
+	ProgrammedConditionFalseInvalidMessage = "Object failed to be configured in Kong - see its attached Events for more information."
+
+	// ProgrammedConditionFalsePendingMessage is the message for the programmed condition when it is False with reason Pending.
+	ProgrammedConditionFalsePendingMessage = "Object is pending configuration in Kong."
+)
+
+// EnsureProgrammedCondition ensures that the programmed condition is present in the conditions slice with the
+// status reflecting the current configuration status of the object.
+// If the condition is already present with the correct status, the conditions slice is returned unmodified and false is
+// returned as the second return value. If the condition is not present or has the wrong status, the conditions slice is
+// returned with the condition updated and true is returned.
+func EnsureProgrammedCondition(configurationStatus object.ConfigurationStatus, objectGeneration int64, conditions []metav1.Condition) (
+	updatedConditions []metav1.Condition,
+	updateNeeded bool,
+) {
+	var (
+		status  metav1.ConditionStatus
+		reason  kongv1.ConditionReason
+		message string
+	)
+	switch configurationStatus {
+	case object.ConfigurationStatusSucceeded:
+		status = metav1.ConditionTrue
+		reason = kongv1.ReasonProgrammed
+		message = ProgrammedConditionTrueMessage
+	case object.ConfigurationStatusFailed:
+		status = metav1.ConditionFalse
+		reason = kongv1.ReasonInvalid
+		message = ProgrammedConditionFalseInvalidMessage
+	case object.ConfigurationStatusUnknown:
+		status = metav1.ConditionFalse
+		reason = kongv1.ReasonPending
+		message = ProgrammedConditionFalsePendingMessage
+	}
+
+	desiredCondition := metav1.Condition{
+		Type:               string(kongv1.ConditionProgrammed),
+		Status:             status,
+		ObservedGeneration: objectGeneration,
+		LastTransitionTime: metav1.Now(),
+		Reason:             string(reason),
+		Message:            message,
+	}
+
+	hasMatchingCondition := util.CheckCondition(
+		conditions,
+		util.ConditionType(desiredCondition.Type),
+		util.ConditionReason(desiredCondition.Reason),
+		desiredCondition.Status,
+		desiredCondition.ObservedGeneration,
+	)
+
+	if hasMatchingCondition {
+		return conditions, false
+	}
+
+	_, idx, ok := lo.FindIndexOf(conditions, func(c metav1.Condition) bool { return c.Type == string(kongv1.ConditionProgrammed) })
+	if !ok {
+		conditions = append(conditions, desiredCondition)
+	} else {
+		conditions[idx] = desiredCondition
+	}
+
+	return conditions, true
+}

--- a/internal/controllers/utils/conditions_test.go
+++ b/internal/controllers/utils/conditions_test.go
@@ -1,0 +1,116 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+)
+
+func TestEnsureProgrammedCondition(t *testing.T) {
+	const testObjectGeneration = 2
+	var (
+		expectedProgrammedConditionTrue = metav1.Condition{
+			Type:               string(kongv1.ConditionProgrammed),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: testObjectGeneration,
+			Reason:             string(kongv1.ReasonProgrammed),
+			Message:            utils.ProgrammedConditionTrueMessage,
+		}
+		expectedProgrammedConditionFalse = metav1.Condition{
+			Type:               string(kongv1.ConditionProgrammed),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: testObjectGeneration,
+			Reason:             string(kongv1.ReasonInvalid),
+			Message:            utils.ProgrammedConditionFalseInvalidMessage,
+		}
+		expectedProgrammedConditionUnknown = metav1.Condition{
+			Type:               string(kongv1.ConditionProgrammed),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: testObjectGeneration,
+			Reason:             string(kongv1.ReasonPending),
+			Message:            utils.ProgrammedConditionFalsePendingMessage,
+		}
+	)
+
+	testCases := []struct {
+		name string
+
+		configurationStatus object.ConfigurationStatus
+		conditions          []metav1.Condition
+
+		expectedUpdatedConditions []metav1.Condition
+		expectedUpdateNeeded      bool
+	}{
+		{
+			name:                      "condition already present with correct status and observed generation",
+			configurationStatus:       object.ConfigurationStatusSucceeded,
+			conditions:                []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdateNeeded:      false,
+		},
+		{
+			name:                "condition present with correct status but older observed generation",
+			configurationStatus: object.ConfigurationStatusSucceeded,
+			conditions: []metav1.Condition{
+				func() metav1.Condition {
+					cond := expectedProgrammedConditionTrue
+					cond.ObservedGeneration = 1
+					return cond
+				}(),
+			},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdateNeeded:      true,
+		},
+		{
+			name:                "condition present with correct observed generation but different status",
+			configurationStatus: object.ConfigurationStatusFailed,
+			conditions: []metav1.Condition{
+				func() metav1.Condition {
+					cond := expectedProgrammedConditionFalse
+					cond.Status = metav1.ConditionTrue
+					return cond
+				}(),
+			},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionFalse},
+			expectedUpdateNeeded:      true,
+		},
+		{
+			name:                "condition present with correct observed generation but different reason",
+			configurationStatus: object.ConfigurationStatusUnknown,
+			conditions: []metav1.Condition{
+				func() metav1.Condition {
+					cond := expectedProgrammedConditionUnknown
+					cond.Reason = string(kongv1.ReasonInvalid)
+					return cond
+				}(),
+			},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionUnknown},
+			expectedUpdateNeeded:      true,
+		},
+		{
+			name:                      "empty conditions",
+			configurationStatus:       object.ConfigurationStatusSucceeded,
+			conditions:                nil,
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdateNeeded:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conditions, updateNeeded := utils.EnsureProgrammedCondition(tc.configurationStatus, testObjectGeneration, tc.conditions)
+			assert.Equal(t, tc.expectedUpdateNeeded, updateNeeded)
+
+			ignoreLastTransitionTime := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
+			diff := cmp.Diff(conditions, tc.expectedUpdatedConditions, ignoreLastTransitionTime)
+			assert.Empty(t, diff, "conditions mismatch")
+		})
+	}
+}

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -227,6 +227,9 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 
 	// generate consumers and credentials
 	result.FillConsumersAndCredentials(p.storer, p.failuresCollector, p.kongVersion)
+	for _, c := range result.Consumers {
+		p.registerSuccessfullyParsedObject(&c.K8sKongConsumer)
+	}
 
 	// process annotation plugins
 	result.FillPlugins(p.logger, p.storer)

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5411,7 +5411,7 @@ func mustNewParser(t *testing.T, storer store.Storer) *Parser {
 
 	p, err := NewParser(logrus.New(), storer,
 		FeatureFlags{
-			// We'll assume these is true for all tests.
+			// We'll assume these are true for all tests.
 			FillIDs:                           true,
 			ReportConfiguredKubernetesObjects: true,
 		},

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -270,6 +270,7 @@ func setupControllers(
 				DisableIngressClassLookups: !c.IngressClassNetV1Enabled,
 				CacheSyncTimeout:           c.CacheSyncTimeout,
 				ReferenceIndexers:          referenceIndexers,
+				StatusQueue:                kubernetesStatusQueue,
 			},
 		},
 		{

--- a/internal/metrics/metrics_envtest_test.go
+++ b/internal/metrics/metrics_envtest_test.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 )
 

--- a/pkg/apis/configuration/v1/conditions.go
+++ b/pkg/apis/configuration/v1/conditions.go
@@ -1,0 +1,53 @@
+package v1
+
+// ConditionType is a type of condition associated with an object.
+// This type should be used with the object's Status.Conditions field.
+type ConditionType string
+
+// ConditionReason defines the set of reasons that explain why a particular
+// condition type has been raised.
+type ConditionReason string
+
+const (
+	// ConditionProgrammed indicates whether the controller has generated Kong configuration
+	// and has successfully applied it to Kong.
+	//
+	// Resources that support this condition are:
+	//
+	// * KongPlugin
+	// * KongClusterPlugin
+	// * KongConsumer
+	//
+	// It is a positive-polarity summary condition, and so should always be
+	// present on the resource with ObservedGeneration set.
+	//
+	// It should be set to Unknown if the controller performs updates to the
+	// status before it has all the information it needs to be able to determine
+	// if the condition is true.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Programmed"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "Invalid"
+	// * "Pending"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
+	ConditionProgrammed ConditionType = "Programmed"
+
+	// ReasonProgrammed is used with the ConditionProgrammed condition when the condition is
+	// true.
+	ReasonProgrammed ConditionReason = "Programmed"
+
+	// ReasonInvalid is used with the ConditionProgrammed condition when the object fails to be
+	// translated into Kong configuration or when Kong rejects the configuration.
+	ReasonInvalid ConditionReason = "Invalid"
+
+	// ReasonPending is used with the ConditionProgrammed when the status is "Unknown".
+	ReasonPending ConditionReason = "Pending"
+)

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -61,6 +61,16 @@ type KongConsumerList struct {
 
 // KongConsumerStatus represents the current status of the KongConsumer resource.
 type KongConsumerStatus struct {
+	// Conditions describe the current conditions of the KongConsumer.
+	//
+	// Known condition types are:
+	//
+	// * "Programmed"
+	//
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/test/envtest/manager_debugendpoints_test.go
+++ b/test/envtest/manager_debugendpoints_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
 
 func TestDebugEndpoints(t *testing.T) {

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -1,0 +1,131 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/conditions"
+)
+
+func TestKongConsumer_ProgrammedCondition(t *testing.T) {
+	t.Parallel()
+
+	err := kongv1.AddToScheme(scheme.Scheme)
+	require.NoError(t, err)
+	envcfg := Setup(t, scheme.Scheme, WithInstallKongCRDs(true))
+	ctrlClient := NewControllerClient(t, envcfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	RunManager(ctx, t, envcfg, func(cfg *manager.Config) {
+		cfg.UpdateStatus = true
+		cfg.PublishStatusAddress = []string{"http://localhost:8080"}
+	})
+
+	ns := CreateNamespace(ctx, t, ctrlClient)
+
+	testCases := []struct {
+		name    string
+		objects []client.Object
+		test    func(t *testing.T, ctrlClient client.Client)
+	}{
+		{
+			name: "valid KongConsumer",
+			objects: []client.Object{
+				&kongv1.KongConsumer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "consumer",
+						Namespace: ns.Name,
+						Annotations: map[string]string{
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
+						},
+					},
+					Username: "username",
+				},
+			},
+			test: func(t *testing.T, ctrlClient client.Client) {
+				require.Eventually(t, func() bool {
+					var consumer kongv1.KongConsumer
+					err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+						Name:      "consumer",
+						Namespace: ns.Name,
+					}, &consumer)
+					if err != nil {
+						t.Logf("error getting consumer: %v", err)
+						return false
+					}
+
+					if !conditions.Contain(
+						consumer.Status.Conditions,
+						conditions.WithType("Programmed"),
+						conditions.WithStatus(metav1.ConditionTrue),
+					) {
+						t.Logf("Programmed condition not found, actual: %v", consumer.Status.Conditions)
+						return false
+					}
+					return true
+				}, 10*time.Second, 50*time.Millisecond)
+			},
+		},
+		{
+			name: "KongConsumer referencing non-existent secret",
+			objects: []client.Object{
+				&kongv1.KongConsumer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "consumer-with-secret",
+						Namespace: ns.Name,
+						Annotations: map[string]string{
+							annotations.IngressClassKey: annotations.DefaultIngressClass,
+						},
+					},
+					Username:    "username",
+					Credentials: []string{"non-existent-secret"},
+				},
+			},
+			test: func(t *testing.T, ctrlClient client.Client) {
+				require.Eventually(t, func() bool {
+					var consumer kongv1.KongConsumer
+					err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+						Name:      "consumer-with-secret",
+						Namespace: ns.Name,
+					}, &consumer)
+					if err != nil {
+						t.Logf("error getting consumer: %v", err)
+						return false
+					}
+
+					if !conditions.Contain(
+						consumer.Status.Conditions,
+						conditions.WithType("Programmed"),
+						conditions.WithStatus(metav1.ConditionFalse),
+						conditions.WithReason(string(kongv1.ReasonInvalid)),
+					) {
+						t.Logf("Programmed condition not found, actual: %v", consumer.Status.Conditions)
+						return false
+					}
+					return true
+				}, 10*time.Second, 50*time.Millisecond)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, obj := range tc.objects {
+				require.NoError(t, ctrlClient.Create(ctx, obj))
+				t.Cleanup(func() { _ = ctrlClient.Delete(ctx, obj) })
+			}
+			tc.test(t, ctrlClient)
+		})
+	}
+}

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	discoveryclient "k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -31,7 +32,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Populates `Programmed` condition for `KongConsumer` objects.

**Which issue this PR fixes**:

Part of #3344.

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
