### PR TITLE
chore: remove non-existent makefile test.integration dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ test.conformance: go-junit-report
 	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -parser gotest
 
 .PHONY: test.integration
-test.integration: test.integration.dbless test.integration.postgres test.integration.cp
+test.integration: test.integration.dbless test.integration.postgres
 
 .PHONY: test.integration.enterprise
 test.integration.enterprise: test.integration.enterprise.postgres test.integration.enterprise.dbless


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes dependency on `test.integration.cp` (that doesn't exist) from `test.integration` Makefile target.

**Which issue this PR fixes**:

```shell
$ make test.integration
...
ok      github.com/kong/kubernetes-ingress-controller/v2/test/integration       1434.591s       coverage: 14.5% of statements in ./pkg/..., ./internal/...
make: *** No rule to make target `test.integration.cp', needed by `test.integration'.  Stop.
```

