### PR TITLE
fix: add type meta when saving them to cache and reference indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,8 @@ Adding a new version? You'll need three changes:
 - Set type meta of objects when adding them to caches and reference indexers
   to ensure that indexes of objects in reference indexers have correct object
   kind. This ensures referece relations of objects are stored and indexed 
-  correctly. 
+  correctly.
+  [#4663](https://github.com/Kong/kubernetes-ingress-controller/pull/4663) 
 - Display Service ports on generated Kong services, instead of a static default
   value. This change is cosmetic only.
   [#4503](https://github.com/Kong/kubernetes-ingress-controller/pull/4503)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,13 +98,17 @@ Adding a new version? You'll need three changes:
 
 ### Changes
 
-- Generate a wildcard routes to match all `HTTP` or `GRPC` requests for rules
+- Generate wildcard routes to match all `HTTP` or `GRPC` requests for rules
   in `HTTPRoute` or `GRPCRoute` if there are no matches in the rule and no
   hostnames in their parent objects.
   [#4526](https://github.com/Kong/kubernetes-ingress-controller/pull/4528)
 
 ### Fixed
 
+- Set type meta of objects when adding them to caches and reference indexers
+  to ensure that indexes of objects in reference indexers have correct object
+  kind. This ensures referece relations of objects are stored and indexed 
+  correctly. 
 - Display Service ports on generated Kong services, instead of a static default
   value. This change is cosmetic only.
   [#4503](https://github.com/Kong/kubernetes-ingress-controller/pull/4503)

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -397,6 +397,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -549,6 +550,12 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) Reconcile(ctx context.Context, re
 
 	// get the relevant object
 	obj := new({{.PackageImportAlias}}.{{.Kind}})
+	// set type meta to the object
+	obj.TypeMeta = metav1.TypeMeta{
+		APIVersion: {{.PackageImportAlias}}.SchemeGroupVersion.String(),
+		Kind: "{{.Kind}}",
+	}
+
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -47,8 +47,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/kubernetes/object/status"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
 // -----------------------------------------------------------------------------
@@ -59,10 +59,10 @@ import (
 type CoreV1ServiceReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
-	CacheSyncTimeout time.Duration
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	DataplaneClient   controllers.DataPlane
+	CacheSyncTimeout  time.Duration
 	ReferenceIndexers ctrlref.CacheIndexers
 }
 
@@ -103,19 +103,19 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: corev1.SchemeGroupVersion.String(),
-		Kind: "Service",
+		Kind:       "Service",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the Service is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -125,12 +125,12 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the Service is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -170,9 +170,9 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 type DiscoveryV1EndpointSliceReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -212,14 +212,14 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: discoveryv1.SchemeGroupVersion.String(),
-		Kind: "EndpointSlice",
+		Kind:       "EndpointSlice",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -229,7 +229,7 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "EndpointSlice", "namespace", req.Namespace, "name", req.Name)
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -259,17 +259,17 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 type NetV1IngressReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
 	StatusQueue            *status.Queue
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
-	ReferenceIndexers ctrlref.CacheIndexers
+	ReferenceIndexers          ctrlref.CacheIndexers
 }
 
 var _ controllers.Reconciler = &NetV1IngressReconciler{}
@@ -316,6 +316,7 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *NetV1IngressReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &netv1.IngressList{}
@@ -354,19 +355,19 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: netv1.SchemeGroupVersion.String(),
-		Kind: "Ingress",
+		Kind:       "Ingress",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the Ingress is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -376,12 +377,12 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Ingress", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the Ingress is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -408,11 +409,11 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -433,7 +434,7 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		log.V(util.DebugLevel).Info("determining whether data-plane configuration has succeeded", "namespace", req.Namespace, "name", req.Name)
 
-		if  !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
+		if !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
 			log.V(util.DebugLevel).Info("resource not yet configured in the data-plane", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{Requeue: true}, nil // requeue until the object has been properly configured
 		}
@@ -466,9 +467,9 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 type NetV1IngressClassReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -508,14 +509,14 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: netv1.SchemeGroupVersion.String(),
-		Kind: "IngressClass",
+		Kind:       "IngressClass",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -525,7 +526,7 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "IngressClass", "namespace", req.Namespace, "name", req.Name)
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -555,9 +556,9 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 type KongV1KongIngressReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -598,14 +599,14 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind: "KongIngress",
+		Kind:       "KongIngress",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -615,7 +616,7 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongIngress", "namespace", req.Namespace, "name", req.Name)
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -645,10 +646,10 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 type KongV1KongPluginReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
-	CacheSyncTimeout time.Duration
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	DataplaneClient   controllers.DataPlane
+	CacheSyncTimeout  time.Duration
 	ReferenceIndexers ctrlref.CacheIndexers
 }
 
