### PR TITLE
chore(tests): move all envtest based tests into test/envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,10 +322,8 @@ test.integration.enterprise: test.integration.enterprise.postgres test.integrati
 
 .PHONY: _test.unit
 .ONESHELL: _test.unit
-_test.unit: gotestsum setup-envtest
-	$(SETUP_ENVTEST) use
-	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
-		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
+_test.unit: gotestsum
+	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) -- \
 		-race $(GOTESTFLAGS) \
 		-tags envtest \

--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -1,6 +1,6 @@
 //go:build envtest
 
-package adminapi_test
+package envtest
 
 import (
 	"context"
@@ -19,15 +19,14 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v2/internal/manager/config/types"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 )
 
 func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThroughResults(t *testing.T) {
 	t.Parallel()
 
-	scheme := envtest.Scheme(t)
-	cfg := envtest.Setup(t, scheme)
-	client := envtest.NewControllerClient(t, scheme, cfg)
+	scheme := Scheme(t)
+	cfg := Setup(t, scheme)
+	client := NewControllerClient(t, scheme, cfg)
 
 	// In tests below we use a deferred cancel to stop the manager and not wait
 	// for its timeout.
@@ -52,7 +51,7 @@ func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThro
 			defer cancel()
 
 			var (
-				ns          = envtest.CreateNamespace(ctx, t, client)
+				ns          = CreateNamespace(ctx, t, client)
 				serviceName = uuid.NewString()
 				service     = k8stypes.NamespacedName{
 					Namespace: ns.Name,

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -174,7 +174,6 @@ func TestCRDValidations(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			ns := CreateNamespace(ctx, t, client)
 			tc.scenario(ctx, t, ns.Name)
 		})

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -1,6 +1,6 @@
 //go:build envtest
 
-package configuration_test
+package envtest
 
 import (
 	"context"
@@ -30,7 +30,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/config/types"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/test/envtest"
 )
 
 type notifier struct {
@@ -58,8 +57,8 @@ func startKongAdminAPIServiceReconciler(ctx context.Context, t *testing.T, clien
 	adminPod corev1.Pod,
 	n *notifier,
 ) {
-	ns := envtest.CreateNamespace(ctx, t, client)
-	adminPod = envtest.CreatePod(ctx, t, client, ns.Name)
+	ns := CreateNamespace(ctx, t, client)
+	adminPod = CreatePod(ctx, t, client, ns.Name)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Logger: logrusr.New(logrus.New()),
@@ -117,7 +116,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	// In tests below we use a deferred cancel to stop the manager and not wait
 	// for its timeout.
 
-	cfg := envtest.Setup(t, envtest.Scheme(t))
+	cfg := Setup(t, Scheme(t))
 	client, err := ctrlclient.New(cfg, ctrlclient.Options{})
 	require.NoError(t, err)
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -30,7 +30,6 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 )
@@ -94,32 +93,13 @@ func TestTelemetry(t *testing.T) {
 func configForEnvTestTelemetry(t *testing.T, envcfg *rest.Config, splunkEndpoint string, telemetryPeriod time.Duration) manager.Config {
 	t.Helper()
 
-	cfg := manager.Config{}
-	cfg.FlagSet() // Just set the defaults.
-
-	// Telemetry is enabled by default so nothing to configure here.
-
-	// Override the APIServer.
-	cfg.APIServerHost = envcfg.Host
-	cfg.APIServerCertData = envcfg.CertData
-	cfg.APIServerKeyData = envcfg.KeyData
-	cfg.APIServerCAData = envcfg.CAData
-	cfg.KongAdminURLs = []string{StartAdminAPIServerMock(t).URL}
-	cfg.UpdateStatus = false
-	cfg.ProxySyncSeconds = 0.1
-
-	// And other settings which are irrelevant.
-	cfg.Konnect.ConfigSynchronizationEnabled = false
-	cfg.Konnect.LicenseSynchronizationEnabled = false
-	cfg.EnableProfiling = false
-	cfg.EnableConfigDumps = false
-
-	cfg.FeatureGates = featuregates.GetFeatureGatesDefaults()
-	cfg.FeatureGates[featuregates.GatewayFeature] = false
-
+	cfg := ConfigForEnvConfig(t, envcfg)
+	cfg.AnonymousReports = true
 	cfg.SplunkEndpoint = splunkEndpoint
 	cfg.SplunkEndpointInsecureSkipVerify = true
 	cfg.TelemetryPeriod = telemetryPeriod
+	cfg.EnableProfiling = false
+	cfg.EnableConfigDumps = false
 
 	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Move all `envtest` based tests into `test/envtest` directory and removing `envtest` dependency from `test.unit` (and related) targets.

