### PR TITLE
refactor: introduce KongTestWorkspace constant

### DIFF
--- a/test/consts/misc.go
+++ b/test/consts/misc.go
@@ -5,6 +5,11 @@ const (
 	// and is left static to help developers debug failures in those testing environments.
 	KongTestPassword = "password"
 
+	// KongTestWorkspace is used as a workspace only within the context of transient integration test runs
+	// when Kong Enterprise is enabled and a database is used (DBmode != off) and is left static to help
+	// developers debug failures in those testing environments.
+	KongTestWorkspace = "notdefault"
+
 	// IngressClass indicates the ingress class name which the tests will use for supported object reconciliation.
 	IngressClass = "kongtests"
 

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -25,7 +25,7 @@ func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
 			kongbuilder.WithProxyEnterpriseSuperAdminPassword(consts.KongTestPassword)
 			extraControllerArgs = append(extraControllerArgs,
 				fmt.Sprintf("--kong-admin-token=%s", consts.KongTestPassword),
-				"--kong-workspace=notdefault",
+				fmt.Sprintf("--kong-workspace=%s", consts.KongTestWorkspace),
 			)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR gets rid of the hardcoded magic string `notdefault` and replaces it with the usage of a const `KongTestWorkspace` that makes it consistent with the password and ingresclass used in the test and easily discoverable. 


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->