### PR TITLE
chore: bump Kong Gateway to 3.4 (#4534)

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         # TODO: Consider changing to "kong:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.3"
+        default: "3.4"
         required: false
       kong-enterprise-container-repo:
         type: string
@@ -21,7 +21,7 @@ on:
         type: string
         # TODO: Consider changing to "kong/kong-gateway:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.3"
+        default: "3.4"
         required: false
 
 jobs:

--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.3'
+  newTag: '3.4'
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.3'
+  newTag: '3.4'

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.3'
+  newTag: '3.4'
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
   newTag: '2.11'

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -2215,7 +2215,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2220,7 +2220,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -2230,7 +2230,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -2230,7 +2230,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.3
+        image: kong:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -2106,7 +2106,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.3
+        image: kong:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -2215,7 +2215,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.3
+        image: kong:3.4
         lifecycle:
           preStop:
             exec:

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -2169,7 +2169,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         lifecycle:
           preStop:
             exec:
@@ -2288,7 +2288,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -2387,7 +2387,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
@@ -2402,7 +2402,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.3
+        image: kong/kong-gateway:3.4
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -2124,7 +2124,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: traditional
-        image: kong:3.3
+        image: kong:3.4
         lifecycle:
           preStop:
             exec:
@@ -2225,7 +2225,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong:3.3
+        image: kong:3.4
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -2314,7 +2314,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.3
+        image: kong:3.4
         name: kong-migrations
       initContainers:
       - command:
@@ -2327,7 +2327,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong:3.3
+        image: kong:3.4
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/internal/dataplane/parser/golden_test.go
+++ b/internal/dataplane/parser/golden_test.go
@@ -29,7 +29,7 @@ var (
 	updateGolden = flag.Bool("update", false, "update golden files")
 
 	// defaultKongVersion is the default Kong version to use in tests. Can be overridden in a test case.
-	defaultKongVersion = semver.MustParse("3.3.0")
+	defaultKongVersion = semver.MustParse("3.4.0")
 
 	// defaultFeatureFlags is the default set of feature flags to use in tests. Can be overridden in a test case.
 	defaultFeatureFlags = func() parser.FeatureFlags {


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #4534 to `release/2.11.x`

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
