### PR TITLE
chore(ci): update test_nightly.yaml GH workflow

### DIFF
--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,7 +1,7 @@
 name: tests-nightly
 
 concurrency:
-  # Limit the concurrency of e2e tests to run only 1 workflow for ref (branch).
+  # Limit the concurrency of tests in this workflow to run only 1 workflow for ref (branch).
   # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,7 +1,9 @@
 name: tests-nightly
 run-name: |
   e2e tests (targeted), branch:${{ github.ref_name }},
-  triggered by @${{ github.actor }}
+  triggered by @${{ github.actor }} for images:
+  ${{ format('{0}:{1}', inputs.kong-gateway-enterprise-registry, inputs.kong-gateway-enterprise-tag) }},
+  ${{ format('{0}:{1}', inputs.kong-gateway-oss-registry, inputs.kong-gateway-oss-tag) }}
 
 concurrency:
   # Limit the concurrency of tests in this workflow to run only 1 workflow for ref (branch).
@@ -38,10 +40,12 @@ jobs:
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      KONG_IMAGE_EE: ${{ format('{0}:{1}', inputs.kong-gateway-enterprise-registry, inputs.kong-gateway-enterprise-tag) }}
+      KONG_IMAGE_OSS: ${{ format('{0}:{1}', inputs.kong-gateway-oss-registry, inputs.kong-gateway-oss-tag) }}
     steps:
       - uses: actions/checkout@v3
       - run: |
-          MSG="Integration (targeted) tests with KIND-based cluster and \`kong/kong-gateway-dev:latest\` image were started at ${URL}"
+          MSG="Integration (targeted) tests with KIND-based cluster and images: \`${KONG_IMAGE_EE}\`, \`${KONG_IMAGE_OSS}\` were started at ${URL}"
           gh pr comment ${PR_NUMBER} --body "${MSG}"
           # Remove the 'ci/run-nightly' label from the PR to prevent the `test_nightly.yaml`
           # workflow from running again.

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,4 +1,7 @@
 name: tests-nightly
+run-name: |
+  e2e tests (targeted), branch:${{ github.ref_name }},
+  triggered by @${{ github.actor }}
 
 concurrency:
   # Limit the concurrency of tests in this workflow to run only 1 workflow for ref (branch).
@@ -10,7 +13,20 @@ on:
   pull_request:
     types:
       - labeled
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      kong-gateway-enterprise-registry:
+        type: string
+        default: kong/kong-gateway-dev
+      kong-gateway-enterprise-tag:
+        type: string
+        default: latest
+      kong-gateway-oss-registry:
+          type: string
+          default: kong/kong
+      kong-gateway-oss-tag:
+          type: string
+          default: latest-ubuntu
 
 jobs:
   post-comment-in-pr:
@@ -56,8 +72,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: kong/kong-gateway-dev
-        TEST_KONG_TAG: latest
+        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-enterprise-registry }}
+        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-enterprise-tag }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
@@ -100,8 +116,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: kong/kong-gateway-dev
-        TEST_KONG_TAG: latest
+        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-enterprise-registry }}
+        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-enterprise-tag }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
@@ -137,8 +153,8 @@ jobs:
       run: make test.integration.postgres
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: kong/kong
-        TEST_KONG_TAG: latest-ubuntu
+        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-oss-registry }}
+        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-oss-tag }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3
@@ -173,8 +189,8 @@ jobs:
       run: make test.integration.dbless
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: kong/kong
-        TEST_KONG_TAG: latest-ubuntu
+        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-oss-registry }}
+        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-oss-tag }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,9 +1,7 @@
 name: tests-nightly
 run-name: |
   e2e tests (targeted), branch:${{ github.ref_name }},
-  triggered by @${{ github.actor }} for images:
-  ${{ format('{0}:{1}', inputs.kong-gateway-enterprise-registry, inputs.kong-gateway-enterprise-tag) }},
-  ${{ format('{0}:{1}', inputs.kong-gateway-oss-registry, inputs.kong-gateway-oss-tag) }}
+  triggered by @${{ github.actor }}
 
 concurrency:
   # Limit the concurrency of tests in this workflow to run only 1 workflow for ref (branch).
@@ -15,20 +13,13 @@ on:
   pull_request:
     types:
       - labeled
