### PR TITLE
feat: use DynamicCRDController with Kong controllers

### DIFF
--- a/internal/controllers/crds/dynamic_controller.go
+++ b/internal/controllers/crds/dynamic_controller.go
@@ -39,7 +39,8 @@ type DynamicCRDController struct {
 	Controller       Controller
 	RequiredCRDs     []schema.GroupVersionResource
 
-	startControllersOnce sync.Once
+	// startControllerOnce ensures that the controller is started only once.
+	startControllerOnce sync.Once
 }
 
 func (r *DynamicCRDController) SetupWithManager(mgr ctrl.Manager) error {
@@ -87,7 +88,7 @@ func (r *DynamicCRDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	var startControllerErr error
-	r.startControllersOnce.Do(func() {
+	r.startControllerOnce.Do(func() {
 		log.V(util.InfoLevel).Info("All required CustomResourceDefinitions are installed, setting up the controller")
 		startControllerErr = r.setupController(r.Manager)
 	})
@@ -96,6 +97,10 @@ func (r *DynamicCRDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *DynamicCRDController) SetLogger(logger logr.Logger) {
+	r.Log = logger
 }
 
 func (r *DynamicCRDController) allRequiredCRDsInstalled() bool {

--- a/internal/manager/conditions.go
+++ b/internal/manager/conditions.go
@@ -1,13 +1,9 @@
 package manager
 
 import (
-	"context"
-	"fmt"
-
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 )
@@ -67,13 +63,4 @@ func negotiateIngressAPI(config *Config, mapper meta.RESTMapper) (IngressAPI, er
 		}
 	}
 	return NoIngressAPI, nil
-}
-
-func ShouldEnableCRDController(ctx context.Context, gvr schema.GroupVersionResource, restMapper meta.RESTMapper) bool {
-	if !ctrlutils.CRDExists(restMapper, gvr) {
-		ctrl.LoggerFrom(ctx).WithName("controllers").WithName("crdCondition").
-			Info(fmt.Sprintf("Disabling controller for Group=%s, Resource=%s due to missing CRD", gvr.GroupVersion(), gvr.Resource))
-		return false
-	}
-	return true
 }

--- a/internal/manager/conditions_test.go
+++ b/internal/manager/conditions_test.go
@@ -1,7 +1,6 @@
 package manager_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,53 +76,6 @@ func TestIngressControllerConditions(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectIngressNetV1, conditions.IngressNetV1Enabled())
 			assert.Equal(t, tc.expectIngressClassNetV1, conditions.IngressClassNetV1Enabled())
-		})
-	}
-}
-
-func TestShouldEnableCRDController(t *testing.T) {
-	knownGvr := schema.GroupVersionResource{
-		Group:    "group",
-		Version:  "v1",
-		Resource: "resources",
-	}
-	unknownGVR := schema.GroupVersionResource{
-		Group:    "otherGroup",
-		Version:  "v1",
-		Resource: "resources",
-	}
-
-	restMapper := meta.NewDefaultRESTMapper(nil)
-	restMapper.Add(schema.GroupVersionKind{
-		Group:   knownGvr.Group,
-		Version: knownGvr.Version,
-		Kind:    "Resource",
-	}, meta.RESTScopeRoot)
-
-	testCases := []struct {
-		name           string
-		gvr            schema.GroupVersionResource
-		expectedResult bool
-	}{
-		{
-			name:           "registered_resource",
-			gvr:            knownGvr,
-			expectedResult: true,
-		},
-		{
-			name:           "not_registered_resource",
-			gvr:            unknownGVR,
-			expectedResult: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(
-				t,
-				tc.expectedResult,
-				manager.ShouldEnableCRDController(context.Background(), tc.gvr, restMapper),
-			)
 		})
 	}
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -130,7 +130,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	mgr, err := ctrl.NewManager(kubeconfig, controllerOpts)
 	if err != nil {
-		return fmt.Errorf("unable to start controller manager: %w", err)
+		return fmt.Errorf("unable to create controller manager: %w", err)
 	}
 
 	if err := waitForKubernetesAPIReadiness(ctx, setupLog, mgr); err != nil {

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -4,7 +4,6 @@ package envtest
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -16,87 +15,78 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 )
 
