### PR TITLE
chore(tests): add namespace selector in ensureAdmissionRegistration

### DIFF
--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -32,6 +32,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 	ensureAdmissionRegistration(
 		ctx,
 		t,
+		ns.Name,
 		configResourceName,
 		[]admregv1.RuleWithOperations{
 			{

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -210,16 +210,20 @@ func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 }
 
 // setUpEnvForTestingHTTPRouteValidationWebhook sets up the environment for testing HTTPRoute validation webhook,
-// it sets it globally. See https://github.com/Kong/kubernetes-ingress-controller/issues/4621 for more details.
+// it sets it only for object applied to namespace specified as argument.
 func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testing.T) (
 	namespace string,
 	gatewayClient *gatewayclient.Clientset,
 	managedGateway *gatewayv1beta1.Gateway,
 	unmanagedGateway *gatewayv1beta1.Gateway,
 ) {
+	ns, cleaner := helpers.Setup(ctx, t, env)
+	namespace = ns.Name
+	t.Logf("created namespace: %q", namespace)
 	ensureAdmissionRegistration(
 		ctx,
 		t,
+		namespace,
 		"kong-validations-gateway",
 		[]admregv1.RuleWithOperations{
 			{
@@ -236,9 +240,6 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 	t.Log("creating a gateway client")
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
-
-	ns, cleaner := helpers.Setup(ctx, t, env)
-	namespace = ns.Name
 
 	t.Log("creating a managed gateway")
 	managedGateway, err = DeployGateway(ctx, gatewayClient, ns.Name, unmanagedGatewayClassName, func(g *gatewayv1beta1.Gateway) {

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -210,7 +210,7 @@ func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 }
 
 // setUpEnvForTestingHTTPRouteValidationWebhook sets up the environment for testing HTTPRoute validation webhook,
-// it sets it only for object applied to namespace specified as argument.
+// it sets it only for objects applied to namespace specified as argument.
 func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testing.T) (
 	namespace string,
 	gatewayClient *gatewayclient.Clientset,

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -34,6 +34,7 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 	ensureAdmissionRegistration(
 		ctx,
 		t,
+		ns.Name,
 		configResourceName,
 		[]admregv1.RuleWithOperations{
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Registered admission webhook is scoped to the namespace passed as an argument to function `ensureAdmissionRegistration`, it introduces better separation for our tests. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes #4621 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

