### PR TITLE
tests: add CI workflow for generating conformance tests report

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -81,6 +81,11 @@ body:
       - label: Mark the PR ready for review.
       - label: Inform and ping the @Kong/team-k8s via slack of impending release with a link to the release PR.
 - type: textarea
+  id: conformance_tests_report
+  attributes:
+    label: Conformance tests report
+    value: Trigger for released version CI workflow `conformance_tests_report.yaml`, verify artifact and submit it to https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports. It's still in experimental phase.
+- type: textarea
   id: release_trouble_shooting_link
   attributes:
     label: Release Troubleshooting

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -1,0 +1,38 @@
+name: Generate Kubernetes Gateway API conformance tests report
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The version of code (e.g. v1.2.3 or commit hash)
+        required: false
+        default: main
+
+jobs:
+  generate-report:
+    name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Run conformance experimental tests
+        run: make test.conformance-experimental
+
+      # Generated report should be submitted to
+      # https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports
+      # in future when experimental becomes stable autamate creating PR (add to release workflow).
+      - name: Collect conformance tests report
+        uses: actions/upload-artifact@v3
+        with:
+          name: kong-kubernetes-ingress-controller.yaml
+          path: conformance-tests-report.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Introduces CI workflow that can be run for a specific version of code (specified by tag or commit hash) and generates the report as an artifact for submitting to https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports. This is still in an experimental phase, hence it's not run automatically as a part of the release workflow. 

It can be run only for code that includes 
- https://github.com/Kong/kubernetes-ingress-controller/pull/4551

Thus it will be used to generate such a report for `KIC 2.12.0`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This is part of
- https://github.com/Kong/kubernetes-ingress-controller/issues/4402

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

