### PR TITLE
refactor: use common helpers for certs in TestMakeHTTPClientWithTLSOpts

### DIFF
--- a/internal/adminapi/kong_test.go
+++ b/internal/adminapi/kong_test.go
@@ -1,96 +1,79 @@
 package adminapi_test
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
 	"io"
-	"math/big"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
 )
 
 func TestMakeHTTPClientWithTLSOpts(t *testing.T) {
-	var caPEM *bytes.Buffer
-	var certPEM *bytes.Buffer
-	var certPrivateKeyPEM *bytes.Buffer
-	var err error
-
-	caPEM, certPEM, certPrivateKeyPEM, err = buildTLS(t)
-	require.NoError(t, err, "Fail to build TLS certificates")
+	cert, key := certificate.MustGenerateSelfSignedCertPEMFormat()
+	caCert := cert
 
 	opts := adminapi.HTTPClientOpts{
 		TLSSkipVerify: true,
 		TLSServerName: "",
 		CACertPath:    "",
-		CACert:        caPEM.String(),
+		CACert:        string(caCert),
 		Headers:       nil,
 		TLSClient: adminapi.TLSClientConfig{
-			Cert: certPEM.String(),
-			Key:  certPrivateKeyPEM.String(),
+			Cert: string(cert),
+			Key:  string(key),
 		},
 	}
 
 	t.Run("without kong admin token", func(t *testing.T) {
-		httpclient, err := adminapi.MakeHTTPClient(&opts, "")
+		c, err := adminapi.MakeHTTPClient(&opts, "")
 		require.NoError(t, err)
-		require.NotNil(t, httpclient)
-		require.NoError(t, validate(t, httpclient, caPEM, certPEM, certPrivateKeyPEM, ""))
+		require.NotNil(t, c)
+		validate(t, c, caCert, cert, key, "")
 	})
 
 	t.Run("with kong admin token", func(t *testing.T) {
-		httpclient, err := adminapi.MakeHTTPClient(&opts, "my-token")
+		const kongAdminToken = "my-token"
+		c, err := adminapi.MakeHTTPClient(&opts, kongAdminToken)
 		require.NoError(t, err)
-		require.NotNil(t, httpclient)
-		require.NoError(t, validate(t, httpclient, caPEM, certPEM, certPrivateKeyPEM, "my-token"))
+		require.NotNil(t, c)
+		validate(t, c, caCert, cert, key, kongAdminToken)
 	})
 }
 
 func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
-	var caPEM *bytes.Buffer
-	var certPEM *bytes.Buffer
-	var certPrivateKeyPEM *bytes.Buffer
-	var err error
+	cert, key := certificate.MustGenerateSelfSignedCertPEMFormat()
+	caCert := cert
 
-	caPEM, certPEM, certPrivateKeyPEM, err = buildTLS(t)
-	require.NoError(t, err, "Fail to build TLS certificates")
+	certDir := t.TempDir()
 
-	caFile, err := os.CreateTemp(os.TempDir(), "ca.crt")
+	caFile, err := os.CreateTemp(certDir, "ca.crt")
 	require.NoError(t, err)
-	writtenBytes, err := caFile.Write(caPEM.Bytes())
+	writtenBytes, err := caFile.Write(caCert)
 	require.NoError(t, err)
-	require.Equal(t, caPEM.Len(), writtenBytes)
-	defer os.Remove(caFile.Name())
+	require.Len(t, caCert, writtenBytes)
 
-	certFile, err := os.CreateTemp(os.TempDir(), "cert.crt")
+	certFile, err := os.CreateTemp(certDir, "cert.crt")
 	require.NoError(t, err)
-	writtenBytes, err = certFile.Write(certPEM.Bytes())
+	writtenBytes, err = certFile.Write(cert)
 	require.NoError(t, err)
-	require.Equal(t, certPEM.Len(), writtenBytes)
-	defer os.Remove(caFile.Name())
+	require.Len(t, cert, writtenBytes)
 