@@ -689,19 +690,19 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind: "KongPlugin",
+		Kind:       "KongPlugin",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the KongPlugin is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -711,12 +712,12 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongPlugin", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the KongPlugin is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -756,14 +757,14 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 type KongV1KongClusterPluginReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
-	ReferenceIndexers ctrlref.CacheIndexers
+	ReferenceIndexers          ctrlref.CacheIndexers
 }
 
 var _ controllers.Reconciler = &KongV1KongClusterPluginReconciler{}
@@ -797,6 +798,7 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1KongClusterPluginReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &kongv1.KongClusterPluginList{}
@@ -835,19 +837,19 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind: "KongClusterPlugin",
+		Kind:       "KongClusterPlugin",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the KongClusterPlugin is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -857,12 +859,12 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongClusterPlugin", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the KongClusterPlugin is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -889,11 +891,11 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -922,15 +924,15 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 type KongV1KongConsumerReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
-	StatusQueue            *status.Queue
+	StatusQueue      *status.Queue
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
-	ReferenceIndexers ctrlref.CacheIndexers
+	ReferenceIndexers          ctrlref.CacheIndexers
 }
 
 var _ controllers.Reconciler = &KongV1KongConsumerReconciler{}
@@ -977,6 +979,7 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1KongConsumerReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &kongv1.KongConsumerList{}
@@ -1015,19 +1018,19 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind: "KongConsumer",
+		Kind:       "KongConsumer",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the KongConsumer is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -1037,12 +1040,12 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongConsumer", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the KongConsumer is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -1069,11 +1072,11 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -1113,15 +1116,15 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 type KongV1Beta1KongConsumerGroupReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
-	StatusQueue            *status.Queue
+	StatusQueue      *status.Queue
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
-	ReferenceIndexers ctrlref.CacheIndexers
+	ReferenceIndexers          ctrlref.CacheIndexers
 }
 
 var _ controllers.Reconciler = &KongV1Beta1KongConsumerGroupReconciler{}
@@ -1168,6 +1171,7 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) SetupWithManager(mgr ctrl.Manag
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1Beta1KongConsumerGroupReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &kongv1beta1.KongConsumerGroupList{}
@@ -1206,19 +1210,19 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind: "KongConsumerGroup",
+		Kind:       "KongConsumerGroup",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the KongConsumerGroup is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -1228,12 +1232,12 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "KongConsumerGroup", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the KongConsumerGroup is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -1260,11 +1264,11 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -1304,17 +1308,17 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 type KongV1Beta1TCPIngressReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
 	StatusQueue            *status.Queue
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
-	ReferenceIndexers ctrlref.CacheIndexers
+	ReferenceIndexers          ctrlref.CacheIndexers
 }
 
 var _ controllers.Reconciler = &KongV1Beta1TCPIngressReconciler{}
@@ -1361,6 +1365,7 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1Beta1TCPIngressReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &kongv1beta1.TCPIngressList{}
@@ -1399,19 +1404,19 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind: "TCPIngress",
+		Kind:       "TCPIngress",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			// remove reference record where the TCPIngress is the referrer
 			if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 				return ctrl.Result{}, err
 			}
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -1421,12 +1426,12 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "TCPIngress", "namespace", req.Namespace, "name", req.Name)
-		
+
 		// remove reference record where the TCPIngress is the referrer
 		if err := ctrlref.DeleteReferencesByReferrer(r.ReferenceIndexers, r.DataplaneClient, obj); err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -1453,11 +1458,11 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -1478,7 +1483,7 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		log.V(util.DebugLevel).Info("determining whether data-plane configuration has succeeded", "namespace", req.Namespace, "name", req.Name)
 