-  workflow_dispatch:
-    inputs:
-      kong-gateway-enterprise-registry:
-        type: string
-        default: kong/kong-gateway-dev
-      kong-gateway-enterprise-tag:
-        type: string
-        default: latest
-      kong-gateway-oss-registry:
-          type: string
-          default: kong/kong
-      kong-gateway-oss-tag:
-          type: string
-          default: latest-ubuntu
+  workflow_dispatch: {}
+
+env:
+  kong-gateway-enterprise-registry: kong/kong-gateway-dev
+  kong-gateway-enterprise-tag: latest
+  kong-gateway-oss-registry: kong/kong
+  kong-gateway-oss-tag: latest-ubuntu
 
 jobs:
   post-comment-in-pr:
@@ -40,12 +31,10 @@ jobs:
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      KONG_IMAGE_EE: ${{ format('{0}:{1}', inputs.kong-gateway-enterprise-registry, inputs.kong-gateway-enterprise-tag) }}
-      KONG_IMAGE_OSS: ${{ format('{0}:{1}', inputs.kong-gateway-oss-registry, inputs.kong-gateway-oss-tag) }}
     steps:
       - uses: actions/checkout@v3
       - run: |
-          MSG="Integration (targeted) tests with KIND-based cluster and images: \`${KONG_IMAGE_EE}\`, \`${KONG_IMAGE_OSS}\` were started at ${URL}"
+          MSG="Integration (targeted) tests with KIND-based cluster and latest images were started at ${URL}"
           gh pr comment ${PR_NUMBER} --body "${MSG}"
           # Remove the 'ci/run-nightly' label from the PR to prevent the `test_nightly.yaml`
           # workflow from running again.
@@ -76,8 +65,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-enterprise-registry }}
-        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-enterprise-tag }}
+        TEST_KONG_IMAGE: ${{ env.kong-gateway-enterprise-registry }}
+        TEST_KONG_TAG: ${{ env.kong-gateway-enterprise-tag }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
@@ -85,7 +74,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: coverage
-        path: coverage.nightlyenterprisepostgres.out
+        path: coverage.enterprisepostgres.out
 
     - name: upload diagnostics
       if: always()
@@ -120,8 +109,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-enterprise-registry }}
-        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-enterprise-tag }}
+        TEST_KONG_IMAGE: ${{ env.kong-gateway-enterprise-registry }}
+        TEST_KONG_TAG: ${{ env.kong-gateway-enterprise-tag }}
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
@@ -129,7 +118,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: coverage
-        path: coverage.nightlyenterprisedbless.out
+        path: coverage.enterprisedbless.out
 
     - name: upload diagnostics
       if: always()
