### PR TITLE
Use Service port in generated Kong services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,11 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
-Nothing yet.
+### Fixed
+
+- Display Service ports on generated Kong services, instead of a static default
+  value. This change is cosmetic only.
+  [#4503](https://github.com/Kong/kubernetes-ingress-controller/pull/4503)
 
 ## [2.11.0]
 

--- a/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
@@ -3,6 +3,7 @@ services:
 - connect_timeout: 60000
   host: httproute..httproute-testing.0
   name: httproute..httproute-testing.0
+  port: 8080
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -3,6 +3,7 @@ services:
 - connect_timeout: 60000
   host: httproute..httproute-testing._.0
   name: httproute..httproute-testing._.0
+  port: 8080
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-routes-off_golden.yaml
@@ -4,7 +4,7 @@ services:
   host: foo-svc.foo-namespace.8000.svc
   name: foo-namespace.foo-svc.pnum-8000
   path: /
-  port: 80
+  port: 8000
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-services_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-services_golden.yaml
@@ -4,7 +4,7 @@ services:
   host: foo-svc.foo-namespace.8000.svc
   name: foo-namespace.foo-svc.8000
   path: /
-  port: 80
+  port: 8000
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
@@ -4,7 +4,7 @@ services:
   host: foo-svc.foo-namespace.8000.svc
   name: foo-namespace.foo-svc.8000
   path: /
-  port: 80
+  port: 8000
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -4,7 +4,7 @@ services:
   host: foo-svc.foo-namespace.8000.svc
   name: foo-namespace.foo-svc.8000
   path: /
-  port: 80
+  port: 8000
   protocol: http
   read_timeout: 60000
   retries: 5

--- a/internal/dataplane/parser/testdata/golden/same-name-services-single-backend/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/same-name-services-single-backend/default_golden.yaml
@@ -3,6 +3,7 @@ services:
 - connect_timeout: 60000
   host: httproute.default.test.0
   name: httproute.default.test.0
+  port: 80
   protocol: http
   read_timeout: 60000
   retries: 5


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses the Service port from the Ingress(like) backend for the Kong service port. Previously we used `80` as a universal default.

This is a cosmetic change. As all KIC-generated services use upstreams, the service port is ignored in favor of the upstream's targets' ports, which are set to the Service's Endpoints' ports.

**Which issue this PR fixes**:

Fix #4470

**Special notes for your reviewer**:

This change still uses the `80` default when initially generating services, e.g. [in the Ingress translator](https://github.com/Kong/kubernetes-ingress-controller/blob/8db8ef5d91852985e27ee130ce1df634ebe5936b/internal/dataplane/parser/translate_ingress.go#L169). Because Ingress(like) backends may use port names instead of numbers, we don't necessarily know the port number until we look up the Service.

We look up Services when generating upstreams, so this moves upstream generation before service generation. I don't love updating the map values in place and returning a new copy, but we were already passing the map by value and don't use the Kong service during upstream generation (we use the attached ServicePort instead).

Moving upstream generation before the skipped services list also feels a bit weird, but apparently we were never using the skipped service list during upstream generation anyway? We were apparently generating some upstreams we weren't actually using, but this probably doesn't matter--worst case I guess you get a bunch of config bloat if you make tons of misconfigured Services, and the fix is "don't do that, it's silly".

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
