### PR TITLE
chore(ci): adjust golangci-lint config, fix reported

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,5 @@
 run:
   timeout: 5m
-  skip-dirs:
-  - pkg/clientset
-  - pkg/apis
-  - config
   build-tags:
   - integration_tests
   - e2e_tests

--- a/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
+++ b/internal/controllers/configuration/kongadminapi_controller_envtest_test.go
@@ -102,7 +102,7 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 	}()
 	t.Cleanup(func() { wg.Wait() })
 
-	return
+	return adminService, adminPod, n
 }
 
 func TestKongAdminAPIController(t *testing.T) {

--- a/internal/dataplane/configfetcher/config_fetcher.go
+++ b/internal/dataplane/configfetcher/config_fetcher.go
@@ -7,10 +7,11 @@ import (
 	"github.com/kong/deck/dump"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
+
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/sendconfig"
-	"github.com/sirupsen/logrus"
 )
 
 type LastValidConfigFetcher interface {

--- a/internal/dataplane/sendconfig/config_change_detector.go
+++ b/internal/dataplane/sendconfig/config_change_detector.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
 	"github.com/sirupsen/logrus"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
 )
 
 const (
@@ -67,7 +68,7 @@ func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
 	}
 
 	// Check if a Kong instance has no configuration yet (could mean it crashed, was rebooted, etc.).
-	hasNoConfiguration, err := kongHasNoConfiguration(ctx, statusClient, d.log)
+	hasNoConfiguration, err := kongHasNoConfiguration(ctx, statusClient)
 	if err != nil {
 		return false, fmt.Errorf("failed to verify kong readiness: %w", err)
 	}
@@ -89,7 +90,7 @@ func (d *DefaultConfigurationChangeDetector) HasConfigurationChanged(
 // If the config hash reported by Kong is the known empty hash, it's considered crashed.
 // This allows providing configuration to Kong instances that have unexpectedly crashed and
 // lost their configuration.
-func kongHasNoConfiguration(ctx context.Context, client StatusClient, log logrus.FieldLogger) (bool, error) {
+func kongHasNoConfiguration(ctx context.Context, client StatusClient) (bool, error) {
 	status, err := client.Status(ctx)
 	if err != nil {
 		return false, err

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -29,8 +29,7 @@ type ConfigError struct {
 }
 
 // ConfigErrorFields is the structure under the "fields" key in a /config error response.
-type ConfigErrorFields struct {
-}
+type ConfigErrorFields struct{}
 
 // FlatEntityError represents a single Kong entity with one or more invalid fields.
 type FlatEntityError struct {
@@ -70,7 +69,8 @@ func parseFlatEntityErrors(body []byte, log logrus.FieldLogger) ([]ResourceError
 			if len(p.Message) > 0 && len(p.Messages) > 0 {
 				log.WithFields(logrus.Fields{
 					"name":  ee.Name,
-					"field": p.Field}).Error("entity has both single and array errors for field")
+					"field": p.Field,
+				}).Error("entity has both single and array errors for field")
 
 				continue
 			}

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
@@ -124,7 +124,7 @@ func resourceErrorsToResourceFailures(resourceErrors []ResourceError, parseErr e
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ee.Namespace,
 				Name:      ee.Name,
-				UID:       types.UID(ee.UID),
+				UID:       k8stypes.UID(ee.UID),
 			},
 		}
 		for field, problem := range ee.Problems {

--- a/internal/manager/utils/kongconfig/root_test.go
+++ b/internal/manager/utils/kongconfig/root_test.go
@@ -51,7 +51,6 @@ func TestValidateRoots(t *testing.T) {
 			assert.Equal(t, tc.expectedKongVersion, kongOptions.Version.String())
 		})
 	}
-
 }
 
 const dblessConfigJSON3_1_1 = `{

--- a/pkg/apis/configuration/v1/conditions.go
+++ b/pkg/apis/configuration/v1/conditions.go
@@ -37,7 +37,7 @@ const (
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
-	// * "Pending"
+	// * "Pending".
 	//
 	ConditionProgrammed ConditionType = "Programmed"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Remove redundant configuration for `skip-dirs` from `.golangci.yaml`. It's not needed since auto-generated Go code is marked with comments and omitted by golangci-lint. Furthermore, this redundant config leads to omitting files that should be checked.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


**Special notes for your reviewer**:

Adding a dot in `pkg/apis/configuration/v1/conditions.go` is questionable, but let's do it to satisfy the linter, it doesn't make "serious harm".