### PR TITLE
chore: remove out of date TODO comment

### DIFF
--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -315,9 +315,6 @@ func getListenerStatus(
 			})
 		}
 
-		// TODO this only handles some Listener conditions and reasons as needed to check cross-listener compatibility
-		// and unattachability due to missing Kong configuration. There are others available and it may be appropriate
-		// for us to add them https://github.com/Kong/kubernetes-ingress-controller/issues/2558
 		if _, ok := portToProtocol[listener.Port]; !ok {
 			// unoccupied ports are free game
 			portToProtocol[listener.Port] = listener.Protocol


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

#2558 is an old issue about setting all the needed conditions into the Gateway API resources. Since the issue was created, many conditions have been added and enforced in KIC. The conformance tests are supposed to check all those conditions, and since we are compliant with them, we can safely assume that the issue is now fixed.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #2558 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
