### PR TITLE
fix: lock problem controller-runtime calls in test

### DIFF
--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -22,7 +22,9 @@ import (
 func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	t.Parallel()
 
+	runtimeMutex.Lock()
 	err := kongv1.AddToScheme(scheme.Scheme)
+	runtimeMutex.Unlock()
 	require.NoError(t, err)
 	cfg := Setup(t, scheme.Scheme, WithInstallKongCRDs(true))
 	client := NewControllerClient(t, cfg)

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -20,7 +20,9 @@ import (
 func TestKongConsumer_ProgrammedCondition(t *testing.T) {
 	t.Parallel()
 
+	runtimeMutex.Lock()
 	err := kongv1.AddToScheme(scheme.Scheme)
+	runtimeMutex.Unlock()
 	require.NoError(t, err)
 	envcfg := Setup(t, scheme.Scheme, WithInstallKongCRDs(true))
 	ctrlClient := NewControllerClient(t, envcfg)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a lock guarding controller-runtime library calls observed to result in a data race internal to the library.

**Which issue this PR fixes**:

Workaround for https://github.com/Kong/kubernetes-ingress-controller/issues/4414. We may not really need a better fix, but this approach feels hacky.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
