### PR TITLE
chore(ci): improve logs for test.conformance

### DIFF
--- a/internal/util/test/crds.go
+++ b/internal/util/test/crds.go
@@ -27,12 +27,12 @@ func DeployCRDsForCluster(ctx context.Context, cluster clusters.Cluster) error {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Kong CRDs to cluster")
+	fmt.Printf("INFO: deploying Kong CRDs to cluster\n")
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongCRDsKustomize); err != nil {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Gateway CRDs to cluster")
+	fmt.Printf("INFO: deploying Gateway CRDs to cluster\n")
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, consts.GatewayExperimentalCRDsKustomizeURL); err != nil {
 		return err
 	}

--- a/internal/util/test/rbacs.go
+++ b/internal/util/test/rbacs.go
@@ -17,21 +17,21 @@ const (
 )
 
 func DeployRBACsForCluster(ctx context.Context, cluster clusters.Cluster) error {
-	fmt.Printf("INFO: deploying Kong RBACs to cluster")
+	fmt.Printf("INFO: deploying Kong RBACs to cluster\n")
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongRBACsKustomize, "-n", consts.ControllerNamespace); err != nil {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Kong knative RBACs to cluster")
+	fmt.Printf("INFO: deploying Kong knative RBACs to cluster\n")
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongKnativeRBACsKustomize, "-n", consts.ControllerNamespace); err != nil {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Kong gateway RBACs to cluster")
+	fmt.Printf("INFO: deploying Kong gateway RBACs to cluster\n")
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongGatewayRBACsKustomize, "-n", consts.ControllerNamespace); err != nil {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Kong CRDs RBACs to cluster")
+	fmt.Printf("INFO: deploying Kong CRDs RBACs to cluster\n")
 	return clusters.KustomizeDeployForCluster(ctx, cluster, kongCRDsRBACsKustomize, "-n", consts.ControllerNamespace)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

In logs for `make test.conformance` the below entry is presented as one line
```log
INFO: deploying Kong RBACs to clusterINFO: deploying Kong knative RBACs to clusterINFO: deploying Kong gateway RBACs to clusterINFO: deploying Kong CRDs RBACs to clusterINFO: deploying Kong CRDs to clusterINFO: deploying Gateway CRDs to cluster    gateway_conformance_test.go:127: creating GatewayClass for gateway conformance tests
```
change in this PR breaks it in separate lines
```log
INFO: deploying Kong RBACs to cluster
INFO: deploying Kong knative RBACs to cluster
INFO: deploying Kong gateway RBACs to cluster
INFO: deploying Kong CRDs RBACs to cluster
INFO: deploying Kong CRDs to cluster
INFO: deploying Gateway CRDs to cluster
```


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Special notes for your reviewer**:

Something to consider is to get rid of bare `fmt.Printf` in test helpers and use a preconfigured logger for this use-case. maybe something to investigate during loggers clean-up proposed in https://github.com/Kong/kubernetes-ingress-controller/issues/1893.

<!-- Here you can add any open questions or notes that you might have for reviewers -->
