### PR TITLE
fix: ensure connectivity with Kubernetes API on start-up

### DIFF
--- a/internal/controllers/crds/dynamic_controller.go
+++ b/internal/controllers/crds/dynamic_controller.go
@@ -39,7 +39,8 @@ type DynamicCRDController struct {
 	Controller       Controller
 	RequiredCRDs     []schema.GroupVersionResource
 
-	startControllersOnce sync.Once
+	// startControllerOnce ensures that the controller is started only once.
+	startControllerOnce sync.Once
 }
 
 func (r *DynamicCRDController) SetupWithManager(mgr ctrl.Manager) error {
@@ -87,7 +88,7 @@ func (r *DynamicCRDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	var startControllerErr error
-	r.startControllersOnce.Do(func() {
+	r.startControllerOnce.Do(func() {
 		log.V(util.InfoLevel).Info("All required CustomResourceDefinitions are installed, setting up the controller")
 		startControllerErr = r.setupController(r.Manager)
 	})
@@ -96,6 +97,10 @@ func (r *DynamicCRDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *DynamicCRDController) SetLogger(logger logr.Logger) {
+	r.Log = logger
 }
 
 func (r *DynamicCRDController) allRequiredCRDsInstalled() bool {

--- a/internal/manager/conditions.go
+++ b/internal/manager/conditions.go
@@ -1,13 +1,9 @@
 package manager
 
 import (
-	"context"
-	"fmt"
-
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/utils"
 )
@@ -67,13 +63,4 @@ func negotiateIngressAPI(config *Config, mapper meta.RESTMapper) (IngressAPI, er
 		}
 	}
 	return NoIngressAPI, nil
-}
-
-func ShouldEnableCRDController(ctx context.Context, gvr schema.GroupVersionResource, restMapper meta.RESTMapper) bool {
-	if !ctrlutils.CRDExists(restMapper, gvr) {
-		ctrl.LoggerFrom(ctx).WithName("controllers").WithName("crdCondition").
-			Info(fmt.Sprintf("Disabling controller for Group=%s, Resource=%s due to missing CRD", gvr.GroupVersion(), gvr.Resource))
-		return false
-	}
-	return true
 }

--- a/internal/manager/conditions_test.go
+++ b/internal/manager/conditions_test.go
@@ -1,7 +1,6 @@
 package manager_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,53 +76,6 @@ func TestIngressControllerConditions(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectIngressNetV1, conditions.IngressNetV1Enabled())
 			assert.Equal(t, tc.expectIngressClassNetV1, conditions.IngressClassNetV1Enabled())
-		})
-	}
-}
-
-func TestShouldEnableCRDController(t *testing.T) {
-	knownGvr := schema.GroupVersionResource{
-		Group:    "group",
-		Version:  "v1",
-		Resource: "resources",
-	}
-	unknownGVR := schema.GroupVersionResource{
-		Group:    "otherGroup",
-		Version:  "v1",
-		Resource: "resources",
-	}
-
-	restMapper := meta.NewDefaultRESTMapper(nil)
-	restMapper.Add(schema.GroupVersionKind{
-		Group:   knownGvr.Group,
-		Version: knownGvr.Version,
-		Kind:    "Resource",
-	}, meta.RESTScopeRoot)
-
-	testCases := []struct {
-		name           string
-		gvr            schema.GroupVersionResource
-		expectedResult bool
-	}{
-		{
-			name:           "registered_resource",
-			gvr:            knownGvr,
-			expectedResult: true,
-		},
-		{
-			name:           "not_registered_resource",
-			gvr:            unknownGVR,
-			expectedResult: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(
-				t,
-				tc.expectedResult,
-				manager.ShouldEnableCRDController(context.Background(), tc.gvr, restMapper),
-			)
 		})
 	}
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
@@ -128,7 +130,11 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	mgr, err := ctrl.NewManager(kubeconfig, controllerOpts)
 	if err != nil {
-		return fmt.Errorf("unable to start controller manager: %w", err)
+		return fmt.Errorf("unable to create controller manager: %w", err)
+	}
+
+	if err := waitForKubernetesAPIReadiness(ctx, setupLog, mgr); err != nil {
+		return fmt.Errorf("unable to connect to Kubernetes API: %w", err)
 	}
 
 	setupLog.Info("Initializing Dataplane Client")
