### PR TITLE
feat(admission): validate path with regex supplied in Ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ Adding a new version? You'll need three changes:
 - Allow regex expressions in `HTTPRoute` configuration and provide validation in admission webhook.
   Before this change admission webhook used to reject entirely such configurations incorrectly as not supported yet.
   [#4608](https://github.com/Kong/kubernetes-ingress-controller/pull/4608)
+- Provide validation in admission webhook for `Ingress` paths (validate regex expressions).
+  [#4647](https://github.com/Kong/kubernetes-ingress-controller/pull/4647)
 - Add new feature gate `RewriteURIs` to enable/disable the `konghq.com/rewrite`
   annotation (default disabled).
   [#4360](https://github.com/Kong/kubernetes-ingress-controller/pull/4360)

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -66,6 +67,10 @@ func (v KongFakeValidator) ValidateGateway(_ context.Context, _ gatewayv1beta1.G
 }
 
 func (v KongFakeValidator) ValidateHTTPRoute(_ context.Context, _ gatewayv1beta1.HTTPRoute) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
+func (v KongFakeValidator) ValidateIngress(_ context.Context, _ netv1.Ingress) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
 

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -121,7 +121,11 @@ func ingressV1ToKongServiceCombinedRoutes(
 
 // ingressV1ToKongServiceLegacy translates a slice IngressV1 object into Kong Services.
 func ingressV1ToKongServiceLegacy(
-	featureFlags FeatureFlags, ingresses []*netv1.Ingress, icp kongv1alpha1.IngressClassParametersSpec, parsedObjectsCollector *ObjectsCollector, failuresCollector *failures.ResourceFailuresCollector,
+	featureFlags FeatureFlags,
+	ingresses []*netv1.Ingress,
+	icp kongv1alpha1.IngressClassParametersSpec,
+	parsedObjectsCollector *ObjectsCollector,
+	failuresCollector *failures.ResourceFailuresCollector,
 ) KongServicesCache {
 	servicesCache := make(KongServicesCache)
 

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	netv1 "k8s.io/api/networking/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/atc"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
@@ -57,7 +58,13 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 	}
 
 	// Translate Ingress objects into Kong Services.
-	servicesCache := p.ingressesV1ToKongServices(ingressList, icp)
+	servicesCache := IngressesV1ToKongServices(
+		p.featureFlags,
+		ingressList,
+		icp,
+		p.parsedObjectsCollector,
+		p.failuresCollector,
+	)
 	for i := range servicesCache {
 		service := servicesCache[i]
 		if err := translators.MaybeRewriteURI(&service, p.featureFlags.RewriteURIs); err != nil {
@@ -79,40 +86,48 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 	return result
 }
 
-// ingressV1ToKongServicesCache is a cache of Kong Services indexed by their name.
-type kongServicesCache map[string]kongstate.Service
+// KongServicesCache is a cache of Kong Services indexed by their name.
+type KongServicesCache map[string]kongstate.Service
 
-// ingressesV1ToKongServices translates IngressV1 object into Kong Service. It inserts the Kong Service into the passed servicesCache.
-// Returns true if the passed servicesCache was updated.
-func (p *Parser) ingressesV1ToKongServices(
+// IngressesV1ToKongServices translates IngressV1 object into Kong Service, returns them indexed by name.
+// Argument parsedObjectsCollector is used to register all successfully parsed objects. In case of a failure,
+// the object is registered in failuresCollector.
+func IngressesV1ToKongServices(
+	featureFlags FeatureFlags,
 	ingresses []*netv1.Ingress,
 	icp kongv1alpha1.IngressClassParametersSpec,
-) kongServicesCache {
-	if p.featureFlags.CombinedServiceRoutes {
-		return p.ingressV1ToKongServiceCombinedRoutes(ingresses, icp)
+	parsedObjectsCollector *ObjectsCollector,
+	failuresCollector *failures.ResourceFailuresCollector,
+) KongServicesCache {
+	if featureFlags.CombinedServiceRoutes {
+		return ingressV1ToKongServiceCombinedRoutes(featureFlags, ingresses, icp, parsedObjectsCollector)
 	}
-	return p.ingressV1ToKongServiceLegacy(ingresses, icp)
+	return ingressV1ToKongServiceLegacy(featureFlags, ingresses, icp, parsedObjectsCollector, failuresCollector)
 }
 
 // ingressV1ToKongServiceLegacy translates a slice of IngressV1 object into Kong Services.
-func (p *Parser) ingressV1ToKongServiceCombinedRoutes(
+func ingressV1ToKongServiceCombinedRoutes(
+	featureFlags FeatureFlags,
 	ingresses []*netv1.Ingress,
 	icp kongv1alpha1.IngressClassParametersSpec,
-) kongServicesCache {
+	parsedObjectsCollector *ObjectsCollector,
+) KongServicesCache {
 	return translators.TranslateIngresses(ingresses, icp, translators.TranslateIngressFeatureFlags{
-		RegexPathPrefix:  p.featureFlags.RegexPathPrefix,
-		ExpressionRoutes: p.featureFlags.ExpressionRoutes,
-		CombinedServices: p.featureFlags.CombinedServices,
-	}, p.parsedObjectsCollector)
+		RegexPathPrefix:  featureFlags.RegexPathPrefix,
+		ExpressionRoutes: featureFlags.ExpressionRoutes,
+		CombinedServices: featureFlags.CombinedServices,
+	}, parsedObjectsCollector)
 }
 
 // ingressV1ToKongServiceLegacy translates a slice IngressV1 object into Kong Services.
-func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp kongv1alpha1.IngressClassParametersSpec) kongServicesCache {
-	servicesCache := make(kongServicesCache)
+func ingressV1ToKongServiceLegacy(
+	featureFlags FeatureFlags, ingresses []*netv1.Ingress, icp kongv1alpha1.IngressClassParametersSpec, parsedObjectsCollector *ObjectsCollector, failuresCollector *failures.ResourceFailuresCollector,
+) KongServicesCache {
+	servicesCache := make(KongServicesCache)
 
 	for _, ingress := range ingresses {
 		ingressSpec := ingress.Spec
-		maybePrependRegexPrefixFn := translators.MaybePrependRegexPrefixForIngressV1Fn(ingress, icp.EnableLegacyRegexDetection && p.featureFlags.RegexPathPrefix)
+		maybePrependRegexPrefixFn := translators.MaybePrependRegexPrefixForIngressV1Fn(ingress, icp.EnableLegacyRegexDetection && featureFlags.RegexPathPrefix)
 		for i, rule := range ingressSpec.Rules {
 			if rule.HTTP == nil {
 				continue
@@ -124,12 +139,10 @@ func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp ko
 					rulePath.PathType = &pathTypeImplementationSpecific
 				}
 
-				paths := translators.PathsFromIngressPaths(rulePath, p.featureFlags.RegexPathPrefix)
+				paths := translators.PathsFromIngressPaths(rulePath, featureFlags.RegexPathPrefix)
 				if paths == nil {
-					// registering a failure, but technically it should never happen thanks to Kubernetes API validations
-					p.registerTranslationFailure(
-						fmt.Sprintf("could not translate Ingress Path %s to Kong paths", rulePath.Path), ingress,
-					)
+					// Registering a failure, but technically it should never happen thanks to Kubernetes API validations.
+					failuresCollector.PushResourceFailure(fmt.Sprintf("could not translate Ingress Path %s to Kong paths", rulePath.Path), ingress)
 					continue
 				}
 
@@ -192,7 +205,7 @@ func (p *Parser) ingressV1ToKongServiceLegacy(ingresses []*netv1.Ingress, icp ko
 
 				service.Routes = append(service.Routes, r)
 				servicesCache[serviceName] = service
-				p.registerSuccessfullyParsedObject(ingress)
+				parsedObjectsCollector.Add(ingress) // Register successfully parsed object.
 			}
 		}
 	}

--- a/internal/util/builder/ingress.go
+++ b/internal/util/builder/ingress.go
@@ -1,0 +1,46 @@
+package builder
+
+import (
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+)
+
+type IngressBuilder struct {
+	ingress netv1.Ingress
+}
+
+// NewIngress builds an Ingress object with the given name and class, when "" is passed as class parameter
+// the field .Spec.IngressClassName is not set.
+func NewIngress(name string, class string) *IngressBuilder {
+	var classToSet *string
+	if class != "" {
+		classToSet = &class
+	}
+	return &IngressBuilder{
+		ingress: netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: make(map[string]string),
+			},
+			Spec: netv1.IngressSpec{
+				IngressClassName: classToSet,
+			},
+		},
+	}
+}
+
+func (b *IngressBuilder) Build() *netv1.Ingress {
+	return &b.ingress
+}
+
+func (b *IngressBuilder) WithLegacyClassAnnotation(class string) *IngressBuilder {
+	b.ingress.Annotations[annotations.IngressClassKey] = class
+	return b
+}
+
+func (b *IngressBuilder) WithRules(rules ...netv1.IngressRule) *IngressBuilder {
+	b.ingress.Spec.Rules = append(b.ingress.Spec.Rules, rules...)
+	return b
+}

--- a/internal/validation/gateway/httproute.go
+++ b/internal/validation/gateway/httproute.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 )
 
-type RouteValidator interface {
+type routeValidator interface {
 	Validate(context.Context, *kong.Route) (bool, string, error)
 }
 
@@ -28,7 +28,7 @@ type RouteValidator interface {
 // validation endpoint.
 func ValidateHTTPRoute(
 	ctx context.Context,
-	routesValidator RouteValidator,
+	routesValidator routeValidator,
 	parserFeatures parser.FeatureFlags,
 	kongVersion semver.Version,
 	httproute *gatewayv1beta1.HTTPRoute,
@@ -188,7 +188,7 @@ func getListenersForHTTPRouteValidation(sectionName *gatewayv1beta1.SectionName,
 }
 
 func validateWithKongGateway(
-	ctx context.Context, routesValidator RouteValidator, parserFeatures parser.FeatureFlags, kongVersion semver.Version, httproute *gatewayv1beta1.HTTPRoute,
+	ctx context.Context, routesValidator routeValidator, parserFeatures parser.FeatureFlags, kongVersion semver.Version, httproute *gatewayv1beta1.HTTPRoute,
 ) (bool, string, error) {
 	// Translate HTTPRoute to Kong Route object(s) that can be sent directly to the Admin API for validation.
 	// Use KIC parser that works both for traditional and expressions based routes.

--- a/internal/validation/ingress/ingress.go
+++ b/internal/validation/ingress/ingress.go
@@ -1,0 +1,81 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
+	netv1 "k8s.io/api/networking/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+)
+
+type routeValidator interface {
+	Validate(context.Context, *kong.Route) (bool, string, error)
+}
+
+func ValidateIngress(
+	ctx context.Context,
+	routesValidator routeValidator,
+	parserFeatures parser.FeatureFlags,
+	kongVersion semver.Version,
+	ingress *netv1.Ingress,
+) (bool, string, error) {
+	discardLogger := logrus.New()
+	discardLogger.Out = io.Discard
+	failuresCollector, err := failures.NewResourceFailuresCollector(discardLogger)
+	if err != nil {
+		return false, "", err
+	}
+	var icp kongv1alpha1.IngressClassParametersSpec
+	if kongVersion.LT(versions.ExplicitRegexPathVersionCutoff) {
+		icp.EnableLegacyRegexDetection = true
+	}
+	result := parser.IngressesV1ToKongServices(
+		parserFeatures,
+		[]*netv1.Ingress{ingress},
+		icp,
+		&parser.ObjectsCollector{}, // It's irrelevant for validation.
+		failuresCollector,
+	)
+
+	var errMsgs []string
+	for _, f := range failuresCollector.PopResourceFailures() {
+		errMsgs = append(errMsgs, f.Message())
+	}
+	if len(errMsgs) > 0 {
+		return false, validationMsg(errMsgs), nil
+	}
+	var kongRoutes []kong.Route
+	for _, r := range result {
+		for _, route := range r.Routes {
+			kongRoutes = append(kongRoutes, route.Route)
+		}
+	}
+	// Validate by using feature of Kong Gateway.
+	for _, kg := range kongRoutes {
+		kg := kg
+		ok, msg, err := routesValidator.Validate(ctx, &kg)
+		if err != nil {
+			return false, fmt.Sprintf("unable to validate Ingress schema: %s", err.Error()), nil
+		}
+		if !ok {
+			errMsgs = append(errMsgs, msg)
+		}
+	}
+	if len(errMsgs) > 0 {
+		return false, validationMsg(errMsgs), nil
+	}
+	return true, "", nil
+}
+
+func validationMsg(errMsgs []string) string {
+	return fmt.Sprintf("Ingress failed schema validation: %s", strings.Join(errMsgs, ", "))
+}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -5,11 +5,10 @@ import (
 )
 
 var (
-	// RegexHeaderVersionCutoff is the Kong version prior to the addition of support for regular expression heade
-	// matches.
+	// RegexHeaderVersionCutoff is the Kong version prior to the addition of support for regular expression for matching headers.
 	RegexHeaderVersionCutoff = semver.Version{Major: 2, Minor: 8}
 
-	// ExplicitRegexPathVersionCutoff is the lowest Kong version adding the explicit "~" prefixes in regular expression paths.
+	// ExplicitRegexPathVersionCutoff is the lowest Kong version requiring the explicit "~" prefixes in regular expression paths.
 	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 
 	// PluginOrderingVersionCutoff is the Kong version prior to the addition of plugin ordering.

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -219,12 +219,12 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 ) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 	namespace = ns.Name
-	t.Logf("created namespace: %q", namespace)
+	const webhookName = "kong-validations-gateway"
 	ensureAdmissionRegistration(
 		ctx,
 		t,
 		namespace,
-		"kong-validations-gateway",
+		webhookName,
 		[]admregv1.RuleWithOperations{
 			{
 				Rule: admregv1.Rule{
@@ -266,7 +266,7 @@ func setUpEnvForTestingHTTPRouteValidationWebhook(ctx context.Context, t *testin
 	t.Logf("created unmanaged gateway: %q", unmanagedGateway.Name)
 
 	t.Log("waiting for webhook service to be connective")
-	ensureWebhookServiceIsConnective(ctx, t, "kong-validations-gateway")
+	ensureWebhookServiceIsConnective(ctx, t, webhookName)
 
 	return namespace, gatewayClient, managedGateway, unmanagedGateway
 }

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -22,7 +22,6 @@ const invalidRegexPath = "/foo[[[["
 type testCaseHTTPRouteValidation struct {
 	Name                   string
 	Route                  *gatewayv1beta1.HTTPRoute
-	WantCreateErr          bool
 	WantCreateErrSubstring string
 }
 
@@ -47,7 +46,6 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		{
 			Name: "a httproute linked to a non-existent gateway fails validation",
@@ -64,7 +62,6 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErr:          true,
 			WantCreateErrSubstring: `Gateway.gateway.networking.k8s.io \"fake-gateway\" not found`,
 		},
 		{
@@ -87,7 +84,6 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		{
 			Name: "a httproute with valid regex expressions for a path and a header pass validation",
@@ -113,7 +109,6 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 	}
 }
@@ -149,7 +144,6 @@ func invalidRegexInPathTestCase(
 				},
 			},
 		},
-		WantCreateErr:          true,
 		WantCreateErrSubstring: wantCreateErrSubstring,
 	}
 }
@@ -202,7 +196,6 @@ func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 					},
 				},
 			},
-			WantCreateErr:          true,
 			WantCreateErrSubstring: "regex parse error:\n    bar[[\n        ^\nerror: unclosed character class)",
 		},
 	)
@@ -278,8 +271,7 @@ func testHTTPRouteValidationWebhook(
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
 			_, err := gatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Create(ctx, tC.Route, metav1.CreateOptions{})
-			if tC.WantCreateErr {
-				require.NotEmpty(t, tC.WantCreateErrSubstring)
+			if tC.WantCreateErrSubstring != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tC.WantCreateErrSubstring)
 			} else {

--- a/test/integration/ingress_webhook_test.go
+++ b/test/integration/ingress_webhook_test.go
@@ -21,7 +21,6 @@ import (
 type testCaseIngressValidation struct {
 	Name                   string
 	Ingress                *netv1.Ingress
-	WantCreateErr          bool
 	WantCreateErrSubstring string
 }
 
@@ -50,7 +49,6 @@ func commonIngressValidationTestCases() []testCaseIngressValidation {
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		{
 			Name: "an invalid ingress passes validation when Ingress class is not set to KIC's (it's not ours)",
@@ -74,7 +72,6 @@ func commonIngressValidationTestCases() []testCaseIngressValidation {
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		{
 			Name: "valid Ingress with multiple hosts, paths (with valid regex expressions) passes validation",
@@ -121,7 +118,6 @@ func commonIngressValidationTestCases() []testCaseIngressValidation {
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		{
 			Name: "fail when path in Ingress does not start with '/' (K8s builtin Ingress validation)",
@@ -145,7 +141,6 @@ func commonIngressValidationTestCases() []testCaseIngressValidation {
 					},
 				},
 			},
-			WantCreateErr:          true,
 			WantCreateErrSubstring: "Invalid value: \"~/foo[1-9]\": must be an absolute path",
 		},
 	}
@@ -186,7 +181,6 @@ func invalidRegexInIngressPathTestCase(wantCreateErrSubstring string) testCaseIn
 				},
 			},
 		},
-		WantCreateErr:          true,
 		WantCreateErrSubstring: wantCreateErrSubstring,
 	}
 }
@@ -224,7 +218,6 @@ func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
 					},
 				},
 			},
