### PR TITLE
chore: replace "runtime_group" with "control_plane" in konnect APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ Adding a new version? You'll need three changes:
 - No more "log.SetLogger(...) was never called..." log entry during shutdown of KIC
   [#4738](https://github.com/Kong/kubernetes-ingress-controller/pull/4738)
 
+### Changed
+
+- Update paths of Konnect APIs from `runtime_groups/*` to `control-planes/*`.
+[#4566](https://github.com/Kong/kubernetes-ingress-controller/pull/4566)
+
 ### Added
 
 - The `FillIDs` feature gate is now enabled by default.

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -52,7 +52,7 @@ func NewKongClientForKonnectRuntimeGroup(c KonnectConfig) (*KonnectClient, error
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tlsConfig
 	client, err := kong.NewClient(
-		lo.ToPtr(fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control_planes", c.RuntimeGroupID)),
+		lo.ToPtr(fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control-planes", c.RuntimeGroupID)),
 		&http.Client{
 			Transport: transport,
 		},

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -52,7 +52,7 @@ func NewKongClientForKonnectRuntimeGroup(c KonnectConfig) (*KonnectClient, error
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tlsConfig
 	client, err := kong.NewClient(
-		lo.ToPtr(fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/runtime_groups", c.RuntimeGroupID)),
+		lo.ToPtr(fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control_planes", c.RuntimeGroupID)),
 		&http.Client{
 			Transport: transport,
 		},

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // KICLicenseAPIPathPattern is the path pattern for KIC license operations.
-var KICLicenseAPIPathPattern = "%s/kic/api/control_planes/%s/v1/licenses"
+var KICLicenseAPIPathPattern = "%s/kic/api/control-planes/%s/v1/licenses"
 
 // NewClient creates a License API Konnect client.
 func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // KICLicenseAPIPathPattern is the path pattern for KIC license operations.
-var KICLicenseAPIPathPattern = "%s/kic/api/runtime_groups/%s/v1/licenses"
+var KICLicenseAPIPathPattern = "%s/kic/api/control_planes/%s/v1/licenses"
 
 // NewClient creates a License API Konnect client.
 func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {

--- a/internal/konnect/nodes/client.go
+++ b/internal/konnect/nodes/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // KicNodeAPIPathPattern is the path pattern for KIC node operations.
-var KicNodeAPIPathPattern = "%s/kic/api/control_planes/%s/v1/kic-nodes"
+var KicNodeAPIPathPattern = "%s/kic/api/control-planes/%s/v1/kic-nodes"
 
 // NewClient creates a Node API Konnect client.
 func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {

--- a/internal/konnect/nodes/client.go
+++ b/internal/konnect/nodes/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // KicNodeAPIPathPattern is the path pattern for KIC node operations.
-var KicNodeAPIPathPattern = "%s/kic/api/runtime_groups/%s/v1/kic-nodes"
+var KicNodeAPIPathPattern = "%s/kic/api/control_planes/%s/v1/kic-nodes"
 
 // NewClient creates a Node API Konnect client.
 func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	konnectRuntimeGroupsBaseURL          = "https://us.kic.api.konghq.tech/v2"
-	konnectRuntimeGroupsConfigBaseURLFmt = "https://us.api.konghq.tech/konnect-api/api/runtime_groups/%s/v1"
+	konnectRuntimeGroupsConfigBaseURLFmt = "https://us.api.konghq.tech/konnect-api/api/control_planes/%s/v2"
 	konnectRuntimeGroupAdminAPIBaseURL   = "https://us.kic.api.konghq.tech"
 	konnectRolesBaseURL                  = "https://global.api.konghq.tech/v2"
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	konnectRuntimeGroupsBaseURL          = "https://us.kic.api.konghq.tech/v2"
-	konnectRuntimeGroupsConfigBaseURLFmt = "https://us.api.konghq.tech/konnect-api/api/control_planes/%s/v2"
+	konnectRuntimeGroupsConfigBaseURLFmt = "https://us.api.konghq.tech/v2/control-planes/%s/"
 	konnectRuntimeGroupAdminAPIBaseURL   = "https://us.kic.api.konghq.tech"
 	konnectRolesBaseURL                  = "https://global.api.konghq.tech/v2"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

replace the `runtime_groups` in paths to `control_planes` in konnect APIs.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #4466

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Still WIP. There are still hundreds appearances of the word "runtime group". Except for the "historical" part, CHANGELOG entries for the older version, they should ALL be replaced to "control plane".

Question: In the envs/config flags, should we support both `runtime_group` and `control_plane` to specify the ID of konnect RG/CP? I suppose to support both, but `control_plane` takes higher priority, for compatibility of old charts/deployments.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