-		if  !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
+		if !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
 			log.V(util.DebugLevel).Info("resource not yet configured in the data-plane", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{Requeue: true}, nil // requeue until the object has been properly configured
 		}
@@ -1511,15 +1516,15 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 type KongV1Beta1UDPIngressReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 
 	DataplaneAddressFinder *dataplane.AddressFinder
 	StatusQueue            *status.Queue
 
-	IngressClassName string
+	IngressClassName           string
 	DisableIngressClassLookups bool
 }
 
@@ -1567,6 +1572,7 @@ func (r *KongV1Beta1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 		preds,
 	)
 }
+
 // listClassless finds and reconciles all objects without ingress class information
 func (r *KongV1Beta1UDPIngressReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
 	resourceList := &kongv1beta1.UDPIngressList{}
@@ -1605,14 +1611,14 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind: "UDPIngress",
+		Kind:       "UDPIngress",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -1622,7 +1628,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -1649,11 +1655,11 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
 	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
 		log.V(util.DebugLevel).Info("object missing ingress class, ensuring it's removed from configuration",
-		"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
 		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 	} else {
 		log.V(util.DebugLevel).Info("object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
-		"class", r.IngressClassName)
+			"class", r.IngressClassName)
 	}
 
 	// update the kong Admin API with the changes
@@ -1664,7 +1670,7 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		log.V(util.DebugLevel).Info("determining whether data-plane configuration has succeeded", "namespace", req.Namespace, "name", req.Name)
 
-		if  !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
+		if !r.DataplaneClient.KubernetesObjectIsConfigured(obj) {
 			log.V(util.DebugLevel).Info("resource not yet configured in the data-plane", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{Requeue: true}, nil // requeue until the object has been properly configured
 		}
@@ -1697,9 +1703,9 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 type KongV1Alpha1IngressClassParametersReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
 	CacheSyncTimeout time.Duration
 }
 
@@ -1739,14 +1745,14 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 	// set type meta to the object
 	obj.TypeMeta = metav1.TypeMeta{
 		APIVersion: kongv1alpha1.SchemeGroupVersion.String(),
-		Kind: "IngressClassParameters",
+		Kind:       "IngressClassParameters",
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace
 			obj.Name = req.Name
-			
+
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
 		}
 		return ctrl.Result{}, err
