### PR TITLE
tests: add experimental conformance test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ e2e-tests
 
 # for this repo only
 kong-ingress-controller
+conformance-tests-report.yaml
 
 # ignore vendor tree
 vendor

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@ run:
   build-tags:
   - integration_tests
   - e2e_tests
-  - experimental
   - conformance_tests
   - istio_tests
   - envtest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ run:
   build-tags:
   - integration_tests
   - e2e_tests
+  - experimental
   - conformance_tests
   - istio_tests
   - envtest

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,22 @@ test.conformance: _check.container.environment go-junit-report
 		./test/conformance | \
 	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -parser gotest
 
+.PHONY: test.conformance-experimental
+test.conformance-experimental: _check.container.environment go-junit-report
+	@TEST_DATABASE_MODE="off" \
+		GOFLAGS="-tags=conformance_tests,experimental" \
+		KONG_TEST_EXPRESSION_ROUTES="true" \
+		go test \
+		-ldflags " \
+		-X $(REPO_URL)/v2/internal/manager/metadata.ProjectURL=$(REPO_URL) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG)" \
+		-v \
+		-race $(GOTESTFLAGS) \
+		-timeout $(INTEGRATION_TEST_TIMEOUT) \
+		-parallel $(NCPU) \
+		./test/conformance | \
+	$(GOJUNIT) -iocopy -out $(JUNIT_REPORT) -parser gotest
+
 .PHONY: test.integration
 test.integration: test.integration.dbless test.integration.postgres
 

--- a/Makefile
+++ b/Makefile
@@ -317,8 +317,9 @@ test.conformance: _check.container.environment go-junit-report
 .PHONY: test.conformance-experimental
 test.conformance-experimental: _check.container.environment go-junit-report
 	@TEST_DATABASE_MODE="off" \
-		GOFLAGS="-tags=conformance_tests,experimental" \
+		GOFLAGS="-tags=conformance_tests" \
 		KONG_TEST_EXPRESSION_ROUTES="true" \
+		TEST_EXPERIMENTAL_CONFORMANCE="true" \
 		go test \
 		-ldflags " \
 		-X $(REPO_URL)/v2/internal/manager/metadata.ProjectURL=$(REPO_URL) \

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,8 @@ test.conformance-experimental: _check.container.environment go-junit-report
 		go test \
 		-ldflags " \
 		-X $(REPO_URL)/v2/internal/manager/metadata.ProjectURL=$(REPO_URL) \
-		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG)" \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Release=$(TAG) \
+		-X $(REPO_URL)/v2/internal/manager/metadata.Repo=$(REPO_INFO)" \
 		-v \
 		-race $(GOTESTFLAGS) \
 		-timeout $(INTEGRATION_TEST_TIMEOUT) \

--- a/internal/manager/metadata/metadata.go
+++ b/internal/manager/metadata/metadata.go
@@ -1,6 +1,8 @@
 // Package metadata includes metadata variables for logging and reporting.
 package metadata
 
+import "strings"
+
 // -----------------------------------------------------------------------------
 // Controller Manager - Versioning Information
 // -----------------------------------------------------------------------------
@@ -10,19 +12,30 @@ package metadata
 
 var (
 	// Release returns the release version, generally a semver like v2.0.0.
-	Release = "NOT_SET"
+	Release = NotSet
 
 	// Repo returns the git repository URL like git@github.com:Kong/kubernetes-ingress-controller.git.
-	Repo = "NOT_SET"
+	Repo = NotSet
 
 	// ProjectURL returns address of project website - git repository like github.com/kong/kubernetes-ingress-controller.
-	ProjectURL = "NOT_SET"
+	ProjectURL = NotSet
 
 	// Commit returns the SHA from the current branch HEAD.
-	Commit = "NOT_SET"
+	Commit = NotSet
+
+	ProjectName = projectNameFromRepo(Repo)
 )
 
 const (
 	Organization = "Kong"
-	ProjectName  = "kubernetes-ingress-controller"
+	NotSet       = "NOT_SET"
 )