@@ -327,6 +333,47 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 
 	setupLog.Info("Starting manager")
 	return mgr.Start(ctx)
+}
+
+// waitForKubernetesAPIReadiness waits for the Kubernetes API to be ready. It's used as a prerequisite to run any
+// controller components (i.e. Manager along with its Runnables).
+// It retries with a timeout of 1m and a fixed delay of 1s.
+func waitForKubernetesAPIReadiness(ctx context.Context, logger logr.Logger, mgr manager.Manager) error {
+	const (
+		timeout = time.Minute
+		delay   = time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	readinessEndpointURL, err := url.JoinPath(mgr.GetConfig().Host, "readyz")
+	if err != nil {
+		return fmt.Errorf("failed to build readiness check URL: %w", err)
+	}
+
+	return retry.Do(func() error {
+		// Call the readiness check of the Kubernetes API server: https://kubernetes.io/docs/reference/using-api/health-checks/.
+		resp, err := mgr.GetHTTPClient().Get(readinessEndpointURL)
+		if err != nil {
+			return fmt.Errorf("failed to connect to %q: %w", readinessEndpointURL, err)
+		}
+		defer resp.Body.Close()
+		// We're waiting for the readiness check to return status 200.
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("readiness check %q returned status %d", readinessEndpointURL, resp.StatusCode)
+		}
+		return nil
+	},
+		retry.Context(ctx),
+		retry.Delay(delay),
+		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(0), // We're using a context with timeout, so we don't need to limit the number of attempts.
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			logger.Info("Retrying Kubernetes API readiness check after error", "error", err.Error())
+		}),
+	)
 }
 
 // setupKonnectNodeAgentWithMgr creates and adds Konnect NodeAgent as the manager's Runnable.

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -25,7 +25,7 @@ import (
 // Gateway's listener.
 // It reproduces https://github.com/Kong/kubernetes-ingress-controller/issues/4456.
 func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
-	scheme := Scheme(t, WithGatewayAPI)
+	scheme := Scheme(t, WithGatewayAPI, WithKong)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -22,7 +22,7 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	t.Parallel()
 
 	scheme := Scheme(t, WithKong)
-	cfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	cfg := Setup(t, scheme)
 	client := NewControllerClient(t, scheme, cfg)
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -1,0 +1,69 @@
+//go:build envtest
+
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+// TestManagerDoesntStartUntilKubernetesAPIReachable ensures that the manager and its Runnables are not start until the
+// Kubernetes API server is reachable.
+func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("Setting up a proxy for Kubernetes API server so that we can interrupt it")
+	u, err := url.Parse(envcfg.Host)
+	require.NoError(t, err)
+	apiServerProxy, err := helpers.NewTCPProxy(u.Host)
+	require.NoError(t, err)
+	go func() {
+		err := apiServerProxy.Run(ctx)
+		assert.NoError(t, err)
+	}()
+	apiServerProxy.StopHandlingConnections()
+
+	t.Log("Replacing Kubernetes API server address with the proxy address")
+	envcfg.Host = fmt.Sprintf("https://%s", apiServerProxy.Address())
+
+	loggerHook := RunManager(ctx, t, envcfg)
+	hasLog := func(expectedLog string) bool {
+		return lo.ContainsBy(loggerHook.AllEntries(), func(entry *logrus.Entry) bool {
+			return strings.Contains(entry.Message, expectedLog)
+		})
+	}
+
+	t.Log("Ensuring manager is waiting for Kubernetes API to be ready")
+	const expectedKubernetesAPICheckErrorLog = "Retrying Kubernetes API readiness check after error"
+	require.Eventually(t, func() bool { return hasLog(expectedKubernetesAPICheckErrorLog) }, time.Minute, time.Millisecond)
+
+	t.Log("Ensure manager hasn't been started yet and no config sync has happened")
+	const configurationSyncedToKongLog = "successfully synced configuration to Kong"
+	const startingManagerLog = "Starting manager"
+	require.False(t, hasLog(configurationSyncedToKongLog))
+	require.False(t, hasLog(startingManagerLog))
+
+	t.Log("Starting accepting connections in Kubernetes API proxy so that manager can start")
+	apiServerProxy.StartHandlingConnections()
+
+	t.Log("Ensuring manager has been started and config sync has happened")
+	require.Eventually(t, func() bool {
+		return hasLog(startingManagerLog) &&
+			hasLog(configurationSyncedToKongLog)
+	}, time.Minute, time.Millisecond)
+}

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -21,7 +21,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 	t.Parallel()
 
 	scheme := Scheme(t, WithKong)