-	certPrivateKeyFile, err := os.CreateTemp(os.TempDir(), "cert.key")
+	certPrivateKeyFile, err := os.CreateTemp(certDir, "cert.key")
 	require.NoError(t, err)
-	writtenBytes, err = certPrivateKeyFile.Write(certPrivateKeyPEM.Bytes())
+	writtenBytes, err = certPrivateKeyFile.Write(key)
 	require.NoError(t, err)
-	require.Equal(t, certPrivateKeyPEM.Len(), writtenBytes)
-	defer os.Remove(caFile.Name())
+	require.Len(t, key, writtenBytes)
 
 	opts := adminapi.HTTPClientOpts{
 		TLSSkipVerify: true,
@@ -105,17 +88,18 @@ func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
 	}
 
 	t.Run("without kong admin token", func(t *testing.T) {
-		httpclient, err := adminapi.MakeHTTPClient(&opts, "")
+		c, err := adminapi.MakeHTTPClient(&opts, "")
 		require.NoError(t, err)
-		require.NotNil(t, httpclient)
-		require.NoError(t, validate(t, httpclient, caPEM, certPEM, certPrivateKeyPEM, ""))
+		require.NotNil(t, c)
+		validate(t, c, caCert, cert, key, "")
 	})
 
 	t.Run("with kong admin token", func(t *testing.T) {
-		httpclient, err := adminapi.MakeHTTPClient(&opts, "my-token")
+		const kongAdminToken = "my-token"
+		c, err := adminapi.MakeHTTPClient(&opts, kongAdminToken)
 		require.NoError(t, err)
-		require.NotNil(t, httpclient)
-		require.NoError(t, validate(t, httpclient, caPEM, certPEM, certPrivateKeyPEM, "my-token"))
+		require.NotNil(t, c)
+		validate(t, c, caCert, cert, key, kongAdminToken)
 	})
 }
 
@@ -180,130 +164,21 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 	}
 }
 
