### PR TITLE
chore(deps): bump dependencies versions in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4 h1:K3x+yU+fbot38x5bQbU2QqUAVyYLEktdNH2GxZLnM3U=
-golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -313,9 +313,8 @@ func TestSecretConfigurationPlugin(t *testing.T) {
 		Services: []*corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "foo-svc",
-					Namespace:   "default",
-					Annotations: map[string]string{},
+					Name:      "foo-svc",
+					Namespace: "default",
 				},
 			},
 		},
@@ -3804,9 +3803,8 @@ func TestPluginAnnotations(t *testing.T) {
 		services := []*corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "foo-svc",
-					Namespace:   "default",
-					Annotations: map[string]string{},
+					Name:      "foo-svc",
+					Namespace: "default",
 				},
 			},
 		}
@@ -3903,9 +3901,8 @@ func TestPluginAnnotations(t *testing.T) {
 		services := []*corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "foo-svc",
-					Namespace:   "default",
-					Annotations: map[string]string{},
+					Name:      "foo-svc",
+					Namespace: "default",
 				},
 			},
 		}
@@ -3993,9 +3990,8 @@ func TestPluginAnnotations(t *testing.T) {
 		services := []*corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "foo-svc",
-					Namespace:   "default",
-					Annotations: map[string]string{},
+					Name:      "foo-svc",
+					Namespace: "default",
 				},
 			},
 		}

