### PR TITLE
chore(ci): remove redundant ${{ ... }} in if statements in workflows

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -33,7 +33,7 @@ jobs:
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
 
       - name: collect test report
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: tests-report

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Parse semver string
-        if: ${{ inputs.tag != '' }}
+        if: inputs.tag != ''
         id: parse-semver-tag
         uses: booxmedialtd/ws-action-parse-semver@v1.4.7
         with:
@@ -53,7 +53,7 @@ jobs:
 
       - name: Add major.minor tag
         id: add-major-minor-tag
-        if: ${{ steps.parse-semver-tag.outputs.prerelease == '' }}
+        if: steps.parse-semver-tag.outputs.prerelease == ''
         run: |
           echo "tag=type=raw,value=${{ steps.parse-semver-tag.outputs.major }}.${{ steps.parse-semver-tag.outputs.minor }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -89,14 +89,14 @@ jobs:
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: Download built image artifact
-        if: ${{ inputs.load-local-image }}
+        if: inputs.load-local-image
         uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp
 
       - name: Load built image
-        if: ${{ inputs.load-local-image }}
+        if: inputs.load-local-image
         run: |
           docker load --input /tmp/image.tar
           docker image ls -a
@@ -123,7 +123,7 @@ jobs:
       # image which is available in the external container image registry but not
       # locally and that fails.
       - name: Pull Gateway image for tests
-        if: ${{ inputs.kong-image != '' && inputs.load-local-image }}
+        if: inputs.kong-image != '' && inputs.load-local-image
         run: docker pull ${{ inputs.kong-image }}
 
       - name: run ${{ matrix.test }}
@@ -139,7 +139,7 @@ jobs:
           GOTESTSUM_JUNITFILE: "e2e-${{ matrix.test }}${{ matrix.kubernetes-version }}-tests.xml"
 
       - name: upload diagnostics
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: "diagnostics-e2e-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
@@ -153,7 +153,7 @@ jobs:
           path: "*-tests.xml"
 
   gke:
-    if: ${{ inputs.run-gke }}
+    if: inputs.run-gke
     environment: "gcloud"
     runs-on: ubuntu-latest
     needs:
@@ -202,7 +202,7 @@ jobs:
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
       - name: upload diagnostics
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: "diagnostics-e2e-gke-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
@@ -216,7 +216,7 @@ jobs:
           path: "*-tests.xml"
 
   istio:
-    if: ${{ inputs.run-istio }}
+    if: inputs.run-istio
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -232,14 +232,14 @@ jobs:
             istio-version: 'v1.15'
     steps:
       - name: Download built image artifact
-        if: ${{ inputs.load-local-image }}
+        if: inputs.load-local-image
         uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp
 
       - name: Load built image
-        if: ${{ inputs.load-local-image }}
+        if: inputs.load-local-image
         run: |
           docker load --input /tmp/image.tar
           docker image ls -a
@@ -273,7 +273,7 @@ jobs:
           GOTESTSUM_JUNITFILE: "istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml"
 
       - name: upload diagnostics
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: diagnostics-e2e-tests

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   coverage:
-    if: ${{ inputs.coverage && !cancelled() }}
+    if: inputs.coverage && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
@@ -43,7 +43,7 @@ jobs:
           verbose: true
 
   buildpulse-report:
-    if: ${{ inputs.buildpulse && !cancelled() }}
+    if: inputs.buildpulse && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -29,7 +29,7 @@ jobs:
           path: coverage.unit.out
 
       - name: collect test report
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: tests-report

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   post-comment-in-pr:
-    if: ${{ github.event.inputs.pr-number != '' }}
+    if: github.event.inputs.pr-number != ''
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
@@ -56,7 +56,7 @@ jobs:
       - run: gh pr edit ${PR_NUMBER} --remove-label ci/run-e2e
 
   build-image:
-    if: ${{ inputs.controller-image == '' }}
+    if: inputs.controller-image == ''
     uses: ./.github/workflows/_docker_build.yaml
     secrets: inherit
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: fail if tag already exists
-        if: ${{ steps.check-tag.outputs.exists == 'true' }}
+        if: steps.check-tag.outputs.exists == 'true'
         run: exit 1
       - name: checkout repository
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
           input_string: ${{ github.event.inputs.tag }}
           version_extractor_regex: 'v(.*)$'
       - name: Verify manifests have requested KIC tag
-        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
+        if: steps.semver_parser.outputs.prerelease == ''
         env:
           # We expect the tag used in manifests to be {major}.{minor} part of the version, e.g.
           # for v2.10.3 we expect manifests to use 2.10 tag.
@@ -73,7 +73,7 @@ jobs:
           echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Add major.minor tag
-        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
+        if: steps.semver_parser.outputs.prerelease == ''
         run: |
           echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   startup-issue-comment:
-    if: ${{ github.event.inputs.issue-number != '' }}
+    if: github.event.inputs.issue-number != ''
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
@@ -79,7 +79,7 @@ jobs:
     - startup-issue-comment
     - run-e2e-tests
     - run-integration-tests
-    if: ${{ github.event.inputs.issue-number != '' }}
+    if: github.event.inputs.issue-number != ''
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

When you use expressions in an if conditional, you may omit the `${{ ... }}` expression syntax because GitHub Actions automatically evaluates the `if` conditional as an expression. [Read more](https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions). I found a corner case where such omit is not applicable, e.g.

https://github.com/Kong/kubernetes-ingress-controller/blob/b6770b6dc5d90ece16d83baf58a04bdc95da3723/.github/workflows/_e2e_tests.yaml#L81

read more [here](https://github.com/orgs/community/discussions/26303#discussioncomment-6739171). 

Issue created in GH docs https://github.com/github/docs/pull/27497

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


