### PR TITLE
fix(plugins) add suffix to instance_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ Adding a new version? You'll need three changes:
 - Create routes that match any service and method for `GRPCRoute` rules with no
   matches.
   [#4512](https://github.com/Kong/kubernetes-ingress-controller/issues/4512)
+- KongPlugins used on multiple resources will no longer result in
+  `instance_name` collisions.
+  [#4588](https://github.com/Kong/kubernetes-ingress-controller/issues/4588)
 
 ## [2.11.1]
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -352,19 +352,19 @@ func buildPlugins(
 			// translator too
 			if rel.Service != "" {
 				plugin.Service = &kong.Service{ID: kong.String(rel.Service)}
-				sha = sha256.Sum256([]byte(rel.Service))
+				sha = sha256.Sum256([]byte("service-" + rel.Service))
 			}
 			if rel.Route != "" {
 				plugin.Route = &kong.Route{ID: kong.String(rel.Route)}
-				sha = sha256.Sum256([]byte(rel.Route))
+				sha = sha256.Sum256([]byte("route-" + rel.Route))
 			}
 			if rel.Consumer != "" {
 				plugin.Consumer = &kong.Consumer{ID: kong.String(rel.Consumer)}
-				sha = sha256.Sum256([]byte(rel.Consumer))
+				sha = sha256.Sum256([]byte("consumer-" + rel.Consumer))
 			}
 			if rel.ConsumerGroup != "" {
 				plugin.ConsumerGroup = &kong.ConsumerGroup{ID: kong.String(rel.ConsumerGroup)}
-				sha = sha256.Sum256([]byte(rel.ConsumerGroup))
+				sha = sha256.Sum256([]byte("group-" + rel.ConsumerGroup))
 			}
 			// instance_name must be unique. Using the same KongPlugin on multiple resources will result in duplicates
 			// unless we add some sort of suffix.

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -765,7 +765,7 @@ func TestKongState_BuildPluginsCollisions(t *testing.T) {
 					Route: []string{"collision", "collision"},
 				},
 			},
-			want: []string{"test-9550e70a7", "test-9550e70a7c3619220570a6ed8b82684edbfc045b698027748b43afa2cadd6bae"},
+			want: []string{"test-bae3267aa", "test-bae3267aafead3adb6031bc1c732516336e7f7b324baf61bb68a39cc89112741"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 plugins:
 - config:
     header_name: kong-id
-  instance_name: example-bdcb8b52a
+  instance_name: example-728157fcb
   name: correlation-id
   route: .httpbin.httpbin..80
   tags:
@@ -12,7 +12,7 @@ plugins:
   - k8s-version:v1
 - config:
     header_name: kong-id
-  instance_name: example-a3140f9c1
+  instance_name: example-c1ebced53
   name: correlation-id
   route: .httpbin-other.httpbin..80
   tags:
@@ -22,7 +22,7 @@ plugins:
   - k8s-version:v1
 - config:
     header_name: kong-id
-  instance_name: example-ada1f5f2a
+  instance_name: example-b8a0ddb44
   name: correlation-id
   route: .httpbin-other.httpbin-other..80
   tags:

--- a/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
@@ -1,0 +1,128 @@
+_format_version: "3.0"
+plugins:
+- config:
+    header_name: kong-id
+  instance_name: example-bdcb8b52a
+  name: correlation-id
+  route: .httpbin.httpbin..80
+  tags:
+  - k8s-name:kong-id
+  - k8s-kind:KongPlugin
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+- config:
+    header_name: kong-id
+  instance_name: example-a3140f9c1
+  name: correlation-id
+  route: .httpbin-other.httpbin..80
+  tags:
+  - k8s-name:kong-id
+  - k8s-kind:KongPlugin
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+- config:
+    header_name: kong-id
+  instance_name: example-ada1f5f2a
+  name: correlation-id
+  route: .httpbin-other.httpbin-other..80
+  tags:
+  - k8s-name:kong-id
+  - k8s-kind:KongPlugin
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+services:
+- connect_timeout: 60000
+  host: httpbin..80.svc
+  name: .httpbin.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    name: .httpbin.httpbin..80
+    path_handling: v0
+    paths:
+    - /httpbin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:httpbin
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  - https_redirect_status_code: 426
+    name: .httpbin-other.httpbin..80
+    path_handling: v0
+    paths:
+    - /httpbin-diff
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:httpbin-other
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:httpbin
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: httpbin-other..80.svc
+  name: .httpbin-other.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    name: .httpbin-other.httpbin-other..80
+    path_handling: v0
+    paths:
+    - /httpbin-other
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:httpbin-other
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:httpbin-other
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: httpbin..80.svc
+  tags:
+  - k8s-name:httpbin
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: httpbin-other..80.svc
+  tags:
+  - k8s-name:httpbin-other
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/in.yaml
+++ b/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/in.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-other
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin
+  annotations:
+    konghq.com/plugins: kong-id
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /httpbin
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: httpbin
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin-other
+  annotations:
+    konghq.com/plugins: kong-id
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /httpbin-diff
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: httpbin
+            port:
+              number: 80
+      - path: /httpbin-other
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: httpbin-other
+            port:
+              number: 80
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: kong-id
+config:
+  header_name: kong-id
+plugin: correlation-id
+instance_name: example

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -80,7 +80,8 @@ func TestPluginEssentials(t *testing.T) {
 			Namespace: ns.Name,
 			Name:      "teapot",
 		},
-		PluginName: "request-termination",
+		InstanceName: "example",
+		PluginName:   "request-termination",
 		Config: apiextensionsv1.JSON{
 			Raw: []byte(`{"status_code": 418}`),
 		},
@@ -92,7 +93,8 @@ func TestPluginEssentials(t *testing.T) {
 				annotations.IngressClassKey: consts.IngressClass,
 			},
 		},
-		PluginName: "request-termination",
+		InstanceName: "example-cluster",
+		PluginName:   "request-termination",
 		Config: apiextensionsv1.JSON{
 			Raw: []byte(`{"status_code": 451}`),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Attach a short hash (or full hash, in the event of a short hash collision) of the attached entity to generated plugin `instance_name` values.

instance_name must be unique. Applying the same KongPlugin to multiple resources, or resources that generate multiple Kong entities, would violate this rule otherwise.

**Which issue this PR fixes**:

Fix #4516 

**Special notes for your reviewer**:

Although not covered in the original issue, the suffixes need to be consistent to avoid constant config updates in DB mode, so random suffixes or counters (the iteration order can vary and changes when new plugins are added) aren't an option. I initially did the entity name verbatim, but this is indeed quite long. Full hashes are actually longer, but should be extremely rare in practice.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
