### PR TITLE
chore: don't use global controller-runtime logger

### DIFF
--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 )
@@ -17,6 +18,7 @@ func Run(ctx context.Context, c *manager.Config, output io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
+	ctx = ctrl.LoggerInto(ctx, logger)
 
 	return RunWithLogger(ctx, c, deprecatedLogger, logger)
 }

--- a/internal/manager/conditions.go
+++ b/internal/manager/conditions.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 
 	netv1 "k8s.io/api/networking/v1"
@@ -68,9 +69,9 @@ func negotiateIngressAPI(config *Config, mapper meta.RESTMapper) (IngressAPI, er
 	return NoIngressAPI, nil
 }
 
-func ShouldEnableCRDController(gvr schema.GroupVersionResource, restMapper meta.RESTMapper) bool {
+func ShouldEnableCRDController(ctx context.Context, gvr schema.GroupVersionResource, restMapper meta.RESTMapper) bool {
 	if !ctrlutils.CRDExists(restMapper, gvr) {
-		ctrl.Log.WithName("controllers").WithName("crdCondition").
+		ctrl.LoggerFrom(ctx).WithName("controllers").WithName("crdCondition").
 			Info(fmt.Sprintf("Disabling controller for Group=%s, Resource=%s due to missing CRD", gvr.GroupVersion(), gvr.Resource))
 		return false
 	}

--- a/internal/manager/conditions_test.go
+++ b/internal/manager/conditions_test.go
@@ -1,6 +1,7 @@
 package manager_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,7 +122,7 @@ func TestShouldEnableCRDController(t *testing.T) {
 			require.Equal(
 				t,
 				tc.expectedResult,
-				manager.ShouldEnableCRDController(tc.gvr, restMapper),
+				manager.ShouldEnableCRDController(context.Background(), tc.gvr, restMapper),
 			)
 		})
 	}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -46,7 +46,7 @@ import (
 
 // Run starts the controller manager and blocks until it exits.
 func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, deprecatedLogger logrus.FieldLogger) error {
-	setupLog := ctrl.Log.WithName("setup")
+	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
 	setupLog.Info("starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.Info("the ingress class name has been set", "value", c.IngressClassName)
 
@@ -121,7 +121,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 	kongConfig.Init(ctx, setupLog, initialKongClients)
 
 	setupLog.Info("configuring and building the controller manager")
-	controllerOpts, err := setupControllerOptions(setupLog, c, dbMode, featureGates)
+	controllerOpts, err := setupControllerOptions(ctx, setupLog, c, dbMode, featureGates)
 	if err != nil {
 		return fmt.Errorf("unable to setup controller options: %w", err)
 	}
@@ -218,6 +218,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	setupLog.Info("Starting Enabled Controllers")
 	controllers, err := setupControllers(
+		ctx,
 		mgr,
 		dataplaneClient,
 		dataplaneAddressFinder,
@@ -284,7 +285,7 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		setupLog.Info("starting license agent")
 		agent := license.NewAgent(
 			konnectLicenseAPIClient,
-			ctrl.Log.WithName("license-agent"),
+			ctrl.LoggerFrom(ctx).WithName("license-agent"),
 			license.WithInitialPollingPeriod(c.Konnect.InitialLicensePollingPeriod),
 			license.WithPollingPeriod(c.Konnect.LicensePollingPeriod),
 		)

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -50,7 +50,6 @@ func SetupLoggers(c *Config, output io.Writer) (logrus.FieldLogger, logr.Logger,
 	}
 
 	logger := logrusr.New(deprecatedLogger)
-	ctrl.SetLogger(logger)
 
 	if c.LogLevel != "trace" && c.LogLevel != "debug" {
 		// disable deck's per-change diff output
@@ -60,7 +59,7 @@ func SetupLoggers(c *Config, output io.Writer) (logrus.FieldLogger, logr.Logger,
 	return deprecatedLogger, logger, nil
 }
 
-func setupControllerOptions(logger logr.Logger, c *Config, dbmode string, featureGates map[string]bool) (ctrl.Options, error) {
+func setupControllerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode string, featureGates map[string]bool) (ctrl.Options, error) {
 	logger.Info("building the manager runtime scheme and loading apis into the scheme")
 	scheme, err := scheme.Get(featureGates)
 	if err != nil {
@@ -79,6 +78,7 @@ func setupControllerOptions(logger logr.Logger, c *Config, dbmode string, featur
 		Cache: cache.Options{
 			SyncPeriod: &c.SyncPeriod,
 		},
+		Logger: ctrl.LoggerFrom(ctx),
 	}
 
 	// If there are no configured watch namespaces, then we're watching ALL namespaces,

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -96,7 +96,7 @@ func RunManager(
 
 	logrusLogger, loggerHook := test.NewNullLogger()
 	logger := logrusr.New(logrusLogger)
-	ctrl.SetLogger(logger)
+	ctx = ctrl.LoggerInto(ctx, logger)
 
 	go func() {
 		err := manager.Run(ctx, &cfg, util.ConfigDumpDiagnostic{}, logrusLogger)


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of using the global `ctrl.Log` and setting it with `ctrl.SetLogger`, let's pass it along in context. This allows injecting logger in tests without interference with other test cases run in the same test binary.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

`ctrl.SetLogger` is effective only once. If we set the logger in one test case, it can never be overridden later, making it impossible to dump/verify logs from a test case that was run not as a first one. I discovered this when working on https://github.com/Kong/kubernetes-ingress-controller/pull/4619 where I'm expecting logs in tests.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

