### PR TITLE
tests: add parser golden tests covering expression routes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 pkg/clientset/** linguist-generated=true
 deploy/single/** linguist-generated=true
 docs/api-reference.md linguist-generated=true
+internal/dataplane/parser/testdata/golden/**/*_golden.yaml linguist-generated=true

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -1,0 +1,43 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.example.com.0
+  name: grpcroute.default.grpcbin.example.com.0
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/grpcbin.GRPCBin/DummyUnary") && (http.host == "example.com")
+    https_redirect_status_code: 426
+    name: grpcroute.default.grpcbin.example.com.0.0
+    preserve_host: true
+    priority: 1713055227461631
+    tags:
+    - k8s-name:grpcbin
+    - k8s-namespace:default
+    - k8s-kind:GRPCRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1alpha2
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.example.com.0
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
@@ -1,0 +1,39 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: httproute..httproute-testing.0
+  name: httproute..httproute-testing.0
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    name: httproute..httproute-testing.0.0
+    path_handling: v0
+    paths:
+    - ~/httproute-testing$
+    - /httproute-testing/
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1beta1
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1beta1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: httproute..httproute-testing.0
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1beta1

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -1,0 +1,35 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: httproute..httproute-testing._.0
+  name: httproute..httproute-testing._.0
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: ((net.protocol == "http") || (net.protocol == "https")) && ((http.path
+      == "/httproute-testing") || (http.path ^= "/httproute-testing/"))
+    https_redirect_status_code: 426
+    name: httproute..httproute-testing._.0.0
+    preserve_host: true
+    priority: 2251808940752895
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1beta1
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1beta1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: httproute..httproute-testing._.0
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1beta1

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/httproute-example/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/in.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: httpbin
+  name: httpbin
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: httpbin
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: nginx
+  type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-testing
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  parentRefs:
+    - name: kong
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httproute-testing
+      backendRefs:
+        - name: httpbin
+          kind: Service
+          port: 80
+          weight: 75
+        - name: nginx
+          kind: Service
+          port: 8080
+          weight: 25

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -1,0 +1,40 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062006273
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -1,0 +1,77 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.8000.svc
+  name: foo-namespace.foo-svc.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.net") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.net.8000
+    preserve_host: true
+    priority: 3382102062006273
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062006273
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.8000.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -1,0 +1,40 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.http.svc
+  name: foo-namespace.foo-svc.http
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.regex-prefix.foo-svc.example.com.http
+    preserve_host: true
+    priority: 3382102062006273
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:regex-prefix
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.http.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -1,0 +1,40 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path == "/whatever") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071817
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -1,0 +1,40 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ~ "^/foo/\\d{3}") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.regex-prefix.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071818
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:regex-prefix
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -1,0 +1,107 @@
+_format_version: "3.0"
+certificates:
+- cert: |-
+    -----BEGIN CERTIFICATE-----
+    MIIBoTCCAQoCCQCjZq2l6IGAATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
+    b25naHEuY29tMB4XDTIzMDYwMTE3NTMyMVoXDTI0MDUzMTE3NTMyMVowFTETMBEG
+    A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuDsJ
+    xkC+QWHD8UfPBjrUXnM69iq8VRzzKVlxUom7/mXT4WbT7vLIb6pWuWGJXwP7IUec
+    LSAFTwMH9xqeB+IcIwOVRyRwTs8vBrx+rNXBS7gLyAtaeGbWnKl+A95KL5jnaEG+
+    TrxMGpZlRSojOWsc/sE/Yt+WqHJ9QqKKvgKEUtECAwEAATANBgkqhkiG9w0BAQsF
+    AAOBgQCeeXGqFiOpPe4EuFE4O/ydvOMmun8ap3e0VNGwWu7ylN2bxggK3IvZ5rNf
+    03Uc8e1eoKWa30gkw1tyQQ0uo33VbxzJVrbMWQG7syYMocgt/8Czg8rX4ezCOstJ
+    PXXJPGS/3O7JOCUbBUZ2aJ7eVHzMNyn7CiZiqI9kJqEGlU/I8w==
+    -----END CERTIFICATE-----
+  id: ""
+  key: |-
+    -----BEGIN PRIVATE KEY-----
+    MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALg7CcZAvkFhw/FH
+    zwY61F5zOvYqvFUc8ylZcVKJu/5l0+Fm0+7yyG+qVrlhiV8D+yFHnC0gBU8DB/ca
+    ngfiHCMDlUckcE7PLwa8fqzVwUu4C8gLWnhm1pypfgPeSi+Y52hBvk68TBqWZUUq
+    IzlrHP7BP2LflqhyfUKiir4ChFLRAgMBAAECgYBBJadsMuLUbgUDIniD5HPKvobA
+    HBajJmyaV6WqIUiYSlvlnh4dpj7Yteya+3G/ZsH8X71Le8JE0XaUnBX8Baoa4gWi
+    Ws6CTX5yHVMihJ3Ixh5dGt6pdKPTCbBgNf+0ySVavbCDhfLisWTMNuN6KxHmx0GW
+    PY85RuzRLl68+h7VEQJBANrPJE2MAxTpZ+Qw2r2jPF5yf1njwuyiIkZNlqz7Vmvy
+    ZCXBZfahUXPcR5ka4xKOLgc7oCah+43gNDmq0vDtEP0CQQDXi09XJyLjnD1RpVIi
+    t/cG5JiDBvtuSGjI7s/mI2Ts0fpo/U35WUGajHagma9c2qlYMeVZ7fupxLNaLD6z
+    1MtlAkEA1h/7wL+RjHdVKeP9S7NgsnSN1+Ohr3yC2hW3rBRR4FVWV/RI2e/IC/+3
+    OUcsi84DkSRydxvxVkfgE8btosP76QJABjMWlB4nDb7nsJp9s0vxSfx3OoWP48sn
+    YGgmCKuJ8pnThwOKI5rinSxfGR1ygswzRLsiqqSCsY5bzkMphoifVQJBAIUmrXPj
+    51od3k5VpWo1S+Mg9IiufrnqtpFu/kEEXluxCqrskb1C7mWMkGqy0bHpA014Squ2
+    7InkkRoDnTrU3Ro=
+    -----END PRIVATE KEY-----
+  snis:
+  - name: 3.example.com
+  - name: 4.example.com
+- cert: |-
+    -----BEGIN CERTIFICATE-----
+    MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
+    b25naHEuY29tMB4XDTIzMDYwMTE3NTAwOFoXDTI0MDUzMTE3NTAwOFowFTETMBEG
+    A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuyL5
+    0o4RyWoYLQTU5wKkYXcx9nDYTn+6O6WQPcDyOfPQmm92vauBK3zNJQxnhK3pdCJs
+    /li+q2BqnBWYoFcp/DETIeOuyI43+BpARjAHntUM02sofcbTMRGA28/uCgq+46LS
+    DqPGl6LeSA1pc7muc1mEmkvklYFzQ57Gee4i5SECAwEAATANBgkqhkiG9w0BAQsF
+    AAOBgQBBvx0bdyFdWxa75R9brz8s1GYLrVmk7zCXspvy9sDy1RoaV7TnYdWxv/HU
+    9fumw+0RoSsxysQRc1iWA8qJ6y2rq3G7A3GHtIPqsDHrjoS9s9YtJo4iT4INJ3Im
+    0fB0QDr1F4F5P6TZyMu1Wjgt2CheqaZH6TLa8Em4Fz/Qrfc1Ag==
+    -----END CERTIFICATE-----
+  id: ""
+  key: |-
+    -----BEGIN PRIVATE KEY-----
+    MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBALsi+dKOEclqGC0E
+    1OcCpGF3MfZw2E5/ujulkD3A8jnz0Jpvdr2rgSt8zSUMZ4St6XQibP5YvqtgapwV
+    mKBXKfwxEyHjrsiON/gaQEYwB57VDNNrKH3G0zERgNvP7goKvuOi0g6jxpei3kgN
+    aXO5rnNZhJpL5JWBc0OexnnuIuUhAgMBAAECgYARpvz11Zzr6Owa4wfKOr+SyhGW
+    c5KT5QyGL9npWVgAC3Wz+6uxvInUtlMLmZ3yMA2DfPPXEjv6IoAr9QWOqmo1TDou
+    vpi7n06GlT8qOMWOpbPoR7hCCa4nlsx48q8QQ+KnnChz0AgNYtlIu9H1l1a20Hut
+    /qoEW7We/GPtbHbAAQJBAPc7wVUGtmHiFtXI2N/bdRkefk67TgytMQVU1eHIhnh8
+    glAVpuGNYcyXYoDfod/yMpIJ4To2FNgRNVaHWgfOhQECQQDBxbIvw+PKrurNIbqr
+    su/fcDJXdKZ+wfuJJX2kRQeMga0nVcqLUZV1RAPmCg0Yv+QNhovq1ouwLNsZKpe5
+    w8AhAkBDGaG4LPE1EcK21SMfZpWacq8/ORDO2faTBtphxCXS76ACkk3Pq6qed3vR
+    lGB/wmE9R5csUF9J4SnDyUqDEecBAkAvVWSeiGJ3m1zd+RRJZu9zjEuv013sbuRL
+    7y2O2BHs/6xVhH5yo943hALTybbDSfSiXTCGkBwVUA/BSQdBKJEhAkA/XSV2JTle
+    g5RhxkuDZst3K8aupwWKC4E9zug+araQknzjMh6MSl6u2+RNifRrz2kThQ3HYj0g
+    5GTyl7XJmyY/
+    -----END PRIVATE KEY-----
+  snis:
+  - name: 1.example.com
+  - name: 2.example.com
+services:
+- connect_timeout: 60000
+  host: foo-svc.bar-namespace.80.svc
+  name: bar-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path == "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: bar-namespace.ing-with-tls.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071809
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:ing-with-tls
+    - k8s-namespace:bar-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.bar-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -1,0 +1,55 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071809
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  - expression: (http.host == "example.com") && (http.path ^= "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo-2.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071809
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo-2
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -1,0 +1,40 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: cert-manager-solver-pod.foo-namespace.80.svc
+  name: foo-namespace.cert-manager-solver-pod.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path ^= "/.well-known/acme-challenge/yolo")
+      && ((net.protocol == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
+    preserve_host: true
+    priority: 3382102062006304
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:cert-manager-solver-pod
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: cert-manager-solver-pod.foo-namespace.80.svc
+  tags:
+  - k8s-name:cert-manager-solver-pod
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -1,0 +1,76 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: foo-svc.foo-namespace.80.svc
+  name: foo-namespace.foo-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.host == "example.com") && (http.path == "/") && ((net.protocol
+      == "http") || (net.protocol == "https"))
+    https_redirect_status_code: 426
+    name: foo-namespace.foo.foo-svc.example.com.80
+    preserve_host: true
+    priority: 3382102062071809
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:foo
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: default-svc.bar-namespace.80.svc
+  name: bar-namespace.default-svc.80
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path ^= "/") && ((net.protocol == "http") || (net.protocol ==
+      "https"))
+    https_redirect_status_code: 426
+    name: bar-namespace.ing-with-default-backend
+    preserve_host: true
+    priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:ing-with-default-backend
+    - k8s-namespace:bar-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:default-svc
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: foo-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:foo-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: default-svc.bar-namespace.80.svc
+  tags:
+  - k8s-name:default-svc
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_settings.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds settings to cover `ExpressionRoutes: true` to the existing Ingress and GRPCRoute tests, adds a new `HTTPRoute` test.