### PR TITLE
fix(tests): validate regex supplied in HTTPRoute for Kong < 3.0

### DIFF
--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -162,7 +162,7 @@ func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
 	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
 	testCases := append(
 		commonHTTPRouteValidationTestCases(managedGateway, unmanagedGateway),
-		invalidRegexInPathTestCase(managedGateway, `HTTPRoute failed schema validation: schema violation (paths.3: invalid regex: '/foo[[[['`),
+		invalidRegexInPathTestCase(managedGateway, `invalid regex: '/foo[[[['`),
 		// No test case for invalid regex in header, because Kong Gateway doesn't return any error in such case (it works only for expressions router).
 	)
 	testHTTPRouteValidationWebhook(ctx, t, namespace, gatewayClient, testCases)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

For Kong Gateway `< 3.0` error message returned is a little bit different

```
schema violation (paths.2: invalid regex: '/foo[[[[' 
```
vs
```
schema violation (paths.3: invalid regex: '/foo[[[['
```
for Kong `>= 3.0`

thus assert only on 

```
invalid regex: '/foo[[[['
```
as good enough.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

- [CI run](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6121766620/job/16616198424#step:6:6770)
- fix for changes introduced in https://github.com/Kong/kubernetes-ingress-controller/pull/4608

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

