### PR TITLE
chore: add looppointer linter and fix found issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ _download_tool:
 		GOBIN=$(PROJECT_DIR)/bin go generate -tags=third_party ./$(TOOL).go )
 
 .PHONY: tools
-tools: controller-gen kustomize client-gen golangci-lint gotestsum crd-ref-docs skaffold
+tools: controller-gen kustomize client-gen golangci-lint gotestsum crd-ref-docs skaffold looppointer
 
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 .PHONY: controller-gen
@@ -101,6 +101,11 @@ GOJUNIT= $(PROJECT_DIR)/bin/go-junit-report
 go-junit-report: ## Download go-junit-report locally if necessary.
 	@$(MAKE) _download_tool TOOL=go-junit-report
 
+LOOPPOINTER= $(PROJECT_DIR)/bin/looppointer
+.PHONY: looppointer.download
+looppointer.download: ## Download looppointer locally if necessary.
+	@$(MAKE) _download_tool TOOL=looppointer
+
 # ------------------------------------------------------------------------------
 # Build
 # ------------------------------------------------------------------------------
@@ -151,7 +156,7 @@ fmt:
 	go fmt ./...
 
 .PHONY: lint
-lint: verify.tidy golangci-lint staticcheck
+lint: verify.tidy golangci-lint staticcheck looppointer
 	$(GOLANGCI_LINT) run -v
 
 .PHONY: staticcheck
@@ -159,6 +164,9 @@ staticcheck: staticcheck.download
 	$(STATICCHECK) -tags envtest,e2e_tests,integration_tests,istio_tests,conformance_tests \
 		-f stylish \
 		./...
