### PR TITLE
test: enable HTTPS redirect tests with expression router

### DIFF
--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestHTTPSRedirect(t *testing.T) {
-	// kong does not support HTTPS redirect yet.
-	skipTestForExpressionRouter(t)
+	// Kong starts to support HTTPS redirect in expression router from 3.4.0.
+	RunWhenKongExpressionRouterWithVersion(t, ">=3.4.0")
 	ctx := context.Background()
 
 	t.Parallel()

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -90,6 +90,20 @@ func GetKongDBMode(proxyAdminURL *url.URL, kongTestPassword string) (string, err
 
 // GetKongRouterFlavor gets router flavor of Kong using the provided Admin API URL.
 func GetKongRouterFlavor(proxyAdminURL *url.URL, kongTestPassword string) (string, error) {
+	const (
+		// ExpressionRouterMinMajorVersion is the lowest major version of Kong that supports expression router.
+		// Kong below this version supports only "traditional" router, and does not contain "router_flavor" field in root configuration.
+		ExpressionRouterMinMajorVersion = 3
+	)
+	kongVersion, err := GetKongVersion(proxyAdminURL, kongTestPassword)
+	if err != nil {
+		return "", err
+	}
+
+	if kongVersion.Major() < ExpressionRouterMinMajorVersion {
+		return "traditional", nil
+	}
+
 	jsonResp, err := GetKongRootConfig(proxyAdminURL, kongTestPassword)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Kong gateway supports HTTPS redirect with expression router since 3.4: https://github.com/Kong/kong/pull/11166. We need to add the case back in integration tests.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