@@ -1756,7 +1762,7 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "IngressClassParameters", "namespace", req.Namespace, "name", req.Name)
-		
+
 		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -41,6 +41,10 @@ import (
 var (
 	ErrUnmanagedAnnotation = errors.New("invalid unmanaged annotation value")
 	gatewayV1beta1Group    = gatewayv1beta1.Group(gatewayv1beta1.GroupName)
+	gatewayTypeMeta        = metav1.TypeMeta{
+		APIVersion: gatewayv1beta1.GroupVersion.String(),
+		Kind:       "Gateway",
+	}
 )
 
 // -----------------------------------------------------------------------------
@@ -339,6 +343,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// gather the gateway object based on the reconciliation trigger. It's possible for the object
 	// to be gone at this point in which case it will be ignored.
 	gateway := new(gatewayv1beta1.Gateway)
+	gateway.TypeMeta = gatewayTypeMeta
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if apierrors.IsNotFound(err) {
 			gateway.Namespace = req.Namespace

--- a/internal/controllers/knative/knative.go
+++ b/internal/controllers/knative/knative.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -50,6 +51,11 @@ type Knativev1alpha1IngressReconciler struct {
 	CacheSyncTimeout           time.Duration
 
 	ReferenceIndexers ctrlref.CacheIndexers
+}
+
+var knativeIngressTypeMeta = metav1.TypeMeta{
+	APIVersion: knativev1alpha1.SchemeGroupVersion.String(),
+	Kind:       "Ingress",
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -125,6 +131,7 @@ func (r *Knativev1alpha1IngressReconciler) Reconcile(ctx context.Context, req ct
 
 	// get the relevant object
 	obj := new(knativev1alpha1.Ingress)
+	obj.TypeMeta = knativeIngressTypeMeta
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.Namespace = req.Namespace

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -3,6 +3,7 @@ package reference
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,11 +37,13 @@ func objectKeyFunc(obj client.Object) string {
 // provided by cache.Indexer. It could do CRUD on reference records when referrer and referent are
 // both provided. It can also list reference records by referrer or by referent.
 type CacheIndexers struct {
+	logger  logr.Logger
 	indexer cache.Indexer
 }
 
-func NewCacheIndexers() CacheIndexers {
+func NewCacheIndexers(logger logr.Logger) CacheIndexers {
 	return CacheIndexers{
+		logger: logger,
 		indexer: cache.NewIndexer(ObjectReferenceKeyFunc,
 			cache.Indexers{
 				IndexNameReferrer: ObjectReferenceIndexerReferrer,
@@ -88,6 +91,14 @@ func ObjectReferenceIndexerReferent(obj interface{}) ([]string, error) {
 
 // SetObjectReference adds or updates a reference record between referrer and referent in reference cache.
 func (c CacheIndexers) SetObjectReference(referrer client.Object, referent client.Object) error {
+	c.logger.Info("set reference",
+		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
+		"referrer_namespace", referrer.GetNamespace(),
+		"referrer_name", referrer.GetName(),
+		"referent_kind", referent.GetObjectKind().GroupVersionKind().String(),
+		"referent_namespace", referent.GetNamespace(),
+		"referent_name", referent.GetName(),
+	)
 	ref := &ObjectReference{
 		Referrer: referrer,
 		Referent: referent,
@@ -97,6 +108,14 @@ func (c CacheIndexers) SetObjectReference(referrer client.Object, referent clien
 
 // DeleteObjectReference deletes the reference record between referrer and referent from reference cache.
 func (c CacheIndexers) DeleteObjectReference(referrer client.Object, referent client.Object) error {
+	c.logger.Info("delete reference",
+		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
+		"referrer_namespace", referrer.GetNamespace(),
+		"referrer_name", referrer.GetName(),
+		"referent_kind", referent.GetObjectKind().GroupVersionKind().String(),
+		"referent_namespace", referent.GetNamespace(),
+		"referent_name", referent.GetName(),
+	)
 	ref := &ObjectReference{
 		Referrer: referrer,
 		Referent: referent,
@@ -161,6 +180,11 @@ func (c CacheIndexers) DeleteObjectIfNotReferred(obj client.Object, dataplaneCli
 		return err
 	}
 	if !referred {
+		c.logger.Info("Delete object because it is no longer referred",
+			"kind", obj.GetObjectKind(),
+			"namespace", obj.GetNamespace(),
+			"name", obj.GetName(),
+		)
 		return dataplaneClient.DeleteObject(obj)
 	}
 	return nil

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 const (
@@ -91,7 +92,7 @@ func ObjectReferenceIndexerReferent(obj interface{}) ([]string, error) {
 
 // SetObjectReference adds or updates a reference record between referrer and referent in reference cache.
 func (c CacheIndexers) SetObjectReference(referrer client.Object, referent client.Object) error {
-	c.logger.Info("set reference",
+	c.logger.V(util.DebugLevel).Info("Set reference relation",
 		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
 		"referrer_namespace", referrer.GetNamespace(),
 		"referrer_name", referrer.GetName(),
@@ -108,7 +109,7 @@ func (c CacheIndexers) SetObjectReference(referrer client.Object, referent clien
 
 // DeleteObjectReference deletes the reference record between referrer and referent from reference cache.
 func (c CacheIndexers) DeleteObjectReference(referrer client.Object, referent client.Object) error {
-	c.logger.Info("delete reference",
+	c.logger.V(util.DebugLevel).Info("Delete reference relation",
 		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
 		"referrer_namespace", referrer.GetNamespace(),
 		"referrer_name", referrer.GetName(),
@@ -180,7 +181,7 @@ func (c CacheIndexers) DeleteObjectIfNotReferred(obj client.Object, dataplaneCli
 		return err
 	}
 	if !referred {
-		c.logger.Info("Delete object because it is no longer referred",
+		c.logger.V(util.DebugLevel).Info("Delete object from cache because it is no longer referred",
 			"kind", obj.GetObjectKind(),
 			"namespace", obj.GetNamespace(),
 			"name", obj.GetName(),

--- a/internal/controllers/reference/indexer_test.go
+++ b/internal/controllers/reference/indexer_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +85,7 @@ func TestSetObjectReference(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCacheIndexers()
+			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
 			require.NoError(t, err, "should not return error on setting reference")
 			item, exists, err := c.indexer.Get(&ObjectReference{Referrer: tc.checkReferrer, Referent: tc.checkReferent})
@@ -129,7 +130,7 @@ func TestDeleteObjectReference(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCacheIndexers()
+			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(testRefService1, testRefSecret1)
 			require.NoError(t, err, "should not return error on setting reference")
 			err = c.SetObjectReference(testRefService1, testRefSecret2)
@@ -171,7 +172,7 @@ func TestObjectReferred(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCacheIndexers()
+			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
 			require.NoError(t, err, "should not return error on setting reference")
 
@@ -209,7 +210,7 @@ func TestListReferredObjects(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCacheIndexers()
+			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
 			require.NoError(t, err, "should not return error on setting reference")
 
@@ -247,7 +248,7 @@ func TestDeleteReferencesByReferrer(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCacheIndexers()
+			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(testRefService1, testRefSecret1)
 			require.NoError(t, err, "should not return error on setting reference")
 			err = c.SetObjectReference(testRefService2, testRefSecret2)

--- a/internal/controllers/reference/reference.go
+++ b/internal/controllers/reference/reference.go
@@ -27,6 +27,10 @@ func UpdateReferencesToSecret(
 ) error {
 	for nsName := range referencedSecretNameMap {
 		secret := &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: VersionV1,
+				Kind:       KindSecret,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: nsName.Namespace,
 				Name:      nsName.Name,
@@ -117,9 +121,20 @@ func removeOutdatedReferencesToSecret(
 func DeleteReferencesByReferrer(indexers CacheIndexers, dataplaneClient controllers.DataPlaneClient, referrer client.Object) error {
 	referents, err := indexers.ListReferredObjects(referrer)
 	if err != nil {
+		indexers.logger.Error(err, "failed to list referred objects",
+			"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
+			"referrer_namespace", referrer.GetNamespace(),
+			"referrer_name", referrer.GetName(),
+		)
 		return err
 	}
 
+	indexers.logger.Info("found referents of object",
+		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
+		"referrer_namespace", referrer.GetNamespace(),
+		"referrer_name", referrer.GetName(),
+		"referent_count", len(referents),
+	)
 	// delete(gc) the reference record between referrer and referent.
 	for _, referent := range referents {
 		err := indexers.DeleteObjectReference(referrer, referent)

--- a/internal/controllers/reference/reference.go
+++ b/internal/controllers/reference/reference.go
@@ -129,12 +129,6 @@ func DeleteReferencesByReferrer(indexers CacheIndexers, dataplaneClient controll
 		return err
 	}
 
-	indexers.logger.Info("found referents of object",
-		"referrer_kind", referrer.GetObjectKind().GroupVersionKind().String(),
-		"referrer_namespace", referrer.GetNamespace(),
-		"referrer_name", referrer.GetName(),
-		"referent_count", len(referents),
-	)
 	// delete(gc) the reference record between referrer and referent.
 	for _, referent := range referents {
 		err := indexers.DeleteObjectReference(referrer, referent)

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -67,7 +67,7 @@ func setupControllers(
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
 ) []ControllerDef {
-	referenceIndexers := ctrlref.NewCacheIndexers()
+	referenceIndexers := ctrlref.NewCacheIndexers(ctrl.LoggerFrom(ctx).WithName("controllers").WithName("reference-indexers"))
 
 	controllers := []ControllerDef{
 		// ---------------------------------------------------------------------------

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1063,56 +1063,101 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	// Kubernetes Core APIs
 	// ----------------------------------------------------------------------------
 	case netv1.SchemeGroupVersion.WithKind("Ingress"):
-		return &netv1.Ingress{}, nil
+		return &netv1.Ingress{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case corev1.SchemeGroupVersion.WithKind("Service"):
-		return &corev1.Service{}, nil
+		return &corev1.Service{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case corev1.SchemeGroupVersion.WithKind("Secret"):
-		return &corev1.Secret{}, nil
+		return &corev1.Secret{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	// ----------------------------------------------------------------------------
 	// Kubernetes Discovery APIs
 	// ----------------------------------------------------------------------------
 	case discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice"):
-		return &discoveryv1.EndpointSlice{}, nil
+		return &discoveryv1.EndpointSlice{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	// ----------------------------------------------------------------------------
 	// Kubernetes Gateway APIs
 	// ----------------------------------------------------------------------------
 	case gatewayv1beta1.SchemeGroupVersion.WithKind("HTTPRoute"):
-		return &gatewayv1beta1.HTTPRoute{}, nil
+		return &gatewayv1beta1.HTTPRoute{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("GRPCRoute"):
-		return &gatewayv1alpha2.GRPCRoute{}, nil
+		return &gatewayv1alpha2.GRPCRoute{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"):
-		return &gatewayv1alpha2.TCPRoute{}, nil
+		return &gatewayv1alpha2.TCPRoute{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"):
-		return &gatewayv1alpha2.UDPRoute{}, nil
+		return &gatewayv1alpha2.UDPRoute{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"):
-		return &gatewayv1alpha2.TLSRoute{}, nil
+		return &gatewayv1alpha2.TLSRoute{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case gatewayv1beta1.SchemeGroupVersion.WithKind("ReferenceGrant"):
-		return &gatewayv1beta1.ReferenceGrant{}, nil
+		return &gatewayv1beta1.ReferenceGrant{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	// ----------------------------------------------------------------------------
 	// Kong APIs
 	// ----------------------------------------------------------------------------
 	case kongv1.SchemeGroupVersion.WithKind("KongIngress"):
-		return &kongv1.KongIngress{}, nil
+		return &kongv1.KongIngress{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("UDPIngress"):
-		return &kongv1beta1.UDPIngress{}, nil
+		return &kongv1beta1.UDPIngress{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("TCPIngress"):
-		return &kongv1beta1.TCPIngress{}, nil
+		return &kongv1beta1.TCPIngress{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongPlugin"):
-		return &kongv1.KongPlugin{}, nil
+		return &kongv1.KongPlugin{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongClusterPlugin"):
-		return &kongv1.KongClusterPlugin{}, nil
+		return &kongv1.KongClusterPlugin{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongConsumer"):
-		return &kongv1.KongConsumer{}, nil
+		return &kongv1.KongConsumer{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"):
-		return &kongv1beta1.KongConsumerGroup{}, nil
+		return &kongv1beta1.KongConsumerGroup{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	case kongv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"):
-		return &kongv1alpha1.IngressClassParameters{}, nil
+		return &kongv1alpha1.IngressClassParameters{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	// ----------------------------------------------------------------------------
 	// Knative APIs
 	// ----------------------------------------------------------------------------
 	case knative.SchemeGroupVersion.WithKind("Ingress"):
-		return &knative.Ingress{}, nil
+		return &knative.Ingress{
+			TypeMeta: typeMetaFromGVK(gvk),
+		}, nil
 	default:
 		return nil, fmt.Errorf("%s is not a supported runtime.Object", gvk)
+	}
+}
+
+func typeMetaFromGVK(gvk schema.GroupVersionKind) metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
 	}
 }

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -320,7 +321,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 					Name:      svc.Name,
 				},
 				DataplaneClient:   mocks.Dataplane{},
-				ReferenceIndexers: ctrlref.NewCacheIndexers(),
+				ReferenceIndexers: ctrlref.NewCacheIndexers(logr.Discard()),
 			}
 			StartReconcilers(ctx, t, client.Scheme(), cfg, gwReconciler)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
The PR sets type meta for objects when adding them to cache stores and reference indexers, and fetching objects referred by when the object gets deleted. This PR is added because cache indexers to store reference relations needs object kind(GVK) for indexing, and this comes from `TypeMeta` of the k8s resource. 
If we do not set the `TypeMeta`, the object kind of objects are always empty so we could not find them correctly in reference indexers. 
It also adds logs when setting or deleting reference relations between objects.
**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3201 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
