### PR TITLE
feat: support `UDPRoute` when expression router enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,11 +81,13 @@ Adding a new version? You'll need three changes:
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)
 - `konghq.com/rewrite` annotation has been introduced to manage URI rewriting.
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)
-- Added translator to translate `TCPRoute` in gateway APIs to
+- Added translator to translate `TCPRoute` and `UDPRoute` in gateway APIs to
   expression based kong routes. Similar to ingresses, this translator is only
   enabled when feature gate `ExpressionRoutes` is turned on and the managed
-  Kong gateway runs in router flavor `expressions`.
+  Kong gateway runs in router flavor `expressions`, and version is greater or
+  equal to `3.4`.
   [#4385](https://github.com/Kong/kubernetes-ingress-controller/pull/4385)
+  [#4550](https://github.com/Kong/kubernetes-ingress-controller/pull/4550)
 
 ### Changes
 

--- a/internal/dataplane/parser/translate_failures_test.go
+++ b/internal/dataplane/parser/translate_failures_test.go
@@ -20,8 +20,9 @@ import (
 
 // This file contains unit test functions to test translation failures genreated by parser.
 
-func newResourceFailure(reason string, objects ...client.Object) failures.ResourceFailure {
-	failure, _ := failures.NewResourceFailure(reason, objects...)
+func newResourceFailure(t *testing.T, reason string, objects ...client.Object) failures.ResourceFailure {
+	failure, err := failures.NewResourceFailure(reason, objects...)
+	require.NoError(t, err)
 	return failure
 }
 

--- a/internal/dataplane/parser/translate_grpcroute_test.go
+++ b/internal/dataplane/parser/translate_grpcroute_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
@@ -27,11 +26,6 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 	parser.featureFlags.CombinedServiceRoutes = true
 	parser.featureFlags.ExpressionRoutes = true
 	grpcRouteTypeMeta := metav1.TypeMeta{Kind: "GRPCRoute", APIVersion: gatewayv1alpha2.SchemeGroupVersion.String()}
-
-	newResourceFailure := func(reason string, objects ...client.Object) failures.ResourceFailure {
-		failure, _ := failures.NewResourceFailure(reason, objects...)
-		return failure
-	}
 
 	testCases := []struct {
 		name                 string

--- a/internal/dataplane/parser/translate_grpcroute_test.go
+++ b/internal/dataplane/parser/translate_grpcroute_test.go
@@ -384,7 +384,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedFailures: []failures.ResourceFailure{
-				newResourceFailure(translators.ErrRouteValidationNoRules.Error(),
+				newResourceFailure(t, translators.ErrRouteValidationNoRules.Error(),
 					&gatewayv1alpha2.GRPCRoute{
 						TypeMeta: grpcRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -28,7 +28,7 @@ func (p *Parser) ingressRulesFromTCPRoutes() ingressRules {
 	for _, tcproute := range tcpRouteList {
 		// Disable the translation to expression routes and register translation errors
 		// when expression route is enabled and Kong version is less than 3.4.
-		if p.featureFlags.ExpressionRoutes && p.kongVersion.Compare(versions.ExpressionRouterL4Cutoff) < 0 {
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.LT(versions.ExpressionRouterL4Cutoff) {
 			p.registerResourceFailureNotSupportedForExpressionRoutes(tcproute)
 			continue
 		}

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -6,6 +6,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -25,6 +26,13 @@ func (p *Parser) ingressRulesFromTCPRoutes() ingressRules {
 
 	var errs []error
 	for _, tcproute := range tcpRouteList {
+		// Disable the translation to expression routes and register translation errors
+		// when expression route is enabled and Kong version is less than 3.4.
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.Compare(versions.ExpressionRouterL4Cutoff) < 0 {
+			p.registerResourceFailureNotSupportedForExpressionRoutes(tcproute)
+			continue
+		}
+
 		if err := p.ingressRulesFromTCPRoute(&result, tcproute); err != nil {
 			err = fmt.Errorf("TCPRoute %s/%s can't be routed: %w", tcproute.Namespace, tcproute.Name, err)
 			errs = append(errs, err)

--- a/internal/dataplane/parser/translate_tcproute_test.go
+++ b/internal/dataplane/parser/translate_tcproute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
@@ -219,6 +220,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 			require.NoError(t, err)
 			parser := mustNewParser(t, fakestore)
 			parser.featureFlags.ExpressionRoutes = true
+			parser.kongVersion = versions.ExpressionRouterL4Cutoff
 
 			failureCollector, err := failures.NewResourceFailuresCollector(logrus.New())
 			require.NoError(t, err)

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -28,7 +28,7 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 	for _, udproute := range udpRouteList {
 		// Disable the translation to expression routes and register translation errors
 		// when expression route is enabled and Kong version is less than 3.4.
-		if p.featureFlags.ExpressionRoutes && p.kongVersion.Compare(versions.ExpressionRouterL4Cutoff) < 0 {
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.LT(versions.ExpressionRouterL4Cutoff) {
 			p.registerResourceFailureNotSupportedForExpressionRoutes(udproute)
 			continue
 		}
@@ -49,7 +49,7 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 		}
 	}
 
-	// translate generated Kong Route to expression based route.
+	// Translate generated Kong Route to expression based route.
 	if p.featureFlags.ExpressionRoutes {
 		applyExpressionToIngressRules(&result)
 	}
@@ -92,7 +92,7 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 }
 
 // validateUDPRoute validates UDPRoute, and return a translation error if the spec is invalid.
-// validation for UDPRoutes will happen at a higher layer, but in spite of that we run
+// Validation for UDPRoutes will happen at a higher layer, but in spite of that we run
 // validation at this level as well as a fallback so that if routes are posted which
 // are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
 // at least try to provide a helpful message about the situation in the manager logs.

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -6,6 +6,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -25,8 +26,16 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 
 	var errs []error
 	for _, udproute := range udpRouteList {
-		if p.featureFlags.ExpressionRoutes {
+		// Disable the translation to expression routes and register translation errors
+		// when expression route is enabled and Kong version is less than 3.4.
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.Compare(versions.ExpressionRouterL4Cutoff) < 0 {
 			p.registerResourceFailureNotSupportedForExpressionRoutes(udproute)
+			continue
+		}
+
+		if err := validateUDPRoute(udproute); err != nil {
+			errs = append(errs, err)
+			p.registerTranslationFailure(err.Error(), udproute)
 			continue
 		}
 
@@ -38,6 +47,11 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 			// reported as successfully parsed.
 			p.registerSuccessfullyParsedObject(udproute)
 		}
+	}
+
+	// translate generated Kong Route to expression based route.
+	if p.featureFlags.ExpressionRoutes {
+		applyExpressionToIngressRules(&result)
 	}
 
 	if len(errs) > 0 {
@@ -53,24 +67,9 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 	// first we grab the spec and gather some metdata about the object
 	spec := udproute.Spec
 
-	// validation for UDPRoutes will happen at a higher layer, but in spite of that we run
-	// validation at this level as well as a fallback so that if routes are posted which
-	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
-	// at least try to provide a helpful message about the situation in the manager logs.
-	if len(spec.Rules) == 0 {
-		return translators.ErrRouteValidationNoRules
-	}
-
 	// each rule may represent a different set of backend services that will be accepting
 	// traffic, so we make separate routes and Kong services for every present rule.
 	for ruleNumber, rule := range spec.Rules {
-		// TODO: add this to a generic UDPRoute validation, and then we should probably
-		//       simply be calling validation on each udproute object at the begininning
-		//       of the topmost list.
-		if len(rule.BackendRefs) == 0 {
-			return fmt.Errorf("missing backendRef in rule")
-		}
-
 		// determine the routes needed to route traffic to services for this rule
 		routes, err := generateKongRoutesFromRouteRule(udproute, ruleNumber, rule)
 		if err != nil {
@@ -89,5 +88,22 @@ func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewa
 		result.ServiceNameToParent[*service.Service.Name] = udproute
 	}
 
+	return nil
+}
+
+// validateUDPRoute validates UDPRoute, and return a translation error if the spec is invalid.
+// validation for UDPRoutes will happen at a higher layer, but in spite of that we run
+// validation at this level as well as a fallback so that if routes are posted which
+// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
+// at least try to provide a helpful message about the situation in the manager logs.
+func validateUDPRoute(udproute *gatewayv1alpha2.UDPRoute) error {
+	if len(udproute.Spec.Rules) == 0 {
+		return translators.ErrRouteValidationNoRules
+	}
+	for _, rule := range udproute.Spec.Rules {
+		if len(rule.BackendRefs) == 0 {
+			return translators.ErrRotueValidationRuleNoBackendRef
+		}
+	}
 	return nil
 }

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -14,8 +15,10 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 var (
@@ -97,6 +100,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					},
 				},
 			},
+
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -189,9 +193,109 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					{
 						Route: kong.Route{
 							Name: kong.String("udproute.default.multiple-backends.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(80)},
+								{Port: kong.Int(81)},
+							},
+							Protocols: kong.StringSlice("udp"),
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "multiple udproutes with translation errors",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule-2", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service2").WithPort(8080).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "no-rule", Namespace: "default"},
+					Spec:       gatewayv1alpha2.UDPRouteSpec{},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule-2.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service2",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.single-rule.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(80)},
+							},
+							Protocols: kong.StringSlice("udp"),
+						},
+					},
+				},
+				"udproute.default.single-rule-2.0": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.single-rule-2.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(8080)},
+							},
+							Protocols: kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+			expectedFailures: []failures.ResourceFailure{
+				newResourceFailure(
+					translators.ErrRouteValidationNoRules.Error(),
+					&gatewayv1alpha2.UDPRoute{
+						TypeMeta:   udpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
+					},
+				),
 			},
 		},
 	}
@@ -258,7 +362,292 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
-	}{}
+	}{
+		{
+			name: "single UDPRoute with single rule",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			kongVersion: versions.ExpressionRouterL4Cutoff,
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.single-rule.0.0"),
+							Expression: kong.String("net.dst.port == 80"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single UDPRoute with multiple rules",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "multiple-rules", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service2").WithPort(81).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			kongVersion: versions.ExpressionRouterL4Cutoff,
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-rules.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-rules.1"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service2",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.multiple-rules.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.multiple-rules.0.0"),
+							Expression: kong.String("net.dst.port == 80"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+				"udproute.default.multiple-rules.1": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.multiple-rules.1.0"),
+							Expression: kong.String("net.dst.port == 81"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single UDPRoute with single rule and multiple backendRefs",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "multiple-backends", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+									builder.NewBackendRef("service1").WithPort(81).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			kongVersion: versions.ExpressionRouterL4Cutoff,
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-backends.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.multiple-backends.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.multiple-backends.0.0"),
+							Expression: kong.String("(net.dst.port == 80) || (net.dst.port == 81)"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple udproutes with translation errors",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule-2", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service2").WithPort(8080).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "no-rule", Namespace: "default"},
+					Spec:       gatewayv1alpha2.UDPRouteSpec{},
+				},
+			},
+			kongVersion: versions.ExpressionRouterL4Cutoff,
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule-2.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service2",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.single-rule.0.0"),
+							Expression: kong.String("net.dst.port == 80"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+				"udproute.default.single-rule-2.0": {
+					{
+						Route: kong.Route{
+							Name:       kong.String("udproute.default.single-rule-2.0.0"),
+							Expression: kong.String("net.dst.port == 8080"),
+							Protocols:  kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+			expectedFailures: []failures.ResourceFailure{
+				newResourceFailure(
+					translators.ErrRouteValidationNoRules.Error(),
+					&gatewayv1alpha2.UDPRoute{
+						TypeMeta:   udpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
+					},
+				),
+			},
+		},
+		{
+			name: "versions less than 3.4 could not translate to expression routes",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			kongVersion: semver.MustParse("3.3.0"),
+			expectedFailures: []failures.ResourceFailure{
+				newResourceFailure(
+					fmt.Sprintf("resource kind %s.%s not supported when expression routes enabled",
+						udpRouteTypeMeta.APIVersion, udpRouteTypeMeta.Kind),
+					&gatewayv1alpha2.UDPRoute{
+						TypeMeta:   udpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					},
+				),
+			},
+		},
+	}
 
 	for _, tc := range testCases {
 		tc := tc
@@ -285,7 +674,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
 				require.Equalf(t, expectedKongService.Backends, kongService.Backends,
 					"service %s should have expected backends", *expectedKongService.Name)
-				require.Equalf(t, "udp", kongService.Protocol, "service %s should use UDP protocol", *expectedKongService.Name)
+				require.Equalf(t, "udp", *kongService.Protocol, "service %s should use UDP protocol", *expectedKongService.Name)
 				// check for routes attached to the service
 				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
 				require.Lenf(t, kongService.Routes, len(expectedKongRoutes),

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -288,7 +288,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			},
 			expectedFailures: []failures.ResourceFailure{
 				newResourceFailure(
-					translators.ErrRouteValidationNoRules.Error(),
+					t, translators.ErrRouteValidationNoRules.Error(),
 					&gatewayv1alpha2.UDPRoute{
 						TypeMeta:   udpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
@@ -608,7 +608,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			},
 			expectedFailures: []failures.ResourceFailure{
 				newResourceFailure(
-					translators.ErrRouteValidationNoRules.Error(),
+					t, translators.ErrRouteValidationNoRules.Error(),
 					&gatewayv1alpha2.UDPRoute{
 						TypeMeta:   udpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
@@ -636,7 +636,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			kongVersion: semver.MustParse("3.3.0"),
 			expectedFailures: []failures.ResourceFailure{
 				newResourceFailure(
-					fmt.Sprintf("resource kind %s.%s not supported when expression routes enabled",
+					t, fmt.Sprintf("resource kind %s.%s not supported when expression routes enabled",
 						udpRouteTypeMeta.APIVersion, udpRouteTypeMeta.Kind),
 					&gatewayv1alpha2.UDPRoute{
 						TypeMeta:   udpRouteTypeMeta,

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -1,0 +1,317 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+)
+
+var (
+	udpRouteTypeMeta = metav1.TypeMeta{Kind: "UDPRoute", APIVersion: gatewayv1alpha2.SchemeGroupVersion.String()}
+)
+
+func TestIngressRulesFromUDPRoutes(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		udpRoutes            []*gatewayv1alpha2.UDPRoute
+		expectedKongServices []kongstate.Service
+		expectedKongRoutes   map[string][]kongstate.Route
+		expectedFailures     []failures.ResourceFailure
+	}{
+		{
+			name: "single UDPRoute with single rule",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.single-rule.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.single-rule.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(80)},
+							},
+							Protocols: kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single UDPRoute with multiple rules",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "multiple-rules", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service2").WithPort(81).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-rules.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+					},
+				},
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-rules.1"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service2",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.multiple-rules.0": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.multiple-rules.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(80)},
+							},
+							Protocols: kong.StringSlice("udp"),
+						},
+					},
+				},
+				"udproute.default.multiple-rules.1": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.multiple-rules.1.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: kong.Int(81)},
+							},
+							Protocols: kong.StringSlice("udp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single UDPRoute with single rule and multiple backendRefs",
+			udpRoutes: []*gatewayv1alpha2.UDPRoute{
+				{
+					TypeMeta:   udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "multiple-backends", Namespace: "default"},
+					Spec: gatewayv1alpha2.UDPRouteSpec{
+						Rules: []gatewayv1alpha2.UDPRouteRule{
+							{
+								BackendRefs: []gatewayv1alpha2.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+									builder.NewBackendRef("service1").WithPort(81).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     kong.String("udproute.default.multiple-backends.0"),
+						Protocol: kong.String("udp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+						},
+						{
+							Name:    "service1",
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
+						},
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"udproute.default.multiple-backends.0": {
+					{
+						Route: kong.Route{
+							Name: kong.String("udproute.default.multiple-backends.0.0"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				UDPRoutes: tc.udpRoutes,
+			})
+			require.NoError(t, err)
+			parser := mustNewParser(t, fakestore)
+			parser.featureFlags.CombinedServiceRoutes = true
+
+			failureCollector, err := failures.NewResourceFailuresCollector(logrus.New())
+			require.NoError(t, err)
+			parser.failuresCollector = failureCollector
+
+			result := parser.ingressRulesFromUDPRoutes()
+			// check services
+			require.Len(t, result.ServiceNameToServices, len(tc.expectedKongServices),
+				"should have expected number of services")
+			for _, expectedKongService := range tc.expectedKongServices {
+				kongService, ok := result.ServiceNameToServices[*expectedKongService.Name]
+				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
+				require.Equalf(t, expectedKongService.Backends, kongService.Backends,
+					"service %s should have expected backends", *expectedKongService.Name)
+				require.Equalf(t, "udp", *kongService.Protocol, "service %s should use UDP protocol", *expectedKongService.Name)
+				// check for routes attached to the service
+				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
+				require.Lenf(t, kongService.Routes, len(expectedKongRoutes),
+					"service %s should have expected number of routes", *expectedKongService.Name)
+
+				kongRouteNameToRoute := lo.SliceToMap(kongService.Routes, func(r kongstate.Route) (string, kongstate.Route) {
+					return *r.Name, r
+				})
+				for _, expectedRoute := range expectedKongRoutes {
+					routeName := expectedRoute.Name
+					r, ok := kongRouteNameToRoute[*routeName]
+					require.Truef(t, ok, "should find route %s", *routeName)
+					require.Equalf(t, expectedRoute.Destinations, r.Destinations, "route %s should have expected destinations", *routeName)
+					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
+				}
+			}
+
+			// check translation failures
+			translationFailures := failureCollector.PopResourceFailures()
+			require.Len(t, translationFailures, len(tc.expectedFailures))
+			for _, expectedTranslationFailure := range tc.expectedFailures {
+				expectedFailureMessage := expectedTranslationFailure.Message()
+				require.True(t, lo.ContainsBy(translationFailures, func(failure failures.ResourceFailure) bool {
+					return strings.Contains(failure.Message(), expectedFailureMessage)
+				}))
+			}
+		})
+	}
+}
+
+func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		udpRoutes            []*gatewayv1alpha2.UDPRoute
+		kongVersion          semver.Version
+		expectedKongServices []kongstate.Service
+		expectedKongRoutes   map[string][]kongstate.Route
+		expectedFailures     []failures.ResourceFailure
+	}{}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				UDPRoutes: tc.udpRoutes,
+			})
+			require.NoError(t, err)
+			parser := mustNewParser(t, fakestore)
+			parser.featureFlags.CombinedServiceRoutes = true
+			parser.featureFlags.ExpressionRoutes = true
+			parser.kongVersion = tc.kongVersion
+
+			failureCollector, err := failures.NewResourceFailuresCollector(logrus.New())
+			require.NoError(t, err)
+			parser.failuresCollector = failureCollector
+
+			result := parser.ingressRulesFromUDPRoutes()
+			// check services
+			require.Len(t, result.ServiceNameToServices, len(tc.expectedKongServices),
+				"should have expected number of services")
+			for _, expectedKongService := range tc.expectedKongServices {
+				kongService, ok := result.ServiceNameToServices[*expectedKongService.Name]
+				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
+				require.Equalf(t, expectedKongService.Backends, kongService.Backends,
+					"service %s should have expected backends", *expectedKongService.Name)
+				require.Equalf(t, "udp", kongService.Protocol, "service %s should use UDP protocol", *expectedKongService.Name)
+				// check for routes attached to the service
+				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
+				require.Lenf(t, kongService.Routes, len(expectedKongRoutes),
+					"service %s should have expected number of routes", *expectedKongService.Name)
+
+				kongRouteNameToRoute := lo.SliceToMap(kongService.Routes, func(r kongstate.Route) (string, kongstate.Route) {
+					return *r.Name, r
+				})
+				for _, expectedRoute := range expectedKongRoutes {
+					routeName := expectedRoute.Name
+					r, ok := kongRouteNameToRoute[*routeName]
+					require.Truef(t, ok, "should find route %s", *routeName)
+					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
+					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
+				}
+			}
+
+			// check translation failures
+			translationFailures := failureCollector.PopResourceFailures()
+			require.Len(t, translationFailures, len(tc.expectedFailures))
+			for _, expectedTranslationFailure := range tc.expectedFailures {
+				expectedFailureMessage := expectedTranslationFailure.Message()
+				require.True(t, lo.ContainsBy(translationFailures, func(failure failures.ResourceFailure) bool {
+					return strings.Contains(failure.Message(), expectedFailureMessage)
+				}))
+			}
+		})
+	}
+}

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
-var (
-	udpRouteTypeMeta = metav1.TypeMeta{Kind: "UDPRoute", APIVersion: gatewayv1alpha2.SchemeGroupVersion.String()}
-)
+var udpRouteTypeMeta = metav1.TypeMeta{Kind: "UDPRoute", APIVersion: gatewayv1alpha2.SchemeGroupVersion.String()}
 
 func TestIngressRulesFromUDPRoutes(t *testing.T) {
 	testCases := []struct {

--- a/internal/dataplane/parser/translators/translator_errors.go
+++ b/internal/dataplane/parser/translators/translator_errors.go
@@ -6,4 +6,5 @@ var (
 	ErrRouteValidationNoRules                          = errors.New("no rules provided")
 	ErrRouteValidationQueryParamMatchesUnsupported     = errors.New("query param matches are not yet supported")
 	ErrRouteValidationNoMatchRulesOrHostnamesSpecified = errors.New("no match rules or hostnames specified")
+	ErrRotueValidationRuleNoBackendRef                 = errors.New("no backendRefs in rule")
 )

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -27,4 +27,7 @@ var (
 
 	// TLSPassthroughCutoff is the lowest Kong version with support for TLS passthrough.
 	TLSPassthroughCutoff = semver.Version{Major: 2, Minor: 7}
+
+	// ExpressionRouterL4Cutoff is the lowest Kong version with support of L4 proxy in expression router.
+	ExpressionRouterL4Cutoff = semver.Version{Major: 3, Minor: 4}
 )

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -102,7 +102,7 @@ func TestHTTPRouteExample(t *testing.T) {
 }
 
 func TestUDPRouteExample(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Log("locking UDP port")
 	udpMutex.Lock()
 	t.Cleanup(func() {
@@ -150,7 +150,7 @@ func TestUDPRouteExample(t *testing.T) {
 }
 
 func TestTCPRouteExample(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	t.Cleanup(func() {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 const (
@@ -423,11 +422,11 @@ func setIngressClassNameWithRetry(ctx context.Context, namespace string, ingress
 
 // Expression router is not supported for some objects and features.
 // For example, KongIngress is not supported by intention;
-// TCPRoute is not supported because Kong does not support expression router on stream proxy.
+// TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
 // When the test case depends on the object or feature not supported, we skip it if expression router is used.
 func skipTestForExpressionRouter(t *testing.T) {
 	t.Helper()
-	routerFlavor := testenv.KongRouterFlavor()
+	routerFlavor := eventuallyGetKongRouterFlavor(t, proxyAdminURL)
 	if routerFlavor == kongRouterFlavorExpressions {
 		t.Skipf("skip test case %s when expression router enabled", t.Name())
 	}

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTCPRouteEssentials(t *testing.T) {
 	ctx := context.Background()
-	RunWhenKongExpressionRouterWithVersion(t, ">=3.4,0")
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	t.Cleanup(func() {

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTCPRouteEssentials(t *testing.T) {
 	ctx := context.Background()
-
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4,0")
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	t.Cleanup(func() {
@@ -412,7 +412,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 func TestTCPRouteReferenceGrant(t *testing.T) {
 	ctx := context.Background()
-
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	t.Cleanup(func() {

--- a/test/integration/udproute_test.go
+++ b/test/integration/udproute_test.go
@@ -28,9 +28,8 @@ import (
 const testdomain = "konghq.com"
 
 func TestUDPRouteEssentials(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	ctx := context.Background()
-
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("locking UDP port")

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -67,7 +67,7 @@ func RunWhenKongExpressionRouterWithVersion(t *testing.T, vRangeStr string) {
 
 	if routerFlavor == kongRouterFlavorExpressions {
 		if !vRange(version) {
-			t.Skipf("skip test when expression router enabled and versio is %s", version.String())
+			t.Skipf("skip test when expression router enabled and version is %s", version.String())
 		}
 	}
 }

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -59,6 +59,19 @@ func RunWhenKongEnterprise(t *testing.T) {
 	}
 }
 
+func RunWhenKongExpressionRouterWithVersion(t *testing.T, vRangeStr string) {
+	routerFlavor := eventuallyGetKongRouterFlavor(t, proxyAdminURL)
+	version := eventuallyGetKongVersion(t, proxyAdminURL)
+	vRange, err := kong.NewRange(vRangeStr)
+	require.NoError(t, err)
+
+	if routerFlavor == kongRouterFlavorExpressions {
+		if !vRange(version) {
+			t.Skipf("skip test when expression router enabled and versio is %s", version.String())
+		}
+	}
+}
+
 func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
 	t.Helper()
 
@@ -87,4 +100,19 @@ func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) string {
 		assert.NoError(t, err)
 	}, time.Minute, time.Second)
 	return dbmode
+}
+
+func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) string {
+	t.Helper()
+
+	var (
+		err          error
+		routerFlavor string
+	)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		routerFlavor, err = helpers.GetKongRouterFlavor(adminURL, consts.KongTestPassword)
+		assert.NoError(t, err)
+	}, time.Minute, time.Second)
+	return routerFlavor
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

support `UDPRoute` with expression router when Kong version is >3.4, and add tests for it.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4539 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