+
+looppointer: looppointer.download
+	$(LOOPPOINTER) -v ./internal/... ./test/...
 
 .PHONY: verify.tidy
 verify.tidy:

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -331,6 +331,7 @@ func TestValidationWebhook(t *testing.T) {
 				},
 			},
 		} {
+			tt := tt
 			t.Run(fmt.Sprintf("%s/%s", apiVersion, tt.name), func(t *testing.T) {
 				// arrange
 				assert := assert.New(t)

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -378,6 +378,7 @@ func (validator KongHTTPValidator) listManagedConsumers(ctx context.Context) ([]
 	// reduce the consumer set to consumers managed by this controller
 	managedConsumers := make([]*kongv1.KongConsumer, 0)
 	for _, consumer := range consumers.Items {
+		consumer := consumer
 		if !validator.ingressClassMatcher(&consumer.ObjectMeta, annotations.IngressClassKey,
 			annotations.ExactClassMatch) {
 			// ignore consumers (and subsequently secrets) that are managed by other controllers

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -433,6 +433,7 @@ func (r *GRPCRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
+		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -512,6 +512,7 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
+		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayv1beta1.RouteParentStatus{
 			ParentRef: ParentReference{

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -442,6 +442,7 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
+		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -428,6 +428,7 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
+		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -433,6 +433,7 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
+		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayv1alpha2.RouteParentStatus{
 			ParentRef: gatewayv1alpha2.ParentReference{

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -113,6 +113,7 @@ func ToDeckContent(
 	})
 
 	for _, u := range k8sState.Upstreams {
+		u := u
 		fillUpstream(&u.Upstream)
 		upstream := file.FUpstream{Upstream: u.Upstream}
 		for _, t := range u.Targets {
@@ -174,24 +175,31 @@ func ToDeckContent(
 		}
 
 		for _, v := range c.KeyAuths {
+			v := v
 			consumer.KeyAuths = append(consumer.KeyAuths, &v.KeyAuth)
 		}
 		for _, v := range c.HMACAuths {
+			v := v
 			consumer.HMACAuths = append(consumer.HMACAuths, &v.HMACAuth)
 		}
 		for _, v := range c.BasicAuths {
+			v := v
 			consumer.BasicAuths = append(consumer.BasicAuths, &v.BasicAuth)
 		}
 		for _, v := range c.JWTAuths {
+			v := v
 			consumer.JWTAuths = append(consumer.JWTAuths, &v.JWTAuth)
 		}
 		for _, v := range c.ACLGroups {
+			v := v
 			consumer.ACLGroups = append(consumer.ACLGroups, &v.ACLGroup)
 		}
 		for _, v := range c.Oauth2Creds {
+			v := v
 			consumer.Oauth2Creds = append(consumer.Oauth2Creds, &v.Oauth2Credential)
 		}
 		for _, v := range c.MTLSAuths {
+			v := v
 			consumer.MTLSAuths = append(consumer.MTLSAuths, &v.MTLSAuth)
 		}
 		content.Consumers = append(content.Consumers, consumer)

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -214,6 +214,7 @@ func TestOverrideRoute(t *testing.T) {
 	}
 
 	for _, testcase := range testTable {
+		testcase := testcase
 		testcase.inRoute.override(logrus.New(), &testcase.inKongIngresss)
 		assert.Equal(testcase.inRoute, testcase.outRoute)
 	}
@@ -496,6 +497,7 @@ func TestOverrideRouteStripPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideStripPath(tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
@@ -899,6 +901,7 @@ func TestOverrideRequestBuffering(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideRequestBuffering(logrus.New(), tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
@@ -972,6 +975,7 @@ func TestOverrideResponseBuffering(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideResponseBuffering(logrus.New(), tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -363,6 +363,7 @@ func TestOverrideService(t *testing.T) {
 	}
 
 	for _, testcase := range testTable {
+		testcase := testcase
 		log := logrus.New()
 		log.SetOutput(io.Discard)
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -343,6 +343,7 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 			}, nil
 		}
 		for _, port := range svc.Spec.Ports {
+			port := port
 			if port.Port == wantPort.Number {
 				return &port, nil
 			}
@@ -353,6 +354,7 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 			return nil, fmt.Errorf("rules with an ExternalName service must specify numeric ports")
 		}
 		for _, port := range svc.Spec.Ports {
+			port := port
 			if port.Name == wantPort.Name {
 				return &port, nil
 			}

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -111,6 +111,7 @@ func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp v1
 				continue
 			}
 			for j, rulePath := range rule.HTTP.Paths {
+				rulePath := rulePath
 				pathTypeImplementationSpecific := netv1.PathTypeImplementationSpecific
 				if rulePath.PathType == nil {
 					rulePath.PathType = &pathTypeImplementationSpecific

--- a/internal/dataplane/parser/translators/ingress.go
+++ b/internal/dataplane/parser/translators/ingress.go
@@ -118,6 +118,7 @@ func (i *ingressTranslationIndex) Add(ingress *netv1.Ingress, addRegexPrefix add
 		}
 
 		for _, httpIngressPath := range ingressRule.HTTP.Paths {
+			httpIngressPath := httpIngressPath
 			httpIngressPath.Path = flattenMultipleSlashes(httpIngressPath.Path)
 
 			if httpIngressPath.Path == "" {

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/go-delve/delve v1.21.0
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
+	github.com/kyoh86/looppointer v0.2.1
 	gotest.tools/gotestsum v1.10.1
 	honnef.co/go/tools v0.4.3
 	k8s.io/code-generator v0.27.4
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230221102149-f6f37e6cc1ec
 	sigs.k8s.io/controller-tools v0.12.1
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
+
 )
 
 // Note: needed for skaffold
@@ -232,6 +234,7 @@ require (
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.7 // indirect
 	github.com/kyoh86/exportloopref v0.1.11 // indirect
+	github.com/kyoh86/nolint v0.0.1 // indirect
 	github.com/ldez/gomoddirectives v0.2.3 // indirect
 	github.com/ldez/tagliatelle v0.5.0 // indirect
 	github.com/leonklingele/grouper v1.1.1 // indirect

--- a/third_party/go.sum
+++ b/third_party/go.sum
@@ -1411,6 +1411,10 @@ github.com/kunwardeep/paralleltest v1.0.7/go.mod h1:2C7s65hONVqY7Q5Efj5aLzRCNLjw
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/ymEyhQ=
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
+github.com/kyoh86/looppointer v0.2.1 h1:Jx9fnkBj/JrIryBLMTYNTj9rvc2SrPS98Dg0w7fxdJg=
+github.com/kyoh86/looppointer v0.2.1/go.mod h1:q358WcM8cMWU+5vzqukvaZtnJi1kw/MpRHQm3xvTrjw=
+github.com/kyoh86/nolint v0.0.1 h1:GjNxDEkVn2wAxKHtP7iNTrRxytRZ1wXxLV5j4XzGfRU=
+github.com/kyoh86/nolint v0.0.1/go.mod h1:1ZiZZ7qqrZ9dZegU96phwVcdQOMKIqRzFJL3ewq9gtI=
 github.com/ldez/gomoddirectives v0.2.3 h1:y7MBaisZVDYmKvt9/l1mjNCiSA1BVn34U0ObUcJwlhA=
 github.com/ldez/gomoddirectives v0.2.3/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=
@@ -2736,6 +2740,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201001104356-43ebab892c4c/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/third_party/looppointer.go
+++ b/third_party/looppointer.go
@@ -1,0 +1,7 @@
+//go:build third_party
+
+package third_party
+
+import _ "github.com/kyoh86/looppointer/cmd/looppointer"
+
+//go:generate go install -modfile go.mod github.com/kyoh86/looppointer/cmd/looppointer


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a restrictive `looppointer` linter that prevents getting a pointer to a loop variable. It may have false positives (as taking an address without storing it and using later can be fine), although I think it's better to be safe than sorry.

Fixes the issues found by the new linter.

It's not enabled in golangci-lint, because it hasn't been included into this suite of linters yet because of [reasons](https://github.com/golangci/golangci-lint/issues/1404).