+
+func projectNameFromRepo(repo string) string {
+	parts := strings.Split(repo, "/")
+	projectName := strings.TrimSpace(strings.TrimSuffix(parts[len(parts)-1], ".git"))
+	if projectName == "" {
+		return NotSet
+	}
+	return projectName
+}

--- a/internal/manager/metadata/metadata.go
+++ b/internal/manager/metadata/metadata.go
@@ -12,9 +12,17 @@ var (
 	// Release returns the release version, generally a semver like v2.0.0.
 	Release = "NOT_SET"
 
-	// Repo returns the git repository URL.
+	// Repo returns the git repository URL like git@github.com:Kong/kubernetes-ingress-controller.git.
 	Repo = "NOT_SET"
+
+	// ProjectURL returns address of project website - git repository like github.com/kong/kubernetes-ingress-controller.
+	ProjectURL = "NOT_SET"
 
 	// Commit returns the SHA from the current branch HEAD.
 	Commit = "NOT_SET"
+)
+
+const (
+	Organization = "Kong"
+	ProjectName  = "kubernetes-ingress-controller"
 )

--- a/internal/manager/metadata/metadata_test.go
+++ b/internal/manager/metadata/metadata_test.go
@@ -1,0 +1,52 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectNameFromRepo(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Repo     string
+		Expected string
+	}{
+		{
+			Name:     "valid Git SSH repo",
+			Repo:     "git@github.com:Kong/kubernetes-ingress-controller.git",
+			Expected: "kubernetes-ingress-controller",
+		},
+		{
+			Name:     "valid Git HTTPS repo",
+			Repo:     "https://github.com/Kong/kubernetes-ingress-controller.git",
+			Expected: "kubernetes-ingress-controller",
+		},
+		{
+			Name:     "not set",
+			Repo:     NotSet,
+			Expected: "NOT_SET",
+		},
+		{
+			Name:     "empty repo",
+			Repo:     "",
+			Expected: "NOT_SET",
+		},
+		{
+			Name:     "empty repo (whitespace)",
+			Repo:     "    ",
+			Expected: "NOT_SET",
+		},
+		{
+			Name:     "repo set to arbitral string",
+			Repo:     "this-is-my-project",
+			Expected: "this-is-my-project",
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			require.Equal(t, tC.Expected, projectNameFromRepo(tC.Repo))
+		})
+	}
+}

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -1,5 +1,8 @@
 //go:build conformance_tests && !experimental
 
