### PR TITLE
tests: do not use global scheme in envtests

### DIFF
--- a/internal/adminapi/endpoints_envtest_test.go
+++ b/internal/adminapi/endpoints_envtest_test.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v2/internal/manager/config/types"
@@ -26,8 +25,9 @@ import (
 func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(t *testing.T) {
 	t.Parallel()
 
-	cfg := envtest.Setup(t, scheme.Scheme)
-	client := envtest.NewControllerClient(t, cfg)
+	scheme := envtest.Scheme(t)
+	cfg := envtest.Setup(t, scheme)
+	client := envtest.NewControllerClient(t, scheme, cfg)
 
 	// In tests below we use a deferred cancel to stop the manager and not wait
 	// for its timeout.

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,7 +111,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	// In tests below we use a deferred cancel to stop the manager and not wait
 	// for its timeout.
 
-	cfg := envtest.Setup(t, scheme.Scheme)
+	cfg := envtest.Setup(t, envtest.Scheme(t))
 	client, err := ctrlclient.New(cfg, ctrlclient.Options{})
 	require.NoError(t, err)
 

--- a/test/envtest/controller.go
+++ b/test/envtest/controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,10 +60,10 @@ func StartReconcilers(ctx context.Context, t *testing.T, scheme *runtime.Scheme,
 	})
 }
 
-// NewControllerClient returns a new controller-runtime Client for provided rest.Config.
-func NewControllerClient(t *testing.T, cfg *rest.Config) ctrlclient.Client {
+// NewControllerClient returns a new controller-runtime Client for provided runtime.Scheme and rest.Config.
+func NewControllerClient(t *testing.T, scheme *runtime.Scheme, cfg *rest.Config) ctrlclient.Client {
 	client, err := ctrlclient.New(cfg, ctrlclient.Options{
-		Scheme: scheme.Scheme,
+		Scheme: scheme,
 	})
 	require.NoError(t, err)
 	return client

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -27,12 +26,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
 )
 
-func init() {
-	if err := gatewayv1beta1.Install(scheme.Scheme); err != nil {
-		panic(err)
-	}
-}
-
 func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 	t.Parallel()
 
@@ -41,8 +34,9 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 		tickDuration = 100 * time.Millisecond
 	)
 
-	cfg := Setup(t, scheme.Scheme)
-	client := NewControllerClient(t, cfg)
+	scheme := Scheme(t, WithGatewayAPI)
+	cfg := Setup(t, scheme)
+	client := NewControllerClient(t, scheme, cfg)
 
 	reconciler := &gateway.HTTPRouteReconciler{
 		Client:          client,

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -23,8 +22,9 @@ import (
 )
 
 func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExceeded(t *testing.T) {
-	envcfg := Setup(t, scheme.Scheme)
-	ctrlClient := NewControllerClient(t, envcfg)
+	scheme := Scheme(t, WithGatewayAPI)
+	envcfg := Setup(t, scheme)
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -22,10 +21,9 @@ import (
 func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	t.Parallel()
 
-	err := kongv1.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-	cfg := Setup(t, scheme.Scheme, WithInstallKongCRDs(true))
-	client := NewControllerClient(t, cfg)
+	scheme := Scheme(t, WithKong)
+	cfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	client := NewControllerClient(t, scheme, cfg)
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
@@ -20,10 +19,9 @@ import (
 func TestKongConsumer_ProgrammedCondition(t *testing.T) {
 	t.Parallel()
 
-	err := kongv1.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-	envcfg := Setup(t, scheme.Scheme, WithInstallKongCRDs(true))
-	ctrlClient := NewControllerClient(t, envcfg)
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/envtest/scheme.go
+++ b/test/envtest/scheme.go
@@ -1,0 +1,43 @@
+package envtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+)
+
+type SchemeOption func(t *testing.T, s *k8sruntime.Scheme)
+
+// WithGatewayAPI registers the Gateway API types with the scheme.
+func WithGatewayAPI(t *testing.T, s *k8sruntime.Scheme) {
+	require.NoError(t, gatewayv1beta1.AddToScheme(s))
+	require.NoError(t, gatewayv1alpha2.AddToScheme(s))
+}
+
+// WithKong registers the Kong types with the scheme.
+func WithKong(t *testing.T, s *k8sruntime.Scheme) {
+	require.NoError(t, kongv1.AddToScheme(s))
+	require.NoError(t, kongv1beta1.AddToScheme(s))
+	require.NoError(t, kongv1alpha1.AddToScheme(s))
+}
+
+// Scheme returns a new scheme with the default Kubernetes types registered.
+// It accepts optional SchemeOptions to register additional types.
+func Scheme(t *testing.T, opts ...SchemeOption) *k8sruntime.Scheme {
+	s := k8sruntime.NewScheme()
+	require.NoError(t, k8sscheme.AddToScheme(s))
+
+	for _, opt := range opts {
+		opt(t, s)
+	}
+
+	return s
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent race conditions adds `envtest.Scheme` function to get a scheme for every test separately. It also allows customizing the scheme with `WithGatewayAPI` and `WithKong` options.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
