### PR TITLE
Support TCPIngress and UDPIngress expression routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,13 +83,13 @@ Adding a new version? You'll need three changes:
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)
 - `konghq.com/rewrite` annotation has been introduced to manage URI rewriting.
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)
-- Added translator to translate `TCPRoute` and `UDPRoute` in gateway APIs to
-  expression based kong routes. Similar to ingresses, this translator is only
-  enabled when feature gate `ExpressionRoutes` is turned on and the managed
-  Kong gateway runs in router flavor `expressions`, and version is greater or
-  equal to `3.4`.
+- Added support for expression-based Kong routes for `TCPRoute`, `UDPRoute`,
+  `TCPIngress`, and `UDPIngress`. This requires the `ExpressionRoutes` feature
+  gate and a Kong 3.4+ install with `KONG_ROUTER_FLAVOR=expressions` set in the
+  environment.
   [#4385](https://github.com/Kong/kubernetes-ingress-controller/pull/4385)
   [#4550](https://github.com/Kong/kubernetes-ingress-controller/pull/4550)
+  [#4612](https://github.com/Kong/kubernetes-ingress-controller/pull/4612)
 
 ### Changes
 

--- a/internal/dataplane/parser/translate_failures_test.go
+++ b/internal/dataplane/parser/translate_failures_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
-	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // This file contains unit test functions to test translation failures genreated by parser.
@@ -56,55 +55,6 @@ func TestTranslationFailureUnsupportedObjectsExpressionRoutes(t *testing.T) {
 				&knative.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "knative-ing-1",
-						Namespace: "default",
-					},
-				},
-			},
-		},
-		{
-			name: "TCPIngresses and UDPIngresses are not supported",
-			objects: store.FakeObjects{
-				TCPIngresses: []*kongv1beta1.TCPIngress{
-					{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "TCPIngress",
-							APIVersion: kongv1beta1.GroupVersion.String(),
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "tcpingress-1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								annotations.IngressClassKey: annotations.DefaultIngressClass,
-							},
-						},
-					},
-				},
-				UDPIngresses: []*kongv1beta1.UDPIngress{
-					{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "UDPIngress",
-							APIVersion: kongv1beta1.GroupVersion.String(),
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "udpingress-1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								annotations.IngressClassKey: annotations.DefaultIngressClass,
-							},
-						},
-					},
-				},
-			},
-			causingObjects: []client.Object{
-				&kongv1beta1.TCPIngress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tcpingress-1",
-						Namespace: "default",
-					},
-				},
-				&kongv1beta1.UDPIngress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "udpingress-1",
 						Namespace: "default",
 					},
 				},

--- a/internal/dataplane/parser/translate_kong_l4.go
+++ b/internal/dataplane/parser/translate_kong_l4.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
@@ -26,7 +27,7 @@ func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
 	})
 
 	for _, ingress := range ingressList {
-		if p.featureFlags.ExpressionRoutes {
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.LT(versions.ExpressionRouterL4Cutoff) {
 			p.registerResourceFailureNotSupportedForExpressionRoutes(ingress)
 			continue
 		}
@@ -89,6 +90,10 @@ func (p *Parser) ingressRulesFromTCPIngressV1beta1() ingressRules {
 		}
 	}
 
+	if p.featureFlags.ExpressionRoutes {
+		applyExpressionToIngressRules(&result)
+	}
+
 	return result
 }
 