-			WantCreateErr:          true,
 			WantCreateErrSubstring: `should start with: / (fixed path) or ~/ (regex path)`,
 		},
 	)
@@ -262,7 +255,6 @@ func TestIngressValidationWebhookExpressionsRouter(t *testing.T) {
 					},
 				},
 			},
-			WantCreateErr: false,
 		},
 		testCaseIngressValidation{
 			Name: "invalid regex path fails validation",
@@ -295,7 +287,6 @@ func TestIngressValidationWebhookExpressionsRouter(t *testing.T) {
 					},
 				},
 			},
-			WantCreateErr:          true,
 			WantCreateErrSubstring: "regex parse error:\n    ^foo[[[\n          ^\nerror: unclosed character class",
 		},
 	)
@@ -335,8 +326,7 @@ func testIngressValidationWebhook(
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
 			_, err := env.Cluster().Client().NetworkingV1().Ingresses(namespace).Create(ctx, tC.Ingress, metav1.CreateOptions{})
-			if tC.WantCreateErr {
-				require.NotEmpty(t, tC.WantCreateErrSubstring)
+			if tC.WantCreateErrSubstring != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tC.WantCreateErrSubstring)
 			} else {

--- a/test/integration/ingress_webhook_test.go
+++ b/test/integration/ingress_webhook_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
@@ -81,6 +83,7 @@ func invalidRegexInIngressPathTestCase(wantCreateErrSubstring string) testCaseIn
 func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
 	skipTestForRouterFlavors(t, expressions)
+	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff))
 
 	ctx := context.Background()
 	namespace := setUpEnvForTestingIngressValidationWebhook(ctx, t)
