### PR TITLE
fix(test_e2e): fix data race in setting proxy URL in TestDefaultIngressClass

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -496,7 +496,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	}, ingressWait, time.Second)
 
 	t.Log("getting kong proxy IP after LB provisioning")
-	proxyURL = "http://" + getKongProxyIP(ctx, t, env)
+	proxyURLForDefaultIngress := "http://" + getKongProxyIP(ctx, t, env)
 
 	t.Log("creating classless global KongClusterPlugin")
 	kongclusterplugin := &kongv1.KongClusterPlugin{
@@ -518,9 +518,9 @@ func TestDefaultIngressClass(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURL))
+		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("%s/abbosiysaltanati", proxyURLForDefaultIngress))
 		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURLForDefaultIngress, err)
 			return false
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

As reported in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/5898822139/job/16000452847#step:5:701, there is a data race in setting proxy URL in e2e test case `TestDefaultIngressClass`. In the PR we set the proxy URL from the ingress with default address in a new variable to avoid the data race.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
