### PR TITLE
refactor: do not copy HTTPRoute to each match in splitting HTTPRoutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Adding a new version? You'll need three changes:
   them to expression based Kong routes. The assigning method follows the
   [specification on priorities of matches in `HTTPRoute`][httproute-specification].
   [#4296](https://github.com/Kong/kubernetes-ingress-controller/pull/4296)
+  [#4430](https://github.com/Kong/kubernetes-ingress-controller/pull/4430)
 - Assign priorities to routes translated from GRPCRoutes when the parser translates 
   them to expression based Kong routes. The priority order follows the
   [specification on match priorities in GRPCRoute][grpcroute-specification].

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -95,9 +95,9 @@ func (p *Parser) ingressRulesFromHTTPRoutesUsingExpressionRoutes(httpRoutes []*g
 	splitHTTPRoutesWithPriorities := translators.AssignRoutePriorityToSplitHTTPRouteMatches(logrusr.New(p.logger), splitHTTPRouteMatches)
 	httpRouteNameToTranslationFailure := map[k8stypes.NamespacedName][]error{}
 
-	// translate split HTTPRoutes to ingress rules, including services, routes, upstreams.
+	// translate split HTTPRoute matches to ingress rules, including services, routes, upstreams.
 	for _, httpRouteWithPriority := range splitHTTPRoutesWithPriorities {
-		err := p.ingressRulesFromSplitHTTPRouteWithPriority(result, httpRouteWithPriority)
+		err := p.ingressRulesFromSplitHTTPRouteMatchWithPriority(result, httpRouteWithPriority)
 		if err != nil {
 			nsName := k8stypes.NamespacedName{
 				Namespace: httpRouteWithPriority.Match.Source.Namespace,
@@ -527,7 +527,9 @@ func httpBackendRefsToBackendRefs(httpBackendRef []gatewayv1beta1.HTTPBackendRef
 	return backendRefs
 }
 
-func (p *Parser) ingressRulesFromSplitHTTPRouteWithPriority(
+// ingressRulesFromSplitHTTPRouteMatchWithPriority translates a single match split from HTTPRoute
+// to ingress rule, including Kong service and Kong route.
+func (p *Parser) ingressRulesFromSplitHTTPRouteMatchWithPriority(
 	rules *ingressRules,
 	httpRouteMatchWithPriority translators.SplitHTTPRouteMatchToKongRoutePriority,
 ) error {

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -541,7 +541,7 @@ func (p *Parser) ingressRulesFromSplitHTTPRouteWithPriority(
 
 	rule := httpRoute.Spec.Rules[match.RuleIndex]
 	backendRefs := httpBackendRefsToBackendRefs(rule.BackendRefs)
-	serviceName := translators.KongServiceNameFromHTTPRouteWithPriority(httpRouteMatchWithPriority)
+	serviceName := translators.KongServiceNameFromSplitHTTPRouteMatch(httpRouteMatchWithPriority.Match)
 
 	kongService, err := generateKongServiceFromBackendRefWithName(
 		p.logger,

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -1825,7 +1825,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				"should have expected number of services")
 			for _, expectedKongService := range tc.expectedKongServices {
 				kongService, ok := result.ServiceNameToServices[*expectedKongService.Name]
-				require.Truef(t, ok, "should find service %s", expectedKongService.Name)
+				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
 				require.Equal(t, expectedKongService.Backends, kongService.Backends)
 				// check routes
 				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
@@ -1938,6 +1938,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 							Rules: []gatewayv1beta1.HTTPRouteRule{
 								{
 									Matches: []gatewayv1beta1.HTTPRouteMatch{
+										builder.NewHTTPRouteMatch().WithPathExact("/foo").Build(),
 										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
 									},
 									BackendRefs: []gatewayv1beta1.HTTPBackendRef{
@@ -1956,7 +1957,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Hostname:   "foo.com",
 					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
 					RuleIndex:  0,
-					MatchIndex: 0,
+					MatchIndex: 1,
 				},
 				Priority: 1024,
 			},

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -2008,10 +2008,6 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Name:      "httproute-1",
-							Annotations: map[string]string{
-								translators.InternalRuleIndexAnnotationKey:  "0",
-								translators.InternalMatchIndexAnnotationKey: "0",
-							},
 						},
 						Spec: gatewayv1beta1.HTTPRouteSpec{
 							Hostnames: []gatewayv1beta1.Hostname{

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -1854,7 +1854,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 }
 
-func TestIngressRulesWithPriority(t *testing.T) {
+func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 	fakestore, err := store.NewFakeStore(store.FakeObjects{})
 	require.NoError(t, err)
 	parser := mustNewParser(t, fakestore)
@@ -1863,37 +1863,38 @@ func TestIngressRulesWithPriority(t *testing.T) {
 	httpRouteTypeMeta := metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayv1beta1.SchemeGroupVersion.String()}
 
 	testCases := []struct {
-		name                  string
-		httpRouteWithPriority translators.SplitHTTPRouteToKongRoutePriority
-		expectedKongService   kongstate.Service
-		expectedKongRoute     kongstate.Route
-		expectedError         error
+		name                string
+		matchWithPriority   translators.SplitHTTPRouteMatchToKongRoutePriority
+		expectedKongService kongstate.Service
+		expectedKongRoute   kongstate.Route
+		expectedError       error
 	}{
 		{
 			name: "no hostname",
-			httpRouteWithPriority: translators.SplitHTTPRouteToKongRoutePriority{
-				HTTPRoute: &gatewayv1beta1.HTTPRoute{
-					TypeMeta: httpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "httproute-1",
-						Annotations: map[string]string{
-							translators.InternalRuleIndexAnnotationKey:  "0",
-							translators.InternalMatchIndexAnnotationKey: "0",
+			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: translators.SplitHTTPRouteMatch{
+					Source: &gatewayv1beta1.HTTPRoute{
+						TypeMeta: httpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "httproute-1",
 						},
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								Matches: []gatewayv1beta1.HTTPRouteMatch{
-									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-								},
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+						Spec: gatewayv1beta1.HTTPRouteSpec{
+							Rules: []gatewayv1beta1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1beta1.HTTPRouteMatch{
+										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+									},
+									BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									},
 								},
 							},
 						},
 					},
+					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+					RuleIndex:  0,
+					MatchIndex: 0,
 				},
 				Priority: 1024,
 			},
@@ -1922,38 +1923,40 @@ func TestIngressRulesWithPriority(t *testing.T) {
 		},
 		{
 			name: "precise hostname and filter",
-			httpRouteWithPriority: translators.SplitHTTPRouteToKongRoutePriority{
-				HTTPRoute: &gatewayv1beta1.HTTPRoute{
-					TypeMeta: httpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "httproute-1",
-						Annotations: map[string]string{
-							translators.InternalRuleIndexAnnotationKey:  "0",
-							translators.InternalMatchIndexAnnotationKey: "1",
+			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: translators.SplitHTTPRouteMatch{
+					Source: &gatewayv1beta1.HTTPRoute{
+						TypeMeta: httpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "httproute-1",
 						},
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						Hostnames: []gatewayv1beta1.Hostname{
-							"foo.com",
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								Matches: []gatewayv1beta1.HTTPRouteMatch{
-									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-								},
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
-								},
-								Filters: []gatewayv1beta1.HTTPRouteFilter{
-									builder.NewHTTPRouteRequestRedirectFilter().
-										WithRequestRedirectStatusCode(301).
-										WithRequestRedirectHost("bar.com").
-										Build(),
+						Spec: gatewayv1beta1.HTTPRouteSpec{
+							Hostnames: []gatewayv1beta1.Hostname{
+								"foo.com",
+							},
+							Rules: []gatewayv1beta1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1beta1.HTTPRouteMatch{
+										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+									},
+									BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									},
+									Filters: []gatewayv1beta1.HTTPRouteFilter{
+										builder.NewHTTPRouteRequestRedirectFilter().
+											WithRequestRedirectStatusCode(301).
+											WithRequestRedirectHost("bar.com").
+											Build(),
+									},
 								},
 							},
 						},
 					},
+					Hostname:   "foo.com",
+					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+					RuleIndex:  0,
+					MatchIndex: 0,
 				},
 				Priority: 1024,
 			},
@@ -1997,33 +2000,39 @@ func TestIngressRulesWithPriority(t *testing.T) {
 		},
 		{
 			name: "wildcard hostname with multiple backends",
-			httpRouteWithPriority: translators.SplitHTTPRouteToKongRoutePriority{
-				HTTPRoute: &gatewayv1beta1.HTTPRoute{
-					TypeMeta: httpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "httproute-1",
-						Annotations: map[string]string{
-							translators.InternalRuleIndexAnnotationKey:  "0",
-							translators.InternalMatchIndexAnnotationKey: "0",
+			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: translators.SplitHTTPRouteMatch{
+					Source: &gatewayv1beta1.HTTPRoute{
+						TypeMeta: httpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "httproute-1",
+							Annotations: map[string]string{
+								translators.InternalRuleIndexAnnotationKey:  "0",
+								translators.InternalMatchIndexAnnotationKey: "0",
+							},
 						},
-					},
-					Spec: gatewayv1beta1.HTTPRouteSpec{
-						Hostnames: []gatewayv1beta1.Hostname{
-							"*.foo.com",
-						},
-						Rules: []gatewayv1beta1.HTTPRouteRule{
-							{
-								Matches: []gatewayv1beta1.HTTPRouteMatch{
-									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-								},
-								BackendRefs: []gatewayv1beta1.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).WithWeight(10).Build(),
-									builder.NewHTTPBackendRef("service2").WithPort(80).WithWeight(20).Build(),
+						Spec: gatewayv1beta1.HTTPRouteSpec{
+							Hostnames: []gatewayv1beta1.Hostname{
+								"*.foo.com",
+							},
+							Rules: []gatewayv1beta1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1beta1.HTTPRouteMatch{
+										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+									},
+									BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+										builder.NewHTTPBackendRef("service1").WithPort(80).WithWeight(10).Build(),
+										builder.NewHTTPBackendRef("service2").WithPort(80).WithWeight(20).Build(),
+									},
 								},
 							},
 						},
 					},
+					Hostname:   "*.foo.com",
+					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+					RuleIndex:  0,
+					MatchIndex: 0,
 				},
 				Priority: 1024,
 			},
@@ -2061,11 +2070,12 @@ func TestIngressRulesWithPriority(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc.expectedKongRoute.Tags = util.GenerateTagsForObject(tc.httpRouteWithPriority.HTTPRoute)
-			tc.expectedKongRoute.Ingress = util.FromK8sObject(tc.httpRouteWithPriority.HTTPRoute)
+			match := tc.matchWithPriority.Match
+			tc.expectedKongRoute.Tags = util.GenerateTagsForObject(match.Source)
+			tc.expectedKongRoute.Ingress = util.FromK8sObject(match.Source)
 
 			res := newIngressRules()
-			err := parser.ingressRulesFromSplitHTTPRouteWithPriority(&res, tc.httpRouteWithPriority)
+			err := parser.ingressRulesFromSplitHTTPRouteWithPriority(&res, tc.matchWithPriority)
 			if tc.expectedError != nil {
 				require.ErrorAs(t, err, tc.expectedError)
 				return
@@ -2078,10 +2088,6 @@ func TestIngressRulesWithPriority(t *testing.T) {
 			require.Equal(t, tc.expectedKongRoute, kongService.Routes[0])
 		})
 	}
-}
-
-func HTTPMethodPointer(method gatewayv1beta1.HTTPMethod) *gatewayv1beta1.HTTPMethod {
-	return &method
 }
 
 func k8sObjectInfoOfHTTPRoute(route *gatewayv1beta1.HTTPRoute) util.K8sObjectInfo {

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -2076,7 +2076,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 			tc.expectedKongRoute.Ingress = util.FromK8sObject(match.Source)
 
 			res := newIngressRules()
-			err := parser.ingressRulesFromSplitHTTPRouteWithPriority(&res, tc.matchWithPriority)
+			err := parser.ingressRulesFromSplitHTTPRouteMatchWithPriority(&res, tc.matchWithPriority)
 			if tc.expectedError != nil {
 				require.ErrorAs(t, err, tc.expectedError)
 				return

--- a/internal/dataplane/parser/translators/grpcroute_atc_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc_test.go
@@ -829,12 +829,8 @@ func TestAssignRoutePriorityToSplitGRPCRouteMatches(t *testing.T) {
 				{
 					Source: &gatewayv1alpha2.GRPCRoute{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "grpcroute-2",
-							Annotations: map[string]string{
-								InternalRuleIndexAnnotationKey:  "0",
-								InternalMatchIndexAnnotationKey: "0",
-							},
+							Namespace:         "default",
+							Name:              "grpcroute-2",
 							CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
 						},
 						Spec: gatewayv1alpha2.GRPCRouteSpec{
@@ -1090,10 +1086,6 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Name:      "precise-hostname-regex-method",
-							Annotations: map[string]string{
-								InternalRuleIndexAnnotationKey:  "0",
-								InternalMatchIndexAnnotationKey: "0",
-							},
 						},
 						Spec: gatewayv1alpha2.GRPCRouteSpec{
 							Hostnames: []gatewayv1alpha2.Hostname{

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -223,11 +223,6 @@ func matchersFromParentHTTPRoute(hostnames []string, metaAnnotations map[string]
 	return ret
 }
 
-const (
-	InternalRuleIndexAnnotationKey  = "internal-rule-index"
-	InternalMatchIndexAnnotationKey = "internal-match-index"
-)
-
 type SplitHTTPRouteMatch struct {
 	Source     *gatewayv1beta1.HTTPRoute
 	Hostname   string

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -499,15 +499,6 @@ func compareSplitHTTPRouteMatchesRelativePriority(match1, match2 SplitHTTPRouteM
 	return true
 }
 
-// getHTTPRouteHostnamesAsSliceOfStrings translates the hostnames defined in an
-// HTTPRoute specification into a string slice, which is the type required by translating to matchers
-// in expression based routes.
-func getHTTPRouteHostnamesAsSliceOfStrings(httproute *gatewayv1beta1.HTTPRoute) []string {
-	return lo.Map(httproute.Spec.Hostnames, func(h gatewayv1beta1.Hostname, _ int) string {
-		return string(h)
-	})
-}
-
 // KongExpressionRouteFromHTTPRouteMatchWithPriority translates a split HTTPRoute match into expression
 // based kong route with assigned priority.
 func KongExpressionRouteFromHTTPRouteMatchWithPriority(
@@ -542,13 +533,12 @@ func KongExpressionRouteFromHTTPRouteMatchWithPriority(
 		Ingress:          util.FromK8sObject(httproute),
 		ExpressionRoutes: true,
 	}
-
-	hostnames := getHTTPRouteHostnamesAsSliceOfStrings(httproute)
+	// generate ATC matcher from hostname in the match and annotations of parent HTTPRoute.
+	hostnames := []string{match.Hostname}
 	matchers := matchersFromParentHTTPRoute(hostnames, httproute.Annotations)
+	// generate ATC matcher from split HTTPRouteMatch itself.
+	matchers = append(matchers, generateMatcherFromHTTPRouteMatch(match.Match))
 
-	if len(httproute.Spec.Rules) > 0 && len(httproute.Spec.Rules[0].Matches) > 0 {
-		matchers = append(matchers, generateMatcherFromHTTPRouteMatch(httproute.Spec.Rules[0].Matches[0]))
-	}
 	atc.ApplyExpression(&r.Route, atc.And(matchers...), httpRouteMatchWithPriority.Priority)
 
 	// translate filters in the rule.
@@ -567,18 +557,15 @@ func KongExpressionRouteFromHTTPRouteMatchWithPriority(
 	return r
 }
 
-// KongServiceNameFromHTTPRouteWithPriority generates service name from split HTTPRoutes.
+// KongServiceNameFromSplitHTTPRouteMatch generates service name from split HTTPRoute match.
 // since one HTTPRoute may be split by hostname and rule, the service name will be generated
-// in the format httproute.<namespace>.<name>.<hostname>.<rule index>.
+// in the format "httproute.<namespace>.<name>.<hostname>.<rule index>".
 // For example: `httproute.default.example.foo.com.0`.
-func KongServiceNameFromHTTPRouteWithPriority(
-	httpRouteMatchWithPriority SplitHTTPRouteMatchToKongRoutePriority,
-) string {
-	match := httpRouteMatchWithPriority.Match
+func KongServiceNameFromSplitHTTPRouteMatch(match SplitHTTPRouteMatch) string {
 	httproute := match.Source
 	hostname := "_"
 	if len(match.Hostname) > 0 {
-		hostname = strings.ReplaceAll(hostname, "*", "_")
+		hostname = strings.ReplaceAll(match.Hostname, "*", "_")
 	}
 	return fmt.Sprintf("httproute.%s.%s.%s.%d",
 		httproute.Namespace,

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -3,7 +3,6 @@ package translators
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -229,50 +228,47 @@ const (
 	InternalMatchIndexAnnotationKey = "internal-match-index"
 )
 
-// SplitHTTPRoute splits HTTPRoutes into HTTPRoutes with at most one hostname, and at most one rule
+type SplitHTTPRouteMatch struct {
+	Source     *gatewayv1beta1.HTTPRoute
+	Hostname   string
+	Match      gatewayv1beta1.HTTPRouteMatch
+	RuleIndex  int
+	MatchIndex int
+}
+
+// SplitHTTPRoute splits HTTPRoutes into matches with at most one hostname, and one rule
 // with exactly one match. It will split one rule with multiple hostnames and multiple matches
 // to one hostname and one match per each HTTPRoute.
-func SplitHTTPRoute(httproute *gatewayv1beta1.HTTPRoute) []*gatewayv1beta1.HTTPRoute {
-	// split HTTPRoutes by hostname.
-	hostnamedRoutes := []*gatewayv1beta1.HTTPRoute{}
-	if len(httproute.Spec.Hostnames) == 0 {
-		hostnamedRoutes = append(hostnamedRoutes, httproute.DeepCopy())
-	} else {
-		for _, hostname := range httproute.Spec.Hostnames {
-			hostNamedRoute := httproute.DeepCopy()
-			hostNamedRoute.Spec.Hostnames = []gatewayv1beta1.Hostname{hostname}
-			hostnamedRoutes = append(hostnamedRoutes, hostNamedRoute)
-		}
-	}
-	// split HTTPRoutes (already split once by hostname) by match.
-	newHTTPRoutes := []*gatewayv1beta1.HTTPRoute{}
-	for _, route := range hostnamedRoutes {
-		for i, rule := range route.Spec.Rules {
-			for j, match := range rule.Matches {
-				splitRoute := route.DeepCopy()
-				splitRoute.Spec.Rules = []gatewayv1beta1.HTTPRouteRule{
-					{
-						Matches:     []gatewayv1beta1.HTTPRouteMatch{match},
-						Filters:     rule.Filters,
-						BackendRefs: rule.BackendRefs,
-					},
-				}
-				if splitRoute.Annotations == nil {
-					splitRoute.Annotations = map[string]string{}
-				}
-				splitRoute.Annotations[InternalRuleIndexAnnotationKey] = strconv.Itoa(i)
-				splitRoute.Annotations[InternalMatchIndexAnnotationKey] = strconv.Itoa(j)
-				newHTTPRoutes = append(newHTTPRoutes, splitRoute)
+func SplitHTTPRoute(httproute *gatewayv1beta1.HTTPRoute) []SplitHTTPRouteMatch {
+	splitMatches := []SplitHTTPRouteMatch{}
+	splitHTTPRouteByMatch := func(hostname string) {
+		for ruleIndex, rule := range httproute.Spec.Rules {
+			for matchIndex, match := range rule.Matches {
+				splitMatches = append(splitMatches, SplitHTTPRouteMatch{
+					Source:     httproute,
+					Hostname:   hostname,
+					Match:      *match.DeepCopy(),
+					RuleIndex:  ruleIndex,
+					MatchIndex: matchIndex,
+				})
 			}
 		}
 	}
 
-	return newHTTPRoutes
+	if len(httproute.Spec.Hostnames) == 0 {
+		splitHTTPRouteByMatch("")
+		return splitMatches
+	}
+
+	for _, hostname := range httproute.Spec.Hostnames {
+		splitHTTPRouteByMatch(string(hostname))
+	}
+	return splitMatches
 }
 
-type SplitHTTPRouteToKongRoutePriority struct {
-	HTTPRoute *gatewayv1beta1.HTTPRoute
-	Priority  int
+type SplitHTTPRouteMatchToKongRoutePriority struct {
+	Match    SplitHTTPRouteMatch
+	Priority int
 }
 
 type HTTPRoutePriorityTraits struct {
@@ -285,8 +281,9 @@ type HTTPRoutePriorityTraits struct {
 	QueryParamCount int
 }
 
-// CalculateSplitHTTPRoutePriorityTraits calculates the parts of priority that can be decided by the
-// fields in spec of the already split HTTPRoute. Specification of priority goes as follow:
+// CalculateHTTPRouteMatchPriorityTraits calculates the parts of priority
+// that can be decided by the fields in spec of the match split from HTTPRoute.
+// Specification of priority goes as follow:
 // (The following comments are extracted from gateway API specification about HTTPRoute)
 //
 // In the event that multiple HTTPRoutes specify intersecting hostnames,
@@ -305,42 +302,41 @@ type HTTPRoutePriorityTraits struct {
 //   - Method match.
 //   - Largest number of header matches.
 //   - Largest number of query param matches.
-func CalculateSplitHTTPRoutePriorityTraits(httpRoute *gatewayv1beta1.HTTPRoute) HTTPRoutePriorityTraits {
+func CalculateHTTPRouteMatchPriorityTraits(match SplitHTTPRouteMatch) HTTPRoutePriorityTraits {
 	traits := HTTPRoutePriorityTraits{}
-	// the HTTPRoute here have been already split by hostnames and matches,
-	// so one HTTPRoute have at most one hostname.
-	if len(httpRoute.Spec.Hostnames) != 0 {
-		hostname := httpRoute.Spec.Hostnames[0]
-		traits.HostnameLength = len(hostname)
+	// fill traits from hostname.
+	if len(match.Hostname) != 0 {
+		traits.HostnameLength = len(match.Hostname)
 		// if the hostname does not start with *, the split HTTPRoute should have precise hostname.
-		if !strings.HasPrefix(string(hostname), "*") {
+		if !strings.HasPrefix(match.Hostname, "*") {
 			traits.PreciseHostname = true
 		}
 	}
 
-	// also, the HTTPRoute have been split so it have at most one match.
-	if len(httpRoute.Spec.Rules) > 0 && len(httpRoute.Spec.Rules[0].Matches) > 0 {
-		match := httpRoute.Spec.Rules[0].Matches[0]
-		if match.Path != nil {
-			// fill path type.
-			if match.Path.Type != nil {
-				traits.PathType = *match.Path.Type
-			}
-			// fill path length.
-			if match.Path.Value != nil {
-				traits.PathLength = len(*match.Path.Value)
-			}
+	// fill traits from path match.
+	if match.Match.Path != nil {
+		pathMatch := match.Match.Path
+		// fill path type.
+		if pathMatch.Type != nil {
+			traits.PathType = *pathMatch.Type
 		}
-
-		// fill number of header matches.
-		traits.HeaderCount = len(match.Headers)
-		// fill method match.
-		if match.Method != nil {
-			traits.HasMethodMatch = true
+		// fill path length.
+		if pathMatch.Value != nil {
+			traits.PathLength = len(*pathMatch.Value)
 		}
-		// fill number of query parameters.
-		traits.QueryParamCount = len(match.QueryParams)
 	}
+
+	// fill method match.
+	if match.Match.Method != nil {
+		traits.HasMethodMatch = true
+	}
+
+	// fill number of header matches.
+	traits.HeaderCount = len(match.Match.Headers)
+
+	// fill number of query parameters.
+	traits.QueryParamCount = len(match.Match.QueryParams)
+
 	return traits
 }
 
@@ -413,52 +409,46 @@ func (t HTTPRoutePriorityTraits) EncodeToPriority() int {
 	return priority
 }
 
-// AssignRoutePriorityToSplitHTTPRoutes assigns priority to ALL split HTTPRoutes
-// that are split by hostnames and matches from HTTPRoutes listed from the cache.
-// Firstly assign "fixed" bits by the following fields of the HTTPRoute:
+// AssignRoutePriorityToSplitHTTPRouteMatches assigns priority to
+// ALL split matches from ALL HTTPRoutes in the cache.
+// Firstly assign "fixed" bits by the following fields of the match:
 // hostname, path type, path length, method match, number of header matches, number of query param matches.
-// If ties exists in the first step, where multiple HTTPRoute has the same priority
-// calculated from the fields, we run a sort for the HTTPRoutes in the tie
-// and assign the bits for "relative order" according to the sorting result of these HTTPRoutes.
-func AssignRoutePriorityToSplitHTTPRoutes(
+// If ties exists in the first step, where multiple matches has the same priority
+// calculated from the fields, we run a sort for the matches in the tie
+// and assign the bits for "relative order" according to the sorting result of these matches.
+func AssignRoutePriorityToSplitHTTPRouteMatches(
 	logger logr.Logger,
-	splitHTTPRoutes []*gatewayv1beta1.HTTPRoute,
-) []SplitHTTPRouteToKongRoutePriority {
-	priorityToSplitHTTPRoutes := map[int][]*gatewayv1beta1.HTTPRoute{}
+	splitHTTPRouteMatches []SplitHTTPRouteMatch,
+) []SplitHTTPRouteMatchToKongRoutePriority {
+	priorityToSplitHTTPRouteMatches := map[int][]SplitHTTPRouteMatch{}
 
-	for _, httpRoute := range splitHTTPRoutes {
-		anns := httpRoute.Annotations
-		// skip if HTTPRoute does not contain the annotation, because this means the HTTPRoute is not a split one.
-		if anns == nil || anns[InternalRuleIndexAnnotationKey] == "" || anns[InternalMatchIndexAnnotationKey] == "" {
-			continue
-		}
-
-		priority := CalculateSplitHTTPRoutePriorityTraits(httpRoute).EncodeToPriority()
-		priorityToSplitHTTPRoutes[priority] = append(priorityToSplitHTTPRoutes[priority], httpRoute)
+	for _, match := range splitHTTPRouteMatches {
+		priority := CalculateHTTPRouteMatchPriorityTraits(match).EncodeToPriority()
+		priorityToSplitHTTPRouteMatches[priority] = append(priorityToSplitHTTPRouteMatches[priority], match)
 	}
 
-	httpRoutesToPriorities := make([]SplitHTTPRouteToKongRoutePriority, 0, len(splitHTTPRoutes))
+	httpRouteMatchesToPriorities := make([]SplitHTTPRouteMatchToKongRoutePriority, 0, len(splitHTTPRouteMatches))
 
-	// Bits 0-17 (18 bits) are assigned for relative order of HTTPRoutes.
-	// If multiple HTTPRoutes are assigned to the same priority in the previous step,
+	// Bits 0-17 (18 bits) are assigned for relative order of matches.
+	// If multiple matches are assigned to the same priority in the previous step,
 	// sort them then starts with 2^18 -1 and decrease by one for each HTTPRoute;
-	// If only one HTTPRoute occupies the priority, fill the relative order bits with all 1s.
+	// If only one match occupies the priority, fill the relative order bits with all 1s.
 	const RelativeOrderAssignedBits = 18
 	const defaultRelativeOrderPriorityBits = (1 << RelativeOrderAssignedBits) - 1
-	for priority, routes := range priorityToSplitHTTPRoutes {
-		if len(routes) == 1 {
-			httpRoutesToPriorities = append(httpRoutesToPriorities, SplitHTTPRouteToKongRoutePriority{
-				HTTPRoute: routes[0],
-				Priority:  priority + defaultRelativeOrderPriorityBits,
+	for priority, matches := range priorityToSplitHTTPRouteMatches {
+		if len(matches) == 1 {
+			httpRouteMatchesToPriorities = append(httpRouteMatchesToPriorities, SplitHTTPRouteMatchToKongRoutePriority{
+				Match:    matches[0],
+				Priority: priority + defaultRelativeOrderPriorityBits,
 			})
 			continue
 		}
 
-		sort.SliceStable(routes, func(i, j int) bool {
-			return compareSplitHTTPRoutesRelativePriority(routes[i], routes[j])
+		sort.SliceStable(matches, func(i, j int) bool {
+			return compareSplitHTTPRouteMatchesRelativePriority(matches[i], matches[j])
 		})
 
-		for i, route := range routes {
+		for i, match := range matches {
 			relativeOrderBits := defaultRelativeOrderPriorityBits - i
 			// Although it is very unlikely that there are 2^18 = 262144 HTTPRoutes
 			// should be given priority by their relative order, here we limit the
@@ -466,22 +456,24 @@ func AssignRoutePriorityToSplitHTTPRoutes(
 			if relativeOrderBits <= 0 {
 				relativeOrderBits = 0
 			}
-			httpRoutesToPriorities = append(httpRoutesToPriorities, SplitHTTPRouteToKongRoutePriority{
-				HTTPRoute: route,
-				Priority:  priority + relativeOrderBits,
+			httpRouteMatchesToPriorities = append(httpRouteMatchesToPriorities, SplitHTTPRouteMatchToKongRoutePriority{
+				Match:    match,
+				Priority: priority + relativeOrderBits,
 			})
 		}
-		// Just in case, log a very unlikely scenario where we have more than 2^18 routes with the same base
+		// Just in case, log a very unlikely scenario where we have more than 2^18 matches with the same base
 		// priority and we have no bit space for them to be deterministically ordered.
-		if len(routes) > (1 << 18) {
-			logger.V(util.WarnLevel).Info("Too many HTTPRoutes to be deterministically ordered", "httproute_number", len(routes))
+		if len(matches) > (1 << 18) {
+			logger.V(util.WarnLevel).Info("Too many HTTPRoute matches to be deterministically ordered", "match_number", len(matches))
 		}
 	}
 
-	return httpRoutesToPriorities
+	return httpRouteMatchesToPriorities
 }
 
-func compareSplitHTTPRoutesRelativePriority(route1, route2 *gatewayv1beta1.HTTPRoute) bool {
+func compareSplitHTTPRouteMatchesRelativePriority(match1, match2 SplitHTTPRouteMatch) bool {
+	route1 := match1.Source
+	route2 := match2.Source
 	// compare by creation timestamp.
 	if !route1.CreationTimestamp.Equal(&route2.CreationTimestamp) {
 		return route1.CreationTimestamp.Before(&route2.CreationTimestamp)
@@ -495,16 +487,12 @@ func compareSplitHTTPRoutesRelativePriority(route1, route2 *gatewayv1beta1.HTTPR
 		return route1.Name < route2.Name
 	}
 	// if ties still exist, compare by internal rule order and match order.
-	ruleIndex1, _ := strconv.Atoi(route1.Annotations[InternalRuleIndexAnnotationKey])
-	ruleIndex2, _ := strconv.Atoi(route2.Annotations[InternalRuleIndexAnnotationKey])
-	if ruleIndex1 != ruleIndex2 {
-		return ruleIndex1 < ruleIndex2
+	if match1.RuleIndex != match2.RuleIndex {
+		return match1.RuleIndex < match2.RuleIndex
 	}
 
-	matchIndex1, _ := strconv.Atoi(route1.Annotations[InternalMatchIndexAnnotationKey])
-	matchIndex2, _ := strconv.Atoi(route2.Annotations[InternalMatchIndexAnnotationKey])
-	if matchIndex1 != matchIndex2 {
-		return matchIndex1 < matchIndex2
+	if match1.MatchIndex != match2.MatchIndex {
+		return match1.MatchIndex < match2.MatchIndex
 	}
 
 	// should be unreachable.
@@ -520,27 +508,27 @@ func getHTTPRouteHostnamesAsSliceOfStrings(httproute *gatewayv1beta1.HTTPRoute) 
 	})
 }
 
-// KongExpressionRouteFromHTTPRouteWithPriority translates split HTTPRoute into expression
+// KongExpressionRouteFromHTTPRouteMatchWithPriority translates a split HTTPRoute match into expression
 // based kong route with assigned priority.
-// the HTTPRoute should have at most one hostname, and at most one rule having exactly one match.
-func KongExpressionRouteFromHTTPRouteWithPriority(
-	httpRouteWithPriority SplitHTTPRouteToKongRoutePriority,
+func KongExpressionRouteFromHTTPRouteMatchWithPriority(
+	httpRouteMatchWithPriority SplitHTTPRouteMatchToKongRoutePriority,
 ) kongstate.Route {
-	httproute := httpRouteWithPriority.HTTPRoute
+	match := httpRouteMatchWithPriority.Match
+	httproute := httpRouteMatchWithPriority.Match.Source
 	tags := util.GenerateTagsForObject(httproute)
 	// since we split HTTPRoutes by hostname, rule and match, we generate the route name in
 	// httproute.<namespace>.<name>.<hostname>.<rule index>.<match index> format.
-	hostname := "_"
-	if len(httproute.Spec.Hostnames) > 0 {
-		hostname = string(httproute.Spec.Hostnames[0])
-		hostname = strings.ReplaceAll(hostname, "*", "_")
+	hostnameInRouteName := "_"
+	if len(match.Hostname) > 0 {
+		hostnameInRouteName = strings.ReplaceAll(match.Hostname, "*", "_")
 	}
-	routeName := fmt.Sprintf("httproute.%s.%s.%s.%s.%s",
+
+	routeName := fmt.Sprintf("httproute.%s.%s.%s.%d.%d",
 		httproute.Namespace,
 		httproute.Name,
-		hostname,
-		httproute.Annotations[InternalRuleIndexAnnotationKey],
-		httproute.Annotations[InternalMatchIndexAnnotationKey],
+		hostnameInRouteName,
+		match.RuleIndex,
+		match.MatchIndex,
 	)
 
 	r := kongstate.Route{
@@ -561,18 +549,15 @@ func KongExpressionRouteFromHTTPRouteWithPriority(
 	if len(httproute.Spec.Rules) > 0 && len(httproute.Spec.Rules[0].Matches) > 0 {
 		matchers = append(matchers, generateMatcherFromHTTPRouteMatch(httproute.Spec.Rules[0].Matches[0]))
 	}
-	atc.ApplyExpression(&r.Route, atc.And(matchers...), httpRouteWithPriority.Priority)
+	atc.ApplyExpression(&r.Route, atc.And(matchers...), httpRouteMatchWithPriority.Priority)
 
 	// translate filters in the rule.
-	if len(httproute.Spec.Rules) > 0 {
-		rule := httproute.Spec.Rules[0]
+	if match.RuleIndex < len(httproute.Spec.Rules) {
+		rule := httproute.Spec.Rules[match.RuleIndex]
 		path := ""
-		// since we have at most one match per rule, we do not need to generate request redirect for each match.
-		if len(rule.Matches) > 0 {
-			match := rule.Matches[0]
-			if match.Path != nil && match.Path.Value != nil {
-				path = *match.Path.Value
-			}
+		// since we have one match to translate, we do not need to generate request redirect for each match.
+		if match.Match.Path != nil && match.Match.Path.Value != nil {
+			path = *match.Match.Path.Value
 		}
 
 		plugins := GeneratePluginsFromHTTPRouteFilters(rule.Filters, path, tags)
@@ -587,18 +572,18 @@ func KongExpressionRouteFromHTTPRouteWithPriority(
 // in the format httproute.<namespace>.<name>.<hostname>.<rule index>.
 // For example: `httproute.default.example.foo.com.0`.
 func KongServiceNameFromHTTPRouteWithPriority(
-	httpRouteWithPriority SplitHTTPRouteToKongRoutePriority,
+	httpRouteMatchWithPriority SplitHTTPRouteMatchToKongRoutePriority,
 ) string {
-	httproute := httpRouteWithPriority.HTTPRoute
+	match := httpRouteMatchWithPriority.Match
+	httproute := match.Source
 	hostname := "_"
-	if len(httproute.Spec.Hostnames) > 0 {
-		hostname = string(httproute.Spec.Hostnames[0])
+	if len(match.Hostname) > 0 {
 		hostname = strings.ReplaceAll(hostname, "*", "_")
 	}
-	return fmt.Sprintf("httproute.%s.%s.%s.%s",
+	return fmt.Sprintf("httproute.%s.%s.%s.%d",
 		httproute.Namespace,
 		httproute.Name,
 		hostname,
-		httproute.Annotations[InternalRuleIndexAnnotationKey],
+		match.RuleIndex,
 	)
 }

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -914,12 +914,8 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 				{
 					Source: &gatewayv1beta1.HTTPRoute{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-2",
-							Annotations: map[string]string{
-								InternalRuleIndexAnnotationKey:  "0",
-								InternalMatchIndexAnnotationKey: "0",
-							},
+							Namespace:         "default",
+							Name:              "httproute-2",
 							CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
 						},
 						Spec: gatewayv1beta1.HTTPRouteSpec{

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -542,9 +542,7 @@ func TestSplitHTTPRoutes(t *testing.T) {
 				Spec: gatewayv1beta1.HTTPRouteSpec{
 					Rules: []gatewayv1beta1.HTTPRouteRule{
 						{
-							Matches: []gatewayv1beta1.HTTPRouteMatch{
-								builder.NewHTTPRouteMatch().WithPathExact("/").Build(),
-							},
+							Matches:     builder.NewHTTPRouteMatch().WithPathExact("/").ToSlice(),
 							BackendRefs: namesToBackendRefs([]string{"svc1"}),
 						},
 					},
@@ -578,9 +576,7 @@ func TestSplitHTTPRoutes(t *testing.T) {
 					},
 					Rules: []gatewayv1beta1.HTTPRouteRule{
 						{
-							Matches: []gatewayv1beta1.HTTPRouteMatch{
-								builder.NewHTTPRouteMatch().WithPathExact("/").Build(),
-							},
+							Matches:     builder.NewHTTPRouteMatch().WithPathExact("/").ToSlice(),
 							BackendRefs: namesToBackendRefs([]string{"svc1", "svc2"}),
 						},
 					},
@@ -745,9 +741,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 							Hostnames: []gatewayv1beta1.Hostname{"foo.com"},
 							Rules: []gatewayv1beta1.HTTPRouteRule{
 								{
-									Matches: []gatewayv1beta1.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/foo").Build(),
-									},
+									Matches: builder.NewHTTPRouteMatch().WithPathExact("/foo").ToSlice(),
 								},
 							},
 						},
@@ -768,9 +762,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 							Hostnames: []gatewayv1beta1.Hostname{"*.bar.com"},
 							Rules: []gatewayv1beta1.HTTPRouteRule{
 								{
-									Matches: []gatewayv1beta1.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/bar").Build(),
-									},
+									Matches: builder.NewHTTPRouteMatch().WithPathExact("/bar").ToSlice(),
 								},
 							},
 						},
@@ -899,9 +891,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 							Hostnames: []gatewayv1beta1.Hostname{"foo.com"},
 							Rules: []gatewayv1beta1.HTTPRouteRule{
 								{
-									Matches: []gatewayv1beta1.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/foo").Build(),
-									},
+									Matches: builder.NewHTTPRouteMatch().WithPathExact("/foo").ToSlice(),
 								},
 							},
 						},
@@ -922,9 +912,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 							Hostnames: []gatewayv1beta1.Hostname{"bar.com"},
 							Rules: []gatewayv1beta1.HTTPRouteRule{
 								{
-									Matches: []gatewayv1beta1.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/foo").Build(),
-									},
+									Matches: builder.NewHTTPRouteMatch().WithPathExact("/foo").ToSlice(),
 								},
 							},
 						},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

refactor splitting of `HTTPRoute`: put each match of HTTPRoute into `SplitHTTPRouteMatch` structure, instead of copying metadata and split match into another HTTPRoute.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4396 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

copied from #4430. The action on the original PR keeps Pending even after pushing new commits and closing/reopening. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
