### PR TITLE
fix: introduce deck content to dbless config converter

### DIFF
--- a/examples/consumer-groups.yaml
+++ b/examples/consumer-groups.yaml
@@ -1,0 +1,16 @@
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongConsumerGroup
+metadata:
+  name: cg1
+  annotations:
+    kubernetes.io/ingress.class: kong
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: c1
+  annotations:
+      kubernetes.io/ingress.class: kong
+username: c1
+consumerGroups:
+  - cg1

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -22,46 +22,6 @@ func GenerateSHA(targetContent *file.Content) ([]byte, error) {
 	return shaSum[:], nil
 }
 
-// CleanUpNullsInPluginConfigs modifies `state` by deleting plugin config map keys that have nil as their value.
-func CleanUpNullsInPluginConfigs(state *file.Content) {
-	for _, s := range state.Services {
-		for _, p := range s.Plugins {
-			for k, v := range p.Config {
-				if v == nil {
-					delete(p.Config, k)
-				}
-			}
-		}
-		for _, r := range state.Routes {
-			for _, p := range r.Plugins {
-				for k, v := range p.Config {
-					if v == nil {
-						delete(p.Config, k)
-					}
-				}
-			}
-		}
-	}
-
-	for _, c := range state.Consumers {
-		for _, p := range c.Plugins {
-			for k, v := range p.Config {
-				if v == nil {
-					delete(p.Config, k)
-				}
-			}
-		}
-	}
-
-	for _, p := range state.Plugins {
-		for k, v := range p.Config {
-			if v == nil {
-				delete(p.Config, k)
-			}
-		}
-	}
-}
-
 // GetFCertificateFromKongCert converts a kong.Certificate to a file.FCertificate.
 func GetFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	var res file.FCertificate

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -24,6 +24,7 @@ type ConfigService interface {
 	) ([]byte, error)
 }
 
+// ContentToDBLessConfigConverter converts a decK's file.Content to a DBLessConfig.
 type ContentToDBLessConfigConverter interface {
 	Convert(content *file.Content) DBLessConfig
 }

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -24,8 +24,9 @@ type ConfigService interface {
 	) ([]byte, error)
 }
 
-// ContentToDBLessConfigConverter converts a decK's file.Content to a DBLessConfig.
 type ContentToDBLessConfigConverter interface {
+	// Convert converts a decK's file.Content to a DBLessConfig.
+	// Implementations are allowed to modify the input *file.Content. Make sure it's copied beforehand if needed.
 	Convert(content *file.Content) DBLessConfig
 }
 

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -8,9 +8,9 @@ import (
 	"io"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/deck/file"
 	"github.com/sirupsen/logrus"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/deckgen"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
@@ -24,23 +24,30 @@ type ConfigService interface {
 	) ([]byte, error)
 }
 
+type ContentToDBLessConfigConverter interface {
+	Convert(content *file.Content) DBLessConfig
+}
+
 // UpdateStrategyInMemory implements the UpdateStrategy interface. It updates Kong's data-plane
 // configuration using its `POST /config` endpoint that is used by ConfigService.ReloadDeclarativeRawConfig.
 type UpdateStrategyInMemory struct {
-	configService ConfigService
-	log           logrus.FieldLogger
-	version       semver.Version
+	configService   ConfigService
+	configConverter ContentToDBLessConfigConverter
+	log             logrus.FieldLogger
+	version         semver.Version
 }
 
 func NewUpdateStrategyInMemory(
 	configService ConfigService,
+	configConverter ContentToDBLessConfigConverter,
 	log logrus.FieldLogger,
 	version semver.Version,
 ) UpdateStrategyInMemory {
 	return UpdateStrategyInMemory{
-		configService: configService,
-		log:           log,
-		version:       version,
+		configService:   configService,
+		configConverter: configConverter,
+		log:             log,
+		version:         version,
 	}
 }
 
