### PR TITLE
fix: gernerate a catch-all route for rules with no matches and no hostnames in HTTPRoute and GRPCRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,14 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+
+### Changes
+
+- Generate a wildcard routes to match all `HTTP` or `GRPC` requests for rules
+  in `HTTPRoute` or `GRPCRoute` if there are no matches in the rule and no
+  hostnames in their parent objects.
+  [#4526](https://github.com/Kong/kubernetes-ingress-controller/pull/4528)
+
 ### Fixed
 
 - Display Service ports on generated Kong services, instead of a static default

--- a/internal/dataplane/parser/translate_grpcroute.go
+++ b/internal/dataplane/parser/translate_grpcroute.go
@@ -168,13 +168,6 @@ func validateGRPCRoute(grpcRoute *gatewayv1alpha2.GRPCRoute) error {
 		if len(grpcRoute.Spec.Rules) == 0 {
 			return translators.ErrRouteValidationNoRules
 		}
-		// REVIEW: remove this to generate a "catch-all" route from rule with no matches and no hostnames in its parent GRPCRoute.
-		for _, rule := range grpcRoute.Spec.Rules {
-			if len(rule.Matches) == 0 {
-				return translators.ErrRouteValidationNoMatchRulesOrHostnamesSpecified
-			}
-		}
 	}
-
 	return nil
 }

--- a/internal/dataplane/parser/translate_grpcroute_test.go
+++ b/internal/dataplane/parser/translate_grpcroute_test.go
@@ -359,6 +359,17 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						},
 					},
 				},
+				{
+					Service: kong.Service{
+						Name: kong.String("grpcroute.default.grpcroute-no-hostnames-no-matches._.0"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service0",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
 				"grpcroute.default.grpcroute-1._.0": {
@@ -366,6 +377,14 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Route: kong.Route{
 							Name:       kong.String("grpcroute.default.grpcroute-1._.0.0"),
 							Expression: kong.String(`http.path == "/v1/foo"`),
+						},
+					},
+				},
+				"grpcroute.default.grpcroute-no-hostnames-no-matches._.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("grpcroute.default.grpcroute-no-hostnames-no-matches._.0.0"),
+							Expression: kong.String(translators.CatchAllHTTPExpression),
 						},
 					},
 				},
@@ -377,14 +396,6 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Name:      "grpcroute-no-rules",
-						},
-					}),
-				newResourceFailure(translators.ErrRouteValidationNoMatchRulesOrHostnamesSpecified.Error(),
-					&gatewayv1alpha2.GRPCRoute{
-						TypeMeta: grpcRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "grpcroute-no-hostnames-no-matches",
 						},
 					}),
 			},

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -339,6 +339,7 @@ func generateKongRoutesFromHTTPRouteMatches(
 		// but only backends as long as there are hostnames. In this case, we
 		// match all traffic based on the hostname and leave all other routing
 		// options default.
+		// for rules with no hostnames, we generate a "catch-all" route for it.
 		r := kongstate.Route{
 			Ingress: ingressObjectInfo,
 			Route: kong.Route{
@@ -348,14 +349,6 @@ func generateKongRoutesFromHTTPRouteMatches(
 				Tags:         tags,
 			},
 		}
-
-		// however in this case there must actually be some present hostnames
-		// configured for the HTTPRoute or else it's not valid.
-		if len(hostnames) == 0 {
-			return []kongstate.Route{}, translators.ErrRouteValidationNoMatchRulesOrHostnamesSpecified
-		}
-
-		// otherwise apply the hostnames to the route
 		r.Hosts = append(r.Hosts, hostnames...)
 
 		return []kongstate.Route{r}, nil

--- a/internal/dataplane/parser/translators/atc_utils.go
+++ b/internal/dataplane/parser/translators/atc_utils.go
@@ -21,6 +21,16 @@ const (
 	ResourceKindBitsGRPCRoute = 1
 )
 
+const (
+	// CatchAllHTTPExpression is the expression to match all HTTP/HTTPS requests.
+	// For rules with no matches and no hostnames in its parent HTTPRoute or GRPCRoute,
+	// we need to generate a "catch-all" route for the rule:
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4526
+	// but Kong does not allow empty expression in expression router,
+	// so we define this is we need a route to match all HTTP/HTTPS requests.
+	CatchAllHTTPExpression = `(net.protocol == "http") || (net.protocol == "https")`
+)
+
 // -----------------------------------------------------------------------------
 // Translator - common functions in translating expression(ATC) routes from multiple kinds of k8s objects.
 // -----------------------------------------------------------------------------

--- a/internal/dataplane/parser/translators/grpcroute_atc.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc.go
@@ -486,6 +486,10 @@ func KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(
 		grpcRoute.Annotations,
 	)
 	atc.ApplyExpression(&r.Route, matcher, matchWithPriority.Priority)
+	if r.Expression == nil || len(*r.Expression) == 0 {
+		r.Expression = kong.String(CatchAllHTTPExpression)
+		r.Priority = &matchWithPriority.Priority
+	}
 
 	return r
 }

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -33,8 +33,17 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 			name:              "no hostnames and no matches",
 			routeName:         "empty_route.default.0.0",
 			ingressObjectInfo: util.K8sObjectInfo{},
-			expectedRoutes:    []kongstate.Route{},
-			expectedError:     ErrRouteValidationNoMatchRulesOrHostnamesSpecified,
+			expectedRoutes: []kongstate.Route{
+				{
+					Route: kong.Route{
+						Name:         kong.String("empty_route.default.0.0"),
+						PreserveHost: kong.Bool(true),
+						StripPath:    kong.Bool(false),
+						Expression:   kong.String(CatchAllHTTPExpression),
+					},
+					ExpressionRoutes: true,
+				},
+			},
 		},
 		{
 			name:              "no matches but have hostnames",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Generate a wildcard route that matches any HTTP/GRPC requests for rules in `HTTPRoute`/`GRPCRoute` with no matches and no hostnames in their parent objects.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4526

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
TODO: add integration tests?
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