@@ -106,7 +111,7 @@ func (p *Parser) ingressRulesFromUDPIngressV1beta1() ingressRules {
 	})
 
 	for _, ingress := range ingressList {
-		if p.featureFlags.ExpressionRoutes {
+		if p.featureFlags.ExpressionRoutes && p.kongVersion.LT(versions.ExpressionRouterL4Cutoff) {
 			p.registerResourceFailureNotSupportedForExpressionRoutes(ingress)
 			continue
 		}
@@ -155,6 +160,10 @@ func (p *Parser) ingressRulesFromUDPIngressV1beta1() ingressRules {
 		if objectSuccessfullyParsed {
 			p.registerSuccessfullyParsedObject(ingress)
 		}
+	}
+
+	if p.featureFlags.ExpressionRoutes {
+		applyExpressionToIngressRules(&result)
 	}
 
 	return result

--- a/internal/dataplane/parser/translators/l4route_atc_test.go
+++ b/internal/dataplane/parser/translators/l4route_atc_test.go
@@ -1,0 +1,105 @@
+package translators
+
+import (
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+)
+
+func TestApplyExpressionToL4KongRoute(t *testing.T) {
+	testCases := []struct {
+		name    string
+		route   kong.Route
+		subExpr string
+	}{
+		{
+			name:    "destination port",
+			subExpr: "net.dst.port == 1234",
+			route: kong.Route{
+				Destinations: []*kong.CIDRPort{
+					{
+						Port: lo.ToPtr(1234),
+					},
+				},
+				Protocols: []*string{
+					lo.ToPtr("tcp"),
+				},
+			},
+		},
+		{
+			name:    "multiple destination ports",
+			subExpr: "(net.dst.port == 1234) || (net.dst.port == 5678)",
+			route: kong.Route{
+				Destinations: []*kong.CIDRPort{
+					{
+						Port: lo.ToPtr(1234),
+					},
+					{
+						Port: lo.ToPtr(5678),
+					},
+				},
+				Protocols: []*string{
+					lo.ToPtr("tcp"),
+				},
+			},
+		},
+		{
+			name:    "SNI host",
+			subExpr: "tls.sni == \"example.com\"",
+			route: kong.Route{
+				SNIs: []*string{
+					lo.ToPtr("example.com"),
+				},
+				Protocols: []*string{
+					lo.ToPtr("tcp"),
+				},
+			},
+		},
+		{
+			name:    "multiple SNI hosts",
+			subExpr: "(tls.sni == \"example.com\") || (tls.sni == \"example.net\")",
+			route: kong.Route{
+				SNIs: []*string{
+					lo.ToPtr("example.com"),
+					lo.ToPtr("example.net"),
+				},
+				Protocols: []*string{
+					lo.ToPtr("tcp"),
+				},
+			},
+		},
+		{
+			name:    "SNI host and multiple destination ports",
+			subExpr: "(tls.sni == \"example.com\") && ((net.dst.port == 1234) || (net.dst.port == 5678))",
+			route: kong.Route{
+				Destinations: []*kong.CIDRPort{
+					{
+						Port: lo.ToPtr(1234),
+					},
+					{
+						Port: lo.ToPtr(5678),
+					},
+				},
+				SNIs: []*string{
+					lo.ToPtr("example.com"),
+				},
+				Protocols: []*string{
+					lo.ToPtr("tcp"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := kongstate.Route{Route: tc.route}
+			ApplyExpressionToL4KongRoute(&wrapped)
+			require.Contains(t, *wrapped.Route.Expression, tc.subExpr)
+		})
+	}
+}

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -36,7 +36,6 @@ var (
 )
 
 func TestTCPIngressEssentials(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	ctx := context.Background()
 
 	t.Parallel()

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -36,6 +36,7 @@ var (
 )
 
 func TestTCPIngressEssentials(t *testing.T) {
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	ctx := context.Background()
 
 	t.Parallel()
@@ -142,7 +143,7 @@ func TestTCPIngressEssentials(t *testing.T) {
 }
 
 func TestTCPIngressTLS(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Parallel()
 
 	t.Log("locking Gateway TLS ports")
@@ -304,6 +305,10 @@ func TestTCPIngressTLS(t *testing.T) {
 func TestTCPIngressTLSPassthrough(t *testing.T) {
 	t.Parallel()
 	skipTestForExpressionRouter(t)
+	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4540
+	// Kong does not currently recognize these requests even though the expression looks correct. This should be enabled
+	// after determining why the gateway is discarding these requests and applying any necessary fixes.
+	// RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 
 	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.TLSPassthroughCutoff))
 

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -33,7 +33,6 @@ var udpMutex sync.Mutex
 const coreDNSImage = "registry.k8s.io/coredns/coredns:v1.8.6"
 
 func TestUDPIngressEssentials(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	t.Parallel()
 
 	// Ensure no other UDP tests run concurrently to avoid fights over the port

--- a/test/integration/udpingress_test.go
+++ b/test/integration/udpingress_test.go
@@ -33,6 +33,7 @@ var udpMutex sync.Mutex
 const coreDNSImage = "registry.k8s.io/coredns/coredns:v1.8.6"
 
 func TestUDPIngressEssentials(t *testing.T) {
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Parallel()
 
 	// Ensure no other UDP tests run concurrently to avoid fights over the port
@@ -155,7 +156,7 @@ func TestUDPIngressEssentials(t *testing.T) {
 }
 
 func TestUDPIngressTCPIngressCollision(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	t.Parallel()
 
 	t.Log("locking TCP and UDP ports")


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds expression routing for TCPIngress and UDPIngress.

Adds a unit test for the L4 kongstate.Route translator.

**Which issue this PR fixes**:

Fix #4541 
Fix #4542 

**Special notes for your reviewer**:

https://github.com/Kong/kubernetes-ingress-controller/pull/4385 is still setting the traditional `protocols` field. Is this correct? https://docs.konghq.com/gateway/latest/reference/router-expressions-language/#main indicates there's a `net.protocol` expression field.

https://github.com/Kong/kubernetes-ingress-controller/pull/4385 added a test for TCPRoute specifically, but I don't think we need a per-resource unit test for these. We already test kongstate.Route creation for resources, and the expression translator operates on kongstate.Routes, so I think we can just test it on those directly.

Kong L4 routes support several features that our CRs and GWAPI Routes do not:

- Routes support both sources and destinations, whereas the Kubernetes resources only support destinations.
- Sources and destinations support IPs, whereas the Kubernetes resources only support ports.

This is the intended feature set of GWAPI L4 Routes. We never added support for the complete set of Kong route capabilities to TCPIngress and UDPIngress, and there is apparently limited demand for the missing functionality (I don't know of any outstanding requests for it). The TCPIngress and UDPIngress feature set is coincidentally the same as what GWAPI Routes can support. As this additional functionality isn't supported by the resources, I didn't add support in the translator, just a comment noting the gap.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