@@ -157,14 +146,14 @@ jobs:
       run: make test.integration.postgres
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-oss-registry }}
-        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-oss-tag }}
+        TEST_KONG_IMAGE: ${{ env.kong-gateway-oss-registry }}
+        TEST_KONG_TAG: ${{ env.kong-gateway-oss-tag }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
         name: coverage
-        path: coverage.nightlypostgres.out
+        path: coverage.postgres.out
 
     - name: upload diagnostics
       if: always()
@@ -193,14 +182,14 @@ jobs:
       run: make test.integration.dbless
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: ${{ github.event.inputs.kong-gateway-oss-registry }}
-        TEST_KONG_TAG: ${{ github.event.inputs.kong-gateway-oss-tag }}
+        TEST_KONG_IMAGE: ${{ env.kong-gateway-oss-registry }}
+        TEST_KONG_TAG: ${{ env.kong-gateway-oss-tag }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3
       with:
         name: coverage
-        path: coverage.nightlydbless.out
+        path: coverage.dbless.out
 
     - name: upload diagnostics
       if: always()

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -1,5 +1,11 @@
 name: tests-nightly
 
+concurrency:
+  # Limit the concurrency of e2e tests to run only 1 workflow for ref (branch).
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:
@@ -7,8 +13,26 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  post-comment-in-pr:
+    if: github.event.pull_request.number != ''
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+      # URL is the current workflow's run URL.
+      # Sadly this is not readily available in github's context.
+      URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          MSG="Integration (targeted) tests with KIND-based cluster and \`kong/kong-gateway-dev:latest\` image were started at ${URL}"
+          gh pr comment ${PR_NUMBER} --body "${MSG}"
+          # Remove the 'ci/run-nightly' label from the PR to prevent the `test_nightly.yaml`
+          # workflow from running again.
+          gh pr edit ${PR_NUMBER} --remove-label ci/run-nightly
+
   integration-tests-enterprise-postgres-nightly:
-    if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
+    if: contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
 
@@ -32,8 +56,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        TEST_KONG_IMAGE: "kong/kong-gateway-internal"
-        TEST_KONG_TAG: "master-alpine"
+        TEST_KONG_IMAGE: kong/kong-gateway-dev
+        TEST_KONG_TAG: latest
         TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
@@ -44,15 +68,59 @@ jobs:
         path: coverage.nightlyenterprisepostgres.out
 
     - name: upload diagnostics
-      if: ${{ always() }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: diagnostics-integration-tests-enterprise-postgres-nightly
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
 
+  integration-tests-enterprise-dbless-nightly:
+    if: contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: setup golang
+      uses: actions/setup-go@v4
+      with:
+        go-version: '^1.20'
+
+    - name: run integration tests
+      run: make test.integration.enterprise.dbless
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        TEST_KONG_IMAGE: kong/kong-gateway-dev
+        TEST_KONG_TAG: latest
+        TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
+        TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
+
+    - name: collect test coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: coverage.nightlyenterprisedbless.out
+
+    - name: upload diagnostics
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests-enterprise-dbless-nightly
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+
   integration-tests-postgres-nightly:
-    if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
+    if: contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - name: checkout repository
@@ -69,8 +137,8 @@ jobs:
       run: make test.integration.postgres
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: "kong/kong"
-        TEST_KONG_TAG: "master-alpine"
+        TEST_KONG_IMAGE: kong/kong
+        TEST_KONG_TAG: latest-ubuntu
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3
@@ -79,7 +147,7 @@ jobs:
         path: coverage.nightlypostgres.out
 
     - name: upload diagnostics
-      if: ${{ always() }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: diagnostics-integration-tests-postgres-nightly
@@ -87,7 +155,7 @@ jobs:
         if-no-files-found: ignore
 
   integration-tests-dbless-nightly:
-    if: ${{ github.event.label.name == 'ci/run-nightly' || github.event_name == 'workflow_dispatch' }}
+    if: contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
 
@@ -105,8 +173,8 @@ jobs:
       run: make test.integration.dbless
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_KONG_IMAGE: "kong/kong"
-        TEST_KONG_TAG: "master-alpine"
+        TEST_KONG_IMAGE: kong/kong
+        TEST_KONG_TAG: latest-ubuntu
 
     - name: collect test coverage
       uses: actions/upload-artifact@v3
@@ -115,7 +183,7 @@ jobs:
         path: coverage.nightlydbless.out
 
     - name: upload diagnostics
-      if: ${{ always() }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: diagnostics-integration-tests-dbless-nightly


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Running KIC integration tests on demand with the latest version of Kong Gateway is useful, thus updating the respective workflow.

- currently nightly builds can be found in the registry [kong-gateway-dev](https://hub.docker.com/r/kong/kong-gateway-dev), so let's use it
- PR https://github.com/Kong/kubernetes-ingress-controller/pull/4389 introduces running tests for enterprise dbless, so let's run them
- add a comment to PR that tests were triggered and remove the label `ci/run-nightly` from PR
- fix names of coverage reports to upload 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It unblocks PRs that have to be tested with newer Gateway images than the last stable version e.g. https://github.com/Kong/docs.konghq.com/pull/5865

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Probably we should have a broader discussion about our workflows and their names. This PR doesn't deduplicate code (it can be improved in the same way as other workflows. Food for thought - maybe introduce support for a more complicated label or comment that will allow specifying a custom tag instead of always using the `latest`. 

Enterprise suites are run with enterprise image and default one with OSS image. This distinction has been made because EE Gateway EE will be detected no matter the license and skipping tests with an invalid/missing license (works like OSS, but still presents EE version) is risky, because it may lead to overlook of e.g. expired license.  See [what happened](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5798696152) when only EE image was used

<!-- Here you can add any open questions or notes that you might have for reviewers -->

