### PR TITLE
chore(tests): get rid of "log.SetLogger(...) was never called..." log

### DIFF
--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/sirupsen/logrus"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
@@ -130,5 +131,8 @@ func SetupLoggers(logLevel string, logFormat string, logReduceRedundancy bool) (
 	}
 
 	deprecated, logger, err := manager.SetupLoggers(&config, output)
+	// Prevents controller-runtime from logging
+	// [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
+	ctrllog.SetLogger(logger)
 	return deprecated, logger, "", err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

For integration tests the below is logged (it's not a problem for running KIC normally)

```log
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 623 [running]:
	>  runtime/debug.Stack()
	>  	/opt/hostedtoolcache/go/1.21.0/x64/src/runtime/debug/stack.go:24 +0x67
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.1/pkg/log/log.go:60 +0xed
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithValues(0xc00074be00, {0x0, 0x0, 0x0})
	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.1/pkg/log/deleg.go:168 +0x55
	>  github.com/go-logr/logr.Logger.WithValues(...)
	>  	/home/runner/go/pkg/mod/github.com/go-logr/logr@v1.2.4/logr.go:323
	>  sigs.k8s.io/controller-runtime/pkg/log.FromContext({0x5113388, 0xc000ac0640}, {0x0, 0x0, 0x0})
	>  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.1/pkg/log/log.go:98 +0x138
	>  github.com/kong/kubernetes-ingress-controller/v2/internal/manager.Run({0x5113388?, 0xc000ac0640}, 0xc0013f2d80, {0x0?, 0xc000fa75c0?}, {0x5130d60?, 0xc000b1a000})
	>  	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/manager/run.go:51 +0x10c
	>  github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd.RunWithLogger({0x5113388, 0xc00010a3c0}, 0x4a54d02?, {0x5130d60, 0xc000b1a000}, {{0x5118b88?, 0xc0007e5080?}, 0xc0013500c0?})
	>  	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/cmd/rootcmd/run.go:42 +0x44c
	>  github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster.func1()
	>  	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:102 +0x231
	>  created by github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster in goroutine 1
	>  	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/internal/util/test/controller_manager.go:99 +0xced
```
e.g. [here](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6161892756/job/16725352156#step:6:536). This PR fixes it. Check logs from CI.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

