### PR TITLE
fix: update kind k8s versions because tags of kindest/node removed

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -72,9 +72,9 @@ jobs:
         name: Set Kind versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.22.17\", \"1.23.17\", \"1.24.16\", \"1.25.12\", \"1.26.7\", \"1.27.4\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.22.17\", \"1.23.17\", \"1.24.15\", \"1.25.11\", \"1.26.6\", \"1.27.3\"]" >> $GITHUB_OUTPUT
           else
-            echo "kind-versions=[\"1.27.4\"]" >> $GITHUB_OUTPUT
+            echo "kind-versions=[\"1.27.3\"]" >> $GITHUB_OUTPUT
           fi
   kind:
     runs-on: ubuntu-latest
@@ -222,13 +222,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kubernetes-version: 'v1.27.4'
+          - kubernetes-version: 'v1.27.3'
             istio-version: 'v1.18'
-          - kubernetes-version: 'v1.26.7'
+          - kubernetes-version: 'v1.26.6'
             istio-version: 'v1.17'
-          - kubernetes-version: 'v1.25.12'
+          - kubernetes-version: 'v1.25.11'
             istio-version: 'v1.16'
-          - kubernetes-version: 'v1.25.12'
+          - kubernetes-version: 'v1.25.11'
             istio-version: 'v1.15'
     steps:
       - name: Download built image artifact

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -28,6 +28,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
@@ -69,7 +70,8 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Log("configuring cluster addons for the testing environment")
 	kongBuilder := kong.NewBuilder().
 		WithControllerDisabled().
-		WithProxyAdminServiceTypeLoadBalancer()
+		WithProxyAdminServiceTypeLoadBalancer().
+		WithNamespace(consts.ControllerNamespace)
 	kongAddon := kongBuilder.Build()
 
 	t.Log("configuring istio cluster addon for the testing environment")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

kind has removed the tags of `kindest/node` image we uses in e2e tests, so we have to update the tags to existing ones in the same kubernetes minor version. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4483 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