-// TestMissingCRDsDontCrashTheManager ensures that in case of missing CRDs installation in the cluster, specific
-// controllers are disabled, this fact is properly logged, and the manager does not crash.
-func TestMissingCRDsDontCrashTheManager(t *testing.T) {
+// TestDynamicCRDController_StartsControllersWhenCRDsInstalled ensures that in case of missing CRDs installation in the
+// cluster, specific controllers are not started until the CRDs are installed.
+func TestDynamicCRDController_StartsControllersWhenCRDsInstalled(t *testing.T) {
 	emptyScheme := runtime.NewScheme()
-	envcfg := Setup(t, emptyScheme)
+	envcfg := Setup(t, emptyScheme, WithInstallGatewayCRDs(false), WithInstallKongCRDs(false))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	loggerHook := RunManager(ctx, t, envcfg, func(cfg *manager.Config) {
-		// Reducing controllers' cache synchronisation timeout in order to trigger the possible sync timeout quicker.
-		// It's a regression test for https://github.com/Kong/gateway-operator/issues/326.
-		cfg.CacheSyncTimeout = time.Millisecond * 500
-	})
+	loggerHook := RunManager(ctx, t, envcfg, WithGatewayFeatureEnabled)
 
-	require.Eventually(t, func() bool {
-		gvrs := []schema.GroupVersionResource{
-			{
-				Group:    kongv1beta1.GroupVersion.Group,
-				Version:  kongv1beta1.GroupVersion.Version,
-				Resource: "udpingresses",
-			},
-			{
-				Group:    kongv1beta1.GroupVersion.Group,
-				Version:  kongv1beta1.GroupVersion.Version,
-				Resource: "tcpingresses",
-			},
-			{
-				Group:    kongv1.GroupVersion.Group,
-				Version:  kongv1.GroupVersion.Version,
-				Resource: "kongingresses",
-			},
-			{
-				Group:    kongv1alpha1.GroupVersion.Group,
-				Version:  kongv1alpha1.GroupVersion.Version,
-				Resource: "ingressclassparameterses",
-			},
-			{
-				Group:    kongv1.GroupVersion.Group,
-				Version:  kongv1.GroupVersion.Version,
-				Resource: "kongplugins",
-			},
-			{
-				Group:    kongv1.GroupVersion.Group,
-				Version:  kongv1.GroupVersion.Version,
-				Resource: "kongconsumers",
-			},
-			{
-				Group:    kongv1beta1.GroupVersion.Group,
-				Version:  kongv1beta1.GroupVersion.Version,
-				Resource: "kongconsumergroups",
-			},
-			{
-				Group:    kongv1.GroupVersion.Group,
-				Version:  kongv1.GroupVersion.Version,
-				Resource: "kongclusterplugins",
-			},
-		}
+	controllers := []string{
+		// Kong
+		"UDPIngress",
+		"TCPIngress",
+		"KongIngress",
+		"IngressClassParameters",
+		"KongPlugin",
+		"KongConsumer",
+		"KongConsumerGroup",
+		"KongClusterPlugin",
+		"Ingress",
 
-		for _, gvr := range gvrs {
-			expectedLog := fmt.Sprintf("Disabling controller for Group=%s, Resource=%s due to missing CRD", gvr.GroupVersion(), gvr.Resource)
-			if !lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
-				return strings.Contains(entry.Message, expectedLog)
-			}) {
-				t.Logf("expected log not found: %s", expectedLog)
-				return false
+		// Gateway API
+		"Gateway",
+		"HTTPRoute",
+		"ReferenceGrant",
+		"UDPRoute",
+		"TCPRoute",
+		"TLSRoute",
+		"GRPCRoute",
+	}
+
+	requireLogForAllControllers := func(expectedLog string) {
+		require.Eventually(t, func() bool {
+			for _, controller := range controllers {
+				if !lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
+					loggerName, ok := entry.Data["logger"].(string)
+					if !ok {
+						return false
+					}
+					return strings.Contains(loggerName, controller) && strings.Contains(entry.Message, expectedLog)
+				}) {
+					t.Logf("expected log not found for %s controller", controller)
+					return false
+				}
 			}
-		}
-		return true
-	}, time.Minute, time.Millisecond*500)
+			return true
+		}, time.Minute, time.Millisecond*500)
+	}
+
+	const (
+		expectedLogOnStartup      = "Required CustomResourceDefinitions are not installed, setting up a watch for them in case they are installed afterward"
+		expectedLogOnCRDInstalled = "All required CustomResourceDefinitions are installed, setting up the controller"
+	)
+
+	t.Log("waiting for all controllers to not start due to missing CRDs")
+	requireLogForAllControllers(expectedLogOnStartup)
+
+	t.Log("installing missing CRDs")
+	installKongCRDs(t, emptyScheme, envcfg)
+	installGatewayCRDs(t, emptyScheme, envcfg)
+
+	t.Log("waiting for all controllers to start after CRDs installation")
+	requireLogForAllControllers(expectedLogOnCRDInstalled)
 }
 
 func TestCRDValidations(t *testing.T) {

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -4,6 +4,8 @@ package envtest
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -21,7 +23,56 @@ import (
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
+
+func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme, WithInstallKongCRDs(true))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("Setting up a proxy for Kubernetes API server so that we can interrupt it")
+	u, err := url.Parse(envcfg.Host)
+	require.NoError(t, err)
+	apiServerProxy, err := helpers.NewTCPProxy(u.Host)
+	require.NoError(t, err)
+	go func() {
+		err := apiServerProxy.Run(ctx)
+		assert.NoError(t, err)
+	}()
+	apiServerProxy.StopHandlingConnections()
+
+	t.Log("Replacing Kubernetes API server address with the proxy address")
+	envcfg.Host = fmt.Sprintf("https://%s", apiServerProxy.Address())
+
+	loggerHook := RunManager(ctx, t, envcfg)
+	hasLog := func(expectedLog string) bool {
+		return lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
+			return strings.Contains(entry.Message, expectedLog)
+		})
+	}
+
+	t.Log("Ensuring manager is waiting for Kubernetes API to be ready")
+	const expectedKubernetesAPICheckErrorLog = "Retrying Kubernetes API readiness check after error"
+	require.Eventually(t, func() bool { return hasLog(expectedKubernetesAPICheckErrorLog) }, time.Minute, time.Millisecond)
+
+	t.Log("Ensure manager hasn't been started yet and no config sync has happened")
+	const configurationSyncedToKongLog = "successfully synced configuration to Kong"
+	const startingManagerLog = "Starting manager"
+	require.False(t, hasLog(configurationSyncedToKongLog))
+	require.False(t, hasLog(startingManagerLog))
+
+	t.Log("Starting accepting connections in Kubernetes API proxy so that manager can start")
+	apiServerProxy.StartHandlingConnections()
+
+	t.Log("Ensuring manager has been started and config sync has happened")
+	require.Eventually(t, func() bool {
+		return hasLog(startingManagerLog) &&
+			hasLog(configurationSyncedToKongLog)
+	}, time.Minute, time.Millisecond)
+}
 
 // TestDynamicCRDController_StartsControllersWhenCRDsInstalled ensures that in case of missing CRDs installation in the
 // cluster, specific controllers are not started until the CRDs are installed.

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -25,7 +25,7 @@ import (
 // Gateway's listener.
 // It reproduces https://github.com/Kong/kubernetes-ingress-controller/issues/4456.
 func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
-	scheme := Scheme(t, WithGatewayAPI)
+	scheme := Scheme(t, WithGatewayAPI, WithKong)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -22,7 +22,7 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	t.Parallel()
 
 	scheme := Scheme(t, WithKong)
-	cfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	cfg := Setup(t, scheme)
 	client := NewControllerClient(t, scheme, cfg)
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -1,0 +1,68 @@
+//go:build envtest
+
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManagerDoesntStartUntilKubernetesAPIReachable ensures that the manager and its Runnables are not start until the
+// Kubernetes API server is reachable.
+func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("Setting up a proxy for Kubernetes API server so that we can interrupt it")
+	u, err := url.Parse(envcfg.Host)
+	require.NoError(t, err)
+	apiServerProxy, err := helpers.NewTCPProxy(u.Host)
+	require.NoError(t, err)
+	go func() {
+		err := apiServerProxy.Run(ctx)
+		assert.NoError(t, err)
+	}()
+	apiServerProxy.StopHandlingConnections()
+
+	t.Log("Replacing Kubernetes API server address with the proxy address")
+	envcfg.Host = fmt.Sprintf("https://%s", apiServerProxy.Address())
+
+	loggerHook := RunManager(ctx, t, envcfg)
+	hasLog := func(expectedLog string) bool {
+		return lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
+			return strings.Contains(entry.Message, expectedLog)
+		})
+	}
+
+	t.Log("Ensuring manager is waiting for Kubernetes API to be ready")
+	const expectedKubernetesAPICheckErrorLog = "Retrying Kubernetes API readiness check after error"
+	require.Eventually(t, func() bool { return hasLog(expectedKubernetesAPICheckErrorLog) }, time.Minute, time.Millisecond)
+
+	t.Log("Ensure manager hasn't been started yet and no config sync has happened")
+	const configurationSyncedToKongLog = "successfully synced configuration to Kong"
+	const startingManagerLog = "Starting manager"
+	require.False(t, hasLog(configurationSyncedToKongLog))
+	require.False(t, hasLog(startingManagerLog))
+
+	t.Log("Starting accepting connections in Kubernetes API proxy so that manager can start")
+	apiServerProxy.StartHandlingConnections()
+
+	t.Log("Ensuring manager has been started and config sync has happened")
+	require.Eventually(t, func() bool {
+		return hasLog(startingManagerLog) &&
+			hasLog(configurationSyncedToKongLog)
+	}, time.Minute, time.Millisecond)
+}

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -21,7 +21,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 	t.Parallel()
 
 	scheme := Scheme(t, WithKong)
