### PR TITLE
chore: bump github.com/kong/deck to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/kong/deck v1.25.1-0.20230807064622-328ae943624a
+	github.com/kong/deck v1.26.0
 	github.com/kong/go-kong v0.46.0
 	github.com/kong/kubernetes-telemetry v0.1.0
 	github.com/kong/kubernetes-testing-framework v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
-github.com/kong/deck v1.25.1-0.20230807064622-328ae943624a h1:RWLUQo7offpoT4dWEVntAW1y6SLLxNIDHzaZYxSy0Nk=
-github.com/kong/deck v1.25.1-0.20230807064622-328ae943624a/go.mod h1:B6f2nPWzTld/aTvtxAC6lWFIcAr4FsG25fgycdzeZQY=
+github.com/kong/deck v1.26.0 h1:9zEnGcfdvyBO7uq/sERO6/I+b0FQVOTGRf7dt9/65P8=
+github.com/kong/deck v1.26.0/go.mod h1:B6f2nPWzTld/aTvtxAC6lWFIcAr4FsG25fgycdzeZQY=
 github.com/kong/go-kong v0.46.0 h1:9I6nlX63WymU5Sg+d13iZDVwpW5vXh8/v0zarU27dzI=
 github.com/kong/go-kong v0.46.0/go.mod h1:41Sot1N/n8UHBp+gE/6nOw3vuzoHbhMSyU/zOS7VzPE=
 github.com/kong/kubernetes-telemetry v0.1.0 h1:dyDhB2SUvxVaDAxaZtLWL7JGAbkgwlCUM1P8gR/rCl0=


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps deck to 1.26 for 2.11.x release branch to get full consumer group support in 2.11.x