-	envcfg := Setup(t, scheme, WithInstallKongCRDs(true))
+	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -128,7 +128,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		// if there are multiple KIC instances within a cluster, they will fight over setting this condition because the
 		// controllers do not filter on ingress class. we need to limit them to only resources referenced from others,
 		// similar to Secrets, to use this
-		//{
+		// {
 		//	name: "valid KongPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -164,8 +164,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionTrue,
 		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
-		//},
-		//{
+		// },
+		// {
 		//	name: "invalid KongPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -209,8 +209,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionFalse,
 		//	expectedProgrammedReason: kongv1.ReasonInvalid,
-		//},
-		//{
+		// },
+		// {
 		//	name: "valid KongClusterPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongClusterPlugin{
@@ -244,8 +244,8 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionTrue,
 		//	expectedProgrammedReason: kongv1.ReasonProgrammed,
-		//},
-		//{
+		// },
+		// {
 		//	name: "invalid KongClusterPlugin",
 		//	objects: []client.Object{
 		//		&kongv1.KongPlugin{
@@ -289,7 +289,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 		//	},
 		//	expectedProgrammedStatus: metav1.ConditionFalse,
 		//	expectedProgrammedReason: kongv1.ReasonInvalid,
-		//},
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -23,19 +23,26 @@ import (
 
 type Options struct {
 	InstallGatewayCRDs bool
-	InstanllKongCRDs   bool
+	InstallKongCRDs    bool
 }
 
 var DefaultEnvTestOpts = Options{
 	InstallGatewayCRDs: true,
-	InstanllKongCRDs:   false,
+	InstallKongCRDs:    true,
 }
 
 type OptionModifier func(Options) Options
 
 func WithInstallKongCRDs(install bool) OptionModifier {
 	return func(opts Options) Options {
-		opts.InstanllKongCRDs = install
+		opts.InstallKongCRDs = install
+		return opts
+	}
+}
+
+func WithInstallGatewayCRDs(install bool) OptionModifier {
+	return func(opts Options) Options {
+		opts.InstallGatewayCRDs = install
 		return opts
 	}
 }
@@ -64,7 +71,7 @@ func Setup(t *testing.T, scheme *k8sruntime.Scheme, optModifiers ...OptionModifi
 	if opts.InstallGatewayCRDs {
 		installGatewayCRDs(t, scheme, cfg)
 	}
-	if opts.InstanllKongCRDs {
+	if opts.InstallKongCRDs {
 		installKongCRDs(t, scheme, cfg)
 	}
 

--- a/test/internal/helpers/tcp.go
+++ b/test/internal/helpers/tcp.go
@@ -1,0 +1,131 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// TCPProxy is a simple server that forwards TCP connections to a given destination.
+// It can be used to simulate network failures by stopping accepting new connections and interrupting existing ones.
+type TCPProxy struct {
+	destination string
+	address     string
+	listener    net.Listener
+
+	// interruptSignalChs is a list of channels that are used to interrupt connections.
+	interruptSignalChs []chan struct{}
+	// shouldHandleNewConnections is a flag that indicates whether new connections should be accepted.
+	shouldHandleNewConnections bool
+
+	mu sync.RWMutex
+}
+
+func NewTCPProxy(destination string) (*TCPProxy, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen: %w", err)
+	}
+	return &TCPProxy{
+		destination:                destination,
+		address:                    listener.Addr().String(),
+		listener:                   listener,
+		shouldHandleNewConnections: true,
+	}, nil
+}
+
+// Run starts connections accepting loop and blocks until the context is canceled.
+func (p *TCPProxy) Run(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		_ = p.listener.Close()
+	}()
+
+	for {
+		c, err := p.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("failed to accept connection: %w", err)
+		}
+
+		if !p.shouldHandleConnections() {
+			_ = c.Close()
+			continue
+		}
+
+		go p.handleConnection(c, p.newInterruptSignalCh())
+	}
+}
+
+// Address returns the address of the proxy.
+func (p *TCPProxy) Address() string {
+	return p.address
+}
+
+// StopHandlingConnections stops handling connections by interrupting all existing connections and immediately closing
+// new connections.
+func (p *TCPProxy) StopHandlingConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Interrupt all connections.
+	for _, ch := range p.interruptSignalChs {
+		close(ch)
+	}
+	p.interruptSignalChs = nil
+
+	// Ensure no new connections are accepted.
+	p.shouldHandleNewConnections = false
+}
+
+// StartHandlingConnections starts handling new connections.
+func (p *TCPProxy) StartHandlingConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.shouldHandleNewConnections = true
+}
+
+func (p *TCPProxy) handleConnection(src net.Conn, interruptSignalCh chan struct{}) {
+	defer func() {
+		_ = src.Close()
+	}()
+
+	dst, err := net.Dial("tcp", p.destination)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	copyDoneCh := make(chan struct{}, 2)
+	go p.copy(dst, src, copyDoneCh)
+	go p.copy(src, dst, copyDoneCh)
+
+	select {
+	case <-copyDoneCh:
+	case <-interruptSignalCh:
+	}
+}
+
+func (p *TCPProxy) copy(dst, src net.Conn, doneCh chan struct{}) {
+	_, _ = io.Copy(dst, src)
+	doneCh <- struct{}{}
+}
+
+func (p *TCPProxy) shouldHandleConnections() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.shouldHandleNewConnections
+}
+
+func (p *TCPProxy) newInterruptSignalCh() chan struct{} {
+	ch := make(chan struct{})
+	p.interruptSignalChs = append(p.interruptSignalChs, ch)
+	return ch
+}

