### PR TITLE
feat: add kubebuilder annotations to programmed conditions

### DIFF
--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -159,6 +159,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -225,7 +233,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -154,6 +154,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -220,7 +228,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -217,6 +217,14 @@ spec:
               resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -283,7 +291,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin
@@ -998,6 +1010,14 @@ spec:
             description: Status represents the current status of the KongPlugin resource.
             properties:
               conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the KongPluginStatus.
+                  \n Known condition types are: \n * \"Programmed\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1064,7 +1084,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - plugin

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -100,6 +100,16 @@ type KongClusterPluginList struct {
 
 // KongClusterPluginStatus represents the current status of the KongClusterPlugin resource.
 type KongClusterPluginStatus struct {
+	// Conditions describe the current conditions of the KongClusterPluginStatus.
+	//
+	// Known condition types are:
+	//
+	// * "Programmed"
+	//
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -100,6 +100,16 @@ type KongPluginList struct {
 
 // KongPluginStatus represents the current status of the KongPlugin resource.
 type KongPluginStatus struct {
+	// Conditions describe the current conditions of the KongPluginStatus.
+	//
+	// Known condition types are:
+	//
+	// * "Programmed"
+	//
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds kubebuilder annotations to the `Conditions` field for `KongClusterPlugin` and `KongPlugin`. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3344.
