### PR TITLE
chore(tests): move metrics envtest to test/envtest

### DIFF
--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -1,6 +1,6 @@
 //go:build envtest
 
-package metrics_test
+package envtest
 
 import (
 	"context"
@@ -12,24 +12,24 @@ import (
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
+	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
 
 func TestMetricsAreServed(t *testing.T) {
 	t.Parallel()
 
 	const (
-		waitTime = 10 * time.Second
-		tickTime = 100 * time.Millisecond
+		waitTime = 30 * time.Second
+		tickTime = 10 * time.Millisecond
 	)
 
-	envcfg := envtest.Setup(t, scheme.Scheme)
-	cfg := envtest.ConfigForEnvConfig(t, envcfg)
+	envcfg := Setup(t, scheme.Scheme)
+	cfg := ConfigForEnvConfig(t, envcfg)
+	cfg.EnableProfiling = false
 	cfg.EnableConfigDumps = false
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
**What this PR does / why we need it**:

This moves `TestMetricsAreServed` envtest based test to `test/envtest`.

Additionally this also fixes error logs emitted in `TestGatewayReconciliation_MoreThan100Routes` which were caused by a missing backend service

```
can't add target for backend backend-svc: no kubernetes service found
```

```
E0831 10:39:17.938573   12044 event.go:240] Unable to write event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"9969e54d-6c3d-484c-9b7e-1d7b5dabd0c9.17806b0b1d7f0b40", GenerateName:"", Namespace:"0afe3c6d-0f4f-4f83-acd4-d5a9c76eef71", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"HTTPRoute", Namespace:"0afe3c6d-0f4f-4f83-acd4-d5a9c76eef71", Name:"9969e54d-6c3d-484c-9b7e-1d7b5dabd0c9", UID:"dbb661a7-53ba-476d-84dc-29b5f82eaae0", APIVersion:"gateway.networking.k8s.io/v1beta1", ResourceVersion:"573", FieldPath:""}, Reason:"KongConfigurationTranslationFailed", Message:"can't add target for backend backend-svc: no kubernetes service found", Source:v1.EventSource{Component:"kong-client", Host:""}, FirstTimestamp:time.Date(2023, time.August, 31, 10, 39, 15, 374984000, time.Local), LastTimestamp:time.Date(2023, time.August, 31, 10, 39, 15, 374984000, time.Local), Count:1, Type:"Warning", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"kong-client", ReportingInstance:""}' (broadcaster is shut down)
```

