### PR TITLE
chore(release) add description file step

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -70,6 +70,7 @@ body:
     options:
       - label: Trigger [release_docs](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/release_docs.yaml) workflow. Note that you will need to update the new version's navigation manifest (e.g. [for 2.7](https://github.com/Kong/docs.konghq.com/blob/main/app/_data/docs_nav_kic_2.7.x.yml) to use the new file after.
       - label: Ensure a draft PR is created in [docs.konghq.com](https://github.com/Kong/docs.konghq.com/pulls) repository.
+      - label: If you are adding a new CRD, add a new description file under `app/_includes/md/kic/crd-ref/`. This is a brief description injected into the CRD reference page.
       - label: Update articles in the new version as needed.
       - label: Update `references/version-compatibility.md` to include the new versions (make sure you capture any new Kubernetes/Istio versions that have been tested)
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.


### PR DESCRIPTION
New step in the release steps template. Missed this in 2.11 initially because we'd never added any new CRDs since adding generated references.