### PR TITLE
ci: add missing up-to-date needs for build job

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -107,6 +107,8 @@ jobs:
     secrets: inherit
 
   build-docker-image:
+    needs:
+    - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_docker_build.yaml
     secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:

#4443 forgot the `needs` clause for `build-docker-image`.