### PR TITLE
fix: generate routes with hostname match only when GRPCRoute rule does not have matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ Adding a new version? You'll need three changes:
 - Display Service ports on generated Kong services, instead of a static default
   value. This change is cosmetic only.
   [#4503](https://github.com/Kong/kubernetes-ingress-controller/pull/4503)
+- Create routes that match any service and method for `GRPCRoute` rules with no
+  matches.
+  [#4512](https://github.com/Kong/kubernetes-ingress-controller/issues/4512)
 
 ## [2.11.0]
 

--- a/internal/dataplane/parser/translate_grpcroute_test.go
+++ b/internal/dataplane/parser/translate_grpcroute_test.go
@@ -328,6 +328,24 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 					Spec: gatewayv1alpha2.GRPCRouteSpec{},
 				},
+				{
+					TypeMeta: grpcRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "grpcroute-no-hostnames-no-matches",
+					},
+					Spec: gatewayv1alpha2.GRPCRouteSpec{
+						Rules: []gatewayv1alpha2.GRPCRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.GRPCBackendRef{
+									{
+										BackendRef: builder.NewBackendRef("service0").WithPort(80).Build(),
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			expectedKongServices: []kongstate.Service{
 				{
@@ -359,6 +377,14 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Name:      "grpcroute-no-rules",
+						},
+					}),
+				newResourceFailure(translators.ErrRouteValidationNoMatchRulesOrHostnamesSpecified.Error(),
+					&gatewayv1alpha2.GRPCRoute{
+						TypeMeta: grpcRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "grpcroute-no-hostnames-no-matches",
 						},
 					}),
 			},

--- a/internal/dataplane/parser/translators/grpcroute.go
+++ b/internal/dataplane/parser/translators/grpcroute.go
@@ -50,10 +50,6 @@ func GenerateKongRoutesFromGRPCRouteRule(
 
 	// generate a route to match hostnames only if there is no match in the rule.
 	if len(rule.Matches) == 0 {
-		// REVIEW: return an error here to tell parser register a translation error event?
-		if len(grpcroute.Spec.Hostnames) == 0 {
-			return nil
-		}
 		routeName := fmt.Sprintf(
 			"grpcroute.%s.%s.%d.0",
 			grpcroute.Namespace,

--- a/internal/dataplane/parser/translators/grpcroute.go
+++ b/internal/dataplane/parser/translators/grpcroute.go
@@ -48,6 +48,29 @@ func GenerateKongRoutesFromGRPCRouteRule(
 	// gather the k8s object information and hostnames from the grpcroute
 	ingressObjectInfo := util.FromK8sObject(grpcroute)
 
+	// generate a route to match hostnames only if there is no match in the rule.
+	if len(rule.Matches) == 0 {
+		// REVIEW: return an error here to tell parser register a translation error event?
+		if len(grpcroute.Spec.Hostnames) == 0 {
+			return nil
+		}
+		routeName := fmt.Sprintf(
+			"grpcroute.%s.%s.%d.0",
+			grpcroute.Namespace,
+			grpcroute.Name,
+			ruleNumber,
+		)
+		r := kongstate.Route{
+			Ingress: ingressObjectInfo,
+			Route: kong.Route{
+				Name:      kong.String(routeName),
+				Protocols: kong.StringSlice("grpc", "grpcs"),
+			},
+		}
+		r.Hosts = getGRPCRouteHostnamesAsSliceOfStringPointers(grpcroute)
+		return []kongstate.Route{r}
+	}
+
 	for matchNumber, match := range rule.Matches {
 		routeName := fmt.Sprintf(
 			"grpcroute.%s.%s.%d.%d",

--- a/internal/dataplane/parser/translators/grpcroute_atc.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc.go
@@ -31,10 +31,6 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayv1alpha2.GR
 
 	// generate a route to match hostnames only if there is no match in the rule.
 	if len(rule.Matches) == 0 {
-		// REVIEW: return an error here to tell parser register a translation error event?
-		if len(grpcroute.Spec.Hostnames) == 0 {
-			return nil
-		}
 		routeName := fmt.Sprintf(
 			"grpcroute.%s.%s.%d.0",
 			grpcroute.Namespace,
@@ -195,7 +191,7 @@ func SplitGRPCRoute(grpcroute *gatewayv1alpha2.GRPCRoute) []SplitGRPCRouteMatch 
 	splitGRPCRouteByMatch := func(hostname string) {
 		for ruleIndex, rule := range grpcroute.Spec.Rules {
 			// split out a match with only the hostname (non-empty only) when there are no matches in rule.
-			if len(rule.Matches) == 0 && len(hostname) > 0 {
+			if len(rule.Matches) == 0 {
 				splitMatches = append(splitMatches, SplitGRPCRouteMatch{
 					Source:     grpcroute,
 					Hostname:   hostname,

--- a/internal/dataplane/parser/translators/grpcroute_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_test.go
@@ -265,6 +265,29 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:               "single hostname, no matches",
+			objectName:         "hostname-only",
+			annotations:        map[string]string{},
+			hostnames:          []string{"foo.com"},
+			rule:               gatewayv1alpha2.GRPCRouteRule{},
+			prependRegexPrefix: true,
+			expectedRoutes: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:             "hostname-only",
+						Namespace:        "default",
+						Annotations:      map[string]string{},
+						GroupVersionKind: grpcRouteGVK,
+					},
+					Route: kong.Route{
+						Name:      kong.String("grpcroute.default.hostname-only.0.0"),
+						Protocols: kong.StringSlice("grpc", "grpcs"),
+						Hosts:     kong.StringSlice("foo.com"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
generate routes matching hostnames only when a `GRPCRoute` rule does not contain a match, covering both traditional and expression routes.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #4154 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
