### PR TITLE
refactor(tests): improve code for webhooks

### DIFF
--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -28,11 +28,11 @@ func TestGatewayValidationWebhook(t *testing.T) {
 	if env.Cluster().Type() != kind.KindClusterType {
 		t.Skip("webhook tests are only available on KIND clusters currently")
 	}
-
+	const configResourceName = "kong-validations-gateway"
 	ensureAdmissionRegistration(
 		ctx,
 		t,
-		"kong-validations-gateway",
+		configResourceName,
 		[]admregv1.RuleWithOperations{
 			{
 				Rule: admregv1.Rule{
@@ -46,7 +46,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 	)
 
 	t.Log("waiting for webhook service to be connective")
-	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-gateway"))
+	ensureWebhookServiceIsConnective(ctx, t, configResourceName)
 
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -265,7 +265,7 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 	t.Logf("created unmanaged gateway: %q", unmanagedGateway.Name)
 
 	t.Log("waiting for webhook service to be connective")
-	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-gateway"))
+	ensureWebhookServiceIsConnective(ctx, t, "kong-validations-gateway")
 
 	return namespace, gatewayClient, managedGateway, unmanagedGateway
 }

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -30,10 +30,11 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 
 	ns, _ := helpers.Setup(ctx, t, env)
 
+	const configResourceName = "kong-validations-kongingress"
 	ensureAdmissionRegistration(
 		ctx,
 		t,
-		"kong-validations-kongingress",
+		configResourceName,
 		[]admregv1.RuleWithOperations{
 			{
 				Rule: admregv1.Rule{
@@ -47,7 +48,7 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 	)
 
 	t.Log("waiting for webhook service to be connective")
-	require.NoError(t, waitForWebhookServiceConnective(ctx, "kong-validations-kongingress"))
+	ensureWebhookServiceIsConnective(ctx, t, configResourceName)
 
 	kongClient, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- get rid of redundant settings like e.g. `TypeMeta`
- refactor functions that start with `ensureXXX` to take `t *testing.T` as a parameter and use `t.Cleanup` instead of returning

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Spotted during CR for 
- https://github.com/Kong/kubernetes-ingress-controller/pull/4608

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