-	envcfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -128,7 +128,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		// if there are multiple KIC instances within a cluster, they will fight over setting this condition because the
 		// controllers do not filter on ingress class. we need to limit them to only resources referenced from others,
 		// similar to Secrets, to use this
-		//{
+		// {
 		//	name: "valid KongPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -164,8 +164,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionTrue,
 		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
-		//},
-		//{
+		// },
+		// {
 		//	name: "invalid KongPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -209,8 +209,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionFalse,
 		//	expectedProgrammedReason: kongv1.ReasonInvalid,
-		//},
-		//{
+		// },
+		// {
 		//	name: "valid KongClusterPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongClusterPlugin{
@@ -244,8 +244,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionTrue,
 		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
-		//},
-		//{
+		// },
+		// {
 		//	name: "invalid KongClusterPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -289,7 +289,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionFalse,
 		//	expectedProgrammedReason: kongv1.ReasonInvalid,
-		//},
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -1,6 +1,7 @@
 package envtest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -95,6 +96,8 @@ func RunManager(
 	}
 
 	logrusLogger, loggerHook := test.NewNullLogger()
+	var b bytes.Buffer
+	logrusLogger.Out = &b
 	logger := logrusr.New(logrusLogger)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
@@ -102,6 +105,11 @@ func RunManager(
 		err := manager.Run(ctx, &cfg, util.ConfigDumpDiagnostic{}, logrusLogger)
 		require.NoError(t, err)
 	}()
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("Test %s failed: dumping controller logs\n%s", t.Name(), b.String())
+		}
+	})
 
 	return loggerHook
 }

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -1,7 +1,6 @@
 package envtest
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -96,8 +95,6 @@ func RunManager(
 	}
 
 	logrusLogger, loggerHook := test.NewNullLogger()
