### PR TITLE
feat(admission) validage groups by version

### DIFF
--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -49,6 +49,7 @@ webhooks:
     - UPDATE
     resources:
     - kongconsumers
+    - kongconsumergroups
     - kongplugins
     - kongclusterplugins
     - kongingresses
@@ -74,6 +75,6 @@ webhooks:
     service:
       namespace: kong
       name: kong-validation-webhook
-    caBundle: $(base64 ${BASE64_OPTIONS:+${BASE64_OPTIONS}} "${TMPDIR}/tls.crt") 
+    caBundle: $(base64 ${BASE64_OPTIONS:+${BASE64_OPTIONS}} "${TMPDIR}/tls.crt")
 EOF
 ) | kubectl apply -f -

--- a/internal/admission/adminapi_provider.go
+++ b/internal/admission/adminapi_provider.go
@@ -37,6 +37,14 @@ func (p DefaultAdminAPIServicesProvider) GetPluginsService() (kong.AbstractPlugi
 	return c.Plugins, true
 }
 
+func (p DefaultAdminAPIServicesProvider) GetConsumerGroupsService() (kong.AbstractConsumerGroupService, bool) {
+	c, ok := p.designatedAdminAPIClient()
+	if !ok {
+		return nil, ok
+	}
+	return c.ConsumerGroups, true
+}
+
 func (p DefaultAdminAPIServicesProvider) designatedAdminAPIClient() (*kong.Client, bool) {
 	gwClients := p.gatewayClientsProvider.GatewayClients()
 	if len(gwClients) == 0 {

--- a/internal/admission/adminapi_provider.go
+++ b/internal/admission/adminapi_provider.go
@@ -37,12 +37,20 @@ func (p DefaultAdminAPIServicesProvider) GetPluginsService() (kong.AbstractPlugi
 	return c.Plugins, true
 }
 
-func (p DefaultAdminAPIServicesProvider) GetConsumerGroupsService() (kong.AbstractConsumerGroupService, bool) {
+func (p DefaultAdminAPIServicesProvider) GetConsumerGroupService() (kong.AbstractConsumerGroupService, bool) {
 	c, ok := p.designatedAdminAPIClient()
 	if !ok {
 		return nil, ok
 	}
 	return c.ConsumerGroups, true
+}
+
+func (p DefaultAdminAPIServicesProvider) GetInfoService() (kong.AbstractInfoService, bool) {
+	c, ok := p.designatedAdminAPIClient()
+	if !ok {
+		return nil, ok
+	}
+	return c.Info, true
 }
 
 func (p DefaultAdminAPIServicesProvider) designatedAdminAPIClient() (*kong.Client, bool) {

--- a/internal/admission/adminapi_provider_test.go
+++ b/internal/admission/adminapi_provider_test.go
@@ -27,6 +27,9 @@ func TestDefaultAdminAPIServicesProvider(t *testing.T) {
 
 		_, ok = p.GetPluginsService()
 		require.False(t, ok)
+
+		_, ok = p.GetConsumerGroupsService()
+		require.False(t, ok)
 	})
 
 	t.Run("when clients available should return first one", func(t *testing.T) {
@@ -45,5 +48,9 @@ func TestDefaultAdminAPIServicesProvider(t *testing.T) {
 		pluginsSvc, ok := p.GetPluginsService()
 		require.True(t, ok)
 		require.Equal(t, firstClient.AdminAPIClient().Plugins, pluginsSvc)
+
+		consumerGroupsSvc, ok := p.GetConsumerGroupsService()
+		require.True(t, ok)
+		require.Equal(t, firstClient.AdminAPIClient().ConsumerGroups, consumerGroupsSvc)
 	})
 }

--- a/internal/admission/adminapi_provider_test.go
+++ b/internal/admission/adminapi_provider_test.go
@@ -28,7 +28,10 @@ func TestDefaultAdminAPIServicesProvider(t *testing.T) {
 		_, ok = p.GetPluginsService()
 		require.False(t, ok)
 
-		_, ok = p.GetConsumerGroupsService()
+		_, ok = p.GetConsumerGroupService()
+		require.False(t, ok)
+
+		_, ok = p.GetInfoService()
 		require.False(t, ok)
 	})
 
@@ -49,8 +52,12 @@ func TestDefaultAdminAPIServicesProvider(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, firstClient.AdminAPIClient().Plugins, pluginsSvc)
 
-		consumerGroupsSvc, ok := p.GetConsumerGroupsService()
+		consumerGroupSvc, ok := p.GetConsumerGroupService()
 		require.True(t, ok)
-		require.Equal(t, firstClient.AdminAPIClient().ConsumerGroups, consumerGroupsSvc)
+		require.Equal(t, firstClient.AdminAPIClient().ConsumerGroups, consumerGroupSvc)
+
+		infoSvc, ok := p.GetInfoService()
+		require.True(t, ok)
+		require.Equal(t, firstClient.AdminAPIClient().Info, infoSvc)
 	})
 }

