### PR TITLE
fix(ci): don't always post comments in PRs from integration tests nightly

### DIFF
--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   post-comment-in-pr:
-    if: github.event.pull_request.number != ''
+    if: (contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch') && github.event.pull_request.number != ''
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Modify the condition so that `.github/workflows/test_nightly.yaml` doesn't always post a comment in PRs. 

This PR should prevent e.g. https://github.com/Kong/kubernetes-ingress-controller/pull/4476#issuecomment-1671557978