-	var b bytes.Buffer
-	logrusLogger.Out = &b
 	logger := logrusr.New(logrusLogger)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
@@ -105,11 +102,6 @@ func RunManager(
 		err := manager.Run(ctx, &cfg, util.ConfigDumpDiagnostic{}, logrusLogger)
 		require.NoError(t, err)
 	}()
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Logf("Test %s failed: dumping controller logs\n%s", t.Name(), b.String())
-		}
-	})
 
 	return loggerHook
 }

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -28,7 +28,7 @@ type Options struct {
 
 var DefaultEnvTestOpts = Options{
 	InstallGatewayCRDs: true,
-	InstallKongCRDs:    false,
+	InstallKongCRDs:    true,
 }
 
 type OptionModifier func(Options) Options

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -23,19 +23,26 @@ import (
 
 type Options struct {
 	InstallGatewayCRDs bool
-	InstanllKongCRDs   bool
+	InstallKongCRDs    bool
 }
 
 var DefaultEnvTestOpts = Options{
 	InstallGatewayCRDs: true,
-	InstanllKongCRDs:   false,
+	InstallKongCRDs:    false,
 }
 
 type OptionModifier func(Options) Options
 
 func WithInstallKongCRDs(install bool) OptionModifier {
 	return func(opts Options) Options {
-		opts.InstanllKongCRDs = install
+		opts.InstallKongCRDs = install
+		return opts
+	}
+}
+
+func WithInstallGatewayCRDs(install bool) OptionModifier {
+	return func(opts Options) Options {
+		opts.InstallGatewayCRDs = install
 		return opts
 	}
 }
@@ -64,7 +71,7 @@ func Setup(t *testing.T, scheme *k8sruntime.Scheme, optModifiers ...OptionModifi
 	if opts.InstallGatewayCRDs {
 		installGatewayCRDs(t, scheme, cfg)
 	}
-	if opts.InstanllKongCRDs {
+	if opts.InstallKongCRDs {
 		installKongCRDs(t, scheme, cfg)
 	}
 

--- a/test/internal/helpers/tcp.go
+++ b/test/internal/helpers/tcp.go
@@ -1,0 +1,131 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// TCPProxy is a simple server that forwards TCP connections to a given destination.
+// It can be used to simulate network failures by stopping accepting new connections and interrupting existing ones.
+type TCPProxy struct {
+	destination string
+	address     string
+	listener    net.Listener
+
+	// interruptSignalChs is a list of channels that are used to interrupt connections.
+	interruptSignalChs []chan struct{}
+	// shouldHandleNewConnections is a flag that indicates whether new connections should be accepted.
+	shouldHandleNewConnections bool
+
+	mu sync.RWMutex
+}
+
+func NewTCPProxy(destination string) (*TCPProxy, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+	return &TCPProxy{
+		destination:                destination,
+		address:                    listener.Addr().String(),
+		listener:                   listener,
+		shouldHandleNewConnections: true,
+	}, nil
+}
+
+// Run starts connections accepting loop and blocks until the context is canceled.
+func (p *TCPProxy) Run(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		_ = p.listener.Close()
+	}()
+
+	for {
+		c, err := p.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("failed to accept connection: %w", err)
+		}
+
+		if !p.shouldHandleConnections() {
+			_ = c.Close()
+			continue
+		}
+
+		go p.handleConnection(c, p.newInterruptSignalCh())
+	}
+}
+
+// Address returns the address of the proxy.
+func (p *TCPProxy) Address() string {
+	return p.address
+}
+
+// StopHandlingConnections stops handling connections by interrupting all existing connections and immediately closing
+// new connections.
+func (p *TCPProxy) StopHandlingConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Interrupt all connections.
+	for _, ch := range p.interruptSignalChs {
+		close(ch)
+	}
+	p.interruptSignalChs = nil
+
+	// Ensure no new connections are accepted.
+	p.shouldHandleNewConnections = false
+}
+
+// StartHandlingConnections starts handling new connections.
+func (p *TCPProxy) StartHandlingConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.shouldHandleNewConnections = true
+}
+
+func (p *TCPProxy) handleConnection(src net.Conn, interruptSignalCh chan struct{}) {
+	defer func() {
+		_ = src.Close()
+	}()
+
+	dst, err := net.Dial("tcp", p.destination)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	copyDoneCh := make(chan struct{}, 2)
+	go p.copy(dst, src, copyDoneCh)
+	go p.copy(src, dst, copyDoneCh)
+
+	select {
+	case <-copyDoneCh:
+	case <-interruptSignalCh:
+	}
+}
+
+func (p *TCPProxy) copy(dst, src net.Conn, doneCh chan struct{}) {
+	_, _ = io.Copy(dst, src)
+	doneCh <- struct{}{}
+}
+
+func (p *TCPProxy) shouldHandleConnections() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.shouldHandleNewConnections
+}
+
+func (p *TCPProxy) newInterruptSignalCh() chan struct{} {
+	ch := make(chan struct{})
+	p.interruptSignalChs = append(p.interruptSignalChs, ch)
+	return ch
+}