--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -1,20 +1,21 @@
 package admission
 
 const (
-	ErrTextConsumerCredentialSecretNotFound       = "consumer referenced non-existent credentials secret"
-	ErrTextConsumerCredentialValidationFailed     = "consumer credential failed validation"
-	ErrTextConsumerExists                         = "consumer already exists"
-	ErrTextConsumerUnretrievable                  = "failed to fetch consumer from kong"
-	ErrTextConsumerGroupUnsupportedByOSS          = "consumer groups are not supported in Kong OSS (only in Enterprise)"
-	ErrTextConsumerGroupUnsupportedWithoutLicense = "consumer groups are not supported in Kong Enterprise runs without a license"
-	ErrTextConsumerUsernameEmpty                  = "username cannot be empty"
-	ErrTextFailedToRetrieveSecret                 = "could not retrieve secrets from the kubernetes API"
-	ErrTextPluginConfigInvalid                    = "could not parse plugin configuration"
-	ErrTextPluginConfigValidationFailed           = "unable to validate plugin schema"
-	ErrTextPluginConfigViolatesSchema             = "plugin failed schema validation: %s"
-	ErrTextPluginNameEmpty                        = "plugin name cannot be empty"
-	ErrTextPluginSecretConfigUnretrievable        = "could not load secret plugin configuration"
-	ErrTextPluginUsesBothConfigTypes              = "plugin cannot use both Config and ConfigFrom"
+	ErrTextAdminAPIUnavailable                = "could not talk to Kong admin API"
+	ErrTextConsumerCredentialSecretNotFound   = "consumer referenced non-existent credentials secret"
+	ErrTextConsumerCredentialValidationFailed = "consumer credential failed validation"
+	ErrTextConsumerExists                     = "consumer already exists"
+	ErrTextConsumerUnretrievable              = "failed to fetch consumer from kong"
+	ErrTextConsumerGroupUnsupported           = "consumer group support requires Kong Enterprise 3.4+"
+	ErrTextConsumerGroupUnlicensed            = "consumer group support requires a valid Kong Enterprise license"
+	ErrTextConsumerUsernameEmpty              = "username cannot be empty"
+	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernetes API"
+	ErrTextPluginConfigInvalid                = "could not parse plugin configuration"
+	ErrTextPluginConfigValidationFailed       = "unable to validate plugin schema"
+	ErrTextPluginConfigViolatesSchema         = "plugin failed schema validation: %s"
+	ErrTextPluginNameEmpty                    = "plugin name cannot be empty"
+	ErrTextPluginSecretConfigUnretrievable    = "could not load secret plugin configuration"
+	ErrTextPluginUsesBothConfigTypes          = "plugin cannot use both Config and ConfigFrom"
 )
 
 const (

--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -1,18 +1,20 @@
 package admission
 
 const (
-	ErrTextConsumerCredentialSecretNotFound   = "consumer referenced non-existent credentials secret"
-	ErrTextConsumerCredentialValidationFailed = "consumer credential failed validation"
-	ErrTextConsumerExists                     = "consumer already exists"
-	ErrTextConsumerUnretrievable              = "failed to fetch consumer from kong"
-	ErrTextConsumerUsernameEmpty              = "username cannot be empty"
-	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernets API" //nolint:gosec
-	ErrTextPluginConfigInvalid                = "could not parse plugin configuration"
-	ErrTextPluginConfigValidationFailed       = "unable to validate plugin schema"
-	ErrTextPluginConfigViolatesSchema         = "plugin failed schema validation: %s"
-	ErrTextPluginNameEmpty                    = "plugin name cannot be empty"
-	ErrTextPluginSecretConfigUnretrievable    = "could not load secret plugin configuration"
-	ErrTextPluginUsesBothConfigTypes          = "plugin cannot use both Config and ConfigFrom"
+	ErrTextConsumerCredentialSecretNotFound       = "consumer referenced non-existent credentials secret"
+	ErrTextConsumerCredentialValidationFailed     = "consumer credential failed validation"
+	ErrTextConsumerExists                         = "consumer already exists"
+	ErrTextConsumerUnretrievable                  = "failed to fetch consumer from kong"
+	ErrTextConsumerGroupUnsupportedByOSS          = "consumer groups are not supported in Kong OSS (only in Enterprise)"
+	ErrTextConsumerGroupUnsupportedWithoutLicense = "consumer groups are not supported in Kong Enterprise runs without a license"
+	ErrTextConsumerUsernameEmpty                  = "username cannot be empty"
+	ErrTextFailedToRetrieveSecret                 = "could not retrieve secrets from the kubernetes API"
+	ErrTextPluginConfigInvalid                    = "could not parse plugin configuration"
+	ErrTextPluginConfigValidationFailed           = "unable to validate plugin schema"
+	ErrTextPluginConfigViolatesSchema             = "plugin failed schema validation: %s"
+	ErrTextPluginNameEmpty                        = "plugin name cannot be empty"
+	ErrTextPluginSecretConfigUnretrievable        = "could not load secret plugin configuration"
+	ErrTextPluginUsesBothConfigTypes              = "plugin cannot use both Config and ConfigFrom"
 )
 
 const (

--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -9,7 +9,7 @@ const (
 	ErrTextConsumerGroupUnsupported           = "consumer group support requires Kong Enterprise 3.4+"
 	ErrTextConsumerGroupUnlicensed            = "consumer group support requires a valid Kong Enterprise license"
 	ErrTextConsumerUsernameEmpty              = "username cannot be empty"
-	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernetes API"
+	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernetes API" //nolint:gosec
 	ErrTextPluginConfigInvalid                = "could not parse plugin configuration"
 	ErrTextPluginConfigValidationFailed       = "unable to validate plugin schema"
 	ErrTextPluginConfigViolatesSchema         = "plugin failed schema validation: %s"

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -18,6 +18,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configuration "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 var decoder = codecs.UniversalDeserializer()
@@ -31,6 +32,13 @@ type KongFakeValidator struct {
 func (v KongFakeValidator) ValidateConsumer(
 	_ context.Context,
 	_ configuration.KongConsumer,
+) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
+func (v KongFakeValidator) ValidateConsumerGroup(
+	_ context.Context,
+	_ configurationv1beta1.KongConsumerGroup,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -42,13 +42,21 @@ func (f fakeConsumersSvc) Get(context.Context, *string) (*kong.Consumer, error) 
 }
 
 type fakeServicesProvider struct {
-	pluginSvc   kong.AbstractPluginService
-	consumerSvc kong.AbstractConsumerService
+	pluginSvc        kong.AbstractPluginService
+	consumerSvc      kong.AbstractConsumerService
+	consumerGroupSvc kong.AbstractConsumerGroupService
 }
 
 func (f fakeServicesProvider) GetConsumersService() (kong.AbstractConsumerService, bool) {
 	if f.consumerSvc != nil {
 		return f.consumerSvc, true
+	}
+	return nil, false
+}
+
+func (f fakeServicesProvider) GetConsumerGroupsService() (kong.AbstractConsumerGroupService, bool) {
+	if f.consumerGroupSvc != nil {
+		return f.consumerGroupSvc, true
 	}
 	return nil, false
 }

--- a/test/integration/consumer_group_webhook_test.go
+++ b/test/integration/consumer_group_webhook_test.go
@@ -1,0 +1,157 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admregv1 "k8s.io/api/admissionregistration/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+const webhookName = "kong-validations-consumer-group"
+
+func TestValidationWebhookConsumerGroupKongOSS(t *testing.T) {
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("webhook tests are only available on KIND clusters currently")
+	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ConsumerGroupsVersionCutoff))
+	RunWhenKongOSS(t)
+
+	t.Parallel()
+
+	ctx := context.Background()
+	ns, kongClient := setupWebhook(ctx, t, env, webhookName)
+
+	t.Log("verifying validation for consumer groups for Kong OSS (rejecting creation)")
+	require.ErrorContains(
+		t,
+		createRandomConsumerGroup(ctx, ns, kongClient),
+		"consumer groups are not supported in Kong OSS (only in Enterprise)",
+	)
+}
+
+func TestValidationWebhookConsumerGroupKongEnterprise(t *testing.T) {
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("webhook tests are only available on KIND clusters currently")
+	}
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ConsumerGroupsVersionCutoff))
+	RunWhenKongEnterprise(t)
+
+	t.Parallel()
+
+	ctx := context.Background()
+	ns, kongClient := setupWebhook(ctx, t, env, webhookName)
+
+	t.Log("verifying validation for consumer groups for Kong Enterprise with valid license")
+	require.NoError(t, createRandomConsumerGroup(ctx, ns, kongClient))
+
+	t.Log("make license invalid for Kong Enterprise")
+	k8sClient := env.Cluster().Client()
+	// Fill in the license secret with an invalid license.
+	_, err := k8sClient.CoreV1().Secrets(consts.ControllerNamespace).Patch(
+		ctx,
+		"kong-enterprise-license",
+		k8stypes.StrategicMergePatchType,
+		[]byte(fmt.Sprintf(`{"data": {"license": "%s"}}`, base64.StdEncoding.EncodeToString([]byte("invalid")))),
+		metav1.PatchOptions{},
+	)
+	require.NoError(t, err)
+	// License secret is passed as env var to the Kong Gateway, so it has to be restarted.
+	restartAnnotation := []byte(fmt.Sprintf(
+		`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.Stamp),
+	))
+	deploymentClient := k8sClient.AppsV1().Deployments(consts.ControllerNamespace)
+	const gateway = "ingress-controller-kong"
+	deploymentPatch, err := deploymentClient.Patch(ctx, gateway, k8stypes.StrategicMergePatchType, restartAnnotation, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	require.Eventuallyf(t, func() bool {
+		current, err := deploymentClient.Get(ctx, gateway, metav1.GetOptions{})
+		if err != nil {
+			t.Log("WARNING: unexpected error getting deployment: ", err)
+			return false
+		}
+		return deploymentComplete(deploymentPatch, &current.Status)
+	}, ingressWait, waitTick, "deployment %q (Kong Gateway) should be ready after restart", gateway)
+	helpers.EventuallyGETPath(t, proxyAdminURL, "/", 200, "", map[string]string{
+		"Kong-Admin-Token": consts.KongTestPassword,
+	}, ingressWait, waitTick)
+	time.Sleep(20 * time.Second) // WHY!!!???? (I want to get rid of this sleep)
+	t.Log("verifying validation for consumer groups for Kong Enterprise with invalid license (rejecting creation)")
+	require.ErrorContains(
+		t,
+		createRandomConsumerGroup(ctx, ns, kongClient),
+		"consumer groups are not supported in Kong Enterprise runs without a license",
+	)
+}
+
+func setupWebhook(ctx context.Context, t *testing.T, env environments.Environment, name string) (string, *clientset.Clientset) {
+	ns := helpers.Namespace(ctx, t, env)
+	closer, err := ensureAdmissionRegistration(
+		ctx,
+		name,
+		[]admregv1.RuleWithOperations{
+			{
+				Rule: admregv1.Rule{
+					APIGroups:   []string{"configuration.konghq.com"},
+					APIVersions: []string{"v1beta1"},
+					Resources:   []string{"kongconsumergroups"},
+				},
+				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
+			},
+		},
+	)
+	assert.NoError(t, err, "creating webhook config")
+	t.Cleanup(func() {
+		assert.NoError(t, closer())
+	})
+
+	err = waitForWebhookServiceConnective(ctx, name)
+	require.NoError(t, err)
+
+	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
+	require.NoError(t, err)
+
+	return ns.Name, kongClient
+}
+
+func createRandomConsumerGroup(ctx context.Context, namespace string, kongClient *clientset.Clientset) error {
+	_, err := kongClient.ConfigurationV1beta1().KongConsumerGroups(namespace).Create(ctx, &kongv1beta1.KongConsumerGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.IngressClassKey: consts.IngressClass,
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// deploymentComplete considers a deployment to be complete once all of its desired replicas
+// are updated and available, and no old pods are running.
+// src: https://github.com/kubernetes/kubernetes/blob/513da69f76f64e5292ee661e033fb9f33ec89161/pkg/controller/deployment/util/deployment_util.go#L706-L713
+func deploymentComplete(deployment *k8sappsv1.Deployment, newStatus *k8sappsv1.DeploymentStatus) bool {
+	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
+		newStatus.Replicas == *(deployment.Spec.Replicas) &&
+		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&
+		newStatus.ObservedGeneration >= deployment.Generation
+}

--- a/test/integration/consumer_group_webhook_test.go
+++ b/test/integration/consumer_group_webhook_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
-	k8sappsv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -149,7 +149,7 @@ func createRandomConsumerGroup(ctx context.Context, namespace string, kongClient
 // deploymentComplete considers a deployment to be complete once all of its desired replicas
 // are updated and available, and no old pods are running.
 // src: https://github.com/kubernetes/kubernetes/blob/513da69f76f64e5292ee661e033fb9f33ec89161/pkg/controller/deployment/util/deployment_util.go#L706-L713
-func deploymentComplete(deployment *k8sappsv1.Deployment, newStatus *k8sappsv1.DeploymentStatus) bool {
+func deploymentComplete(deployment *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
 	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
 		newStatus.Replicas == *(deployment.Spec.Replicas) &&
 		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -59,6 +59,16 @@ func RunWhenKongEnterprise(t *testing.T) {
 	}
 }
 
+func RunWhenKongOSS(t *testing.T) {
+	t.Helper()
+
+	version := eventuallyGetKongVersion(t, proxyAdminURL)
+
+	if version.IsKongGatewayEnterprise() {
+		t.Skipf("skipping because Kong is not running as OSS, detected version %q", version)
+	}
+}
+
 func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
 	t.Helper()
 


### PR DESCRIPTION
Didn't check what was going on weird in the integration tests, but we should probably drop them. The admission tests support mocking well enough, and we need it since integration is only going to test against the current version and with a license if Enterprise.

We don't really design integration tests with the expectation that the license state will change or that the Kong instance will restart. Doing so may interrupt other tests running in parallel. We usually use E2E tests for anything that requires restarts or conditions that the integration environments don't support. Between that, the issues getting the integration test to behave, needing to test older versions, I'd say just use units, which this adds.

We should arguably use the InfoService to handle the unlicensed case as well, by checking the `.license` key in the root output. Relying on the entity endpoint returning a 403, while not inaccurate, feels a bit wonky--we should check configuration rather than its side effects. The Info struct doesn't include this, however, and I didn't want to try and stuff it into go-kong last minute.

I did remember that there is a separate LicenseService that we could use, though it's maybe a bit cumbersome for this purpose, since we have to list and walk through it. Ultimately, we can count it as minor debt and fix that up in a patch release.

---

The main elements of this change:
- Add an info service to the admission validator and use it for version-based checks.
- Add mocks for the version and consumer groups service and info service.
- Add unit tests for the expected failure and pass consumer groups cases.

Minor additional things:
- Use `ConsumerGroup` singular for the service name throughout. Some locations used `ConsumerGroups`. go-kong uses singular; we should match that.
- Shorten error names and reword contents. The unsupported error needed to be broader. Changed the other to use like sentence structure and remove an unnecessary `runs`.
- Removed some print debugs. Those should probably go in stash, or in a separate tmp commit so it's easier to drop them before merge.

It does not delete the integration test. I figure that can be done separately in the original PR branch.