### PR TITLE
chore(tests): more debug information when getting kong's version in integration tests

### DIFF
--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -118,7 +118,9 @@ func GetKongRouterFlavor(proxyAdminURL *url.URL, kongTestPassword string) (strin
 	}
 	routerFlavor, ok := rootConfig["router_flavor"]
 	if !ok {
-		return "", fmt.Errorf("missing 'router_flavor' key in kong's (URL: %s) configuration", proxyAdminURL)
+		return "", fmt.Errorf("missing 'router_flavor' key in kong's (version: %s, URL: %s) configuration: %s",
+			kongVersion, proxyAdminURL, rootConfig,
+		)
 	}
 
 	routerFlavorStr, ok := routerFlavor.(string)


### PR DESCRIPTION
**What this PR does / why we need it**:

To get more information when an integration tests fails when getting Kong's version.

Example in CI: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6084077012/job/16505256272#step:6:1197

```
    version_test.go:63: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/version_test.go:115
        	            				/opt/hostedtoolcache/go/1.21.0/x64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	missing 'router_flavor' key in kong's (URL: http://172.18.0.100:8001) configuration
    version_test.go:63: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/version_test.go:113
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/version_test.go:63
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/examples_test.go:153
        	Error:      	Condition never satisfied
        	Test:       	TestTCPRouteExample
```
