### PR TITLE
refactor: use helpers for certificates in TestWebhookUpdate, fix typo

### DIFF
--- a/test/helpers/certificate/certificate.go
+++ b/test/helpers/certificate/certificate.go
@@ -14,36 +14,36 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 )
 
-type SelfSignedCeritificateOptions struct {
+type SelfSignedCertificateOptions struct {
 	CommonName string
 	DNSNames   []string
 }
 
-type SelfSignedCeritificateOptionsDecorator func(SelfSignedCeritificateOptions) SelfSignedCeritificateOptions
+type SelfSignedCertificateOptionsDecorator func(SelfSignedCertificateOptions) SelfSignedCertificateOptions
 
-func WithCommonName(commonName string) SelfSignedCeritificateOptionsDecorator {
-	return func(opts SelfSignedCeritificateOptions) SelfSignedCeritificateOptions {
+func WithCommonName(commonName string) SelfSignedCertificateOptionsDecorator {
+	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
 		opts.CommonName = commonName
 		return opts
 	}
 }
 
-func WithDNSNames(dnsNames ...string) SelfSignedCeritificateOptionsDecorator {
-	return func(opts SelfSignedCeritificateOptions) SelfSignedCeritificateOptions {
+func WithDNSNames(dnsNames ...string) SelfSignedCertificateOptionsDecorator {
+	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
 		opts.DNSNames = append(opts.DNSNames, dnsNames...)
 		return opts
 	}
 }
 
 // MustGenerateSelfSignedCert generates a tls.Certificate struct to be used in TLS client/listener configurations.
-func MustGenerateSelfSignedCert(decorators ...SelfSignedCeritificateOptionsDecorator) tls.Certificate {
+func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOptionsDecorator) tls.Certificate {
 	// Generate a new RSA private key.
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate RSA key: %s", err))
 	}
 
-	options := SelfSignedCeritificateOptions{
+	options := SelfSignedCertificateOptions{
 		CommonName: "",
 		DNSNames:   []string{},
 	}
@@ -85,7 +85,7 @@ func MustGenerateSelfSignedCert(decorators ...SelfSignedCeritificateOptionsDecor
 
 // MustGenerateSelfSignedCertPEMFormat generates self-signed certificate
 // and returns certificate and key in PEM format.
-func MustGenerateSelfSignedCertPEMFormat(decorators ...SelfSignedCeritificateOptionsDecorator) (cert []byte, key []byte) {
+func MustGenerateSelfSignedCertPEMFormat(decorators ...SelfSignedCertificateOptionsDecorator) (cert []byte, key []byte) {
 	tlsCert := MustGenerateSelfSignedCert(decorators...)
 
 	certBlock := &pem.Block{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- fix typo for `Ceritificate` -> `Certificate`
- get rid of hardcoded TLS certificates in test `TestWebhookUpdate` 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:



part of https://github.com/Kong/kubernetes-ingress-controller/issues/4118
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The original comment describing `openssl` command for generating hardcoded certs is misleading because the second cert has `CN=second.example` instead of `CN=first.example` (and this is further checked like this in the test).

<!-- Here you can add any open questions or notes that you might have for reviewers -->
