### PR TITLE
chore: unify import aliases for Kong CRDs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,6 +83,8 @@ linters-settings:
       alias: metav1
     - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
       alias: gateway${1}
+    - pkg: github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/(v[\w\d]+)
+      alias: kong${1}
   forbidigo:
     exclude_godoc_examples: false
     forbid:

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -12,8 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	configuration "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // RequestHandler is an HTTP server that can validate Kong Ingress Controllers'
@@ -59,28 +59,28 @@ func (h RequestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 var (
 	consumerGVResource = metav1.GroupVersionResource{
-		Group:    configuration.SchemeGroupVersion.Group,
-		Version:  configuration.SchemeGroupVersion.Version,
+		Group:    kongv1.SchemeGroupVersion.Group,
+		Version:  kongv1.SchemeGroupVersion.Version,
 		Resource: "kongconsumers",
 	}
 	consumerGroupGVResource = metav1.GroupVersionResource{
-		Group:    configurationv1beta1.SchemeGroupVersion.Group,
-		Version:  configurationv1beta1.SchemeGroupVersion.Version,
+		Group:    kongv1beta1.SchemeGroupVersion.Group,
+		Version:  kongv1beta1.SchemeGroupVersion.Version,
 		Resource: "kongconsumergroups",
 	}
 	pluginGVResource = metav1.GroupVersionResource{
-		Group:    configuration.SchemeGroupVersion.Group,
-		Version:  configuration.SchemeGroupVersion.Version,
+		Group:    kongv1.SchemeGroupVersion.Group,
+		Version:  kongv1.SchemeGroupVersion.Version,
 		Resource: "kongplugins",
 	}
 	clusterPluginGVResource = metav1.GroupVersionResource{
-		Group:    configuration.SchemeGroupVersion.Group,
-		Version:  configuration.SchemeGroupVersion.Version,
+		Group:    kongv1.SchemeGroupVersion.Group,
+		Version:  kongv1.SchemeGroupVersion.Version,
 		Resource: "kongclusterplugins",
 	}
 	kongIngressGVResource = metav1.GroupVersionResource{
-		Group:    configuration.SchemeGroupVersion.Group,
-		Version:  configuration.SchemeGroupVersion.Version,
+		Group:    kongv1.SchemeGroupVersion.Group,
+		Version:  kongv1.SchemeGroupVersion.Version,
 		Resource: "kongingresses",
 	}
 	secretGVResource = metav1.GroupVersionResource{
@@ -134,7 +134,7 @@ func (h RequestHandler) handleKongConsumer(
 	request admissionv1.AdmissionRequest,
 	responseBuilder *ResponseBuilder,
 ) (*admissionv1.AdmissionResponse, error) {
-	consumer := configuration.KongConsumer{}
+	consumer := kongv1.KongConsumer{}
 	deserializer := codecs.UniversalDeserializer()
 	_, _, err := deserializer.Decode(request.Object.Raw, nil, &consumer)
 	if err != nil {
@@ -149,7 +149,7 @@ func (h RequestHandler) handleKongConsumer(
 		}
 		return responseBuilder.Allowed(ok).WithMessage(msg).Build(), nil
 	case admissionv1.Update:
-		var oldConsumer configuration.KongConsumer
+		var oldConsumer kongv1.KongConsumer
 		_, _, err = deserializer.Decode(request.OldObject.Raw, nil, &oldConsumer)
 		if err != nil {
 			return nil, err
@@ -173,7 +173,7 @@ func (h RequestHandler) handleKongConsumerGroup(
 	request admissionv1.AdmissionRequest,
 	responseBuilder *ResponseBuilder,
 ) (*admissionv1.AdmissionResponse, error) {
-	var consumerGroup configurationv1beta1.KongConsumerGroup
+	var consumerGroup kongv1beta1.KongConsumerGroup
 	if _, _, err := codecs.UniversalDeserializer().Decode(request.Object.Raw, nil, &consumerGroup); err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (h RequestHandler) handleKongPlugin(
 	request admissionv1.AdmissionRequest,
 	responseBuilder *ResponseBuilder,
 ) (*admissionv1.AdmissionResponse, error) {
-	plugin := configuration.KongPlugin{}
+	plugin := kongv1.KongPlugin{}
 	_, _, err := codecs.UniversalDeserializer().Decode(request.Object.Raw, nil, &plugin)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (h RequestHandler) handleKongClusterPlugin(
 	request admissionv1.AdmissionRequest,
 	responseBuilder *ResponseBuilder,
 ) (*admissionv1.AdmissionResponse, error) {
-	plugin := configuration.KongClusterPlugin{}
+	plugin := kongv1.KongClusterPlugin{}
 	_, _, err := codecs.UniversalDeserializer().Decode(request.Object.Raw, nil, &plugin)
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (h RequestHandler) handleHTTPRoute(
 }
 
 func (h RequestHandler) handleKongIngress(_ context.Context, request admissionv1.AdmissionRequest, responseBuilder *ResponseBuilder) (*admissionv1.AdmissionResponse, error) {
-	kongIngress := configuration.KongIngress{}
+	kongIngress := kongv1.KongIngress{}
 	_, _, err := codecs.UniversalDeserializer().Decode(request.Object.Raw, nil, &kongIngress)
 	if err != nil {
 		return nil, err

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -17,8 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	configuration "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 var decoder = codecs.UniversalDeserializer()
@@ -31,28 +31,28 @@ type KongFakeValidator struct {
 
 func (v KongFakeValidator) ValidateConsumer(
 	_ context.Context,
-	_ configuration.KongConsumer,
+	_ kongv1.KongConsumer,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 
 func (v KongFakeValidator) ValidateConsumerGroup(
 	_ context.Context,
-	_ configurationv1beta1.KongConsumerGroup,
+	_ kongv1beta1.KongConsumerGroup,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 
 func (v KongFakeValidator) ValidatePlugin(
 	_ context.Context,
-	_ configuration.KongPlugin,
+	_ kongv1.KongPlugin,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 
 func (v KongFakeValidator) ValidateClusterPlugin(
 	_ context.Context,
-	_ configuration.KongClusterPlugin,
+	_ kongv1.KongClusterPlugin,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 type fakePluginSvc struct {
@@ -81,7 +81,7 @@ func (f fakeServicesProvider) GetPluginsService() (kong.AbstractPluginService, b
 func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 	store, _ := store.NewFakeStore(store.FakeObjects{})
 	type args struct {
-		plugin configurationv1.KongPlugin
+		plugin kongv1.KongPlugin
 	}
 	tests := []struct {
 		name        string
@@ -95,7 +95,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin is valid",
 			PluginSvc: &fakePluginSvc{valid: true},
 			args: args{
-				plugin: configurationv1.KongPlugin{PluginName: "foo"},
+				plugin: kongv1.KongPlugin{PluginName: "foo"},
 			},
 			wantOK:      true,
 			wantMessage: "",
@@ -105,7 +105,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin is not valid",
 			PluginSvc: &fakePluginSvc{valid: false, msg: "now where could my pipe be"},
 			args: args{
-				plugin: configurationv1.KongPlugin{PluginName: "foo"},
+				plugin: kongv1.KongPlugin{PluginName: "foo"},
 			},
 			wantOK:      false,
 			wantMessage: fmt.Sprintf(ErrTextPluginConfigViolatesSchema, "now where could my pipe be"),
@@ -115,7 +115,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin lacks plugin name",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongPlugin{},
+				plugin: kongv1.KongPlugin{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginNameEmpty,
@@ -125,7 +125,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin has invalid configuration",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongPlugin{
+				plugin: kongv1.KongPlugin{
 					PluginName: "key-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{{}`),
@@ -140,13 +140,13 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin has both Config and ConfigFrom",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongPlugin{
+				plugin: kongv1.KongPlugin{
 					PluginName: "key-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"key_names": "whatever"}`),
 					},
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "key-auth-config",
 							Secret: "conf-secret",
 						},
@@ -161,10 +161,10 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "plugin ConfigFrom references non-existent Secret",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongPlugin{
+				plugin: kongv1.KongPlugin{
 					PluginName: "key-auth",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "key-auth-config",
 							Secret: "conf-secret",
 						},
@@ -179,7 +179,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			name:      "failed to retrieve validation info",
 			PluginSvc: &fakePluginSvc{valid: false, err: fmt.Errorf("everything broke")},
 			args: args{
-				plugin: configurationv1.KongPlugin{PluginName: "foo"},
+				plugin: kongv1.KongPlugin{PluginName: "foo"},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigValidationFailed,
@@ -213,7 +213,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 	store, _ := store.NewFakeStore(store.FakeObjects{})
 	type args struct {
-		plugin configurationv1.KongClusterPlugin
+		plugin kongv1.KongClusterPlugin
 	}
 	tests := []struct {
 		name        string
@@ -227,7 +227,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin is valid",
 			PluginSvc: &fakePluginSvc{valid: true},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{PluginName: "foo"},
+				plugin: kongv1.KongClusterPlugin{PluginName: "foo"},
 			},
 			wantOK:      true,
 			wantMessage: "",
@@ -237,7 +237,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin is not valid",
 			PluginSvc: &fakePluginSvc{valid: false, msg: "now where could my pipe be"},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{PluginName: "foo"},
+				plugin: kongv1.KongClusterPlugin{PluginName: "foo"},
 			},
 			wantOK:      false,
 			wantMessage: fmt.Sprintf(ErrTextPluginConfigViolatesSchema, "now where could my pipe be"),
@@ -247,7 +247,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin lacks plugin name",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{},
+				plugin: kongv1.KongClusterPlugin{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginNameEmpty,
@@ -257,7 +257,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin has invalid configuration",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
+				plugin: kongv1.KongClusterPlugin{
 					PluginName: "key-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{{}`),
@@ -272,13 +272,13 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin has both Config and ConfigFrom",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
+				plugin: kongv1.KongClusterPlugin{
 					PluginName: "key-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"key_names": "whatever"}`),
 					},
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "key-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -294,10 +294,10 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "plugin ConfigFrom references non-existent Secret",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
+				plugin: kongv1.KongClusterPlugin{
 					PluginName: "key-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "key-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -313,7 +313,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "failed to retrieve validation info",
 			PluginSvc: &fakePluginSvc{valid: false, err: fmt.Errorf("everything broke")},
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{PluginName: "foo"},
+				plugin: kongv1.KongClusterPlugin{PluginName: "foo"},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigValidationFailed,
@@ -323,7 +323,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			name:      "no gateway was available at the time of validation",
 			PluginSvc: nil, // no plugin service is available as there's no gateways
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{PluginName: "foo"},
+				plugin: kongv1.KongClusterPlugin{PluginName: "foo"},
 			},
 			wantOK:      true,
 			wantMessage: "",
@@ -365,7 +365,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, errText, err := validator.ValidateConsumer(context.Background(), configurationv1.KongConsumer{
+		valid, errText, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -375,7 +375,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 		// make services unavailable
 		validator.AdminAPIServicesProvider = fakeServicesProvider{}
 
-		valid, errText, err = validator.ValidateConsumer(context.Background(), configurationv1.KongConsumer{
+		valid, errText, err = validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, errText, err := validator.ValidateConsumer(context.Background(), configurationv1.KongConsumer{
+		valid, errText, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -430,7 +430,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 	store, err := store.NewFakeStore(store.FakeObjects{})
 	require.NoError(t, err)
 	type args struct {
-		cg configurationv1beta1.KongConsumerGroup
+		cg kongv1beta1.KongConsumerGroup
 	}
 	tests := []struct {
 		name             string
@@ -446,7 +446,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
 			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      true,
 			wantMessage: "",
@@ -457,7 +457,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
 			InfoSvc:          &fakeInfoSvc{version: "3.2.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextConsumerGroupUnsupported,
@@ -468,7 +468,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
 			InfoSvc:          &fakeInfoSvc{version: "3.4.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextConsumerGroupUnsupported,
@@ -479,7 +479,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusForbidden, "no license")},
 			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextConsumerGroupUnlicensed,
@@ -490,7 +490,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusNotFound, "well, this is awkward")},
 			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextConsumerGroupUnsupported,
@@ -501,7 +501,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
 			InfoSvc:          &fakeInfoSvc{version: "a.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      true,
 			wantMessage: "",
@@ -512,7 +512,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusNotFound, "ConsumerGroups API not found")},
 			InfoSvc:          &fakeInfoSvc{version: "a.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: ErrTextConsumerGroupUnsupported,
@@ -523,7 +523,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusTeapot, "I'm a teapot")},
 			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
 			args: args{
-				cg: configurationv1beta1.KongConsumerGroup{},
+				cg: kongv1beta1.KongConsumerGroup{},
 			},
 			wantOK:      false,
 			wantMessage: fmt.Sprintf("%s: %s", ErrTextConsumerGroupUnexpected, `HTTP status 418 (message: "I'm a teapot")`),

--- a/internal/dataplane/failures/failures_test.go
+++ b/internal/dataplane/failures/failures_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 const someValidResourceFailureReason = "some valid message"
@@ -115,11 +115,11 @@ func someResourceFailureCausingObjects() []client.Object {
 	return []client.Object{validCausingObject(), validCausingObject()}
 }
 
-func validCausingObject() *configurationv1.KongPlugin {
-	return &configurationv1.KongPlugin{
+func validCausingObject() *kongv1.KongPlugin {
+	return &kongv1.KongPlugin{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KongPlugin",
-			APIVersion: configurationv1.SchemeGroupVersion.String(),
+			APIVersion: kongv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "plugin-name",

--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 // Consumer holds a Kong consumer and its plugins and credentials.
@@ -25,7 +25,7 @@ type Consumer struct {
 	Oauth2Creds []*Oauth2Credential
 	MTLSAuths   []*MTLSAuth
 
-	K8sKongConsumer configurationv1.KongConsumer
+	K8sKongConsumer kongv1.KongConsumer
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func int64Ptr(i int64) *int64 {
@@ -42,7 +42,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					{kong.Oauth2Credential{ID: kong.String("1"), ClientSecret: kong.String("secret")}},
 				},
 				MTLSAuths:       []*MTLSAuth{{kong.MTLSAuth{ID: kong.String("1"), SubjectName: kong.String("foo@example.com")}}},
-				K8sKongConsumer: configurationv1.KongConsumer{Username: "foo"},
+				K8sKongConsumer: kongv1.KongConsumer{Username: "foo"},
 			},
 			want: Consumer{
 				Consumer: kong.Consumer{
@@ -62,7 +62,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					{kong.Oauth2Credential{ID: kong.String("1"), ClientSecret: redactedString}},
 				},
 				MTLSAuths:       []*MTLSAuth{{kong.MTLSAuth{ID: kong.String("1"), SubjectName: kong.String("foo@example.com")}}},
-				K8sKongConsumer: configurationv1.KongConsumer{Username: "foo"},
+				K8sKongConsumer: kongv1.KongConsumer{Username: "foo"},
 			},
 		},
 	} {

--- a/internal/dataplane/kongstate/consumergroup.go
+++ b/internal/dataplane/kongstate/consumergroup.go
@@ -3,12 +3,12 @@ package kongstate
 import (
 	"github.com/kong/go-kong/kong"
 
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // ConsumerGroup holds a Kong Consumer.
 type ConsumerGroup struct {
 	kong.ConsumerGroup
 
-	K8sKongConsumerGroup configurationv1beta1.KongConsumerGroup
+	K8sKongConsumerGroup kongv1beta1.KongConsumerGroup
 }

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 var kongConsumerTypeMeta = metav1.TypeMeta{
-	APIVersion: configurationv1.GroupVersion.String(),
+	APIVersion: kongv1.GroupVersion.String(),
 	Kind:       "KongConsumer",
 }
 
@@ -88,7 +88,7 @@ func TestGetPluginRelations(t *testing.T) {
 							Consumer: kong.Consumer{
 								Username: kong.String("foo-consumer"),
 							},
-							K8sKongConsumer: configurationv1.KongConsumer{
+							K8sKongConsumer: kongv1.KongConsumer{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
@@ -219,7 +219,7 @@ func TestGetPluginRelations(t *testing.T) {
 							Consumer: kong.Consumer{
 								Username: kong.String("foo-consumer"),
 							},
-							K8sKongConsumer: configurationv1.KongConsumer{
+							K8sKongConsumer: kongv1.KongConsumer{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
@@ -232,7 +232,7 @@ func TestGetPluginRelations(t *testing.T) {
 							Consumer: kong.Consumer{
 								Username: kong.String("foo-consumer"),
 							},
-							K8sKongConsumer: configurationv1.KongConsumer{
+							K8sKongConsumer: kongv1.KongConsumer{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns2",
 									Annotations: map[string]string{
@@ -245,7 +245,7 @@ func TestGetPluginRelations(t *testing.T) {
 							Consumer: kong.Consumer{
 								Username: kong.String("bar-consumer"),
 							},
-							K8sKongConsumer: configurationv1.KongConsumer{
+							K8sKongConsumer: kongv1.KongConsumer{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "ns1",
 									Annotations: map[string]string{
@@ -369,13 +369,13 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 
 	testCases := []struct {
 		name                               string
-		k8sConsumers                       []*configurationv1.KongConsumer
+		k8sConsumers                       []*kongv1.KongConsumer
 		expectedKongStateConsumers         []Consumer
 		expectedTranslationFailureMessages map[k8stypes.NamespacedName]string
 	}{
 		{
 			name: "KongConsumer with key-auth and oauth2",
-			k8sConsumers: []*configurationv1.KongConsumer{
+			k8sConsumers: []*kongv1.KongConsumer{
 				{
 					TypeMeta: kongConsumerTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
@@ -425,7 +425,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 		},
 		{
 			name: "missing username and custom_id",
-			k8sConsumers: []*configurationv1.KongConsumer{
+			k8sConsumers: []*kongv1.KongConsumer{
 				{
 					TypeMeta: kongConsumerTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
@@ -447,7 +447,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 		},
 		{
 			name: "referring to non-exist secret",
-			k8sConsumers: []*configurationv1.KongConsumer{
+			k8sConsumers: []*kongv1.KongConsumer{
 				{
 					TypeMeta: kongConsumerTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
@@ -476,7 +476,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 		},
 		{
 			name: "referring to secret with unsupported credType",
-			k8sConsumers: []*configurationv1.KongConsumer{
+			k8sConsumers: []*kongv1.KongConsumer{
 				{
 					TypeMeta: kongConsumerTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 // Route represents a Kong Route and holds a reference to the Ingress
@@ -250,7 +250,7 @@ func (r *Route) overrideByAnnotation(log logrus.FieldLogger) {
 }
 
 // override sets Route fields by KongIngress first, then by annotation.
-func (r *Route) override(log logrus.FieldLogger, kongIngress *configurationv1.KongIngress) {
+func (r *Route) override(log logrus.FieldLogger, kongIngress *kongv1.KongIngress) {
 	if r == nil {
 		return
 	}
@@ -275,7 +275,7 @@ func (r *Route) override(log logrus.FieldLogger, kongIngress *configurationv1.Ko
 }
 
 // overrideByKongIngress sets Route fields by KongIngress.
-func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *configurationv1.KongIngress) {
+func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *kongv1.KongIngress) {
 	// disable overriding routes by KongIngress if expression routes is enabled.
 	if r.ExpressionRoutes {
 		return

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func TestOverrideRoute(t *testing.T) {
@@ -18,7 +18,7 @@ func TestOverrideRoute(t *testing.T) {
 
 	testTable := []struct {
 		inRoute        Route
-		inKongIngresss configurationv1.KongIngress
+		inKongIngresss kongv1.KongIngress
 		outRoute       Route
 	}{
 		{
@@ -27,7 +27,7 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{},
+			kongv1.KongIngress{},
 			Route{
 				Route: kong.Route{
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
@@ -40,8 +40,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					Methods: kong.StringSlice("GET", "POST"),
 				},
 			},
@@ -58,8 +58,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					Methods: kong.StringSlice("GET   ", "post"),
 				},
 			},
@@ -76,8 +76,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					Methods: kong.StringSlice("GET", "-1"),
 				},
 			},
@@ -93,8 +93,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					HTTPSRedirectStatusCode: kong.Int(302),
 				},
 			},
@@ -113,9 +113,9 @@ func TestOverrideRoute(t *testing.T) {
 					StripPath:    kong.Bool(true),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
-					Protocols:     configurationv1.ProtocolSlice("http"),
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
+					Protocols:     kongv1.ProtocolSlice("http"),
 					PreserveHost:  kong.Bool(false),
 					StripPath:     kong.Bool(false),
 					RegexPriority: kong.Int(10),
@@ -138,8 +138,8 @@ func TestOverrideRoute(t *testing.T) {
 					Protocols: kong.StringSlice("http", "https"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					Headers: map[string][]string{
 						"foo-header": {"bar-value"},
 					},
@@ -161,9 +161,9 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
-					Protocols: configurationv1.ProtocolSlice("grpc", "grpcs"),
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
+					Protocols: kongv1.ProtocolSlice("grpc", "grpcs"),
 				},
 			},
 			Route{
@@ -180,8 +180,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					PathHandling: kong.String("v1"),
 				},
 			},
@@ -198,8 +198,8 @@ func TestOverrideRoute(t *testing.T) {
 					Hosts: kong.StringSlice("foo.com", "bar.com"),
 				},
 			},
-			configurationv1.KongIngress{
-				Route: &configurationv1.KongIngressRoute{
+			kongv1.KongIngress{
+				Route: &kongv1.KongIngressRoute{
 					RequestBuffering:  kong.Bool(true),
 					ResponseBuffering: kong.Bool(true),
 				},
@@ -318,9 +318,9 @@ func TestOverrideExpressionRoute(t *testing.T) {
 func TestOverrideRoutePriority(t *testing.T) {
 	assert := assert.New(t)
 
-	kongIngress := configurationv1.KongIngress{
-		Route: &configurationv1.KongIngressRoute{
-			Protocols: configurationv1.ProtocolSlice("http"),
+	kongIngress := kongv1.KongIngress{
+		Route: &kongv1.KongIngressRoute{
+			Protocols: kongv1.ProtocolSlice("http"),
 		},
 	}
 
@@ -348,9 +348,9 @@ func TestOverrideRouteByKongIngress(t *testing.T) {
 			Hosts: kong.StringSlice("foo.com", "bar.com"),
 		},
 	}
-	kongIngress := configurationv1.KongIngress{
-		Route: &configurationv1.KongIngressRoute{
-			Protocols: configurationv1.ProtocolSlice("http"),
+	kongIngress := kongv1.KongIngress{
+		Route: &kongv1.KongIngressRoute{
+			Protocols: kongv1.ProtocolSlice("http"),
 		},
 	}
 

--- a/internal/dataplane/kongstate/service.go
+++ b/internal/dataplane/kongstate/service.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 // Services is a list of kongstate.Service objects with sorting enabled based
@@ -61,7 +61,7 @@ type Service struct {
 }
 
 // overrideByKongIngress sets Service fields by KongIngress.
-func (s *Service) overrideByKongIngress(kongIngress *configurationv1.KongIngress) {
+func (s *Service) overrideByKongIngress(kongIngress *kongv1.KongIngress) {
 	if kongIngress == nil || kongIngress.Proxy == nil {
 		return
 	}
@@ -189,7 +189,7 @@ func (s *Service) overrideByAnnotation(anns map[string]string) {
 // override sets Service fields by KongIngress first, then by k8s Service's annotations.
 func (s *Service) override(
 	log logrus.FieldLogger,
-	kongIngress *configurationv1.KongIngress,
+	kongIngress *kongv1.KongIngress,
 	svc *corev1.Service,
 ) {
 	if s == nil {

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func TestOverrideService(t *testing.T) {
@@ -17,7 +17,7 @@ func TestOverrideService(t *testing.T) {
 
 	testTable := []struct {
 		inService      Service
-		inKongIngresss configurationv1.KongIngress
+		inKongIngresss kongv1.KongIngress
 		outService     Service
 		inAnnotation   map[string]string
 	}{
@@ -31,8 +31,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{},
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{},
 			},
 			Service{
 				Service: kong.Service{
@@ -55,8 +55,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("https"),
 				},
 			},
@@ -81,8 +81,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Retries: kong.Int(0),
 				},
 			},
@@ -108,8 +108,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Path: kong.String("/new-path"),
 				},
 			},
@@ -134,8 +134,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Retries: kong.Int(1),
 				},
 			},
@@ -161,8 +161,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					ConnectTimeout: kong.Int(100),
 					ReadTimeout:    kong.Int(100),
 					WriteTimeout:   kong.Int(100),
@@ -192,8 +192,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     nil,
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("grpc"),
 				},
 			},
@@ -218,8 +218,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     nil,
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("grpcs"),
 				},
 			},
@@ -244,8 +244,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("grpcs"),
 				},
 			},
@@ -270,8 +270,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("grpcs"),
 				},
 			},
@@ -296,8 +296,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{},
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{},
 			},
 			Service{
 				Service: kong.Service{
@@ -320,8 +320,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{
 					Protocol: kong.String("grpcs"),
 				},
 			},
@@ -346,8 +346,8 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			configurationv1.KongIngress{
-				Proxy: &configurationv1.KongIngressService{},
+			kongv1.KongIngress{
+				Proxy: &kongv1.KongIngressService{},
 			},
 			Service{
 				Service: kong.Service{

--- a/internal/dataplane/kongstate/upstream.go
+++ b/internal/dataplane/kongstate/upstream.go
@@ -6,7 +6,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 // Upstream is a wrapper around Upstream object in Kong.
@@ -39,7 +39,7 @@ func (u *Upstream) overrideByAnnotation(anns map[string]string) {
 
 // overrideByKongIngress modifies the Kong upstream based on KongIngresses
 // associated with the Kubernetes service.
-func (u *Upstream) overrideByKongIngress(kongIngress *configurationv1.KongIngress) {
+func (u *Upstream) overrideByKongIngress(kongIngress *kongv1.KongIngress) {
 	if u == nil {
 		return
 	}
@@ -95,7 +95,7 @@ func (u *Upstream) overrideByKongIngress(kongIngress *configurationv1.KongIngres
 
 // override sets Upstream fields by KongIngress first, then by k8s Service's annotations.
 func (u *Upstream) override(
-	kongIngress *configurationv1.KongIngress,
+	kongIngress *kongv1.KongIngress,
 	svc *corev1.Service,
 ) {
 	if u == nil {

--- a/internal/dataplane/kongstate/upstream_test.go
+++ b/internal/dataplane/kongstate/upstream_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func TestOverrideUpstream(t *testing.T) {
@@ -16,7 +16,7 @@ func TestOverrideUpstream(t *testing.T) {
 
 	testTable := []struct {
 		inUpstream     Upstream
-		inKongIngresss *configurationv1.KongIngress
+		inKongIngresss *kongv1.KongIngress
 		outUpstream    Upstream
 		svc            *corev1.Service
 	}{
@@ -39,8 +39,8 @@ func TestOverrideUpstream(t *testing.T) {
 					Name: kong.String("foo.com"),
 				},
 			},
-			inKongIngresss: &configurationv1.KongIngress{
-				Upstream: &configurationv1.KongIngressUpstream{
+			inKongIngresss: &kongv1.KongIngress{
+				Upstream: &kongv1.KongIngressUpstream{
 					HashOn:                 kong.String("HashOn"),
 					HashOnCookie:           kong.String("HashOnCookie"),
 					HashOnCookiePath:       kong.String("HashOnCookiePath"),

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -13,13 +13,13 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func getKongIngressForServices(
 	s store.Storer,
 	services map[string]*corev1.Service,
-) (*configurationv1.KongIngress, error) {
+) (*kongv1.KongIngress, error) {
 	// loop through each service and retrieve the attached KongIngress resources.
 	// there can only be one KongIngress for a group of services: either one of
 	// them is configured with a KongIngress and this configures the Kong Service
@@ -52,7 +52,7 @@ func getKongIngressFromObjectMeta(
 	s store.Storer,
 	obj util.K8sObjectInfo,
 ) (
-	*configurationv1.KongIngress, error,
+	*kongv1.KongIngress, error,
 ) {
 	return getKongIngressFromObjAnnotations(s, obj)
 }
@@ -61,7 +61,7 @@ func getKongIngressFromObjAnnotations(
 	s store.Storer,
 	obj util.K8sObjectInfo,
 ) (
-	*configurationv1.KongIngress, error,
+	*kongv1.KongIngress, error,
 ) {
 	confName := annotations.ExtractConfigurationName(obj.Annotations)
 	if confName != "" {
@@ -81,8 +81,8 @@ func getKongIngressFromObjAnnotations(
 // getKongPluginOrKongClusterPlugin fetches a KongPlugin or KongClusterPlugin (as fallback) from the store.
 // If both are not found, an error is returned.
 func getKongPluginOrKongClusterPlugin(s store.Storer, namespace, name string) (
-	*configurationv1.KongPlugin,
-	*configurationv1.KongClusterPlugin,
+	*kongv1.KongPlugin,
+	*kongv1.KongClusterPlugin,
 	error,
 ) {
 	plugin, pluginErr := s.GetKongPlugin(namespace, name)
@@ -110,7 +110,7 @@ func getKongPluginOrKongClusterPlugin(s store.Storer, namespace, name string) (
 
 func kongPluginFromK8SClusterPlugin(
 	s store.Storer,
-	k8sPlugin configurationv1.KongClusterPlugin,
+	k8sPlugin kongv1.KongClusterPlugin,
 ) (Plugin, error) {
 	var config kong.Configuration
 	config, err := RawConfigToConfiguration(k8sPlugin.Config)
@@ -151,14 +151,14 @@ func kongPluginFromK8SClusterPlugin(
 	}, nil
 }
 
-func protocolPointersToStringPointers(protocols []*configurationv1.KongProtocol) (res []*string) {
+func protocolPointersToStringPointers(protocols []*kongv1.KongProtocol) (res []*string) {
 	for _, protocol := range protocols {
 		res = append(res, kong.String(string(*protocol)))
 	}
 	return
 }
 
-func protocolsToStrings(protocols []configurationv1.KongProtocol) (res []string) {
+func protocolsToStrings(protocols []kongv1.KongProtocol) (res []string) {
 	for _, protocol := range protocols {
 		res = append(res, string(protocol))
 	}
@@ -167,7 +167,7 @@ func protocolsToStrings(protocols []configurationv1.KongProtocol) (res []string)
 
 func kongPluginFromK8SPlugin(
 	s store.Storer,
-	k8sPlugin configurationv1.KongPlugin,
+	k8sPlugin kongv1.KongPlugin,
 ) (Plugin, error) {
 	var config kong.Configuration
 	config, err := RawConfigToConfiguration(k8sPlugin.Config)
@@ -221,10 +221,10 @@ func RawConfigToConfiguration(config apiextensionsv1.JSON) (kong.Configuration, 
 
 func namespacedSecretToConfiguration(
 	s store.Storer,
-	reference configurationv1.NamespacedSecretValueFromSource) (
+	reference kongv1.NamespacedSecretValueFromSource) (
 	kong.Configuration, error,
 ) {
-	bareReference := configurationv1.SecretValueFromSource{
+	bareReference := kongv1.SecretValueFromSource{
 		Secret: reference.Secret,
 		Key:    reference.Key,
 	}
@@ -237,7 +237,7 @@ type SecretGetter interface {
 
 func SecretToConfiguration(
 	s SecretGetter,
-	reference configurationv1.SecretValueFromSource, namespace string) (
+	reference kongv1.SecretValueFromSource, namespace string) (
 	kong.Configuration, error,
 ) {
 	secret, err := s.GetSecret(namespace, reference.Secret)

--- a/internal/dataplane/kongstate/util_test.go
+++ b/internal/dataplane/kongstate/util_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
@@ -36,7 +36,7 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		},
 	})
 	type args struct {
-		plugin configurationv1.KongClusterPlugin
+		plugin kongv1.KongClusterPlugin
 	}
 	tests := []struct {
 		name    string
@@ -47,8 +47,8 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		{
 			name: "basic configuration",
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
-					Protocols:    []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongClusterPlugin{
+					Protocols:    []kongv1.KongProtocol{"http"},
 					PluginName:   "correlation-id",
 					InstanceName: "example",
 					Config: apiextensionsv1.JSON{
@@ -69,11 +69,11 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		{
 			name: "secret configuration",
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongClusterPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "correlation-id-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -93,11 +93,11 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		{
 			name: "missing secret configuration",
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongClusterPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "correlation-id-config",
 							Secret:    "missing",
 							Namespace: "default",
@@ -111,8 +111,8 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		{
 			name: "non-JSON configuration",
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongClusterPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{{}`),
@@ -125,14 +125,14 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 		{
 			name: "both Config and ConfigFrom set",
 			args: args{
-				plugin: configurationv1.KongClusterPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongClusterPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "correlation-id-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -173,7 +173,7 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		},
 	})
 	type args struct {
-		plugin configurationv1.KongPlugin
+		plugin kongv1.KongPlugin
 	}
 	tests := []struct {
 		name    string
@@ -184,8 +184,8 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		{
 			name: "basic configuration",
 			args: args{
-				plugin: configurationv1.KongPlugin{
-					Protocols:    []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongPlugin{
+					Protocols:    []kongv1.KongProtocol{"http"},
 					PluginName:   "correlation-id",
 					InstanceName: "example",
 					Config: apiextensionsv1.JSON{
@@ -206,15 +206,15 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		{
 			name: "secret configuration",
 			args: args{
-				plugin: configurationv1.KongPlugin{
+				plugin: kongv1.KongPlugin{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
 					},
-					Protocols:  []configurationv1.KongProtocol{"http"},
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "correlation-id-config",
 							Secret: "conf-secret",
 						},
@@ -233,15 +233,15 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		{
 			name: "missing secret configuration",
 			args: args{
-				plugin: configurationv1.KongPlugin{
+				plugin: kongv1.KongPlugin{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
 					},
-					Protocols:  []configurationv1.KongProtocol{"http"},
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "correlation-id-config",
 							Secret: "missing",
 						},
@@ -254,8 +254,8 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		{
 			name: "non-JSON configuration",
 			args: args{
-				plugin: configurationv1.KongPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{{}`),
@@ -268,14 +268,14 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		{
 			name: "both Config and ConfigFrom set",
 			args: args{
-				plugin: configurationv1.KongPlugin{
-					Protocols:  []configurationv1.KongProtocol{"http"},
+				plugin: kongv1.KongPlugin{
+					Protocols:  []kongv1.KongProtocol{"http"},
 					PluginName: "correlation-id",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "correlation-id-config",
 							Secret: "conf-secret",
 						},
@@ -305,13 +305,13 @@ func TestGetKongIngressForServices(t *testing.T) {
 	for _, tt := range []struct {
 		name                string
 		services            map[string]*corev1.Service
-		kongIngresses       []*configurationv1.KongIngress
-		expectedKongIngress *configurationv1.KongIngress
+		kongIngresses       []*kongv1.KongIngress
+		expectedKongIngress *kongv1.KongIngress
 		expectedError       error
 	}{
 		{
 			name: "when no services are provided, no KongIngress will be provided",
-			kongIngresses: []*configurationv1.KongIngress{{
+			kongIngresses: []*kongv1.KongIngress{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kongingress1",
 					Namespace: corev1.NamespaceDefault,
@@ -334,7 +334,7 @@ func TestGetKongIngressForServices(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{{
+			kongIngresses: []*kongv1.KongIngress{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kongingress1",
 					Namespace: corev1.NamespaceDefault,
@@ -360,7 +360,7 @@ func TestGetKongIngressForServices(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",
@@ -374,7 +374,7 @@ func TestGetKongIngressForServices(t *testing.T) {
 					},
 				},
 			},
-			expectedKongIngress: &configurationv1.KongIngress{
+			expectedKongIngress: &kongv1.KongIngress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kongingress2",
 					Namespace: corev1.NamespaceDefault,
@@ -412,7 +412,7 @@ func TestGetKongIngressForServices(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",
@@ -432,7 +432,7 @@ func TestGetKongIngressForServices(t *testing.T) {
 					},
 				},
 			},
-			expectedKongIngress: &configurationv1.KongIngress{
+			expectedKongIngress: &kongv1.KongIngress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kongingress2",
 					Namespace: corev1.NamespaceDefault,
@@ -461,8 +461,8 @@ func TestGetKongIngressFromObjectMeta(t *testing.T) {
 	for _, tt := range []struct {
 		name                string
 		route               client.Object
-		kongIngresses       []*configurationv1.KongIngress
-		expectedKongIngress *configurationv1.KongIngress
+		kongIngresses       []*kongv1.KongIngress
+		expectedKongIngress *kongv1.KongIngress
 		expectedError       error
 	}{
 		{
@@ -480,7 +480,7 @@ func TestGetKongIngressFromObjectMeta(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",
@@ -505,7 +505,7 @@ func TestGetKongIngressFromObjectMeta(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",
@@ -530,7 +530,7 @@ func TestGetKongIngressFromObjectMeta(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",
@@ -555,7 +555,7 @@ func TestGetKongIngressFromObjectMeta(t *testing.T) {
 					},
 				},
 			},
-			kongIngresses: []*configurationv1.KongIngress{
+			kongIngresses: []*kongv1.KongIngress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-kongingress1",

--- a/internal/dataplane/parser/ingressclassparemeters_test.go
+++ b/internal/dataplane/parser/ingressclassparemeters_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
-	configurationv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 func TestGetIngressClassParameters(t *testing.T) {
@@ -23,13 +23,13 @@ func TestGetIngressClassParameters(t *testing.T) {
 		testIcpName       = "test-icp"
 	)
 
-	defaultIcpSpec := &configurationv1alpha1.IngressClassParametersSpec{}
-	icp := &configurationv1alpha1.IngressClassParameters{
+	defaultIcpSpec := &kongv1alpha1.IngressClassParametersSpec{}
+	icp := &kongv1alpha1.IngressClassParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespaceName,
 			Name:      testIcpName,
 		},
-		Spec: configurationv1alpha1.IngressClassParametersSpec{
+		Spec: kongv1alpha1.IngressClassParametersSpec{
 			EnableLegacyRegexDetection: true,
 		},
 	}
@@ -37,7 +37,7 @@ func TestGetIngressClassParameters(t *testing.T) {
 	testCases := []struct {
 		name          string
 		paramRef      *netv1.IngressClassParametersReference
-		parameterSpec *configurationv1alpha1.IngressClassParametersSpec
+		parameterSpec *kongv1alpha1.IngressClassParametersSpec
 		err           error
 	}{
 		{
@@ -57,8 +57,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "nil-scope",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup:  &configurationv1alpha1.GroupVersion.Group,
-				Kind:      configurationv1alpha1.IngressClassParametersKind,
+				APIGroup:  &kongv1alpha1.GroupVersion.Group,
+				Kind:      kongv1alpha1.IngressClassParametersKind,
 				Namespace: &testNamespaceName,
 				Name:      testIcpName,
 			},
@@ -68,8 +68,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "nil-namespace",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup: &configurationv1alpha1.GroupVersion.Group,
-				Kind:     configurationv1alpha1.IngressClassParametersKind,
+				APIGroup: &kongv1alpha1.GroupVersion.Group,
+				Kind:     kongv1alpha1.IngressClassParametersKind,
 				Scope:    &scopeNamespace,
 				Name:     testIcpName,
 			},
@@ -79,8 +79,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "matched-parameters",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup:  &configurationv1alpha1.GroupVersion.Group,
-				Kind:      configurationv1alpha1.IngressClassParametersKind,
+				APIGroup:  &kongv1alpha1.GroupVersion.Group,
+				Kind:      kongv1alpha1.IngressClassParametersKind,
 				Scope:     &scopeNamespace,
 				Namespace: &testNamespaceName,
 				Name:      testIcpName,
@@ -90,7 +90,7 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "unmatched-kind",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup:  &configurationv1alpha1.GroupVersion.Group,
+				APIGroup:  &kongv1alpha1.GroupVersion.Group,
 				Kind:      "SomeKind",
 				Scope:     &scopeNamespace,
 				Namespace: &testNamespaceName,
@@ -102,8 +102,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "unmatched-namespace",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup:  &configurationv1alpha1.GroupVersion.Group,
-				Kind:      configurationv1alpha1.IngressClassParametersKind,
+				APIGroup:  &kongv1alpha1.GroupVersion.Group,
+				Kind:      kongv1alpha1.IngressClassParametersKind,
 				Scope:     &scopeNamespace,
 				Namespace: new(string),
 				Name:      testIcpName,
@@ -114,8 +114,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 		{
 			name: "unmatched-name",
 			paramRef: &netv1.IngressClassParametersReference{
-				APIGroup:  &configurationv1alpha1.GroupVersion.Group,
-				Kind:      configurationv1alpha1.IngressClassParametersKind,
+				APIGroup:  &kongv1alpha1.GroupVersion.Group,
+				Kind:      kongv1alpha1.IngressClassParametersKind,
 				Scope:     &scopeNamespace,
 				Namespace: &testNamespaceName,
 				Name:      "another-icp",

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -28,8 +28,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
-	configurationv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // -----------------------------------------------------------------------------
@@ -318,7 +318,7 @@ func knativeIngressToNetworkingTLS(tls []knative.IngressTLS) []netv1.IngressTLS 
 	return result
 }
 
-func tcpIngressToNetworkingTLS(tls []configurationv1beta1.IngressTLS) []netv1.IngressTLS {
+func tcpIngressToNetworkingTLS(tls []kongv1beta1.IngressTLS) []netv1.IngressTLS {
 	var result []netv1.IngressTLS
 
 	for _, t := range tls {
@@ -745,16 +745,16 @@ func getServiceEndpoints(
 // getIngressClassParametersOrDefault returns the parameters for the current ingress class.
 // If the cluster operators have specified a set of parameters explicitly, it returns those.
 // Otherwise, it returns a default set of parameters.
-func getIngressClassParametersOrDefault(s store.Storer) (configurationv1alpha1.IngressClassParametersSpec, error) {
+func getIngressClassParametersOrDefault(s store.Storer) (kongv1alpha1.IngressClassParametersSpec, error) {
 	ingressClassName := s.GetIngressClassName()
 	ingressClass, err := s.GetIngressClassV1(ingressClassName)
 	if err != nil {
-		return configurationv1alpha1.IngressClassParametersSpec{}, err
+		return kongv1alpha1.IngressClassParametersSpec{}, err
 	}
 
 	params, err := s.GetIngressClassParametersV1Alpha1(ingressClass)
 	if err != nil {
-		return configurationv1alpha1.IngressClassParametersSpec{}, err
+		return kongv1alpha1.IngressClassParametersSpec{}, err
 	}
 
 	return params.Spec, nil

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 type TLSPair struct {
@@ -268,7 +268,7 @@ func TestGlobalPlugin(t *testing.T) {
 	assert := assert.New(t)
 	t.Run("global plugins are processed correctly", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			KongClusterPlugins: []*configurationv1.KongClusterPlugin{
+			KongClusterPlugins: []*kongv1.KongClusterPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar-plugin",
@@ -279,7 +279,7 @@ func TestGlobalPlugin(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"foo1": "bar1"}`),
@@ -393,22 +393,22 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 	t.Run("plugins with secret configuration are processed correctly",
 		func(t *testing.T) {
 			objects := stock
-			objects.KongPlugins = []*configurationv1.KongPlugin{
+			objects.KongPlugins = []*kongv1.KongPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-plugin",
 						Namespace: "default",
 					},
 					PluginName: "jwt",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "jwt-config",
 							Secret: "conf-secret",
 						},
 					},
 				},
 			}
-			objects.KongClusterPlugins = []*configurationv1.KongClusterPlugin{
+			objects.KongClusterPlugins = []*kongv1.KongClusterPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "global-bar-plugin",
@@ -419,10 +419,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							annotations.IngressClassKey: annotations.DefaultIngressClass,
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -439,10 +439,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							// explicitly none, this should not get rendered
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -453,10 +453,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar-plugin",
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -507,7 +507,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 	t.Run("plugins with missing secrets or keys are not constructed",
 		func(t *testing.T) {
 			objects := stock
-			objects.KongPlugins = []*configurationv1.KongPlugin{
+			objects.KongPlugins = []*kongv1.KongPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "global-foo-plugin",
@@ -517,8 +517,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						},
 					},
 					PluginName: "jwt",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "missing-key",
 							Secret: "conf-secret",
 						},
@@ -530,15 +530,15 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						Namespace: "default",
 					},
 					PluginName: "jwt",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "missing-key",
 							Secret: "conf-secret",
 						},
 					},
 				},
 			}
-			objects.KongClusterPlugins = []*configurationv1.KongClusterPlugin{
+			objects.KongClusterPlugins = []*kongv1.KongClusterPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "global-bar-plugin",
@@ -546,10 +546,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							"global": "true",
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "missing-secret",
 							Namespace: "default",
@@ -560,10 +560,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar-plugin",
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "missing-secret",
 							Namespace: "default",
@@ -599,7 +599,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 	t.Run("plugins with both config and configFrom are not constructed",
 		func(t *testing.T) {
 			objects := stock
-			objects.KongPlugins = []*configurationv1.KongPlugin{
+			objects.KongPlugins = []*kongv1.KongPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "global-foo-plugin",
@@ -612,8 +612,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"fake": true}`),
 					},
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "jwt-config",
 							Secret: "conf-secret",
 						},
@@ -628,15 +628,15 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"fake": true}`),
 					},
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "jwt-config",
 							Secret: "conf-secret",
 						},
 					},
 				},
 			}
-			objects.KongClusterPlugins = []*configurationv1.KongClusterPlugin{
+			objects.KongClusterPlugins = []*kongv1.KongClusterPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "global-bar-plugin",
@@ -644,13 +644,13 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							"global": "true",
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"fake": true}`),
 					},
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -661,13 +661,13 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar-plugin",
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
 					Config: apiextensionsv1.JSON{
 						Raw: []byte(`{"fake": true}`),
 					},
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "conf-secret",
 							Namespace: "default",
@@ -721,7 +721,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 				},
 			},
 		}
-		references := []*configurationv1.SecretValueFromSource{
+		references := []*kongv1.SecretValueFromSource{
 			{
 				Secret: "conf-secret",
 				Key:    "jwt-config",
@@ -731,7 +731,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 				Key:    "basic-auth-config",
 			},
 		}
-		badReferences := []*configurationv1.SecretValueFromSource{
+		badReferences := []*kongv1.SecretValueFromSource{
 			{
 				Secret: "conf-secret",
 				Key:    "bad-basic-auth-config",
@@ -764,7 +764,7 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 			jwtPluginConfig := "22222"        // not JSON
 			basicAuthPluginConfig := "111111" // not YAML
 			objects := stock
-			objects.KongPlugins = []*configurationv1.KongPlugin{
+			objects.KongPlugins = []*kongv1.KongPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "global-foo-plugin",
@@ -774,8 +774,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						},
 					},
 					PluginName: "jwt",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "missing-key",
 							Secret: "conf-secret",
 						},
@@ -787,15 +787,15 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 						Namespace: "default",
 					},
 					PluginName: "jwt",
-					ConfigFrom: &configurationv1.ConfigSource{
-						SecretValue: configurationv1.SecretValueFromSource{
+					ConfigFrom: &kongv1.ConfigSource{
+						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "missing-key",
 							Secret: "conf-secret",
 						},
 					},
 				},
 			}
-			objects.KongClusterPlugins = []*configurationv1.KongClusterPlugin{
+			objects.KongClusterPlugins = []*kongv1.KongClusterPlugin{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "global-bar-plugin",
@@ -803,10 +803,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 							"global": "true",
 						},
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "missing-secret",
 							Namespace: "default",
@@ -817,10 +817,10 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bar-plugin",
 					},
-					Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+					Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 					PluginName: "basic-auth",
-					ConfigFrom: &configurationv1.NamespacedConfigSource{
-						SecretValue: configurationv1.NamespacedSecretValueFromSource{
+					ConfigFrom: &kongv1.NamespacedConfigSource{
+						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "basic-auth-config",
 							Secret:    "missing-secret",
 							Namespace: "default",
@@ -2324,14 +2324,14 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 				},
 			},
 		}
-		kongIngresses := []*configurationv1.KongIngress{
+		kongIngresses := []*kongv1.KongIngress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "https-only",
 					Namespace: "foo-ns",
 				},
-				Route: &configurationv1.KongIngressRoute{
-					Protocols:               configurationv1.ProtocolSlice("https"),
+				Route: &kongv1.KongIngressRoute{
+					Protocols:               kongv1.ProtocolSlice("https"),
 					HTTPSRedirectStatusCode: kong.Int(308),
 				},
 			},
@@ -2404,14 +2404,14 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 				},
 			},
 		}
-		kongIngresses := []*configurationv1.KongIngress{
+		kongIngresses := []*kongv1.KongIngress{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "https-only",
 					Namespace: "foo-ns",
 				},
-				Route: &configurationv1.KongIngressRoute{
-					Protocols:               configurationv1.ProtocolSlice("https"),
+				Route: &kongv1.KongIngressRoute{
+					Protocols:               kongv1.ProtocolSlice("https"),
 					HTTPSRedirectStatusCode: kong.Int(308),
 				},
 			},
@@ -2569,14 +2569,14 @@ func TestKnativeIngressAndPlugins(t *testing.T) {
 				},
 			},
 		}
-		plugins := []*configurationv1.KongPlugin{
+		plugins := []*kongv1.KongPlugin{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "knative-key-auth",
 					Namespace: "foo-ns",
 				},
 				PluginName: "key-auth",
-				Protocols:  configurationv1.StringsToKongProtocols([]string{"http"}),
+				Protocols:  kongv1.StringsToKongProtocols([]string{"http"}),
 				Config: apiextensionsv1.JSON{
 					Raw: []byte(`{"foo": "bar", "knative": "yo"}`),
 				},
@@ -3846,14 +3846,14 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		plugins := []*configurationv1.KongPlugin{
+		plugins := []*kongv1.KongPlugin{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-plugin",
 					Namespace: "default",
 				},
 				PluginName: "key-auth",
-				Protocols:  []configurationv1.KongProtocol{"grpc"},
+				Protocols:  []kongv1.KongProtocol{"grpc"},
 				Config: apiextensionsv1.JSON{
 					Raw: []byte(`{
 					"foo": "bar",
@@ -3945,27 +3945,27 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		clusterPlugins := []*configurationv1.KongClusterPlugin{
+		clusterPlugins := []*kongv1.KongClusterPlugin{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-plugin",
 					Namespace: "default",
 				},
 				PluginName: "basic-auth",
-				Protocols:  []configurationv1.KongProtocol{"grpc"},
+				Protocols:  []kongv1.KongProtocol{"grpc"},
 				Config: apiextensionsv1.JSON{
 					Raw: []byte(`{"foo": "bar"}`),
 				},
 			},
 		}
-		plugins := []*configurationv1.KongPlugin{
+		plugins := []*kongv1.KongPlugin{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-plugin",
 					Namespace: "default",
 				},
 				PluginName: "key-auth",
-				Protocols:  []configurationv1.KongProtocol{"grpc"},
+				Protocols:  []kongv1.KongProtocol{"grpc"},
 				Config: apiextensionsv1.JSON{
 					Raw: []byte(`{"foo": "bar"}`),
 				},
@@ -4035,14 +4035,14 @@ func TestPluginAnnotations(t *testing.T) {
 				},
 			},
 		}
-		clusterPlugins := []*configurationv1.KongClusterPlugin{
+		clusterPlugins := []*kongv1.KongClusterPlugin{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-plugin",
 					Namespace: "default",
 				},
 				PluginName: "basic-auth",
-				Protocols:  []configurationv1.KongProtocol{"grpc"},
+				Protocols:  []kongv1.KongProtocol{"grpc"},
 				Config: apiextensionsv1.JSON{
 					Raw: []byte(`{"foo": "bar"}`),
 				},
@@ -5161,7 +5161,7 @@ func TestParser_FillsEntitiesIDs(t *testing.T) {
 				},
 			},
 		},
-		KongConsumers: []*configurationv1.KongConsumer{
+		KongConsumers: []*kongv1.KongConsumer{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "user.foo",
@@ -5370,7 +5370,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 		{
 			name: "KongConsumers",
 			objectsInStore: store.FakeObjects{
-				KongConsumers: []*configurationv1.KongConsumer{
+				KongConsumers: []*kongv1.KongConsumer{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "consumer1",
@@ -5397,7 +5397,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 		{
 			name: "KongConsumerGroup",
 			objectsInStore: store.FakeObjects{
-				KongConsumerGroups: []*configurationv1beta1.KongConsumerGroup{
+				KongConsumerGroups: []*kongv1beta1.KongConsumerGroup{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "consumer-group1",
@@ -5422,7 +5422,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 		{
 			name: "KongPlugins with KongConsumer",
 			objectsInStore: store.FakeObjects{
-				KongPlugins: []*configurationv1.KongPlugin{
+				KongPlugins: []*kongv1.KongPlugin{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "plugin1",
@@ -5440,7 +5440,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 						PluginName: "plugin2",
 					},
 				},
-				KongConsumers: []*configurationv1.KongConsumer{
+				KongConsumers: []*kongv1.KongConsumer{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "consumer",
@@ -5463,7 +5463,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 		{
 			name: "KongClusterPlugins with KongConsumer",
 			objectsInStore: store.FakeObjects{
-				KongClusterPlugins: []*configurationv1.KongClusterPlugin{
+				KongClusterPlugins: []*kongv1.KongClusterPlugin{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "plugin1",
@@ -5479,7 +5479,7 @@ func TestParser_ConfiguredKubernetesObjects(t *testing.T) {
 						PluginName: "plugin2",
 					},
 				},
-				KongConsumers: []*configurationv1.KongConsumer{
+				KongConsumers: []*kongv1.KongConsumer{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "consumer",

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 func serviceBackendPortToStr(port netv1.ServiceBackendPort) string {
@@ -79,7 +79,7 @@ type kongServicesCache map[string]kongstate.Service
 // Returns true if the passed servicesCache was updated.
 func (p *Parser) ingressesV1ToKongServices(
 	ingresses []*netv1.Ingress,
-	icp v1alpha1.IngressClassParametersSpec,
+	icp kongv1alpha1.IngressClassParametersSpec,
 ) kongServicesCache {
 	if p.featureFlags.CombinedServiceRoutes {
 		return p.ingressV1ToKongServiceCombinedRoutes(ingresses, icp)
@@ -90,7 +90,7 @@ func (p *Parser) ingressesV1ToKongServices(
 // ingressV1ToKongServiceLegacy translates a slice of IngressV1 object into Kong Services.
 func (p *Parser) ingressV1ToKongServiceCombinedRoutes(
 	ingresses []*netv1.Ingress,
-	icp v1alpha1.IngressClassParametersSpec,
+	icp kongv1alpha1.IngressClassParametersSpec,
 ) kongServicesCache {
 	return translators.TranslateIngresses(ingresses, icp, translators.TranslateIngressFeatureFlags{
 		RegexPathPrefix:  p.featureFlags.RegexPathPrefix,
@@ -100,7 +100,7 @@ func (p *Parser) ingressV1ToKongServiceCombinedRoutes(
 }
 
 // ingressV1ToKongServiceLegacy translates a slice IngressV1 object into Kong Services.
-func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp v1alpha1.IngressClassParametersSpec) kongServicesCache {
+func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp kongv1alpha1.IngressClassParametersSpec) kongServicesCache {
 	servicesCache := make(kongServicesCache)
 
 	for _, ingress := range ingresses {

--- a/internal/dataplane/parser/translate_kong_l4_test.go
+++ b/internal/dataplane/parser/translate_kong_l4_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 func TestFromTCPIngressV1beta1(t *testing.T) {
 	assert := assert.New(t)
-	tcpIngressList := []*configurationv1beta1.TCPIngress{
+	tcpIngressList := []*kongv1beta1.TCPIngress{
 		// 0
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -36,11 +36,11 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				Rules: []configurationv1beta1.IngressRule{
+			Spec: kongv1beta1.TCPIngressSpec{
+				Rules: []kongv1beta1.IngressRule{
 					{
 						Port: 9000,
-						Backend: configurationv1beta1.IngressBackend{
+						Backend: kongv1beta1.IngressBackend{
 							ServiceName: "foo-svc",
 							ServicePort: 80,
 						},
@@ -57,12 +57,12 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				Rules: []configurationv1beta1.IngressRule{
+			Spec: kongv1beta1.TCPIngressSpec{
+				Rules: []kongv1beta1.IngressRule{
 					{
 						Host: "example.com",
 						Port: 9000,
-						Backend: configurationv1beta1.IngressBackend{
+						Backend: kongv1beta1.IngressBackend{
 							ServiceName: "foo-svc",
 							ServicePort: 80,
 						},
@@ -79,8 +79,8 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				TLS: []configurationv1beta1.IngressTLS{
+			Spec: kongv1beta1.TCPIngressSpec{
+				TLS: []kongv1beta1.IngressTLS{
 					{
 						Hosts: []string{
 							"1.example.com",
@@ -101,7 +101,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 	}
 	t.Run("no TCPIngress returns empty info", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			TCPIngresses: []*configurationv1beta1.TCPIngress{},
+			TCPIngresses: []*kongv1beta1.TCPIngress{},
 		})
 		assert.NoError(err)
 		p := mustNewParser(t, store)
@@ -115,7 +115,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 	})
 	t.Run("empty TCPIngress return empty info", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			TCPIngresses: []*configurationv1beta1.TCPIngress{
+			TCPIngresses: []*kongv1beta1.TCPIngress{
 				tcpIngressList[0],
 			},
 		})
@@ -131,7 +131,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 	})
 	t.Run("simple TCPIngress rule is parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			TCPIngresses: []*configurationv1beta1.TCPIngress{
+			TCPIngresses: []*kongv1beta1.TCPIngress{
 				tcpIngressList[1],
 			},
 		})
@@ -163,7 +163,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 	})
 	t.Run("TCPIngress rule with host is parsed", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			TCPIngresses: []*configurationv1beta1.TCPIngress{
+			TCPIngresses: []*kongv1beta1.TCPIngress{
 				tcpIngressList[2],
 			},
 		})
@@ -196,7 +196,7 @@ func TestFromTCPIngressV1beta1(t *testing.T) {
 	})
 	t.Run("TCPIngress with TLS", func(t *testing.T) {
 		store, err := store.NewFakeStore(store.FakeObjects{
-			TCPIngresses: []*configurationv1beta1.TCPIngress{
+			TCPIngresses: []*kongv1beta1.TCPIngress{
 				tcpIngressList[3],
 			},
 		})

--- a/internal/dataplane/parser/translators/ingress.go
+++ b/internal/dataplane/parser/translators/ingress.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 // -----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ type TranslateIngressFeatureFlags struct {
 // and kong.Routes which will come wrapped in a kongstate.Service object.
 func TranslateIngresses(
 	ingresses []*netv1.Ingress,
-	icp v1alpha1.IngressClassParametersSpec,
+	icp kongv1alpha1.IngressClassParametersSpec,
 	flags TranslateIngressFeatureFlags,
 	translatedObjectsCollector TranslatedKubernetesObjectsCollector,
 ) map[string]kongstate.Service {

--- a/internal/dataplane/parser/translators/ingress_atc_test.go
+++ b/internal/dataplane/parser/translators/ingress_atc_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 func TestTranslateIngressATC(t *testing.T) {
@@ -283,7 +283,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			services := TranslateIngresses(
 				[]*netv1.Ingress{tc.ingress},
-				v1alpha1.IngressClassParametersSpec{},
+				kongv1alpha1.IngressClassParametersSpec{},
 				TranslateIngressFeatureFlags{
 					ExpressionRoutes: true,
 					RegexPathPrefix:  false,

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 )
 
 var (
@@ -1290,7 +1290,7 @@ func TestTranslateIngress(t *testing.T) {
 			})
 			diff := cmp.Diff(tt.expected, TranslateIngresses(
 				[]*netv1.Ingress{tt.ingress},
-				v1alpha1.IngressClassParametersSpec{},
+				kongv1alpha1.IngressClassParametersSpec{},
 				TranslateIngressFeatureFlags{
 					RegexPathPrefix:  tt.addRegexPrefix,
 					ExpressionRoutes: false,

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -20,9 +20,9 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
-	konghqcomv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	konghqcomv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
-	konghqcomv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // -----------------------------------------------------------------------------
@@ -160,8 +160,8 @@ func setupControllers(
 		{
 			Enabled: c.UDPIngressEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1beta1.GroupVersion.Group,
-					Version:  konghqcomv1beta1.GroupVersion.Version,
+					Group:    kongv1beta1.GroupVersion.Group,
+					Version:  kongv1beta1.GroupVersion.Version,
 					Resource: "udpingresses",
 				},
 				restMapper,
@@ -181,8 +181,8 @@ func setupControllers(
 		{
 			Enabled: c.TCPIngressEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1beta1.GroupVersion.Group,
-					Version:  konghqcomv1beta1.GroupVersion.Version,
+					Group:    kongv1beta1.GroupVersion.Group,
+					Version:  kongv1beta1.GroupVersion.Version,
 					Resource: "tcpingresses",
 				},
 				restMapper,
@@ -203,8 +203,8 @@ func setupControllers(
 		{
 			Enabled: c.KongIngressEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1.GroupVersion.Group,
-					Version:  konghqcomv1.GroupVersion.Version,
+					Group:    kongv1.GroupVersion.Group,
+					Version:  kongv1.GroupVersion.Version,
 					Resource: "kongingresses",
 				},
 				restMapper,
@@ -220,8 +220,8 @@ func setupControllers(
 		{
 			Enabled: c.IngressClassParametersEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1alpha1.GroupVersion.Group,
-					Version:  konghqcomv1alpha1.GroupVersion.Version,
+					Group:    kongv1alpha1.GroupVersion.Group,
+					Version:  kongv1alpha1.GroupVersion.Version,
 					Resource: "ingressclassparameterses",
 				},
 				restMapper,
@@ -237,8 +237,8 @@ func setupControllers(
 		{
 			Enabled: c.KongPluginEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1.GroupVersion.Group,
-					Version:  konghqcomv1.GroupVersion.Version,
+					Group:    kongv1.GroupVersion.Group,
+					Version:  kongv1.GroupVersion.Version,
 					Resource: "kongplugins",
 				},
 				restMapper,
@@ -256,8 +256,8 @@ func setupControllers(
 		{
 			Enabled: c.KongConsumerEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1.GroupVersion.Group,
-					Version:  konghqcomv1.GroupVersion.Version,
+					Group:    kongv1.GroupVersion.Group,
+					Version:  kongv1.GroupVersion.Version,
 					Resource: "kongconsumers",
 				},
 				restMapper,
@@ -277,8 +277,8 @@ func setupControllers(
 		{
 			Enabled: c.KongConsumerEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1beta1.GroupVersion.Group,
-					Version:  konghqcomv1beta1.GroupVersion.Version,
+					Group:    kongv1beta1.GroupVersion.Group,
+					Version:  kongv1beta1.GroupVersion.Version,
 					Resource: "kongconsumergroups",
 				},
 				restMapper,
@@ -298,8 +298,8 @@ func setupControllers(
 		{
 			Enabled: c.KongClusterPluginEnabled && ShouldEnableCRDController(
 				schema.GroupVersionResource{
-					Group:    konghqcomv1.GroupVersion.Group,
-					Version:  konghqcomv1.GroupVersion.Version,
+					Group:    kongv1.GroupVersion.Group,
+					Version:  kongv1.GroupVersion.Version,
 					Resource: "kongclusterplugins",
 				},
 				restMapper,

--- a/internal/manager/scheme/scheme.go
+++ b/internal/manager/scheme/scheme.go
@@ -9,9 +9,9 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
-	konghqcomv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	konghqcomv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // Get returns the scheme for the manager, enabling all the default schemes and
@@ -27,13 +27,13 @@ func Get(fg map[string]bool) (*runtime.Scheme, error) {
 		return nil, err
 	}
 
-	if err := konghqcomv1.AddToScheme(scheme); err != nil {
+	if err := kongv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	if err := konghqcomv1alpha1.AddToScheme(scheme); err != nil {
+	if err := kongv1alpha1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	if err := configurationv1beta1.AddToScheme(scheme); err != nil {
+	if err := kongv1beta1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -20,9 +20,9 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 func keyFunc(obj interface{}) (string, error) {
@@ -48,17 +48,17 @@ type FakeObjects struct {
 	GRPCRoutes                     []*gatewayv1alpha2.GRPCRoute
 	ReferenceGrants                []*gatewayv1beta1.ReferenceGrant
 	Gateways                       []*gatewayv1beta1.Gateway
-	TCPIngresses                   []*configurationv1beta1.TCPIngress
-	UDPIngresses                   []*configurationv1beta1.UDPIngress
-	IngressClassParametersV1alpha1 []*configurationv1alpha1.IngressClassParameters
+	TCPIngresses                   []*kongv1beta1.TCPIngress
+	UDPIngresses                   []*kongv1beta1.UDPIngress
+	IngressClassParametersV1alpha1 []*kongv1alpha1.IngressClassParameters
 	Services                       []*corev1.Service
 	EndpointSlices                 []*discoveryv1.EndpointSlice
 	Secrets                        []*corev1.Secret
-	KongPlugins                    []*configurationv1.KongPlugin
-	KongClusterPlugins             []*configurationv1.KongClusterPlugin
-	KongIngresses                  []*configurationv1.KongIngress
-	KongConsumers                  []*configurationv1.KongConsumer
-	KongConsumerGroups             []*configurationv1beta1.KongConsumerGroup
+	KongPlugins                    []*kongv1.KongPlugin
+	KongClusterPlugins             []*kongv1.KongClusterPlugin
+	KongIngresses                  []*kongv1.KongIngress
+	KongConsumers                  []*kongv1.KongConsumer
+	KongConsumerGroups             []*kongv1beta1.KongConsumerGroup
 
 	KnativeIngresses []*knative.Ingress
 }
@@ -248,26 +248,26 @@ func (objects FakeObjects) MarshalToYAML() ([]byte, error) {
 	// In many cases objects we'd like to dump do not have their GVK set, so we need to set it manually based on
 	// their known type - otherwise the YAML dump will not work.
 	typeToGVK := map[reflect.Type]schema.GroupVersionKind{
-		reflect.TypeOf(&netv1.Ingress{}):                                netv1.SchemeGroupVersion.WithKind("Ingress"),
-		reflect.TypeOf(&netv1.IngressClass{}):                           netv1.SchemeGroupVersion.WithKind("IngressClass"),
-		reflect.TypeOf(&gatewayv1beta1.HTTPRoute{}):                     gatewayv1beta1.SchemeGroupVersion.WithKind("HTTPRoute"),
-		reflect.TypeOf(&gatewayv1alpha2.UDPRoute{}):                     gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"),
-		reflect.TypeOf(&gatewayv1alpha2.TCPRoute{}):                     gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"),
-		reflect.TypeOf(&gatewayv1alpha2.TLSRoute{}):                     gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"),
-		reflect.TypeOf(&gatewayv1alpha2.GRPCRoute{}):                    gatewayv1alpha2.SchemeGroupVersion.WithKind("GRPCRoute"),
-		reflect.TypeOf(&gatewayv1beta1.ReferenceGrant{}):                gatewayv1beta1.SchemeGroupVersion.WithKind("ReferenceGrant"),
-		reflect.TypeOf(&gatewayv1beta1.Gateway{}):                       gatewayv1beta1.SchemeGroupVersion.WithKind("Gateway"),
-		reflect.TypeOf(&configurationv1beta1.TCPIngress{}):              configurationv1beta1.SchemeGroupVersion.WithKind("TCPIngress"),
-		reflect.TypeOf(&configurationv1beta1.UDPIngress{}):              configurationv1beta1.SchemeGroupVersion.WithKind("UDPIngress"),
-		reflect.TypeOf(&configurationv1alpha1.IngressClassParameters{}): configurationv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"),
-		reflect.TypeOf(&corev1.Service{}):                               corev1.SchemeGroupVersion.WithKind("Service"),
-		reflect.TypeOf(&discoveryv1.EndpointSlice{}):                    discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice"),
-		reflect.TypeOf(&corev1.Secret{}):                                corev1.SchemeGroupVersion.WithKind("Secret"),
-		reflect.TypeOf(&configurationv1.KongPlugin{}):                   configurationv1.SchemeGroupVersion.WithKind("KongPlugin"),
-		reflect.TypeOf(&configurationv1.KongClusterPlugin{}):            configurationv1.SchemeGroupVersion.WithKind("KongClusterPlugin"),
-		reflect.TypeOf(&configurationv1.KongIngress{}):                  configurationv1.SchemeGroupVersion.WithKind("KongIngress"),
-		reflect.TypeOf(&configurationv1.KongConsumer{}):                 configurationv1.SchemeGroupVersion.WithKind("KongConsumer"),
-		reflect.TypeOf(&configurationv1beta1.KongConsumerGroup{}):       configurationv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"),
+		reflect.TypeOf(&netv1.Ingress{}):                       netv1.SchemeGroupVersion.WithKind("Ingress"),
+		reflect.TypeOf(&netv1.IngressClass{}):                  netv1.SchemeGroupVersion.WithKind("IngressClass"),
+		reflect.TypeOf(&gatewayv1beta1.HTTPRoute{}):            gatewayv1beta1.SchemeGroupVersion.WithKind("HTTPRoute"),
+		reflect.TypeOf(&gatewayv1alpha2.UDPRoute{}):            gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"),
+		reflect.TypeOf(&gatewayv1alpha2.TCPRoute{}):            gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"),
+		reflect.TypeOf(&gatewayv1alpha2.TLSRoute{}):            gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"),
+		reflect.TypeOf(&gatewayv1alpha2.GRPCRoute{}):           gatewayv1alpha2.SchemeGroupVersion.WithKind("GRPCRoute"),
+		reflect.TypeOf(&gatewayv1beta1.ReferenceGrant{}):       gatewayv1beta1.SchemeGroupVersion.WithKind("ReferenceGrant"),
+		reflect.TypeOf(&gatewayv1beta1.Gateway{}):              gatewayv1beta1.SchemeGroupVersion.WithKind("Gateway"),
+		reflect.TypeOf(&kongv1beta1.TCPIngress{}):              kongv1beta1.SchemeGroupVersion.WithKind("TCPIngress"),
+		reflect.TypeOf(&kongv1beta1.UDPIngress{}):              kongv1beta1.SchemeGroupVersion.WithKind("UDPIngress"),
+		reflect.TypeOf(&kongv1alpha1.IngressClassParameters{}): kongv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"),
+		reflect.TypeOf(&corev1.Service{}):                      corev1.SchemeGroupVersion.WithKind("Service"),
+		reflect.TypeOf(&discoveryv1.EndpointSlice{}):           discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice"),
+		reflect.TypeOf(&corev1.Secret{}):                       corev1.SchemeGroupVersion.WithKind("Secret"),
+		reflect.TypeOf(&kongv1.KongPlugin{}):                   kongv1.SchemeGroupVersion.WithKind("KongPlugin"),
+		reflect.TypeOf(&kongv1.KongClusterPlugin{}):            kongv1.SchemeGroupVersion.WithKind("KongClusterPlugin"),
+		reflect.TypeOf(&kongv1.KongIngress{}):                  kongv1.SchemeGroupVersion.WithKind("KongIngress"),
+		reflect.TypeOf(&kongv1.KongConsumer{}):                 kongv1.SchemeGroupVersion.WithKind("KongConsumer"),
+		reflect.TypeOf(&kongv1beta1.KongConsumerGroup{}):       kongv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"),
 	}
 
 	out := &bytes.Buffer{}

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -16,8 +16,8 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	configurationv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 func TestKeyFunc(t *testing.T) {
@@ -235,7 +235,7 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	ingresses := []*configurationv1beta1.TCPIngress{
+	ingresses := []*kongv1beta1.TCPIngress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -244,11 +244,11 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 					annotations.IngressClassKey: annotations.DefaultIngressClass,
 				},
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				Rules: []configurationv1beta1.IngressRule{
+			Spec: kongv1beta1.TCPIngressSpec{
+				Rules: []kongv1beta1.IngressRule{
 					{
 						Port: 9000,
-						Backend: configurationv1beta1.IngressBackend{
+						Backend: kongv1beta1.IngressBackend{
 							ServiceName: "foo-svc",
 							ServicePort: 80,
 						},
@@ -262,11 +262,11 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 				Name:      "baz",
 				Namespace: "default",
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				Rules: []configurationv1beta1.IngressRule{
+			Spec: kongv1beta1.TCPIngressSpec{
+				Rules: []kongv1beta1.IngressRule{
 					{
 						Port: 9000,
-						Backend: configurationv1beta1.IngressBackend{
+						Backend: kongv1beta1.IngressBackend{
 							ServiceName: "foo-svc",
 							ServicePort: 80,
 						},
@@ -282,11 +282,11 @@ func TestFakeStoreListTCPIngress(t *testing.T) {
 					annotations.IngressClassKey: "not-kong",
 				},
 			},
-			Spec: configurationv1beta1.TCPIngressSpec{
-				Rules: []configurationv1beta1.IngressRule{
+			Spec: kongv1beta1.TCPIngressSpec{
+				Rules: []kongv1beta1.IngressRule{
 					{
 						Port: 8000,
-						Backend: configurationv1beta1.IngressBackend{
+						Backend: kongv1beta1.IngressBackend{
 							ServiceName: "bar-svc",
 							ServicePort: 80,
 						},
@@ -460,7 +460,7 @@ func TestFakeStoreConsumer(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	consumers := []*configurationv1.KongConsumer{
+	consumers := []*kongv1.KongConsumer{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -489,7 +489,7 @@ func TestFakeStoreConsumerGroup(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	consumerGroups := []*configurationv1beta1.KongConsumerGroup{
+	consumerGroups := []*kongv1beta1.KongConsumerGroup{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -518,7 +518,7 @@ func TestFakeStorePlugins(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	plugins := []*configurationv1.KongPlugin{
+	plugins := []*kongv1.KongPlugin{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -530,7 +530,7 @@ func TestFakeStorePlugins(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(store)
 
-	plugins = []*configurationv1.KongPlugin{
+	plugins = []*kongv1.KongPlugin{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "baz",
@@ -555,7 +555,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	plugins := []*configurationv1.KongClusterPlugin{
+	plugins := []*kongv1.KongClusterPlugin{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -569,7 +569,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(plugins, 0)
 
-	plugins = []*configurationv1.KongClusterPlugin{
+	plugins = []*kongv1.KongClusterPlugin{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -642,7 +642,7 @@ func TestFakeKongIngress(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	kongIngresses := []*configurationv1.KongIngress{
+	kongIngresses := []*kongv1.KongIngress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",

--- a/pkg/clientset_test/clientset_test.go
+++ b/pkg/clientset_test/clientset_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongfake "github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/fake"
 )
 
 func TestClientset(t *testing.T) {
 	t.Run("it can retrieve a fake KongPlugin", func(t *testing.T) {
-		cl := kongfake.NewSimpleClientset(&configurationv1.KongPlugin{
+		cl := kongfake.NewSimpleClientset(&kongv1.KongPlugin{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-plugin",
 				Namespace: "test-ns",

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
@@ -515,11 +515,11 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an IngressClassParameters with legacy regex detection enabled")
-	params := &v1alpha1.IngressClassParameters{
+	params := &kongv1alpha1.IngressClassParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: consts.IngressClass,
 		},
-		Spec: v1alpha1.IngressClassParametersSpec{
+		Spec: kongv1alpha1.IngressClassParametersSpec{
 			EnableLegacyRegexDetection: true,
 		},
 	}
@@ -533,8 +533,8 @@ func TestIngressClassRegexToggle(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("adding legacy regex IngressClassParameters to the %q IngressClass", class.Name)
 	class.Spec.Parameters = &netv1.IngressClassParametersReference{
-		APIGroup:  &v1alpha1.GroupVersion.Group,
-		Kind:      v1alpha1.IngressClassParametersKind,
+		APIGroup:  &kongv1alpha1.GroupVersion.Group,
+		Kind:      kongv1alpha1.IngressClassParametersKind,
 		Name:      params.Name,
 		Scope:     kong.String(netv1.IngressClassParametersReferenceScopeNamespace),
 		Namespace: &params.Namespace,

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
 
-	configurationv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
@@ -56,16 +56,16 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("when deprecated fields are populated warnings are returned", func(t *testing.T) {
-		kongIngress := &configurationv1.KongIngress{
+		kongIngress := &kongv1.KongIngress{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "kong-ingress-validation-",
 			},
 			// Proxy field is deprecated, expecting warning for it.
-			Proxy: &configurationv1.KongIngressService{
+			Proxy: &kongv1.KongIngressService{
 				Protocol: lo.ToPtr("tcp"),
 			},
 			// Route field is deprecated, expecting warning for it.
-			Route: &configurationv1.KongIngressRoute{
+			Route: &kongv1.KongIngressRoute{
 				Methods: []*string{lo.ToPtr("POST")},
 			},
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Unify imports of Kong-specific CRDs in the same way as K8s are imported. Configure `importas` to enforce it. Similar to https://github.com/Kong/kubernetes-ingress-controller/pull/4016

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->



<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.


-->

**Special notes for your reviewer**:

In autogenerated `pkg/clientset` noting is changed (the same as for K8s objects).


<!-- Here you can add any open questions or notes that you might have for reviewers -->

