### PR TITLE
fix: do not use address to a loop variable in parser

### DIFF
--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -228,20 +228,20 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 
 	// generate consumers and credentials
 	result.FillConsumersAndCredentials(p.storer, p.failuresCollector, p.kongVersion)
-	for _, c := range result.Consumers {
-		p.registerSuccessfullyParsedObject(&c.K8sKongConsumer)
+	for i := range result.Consumers {
+		p.registerSuccessfullyParsedObject(&result.Consumers[i].K8sKongConsumer)
 	}
 
 	// process annotation plugins
 	result.FillPlugins(p.logger, p.storer)
-	for _, pl := range result.Plugins {
-		p.registerSuccessfullyParsedObject(pl.K8sParent)
+	for i := range result.Plugins {
+		p.registerSuccessfullyParsedObject(result.Plugins[i].K8sParent)
 	}
 
 	// process consumer groups
 	result.FillConsumerGroups(p.logger, p.storer)
-	for _, cg := range result.ConsumerGroups {
-		p.registerSuccessfullyParsedObject(&cg.K8sKongConsumerGroup)
+	for i := range result.ConsumerGroups {
+		p.registerSuccessfullyParsedObject(&result.ConsumerGroups[i].K8sKongConsumerGroup)
 	}
 
 	// generate Certificates and SNIs

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5368,21 +5368,30 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 			expectedObjectsToBeConfigured: []k8stypes.NamespacedName{},
 		},
 		{
-			name: "KongConsumer",
+			name: "KongConsumers",
 			objectsInStore: store.FakeObjects{
 				KongConsumers: []*configurationv1.KongConsumer{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:        "consumer",
+							Name:        "consumer1",
 							Namespace:   "bar",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						Username: "foo",
+						Username: "consumer1",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "consumer2",
+							Namespace:   "bar",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						Username: "consumer2",
 					},
 				},
 			},
 			expectedObjectsToBeConfigured: []k8stypes.NamespacedName{
-				{Name: "consumer", Namespace: "bar"},
+				{Name: "consumer1", Namespace: "bar"},
+				{Name: "consumer2", Namespace: "bar"},
 			},
 		},
 		{
@@ -5391,7 +5400,14 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 				KongConsumerGroups: []*configurationv1beta1.KongConsumerGroup{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:        "consumer-group",
+							Name:        "consumer-group1",
+							Namespace:   "bar",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "consumer-group2",
 							Namespace:   "bar",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
@@ -5399,20 +5415,29 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 				},
 			},
 			expectedObjectsToBeConfigured: []k8stypes.NamespacedName{
-				{Name: "consumer-group", Namespace: "bar"},
+				{Name: "consumer-group1", Namespace: "bar"},
+				{Name: "consumer-group2", Namespace: "bar"},
 			},
 		},
 		{
-			name: "KongPlugin with KongConsumer",
+			name: "KongPlugins with KongConsumer",
 			objectsInStore: store.FakeObjects{
 				KongPlugins: []*configurationv1.KongPlugin{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:        "plugin",
+							Name:        "plugin1",
 							Namespace:   "bar",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						PluginName: "plugin",
+						PluginName: "plugin1",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "plugin2",
+							Namespace:   "bar",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						PluginName: "plugin2",
 					},
 				},
 				KongConsumers: []*configurationv1.KongConsumer{
@@ -5422,7 +5447,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 							Namespace: "bar",
 							Annotations: map[string]string{
 								annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-								annotations.AnnotationPrefix + annotations.PluginsKey: "plugin",
+								annotations.AnnotationPrefix + annotations.PluginsKey: "plugin1,plugin2",
 							},
 						},
 						Username: "foo",
@@ -5430,20 +5455,28 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 				},
 			},
 			expectedObjectsToBeConfigured: []k8stypes.NamespacedName{
-				{Name: "plugin", Namespace: "bar"},
+				{Name: "plugin1", Namespace: "bar"},
+				{Name: "plugin2", Namespace: "bar"},
 				{Name: "consumer", Namespace: "bar"},
 			},
 		},
 		{
-			name: "KongClusterPlugin with KongConsumer",
+			name: "KongClusterPlugins with KongConsumer",
 			objectsInStore: store.FakeObjects{
 				KongClusterPlugins: []*configurationv1.KongClusterPlugin{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:        "plugin",
+							Name:        "plugin1",
 							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
 						},
-						PluginName: "plugin",
+						PluginName: "plugin2",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "plugin2",
+							Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+						},
+						PluginName: "plugin2",
 					},
 				},
 				KongConsumers: []*configurationv1.KongConsumer{
@@ -5453,7 +5486,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 							Namespace: "bar",
 							Annotations: map[string]string{
 								annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-								annotations.AnnotationPrefix + annotations.PluginsKey: "plugin",
+								annotations.AnnotationPrefix + annotations.PluginsKey: "plugin1,plugin2",
 							},
 						},
 						Username: "foo",
@@ -5461,7 +5494,8 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 				},
 			},
 			expectedObjectsToBeConfigured: []k8stypes.NamespacedName{
-				{Name: "plugin"},
+				{Name: "plugin1"},
+				{Name: "plugin2"},
 				{Name: "consumer", Namespace: "bar"},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

@programmer04 has found that when creating two `Consumer`s at once, only one gets its `Programmed` condition properly set to `True`, and the other one stays `False` forever. This PR fixes the root cause of the bug.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #3344.
