### PR TITLE
refactor: use helpers for certs in konnect_test.go, remove redundant type TLSPair

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -44,11 +44,6 @@ import (
 // conflicts with the integration configuration.
 // -----------------------------------------------------------------------------
 
-// TLSPair is a PEM certificate+key pair.
-type TLSPair struct {
-	Key, Cert string
-}
-
 const (
 	// webhookKINDConfig is a KIND configuration used for TestWebhookUpdate. KIND, when running in GitHub Actions, is
 	// a bit wonky with handling Secret updates, and they do not propagate to container filesystems in a reasonable


### PR DESCRIPTION


**What this PR does / why we need it**:

- get rid of the redundant type (nowhere used) `TLSPair` defined in the package `e2e` (file `test/e2e/features_test.go`)
- in `test/e2e/konnect_test.go` for generating certificate to be used with connect for authentication use helper `certificate.MustGenerateSelfSignedCertPEMFormat()`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Last from the series, closes #4118

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

I think everywhere in tests now helpers are used for certs if you know omitted place please point me at it.

Since the proposed change modifies `e2e` tests, they are run for this PR with the label `ci/run-e2e` to verify the proposed change.

<!-- Here you can add any open questions or notes that you might have for reviewers -->