--- a/internal/dataplane/parser/translate_httproute_test.go
+++ b/internal/dataplane/parser/translate_httproute_test.go
@@ -2088,11 +2088,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 }
 
 func k8sObjectInfoOfHTTPRoute(route *gatewayv1beta1.HTTPRoute) util.K8sObjectInfo {
-	// parsers always provide the annotations map, even if route didn't have any
 	anotations := route.Annotations
-	if anotations == nil {
-		anotations = make(map[string]string)
-	}
 
 	return util.K8sObjectInfo{
 		Name:        route.Name,

--- a/internal/dataplane/parser/translate_routes_helpers_test.go
+++ b/internal/dataplane/parser/translate_routes_helpers_test.go
@@ -41,9 +41,8 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 			expected: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
-						Name:        "mytcproute-name",
-						Namespace:   "mynamespace",
-						Annotations: map[string]string{},
+						Name:      "mytcproute-name",
+						Namespace: "mynamespace",
 					},
 					Route: kong.Route{
 						Name: lo.ToPtr("tcproute.mynamespace.mytcproute-name.0.0"),
@@ -106,9 +105,8 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 			expected: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
-						Name:        "myudproute-name",
-						Namespace:   "mynamespace",
-						Annotations: map[string]string{},
+						Name:      "myudproute-name",
+						Namespace: "mynamespace",
 					},
 					Route: kong.Route{
 						Name: lo.ToPtr("udproute.mynamespace.myudproute-name.0.0"),
@@ -169,9 +167,8 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 			expected: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
-						Name:        "mytlsroute-name",
-						Namespace:   "mynamespace",
-						Annotations: map[string]string{},
+						Name:      "mytlsroute-name",
+						Namespace: "mynamespace",
 					},
 					Route: kong.Route{
 						Name: lo.ToPtr("tlsroute.mynamespace.mytlsroute-name.0.0"),
@@ -203,9 +200,8 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 			expected: []kongstate.Route{
 				{
 					Ingress: util.K8sObjectInfo{
-						Name:        "mytlsroute-name",
-						Namespace:   "mynamespace",
-						Annotations: map[string]string{},
+						Name:      "mytlsroute-name",
+						Namespace: "mynamespace",
 					},
 					Route: kong.Route{
 						Name: lo.ToPtr("tlsroute.mynamespace.mytlsroute-name.0.0"),

--- a/internal/dataplane/parser/translate_utils_test.go
+++ b/internal/dataplane/parser/translate_utils_test.go
@@ -182,9 +182,8 @@ func TestGetPermittedForReferenceGrantFrom(t *testing.T) {
 	grants := []*gatewayv1beta1.ReferenceGrant{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        uuid.NewString(),
-				Annotations: map[string]string{},
-				Namespace:   "fitrat",
+				Name:      uuid.NewString(),
+				Namespace: "fitrat",
 			},
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{
@@ -214,9 +213,8 @@ func TestGetPermittedForReferenceGrantFrom(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        uuid.NewString(),
-				Annotations: map[string]string{},
-				Namespace:   "cholpon",
+				Name:      uuid.NewString(),
+				Namespace: "cholpon",
 			},
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{
@@ -332,9 +330,8 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 	grants := []*gatewayv1beta1.ReferenceGrant{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        uuid.NewString(),
-				Annotations: map[string]string{},
-				Namespace:   "fitrat",
+				Name:      uuid.NewString(),
+				Namespace: "fitrat",
 			},
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{
@@ -364,9 +361,8 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        uuid.NewString(),
-				Annotations: map[string]string{},
-				Namespace:   "cholpon",
+				Name:      uuid.NewString(),
+				Namespace: "cholpon",
 			},
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
 				From: []gatewayv1beta1.ReferenceGrantFrom{

--- a/internal/dataplane/parser/translators/grpcroute_atc_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc_test.go
@@ -130,7 +130,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					Ingress: util.K8sObjectInfo{
 						Name:             "multiple-matches",
 						Namespace:        "default",
-						Annotations:      map[string]string{},
 						GroupVersionKind: grpcRouteGVK,
 					},
 					ExpressionRoutes: true,
@@ -144,7 +143,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					Ingress: util.K8sObjectInfo{
 						Name:             "multiple-matches",
 						Namespace:        "default",
-						Annotations:      map[string]string{},
 						GroupVersionKind: grpcRouteGVK,
 					},
 					ExpressionRoutes: true,

--- a/internal/dataplane/parser/translators/grpcroute_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_test.go
@@ -170,7 +170,6 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 					Ingress: util.K8sObjectInfo{
 						Name:             "multiple-matches",
 						Namespace:        "default",
-						Annotations:      map[string]string{},
 						GroupVersionKind: grpcRouteGVK,
 					},
 					Route: kong.Route{
@@ -187,7 +186,6 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 					Ingress: util.K8sObjectInfo{
 						Name:             "multiple-matches",
 						Namespace:        "default",
-						Annotations:      map[string]string{},
 						GroupVersionKind: grpcRouteGVK,
 					},
 					Route: kong.Route{

--- a/internal/util/objectmeta_test.go
+++ b/internal/util/objectmeta_test.go
@@ -24,9 +24,8 @@ func TestFromK8sObject(t *testing.T) {
 				},
 			},
 			want: K8sObjectInfo{
-				Name:        "name",
-				Namespace:   "namespace",
-				Annotations: map[string]string{},
+				Name:      "name",
+				Namespace: "namespace",
 			},
 		},
 		{

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -132,8 +132,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	tcpPortDefault := gatewayv1alpha2.PortNumber(ktfkong.DefaultTCPServicePort)
 	tcpRoute := &gatewayv1alpha2.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
@@ -514,8 +513,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	remoteNamespace := gatewayv1alpha2.Namespace(otherNs.Name)
 	tcproute := &gatewayv1alpha2.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
@@ -559,8 +557,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	t.Logf("creating a ReferenceGrant that permits tcproute access from %s to services in %s", ns.Name, otherNs.Name)
 	grant := &gatewayv1beta1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1beta1.ReferenceGrantSpec{
 			From: []gatewayv1beta1.ReferenceGrantFrom{

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -155,8 +155,7 @@ func TestTLSRouteEssentials(t *testing.T) {
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsRoute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
@@ -508,8 +507,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	t.Logf("creating a ReferenceGrant that permits tcproute access from %s to services in %s", ns.Name, otherNs.Name)
 	grant := &gatewayv1beta1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1beta1.ReferenceGrantSpec{
 			From: []gatewayv1beta1.ReferenceGrantFrom{
@@ -558,8 +556,7 @@ func TestTLSRouteReferenceGrant(t *testing.T) {
 	t.Logf("creating a tlsroute to access deployment %s via kong", deployment.Name)
 	tlsroute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
@@ -735,8 +732,7 @@ func TestTLSRoutePassthrough(t *testing.T) {
 	sectionName := gatewayv1alpha2.SectionName("tls-passthrough")
 	tlsroute := &gatewayv1alpha2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -150,8 +150,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 	udpPortDefault := gatewayv1alpha2.PortNumber(ktfkong.DefaultUDPServicePort)
 	udpRoute := &gatewayv1alpha2.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        uuid.NewString(),
-			Annotations: map[string]string{},
+			Name: uuid.NewString(),
 		},
 		Spec: gatewayv1alpha2.UDPRouteSpec{
 			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/GoogleContainerTools/skaffold/v2 v2.6.2
-	github.com/elastic/crd-ref-docs v0.0.8
+	github.com/elastic/crd-ref-docs v0.0.9
 	github.com/go-delve/delve v1.21.0
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
@@ -12,7 +12,7 @@ require (
 	gotest.tools/gotestsum v1.10.1
 	honnef.co/go/tools v0.4.3
 	k8s.io/code-generator v0.27.4
-	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230221102149-f6f37e6cc1ec
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230728161957-7f0c6dc440f3
 	sigs.k8s.io/controller-tools v0.12.1
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
 
@@ -168,7 +168,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
 	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/goccy/go-yaml v1.9.8 // indirect
+	github.com/goccy/go-yaml v1.11.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect

--- a/third_party/go.sum
+++ b/third_party/go.sum
@@ -686,8 +686,8 @@ github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e/go.mod h1:CgNC6SGbT
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/crd-ref-docs v0.0.8 h1:Sy0A24E+L5aCj/8BGTgxkumCSNeckg4650d96o7QHiU=
-github.com/elastic/crd-ref-docs v0.0.8/go.mod h1:Jd1XDGgrvHzd/+qCf4SwBnOnLl4RaFRjind0ORnHovo=
+github.com/elastic/crd-ref-docs v0.0.9 h1:fkkjFPQMIH2U75Ma5AxQkW7NIydxx2tY2uo/A4+xPO0=
+github.com/elastic/crd-ref-docs v0.0.9/go.mod h1:k7DCVDJCqaEozDFcnfhTQd/Foxd8Ip18qKNPAgMpzyo=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -726,7 +726,6 @@ github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 h1:a4DFiKFJiDRGF
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
@@ -887,12 +886,8 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-openapi/validate v0.22.1 h1:G+c2ub6q47kfX1sOBLwIQwzBVt8qmOAARyo/9Fqs9NU=
 github.com/go-openapi/validate v0.22.1/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
-github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
-github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
-github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
-github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-playground/validator/v10 v10.13.0 h1:cFRQdfaSMCOSfGCCLB20MHvuoHb/s5G8L5pu2ppK5AQ=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -962,8 +957,8 @@ github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/V
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/goccy/go-yaml v1.9.8 h1:5gMyLUeU1/6zl+WFfR1hN7D2kf+1/eRGa7DFtToiBvQ=
-github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
+github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
+github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
@@ -1419,7 +1414,6 @@ github.com/ldez/gomoddirectives v0.2.3 h1:y7MBaisZVDYmKvt9/l1mjNCiSA1BVn34U0ObUc
 github.com/ldez/gomoddirectives v0.2.3/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=
 github.com/ldez/tagliatelle v0.5.0/go.mod h1:rj1HmWiL1MiKQuOONhd09iySTEkUuE/8+5jtPYz9xa4=
-github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.3 h1:6BE2vPT0lqoz3fmOesHZiaiFh7889ssCo2GMvLCfiuA=
 github.com/leonklingele/grouper v1.1.1 h1:suWXRU57D4/Enn6pXR0QVqqWWrnJ9Osrz+5rjt8ivzU=
 github.com/leonklingele/grouper v1.1.1/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7snXgR4yDYQVDY=
@@ -1472,7 +1466,6 @@ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcncea
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -2597,7 +2590,6 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220702020025-31831981b65f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -3186,8 +3178,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/cli-utils v0.22.0 h1:IlobQOJxDvPAB2O1AO93Ve6prnTkQ29Z6NZuEao/Vj0=
 sigs.k8s.io/cli-utils v0.22.0/go.mod h1:Mt1gLc/Nfa7Z3Lhbfk72uT2Kc4GNyuX4oMqEN9FbPMs=
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
-sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230221102149-f6f37e6cc1ec h1:NypTW99ygj1bLBoJWEe17qUXHfNa8hk44Y+6/YuQYas=
-sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230221102149-f6f37e6cc1ec/go.mod h1:Lm5xRgQejdMHAz81exSpqvwEkIdTfoNtUDA6MM4kltw=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230728161957-7f0c6dc440f3 h1:wi7cNi1Fic5lOeboayUElQJhWp3CAwmzeLBdUG0QwOY=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230728161957-7f0c6dc440f3/go.mod h1:B6HLcvOy2S1qq2eWOFm9xepiKPMIc8Z9OXSPsnUDaR4=
 sigs.k8s.io/controller-tools v0.12.1 h1:GyQqxzH5wksa4n3YDIJdJJOopztR5VDM+7qsyg5yE4U=
 sigs.k8s.io/controller-tools v0.12.1/go.mod h1:rXlpTfFHZMpZA8aGq9ejArgZiieHd+fkk/fTatY8A2M=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump some dependencies versions (e.g. those without a semver which are not being bumped by dependabot).