+// Due to having !experimental, this file is not checked by golangci-lint.
+// This is shortcoming of golangci-lint, see https://github.com/golangci/golangci-lint/issues/1646
+
 package conformance
 
 import (
@@ -66,15 +69,12 @@ func TestGatewayConformance(t *testing.T) {
 	if testenv.ExpressionRoutesEnabled() {
 		skipTests = skippedTestsForExpressionRoutes
 	}
-	cleanUpResources := true
-	if testenv.IsCI() {
-		cleanUpResources = false
-	}
+
 	cSuite := suite.New(suite.Options{
 		Client:                     client,
 		GatewayClassName:           gatewayClassName,
 		Debug:                      true,
-		CleanupBaseResources:       cleanUpResources,
+		CleanupBaseResources:       !testenv.IsCI(),
 		EnableAllSupportedFeatures: true,
 		ExemptFeatures:             suite.MeshCoreFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -7,6 +7,8 @@ import (
 
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 var skippedTestsForTraditionalAndExpressionRoutes = []string{
@@ -61,14 +63,18 @@ func TestGatewayConformance(t *testing.T) {
 	// Conformance tests are run for both configs with and without
 	// KONG_TEST_EXPRESSION_ROUTES='true'.
 	skipTests := skippedTestsForTraditionalRoutes
-	if expressionRoutesEnabled() {
+	if testenv.ExpressionRoutesEnabled() {
 		skipTests = skippedTestsForExpressionRoutes
+	}
+	cleanUpResources := true
+	if testenv.IsCI() {
+		cleanUpResources = false
 	}
 	cSuite := suite.New(suite.Options{
 		Client:                     client,
 		GatewayClassName:           gatewayClassName,
 		Debug:                      true,
-		CleanupBaseResources:       true,
+		CleanupBaseResources:       cleanUpResources,
 		EnableAllSupportedFeatures: true,
 		ExemptFeatures:             suite.MeshCoreFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -1,38 +1,15 @@
-//go:build conformance_tests
+//go:build conformance_tests && !experimental
 
 package conformance
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
-	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 )
 
-const (
-	showDebug                  = true
-	shouldCleanup              = true
-	enableAllSupportedFeatures = true
-)
-
-var conformanceTestsBaseManifests = fmt.Sprintf("%s/conformance/base/manifests.yaml", consts.GatewayRawRepoURL)
-
-var skippedTestsForExpressionRoutes = []string{
+var skippedTestsForTraditionalAndExpressionRoutes = []string{
 	// extended conformance
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4166
 	// requires an 8080 listener, which our manually-built test gateway does not have
@@ -64,108 +41,40 @@ var skippedTestsForExpressionRoutes = []string{
 	tests.HTTPRouteRewritePath.ShortName,
 }
 
-var skippedTestsForTraditionalRoutes = []string{
+var skippedTestsForExpressionRoutes = skippedTestsForTraditionalAndExpressionRoutes
+
+var skippedTestsForTraditionalRoutes = append(
+	skippedTestsForTraditionalAndExpressionRoutes,
 	// core conformance
 	tests.HTTPRouteHeaderMatching.ShortName,
-
 	// extended conformance
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4164
 	// only 10 and 11 broken because traditional/traditional_compatible router
 	// cannot support the path > method > header precedence,
 	// but no way to omit individual cases.
 	tests.HTTPRouteMethodMatching.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/4166
-	// requires an 8080 listener, which our manually-built test gateway does not have
-	tests.HTTPRouteRedirectPortAndScheme.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3680
-	tests.GatewayClassObservedGenerationBump.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3678
-	tests.TLSRouteSimpleSameNamespace.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3679
-	tests.HTTPRouteQueryParamMatching.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3681
-	tests.HTTPRouteRedirectPort.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3682
-	tests.HTTPRouteRedirectScheme.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/4165
-	tests.HTTPRouteRequestMirror.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/4546
-	tests.GatewayWithAttachedRoutes.ShortName,
-	tests.GatewayWithAttachedRoutesWithPort8080.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/4562
-	tests.TLSRouteInvalidReferenceGrant.ShortName,
-
-	// experimental conformance
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3684
-	tests.HTTPRouteRedirectPath.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3685
-	tests.HTTPRouteRewriteHost.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3686
-	tests.HTTPRouteRewritePath.ShortName,
-}
+)
 
 func TestGatewayConformance(t *testing.T) {
-	t.Log("configuring environment for gateway conformance tests")
-	client, err := client.New(env.Cluster().Config(), client.Options{})
-	require.NoError(t, err)
-	require.NoError(t, gatewayv1alpha2.AddToScheme(client.Scheme()))
-	require.NoError(t, gatewayv1beta1.AddToScheme(client.Scheme()))
+	client, gatewayClassName := prepareEnvForGatewayConformanceTests(t)
 
-	featureGateFlag := fmt.Sprintf("--feature-gates=%s", consts.DefaultFeatureGates)
+	// Conformance tests are run for both configs with and without
+	// KONG_TEST_EXPRESSION_ROUTES='true'.
+	skipTests := skippedTestsForTraditionalRoutes
 	if expressionRoutesEnabled() {
-		t.Log("expression routes enabled")
-		featureGateFlag = fmt.Sprintf("--feature-gates=%s", consts.ConformanceExpressionRoutesTestsFeatureGates)
-	}
-
-	t.Log("starting the controller manager")
-	cert, key := certificate.GetKongSystemSelfSignedCerts()
-	args := []string{
-		fmt.Sprintf("--ingress-class=%s", ingressClass),
-		fmt.Sprintf("--admission-webhook-cert=%s", cert),
-		fmt.Sprintf("--admission-webhook-key=%s", key),
-		fmt.Sprintf("--admission-webhook-listen=%s:%d", testutils.AdmissionWebhookListenHost, testutils.AdmissionWebhookListenPort),
-		"--profiling",
-		"--dump-config",
-		"--log-level=trace",
-		"--debug-log-reduce-redundancy",
-		featureGateFlag,
-		"--anonymous-reports=false",
-	}
-
-	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalDeprecatedLogger, globalLogger, env.Cluster(), args...))
-
-	t.Log("creating GatewayClass for gateway conformance tests")
-	gatewayClass := &gatewayv1beta1.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-			Annotations: map[string]string{
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
-			},
-		},
-		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: gateway.GetControllerName(),
-		},
-	}
-	require.NoError(t, client.Create(ctx, gatewayClass))
-	t.Cleanup(func() { assert.NoError(t, client.Delete(ctx, gatewayClass)) })
-
-	exemptFeatures := sets.New(suite.SupportMesh)
-
-	t.Log("starting the gateway conformance test suite")
-	skippedTests := skippedTestsForTraditionalRoutes
-	if expressionRoutesEnabled() {
-		skippedTests = skippedTestsForExpressionRoutes
+		skipTests = skippedTestsForExpressionRoutes
 	}
 	cSuite := suite.New(suite.Options{
 		Client:                     client,
-		GatewayClassName:           gatewayClass.Name,
-		Debug:                      showDebug,
-		CleanupBaseResources:       shouldCleanup,
-		EnableAllSupportedFeatures: enableAllSupportedFeatures,
-		ExemptFeatures:             exemptFeatures,
+		GatewayClassName:           gatewayClassName,
+		Debug:                      true,
+		CleanupBaseResources:       true,
+		EnableAllSupportedFeatures: true,
+		ExemptFeatures:             suite.MeshCoreFeatures,
 		BaseManifests:              conformanceTestsBaseManifests,
-		SkipTests:                  skippedTests,
+		SkipTests:                  skipTests,
 	})
+	t.Log("starting the gateway conformance test suite")
 	cSuite.Setup(t)
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -1,7 +1,4 @@
-//go:build conformance_tests && !experimental
-
-// Due to having !experimental, this file is not checked by golangci-lint.
-// This is shortcoming of golangci-lint, see https://github.com/golangci/golangci-lint/issues/1646
+//go:build conformance_tests
 
 package conformance
 
@@ -61,8 +58,11 @@ var skippedTestsForTraditionalRoutes = append(
 )
 
 func TestGatewayConformance(t *testing.T) {
-	client, gatewayClassName := prepareEnvForGatewayConformanceTests(t)
+	if shouldRunExperimentalConformance() {
+		t.Skip("skipping standard conformance tests")
+	}
 
+	client, gatewayClassName := prepareEnvForGatewayConformanceTests(t)
 	// Conformance tests are run for both configs with and without
 	// KONG_TEST_EXPRESSION_ROUTES='true'.
 	skipTests := skippedTestsForTraditionalRoutes
@@ -82,6 +82,7 @@ func TestGatewayConformance(t *testing.T) {
 	})
 	t.Log("starting the gateway conformance test suite")
 	cSuite.Setup(t)
+
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:
 	//

--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -29,17 +29,13 @@ func TestGatewayExperimentalConformance(t *testing.T) {
 	_, err := semver.Parse(strings.TrimPrefix(metadata.Release, "v"))
 	require.NoError(t, err)
 
-	cleanUpResources := true
-	if testenv.IsCI() {
-		cleanUpResources = false
-	}
 	cSuite, err := suite.NewExperimentalConformanceTestSuite(
 		suite.ExperimentalConformanceOptions{
 			Options: suite.Options{
 				Client:               client,
 				GatewayClassName:     gatewayClassName,
 				Debug:                true,
-				CleanupBaseResources: cleanUpResources,
+				CleanupBaseResources: !testenv.IsCI(),
 				BaseManifests:        conformanceTestsBaseManifests,
 				SupportedFeatures: sets.New(
 					suite.SupportHTTPRouteMethodMatching,

--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -1,0 +1,78 @@
+//go:build conformance_tests && experimental
+
+package conformance
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/metadata"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
+	"sigs.k8s.io/gateway-api/conformance/tests"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/yaml"
+)
+
+func TestGatewayExperimentalConformance(t *testing.T) {
+	// Experimental conformance tests passes only when expression routes are enabled
+	// (KONG_TEST_EXPRESSION_ROUTES='true' set automatically in make test.conformance-experimental)
+	// because it supports more features and it's the desired way to use Kong in the future.
+	client, gatewayClassName := prepareEnvForGatewayConformanceTests(t)
+	// Release is expected to have format v2.8.1 (when run on tagged commit) or v2.8.1-731-g4a32cf0b.
+	_, err := semver.Parse(strings.TrimPrefix(metadata.Release, "v"))
+	require.NoError(t, err)
+
+	cSuite, err := suite.NewExperimentalConformanceTestSuite(
+		suite.ExperimentalConformanceOptions{
+			Options: suite.Options{
+				Client:               client,
+				GatewayClassName:     gatewayClassName,
+				Debug:                true,
+				CleanupBaseResources: true,
+				BaseManifests:        conformanceTestsBaseManifests,
+				SupportedFeatures: sets.New(
+					suite.SupportHTTPRouteMethodMatching,
+					suite.SupportHTTPResponseHeaderModification,
+				),
+				SkipTests: []string{
+					tests.GatewayWithAttachedRoutes.ShortName,
+					tests.GatewayClassObservedGenerationBump.ShortName,
+				},
+			},
+			ConformanceProfiles: sets.New(
+				suite.HTTPConformanceProfileName,
+			),
+			Implementation: v1alpha1.Implementation{
+				Organization: metadata.Organization,
+				Project:      metadata.ProjectName,
+				URL:          metadata.ProjectURL,
+				Version:      metadata.Release,
+				Contact: []string{
+					path.Join(metadata.ProjectURL, "/issues/new/choose"),
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Log("starting the gateway conformance test suite")
+	cSuite.Setup(t)
+	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
+	// single test only, e.g.:
+	//
+	//cSuite.Run(t, []suite.ConformanceTest{tests.HTTPRouteRedirectPortAndScheme})
+	require.NoError(t, cSuite.Run(t, tests.ConformanceTests))
+
+	const reportFileName = "conformance-tests-report.yaml"
+	t.Log("saving the gateway conformance test report to file:", reportFileName)
+	report, err := cSuite.Report()
+	require.NoError(t, err)
+	rawReport, err := yaml.Marshal(report)
+	require.NoError(t, err)
+	// Save report in root of the repository, file name is in .gitignore.
+	require.NoError(t, os.WriteFile("../../"+reportFileName, rawReport, 0644))
+}

--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -1,4 +1,4 @@
-//go:build conformance_tests && experimental
+//go:build conformance_tests
 
 package conformance
 
@@ -21,6 +21,9 @@ import (
 )
 
 func TestGatewayExperimentalConformance(t *testing.T) {
+	if !shouldRunExperimentalConformance() {
+		t.Skip("skipping experimental conformance tests")
+	}
 	// Experimental conformance tests passes only when expression routes are enabled
 	// (KONG_TEST_EXPRESSION_ROUTES='true' set automatically in make test.conformance-experimental)
 	// because it supports more features and it's the desired way to use Kong in the future.

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -10,39 +10,44 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 var (
-	existingCluster      = os.Getenv("KONG_TEST_CLUSTER")
-	expressionRoutesMode = os.Getenv("KONG_TEST_EXPRESSION_ROUTES")
-	ingressClass         = "kong-conformance-tests"
+	conformanceTestsBaseManifests = fmt.Sprintf("%s/conformance/base/manifests.yaml", consts.GatewayRawRepoURL)
+	existingCluster               = os.Getenv("KONG_TEST_CLUSTER")
+	expressionRoutesMode          = os.Getenv("KONG_TEST_EXPRESSION_ROUTES")
+	ingressClass                  = "kong-conformance-tests"
 
 	env                    environments.Environment
 	ctx                    context.Context
 	globalDeprecatedLogger logrus.FieldLogger
 	globalLogger           logr.Logger
 )
-
-func expressionRoutesEnabled() bool {
-	return strings.ToLower(expressionRoutesMode) == "true"
-}
 
 func TestMain(m *testing.M) {
 	var code int
@@ -73,6 +78,7 @@ func TestMain(m *testing.M) {
 	kongBuilder := kong.NewBuilder().WithControllerDisabled().WithProxyAdminServiceTypeLoadBalancer().
 		WithNamespace(consts.ControllerNamespace)
 	if expressionRoutesEnabled() {
+		fmt.Println("INFO: expression routes enabled")
 		kongBuilder = kongBuilder.WithProxyEnvVar("router_flavor", "expressions")
 	}
 
@@ -103,6 +109,56 @@ func TestMain(m *testing.M) {
 		defer cancel()
 		exitOnErr(helpers.RemoveCluster(ctx, env.Cluster()))
 	}
+}
+
+// prepareEnvForGatewayConformanceTests prepares the environment for running the gateway conformance test suite
+// from the gateway-api project. Used as a helper function for both the stable and experimental conformance tests.
+func prepareEnvForGatewayConformanceTests(t *testing.T) (c client.Client, gatewayClassName string) {
+	t.Log("configuring environment for gateway conformance tests")
+	client, err := client.New(env.Cluster().Config(), client.Options{})
+	require.NoError(t, err)
+	require.NoError(t, gatewayv1alpha2.AddToScheme(client.Scheme()))
+	require.NoError(t, gatewayv1beta1.AddToScheme(client.Scheme()))
+
+	featureGateFlag := fmt.Sprintf("--feature-gates=%s", consts.DefaultFeatureGates)
+	if expressionRoutesEnabled() {
+		featureGateFlag = fmt.Sprintf("--feature-gates=%s", consts.ConformanceExpressionRoutesTestsFeatureGates)
+	}
+
+	t.Log("starting the controller manager")
+	cert, key := certificate.GetKongSystemSelfSignedCerts()
+	args := []string{
+		fmt.Sprintf("--ingress-class=%s", ingressClass),
+		fmt.Sprintf("--admission-webhook-cert=%s", cert),
+		fmt.Sprintf("--admission-webhook-key=%s", key),
+		fmt.Sprintf("--admission-webhook-listen=%s:%d", testutils.AdmissionWebhookListenHost, testutils.AdmissionWebhookListenPort),
+		"--profiling",
+		"--dump-config",
+		"--log-level=trace",
+		"--debug-log-reduce-redundancy",
+		featureGateFlag,
+		"--anonymous-reports=false",
+	}
+
+	require.NoError(t, testutils.DeployControllerManagerForCluster(ctx, globalDeprecatedLogger, globalLogger, env.Cluster(), args...))
+
+	t.Log("creating GatewayClass for gateway conformance tests")
+	gatewayClass := &gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+			Annotations: map[string]string{
+				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+			},
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: gateway.GetControllerName(),
+		},
+	}
+	require.NoError(t, client.Create(ctx, gatewayClass))
+	t.Cleanup(func() { require.NoError(t, client.Delete(ctx, gatewayClass)) })
+	t.Logf("created GatewayClass %q", gatewayClass.Name)
+
+	return client, gatewayClass.Name
 }
 
 func ensureConformanceTestsNamespacesAreNotPresent(ctx context.Context, client *kubernetes.Clientset) error {
@@ -180,4 +236,8 @@ func exitOnErr(err error) {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
+}
+
+func expressionRoutesEnabled() bool {
+	return strings.ToLower(expressionRoutesMode) == "true"
 }

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -235,3 +235,7 @@ func exitOnErr(err error) {
 		os.Exit(1)
 	}
 }
+
+func shouldRunExperimentalConformance() bool {
+	return os.Getenv("TEST_EXPERIMENTAL_CONFORMANCE") == "true"
+}

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -92,6 +92,13 @@ func ControllerFeatureGates() string {
 	return featureGates
 }
 
+// ExpressionRoutesEnabled indicates whether or not to enable expression routes
+// for the Kong Gateway and the controller.
+// If none specified, we fall back to default values.
+func ExpressionRoutesEnabled() bool {
+	return os.Getenv("KONG_TEST_EXPRESSION_ROUTES") == "true"
+}
+
 // -----------------------------------------------------------------------------
 // Environment variables related helpers
 // -----------------------------------------------------------------------------

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -94,7 +94,7 @@ func ControllerFeatureGates() string {
 
 // ExpressionRoutesEnabled indicates whether or not to enable expression routes
 // for the Kong Gateway and the controller.
-// If none specified, we fall back to default values.
+// If none specified, we fall back to default value - traditional_compatible.
 func ExpressionRoutesEnabled() bool {
 	return os.Getenv("KONG_TEST_EXPRESSION_ROUTES") == "true"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Add the experimental conformance suite to KIC tests. Create `Makefile` target `test.conformance-experimental` to run them. Since it's still experimental leave it as a separate target. The generated report is saved in the root of the repository `conformance-tests-report.yaml` (it's added to `.gitignore`). Those tests are run only for KIC with expression routes enabled. In the future (probably when gateway-api reaches 1.0.0) it will stop being experimental and it will be the default and only way of running conformance tests.

Generated report on code from this PR `make test.conformance-experimental` looks like that

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha1
date: "2023-09-06T11:13:41+02:00"
gatewayAPIVersion: TODO
implementation:
  contact:
  - github.com/kong/kubernetes-ingress-controller/issues/new/choose
  organization: Kong
  project: kubernetes-ingress-controller
  url: github.com/kong/kubernetes-ingress-controller
  version: v2.8.1-760-gab48dde3
kind: ConformanceReport
profiles:
- core:
    result: partial
    skippedTests:
    - GatewayWithAttachedRoutes
    - GatewayClassObservedGenerationBump
    statistics:
      Failed: 0
      Passed: 27
      Skipped: 2
    summary: ""
  extended:
    result: success
    statistics:
      Failed: 0
      Passed: 2
      Skipped: 0
    summary: ""
    supportedFeatures:
    - HTTPRouteMethodMatching
    - HTTPResponseHeaderModification
    unsupportedFeatures:
    - HTTPRoutePathRedirect
    - HTTPRouteHostRewrite
    - HTTPRoutePathRewrite
    - HTTPRouteQueryParamMatching
    - HTTPRouteSchemeRedirect
    - HTTPRouteRequestMirror
    - HTTPRoutePortRedirect
  name: HTTP

```

be aware of wrong `version:v2.8.1-760-gab48dde3`, read more in **Special notes for your reviewer**.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of the https://github.com/Kong/kubernetes-ingress-controller/issues/4402

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:
- In terms of how the version number for KIC is generated, it'd be beneficial to address https://github.com/Kong/kubernetes-ingress-controller/issues/4120#issuecomment-1580398292 about properly creating `vX.Y.0` tags on the branch `main`. 
- In separate PR running it in CI will be provided (after merging this to `main`), Since it's experimental we want to trigger run manually.
- The way the report is saved may change in the future because currently upstream doesn't provide a way that fits our needs, so we have to do it explicitly, [check the code](https://github.com/kubernetes-sigs/gateway-api/blob/1dca4afb179803f415911066e0d1f4a4d2a7309f/conformance/experimental_conformance_test.go).

<!-- Here you can add any open questions or notes that you might have for reviewers -->

