### PR TITLE
Disable Kong(Cluster)Plugin Programmed status

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -114,8 +114,8 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongplugins",
 		CacheType:                         "Plugin",
 		NeedsStatusPermissions:            true,
-		ConfigStatusNotificationsEnabled:  true,
-		ProgrammedConditionUpdatesEnabled: true,
+		ConfigStatusNotificationsEnabled:  false, // TODO true after https://github.com/Kong/kubernetes-ingress-controller/issues/4578
+		ProgrammedConditionUpdatesEnabled: false, // TODO true after https://github.com/Kong/kubernetes-ingress-controller/issues/4578
 		AcceptsIngressClassNameAnnotation: false,
 		AcceptsIngressClassNameSpec:       false,
 		NeedsUpdateReferences:             true,
@@ -131,8 +131,8 @@ var inputControllersNeeded = &typesNeeded{
 		Plural:                            "kongclusterplugins",
 		CacheType:                         "ClusterPlugin",
 		NeedsStatusPermissions:            true,
-		ConfigStatusNotificationsEnabled:  true,
-		ProgrammedConditionUpdatesEnabled: true,
+		ConfigStatusNotificationsEnabled:  false, // TODO true after https://github.com/Kong/kubernetes-ingress-controller/issues/4578
+		ProgrammedConditionUpdatesEnabled: false, // TODO true after https://github.com/Kong/kubernetes-ingress-controller/issues/4578
 		AcceptsIngressClassNameAnnotation: true,
 		AcceptsIngressClassNameSpec:       false,
 		NeedsUpdateReferences:             true,

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -619,7 +619,6 @@ type KongV1KongPluginReconciler struct {
 	Scheme            *runtime.Scheme
 	DataplaneClient   controllers.DataPlane
 	CacheSyncTimeout  time.Duration
-	StatusQueue       *status.Queue
 	ReferenceIndexers ctrlref.CacheIndexers
 }
 
@@ -636,19 +635,6 @@ func (r *KongV1KongPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	if err != nil {
 		return err
-	}
-	// if configured, start the status updater controller
-	if r.StatusQueue != nil {
-		if err := c.Watch(
-			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
-				Group:   "configuration.konghq.com",
-				Version: "v1",
-				Kind:    "KongPlugin",
-			})},
-			&handler.EnqueueRequestForObject{},
-		); err != nil {
-			return err
-		}
 	}
 	return c.Watch(
 		source.Kind(mgr.GetCache(), &kongv1.KongPlugin{}),
@@ -712,17 +698,6 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.DataplaneClient.UpdateObject(obj); err != nil {
 		return ctrl.Result{}, err
 	}
-	// if status updates are enabled report the status for the object
-	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(util.DebugLevel).Info("updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
-		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
-		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(configurationStatus, obj.Generation, obj.Status.Conditions)
-		obj.Status.Conditions = conditions
-		if updateNeeded {
-			return ctrl.Result{}, r.Status().Update(ctx, obj)
-		}
-		log.V(util.DebugLevel).Info("status update not needed", "namespace", req.Namespace, "name", req.Name)
-	}
 	// update reference relationship from the KongPlugin to other objects.
 	if err := updateReferredObjects(ctx, r.Client, r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -749,7 +724,6 @@ type KongV1KongClusterPluginReconciler struct {
 	Scheme           *runtime.Scheme
 	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
-	StatusQueue      *status.Queue
 
 	IngressClassName           string
 	DisableIngressClassLookups bool
@@ -769,19 +743,6 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 	})
 	if err != nil {
 		return err
-	}
-	// if configured, start the status updater controller
-	if r.StatusQueue != nil {
-		if err := c.Watch(
-			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
-				Group:   "configuration.konghq.com",
-				Version: "v1",
-				Kind:    "KongClusterPlugin",
-			})},
-			&handler.EnqueueRequestForObject{},
-		); err != nil {
-			return err
-		}
 	}
 	if !r.DisableIngressClassLookups {
 		err = c.Watch(
@@ -897,17 +858,6 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// update the kong Admin API with the changes
 	if err := r.DataplaneClient.UpdateObject(obj); err != nil {
 		return ctrl.Result{}, err
-	}
-	// if status updates are enabled report the status for the object
-	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(util.DebugLevel).Info("updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
-		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
-		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(configurationStatus, obj.Generation, obj.Status.Conditions)
-		obj.Status.Conditions = conditions
-		if updateNeeded {
-			return ctrl.Result{}, r.Status().Update(ctx, obj)
-		}
-		log.V(util.DebugLevel).Info("status update not needed", "namespace", req.Namespace, "name", req.Name)
 	}
 	// update reference relationship from the KongClusterPlugin to other objects.
 	if err := updateReferredObjects(ctx, r.Client, r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -250,7 +250,8 @@ func setupControllers(
 				DataplaneClient:   dataplaneClient,
 				CacheSyncTimeout:  c.CacheSyncTimeout,
 				ReferenceIndexers: referenceIndexers,
-				StatusQueue:       kubernetesStatusQueue,
+				// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4578
+				// StatusQueue:       kubernetesStatusQueue,
 			},
 		},
 		{
@@ -313,7 +314,8 @@ func setupControllers(
 				DisableIngressClassLookups: !c.IngressClassNetV1Enabled,
 				CacheSyncTimeout:           c.CacheSyncTimeout,
 				ReferenceIndexers:          referenceIndexers,
-				StatusQueue:                kubernetesStatusQueue,
+				// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4578
+				// StatusQueue:       kubernetesStatusQueue,
 			},
 		},
 		// ---------------------------------------------------------------------------

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -125,168 +124,172 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 			expectedProgrammedStatus: metav1.ConditionTrue,
 			expectedProgrammedReason: kongv1.ReasonProgrammed,
 		},
-		{
-			name: "valid KongPlugin",
-			objects: []client.Object{
-				&kongv1.KongPlugin{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "kong-plugin",
-						Namespace:   ns.Name,
-						Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
-					},
-					PluginName: "plugin",
-				},
-				&kongv1.KongConsumer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "consumer-for-plugin",
-						Namespace: ns.Name,
-						Annotations: map[string]string{
-							annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-							annotations.AnnotationPrefix + annotations.PluginsKey: "kong-plugin",
-						},
-					},
-					Username: "foo",
-				},
-			},
-			getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
-				var plugin kongv1.KongPlugin
-				err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
-					Name:      "kong-plugin",
-					Namespace: ns.Name,
-				}, &plugin)
-				if err != nil {
-					return nil, err
-				}
-				return plugin.Status.Conditions, nil
-			},
-			expectedProgrammedStatus: metav1.ConditionTrue,
-			expectedProgrammedReason: kongv1.ReasonProgrammed,
-		},
-		{
-			name: "invalid KongPlugin",
-			objects: []client.Object{
-				&kongv1.KongPlugin{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "invalid-kong-plugin",
-						Namespace:   ns.Name,
-						Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
-					},
-					PluginName: "plugin",
-					// Specifying both Config and ConfigFrom is invalid.
-					Config: apiextensionsv1.JSON{Raw: []byte(`{"key": "value"}`)},
-					ConfigFrom: &kongv1.ConfigSource{
-						SecretValue: kongv1.SecretValueFromSource{
-							Secret: "secret",
-							Key:    "key",
-						},
-					},
-				},
-				&kongv1.KongConsumer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "consumer-for-invalid-plugin",
-						Namespace: ns.Name,
-						Annotations: map[string]string{
-							annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-							annotations.AnnotationPrefix + annotations.PluginsKey: "invalid-kong-plugin",
-						},
-					},
-					Username: "foo",
-				},
-			},
-			getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
-				var plugin kongv1.KongPlugin
-				err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
-					Name:      "invalid-kong-plugin",
-					Namespace: ns.Name,
-				}, &plugin)
-				if err != nil {
-					return nil, err
-				}
-				return plugin.Status.Conditions, nil
-			},
-			expectedProgrammedStatus: metav1.ConditionFalse,
-			expectedProgrammedReason: kongv1.ReasonInvalid,
-		},
-		{
-			name: "valid KongClusterPlugin",
-			objects: []client.Object{
-				&kongv1.KongClusterPlugin{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "kong-cluster-plugin",
-						Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
-					},
-					PluginName: "plugin",
-				},
-				&kongv1.KongConsumer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "consumer-for-cluster-plugin",
-						Namespace: ns.Name,
-						Annotations: map[string]string{
-							annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-							annotations.AnnotationPrefix + annotations.PluginsKey: "kong-cluster-plugin",
-						},
-					},
-					Username: "foo",
-				},
-			},
-			getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
-				var clusterPlugin kongv1.KongClusterPlugin
-				err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
-					Name: "kong-cluster-plugin",
-				}, &clusterPlugin)
-				if err != nil {
-					return nil, err
-				}
-				return clusterPlugin.Status.Conditions, nil
-			},
-			expectedProgrammedStatus: metav1.ConditionTrue,
-			expectedProgrammedReason: kongv1.ReasonProgrammed,
-		},
-		{
-			name: "invalid KongClusterPlugin",
-			objects: []client.Object{
-				&kongv1.KongPlugin{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "invalid-kong-cluster-plugin",
-						Namespace:   ns.Name,
-						Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
-					},
-					PluginName: "plugin",
-					// Specifying both Config and ConfigFrom is invalid.
-					Config: apiextensionsv1.JSON{Raw: []byte(`{"key": "value"}`)},
-					ConfigFrom: &kongv1.ConfigSource{
-						SecretValue: kongv1.SecretValueFromSource{
-							Secret: "secret",
-							Key:    "key",
-						},
-					},
-				},
-				&kongv1.KongConsumer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "consumer-for-invalid-cluster-plugin",
-						Namespace: ns.Name,
-						Annotations: map[string]string{
-							annotations.IngressClassKey:                           annotations.DefaultIngressClass,
-							annotations.AnnotationPrefix + annotations.PluginsKey: "invalid-kong-cluster-plugin",
-						},
-					},
-					Username: "foo",
-				},
-			},
-			getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
-				var plugin kongv1.KongPlugin
-				err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
-					Name:      "invalid-kong-cluster-plugin",
-					Namespace: ns.Name,
-				}, &plugin)
-				if err != nil {
-					return nil, err
-				}
-				return plugin.Status.Conditions, nil
-			},
-			expectedProgrammedStatus: metav1.ConditionFalse,
-			expectedProgrammedReason: kongv1.ReasonInvalid,
-		},
+		// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4578
+		// if there are multiple KIC instances within a cluster, they will fight over setting this condition because the
+		// controllers do not filter on ingress class. we need to limit them to only resources referenced from others,
+		// similar to Secrets, to use this
+		//{
+		//	name: "valid KongPlugin",
+		//	objects: []client.Object{
+		//		&kongv1.KongPlugin{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:        "kong-plugin",
+		//				Namespace:   ns.Name,
+		//				Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+		//			},
+		//			PluginName: "plugin",
+		//		},
+		//		&kongv1.KongConsumer{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:      "consumer-for-plugin",
+		//				Namespace: ns.Name,
+		//				Annotations: map[string]string{
+		//					annotations.IngressClassKey:                           annotations.DefaultIngressClass,
+		//					annotations.AnnotationPrefix + annotations.PluginsKey: "kong-plugin",
+		//				},
+		//			},
+		//			Username: "foo",
+		//		},
+		//	},
+		//	getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
+		//		var plugin kongv1.KongPlugin
+		//		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+		//			Name:      "kong-plugin",
+		//			Namespace: ns.Name,
+		//		}, &plugin)
+		//		if err != nil {
+		//			return nil, err
+		//		}
+		//		return plugin.Status.Conditions, nil
+		//	},
+		//	expectedProgrammedStatus: metav1.ConditionTrue,
+		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
+		//},
+		//{
+		//	name: "invalid KongPlugin",
+		//	objects: []client.Object{
+		//		&kongv1.KongPlugin{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:        "invalid-kong-plugin",
+		//				Namespace:   ns.Name,
+		//				Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+		//			},
+		//			PluginName: "plugin",
+		//			// Specifying both Config and ConfigFrom is invalid.
+		//			Config: apiextensionsv1.JSON{Raw: []byte(`{"key": "value"}`)},
+		//			ConfigFrom: &kongv1.ConfigSource{
+		//				SecretValue: kongv1.SecretValueFromSource{
+		//					Secret: "secret",
+		//					Key:    "key",
+		//				},
+		//			},
+		//		},
+		//		&kongv1.KongConsumer{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:      "consumer-for-invalid-plugin",
+		//				Namespace: ns.Name,
+		//				Annotations: map[string]string{
+		//					annotations.IngressClassKey:                           annotations.DefaultIngressClass,
+		//					annotations.AnnotationPrefix + annotations.PluginsKey: "invalid-kong-plugin",
+		//				},
+		//			},
+		//			Username: "foo",
+		//		},
+		//	},
+		//	getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
+		//		var plugin kongv1.KongPlugin
+		//		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+		//			Name:      "invalid-kong-plugin",
+		//			Namespace: ns.Name,
+		//		}, &plugin)
+		//		if err != nil {
+		//			return nil, err
+		//		}
+		//		return plugin.Status.Conditions, nil
+		//	},
+		//	expectedProgrammedStatus: metav1.ConditionFalse,
+		//	expectedProgrammedReason: kongv1.ReasonInvalid,
+		//},
+		//{
+		//	name: "valid KongClusterPlugin",
+		//	objects: []client.Object{
+		//		&kongv1.KongClusterPlugin{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:        "kong-cluster-plugin",
+		//				Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+		//			},
+		//			PluginName: "plugin",
+		//		},
+		//		&kongv1.KongConsumer{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:      "consumer-for-cluster-plugin",
+		//				Namespace: ns.Name,
+		//				Annotations: map[string]string{
+		//					annotations.IngressClassKey:                           annotations.DefaultIngressClass,
+		//					annotations.AnnotationPrefix + annotations.PluginsKey: "kong-cluster-plugin",
+		//				},
+		//			},
+		//			Username: "foo",
+		//		},
+		//	},
+		//	getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
+		//		var clusterPlugin kongv1.KongClusterPlugin
+		//		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+		//			Name: "kong-cluster-plugin",
+		//		}, &clusterPlugin)
+		//		if err != nil {
+		//			return nil, err
+		//		}
+		//		return clusterPlugin.Status.Conditions, nil
+		//	},
+		//	expectedProgrammedStatus: metav1.ConditionTrue,
+		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
+		//},
+		//{
+		//	name: "invalid KongClusterPlugin",
+		//	objects: []client.Object{
+		//		&kongv1.KongPlugin{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:        "invalid-kong-cluster-plugin",
+		//				Namespace:   ns.Name,
+		//				Annotations: map[string]string{annotations.IngressClassKey: annotations.DefaultIngressClass},
+		//			},
+		//			PluginName: "plugin",
+		//			// Specifying both Config and ConfigFrom is invalid.
+		//			Config: apiextensionsv1.JSON{Raw: []byte(`{"key": "value"}`)},
+		//			ConfigFrom: &kongv1.ConfigSource{
+		//				SecretValue: kongv1.SecretValueFromSource{
+		//					Secret: "secret",
+		//					Key:    "key",
+		//				},
+		//			},
+		//		},
+		//		&kongv1.KongConsumer{
+		//			ObjectMeta: metav1.ObjectMeta{
+		//				Name:      "consumer-for-invalid-cluster-plugin",
+		//				Namespace: ns.Name,
+		//				Annotations: map[string]string{
+		//					annotations.IngressClassKey:                           annotations.DefaultIngressClass,
+		//					annotations.AnnotationPrefix + annotations.PluginsKey: "invalid-kong-cluster-plugin",
+		//				},
+		//			},
+		//			Username: "foo",
+		//		},
+		//	},
+		//	getExpectedObjectConditions: func(ctrlClient client.Client) ([]metav1.Condition, error) {
+		//		var plugin kongv1.KongPlugin
+		//		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
+		//			Name:      "invalid-kong-cluster-plugin",
+		//			Namespace: ns.Name,
+		//		}, &plugin)
+		//		if err != nil {
+		//			return nil, err
+		//		}
+		//		return plugin.Status.Conditions, nil
+		//	},
+		//	expectedProgrammedStatus: metav1.ConditionFalse,
+		//	expectedProgrammedReason: kongv1.ReasonInvalid,
+		//},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables Kong(Cluster)Plugin status updates. Add TODOs for the relevant bug.

**Which issue this PR fixes**:

Multiple KIC instances in the same cluster [will fight over plugin statuses](https://github.com/Kong/kubernetes-ingress-controller/issues/4578) because plugins have no class. We don't want them to have class, unless they're global.

**Special notes for your reviewer**:

Double duty as a release PR for https://github.com/Kong/kubernetes-ingress-controller/issues/4582. AFAIK we're no longer doing updates other than the fixes themselves since we're now using relative tags, so the manifests remain unchanged.

A proper fix for this probably requires breaking out the plugin controller, so I think we want a hotfix for now. The feature isn't critical.

See https://github.com/Kong/kubernetes-ingress-controller/pull/4412/files for the original change. There are some other struct changes there, but AFAIK disabling the reconciler bit alone avoids the issue.

~Didn't want to send this to main and backport since it touches generated code. I think we need to cherry-pick the first commit and generate separately if we don't have a more complete fix in for 2.12.~ There haven't been changes to the generated controllers since 2.11.0, so this one's actually fine.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ Separately to main only. https://github.com/Kong/kubernetes-ingress-controller/pull/4583
