### PR TITLE
chore(ci): disable toolchain in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,21 @@ module github.com/kong/kubernetes-ingress-controller/v2
 
 go 1.21
 
-toolchain go1.21.0
+// TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
+//
+//  Error parsing file: /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/go.mod.
+//
+//      /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/go.mod:5:1:
+//        |
+//      5 | toolchain go1.21.0
+//        | ^
+//      unexpected 't'
+//      expecting "exclude", "go", "replace", "require", "retract", or end of input
+//
+//
+// Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/4635
+//
+// toolchain go1.21.0
 
 require (
 	cloud.google.com/go/container v1.25.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This unbreaks the CI. Reason for this is that FOSSA Github action doesn't support go 1.21's `toolchain` directive.

Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/4635

This aims to prevent failures like this: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6141226981/job/16661215380

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
