### PR TITLE
Revert "ci(deps): group updates of several dependencies (#4455)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,6 @@ updates:
     interval: daily
   labels:
   - dependencies
-  groups:
-    github.com/kong:
-        patterns:
-          - "github.com/kong/*"
-    k8s.io:
-        patterns:
-          - "k8s.io/*"
-    knative.dev:
-        patterns:
-          - "knative.dev/*"
-    sigs.k8s.io:
-        patterns:
-          - "sigs.k8s.io/*"
 - package-ecosystem: gomod
   directory: /third_party/
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit 59e67144a433b1e6c9ca2c3e60e85eb33b8ceed2.

The reason for this revert is to prevent dependency bump lock ups like https://github.com/Kong/kubernetes-ingress-controller/pull/4460

Commented about this in here: https://github.com/Kong/kubernetes-ingress-controller/pull/4455#issuecomment-1667817979
