### PR TITLE
ci: don't build the image on main when PR branch was up to date

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - name: Check if PR is up to date, if it is skip workflows for this ref
         id: 'up-to-date'
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         uses: Kong/public-shared-actions/pr-previews/up-to-date@v1.12.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     outputs:
       result: ${{ steps.check.outputs.result }}
     steps:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -73,21 +73,21 @@ jobs:
   linters:
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_linters.yaml
     secrets: inherit
 
   unit-tests:
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_unit_tests.yaml
     secrets: inherit
 
   envtest-tests:
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_envtest_tests.yaml
     secrets: inherit
 
@@ -95,18 +95,19 @@ jobs:
     needs:
     - should-run-with-secrets
     - up-to-date
-    if: ${{ needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true' }}
+    if: needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_integration_tests.yaml
     secrets: inherit
 
   conformance-tests:
     needs:
     - up-to-date
-    if: ${{ needs.up-to-date.outputs.status != 'true' }}
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_conformance_tests.yaml
     secrets: inherit
 
   build-docker-image:
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_docker_build.yaml
     secrets: inherit
 
@@ -116,6 +117,7 @@ jobs:
   passed:
     runs-on: ubuntu-latest
     needs:
+      - up-to-date
       - tools
       - linters
       - unit-tests
@@ -125,7 +127,7 @@ jobs:
       - build-docker-image
     if: always()
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Some jobs failed or were cancelled."
           exit 1
@@ -138,6 +140,6 @@ jobs:
       - integration-tests
       - conformance-tests
       - up-to-date
-    if: ${{ always() && needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true' }}
+    if: always() && needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_test_reports.yaml
     secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends https://github.com/Kong/kubernetes-ingress-controller/pull/4433 and https://github.com/Kong/kubernetes-ingress-controller/pull/4441 to prevent building the image if PR branch was up to date with `main`.
