### PR TITLE
fix(ci) correct latest push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,4 +190,4 @@ jobs:
       run: |
         git checkout latest
         git reset --hard v${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
-        git push latest
+        git push -f origin latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the latest push job.

**Which issue this PR fixes**:

The job was failing:

```
Run git checkout latest
  git checkout latest
  git reset --hard v2.11.0
  git push latest
  shell: /usr/bin/bash -e {0}
Switched to a new branch 'latest'
branch 'latest' set up to track 'origin/latest'.
HEAD is now at 46f0739c chore(deploy) bump manifest versions
fatal: 'latest' does not appear to be a git repository
fatal: Could not read from remote repository.
```

Changes are what I ran locally to handle it outside CI.

**Special notes for your reviewer**:

Git indicated that my `latest`, after resetting to v2.11.0, was missing commits from `origin/latest`. I'm not sure if this should be the case (the succession of latests should be entirely linear unless we accidentally pushed a backport to it), but I can't think of any reason we'd not want it to be an exact replica of the tag, so I don't think there's any reason not to force push.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
