### PR TITLE
fix: fix panic when last known configuration fetcher gets a nil status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ Adding a new version? You'll need three changes:
 - KongPlugins used on multiple resources will no longer result in
   `instance_name` collisions.
   [#4588](https://github.com/Kong/kubernetes-ingress-controller/issues/4588)
+- Fix `panic` when last known configuratino fetcher gets a `nil` Status when requesting
+  `/status` from Kong Gateway.
+  This happens when Gateway is responding with a 50x HTTP status code.
+  [#4627](https://github.com/Kong/kubernetes-ingress-controller/issues/4627)
 
 ## [2.11.1]
 

--- a/internal/dataplane/configfetcher/config_fetcher_test.go
+++ b/internal/dataplane/configfetcher/config_fetcher_test.go
@@ -1,0 +1,104 @@
+package configfetcher
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/mocks"
+)
+
+func TestTryFetchingValidConfigFromGateways(t *testing.T) {
+	const (
+		zeroConfigHash = "00000000000000000000000000000000"
+		configHash     = "8f1dd2f83bc2627cc6b71c76d1476592"
+	)
+
+	startAdminAPI := func(t *testing.T, ctx context.Context, opts ...mocks.AdminAPIHandlerOpt) *adminapi.Client {
+		adminAPIHandler := mocks.NewAdminAPIHandler(t, opts...)
+		adminAPIServer := httptest.NewServer(adminAPIHandler)
+		t.Cleanup(func() { adminAPIServer.Close() })
+
+		client, err := adminapi.NewKongClientForWorkspace(
+			ctx,
+			adminAPIServer.URL,
+			"", // no workspace
+			adminAPIServer.Client(),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		return client
+	}
+
+	testCases := []struct {
+		name                    string
+		expectError             bool
+		expectedLastValidStatus bool
+		adminAPIClients         func(t *testing.T, ctx context.Context) []*adminapi.Client
+	}{
+		{
+			name: "correct configuration hash",
+			adminAPIClients: func(t *testing.T, ctx context.Context) []*adminapi.Client {
+				return []*adminapi.Client{
+					startAdminAPI(t, ctx, mocks.WithReady(true), mocks.WithConfigurationHash(configHash)),
+					startAdminAPI(t, ctx, mocks.WithReady(true), mocks.WithConfigurationHash(configHash)),
+				}
+			},
+			expectedLastValidStatus: true,
+		},
+		{
+			name: "zero configuration hash",
+			adminAPIClients: func(t *testing.T, ctx context.Context) []*adminapi.Client {
+				return []*adminapi.Client{
+					startAdminAPI(t, ctx, mocks.WithReady(true), mocks.WithConfigurationHash(zeroConfigHash)),
+					startAdminAPI(t, ctx, mocks.WithReady(true), mocks.WithConfigurationHash(zeroConfigHash)),
+				}
+			},
+		},
+		{
+			name: "none are ready",
+			adminAPIClients: func(t *testing.T, ctx context.Context) []*adminapi.Client {
+				return []*adminapi.Client{
+					startAdminAPI(t, ctx, mocks.WithReady(false)),
+					startAdminAPI(t, ctx, mocks.WithReady(false)),
+				}
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fetcher := NewDefaultKongLastGoodConfigFetcher(false)
+			state, ok := fetcher.LastValidConfig()
+			require.False(t, ok)
+			require.Nil(t, state)
+
+			ctx := context.Background()
+			err := fetcher.TryFetchingValidConfigFromGateways(ctx, logrus.New(), tc.adminAPIClients(t, ctx))
+			if tc.expectError {
+				require.Error(t, err)
+				assert.False(t, ok)
+				assert.Nil(t, state)
+				return
+			}
+
+			require.NoError(t, err)
+
+			state, ok = fetcher.LastValidConfig()
+			if tc.expectedLastValidStatus {
+				assert.True(t, ok)
+				assert.NotNil(t, state)
+			} else {
+				assert.False(t, ok)
+				assert.Nil(t, state)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When last known configuration fetcher gets a `nil` status from `Client.Status()` in https://github.com/Kong/kubernetes-ingress-controller/blob/25d37902dd781924cf7604a333449fad31ae905c/internal/dataplane/configfetcher/config_fetcher.go#L69 the controller panic as can be observed when downloading one of the last E2E failure runs: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6114470254

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x19f329a]

goroutine 198 [running]:
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/configfetcher.(*DefaultKongLastGoodConfigFetcher).TryFetchingValidConfigFromGateways(0xc0008dabe0, {0x225e490, 0xc0008da9b0}, {0x2272c00, 0xc0000cef00}, {0xc0009cee80, 0x2, 0x0?})
	/workspace/internal/dataplane/configfetcher/config_fetcher.go:74 +0x2fa
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*KongClient).Update(0xc000878200, {0x225e490, 0xc0008da9b0})
	/workspace/internal/dataplane/kong_client.go:398 +0x17b
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*Synchronizer).startUpdateServer(0xc000360540, {0x225e490, 0xc0008da9b0})
	/workspace/internal/dataplane/synchronizer.go:185 +0xef
created by github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*Synchronizer).Start
	/workspace/internal/dataplane/synchronizer.go:122 +0x245
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
