### PR TITLE
fix(log): do not parse error body when response is empty in reloading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
+- Do not parse error body when failed to get response from reloading declartive
+  configurations to produce proper error log in such situations,
+  [#4666](https://github.com/Kong/kubernetes-ingress-controller/pull/4666) 
 - Set type meta of objects when adding them to caches and reference indexers
   to ensure that indexes of objects in reference indexers have correct object
   kind. This ensures referece relations of objects are stored and indexed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- Do not parse error body when failed to get response from reloading declartive
+- Do not parse error body when failed to get response from reloading declarative
   configurations to produce proper error log in such situations,
   [#4666](https://github.com/Kong/kubernetes-ingress-controller/pull/4666) 
 - Set type meta of objects when adding them to caches and reference indexers

--- a/internal/dataplane/sendconfig/error_handling_test.go
+++ b/internal/dataplane/sendconfig/error_handling_test.go
@@ -147,6 +147,12 @@ func TestParseFlatEntityErrors(t *testing.T) {
   "code": 14
 }`),
 		},
+		{
+			name:    "empty response body",
+			body:    nil,
+			want:    nil,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -66,6 +66,11 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 
 	flattenErrors := shouldUseFlattenedErrors(s.version)
 	if errBody, err := s.configService.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(config), true, flattenErrors); err != nil {
+		if len(errBody) == 0 {
+			// if we failed to get response in reloading config, we put the error from reloading in the parseErr return value
+			// to generate a proper error log.
+			return err, nil, err
+		}
 		resourceErrors, parseErr := parseFlatEntityErrors(errBody, s.log)
 		return err, resourceErrors, parseErr
 	}

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -66,11 +66,6 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 
 	flattenErrors := shouldUseFlattenedErrors(s.version)
 	if errBody, err := s.configService.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(config), true, flattenErrors); err != nil {
-		if len(errBody) == 0 {
-			// if we failed to get response in reloading config, we put the error from reloading in the parseErr return value
-			// to generate a proper error log.
-			return err, nil, err
-		}
 		resourceErrors, parseErr := parseFlatEntityErrors(errBody, s.log)
 		return err, resourceErrors, parseErr
 	}

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -52,8 +52,14 @@ type FlatFieldError struct {
 // parseFlatEntityErrors takes a Kong /config error response body and parses its "fields.flattened_errors" value
 // into errors associated with Kubernetes resources.
 func parseFlatEntityErrors(body []byte, log logrus.FieldLogger) ([]ResourceError, error) {
+	// Directly return here to avoid the misleading "could not unmarshal config" message appear in logs.
+	if len(body) == 0 {
+		return nil, nil
+	}
+
 	var resourceErrors []ResourceError
 	var configError ConfigError
+
 	err := json.Unmarshal(body, &configError)
 	if err != nil {
 		return resourceErrors, fmt.Errorf("could not unmarshal config error: %w", err)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When Kong client fails to get response from reloading declarative configuration (`POST /config`), do not parse the error body and directly return the error for not getting response, to produce less misleading error log (than `could not unmarshal config error: unexpected end of JSON input`) for the situations.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #4665

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
