### PR TITLE
fix(tests): remove cluster after test.expression_router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,6 @@ test.istio: gotestsum
 
 .PHONY: test.expression_router
 test.expression_router: gotestsum
-	GOTAGS="expression_router_tests"
 	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 	GOFLAGS="-tags=expression_router_tests" $(GOTESTSUM) -- $(GOTESTFLAGS) \
 		-race \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Running
```
make  test.expression_router
```
leaves cluster after tests, this PR fixes it.

Furthermore, it skips removing clusters for conformance and integration tests when an ephemeral CI environment is used to save some time.