### PR TITLE
feat(admission): validate regex supplied in HTTPRoute (stop rejecting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ Adding a new version? You'll need three changes:
 
 ### Added
 
+- Add validation in admission webhook for regex expressions supplied in HTTPRoute
+  (stop rejecting such configurations).
+  [#4608](https://github.com/Kong/kubernetes-ingress-controller/pull/4608)
 - Add new feature gate `RewriteURIs` to enable/disable the `konghq.com/rewrite`
   annotation (default disabled).
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ Adding a new version? You'll need three changes:
 
 ### Added
 
-- Add validation in admission webhook for regex expressions supplied in HTTPRoute
-  (stop rejecting such configurations).
+- Allow regex expressions in `HTTPRoute` configuration and provide validation in admission webhook.
+  Before this change admission webhook used to reject entirely such configurations incorrectly as not supported yet.
   [#4608](https://github.com/Kong/kubernetes-ingress-controller/pull/4608)
 - Add new feature gate `RewriteURIs` to enable/disable the `konghq.com/rewrite`
   annotation (default disabled).
@@ -164,7 +164,7 @@ Adding a new version? You'll need three changes:
   [#4211](https://github.com/Kong/kubernetes-ingress-controller/pull/4211)
 - Assign priorities to routes translated from Ingresses when parser translate
   them to expression based Kong routes. The assigning method is basically the
-  same as in Kong gateway's `traditional_compatible` router, except that 
+  same as in Kong gateway's `traditional_compatible` router, except that
   `regex_priority` field in Kong traditional route is not supported. This
   method is adopted to keep the compatibility with traditional router on
   maximum effort.
@@ -174,7 +174,7 @@ Adding a new version? You'll need three changes:
   [specification on priorities of matches in `HTTPRoute`][httproute-specification].
   [#4296](https://github.com/Kong/kubernetes-ingress-controller/pull/4296)
   [#4434](https://github.com/Kong/kubernetes-ingress-controller/pull/4434)
-- Assign priorities to routes translated from GRPCRoutes when the parser translates 
+- Assign priorities to routes translated from GRPCRoutes when the parser translates
   them to expression based Kong routes. The priority order follows the
   [specification on match priorities in GRPCRoute][grpcroute-specification].
   [#4364](https://github.com/Kong/kubernetes-ingress-controller/pull/4364)
@@ -227,10 +227,10 @@ Adding a new version? You'll need three changes:
   to `/status/ready`. Gateways will be considered ready only after an initial
   configuration is applied by the controller.
   [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
-- When translating to expression based Kong routes, annotations to specify 
+- When translating to expression based Kong routes, annotations to specify
   protocols are translated to `protocols` field of the result Kong route,
-  instead of putting the conditions to match protocols inside expressions. 
-  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422) 
+  instead of putting the conditions to match protocols inside expressions.
+  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422)
 
 ### Fixed
 
@@ -246,7 +246,7 @@ Adding a new version? You'll need three changes:
 - `Gateway` can now correctly update `AttachedRoutes` even if there are more
   than 100 `HttpRoute`s.
   [#4458](https://github.com/Kong/kubernetes-ingress-controller/pull/4458)
- 
+
 [gojson]: https://github.com/goccy/go-json
 [httproute-specification]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
 [grpcroute-specification]:  https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteRule
@@ -518,7 +518,7 @@ backported properly. It is included in the next patch release.
   configuration.
   [#3359](https://github.com/Kong/kubernetes-ingress-controller/pull/3359)
 - Added `version` command
-  [#3379](https://github.com/Kong/kubernetes-ingress-controller/pull/3379)  
+  [#3379](https://github.com/Kong/kubernetes-ingress-controller/pull/3379)
 - Added `--publish-service-udp` to indicate the Service that handles inbound
   UDP traffic.
   [#3325](https://github.com/Kong/kubernetes-ingress-controller/pull/3325)
@@ -552,7 +552,7 @@ backported properly. It is included in the next patch release.
   [#3469](https://github.com/Kong/kubernetes-ingress-controller/pull/3469)
 - Added Gateway discovery using Kong Admin API service configured via `--kong-admin-svc`
   which accepts a namespaced name of a headless service which should have
-  Admin API endpoints exposed under a named port called `admin`. Gateway 
+  Admin API endpoints exposed under a named port called `admin`. Gateway
   discovery is only allowed to run with dbless kong gateways.
   [#3421](https://github.com/Kong/kubernetes-ingress-controller/pull/3421)
   [#3642](https://github.com/Kong/kubernetes-ingress-controller/pull/3642)
@@ -572,27 +572,27 @@ backported properly. It is included in the next patch release.
   [#3446](https://github.com/Kong/kubernetes-ingress-controller/pull/3446)
 - Leader election is enabled by default when Kong Gateway discovery is enabled.
   [#3529](https://github.com/Kong/kubernetes-ingress-controller/pull/3529)
-- Added flag `--konnect-refresh-node-period` to set the period of uploading 
+- Added flag `--konnect-refresh-node-period` to set the period of uploading
   status of KIC instance to Konnect runtime group.
   [#3533](https://github.com/Kong/kubernetes-ingress-controller/pull/3533)
-- Replaced service account's token static secret with a projected volume in 
+- Replaced service account's token static secret with a projected volume in
   deployment manifests.
   [#3563](https://github.com/Kong/kubernetes-ingress-controller/pull/3563)
 - Added `GRPCRoute` controller and implemented basic `GRPCRoute` functionality.
   [#3537](https://github.com/Kong/kubernetes-ingress-controller/pull/3537)
 - Included Konnect sync and Gateway discovery features in telemetry reports.
   [#3588](https://github.com/Kong/kubernetes-ingress-controller/pull/3588)
-- Upload the status of controlled Kong gateway nodes to Konnect when syncing with 
-  Konnect is enabled by setting the flag `--konnect-sync-enabled` to true. 
-  If gateway discovery is enabled via `--kong-admin-svc` flag, the hostname of a node 
-  corresponding to each Kong gateway instance will use `<pod_namespace>/<pod_name>` 
-  format, where `pod_namespace` and `pod_name` are the namespace and name of the Kong 
-  gateway pod. If gateway discovery is disabled, the Kong gateway nodes will use `gateway_<address>` 
+- Upload the status of controlled Kong gateway nodes to Konnect when syncing with
+  Konnect is enabled by setting the flag `--konnect-sync-enabled` to true.
+  If gateway discovery is enabled via `--kong-admin-svc` flag, the hostname of a node
+  corresponding to each Kong gateway instance will use `<pod_namespace>/<pod_name>`
+  format, where `pod_namespace` and `pod_name` are the namespace and name of the Kong
+  gateway pod. If gateway discovery is disabled, the Kong gateway nodes will use `gateway_<address>`
   as the hostname, where `address` is the Admin API address used by KIC.
   [#3587](https://github.com/Kong/kubernetes-ingress-controller/pull/3587)
-- All all-in-one DB-less deployment manifests will now use separate deployments 
+- All all-in-one DB-less deployment manifests will now use separate deployments
   for the controller and the proxy. This enables the proxy to be scaled independently
-  of the controller. The old `all-in-one-dbless.yaml` manifest has been deprecated and 
+  of the controller. The old `all-in-one-dbless.yaml` manifest has been deprecated and
   renamed to `all-in-one-dbless-legacy.yaml`. It will be removed in a future release.
   [#3629](https://github.com/Kong/kubernetes-ingress-controller/pull/3629)
 - The RequestRedirect Gateway API filter is now supported and translated
@@ -701,37 +701,37 @@ backported properly. It is included in the next patch release.
 ### Added
 
 - Added `HTTPRoute` support for `CombinedRoutes` feature. When enabled,
-  `HTTPRoute.HTTPRouteRule` objects with identical `backendRefs` generate a 
-  single Kong service instead of a service per rule, and 
-  `HTTPRouteRule.HTTPRouteMatche` objects using the same `backendRefs` can be 
-  consolidated into a single Kong route instead of always creating a route per 
+  `HTTPRoute.HTTPRouteRule` objects with identical `backendRefs` generate a
+  single Kong service instead of a service per rule, and
+  `HTTPRouteRule.HTTPRouteMatche` objects using the same `backendRefs` can be
+  consolidated into a single Kong route instead of always creating a route per
   match, reducing configuration size.
   The following limitations apply:
-  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service
     if they belong to different `HTTPRoute`.
-  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service
     if they have different `HTTPRouteRule.HTTPBackendRef[]` objects. The order
     of the backend references is not important.
   - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
     if parent `HTTPRouteRule` objects cannot be consolidated into a single Kong Service.
   - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
     if parent `HTTPRouteRule` objects have different `HTTPRouteRule.HTTPRouteFilter[]` filters.
-  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route 
-    if they have different matching spec (`HTTPHeaderMatch.Headers`, `HTTPHeaderMatch.QueryParams`, 
-    `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between 
+  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
+    if they have different matching spec (`HTTPHeaderMatch.Headers`, `HTTPHeaderMatch.QueryParams`,
+    `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between
     `HTTPRouteMatch[]` objects does not prevent consolidation.
   This change does not functionally impact routing: requests that went to a given Service
   using the original method still go to the same Service when `CombinedRoutes` is enabled.
   [#3008](https://github.com/Kong/kubernetes-ingress-controller/pull/3008)
   [#3060]https://github.com/Kong/kubernetes-ingress-controller/pull/3060)
-- Added `--cache-sync-timeout` flag allowing to change the default controllers' 
-  cache synchronisation timeout. 
+- Added `--cache-sync-timeout` flag allowing to change the default controllers'
+  cache synchronisation timeout.
   [#3013](https://github.com/Kong/kubernetes-ingress-controller/pull/3013)
 - Secrets validation introduced: CA certificates won't be synchronized
   to Kong if the certificate is expired.
   [#3063](https://github.com/Kong/kubernetes-ingress-controller/pull/3063)
 - Changed the logic of storing secrets into object cache. Now only the secrets
-  that are possibly used in Kong configuration are stored into cache, and the 
+  that are possibly used in Kong configuration are stored into cache, and the
   irrelevant secrets (e.g: service account tokens) are not stored. This change
   is made to reduce memory usage of the cache.
   [#3047](https://github.com/Kong/kubernetes-ingress-controller/pull/3047)
@@ -747,7 +747,7 @@ backported properly. It is included in the next patch release.
   [#3155](https://github.com/Kong/kubernetes-ingress-controller/pull/3155)
 - Routes support annotations for path handling.
   [#3121](https://github.com/Kong/kubernetes-ingress-controller/pull/3121)
-- Warning Kubernetes API events with a `KongConfigurationTranslationFailed` 
+- Warning Kubernetes API events with a `KongConfigurationTranslationFailed`
   reason are recorded when:
   - CA secrets cannot be properly translated into Kong configuration
     [#3125](https://github.com/Kong/kubernetes-ingress-controller/pull/3125)
@@ -755,10 +755,10 @@ backported properly. It is included in the next patch release.
     [#3130](https://github.com/Kong/kubernetes-ingress-controller/pull/3130)
   - A service's referred client-cert does not exist.
     [#3137](https://github.com/Kong/kubernetes-ingress-controller/pull/3137)
-  - One of `netv1.Ingress` related issues occurs (e.g. backing Kubernetes service couldn't 
+  - One of `netv1.Ingress` related issues occurs (e.g. backing Kubernetes service couldn't
     be found, matching Kubernetes service port couldn't be found).
     [#3138](https://github.com/Kong/kubernetes-ingress-controller/pull/3138)
-  - A Gateway Listener has more than one CertificateRef specified or refers to a Secret 
+  - A Gateway Listener has more than one CertificateRef specified or refers to a Secret
     that has no valid TLS key-pair.
     [#3147](https://github.com/Kong/kubernetes-ingress-controller/pull/3147)
   - An Ingress refers to a TLS secret that does not exist or
@@ -808,15 +808,15 @@ backported properly. It is included in the next patch release.
 - Admin and proxy listens in the deploy manifests now use the same parameters
   as the default upstream kong.conf.
   [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
-- Fix the behavior of filtering hostnames in `HTTPRoute` when listeners 
+- Fix the behavior of filtering hostnames in `HTTPRoute` when listeners
   of parent gateways specified hostname.
   If an `HTTPRoute` does not specify hostnames, and one of its parent listeners
-  has not specified hostname, the `HTTPRoute` matches any hostname. 
-  If an `HTTPRoute` specifies hostnames, and no intersecting hostnames 
+  has not specified hostname, the `HTTPRoute` matches any hostname.
+  If an `HTTPRoute` specifies hostnames, and no intersecting hostnames
   could be found in its parent listners, it is not accepted.
   [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)
-- Matches `sectionName` in parentRefs of route objects in gateway API. Now 
-  if a route specifies `sectionName` in parentRefs, and no listener can 
+- Matches `sectionName` in parentRefs of route objects in gateway API. Now
+  if a route specifies `sectionName` in parentRefs, and no listener can
   match the specified name, the route is not accepted.
   [#3230](https://github.com/Kong/kubernetes-ingress-controller/pull/3230)
 - If there's no matching Kong listener for a protocol specified in a Gateway's
@@ -1121,9 +1121,9 @@ instructions and the [revised Kong 3.x upgrade instructions](https://docs.konghq
   [#2446](https://github.com/Kong/kubernetes-ingress-controller/issues/2446)
 - Added a mechanism to retry the initial connection to the Kong
   Admin API on controller start to fix an issue where the controller
-  pod could crash loop on start when waiting for Gateway readiness 
-  (e.g. if the Gateway is waiting for its database to initialize). 
-  The new retry mechanism can be manually configured using the 
+  pod could crash loop on start when waiting for Gateway readiness
+  (e.g. if the Gateway is waiting for its database to initialize).
+  The new retry mechanism can be manually configured using the
   `--kong-admin-init-retries` and `--kong-admin-init-retry-delay` flags.
   [#2274](https://github.com/Kong/kubernetes-ingress-controller/issues/2274)
 - diff logging now honors log level instead of printing at all log levels. It
@@ -1241,7 +1241,7 @@ instructions and the [revised Kong 3.x upgrade instructions](https://docs.konghq
 
 #### Added
 
-- Support for Kubernetes [Gateway APIs][gwapis] is now available [by enabling 
+- Support for Kubernetes [Gateway APIs][gwapis] is now available [by enabling
   the `Gateway` feature gate](https://docs.konghq.com/kubernetes-ingress-controller/2.2.x/guides/using-gateway-api/).
   This is an alpha feature, with limited support for the `HTTPRoute` API.
   [Gateway Milestone 1][gwm1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,7 @@ Adding a new version? You'll need three changes:
   [#4211](https://github.com/Kong/kubernetes-ingress-controller/pull/4211)
 - Assign priorities to routes translated from Ingresses when parser translate
   them to expression based Kong routes. The assigning method is basically the
-  same as in Kong gateway's `traditional_compatible` router, except that
+  same as in Kong gateway's `traditional_compatible` router, except that 
   `regex_priority` field in Kong traditional route is not supported. This
   method is adopted to keep the compatibility with traditional router on
   maximum effort.
@@ -174,7 +174,7 @@ Adding a new version? You'll need three changes:
   [specification on priorities of matches in `HTTPRoute`][httproute-specification].
   [#4296](https://github.com/Kong/kubernetes-ingress-controller/pull/4296)
   [#4434](https://github.com/Kong/kubernetes-ingress-controller/pull/4434)
-- Assign priorities to routes translated from GRPCRoutes when the parser translates
+- Assign priorities to routes translated from GRPCRoutes when the parser translates 
   them to expression based Kong routes. The priority order follows the
   [specification on match priorities in GRPCRoute][grpcroute-specification].
   [#4364](https://github.com/Kong/kubernetes-ingress-controller/pull/4364)
@@ -227,10 +227,10 @@ Adding a new version? You'll need three changes:
   to `/status/ready`. Gateways will be considered ready only after an initial
   configuration is applied by the controller.
   [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
-- When translating to expression based Kong routes, annotations to specify
+- When translating to expression based Kong routes, annotations to specify 
   protocols are translated to `protocols` field of the result Kong route,
-  instead of putting the conditions to match protocols inside expressions.
-  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422)
+  instead of putting the conditions to match protocols inside expressions. 
+  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422) 
 
 ### Fixed
 
@@ -246,7 +246,7 @@ Adding a new version? You'll need three changes:
 - `Gateway` can now correctly update `AttachedRoutes` even if there are more
   than 100 `HttpRoute`s.
   [#4458](https://github.com/Kong/kubernetes-ingress-controller/pull/4458)
-
+ 
 [gojson]: https://github.com/goccy/go-json
 [httproute-specification]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
 [grpcroute-specification]:  https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteRule
@@ -518,7 +518,7 @@ backported properly. It is included in the next patch release.
   configuration.
   [#3359](https://github.com/Kong/kubernetes-ingress-controller/pull/3359)
 - Added `version` command
-  [#3379](https://github.com/Kong/kubernetes-ingress-controller/pull/3379)
+  [#3379](https://github.com/Kong/kubernetes-ingress-controller/pull/3379)  
 - Added `--publish-service-udp` to indicate the Service that handles inbound
   UDP traffic.
   [#3325](https://github.com/Kong/kubernetes-ingress-controller/pull/3325)
@@ -552,7 +552,7 @@ backported properly. It is included in the next patch release.
   [#3469](https://github.com/Kong/kubernetes-ingress-controller/pull/3469)
 - Added Gateway discovery using Kong Admin API service configured via `--kong-admin-svc`
   which accepts a namespaced name of a headless service which should have
-  Admin API endpoints exposed under a named port called `admin`. Gateway
+  Admin API endpoints exposed under a named port called `admin`. Gateway 
   discovery is only allowed to run with dbless kong gateways.
   [#3421](https://github.com/Kong/kubernetes-ingress-controller/pull/3421)
   [#3642](https://github.com/Kong/kubernetes-ingress-controller/pull/3642)
@@ -572,27 +572,27 @@ backported properly. It is included in the next patch release.
   [#3446](https://github.com/Kong/kubernetes-ingress-controller/pull/3446)
 - Leader election is enabled by default when Kong Gateway discovery is enabled.
   [#3529](https://github.com/Kong/kubernetes-ingress-controller/pull/3529)
-- Added flag `--konnect-refresh-node-period` to set the period of uploading
+- Added flag `--konnect-refresh-node-period` to set the period of uploading 
   status of KIC instance to Konnect runtime group.
   [#3533](https://github.com/Kong/kubernetes-ingress-controller/pull/3533)
-- Replaced service account's token static secret with a projected volume in
+- Replaced service account's token static secret with a projected volume in 
   deployment manifests.
   [#3563](https://github.com/Kong/kubernetes-ingress-controller/pull/3563)
 - Added `GRPCRoute` controller and implemented basic `GRPCRoute` functionality.
   [#3537](https://github.com/Kong/kubernetes-ingress-controller/pull/3537)
 - Included Konnect sync and Gateway discovery features in telemetry reports.
   [#3588](https://github.com/Kong/kubernetes-ingress-controller/pull/3588)
-- Upload the status of controlled Kong gateway nodes to Konnect when syncing with
-  Konnect is enabled by setting the flag `--konnect-sync-enabled` to true.
-  If gateway discovery is enabled via `--kong-admin-svc` flag, the hostname of a node
-  corresponding to each Kong gateway instance will use `<pod_namespace>/<pod_name>`
-  format, where `pod_namespace` and `pod_name` are the namespace and name of the Kong
-  gateway pod. If gateway discovery is disabled, the Kong gateway nodes will use `gateway_<address>`
+- Upload the status of controlled Kong gateway nodes to Konnect when syncing with 
+  Konnect is enabled by setting the flag `--konnect-sync-enabled` to true. 
+  If gateway discovery is enabled via `--kong-admin-svc` flag, the hostname of a node 
+  corresponding to each Kong gateway instance will use `<pod_namespace>/<pod_name>` 
+  format, where `pod_namespace` and `pod_name` are the namespace and name of the Kong 
+  gateway pod. If gateway discovery is disabled, the Kong gateway nodes will use `gateway_<address>` 
   as the hostname, where `address` is the Admin API address used by KIC.
   [#3587](https://github.com/Kong/kubernetes-ingress-controller/pull/3587)
-- All all-in-one DB-less deployment manifests will now use separate deployments
+- All all-in-one DB-less deployment manifests will now use separate deployments 
   for the controller and the proxy. This enables the proxy to be scaled independently
-  of the controller. The old `all-in-one-dbless.yaml` manifest has been deprecated and
+  of the controller. The old `all-in-one-dbless.yaml` manifest has been deprecated and 
   renamed to `all-in-one-dbless-legacy.yaml`. It will be removed in a future release.
   [#3629](https://github.com/Kong/kubernetes-ingress-controller/pull/3629)
 - The RequestRedirect Gateway API filter is now supported and translated
@@ -701,37 +701,37 @@ backported properly. It is included in the next patch release.
 ### Added
 
 - Added `HTTPRoute` support for `CombinedRoutes` feature. When enabled,
-  `HTTPRoute.HTTPRouteRule` objects with identical `backendRefs` generate a
-  single Kong service instead of a service per rule, and
-  `HTTPRouteRule.HTTPRouteMatche` objects using the same `backendRefs` can be
-  consolidated into a single Kong route instead of always creating a route per
+  `HTTPRoute.HTTPRouteRule` objects with identical `backendRefs` generate a 
+  single Kong service instead of a service per rule, and 
+  `HTTPRouteRule.HTTPRouteMatche` objects using the same `backendRefs` can be 
+  consolidated into a single Kong route instead of always creating a route per 
   match, reducing configuration size.
   The following limitations apply:
-  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
     if they belong to different `HTTPRoute`.
-  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service
+  - `HTTPRouteRule` objects cannot be consolidated into a single Kong Service 
     if they have different `HTTPRouteRule.HTTPBackendRef[]` objects. The order
     of the backend references is not important.
   - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
     if parent `HTTPRouteRule` objects cannot be consolidated into a single Kong Service.
   - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
     if parent `HTTPRouteRule` objects have different `HTTPRouteRule.HTTPRouteFilter[]` filters.
-  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route
-    if they have different matching spec (`HTTPHeaderMatch.Headers`, `HTTPHeaderMatch.QueryParams`,
-    `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between
+  - `HTTPRouteMatch` objects cannot be consolidated into a single Kong Route 
+    if they have different matching spec (`HTTPHeaderMatch.Headers`, `HTTPHeaderMatch.QueryParams`, 
+    `HTTPHeaderMatch.Method`). Different `HTTPHeaderMatch.Path` paths between 
     `HTTPRouteMatch[]` objects does not prevent consolidation.
   This change does not functionally impact routing: requests that went to a given Service
   using the original method still go to the same Service when `CombinedRoutes` is enabled.
   [#3008](https://github.com/Kong/kubernetes-ingress-controller/pull/3008)
   [#3060]https://github.com/Kong/kubernetes-ingress-controller/pull/3060)
-- Added `--cache-sync-timeout` flag allowing to change the default controllers'
-  cache synchronisation timeout.
+- Added `--cache-sync-timeout` flag allowing to change the default controllers' 
+  cache synchronisation timeout. 
   [#3013](https://github.com/Kong/kubernetes-ingress-controller/pull/3013)
 - Secrets validation introduced: CA certificates won't be synchronized
   to Kong if the certificate is expired.
   [#3063](https://github.com/Kong/kubernetes-ingress-controller/pull/3063)
 - Changed the logic of storing secrets into object cache. Now only the secrets
-  that are possibly used in Kong configuration are stored into cache, and the
+  that are possibly used in Kong configuration are stored into cache, and the 
   irrelevant secrets (e.g: service account tokens) are not stored. This change
   is made to reduce memory usage of the cache.
   [#3047](https://github.com/Kong/kubernetes-ingress-controller/pull/3047)
@@ -747,7 +747,7 @@ backported properly. It is included in the next patch release.
   [#3155](https://github.com/Kong/kubernetes-ingress-controller/pull/3155)
 - Routes support annotations for path handling.
   [#3121](https://github.com/Kong/kubernetes-ingress-controller/pull/3121)
-- Warning Kubernetes API events with a `KongConfigurationTranslationFailed`
+- Warning Kubernetes API events with a `KongConfigurationTranslationFailed` 
   reason are recorded when:
   - CA secrets cannot be properly translated into Kong configuration
     [#3125](https://github.com/Kong/kubernetes-ingress-controller/pull/3125)
@@ -755,10 +755,10 @@ backported properly. It is included in the next patch release.
     [#3130](https://github.com/Kong/kubernetes-ingress-controller/pull/3130)
   - A service's referred client-cert does not exist.
     [#3137](https://github.com/Kong/kubernetes-ingress-controller/pull/3137)
-  - One of `netv1.Ingress` related issues occurs (e.g. backing Kubernetes service couldn't
+  - One of `netv1.Ingress` related issues occurs (e.g. backing Kubernetes service couldn't 
     be found, matching Kubernetes service port couldn't be found).
     [#3138](https://github.com/Kong/kubernetes-ingress-controller/pull/3138)
-  - A Gateway Listener has more than one CertificateRef specified or refers to a Secret
+  - A Gateway Listener has more than one CertificateRef specified or refers to a Secret 
     that has no valid TLS key-pair.
     [#3147](https://github.com/Kong/kubernetes-ingress-controller/pull/3147)
   - An Ingress refers to a TLS secret that does not exist or
@@ -808,15 +808,15 @@ backported properly. It is included in the next patch release.
 - Admin and proxy listens in the deploy manifests now use the same parameters
   as the default upstream kong.conf.
   [#3165](https://github.com/Kong/kubernetes-ingress-controller/pull/3165)
-- Fix the behavior of filtering hostnames in `HTTPRoute` when listeners
+- Fix the behavior of filtering hostnames in `HTTPRoute` when listeners 
   of parent gateways specified hostname.
   If an `HTTPRoute` does not specify hostnames, and one of its parent listeners
-  has not specified hostname, the `HTTPRoute` matches any hostname.
-  If an `HTTPRoute` specifies hostnames, and no intersecting hostnames
+  has not specified hostname, the `HTTPRoute` matches any hostname. 
+  If an `HTTPRoute` specifies hostnames, and no intersecting hostnames 
   could be found in its parent listners, it is not accepted.
   [#3180](https://github.com/Kong/kubernetes-ingress-controller/pull/3180)
-- Matches `sectionName` in parentRefs of route objects in gateway API. Now
-  if a route specifies `sectionName` in parentRefs, and no listener can
+- Matches `sectionName` in parentRefs of route objects in gateway API. Now 
+  if a route specifies `sectionName` in parentRefs, and no listener can 
   match the specified name, the route is not accepted.
   [#3230](https://github.com/Kong/kubernetes-ingress-controller/pull/3230)
 - If there's no matching Kong listener for a protocol specified in a Gateway's
@@ -1121,9 +1121,9 @@ instructions and the [revised Kong 3.x upgrade instructions](https://docs.konghq
   [#2446](https://github.com/Kong/kubernetes-ingress-controller/issues/2446)
 - Added a mechanism to retry the initial connection to the Kong
   Admin API on controller start to fix an issue where the controller
-  pod could crash loop on start when waiting for Gateway readiness
-  (e.g. if the Gateway is waiting for its database to initialize).
-  The new retry mechanism can be manually configured using the
+  pod could crash loop on start when waiting for Gateway readiness 
+  (e.g. if the Gateway is waiting for its database to initialize). 
+  The new retry mechanism can be manually configured using the 
   `--kong-admin-init-retries` and `--kong-admin-init-retry-delay` flags.
   [#2274](https://github.com/Kong/kubernetes-ingress-controller/issues/2274)
 - diff logging now honors log level instead of printing at all log levels. It
@@ -1241,7 +1241,7 @@ instructions and the [revised Kong 3.x upgrade instructions](https://docs.konghq
 
 #### Added
 
-- Support for Kubernetes [Gateway APIs][gwapis] is now available [by enabling
+- Support for Kubernetes [Gateway APIs][gwapis] is now available [by enabling 
   the `Gateway` feature gate](https://docs.konghq.com/kubernetes-ingress-controller/2.2.x/guides/using-gateway-api/).
   This is an alpha feature, with limited support for the `HTTPRoute` API.
   [Gateway Milestone 1][gwm1]

--- a/internal/admission/adminapi_provider.go
+++ b/internal/admission/adminapi_provider.go
@@ -53,6 +53,14 @@ func (p DefaultAdminAPIServicesProvider) GetInfoService() (kong.AbstractInfoServ
 	return c.Info, true
 }
 
+func (p DefaultAdminAPIServicesProvider) GetRoutesService() (kong.AbstractRouteService, bool) {
+	c, ok := p.designatedAdminAPIClient()
+	if !ok {
+		return nil, ok
+	}
+	return c.Routes, true
+}
+
 func (p DefaultAdminAPIServicesProvider) designatedAdminAPIClient() (*kong.Client, bool) {
 	gwClients := p.gatewayClientsProvider.GatewayClients()
 	if len(gwClients) == 0 {

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	gatewaycontroller "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	credsvalidation "github.com/kong/kubernetes-ingress-controller/v2/internal/validation/consumers/credentials"
 	gatewayvalidators "github.com/kong/kubernetes-ingress-controller/v2/internal/validation/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
@@ -41,6 +42,7 @@ type AdminAPIServicesProvider interface {
 	GetPluginsService() (kong.AbstractPluginService, bool)
 	GetConsumerGroupsService() (kong.AbstractConsumerGroupService, bool)
 	GetInfoService() (kong.AbstractInfoService, bool)
+	GetRoutesService() (kong.AbstractRouteService, bool)
 }
 
 // KongHTTPValidator implements KongValidator interface to validate Kong
@@ -50,6 +52,8 @@ type KongHTTPValidator struct {
 	SecretGetter             kongstate.SecretGetter
 	ManagerClient            client.Client
 	AdminAPIServicesProvider AdminAPIServicesProvider
+	ParserFeatures           parser.FeatureFlags
+	KongVersion              semver.Version
 
 	ingressClassMatcher func(*metav1.ObjectMeta, string, annotations.ClassMatching) bool
 }
@@ -63,6 +67,8 @@ func NewKongHTTPValidator(
 	managerClient client.Client,
 	ingressClass string,
 	servicesProvider AdminAPIServicesProvider,
+	parserFeatures parser.FeatureFlags,
+	kongVersion semver.Version,
 ) KongHTTPValidator {
 	matcher := annotations.IngressClassValidatorFuncFromObjectMeta(ingressClass)
 	return KongHTTPValidator{
@@ -70,6 +76,8 @@ func NewKongHTTPValidator(
 		SecretGetter:             &managerClientSecretGetter{managerClient: managerClient},
 		ManagerClient:            managerClient,
 		AdminAPIServicesProvider: servicesProvider,
+		ParserFeatures:           parserFeatures,
+		KongVersion:              kongVersion,
 
 		ingressClassMatcher: matcher,
 	}
@@ -413,9 +421,15 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 		return true, "", nil
 	}
 
-	// now that we know whether or not the HTTPRoute is linked to a managed
+	// Now that we know whether or not the HTTPRoute is linked to a managed
 	// Gateway we can run it through full validation.
-	return gatewayvalidators.ValidateHTTPRoute(&httproute, managedGateways...)
+	routesSvc, ok := validator.AdminAPIServicesProvider.GetRoutesService()
+	if !ok {
+		routesSvc = nil // For nil the below just skips calling Kong Gateway API.
+	}
+	return gatewayvalidators.ValidateHTTPRoute(
+		ctx, routesSvc, validator.ParserFeatures, validator.KongVersion, &httproute, managedGateways...,
+	)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -48,6 +48,7 @@ type fakeServicesProvider struct {
 	consumerSvc      kong.AbstractConsumerService
 	consumerGroupSvc kong.AbstractConsumerGroupService
 	infoSvc          kong.AbstractInfoService
+	routeSvc         kong.AbstractRouteService
 }
 
 func (f fakeServicesProvider) GetConsumersService() (kong.AbstractConsumerService, bool) {
@@ -74,6 +75,13 @@ func (f fakeServicesProvider) GetConsumerGroupsService() (kong.AbstractConsumerG
 func (f fakeServicesProvider) GetPluginsService() (kong.AbstractPluginService, bool) {
 	if f.pluginSvc != nil {
 		return f.pluginSvc, true
+	}
+	return nil, false
+}
+
+func (f fakeServicesProvider) GetRoutesService() (kong.AbstractRouteService, bool) {
+	if f.routeSvc != nil {
+		return f.routeSvc, true
 	}
 	return nil, false
 }

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -141,7 +141,7 @@ func (p *Parser) ingressRulesFromHTTPRouteWithCombinedServiceRoutes(httproute *g
 
 		// generate the routes for the service and attach them to the service
 		for _, kongRouteTranslation := range kongServiceTranslation.KongRoutes {
-			routes, err := generateKongRouteFromTranslation(httproute, kongRouteTranslation, p.featureFlags.RegexPathPrefix, p.featureFlags.ExpressionRoutes, p.kongVersion)
+			routes, err := GenerateKongRouteFromTranslation(httproute, kongRouteTranslation, p.featureFlags.RegexPathPrefix, p.featureFlags.ExpressionRoutes, p.kongVersion)
 			if err != nil {
 				return err
 			}
@@ -284,7 +284,9 @@ func generateKongRoutesFromHTTPRouteRule(
 	return routes, nil
 }
 
-func generateKongRouteFromTranslation(
+// GenerateKongRouteFromTranslation generates Kong routes from HTTPRoute
+// pointing to a specific backend. It is used for both traditional and expression based routes.
+func GenerateKongRouteFromTranslation(
 	httproute *gatewayv1beta1.HTTPRoute,
 	translation translators.KongRouteTranslation,
 	addRegexPrefix bool,

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -149,11 +149,6 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		clientsManager.Run()
 	}
 
-	setupLog.Info("Starting Admission Server")
-	if err := setupAdmissionServer(ctx, c, clientsManager, mgr.GetClient(), deprecatedLogger); err != nil {
-		return err
-	}
-
 	parserFeatureFlags := parser.NewFeatureFlags(
 		deprecatedLogger,
 		featureGates,
@@ -161,6 +156,12 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		routerFlavor,
 		c.UpdateStatus,
 	)
+
+	setupLog.Info("Starting Admission Server")
+	if err := setupAdmissionServer(ctx, c, clientsManager, mgr.GetClient(), deprecatedLogger, parserFeatureFlags, kongSemVersion); err != nil {
+		return err
+	}
+
 	cache := store.NewCacheStores()
 	configParser, err := parser.NewParser(
 		deprecatedLogger,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/blang/semver/v4"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/deck/cprint"
@@ -26,6 +27,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v2/internal/util/dataplane"
@@ -171,6 +173,8 @@ func setupAdmissionServer(
 	clientsManager *clients.AdminAPIClientsManager,
 	managerClient client.Client,
 	deprecatedLogger logrus.FieldLogger,
+	parserFeatures parser.FeatureFlags,
+	kongVersion semver.Version,
 ) error {
 	logger := deprecatedLogger.WithField("component", "admission-server")
 
@@ -186,6 +190,8 @@ func setupAdmissionServer(
 			managerClient,
 			managerConfig.IngressClassName,
 			adminAPIServicesProvider,
+			parserFeatures,
+			kongVersion,
 		),
 		Logger: logger,
 	}, logger)

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -196,16 +196,12 @@ func validateWithKongGateway(
 	var kongRoutes []kong.Route
 	var errMsgs []string
 	for _, rule := range httproute.Spec.Rules {
-		var (
-			routes []kongstate.Route
-			err    error
-		)
 		translation := translators.KongRouteTranslation{
 			Name:    "validation-attempt",
 			Matches: rule.Matches,
 			Filters: rule.Filters,
 		}
-		routes, err = parser.GenerateKongRouteFromTranslation(
+		routes, err := parser.GenerateKongRouteFromTranslation(
 			httproute, translation, parserFeatures.RegexPathPrefix, parserFeatures.ExpressionRoutes, kongVersion,
 		)
 		if err != nil {

--- a/internal/validation/gateway/httproute_test.go
+++ b/internal/validation/gateway/httproute_test.go
@@ -1,14 +1,17 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/kong/go-kong/kong"
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 )
 
 func TestValidateHTTPRoute(t *testing.T) {
@@ -16,8 +19,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 		nonexistentListener = gatewayv1beta1.SectionName("listener-that-doesnt-exist")
 		group               = gatewayv1beta1.Group("gateway.networking.k8s.io")
 		defaultGWNamespace  = gatewayv1beta1.Namespace(corev1.NamespaceDefault)
-		pathMatchRegex      = gatewayv1beta1.PathMatchRegularExpression
-		headerMatchRegex    = gatewayv1beta1.HeaderMatchRegularExpression
 		exampleGroup        = gatewayv1beta1.Group("example")
 		podKind             = gatewayv1beta1.Kind("Pod")
 	)
@@ -256,113 +257,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 			err:           fmt.Errorf("queryparam matching is not yet supported for httproute"),
 		},
 		{
-			msg: "if an HTTPRoute is using regex path matching it fails validation due to lack of support",
-			route: &gatewayv1beta1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "testing-httproute",
-				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Name: "testing-gateway",
-						}},
-					},
-					Rules: []gatewayv1beta1.HTTPRouteRule{{
-						Matches: []gatewayv1beta1.HTTPRouteMatch{{
-							Path: &gatewayv1beta1.HTTPPathMatch{
-								Type:  &pathMatchRegex,
-								Value: kong.String("^path/to/stuff/*$"),
-							},
-						}},
-						BackendRefs: []gatewayv1beta1.HTTPBackendRef{{
-							BackendRef: gatewayv1beta1.BackendRef{
-								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-									Namespace: &defaultGWNamespace,
-								},
-							},
-						}},
-					}},
-				},
-			},
-			gateways: []*gatewayv1beta1.Gateway{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "testing-gateway",
-				},
-				Spec: gatewayv1beta1.GatewaySpec{
-					Listeners: []gatewayv1beta1.Listener{{
-						Name:     "http",
-						Port:     80,
-						Protocol: (gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
-							Kinds: []gatewayv1beta1.RouteGroupKind{{
-								Group: &group,
-								Kind:  "HTTPRoute",
-							}},
-						},
-					}},
-				},
-			}},
-			valid:         false,
-			validationMsg: "httproute spec did not pass validation",
-			err:           fmt.Errorf("regex path matching is not yet supported for httproute"),
-		},
-		{
-			msg: "if an HTTPRoute is using regex header matching it fails validation due to lack of support",
-			route: &gatewayv1beta1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "testing-httproute",
-				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Name: "testing-gateway",
-						}},
-					},
-					Rules: []gatewayv1beta1.HTTPRouteRule{{
-						Matches: []gatewayv1beta1.HTTPRouteMatch{{
-							Headers: []gatewayv1beta1.HTTPHeaderMatch{{
-								Type:  &headerMatchRegex,
-								Name:  "Content-Type",
-								Value: "audio/vorbis",
-							}},
-						}},
-						BackendRefs: []gatewayv1beta1.HTTPBackendRef{{
-							BackendRef: gatewayv1beta1.BackendRef{
-								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
-									Namespace: &defaultGWNamespace,
-								},
-							},
-						}},
-					}},
-				},
-			},
-			gateways: []*gatewayv1beta1.Gateway{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "testing-gateway",
-				},
-				Spec: gatewayv1beta1.GatewaySpec{
-					Listeners: []gatewayv1beta1.Listener{{
-						Name:     "http",
-						Port:     80,
-						Protocol: (gatewayv1beta1.HTTPProtocolType),
-						AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
-							Kinds: []gatewayv1beta1.RouteGroupKind{{
-								Group: &group,
-								Kind:  "HTTPRoute",
-							}},
-						},
-					}},
-				},
-			}},
-			valid:         false,
-			validationMsg: "httproute spec did not pass validation",
-			err:           fmt.Errorf("regex header matching is not yet supported for httproute"),
-		},
-		{
 			msg: "we don't support any group except core kubernetes for backendRefs",
 			route: &gatewayv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -478,7 +372,10 @@ func TestValidateHTTPRoute(t *testing.T) {
 			err:           fmt.Errorf("Pod is not a supported kind for httproute backendRefs, only Service is supported"),
 		},
 	} {
-		valid, validMsg, err := ValidateHTTPRoute(tt.route, tt.gateways...)
+		// Passed Kong version is irrelevant for the above test cases.
+		valid, validMsg, err := ValidateHTTPRoute(
+			context.Background(), nil, parser.FeatureFlags{}, semver.MustParse("3.0.0"), tt.route, tt.gateways...,
+		)
 		assert.Equal(t, tt.valid, valid, tt.msg)
 		assert.Equal(t, tt.validationMsg, validMsg, tt.msg)
 		assert.Equal(t, tt.err, err, tt.msg)

--- a/internal/validation/gateway/httproute_test.go
+++ b/internal/validation/gateway/httproute_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -372,12 +373,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 			err:           fmt.Errorf("Pod is not a supported kind for httproute backendRefs, only Service is supported"),
 		},
 	} {
-		// Passed Kong version is irrelevant for the above test cases.
+		// Passed Kong version and routesValidator are irrelevant for the above test cases.
 		valid, validMsg, err := ValidateHTTPRoute(
-			context.Background(), nil, parser.FeatureFlags{}, semver.MustParse("3.0.0"), tt.route, tt.gateways...,
+			context.Background(), mockRoutesValidator{}, parser.FeatureFlags{}, semver.MustParse("3.0.0"), tt.route, tt.gateways...,
 		)
 		assert.Equal(t, tt.valid, valid, tt.msg)
 		assert.Equal(t, tt.validationMsg, validMsg, tt.msg)
 		assert.Equal(t, tt.err, err, tt.msg)
 	}
+}
+
+type mockRoutesValidator struct{}
+
+func (mockRoutesValidator) Validate(_ context.Context, _ *kong.Route) (bool, string, error) {
+	return true, "", nil
 }

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +29,9 @@ func TestGatewayValidationWebhook(t *testing.T) {
 		t.Skip("webhook tests are only available on KIND clusters currently")
 	}
 
-	closer, err := ensureAdmissionRegistration(ctx,
+	ensureAdmissionRegistration(
+		ctx,
+		t,
 		"kong-validations-gateway",
 		[]admregv1.RuleWithOperations{
 			{
@@ -43,14 +44,9 @@ func TestGatewayValidationWebhook(t *testing.T) {
 			},
 		},
 	)
-	assert.NoError(t, err, "creating webhook config")
-	defer func() {
-		assert.NoError(t, closer())
-	}()
 
 	t.Log("waiting for webhook service to be connective")
-	err = waitForWebhookServiceConnective(ctx, "kong-validations-gateway")
-	require.NoError(t, err)
+	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-gateway"))
 
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -414,38 +413,4 @@ func setIngressClassNameWithRetry(ctx context.Context, namespace string, ingress
 		_, err = ingressClient.Update(ctx, ingress, metav1.UpdateOptions{})
 		return err
 	})
-}
-
-type routerFlavor string
-
-const (
-	traditional           routerFlavor = "traditional"
-	traditionalCompatible routerFlavor = "traditional_compatible"
-	expressions           routerFlavor = "expressions"
-)
-
-func skipTestForRouterFlavor(t *testing.T, flavor ...routerFlavor) {
-	t.Helper()
-	routerFlavor := routerFlavor(eventuallyGetKongRouterFlavor(t, proxyAdminURL))
-	for _, f := range flavor {
-		if routerFlavor == f {
-			t.Skipf("router flavor:%q skipping", f)
-		}
-	}
-}
-
-// Expression router is not supported for some objects and features.
-// For example, KongIngress is not supported by intention;
-// TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
-// When the test case depends on the object or feature not supported, we skip it if expression router is used.
-func skipTestForExpressionRouter(t *testing.T) {
-	t.Helper()
-	skipTestForRouterFlavor(t, expressions)
-}
-
-func skipTestForNonKindCluster(t *testing.T) {
-	t.Helper()
-	if env.Cluster().Type() != kind.KindClusterType {
-		t.Skip("this test is only available on KIND clusters currently")
-	}
 }

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -415,14 +416,36 @@ func setIngressClassNameWithRetry(ctx context.Context, namespace string, ingress
 	})
 }
 
+type routerFlavor string
+
+const (
+	traditional           routerFlavor = "traditional"
+	traditionalCompatible routerFlavor = "traditional_compatible"
+	expressions           routerFlavor = "expressions"
+)
+
+func skipTestForRouterFlavor(t *testing.T, flavor ...routerFlavor) {
+	t.Helper()
+	routerFlavor := routerFlavor(eventuallyGetKongRouterFlavor(t, proxyAdminURL))
+	for _, f := range flavor {
+		if routerFlavor == f {
+			t.Skipf("router flavor:%q skipping", f)
+		}
+	}
+}
+
 // Expression router is not supported for some objects and features.
 // For example, KongIngress is not supported by intention;
 // TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
 // When the test case depends on the object or feature not supported, we skip it if expression router is used.
 func skipTestForExpressionRouter(t *testing.T) {
 	t.Helper()
-	routerFlavor := eventuallyGetKongRouterFlavor(t, proxyAdminURL)
-	if routerFlavor == kongRouterFlavorExpressions {
-		t.Skipf("skip test case %s when expression router enabled", t.Name())
+	skipTestForRouterFlavor(t, expressions)
+}
+
+func skipTestForNonKindCluster(t *testing.T) {
+	t.Helper()
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("this test is only available on KIND clusters currently")
 	}
 }

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -90,7 +90,7 @@ func commonHTTPRouteValidationTestCases(
 			WantCreateErr: false,
 		},
 		{
-			Name: "a httproute with valid regex and header pass validation",
+			Name: "a httproute with valid regex expressions for a path and a header pass validation",
 			Route: &gatewayv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: uuid.NewString(),
@@ -156,7 +156,7 @@ func invalidRegexInPathTestCase(
 
 func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavor(t, expressions)
+	skipTestForRouterFlavors(t, expressions)
 
 	ctx := context.Background()
 	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
@@ -170,7 +170,7 @@ func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
 
 func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavor(t, traditional, traditionalCompatible)
+	skipTestForRouterFlavors(t, traditional, traditionalCompatible)
 
 	ctx := context.Background()
 	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
@@ -15,21 +14,210 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
-func TestHTTPRouteValidationWebhook(t *testing.T) {
-	ctx := context.Background()
+const invalidRegexPath = "/foo[[[["
 
-	ns, cleaner := helpers.Setup(ctx, t, env)
+type testCaseHTTPRouteValidation struct {
+	Name                   string
+	Route                  *gatewayv1beta1.HTTPRoute
+	WantCreateErr          bool
+	WantCreateErrSubstring string
+}
 
-	if env.Cluster().Type() != kind.KindClusterType {
-		t.Skip("webhook tests are only available on KIND clusters currently")
+// commonHTTPRouteValidationTestCases returns a list of test cases for validating HTTPRoutes
+// that are common to both traditional and expressions routers (the same error message is returned).
+func commonHTTPRouteValidationTestCases(
+	managedGateway *gatewayv1beta1.Gateway, unmanagedGateway *gatewayv1beta1.Gateway,
+) []testCaseHTTPRouteValidation {
+	return []testCaseHTTPRouteValidation{
+		{
+			Name: "a valid httproute linked to a managed gateway passes validation",
+			Route: &gatewayv1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{{
+							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
+							Name:      gatewayv1beta1.ObjectName(managedGateway.Name),
+						}},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		{
+			Name: "a httproute linked to a non-existent gateway fails validation",
+			Route: &gatewayv1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{{
+							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
+							Name:      gatewayv1beta1.ObjectName("fake-gateway"),
+						}},
+					},
+				},
+			},
+			WantCreateErr:          true,
+			WantCreateErrSubstring: `Gateway.gateway.networking.k8s.io \"fake-gateway\" not found`,
+		},
+		{
+			Name: "an invalid httproute will pass validation if it's not linked to a managed controller (it's not ours)",
+			Route: &gatewayv1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					Rules: []gatewayv1beta1.HTTPRouteRule{{
+						Matches: []gatewayv1beta1.HTTPRouteMatch{
+							builder.NewHTTPRouteMatch().WithPathRegex(invalidRegexPath).Build(),
+						},
+					}},
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{{
+							Namespace: (*gatewayv1beta1.Namespace)(&unmanagedGateway.Namespace),
+							Name:      gatewayv1beta1.ObjectName(unmanagedGateway.Name),
+						}},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		{
+			Name: "a httproute with valid regex and header pass validation",
+			Route: &gatewayv1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayv1beta1.Hostname{"foo.com"},
+					Rules: []gatewayv1beta1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								builder.NewHTTPRouteMatch().WithPathRegex("/path[1-8]").Build(),
+								builder.NewHTTPRouteMatch().WithHeaderRegex("foo", "bar[1-8]").Build(),
+							},
+						},
+					},
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{{
+							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
+							Name:      gatewayv1beta1.ObjectName(managedGateway.Name),
+						}},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
 	}
+}
 
-	pathMatchRegex := gatewayv1beta1.PathMatchRegularExpression
+// invalidRegexInPathTestCase returns a test case for a HTTPRoute with an invalid regex in the path.
+// The expected error substring is different for traditional and expressions routers, thus it has
+// passed by caller.
+func invalidRegexInPathTestCase(
+	managedGateway *gatewayv1beta1.Gateway, wantCreateErrSubstring string,
+) testCaseHTTPRouteValidation {
+	return testCaseHTTPRouteValidation{
+		Name: "a httproute with invalid regex for path does not pass validation",
+		Route: &gatewayv1beta1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: uuid.NewString(),
+			},
+			Spec: gatewayv1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayv1beta1.Hostname{"foo.com"},
+				Rules: []gatewayv1beta1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1beta1.HTTPRouteMatch{
+							builder.NewHTTPRouteMatch().WithPathPrefix("/path-6").Build(),
+							builder.NewHTTPRouteMatch().WithPathRegex(invalidRegexPath).Build(),
+							builder.NewHTTPRouteMatch().WithPathPrefix("/path-7").Build(),
+						},
+					},
+				},
+				CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayv1beta1.ParentReference{{
+						Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
+						Name:      gatewayv1beta1.ObjectName(managedGateway.Name),
+					}},
+				},
+			},
+		},
+		WantCreateErr:          true,
+		WantCreateErrSubstring: wantCreateErrSubstring,
+	}
+}
 
-	closer, err := ensureAdmissionRegistration(ctx,
+func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavor(t, expressions)
+
+	ctx := context.Background()
+	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
+	testCases := append(
+		commonHTTPRouteValidationTestCases(managedGateway, unmanagedGateway),
+		invalidRegexInPathTestCase(managedGateway, `HTTPRoute failed schema validation: schema violation (paths.3: invalid regex: '/foo[[[['`),
+		// No test case for invalid regex in header, because Kong Gateway doesn't return any error in such case (it works only for expressions router).
+	)
+	testHTTPRouteValidationWebhook(ctx, t, namespace, gatewayClient, testCases)
+}
+
+func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavor(t, traditional, traditionalCompatible)
+
+	ctx := context.Background()
+	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
+	testCases := append(
+		commonHTTPRouteValidationTestCases(managedGateway, unmanagedGateway),
+		invalidRegexInPathTestCase(managedGateway, "regex parse error:\n    ^/foo[[[[\n            ^\nerror: unclosed character class)"),
+		testCaseHTTPRouteValidation{
+			Name: "a httproute with invalid regex for header does not pass validation",
+			Route: &gatewayv1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: gatewayv1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayv1beta1.Hostname{"foo.com"},
+					Rules: []gatewayv1beta1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1beta1.HTTPRouteMatch{
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-6").Build(),
+								builder.NewHTTPRouteMatch().WithHeaderRegex("foo", "bar[[").Build(),
+								builder.NewHTTPRouteMatch().WithPathPrefix("/path-7").Build(),
+							},
+						},
+					},
+					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayv1beta1.ParentReference{{
+							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
+							Name:      gatewayv1beta1.ObjectName(managedGateway.Name),
+						}},
+					},
+				},
+			},
+			WantCreateErr:          true,
+			WantCreateErrSubstring: "regex parse error:\n    bar[[\n        ^\nerror: unclosed character class)",
+		},
+	)
+	testHTTPRouteValidationWebhook(ctx, t, namespace, gatewayClient, testCases)
+}
+
+func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testing.T) (
+	namespace string,
+	gatewayClient *gatewayclient.Clientset,
+	managedGateway *gatewayv1beta1.Gateway,
+	unmanagedGateway *gatewayv1beta1.Gateway,
+) {
+	closer, err := ensureAdmissionRegistration(
+		ctx,
 		"kong-validations-gateway",
 		[]admregv1.RuleWithOperations{
 			{
@@ -43,16 +231,18 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err, "creating webhook config")
-	defer func() {
+	t.Cleanup(func() {
 		assert.NoError(t, closer())
-	}()
+	})
 
-	t.Log("creating a gateway client ")
-	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
+	t.Log("creating a gateway client")
+	gatewayClient, err = gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
 
+	ns, cleaner := helpers.Setup(ctx, t, env)
+	namespace = ns.Name
 	t.Log("creating a managed gateway")
-	managedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClassName, func(g *gatewayv1beta1.Gateway) {
+	managedGateway, err = DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClassName, func(g *gatewayv1beta1.Gateway) {
 		g.Name = uuid.NewString()
 	})
 	require.NoError(t, err)
@@ -66,86 +256,29 @@ func TestHTTPRouteValidationWebhook(t *testing.T) {
 	cleaner.Add(unmanagedGatewayClass)
 
 	t.Log("creating an unmanaged gateway")
-	unmanagedGateway, err := DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClass.Name, func(g *gatewayv1beta1.Gateway) {
+	unmanagedGateway, err = DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClass.Name, func(g *gatewayv1beta1.Gateway) {
 		g.Name = uuid.NewString()
 	})
 	require.NoError(t, err)
 	cleaner.Add(unmanagedGateway)
 
 	t.Log("waiting for webhook service to be connective")
-	err = waitForWebhookServiceConnective(ctx, "kong-validations-gateway")
-	require.NoError(t, err)
+	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-gateway"))
 
-	for _, tt := range []struct {
-		name                   string
-		route                  *gatewayv1beta1.HTTPRoute
-		wantCreateErr          bool
-		wantCreateErrSubstring string
-	}{
-		{
-			name: "a valid httproute linked to a managed gateway passes validation",
-			route: &gatewayv1beta1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uuid.NewString(),
-				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
-							Name:      gatewayv1beta1.ObjectName(managedGateway.Name),
-						}},
-					},
-				},
-			},
-			wantCreateErr: false,
-		},
-		{
-			name: "an httproute linked to a non-existent gateway fails validation",
-			route: &gatewayv1beta1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uuid.NewString(),
-				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Namespace: (*gatewayv1beta1.Namespace)(&managedGateway.Namespace),
-							Name:      gatewayv1beta1.ObjectName("fake-gateway"),
-						}},
-					},
-				},
-			},
-			wantCreateErr:          true,
-			wantCreateErrSubstring: `Gateway.gateway.networking.k8s.io \"fake-gateway\" not found`,
-		},
-		{
-			name: "an invalid httproute will pass validation if it's not linked to a managed controller (it's not ours)",
-			route: &gatewayv1beta1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uuid.NewString(),
-				},
-				Spec: gatewayv1beta1.HTTPRouteSpec{
-					Rules: []gatewayv1beta1.HTTPRouteRule{{
-						Matches: []gatewayv1beta1.HTTPRouteMatch{{
-							Path: &gatewayv1beta1.HTTPPathMatch{
-								Type: &pathMatchRegex, // this route is invalid because we don't support regex path matches (yet)
-							},
-						}},
-					}},
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{{
-							Namespace: (*gatewayv1beta1.Namespace)(&unmanagedGateway.Namespace),
-							Name:      gatewayv1beta1.ObjectName(unmanagedGateway.Name),
-						}},
-					},
-				},
-			},
-			wantCreateErr: false, // shouldn't fail because it's considered unmanaged
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Create(ctx, tt.route, metav1.CreateOptions{})
-			if tt.wantCreateErr {
-				require.Contains(t, err.Error(), tt.wantCreateErrSubstring)
+	return namespace, gatewayClient, managedGateway, unmanagedGateway
+}
+
+// testHTTPRouteValidationWebhook tries to create the given HTTPRoutes (passed in testCaseHTTPRouteValidation) and asserts expected results.
+func testHTTPRouteValidationWebhook(
+	ctx context.Context, t *testing.T, namespace string, gatewayClient *gatewayclient.Clientset, testCases []testCaseHTTPRouteValidation,
+) {
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			_, err := gatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Create(ctx, tC.Route, metav1.CreateOptions{})
+			if tC.WantCreateErr {
+				require.NotEmpty(t, tC.WantCreateErrSubstring)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tC.WantCreateErrSubstring)
 			} else {
 				require.NoError(t, err)
 			}

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -230,7 +230,7 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 			},
 		},
 	)
-	assert.NoError(t, err, "creating webhook config")
+	require.NoError(t, err, "creating webhook config")
 	t.Cleanup(func() {
 		assert.NoError(t, closer())
 	})

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -209,6 +209,8 @@ func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 	testHTTPRouteValidationWebhook(ctx, t, namespace, gatewayClient, testCases)
 }
 
+// setUpEnvForTestingHTTPRouteValidationWebhook sets up the environment for testing HTTPRoute validation webhook,
+// it sets it globally. See https://github.com/Kong/kubernetes-ingress-controller/issues/4621 for more details.
 func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testing.T) (
 	namespace string,
 	gatewayClient *gatewayclient.Clientset,
@@ -237,7 +239,6 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 	namespace = ns.Name
-	t.Logf("created namespace: %q", namespace)
 
 	t.Log("creating a managed gateway")
 	managedGateway, err = DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClassName, func(g *gatewayv1beta1.Gateway) {

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -30,7 +30,9 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 
 	ns, _ := helpers.Setup(ctx, t, env)
 
-	closer, err := ensureAdmissionRegistration(ctx,
+	ensureAdmissionRegistration(
+		ctx,
+		t,
 		"kong-validations-kongingress",
 		[]admregv1.RuleWithOperations{
 			{
@@ -43,14 +45,9 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 			},
 		},
 	)
-	assert.NoError(t, err, "creating webhook config")
-	defer func() {
-		assert.NoError(t, closer())
-	}()
 
 	t.Log("waiting for webhook service to be connective")
-	err = waitForWebhookServiceConnective(ctx, "kong-validations-kongingress")
-	require.NoError(t, err)
+	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-kongingress"))
 
 	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)

--- a/test/integration/skip_helpers_test.go
+++ b/test/integration/skip_helpers_test.go
@@ -1,0 +1,43 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
+)
+
+type routerFlavor string
+
+const (
+	traditional           routerFlavor = "traditional"
+	traditionalCompatible routerFlavor = "traditional_compatible"
+	expressions           routerFlavor = "expressions"
+)
+
+func skipTestForRouterFlavor(t *testing.T, flavor ...routerFlavor) {
+	t.Helper()
+	routerFlavor := routerFlavor(eventuallyGetKongRouterFlavor(t, proxyAdminURL))
+	for _, f := range flavor {
+		if routerFlavor == f {
+			t.Skipf("router flavor:%q skipping", f)
+		}
+	}
+}
+
+// Expression router is not supported for some objects and features.
+// For example, KongIngress is not supported by intention;
+// TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
+// When the test case depends on the object or feature not supported, we skip it if expression router is used.
+func skipTestForExpressionRouter(t *testing.T) {
+	t.Helper()
+	skipTestForRouterFlavor(t, expressions)
+}
+
+func skipTestForNonKindCluster(t *testing.T) {
+	t.Helper()
+	if env.Cluster().Type() != kind.KindClusterType {
+		t.Skip("this test is only available on KIND clusters currently")
+	}
+}

--- a/test/integration/skip_helpers_test.go
+++ b/test/integration/skip_helpers_test.go
@@ -16,7 +16,7 @@ const (
 	expressions           routerFlavor = "expressions"
 )
 
-func skipTestForRouterFlavor(t *testing.T, flavor ...routerFlavor) {
+func skipTestForRouterFlavors(t *testing.T, flavor ...routerFlavor) {
 	t.Helper()
 	routerFlavor := routerFlavor(eventuallyGetKongRouterFlavor(t, proxyAdminURL))
 	for _, f := range flavor {
@@ -27,12 +27,12 @@ func skipTestForRouterFlavor(t *testing.T, flavor ...routerFlavor) {
 }
 
 // Expression router is not supported for some objects and features.
-// For example, KongIngress is not supported by intention;
+// For example, KongIngress is intentionally unsupported.
 // TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
 // When the test case depends on the object or feature not supported, we skip it if expression router is used.
 func skipTestForExpressionRouter(t *testing.T) {
 	t.Helper()
-	skipTestForRouterFlavor(t, expressions)
+	skipTestForRouterFlavors(t, expressions)
 }
 
 func skipTestForNonKindCluster(t *testing.T) {

--- a/test/integration/skip_helpers_test.go
+++ b/test/integration/skip_helpers_test.go
@@ -21,7 +21,7 @@ func skipTestForRouterFlavors(t *testing.T, flavor ...routerFlavor) {
 	routerFlavor := routerFlavor(eventuallyGetKongRouterFlavor(t, proxyAdminURL))
 	for _, f := range flavor {
 		if routerFlavor == f {
-			t.Skipf("router flavor:%q skipping", f)
+			t.Skipf("router flavor: %q for ingress: %q skipping", f, proxyAdminURL)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It introduces better validation for `HTTPRoute` object:
- uses the Kong Gateway endpoint for validating `KongRoute` by calling method [RouteService.Validate](https://pkg.go.dev/github.com/kong/go-kong/kong#RouteService.Validate)
- stops rejecting
     - regex path matching rules (implemented https://github.com/Kong/kubernetes-ingress-controller/issues/2153)
     - regex header matching rules (implemented https://github.com/Kong/kubernetes-ingress-controller/issues/2154)
- still reject - query parameters matching (not implemented yet https://github.com/Kong/kubernetes-ingress-controller/issues/3679)
- introduces test coverage for both  expressions based routers and old ones
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This is part of https://github.com/Kong/kubernetes-ingress-controller/issues/4557
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Since integration tests are run in a matrix for expressions router and old ones it can be covered with tests that are exclusively run when the particular router is used. As it's been written in the comment, for non-expression router regex expressions for headers are not validated (require further investigation).

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