--- a/test/internal/helpers/tcp_test.go
+++ b/test/internal/helpers/tcp_test.go
@@ -1,0 +1,81 @@
+package helpers_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+func TestTCPProxy(t *testing.T) {
+	ls, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	var (
+		destAcceptedConn atomic.Bool
+		destDroppedConn  atomic.Bool
+		destReceivedData bytes.Buffer
+	)
+	go func() {
+		for {
+			c, err := ls.Accept()
+			if err != nil {
+				return
+			}
+			destAcceptedConn.Store(true)
+			go func() {
+				_, _ = io.Copy(&destReceivedData, c)
+				destDroppedConn.Store(true)
+			}()
+		}
+	}()
+
+	proxy, err := helpers.NewTCPProxy(ls.Addr().String())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := proxy.Run(ctx)
+		assert.NoError(t, err)
+	}()
+
+	t.Log("Ensuring proxy is accepting connections by default")
+	conn, err := net.Dial("tcp", proxy.Address())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return destAcceptedConn.Load() }, time.Second, time.Millisecond, "destination didn't accept connection")
+
+	t.Log("Ensuring proxy forwards data from the source to the destination")
+	_, err = conn.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return destReceivedData.String() == "hello" }, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy dropped connection after StopHandlingConnections")
+	proxy.StopHandlingConnections()
+	require.Eventually(t, func() bool { return destDroppedConn.Load() }, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy dropped existing connection after StopHandlingConnections")
+	require.Eventually(t, func() bool {
+		_, err = conn.Write([]byte("hello"))
+		return err != nil
+	}, time.Second, time.Millisecond)
+
+	t.Log("Ensuring proxy handles connections after StartHandlingConnections")
+	proxy.StartHandlingConnections()
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", proxy.Address())
+		if err != nil {
+			return false
+		}
+		_, err = conn.Write([]byte("hello"))
+		return err == nil
+	}, time.Second, time.Millisecond)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It introduces a Kubernetes API status check on start-up to prevent issues like https://github.com/Kong/kubernetes-ingress-controller/issues/4603 and https://github.com/Kong/kubernetes-ingress-controller/issues/4207. With the connectivity ensured, we may rely on controller-runtime default behavior (cache sync timeout will be triggered in case of missing CRDs) and drop our manual checks for Kong's CRD existence.

Adds envtests:

- `TestManagerDoesntStartUntilKubernetesAPIReachable` to ensure the manager will not start its runnables (including the config sync loop) until the Kubernetes API is reachable.
- `TestNoKongCRDsInstalledIsFatal` to ensure that in case of missing Kong CRDs installation, the controller will eventually crash. 
- `TestGatewayAPIControllersMayBeDynamicallyStarted` to ensure Gateway API CRDs can be installed during the runtime and their controllers will be started dynamically in such a case.

Also, migrates Knative Ingress controller to use `DynamicCRCController` just to not maintain 3 ways of initializing the controllers.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Should fix #4603 and #4207.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
