### PR TITLE
feat: add printer columns for programmed condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@ Adding a new version? You'll need three changes:
   whether an object was successfully translated into Kong entities and sent to Kong.
   [#4409](https://github.com/Kong/kubernetes-ingress-controller/pull/4409)
   [#4412](https://github.com/Kong/kubernetes-ingress-controller/pull/4412)
+- `KongConsumer`, `KongPlugin`, and `KongClusterPlugin`'s `additionalPrinterColumns`
+  were extended with `Programmed` column. It will display the status of the 
+  `Programmed` condition of an object when `kubectl get` is used.
+  [#4425](https://github.com/Kong/kubernetes-ingress-controller/pull/4425)
 
 ### Changed
 

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -37,6 +37,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -27,6 +27,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -37,6 +37,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -95,6 +95,9 @@ spec:
       name: Config
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -368,6 +371,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -880,6 +886,9 @@ spec:
       jsonPath: .config
       name: Config
       priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     name: v1
     schema:

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
+// +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API.
 type KongClusterPlugin struct {

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -29,6 +29,7 @@ import (
 // +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Username",type=string,JSONPath=`.username`,description="Username of a Kong Consumer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
+// +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 
 // KongConsumer is the Schema for the kongconsumers API.
 type KongConsumer struct {

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
+// +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 
 // KongPlugin is the Schema for the kongplugins API.
 type KongPlugin struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `additionalPrinterColumns` entry for a `Programmed` condition to be displayed for `KongConsumer`, `KongPlugin`, and `KongClusterPlugin`.

```shell
$ k get kongplugins
NAME   PLUGIN-TYPE   AGE   PROGRAMMED
auth   key-auth      9s    True
```

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3344.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