@@ -93,6 +96,34 @@ func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
 				constructIngressRuleWithPathsImplSpecific("", "/bar", "/~foo[1-9]"),
 			).Build(),
 			WantCreateErrSubstring: `should start with: / (fixed path) or ~/ (regex path)`,
+		},
+	)
+	testIngressValidationWebhook(ctx, t, namespace, testCases)
+}
+
+func TestIngressValidationWebhookTraditionalRouterBeforeRequiringExplicitRegexPath(t *testing.T) {
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavors(t, expressions)
+	RunWhenKongVersion(t, fmt.Sprintf("<%s", versions.ExplicitRegexPathVersionCutoff))
+
+	ctx := context.Background()
+	namespace := setUpEnvForTestingIngressValidationWebhook(ctx, t)
+	testCases := append(
+		commonIngressValidationTestCases(),
+		invalidRegexInIngressPathTestCase("should start with: /"),
+		testCaseIngressValidation{
+			Name: "path should start with / without any explicit regex prefixes",
+			Ingress: builder.NewIngress(uuid.NewString(), "").WithLegacyClassAnnotation(consts.IngressClass).WithRules(
+				constructIngressRuleWithPathsImplSpecific("", "/bar", "/~foo[1-9]"),
+			).Build(),
+			WantCreateErrSubstring: "should start with: /",
+		},
+		testCaseIngressValidation{
+			Name: "path with invalid regex should fail validation",
+			Ingress: builder.NewIngress(uuid.NewString(), "").WithLegacyClassAnnotation(consts.IngressClass).WithRules(
+				constructIngressRuleWithPathsImplSpecific("", "/foo[[["),
+			).Build(),
+			WantCreateErrSubstring: `invalid regex: '/foo[[['`,
 		},
 	)
 	testIngressValidationWebhook(ctx, t, namespace, testCases)

--- a/test/integration/ingress_webhook_test.go
+++ b/test/integration/ingress_webhook_test.go
@@ -1,0 +1,362 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	admregv1 "k8s.io/api/admissionregistration/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+)
+
+type testCaseIngressValidation struct {
+	Name                   string
+	Ingress                *netv1.Ingress
+	WantCreateErr          bool
+	WantCreateErrSubstring string
+}
+
+// commonIngressValidationTestCases returns a list of test cases for validating Ingress that are common
+// to both traditional and expressions routers (in case of an expected error the same message is returned).
+func commonIngressValidationTestCases() []testCaseIngressValidation {
+	return []testCaseIngressValidation{
+		{
+			Name: "a valid ingress passes validation",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: lo.ToPtr(consts.IngressClass),
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/foo"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		{
+			Name: "an invalid ingress passes validation when Ingress class is not set to KIC's (it's not ours)",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: lo.ToPtr("third-party-ingress-class"),
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/foo"),
+										constructIngressPathImplSpecific("/~/foo[[["),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		{
+			Name: "valid Ingress with multiple hosts, paths (with valid regex expressions) passes validation",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							Host: "foo.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/foo"),
+										constructIngressPathImplSpecific("/bar[1-9]"),
+									},
+								},
+							},
+						},
+						{
+							Host: "bar.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/baz"),
+									},
+								},
+							},
+						},
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/test"),
+										constructIngressPathImplSpecific("/~/foo[1-9]"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		{
+			Name: "fail when path in Ingress does not start with '/' (K8s builtin Ingress validation)",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: lo.ToPtr(consts.IngressClass),
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("~/foo[1-9]"),
+										constructIngressPathImplSpecific("/bar"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr:          true,
+			WantCreateErrSubstring: "Invalid value: \"~/foo[1-9]\": must be an absolute path",
+		},
+	}
+}
+
+// invalidRegexInIngressPathTestCase returns a test case for a Ingress with an invalid regex in the path,
+// in the format that is common for both traditional and expressions routers. Error message is different
+// for router flavors, thus it has passed by caller.
+func invalidRegexInIngressPathTestCase(wantCreateErrSubstring string) testCaseIngressValidation {
+	return testCaseIngressValidation{
+		Name: "valid path format with invalid regex expression fails validation",
+		Ingress: &netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: uuid.NewString(),
+			},
+			Spec: netv1.IngressSpec{
+				IngressClassName: lo.ToPtr(consts.IngressClass),
+				Rules: []netv1.IngressRule{
+					{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									constructIngressPathImplSpecific("/bar"),
+									constructIngressPathImplSpecific("/~/baz[1-9]"),
+								},
+							},
+						},
+					},
+					{
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									constructIngressPathImplSpecific(`/~/foo[[[`),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		WantCreateErr:          true,
+		WantCreateErrSubstring: wantCreateErrSubstring,
+	}
+}
+
+func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavors(t, expressions)
+
+	ctx := context.Background()
+	namespace := setUpEnvForTestingIngressValidationWebhook(ctx, t)
+	testCases := append(
+		commonIngressValidationTestCases(),
+		invalidRegexInIngressPathTestCase(`invalid regex: '/foo[[['`),
+		testCaseIngressValidation{
+			Name: "path should start with '/' or '~/' (regex path) (Kong Gateway requirement for non-expressions router)",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/bar"),
+										constructIngressPathImplSpecific("/~foo[1-9]"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr:          true,
+			WantCreateErrSubstring: `should start with: / (fixed path) or ~/ (regex path)`,
+		},
+	)
+	testIngressValidationWebhook(ctx, t, namespace, testCases)
+}
+
+func TestIngressValidationWebhookExpressionsRouter(t *testing.T) {
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavors(t, traditional, traditionalCompatible)
+
+	ctx := context.Background()
+	namespace := setUpEnvForTestingIngressValidationWebhook(ctx, t)
+	testCases := append(
+		commonIngressValidationTestCases(),
+		invalidRegexInIngressPathTestCase("regex parse error:\n    ^/foo[[[\n           ^\nerror: unclosed character class"),
+		testCaseIngressValidation{
+			Name: "valid regex path passes validation",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: lo.ToPtr(consts.IngressClass),
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/bar"),
+										constructIngressPathImplSpecific("/~baz[1-9]"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr: false,
+		},
+		testCaseIngressValidation{
+			Name: "invalid regex path fails validation",
+			Ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: uuid.NewString(),
+				},
+				Spec: netv1.IngressSpec{
+					IngressClassName: lo.ToPtr(consts.IngressClass),
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/bar"),
+										constructIngressPathImplSpecific("/~baz[1-9]"),
+									},
+								},
+							},
+						},
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										constructIngressPathImplSpecific("/~foo[[["),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WantCreateErr:          true,
+			WantCreateErrSubstring: "regex parse error:\n    ^foo[[[\n          ^\nerror: unclosed character class",
+		},
+	)
+	testIngressValidationWebhook(ctx, t, namespace, testCases)
+}
+
+// setUpEnvForTestingIngressValidationWebhook sets up the environment for testing Ingress validation webhook,
+// it sets it only for objects applied to namespace specified as argument.
+func setUpEnvForTestingIngressValidationWebhook(ctx context.Context, t *testing.T) (namespace string) {
+	ns, _ := helpers.Setup(ctx, t, env)
+	namespace = ns.Name
+	const webhookName = "kong-validations-ingress"
+	ensureAdmissionRegistration(
+		ctx,
+		t,
+		namespace,
+		webhookName,
+		[]admregv1.RuleWithOperations{
+			{
+				Rule: admregv1.Rule{
+					APIGroups:   []string{"networking.k8s.io"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"ingresses"},
+				},
+				Operations: []admregv1.OperationType{admregv1.Create, admregv1.Update},
+			},
+		},
+	)
+	ensureWebhookServiceIsConnective(ctx, t, webhookName)
+	return namespace
+}
+
+// testIngressValidationWebhook tries to create the given Ingress (passed in testCaseIngressValidation) and asserts expected results.
+func testIngressValidationWebhook(
+	ctx context.Context, t *testing.T, namespace string, testCases []testCaseIngressValidation,
+) {
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			_, err := env.Cluster().Client().NetworkingV1().Ingresses(namespace).Create(ctx, tC.Ingress, metav1.CreateOptions{})
+			if tC.WantCreateErr {
+				require.NotEmpty(t, tC.WantCreateErrSubstring)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tC.WantCreateErrSubstring)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func constructIngressPathImplSpecific(path string) netv1.HTTPIngressPath {
+	return netv1.HTTPIngressPath{
+		Path:     path,
+		PathType: lo.ToPtr(netv1.PathTypeImplementationSpecific),
+		Backend: netv1.IngressBackend{
+			Service: &netv1.IngressServiceBackend{
+				Name: "foo",
+				Port: netv1.ServiceBackendPort{
+					Number: 80,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Introduce custom validation for `Ingress` object:

- uses the Kong Gateway endpoint for validating KongRoute by calling method [RouteService.Validate](https://pkg.go.dev/github.com/kong/go-kong/kong#RouteService.Validate)
- the above allows validating regex expressions configured by users in `Ingress` paths
- introduces test coverage for both expressions router and old ones

**Which issue this PR fixes:**

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4557

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->



<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Run also test suit manually for Kong Gateway `< 3.0` - `kong-gateway:2.8.4.2` on this branch to ensure that integration tests that rely on messages returned from the Gateway are compatible
- [results](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6161899368) - section `run-integration-tests` is relevant (it takes KIC code from the branch, not run it from prebuild container image `latest`)

Since integration tests are run in a matrix for expressions router and old ones it can be covered with tests that are exclusively run when the particular router is used.

Using two class matches `ingressClassMatcher` and `ingressV1ClassMatcher` replicates the approach used in other parts of the codebase. Refactoring this everywhere in separate PR in my opinion is worth consideration.

Also moving the whole `internal/validation` to `internal/admission/validation` is something to consider too.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