--- a/test/internal/helpers/tcp.go
+++ b/test/internal/helpers/tcp.go
@@ -27,7 +27,7 @@ type TCPProxy struct {
 func NewTCPProxy(destination string) (*TCPProxy, error) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
 	return &TCPProxy{
 		destination:                destination,

--- a/test/internal/helpers/tcp_test.go
+++ b/test/internal/helpers/tcp_test.go
@@ -1,0 +1,81 @@
+package helpers_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+func TestTCPProxy(t *testing.T) {
+	ls, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	var (
+		destAcceptedConn atomic.Bool
+		destDroppedConn  atomic.Bool
+		destReceivedData bytes.Buffer
+	)
+	go func() {
+		for {
+			c, err := ls.Accept()
+			if err != nil {
+				return
+			}
+			destAcceptedConn.Store(true)
+			go func() {
+				_, _ = io.Copy(&destReceivedData, c)
+				destDroppedConn.Store(true)
+			}()
+		}
+	}()
+
+	proxy, err := helpers.NewTCPProxy(ls.Addr().String())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := proxy.Run(ctx)
+		assert.NoError(t, err)
+	}()
+
+	t.Log("Ensuring proxy is accepting connections by default")
+	conn, err := net.Dial("tcp", proxy.Address())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return destAcceptedConn.Load() }, time.Second, time.Millisecond, "destination didn't accept connection")
+
+	t.Log("Ensuring proxy forwards data from the source to the destination")
+	_, err = conn.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return destReceivedData.String() == "hello" }, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy dropped connection after StopHandlingConnections")
+	proxy.StopHandlingConnections()
+	require.Eventually(t, func() bool { return destDroppedConn.Load() }, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy dropped existing connection after StopHandlingConnections")
+	require.Eventually(t, func() bool {
+		_, err = conn.Write([]byte("hello"))
+		return err != nil
+	}, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy handles connections after StartHandlingConnections")
+	proxy.StartHandlingConnections()
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", proxy.Address())
+		if err != nil {
+			return false
+		}
+		_, err = conn.Write([]byte("hello"))
+		return err == nil
+	}, time.Second, time.Millisecond)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `DynamicCRDController` instead of a single `ShouldEnableCRDController` call on startup to decide whether Kong CRDs' controllers should be run. This should fix the issue of these controllers not being started in a scenario where there's a temporary API server connection problem (e.g. because of waiting for Istio sidecar to startup).


**Which issue this PR fixes**:

Should fix https://github.com/Kong/kubernetes-ingress-controller/issues/4618.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