@@ -49,13 +56,8 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 	resourceErrors []ResourceError,
 	resourceErrorsParseErr error,
 ) {
-	// Kong will error out if this is set
-	targetState.Content.Info = nil
-
-	// Kong errors out if `null`s are present in `config` of plugins
-	deckgen.CleanUpNullsInPluginConfigs(targetState.Content)
-
-	config, err := json.Marshal(targetState.Content)
+	dblessConfig := s.configConverter.Convert(targetState.Content)
+	config, err := json.Marshal(dblessConfig)
 	if err != nil {
 		return fmt.Errorf("constructing kong configuration: %w", err), nil, nil
 	}

--- a/internal/dataplane/sendconfig/inmemory_schema.go
+++ b/internal/dataplane/sendconfig/inmemory_schema.go
@@ -1,0 +1,97 @@
+package sendconfig
+
+import (
+	"github.com/kong/deck/file"
+)
+
+type ConsumerGroupConsumerRelationship struct {
+	ConsumerGroup string `json:"consumer_group"`
+	Consumer      string `json:"consumer"`
+}
+
+type ConsumerGroupPluginRelationship struct {
+	ConsumerGroup string `json:"consumer_group"`
+	Plugin        string `json:"plugin"`
+}
+
+type DBLessConfig struct {
+	file.Content                       `json:",inline"`
+	ConsumerGroupConsumerRelationships []ConsumerGroupConsumerRelationship `json:"consumer_group_consumers,omitempty"`
+	ConsumerGroupPluginRelationships   []ConsumerGroupPluginRelationship   `json:"consumer_group_plugins,omitempty"`
+}
+
+type DefaultContentToDBLessConfigConverter struct{}
+
+func (d DefaultContentToDBLessConfigConverter) Convert(content *file.Content) DBLessConfig {
+	dblessConfig := DBLessConfig{
+		Content: *content,
+	}
+
+	// DBLess schema does not support decK's Info section.
+	dblessConfig.Content.Info = nil
+
+	// DBLess schema does not support nulls in plugin configs.
+	cleanUpNullsInPluginConfigs(&dblessConfig.Content)
+
+	// DBLess schema does not support ConsumerGroup.Consumer and ConsumerGroup.Plugins ...
+	for i, cg := range dblessConfig.Content.ConsumerGroups {
+		// ... instead, it uses ConsumerGroupConsumerRelationships and ConsumerGroupPluginRelationships.
+		for _, consumer := range cg.Consumers {
+			dblessConfig.ConsumerGroupConsumerRelationships = append(dblessConfig.ConsumerGroupConsumerRelationships, ConsumerGroupConsumerRelationship{
+				ConsumerGroup: *cg.Name,
+				Consumer:      *consumer.Username,
+			})
+		}
+		for _, plugin := range cg.Plugins {
+			dblessConfig.ConsumerGroupPluginRelationships = append(dblessConfig.ConsumerGroupPluginRelationships, ConsumerGroupPluginRelationship{
+				ConsumerGroup: *cg.Name,
+				Plugin:        *plugin.Name,
+			})
+		}
+
+		// ... so we need to remove them from the ConsumerGroup struct.
+		content.ConsumerGroups[i].Consumers = nil
+		content.ConsumerGroups[i].Plugins = nil
+	}
+
+	return dblessConfig
+}
+
+func cleanUpNullsInPluginConfigs(state *file.Content) {
+	for _, s := range state.Services {
+		for _, p := range s.Plugins {
+			for k, v := range p.Config {
+				if v == nil {
+					delete(p.Config, k)
+				}
+			}
+		}
+		for _, r := range state.Routes {
+			for _, p := range r.Plugins {
+				for k, v := range p.Config {
+					if v == nil {
+						delete(p.Config, k)
+					}
+				}
+			}
+		}
+	}
+
+	for _, c := range state.Consumers {
+		for _, p := range c.Plugins {
+			for k, v := range p.Config {
+				if v == nil {
+					delete(p.Config, k)
+				}
+			}
+		}
+	}
+
+	for _, p := range state.Plugins {
+		for k, v := range p.Config {
+			if v == nil {
+				delete(p.Config, k)
+			}
+		}
+	}
+}

--- a/internal/dataplane/sendconfig/inmemory_schema.go
+++ b/internal/dataplane/sendconfig/inmemory_schema.go
@@ -94,13 +94,6 @@ func cleanUpNullsInPluginConfigs(state *file.Content) {
 //   - ConsumerGroupConsumerRelationships
 //   - ConsumerGroupPluginRelationships
 func convertConsumerGroups(dblessConfig *DBLessConfig) {
-	// Before any modification to the Plugins slice, we need to make a copy of it to not modify the original slice.
-	if len(dblessConfig.Content.Consumers) > 0 {
-		copiedConsumers := make([]file.FConsumer, len(dblessConfig.Content.Consumers))
-		copy(copiedConsumers, dblessConfig.Content.Consumers)
-		dblessConfig.Content.Consumers = copiedConsumers
-	}
-
 	// DBLess schema does not support Consumer.Groups field...
 	for i, c := range dblessConfig.Content.Consumers {
 		// ... therefore we need to convert them to relationships...
@@ -112,13 +105,6 @@ func convertConsumerGroups(dblessConfig *DBLessConfig) {
 		}
 		// ... and remove them from the Consumer struct.
 		dblessConfig.Content.Consumers[i].Groups = nil
-	}
-
-	// Before any modification to the Plugins slice, we need to make a copy of it to not modify the original slice.
-	if len(dblessConfig.Content.Plugins) > 0 {
-		copiedPlugins := make([]file.FPlugin, len(dblessConfig.Content.Plugins))
-		copy(copiedPlugins, dblessConfig.Content.Plugins)
-		dblessConfig.Content.Plugins = copiedPlugins
 	}
 
 	// DBLess schema does not support Consumer.ConsumerGroup field...
@@ -135,12 +121,7 @@ func convertConsumerGroups(dblessConfig *DBLessConfig) {
 	}
 
 	// DBLess schema does not support ConsumerGroups.Consumers and ConsumerGroups.Plugins fields so we need to remove
-	// them. We also need to make a copy of the ConsumerGroups slice to not modify the original slice.
-	if len(dblessConfig.Content.ConsumerGroups) > 0 {
-		copiedConsumerGroups := make([]file.FConsumerGroupObject, len(dblessConfig.Content.ConsumerGroups))
-		copy(copiedConsumerGroups, dblessConfig.Content.ConsumerGroups)
-		dblessConfig.Content.ConsumerGroups = copiedConsumerGroups
-	}
+	// them.
 	for i := range dblessConfig.Content.ConsumerGroups {
 		dblessConfig.Content.ConsumerGroups[i].Consumers = nil
 		dblessConfig.Content.ConsumerGroups[i].Plugins = nil

--- a/internal/dataplane/sendconfig/inmemory_schema.go
+++ b/internal/dataplane/sendconfig/inmemory_schema.go
@@ -22,7 +22,7 @@ type DBLessConfig struct {
 
 type DefaultContentToDBLessConfigConverter struct{}
 
-func (d DefaultContentToDBLessConfigConverter) Convert(content *file.Content) DBLessConfig {
+func (DefaultContentToDBLessConfigConverter) Convert(content *file.Content) DBLessConfig {
 	dblessConfig := DBLessConfig{
 		Content: *content,
 	}
@@ -33,30 +33,13 @@ func (d DefaultContentToDBLessConfigConverter) Convert(content *file.Content) DB
 	// DBLess schema does not support nulls in plugin configs.
 	cleanUpNullsInPluginConfigs(&dblessConfig.Content)
 
-	// DBLess schema does not support ConsumerGroup.Consumer and ConsumerGroup.Plugins ...
-	for i, cg := range dblessConfig.Content.ConsumerGroups {
-		// ... instead, it uses ConsumerGroupConsumerRelationships and ConsumerGroupPluginRelationships.
-		for _, consumer := range cg.Consumers {
-			dblessConfig.ConsumerGroupConsumerRelationships = append(dblessConfig.ConsumerGroupConsumerRelationships, ConsumerGroupConsumerRelationship{
-				ConsumerGroup: *cg.Name,
-				Consumer:      *consumer.Username,
-			})
-		}
-		for _, plugin := range cg.Plugins {
-			dblessConfig.ConsumerGroupPluginRelationships = append(dblessConfig.ConsumerGroupPluginRelationships, ConsumerGroupPluginRelationship{
-				ConsumerGroup: *cg.Name,
-				Plugin:        *plugin.Name,
-			})
-		}
-
-		// ... so we need to remove them from the ConsumerGroup struct.
-		content.ConsumerGroups[i].Consumers = nil
-		content.ConsumerGroups[i].Plugins = nil
-	}
+	// DBLess schema does not 1-1 match decK's schema for ConsumerGroups.
+	cleanupConsumerGroups(&dblessConfig)
 
 	return dblessConfig
 }
 
+// cleanUpNullsInPluginConfigs removes null values from plugins' configs.
 func cleanUpNullsInPluginConfigs(state *file.Content) {
 	for _, s := range state.Services {
 		for _, p := range s.Plugins {
@@ -93,5 +76,49 @@ func cleanUpNullsInPluginConfigs(state *file.Content) {
 				delete(p.Config, k)
 			}
 		}
+	}
+}
+
+// cleanupConsumerGroups drops consumer groups related fields that are not supported in DBLess schema:
+//   - Content.Plugins[].ConsumerGroup
+//   - Content.Consumers[].Group,
+//   - Content.ConsumerGroups[].Plugins
+//   - Content.ConsumerGroups[].Consumers
+//
+// In place of them, it creates relationships slices:
+//   - ConsumerGroupConsumerRelationships
+//   - ConsumerGroupPluginRelationships
+func cleanupConsumerGroups(dblessConfig *DBLessConfig) {
+	// DBLess schema does not support Consumer.Groups field...
+	for i, c := range dblessConfig.Content.Consumers {
+		// ... therefore we need to convert them to relationships...
+		for _, cg := range dblessConfig.Content.Consumers[i].Groups {
+			dblessConfig.ConsumerGroupConsumerRelationships = append(dblessConfig.ConsumerGroupConsumerRelationships, ConsumerGroupConsumerRelationship{
+				ConsumerGroup: *cg.Name,
+				Consumer:      *c.Username,
+			})
+		}
+		// ... and remove them from the Consumer struct.
+		dblessConfig.Content.Consumers[i].Groups = nil
+	}
+
+	// DBLess schema does not support Consumer.ConsumerGroup field...
+	for i, p := range dblessConfig.Content.Plugins {
+		// ... therefore we need to convert it to relationships...
+		if p.ConsumerGroup != nil {
+			dblessConfig.ConsumerGroupPluginRelationships = append(dblessConfig.ConsumerGroupPluginRelationships, ConsumerGroupPluginRelationship{
+				ConsumerGroup: *p.ConsumerGroup.Name,
+				Plugin:        *p.Name,
+			})
+		}
+		// ... and remove it from the Plugin struct.
+		dblessConfig.Content.Plugins[i].ConsumerGroup = nil
+	}
+
+	// DBLess schema does not support ConsumerGroups.Consumers and ConsumerGroups.Plugins fields so we need to remove
+	// them.
+	for i := range dblessConfig.Content.ConsumerGroups {
+		dblessConfig.Content.ConsumerGroups[i].Consumers = nil
+		dblessConfig.Content.ConsumerGroups[i].Plugins = nil
 	}
 }

--- a/internal/dataplane/sendconfig/inmemory_schema_test.go
+++ b/internal/dataplane/sendconfig/inmemory_schema_test.go
@@ -1,0 +1,269 @@
+package sendconfig_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kong/deck/file"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/sendconfig"
+)
+
+func TestDBLessConfigMarshalToJSON(t *testing.T) {
+	dblessConfig := sendconfig.DBLessConfig{
+		Content: file.Content{
+			Services: []file.FService{
+				{
+					Service: kong.Service{
+						Name: kong.String("service-id"),
+					},
+				},
+			},
+		},
+		ConsumerGroupConsumerRelationships: []sendconfig.ConsumerGroupConsumerRelationship{
+			{
+				ConsumerGroup: "cg1",
+				Consumer:      "c1",
+			},
+		},
+		ConsumerGroupPluginRelationships: []sendconfig.ConsumerGroupPluginRelationship{
+			{
+				ConsumerGroup: "cg1",
+				Plugin:        "p1",
+			},
+		},
+	}
+
+	expected := `{
+  "services": [
+    {
+      "name": "service-id"
+    }
+  ],
+  "consumer_group_consumers": [
+    {
+      "consumer_group": "cg1",
+      "consumer": "c1"
+    }
+  ],
+  "consumer_group_plugins": [
+    {
+      "consumer_group": "cg1",
+      "plugin": "p1"
+    }
+  ]
+}`
+	b, err := json.MarshalIndent(dblessConfig, "", "  ")
+	require.NoError(t, err)
+	require.Equal(t, expected, string(b))
+}
+
+func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
+	converter := sendconfig.DefaultContentToDBLessConfigConverter{}
+
+	testCases := []struct {
+		name                 string
+		content              *file.Content
+		expectedDBLessConfig sendconfig.DBLessConfig
+	}{
+		{
+			name:    "empty content",
+			content: &file.Content{},
+			expectedDBLessConfig: sendconfig.DBLessConfig{
+				Content: file.Content{},
+			},
+		},
+		{
+			name: "content with info",
+			content: &file.Content{
+				Info: &file.Info{
+					SelectorTags: []string{"tag1", "tag2"},
+				},
+			},
+			expectedDBLessConfig: sendconfig.DBLessConfig{
+				Content: file.Content{},
+			},
+		},
+		{
+			name: "content with consumer group consumers and plugins",
+			content: &file.Content{
+				ConsumerGroups: []file.FConsumerGroupObject{
+					{
+						ConsumerGroup: kong.ConsumerGroup{
+							Name: kong.String("cg1"),
+						},
+						Consumers: []*kong.Consumer{{Username: kong.String("c1")}},
+						Plugins:   []*kong.ConsumerGroupPlugin{{Name: kong.String("p1")}},
+					},
+				},
+			},
+			expectedDBLessConfig: sendconfig.DBLessConfig{
+				Content: file.Content{
+					ConsumerGroups: []file.FConsumerGroupObject{
+						{
+							ConsumerGroup: kong.ConsumerGroup{
+								Name: kong.String("cg1"),
+							},
+						},
+					},
+				},
+				ConsumerGroupConsumerRelationships: []sendconfig.ConsumerGroupConsumerRelationship{
+					{
+						ConsumerGroup: "cg1",
+						Consumer:      "c1",
+					},
+				},
+				ConsumerGroupPluginRelationships: []sendconfig.ConsumerGroupPluginRelationship{
+					{
+						ConsumerGroup: "cg1",
+						Plugin:        "p1",
+					},
+				},
+			},
+		},
+		{
+			name: "content with plugin config nulls",
+			content: &file.Content{
+				Plugins: []file.FPlugin{
+					{
+						Plugin: kong.Plugin{
+							Name: kong.String("p1"),
+							Config: kong.Configuration{
+								"config1": nil,
+								"config2": "value2",
+							},
+						},
+					},
+				},
+				Consumers: []file.FConsumer{
+					{
+						Consumer: kong.Consumer{
+							Username: kong.String("c1"),
+						},
+						Plugins: []*file.FPlugin{
+							{
+								Plugin: kong.Plugin{
+									Name: kong.String("p1"),
+									Config: kong.Configuration{
+										"config1": nil,
+										"config2": "value2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Routes: []file.FRoute{
+					{
+						Route: kong.Route{
+							Name: kong.String("r1"),
+						},
+						Plugins: []*file.FPlugin{
+							{
+								Plugin: kong.Plugin{
+									Name: kong.String("p1"),
+									Config: kong.Configuration{
+										"config1": nil,
+										"config2": "value2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Services: []file.FService{
+					{
+						Service: kong.Service{
+							Name: kong.String("s1"),
+						},
+						Plugins: []*file.FPlugin{
+							{
+								Plugin: kong.Plugin{
+									Name: kong.String("p1"),
+									Config: kong.Configuration{
+										"config1": nil,
+										"config2": "value2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDBLessConfig: sendconfig.DBLessConfig{
+				Content: file.Content{
+					Plugins: []file.FPlugin{
+						{
+							Plugin: kong.Plugin{
+								Name: kong.String("p1"),
+								Config: kong.Configuration{
+									"config2": "value2",
+								},
+							},
+						},
+					},
+					Consumers: []file.FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("c1"),
+							},
+							Plugins: []*file.FPlugin{
+								{
+									Plugin: kong.Plugin{
+										Name: kong.String("p1"),
+										Config: kong.Configuration{
+											"config2": "value2",
+										},
+									},
+								},
+							},
+						},
+					},
+					Routes: []file.FRoute{
+						{
+							Route: kong.Route{
+								Name: kong.String("r1"),
+							},
+							Plugins: []*file.FPlugin{
+								{
+									Plugin: kong.Plugin{
+										Name: kong.String("p1"),
+										Config: kong.Configuration{
+											"config2": "value2",
+										},
+									},
+								},
+							},
+						},
+					},
+					Services: []file.FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("s1"),
+							},
+							Plugins: []*file.FPlugin{
+								{
+									Plugin: kong.Plugin{
+										Name: kong.String("p1"),
+										Config: kong.Configuration{
+											"config2": "value2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dblessConfig := converter.Convert(tc.content)
+			require.Equal(t, tc.expectedDBLessConfig, dblessConfig)
+		})
+	}
+}

--- a/internal/dataplane/sendconfig/inmemory_schema_test.go
+++ b/internal/dataplane/sendconfig/inmemory_schema_test.go
@@ -1,9 +1,13 @@
 package sendconfig_test
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kong/deck/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/require"
@@ -55,9 +59,9 @@ func TestDBLessConfigMarshalToJSON(t *testing.T) {
     }
   ]
 }`
-	b, err := json.MarshalIndent(dblessConfig, "", "  ")
+	b, err := json.Marshal(dblessConfig)
 	require.NoError(t, err)
-	require.Equal(t, expected, string(b))
+	require.JSONEq(t, expected, string(b))
 }
 
 func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
@@ -103,14 +107,14 @@ func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
 						Consumer: kong.Consumer{
 							Username: kong.String("c1"),
 						},
-						Groups: []*kong.ConsumerGroup{{Name: kong.String("cg1")}},
+						Groups: []*kong.ConsumerGroup{{ID: kong.String("cg1"), Name: kong.String("cg1")}},
 					},
 				},
 				Plugins: []file.FPlugin{
 					{
 						Plugin: kong.Plugin{
 							Name:          kong.String("p1"),
-							ConsumerGroup: &kong.ConsumerGroup{Name: kong.String("cg1")},
+							ConsumerGroup: &kong.ConsumerGroup{ID: kong.String("cg1"), Name: kong.String("cg1")},
 						},
 					},
 				},
@@ -290,10 +294,88 @@ func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
 		},
 	}
 
+	// deepCopyContent makes a deep copy of the given file.Content. We use gob to do this, instead of e.g. json, because
+	// various types inside *file.Content implement custom json marshalling/unmarshalling, which would break the test
+	// because of some fields being dropped in this process (e.g. FPlugin.MarshalJSON drops all its fields but ID).
+	deepCopyContent := func(t *testing.T, content *file.Content) *file.Content {
+		var originalContentBlob bytes.Buffer
+		enc := gob.NewEncoder(&originalContentBlob)
+		err := enc.Encode(content)
+		require.NoError(t, err)
+
+		copiedContent := &file.Content{}
+		err = gob.NewDecoder(&originalContentBlob).Decode(copiedContent)
+		require.NoError(t, err)
+		return copiedContent
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Preserve original content to make sure it's not modified after conversion.
+			originalContent := deepCopyContent(t, tc.content)
+
 			dblessConfig := converter.Convert(tc.content)
 			require.Equal(t, tc.expectedDBLessConfig, dblessConfig)
+
+			// We're fine with Config being modified in the original *file.Content - we're just dropping null values.
+			ignorePluginConfig := cmpopts.IgnoreFields(kong.Plugin{}, "Config")
+			require.Empty(t, cmp.Diff(originalContent, tc.content, ignorePluginConfig),
+				"passed *file.Content should not be modified",
+			)
 		})
+	}
+}
+
+func BenchmarkDefaultContentToDBLessConfigConverter_Convert(b *testing.B) {
+	content := &file.Content{
+		Info: &file.Info{
+			SelectorTags: []string{"tag1", "tag2"},
+		},
+		ConsumerGroups: []file.FConsumerGroupObject{
+			{
+				ConsumerGroup: kong.ConsumerGroup{
+					Name: kong.String("cg1"),
+				},
+				Consumers: []*kong.Consumer{{Username: kong.String("c1")}},
+				Plugins:   []*kong.ConsumerGroupPlugin{{Name: kong.String("p1")}},
+			},
+		},
+		Consumers: []file.FConsumer{
+			{
+				Consumer: kong.Consumer{
+					Username: kong.String("c1"),
+				},
+				Groups: []*kong.ConsumerGroup{{Name: kong.String("cg1")}},
+			},
+		},
+		Plugins: []file.FPlugin{
+			{
+				Plugin: kong.Plugin{
+					Name:          kong.String("p1"),
+					ConsumerGroup: &kong.ConsumerGroup{Name: kong.String("cg1")},
+					Config:        kong.Configuration{"config1": nil},
+				},
+			},
+			{
+				Plugin: kong.Plugin{
+					Name:          kong.String("p2"),
+					ConsumerGroup: &kong.ConsumerGroup{Name: kong.String("cg1")},
+					Config:        kong.Configuration{"config1": nil},
+				},
+			},
+			{
+				Plugin: kong.Plugin{
+					Name:          kong.String("p3"),
+					ConsumerGroup: &kong.ConsumerGroup{Name: kong.String("cg1")},
+					Config:        kong.Configuration{"config1": nil},
+				},
+			},
+		},
+	}
+
+	converter := sendconfig.DefaultContentToDBLessConfigConverter{}
+	for i := 0; i < b.N; i++ {
+		dblessConfig := converter.Convert(content)
+		_ = dblessConfig
 	}
 }

--- a/internal/dataplane/sendconfig/inmemory_schema_test.go
+++ b/internal/dataplane/sendconfig/inmemory_schema_test.go
@@ -98,6 +98,22 @@ func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
 						Plugins:   []*kong.ConsumerGroupPlugin{{Name: kong.String("p1")}},
 					},
 				},
+				Consumers: []file.FConsumer{
+					{
+						Consumer: kong.Consumer{
+							Username: kong.String("c1"),
+						},
+						Groups: []*kong.ConsumerGroup{{Name: kong.String("cg1")}},
+					},
+				},
+				Plugins: []file.FPlugin{
+					{
+						Plugin: kong.Plugin{
+							Name:          kong.String("p1"),
+							ConsumerGroup: &kong.ConsumerGroup{Name: kong.String("cg1")},
+						},
+					},
+				},
 			},
 			expectedDBLessConfig: sendconfig.DBLessConfig{
 				Content: file.Content{
@@ -105,6 +121,20 @@ func TestDefaultContentToDBLessConfigConverter(t *testing.T) {
 						{
 							ConsumerGroup: kong.ConsumerGroup{
 								Name: kong.String("cg1"),
+							},
+						},
+					},
+					Consumers: []file.FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("c1"),
+							},
+						},
+					},
+					Plugins: []file.FPlugin{
+						{
+							Plugin: kong.Plugin{
+								Name: kong.String("p1"),
 							},
 						},
 					},

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -115,6 +115,7 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(client UpdateClient
 
 	return NewUpdateStrategyInMemory(
 		adminAPIClient,
+		DefaultContentToDBLessConfigConverter{},
 		r.log,
 		r.config.Version,
 	)

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -28,12 +28,6 @@ func TestConsumerGroup(t *testing.T) {
 	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ConsumerGroupsVersionCutoff))
 	RunWhenKongEnterprise(t)
 
-	// Get rid of skip when Gateway 3.4 will be released.
-	// Issue https://konghq.atlassian.net/browse/FTI-5264 will be resolved.
-	if testenv.DBMode() == testenv.DBModeOff {
-		t.Skip("due to a bug in Kong Gateway for DB-less mode and consumer groups, this test has to be skipped")
-	}
-
 	ctx := context.Background()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces `ContentToDBLessConfigConverter` used by `UpdateStrategyInMemory` to adapt decK's `file.Content` to match DBLess schema constraints.

It extracts the already existing conversions from `UpdateStrategyInMemory` (dropping `Info` field, cleaning up nulls in plugins' configs), and also adds cleanups for `ConsumerGroups` related fields (dropping `Plugins[i].ConsumerGroup`, `Consumers[i].Group`, `ConsumerGroups[i].Plugins`, `ConsumerGroups[i].Consumers`, filling relationships).

Also adds an example config for `ConsumerGroup`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/4448.