-func buildTLS(t *testing.T) (caPEM *bytes.Buffer, certPEM *bytes.Buffer, certPrivateKeyPEM *bytes.Buffer, err error) {
-	const rsaKeySize = 2048
-
-	var ca *x509.Certificate
-	var caPrivateKeyPEM *bytes.Buffer
-
-	ca = &x509.Certificate{
-		SerialNumber: big.NewInt(2022),
-		Subject: pkix.Name{
-			Organization:  []string{"Kong HQ"},
-			Country:       []string{"US"},
-			Province:      []string{"California"},
-			Locality:      []string{"San Francisco"},
-			StreetAddress: []string{"150 Spear Street, Suite 1600"},
-			PostalCode:    []string{"94105"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(0, 0, 1),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-
-	caPrivateKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
-	if err != nil {
-		t.Errorf("Fail to generate CA key %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivateKey.PublicKey, caPrivateKey)
-	if err != nil {
-		t.Errorf("Fail to generate CA certificate %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	caPEM = new(bytes.Buffer)
-	err = pem.Encode(caPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caBytes,
-	})
-	if err != nil {
-		t.Errorf("Fail to encode CA certificate %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	caPrivateKeyPEM = new(bytes.Buffer)
-	err = pem.Encode(caPrivateKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(caPrivateKey),
-	})
-	if err != nil {
-		t.Errorf("Fail to encode CA key %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	cert := &x509.Certificate{
-		SerialNumber: big.NewInt(1658),
-		Subject: pkix.Name{
-			Organization:  []string{"Kong HQ"},
-			Country:       []string{"US"},
-			Province:      []string{"California"},
-			Locality:      []string{"San Francisco"},
-			StreetAddress: []string{"150 Spear Street, Suite 1600"},
-			PostalCode:    []string{"94105"},
-		},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(0, 0, 1),
-		SubjectKeyId: []byte{1, 2, 3, 4, 6},
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-	}
-
-	certPrivateKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
-	if err != nil {
-		t.Errorf("Fail to generate ingress key %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivateKey.PublicKey, certPrivateKey)
-	if err != nil {
-		t.Errorf("Fail to generate ingress certificate %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	certPEM = new(bytes.Buffer)
-	err = pem.Encode(certPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certBytes,
-	})
-	if err != nil {
-		t.Errorf("Fail to encode certificate %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	certPrivateKeyPEM = new(bytes.Buffer)
-	err = pem.Encode(certPrivateKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(certPrivateKey),
-	})
-	if err != nil {
-		t.Errorf("Fail to encode key %s", err.Error())
-		return nil, nil, nil, err
-	}
-
-	return caPEM, certPEM, certPrivateKeyPEM, nil
-}
-
-func validate(t *testing.T,
-	httpclient *http.Client,
-	caPEM *bytes.Buffer,
-	certPEM *bytes.Buffer,
-	certPrivateKeyPEM *bytes.Buffer,
+// validate spins up a test server with the given TLS configuration and verifies
+// whether the passed client can connect to it successfully.
+func validate(
+	t *testing.T,
+	httpClient *http.Client,
+	caPEM []byte,
+	certPEM []byte,
+	certPrivateKeyPEM []byte,
 	kongAdminToken string,
-) (err error) {
-	serverCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivateKeyPEM.Bytes())
-	if err != nil {
-		t.Errorf("Fail to load server certificates %s", err.Error())
-		return err
-	}
+) {
+	serverCert, err := tls.X509KeyPair(certPEM, certPrivateKeyPEM)
+	require.NoError(t, err, "fail to load server certificates")
 
 	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caPEM.Bytes())
+	require.True(t, certPool.AppendCertsFromPEM(caPEM))
 
 	serverTLSConf := &tls.Config{
 		RootCAs:      certPool,
@@ -313,7 +188,7 @@ func validate(t *testing.T,
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	successMessage := "connection successful"
+	const successMessage = "connection successful"
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if kongAdminToken != "" {
 			v, ok := r.Header[http.CanonicalHeaderKey(adminapi.HeaderNameAdminToken)]
@@ -338,24 +213,11 @@ func validate(t *testing.T,
 	server.StartTLS()
 	defer server.Close()
 
-	response, err := httpclient.Get(server.URL)
-	if err != nil {
-		t.Errorf("HTTP client failed to issue a GET request %s", err.Error())
-		return err
-	}
+	response, err := httpClient.Get(server.URL)
+	require.NoError(t, err, "HTTP client failed to issue a GET request")
 	defer response.Body.Close()
 
-	// verify the response
 	data, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("HTTP client failed to process a GET request %s", err.Error())
-		return err
-	}
-
-	body := strings.TrimSpace(string(data[:]))
-	if body != successMessage {
-		return fmt.Errorf("invalid server response: %s", body)
-	}
-
-	return nil
+	require.NoError(t, err, "failed to read response body")
+	require.Equal(t, strings.TrimSpace(string(data)), successMessage, "unexpected content of response body")
 }

--- a/test/helpers/certificate/certificate.go
+++ b/test/helpers/certificate/certificate.go
@@ -36,6 +36,7 @@ func WithDNSNames(dnsNames ...string) SelfSignedCertificateOptionsDecorator {
 }
 
 // MustGenerateSelfSignedCert generates a tls.Certificate struct to be used in TLS client/listener configurations.
+// Certificate is self-signed thus returned cert can be used as CA for it.
 func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOptionsDecorator) tls.Certificate {
 	// Generate a new RSA private key.
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -84,7 +85,8 @@ func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOptionsDecora
 }
 
 // MustGenerateSelfSignedCertPEMFormat generates self-signed certificate
-// and returns certificate and key in PEM format.
+// and returns certificate and key in PEM format. Certificate is self-signed
+// thus returned cert can be used as CA for it.
 func MustGenerateSelfSignedCertPEMFormat(decorators ...SelfSignedCertificateOptionsDecorator) (cert []byte, key []byte) {
 	tlsCert := MustGenerateSelfSignedCert(decorators...)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Make dealing with certs consistent across the codebase. Use common helpers for certs from package `certificate` in `TestMakeHTTPClientWithTLSOpts`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

part of https://github.com/Kong/kubernetes-ingress-controller/issues/4118
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


