### PR TITLE
docs: add sections to tell usage of Draft PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,6 @@ If your pull request is still in progress, but you want to get early reviews bef
 it is ready to be merged, please add `do not merge` or `work in progress` labels to the
 pull request. If your pull request is not ready to be reviewed yet, please convert it to `Draft`.
 `Draft` pull requests will not be reviewed until they are converted to `Open` status.
-
-
-
 ## Stale issue and pull request policy
 
 To ensure our backlog is organized and up to date, we will close issues and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,19 @@ If you wish to contribute code (features or bug fixes) please keep in mind the f
 - bug fix pull requests should be opened against `main` as the base branch
 - feature pull requests should be opened with `next` as the base branch
 
+## Working with Pull Requests 
+
+When you finish your work and want your contributions to be included, please submit a pull request
+and include necessary information about the pull request in its description following our
+[pull request template](https://github.com/Kong/kubernetes-ingress-controller/blob/a5cfca4a97927c2878fce593929a8e48442f3127/.github/PULL_REQUEST_TEMPLATE.md). 
+A clear title and description is helpful to encourage your pull request to be reviewed and merged.
+
 If your pull request is still in progress, but you want to get early reviews before
 it is ready to be merged, please add `do not merge` or `work in progress` labels to the
 pull request. If your pull request is not ready to be reviewed yet, please convert it to `Draft`.
 `Draft` pull requests will not be reviewed until they are converted to `Open` status.
+
+
 
 ## Stale issue and pull request policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ If you wish to contribute code (features or bug fixes) please keep in mind the f
 - bug fix pull requests should be opened against `main` as the base branch
 - feature pull requests should be opened with `next` as the base branch
 
+If your pull request is still in progress, but you want get some early reviews before
+it is ready to be merged, please add `do not merge` or `work in progress` labels to the
+pull request. If your pull request is not ready to be reviewed yet, please convert it to `Draft`.
+`Draft` pull requests will not be reviewed until they are converted to `Open` status.
+
 ## Stale issue and pull request policy
 
 To ensure our backlog is organized and up to date, we will close issues and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you wish to contribute code (features or bug fixes) please keep in mind the f
 - bug fix pull requests should be opened against `main` as the base branch
 - feature pull requests should be opened with `next` as the base branch
 
-If your pull request is still in progress, but you want get some early reviews before
+If your pull request is still in progress, but you want to get early reviews before
 it is ready to be merged, please add `do not merge` or `work in progress` labels to the
 pull request. If your pull request is not ready to be reviewed yet, please convert it to `Draft`.
 `Draft` pull requests will not be reviewed until they are converted to `Open` status.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ If your pull request is still in progress, but you want to get early reviews bef
 it is ready to be merged, please add `do not merge` or `work in progress` labels to the
 pull request. If your pull request is not ready to be reviewed yet, please convert it to `Draft`.
 `Draft` pull requests will not be reviewed until they are converted to `Open` status.
+
 ## Stale issue and pull request policy
 
 To ensure our backlog is organized and up to date, we will close issues and


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Add a section in `CONTRIBUTING.md` to tell usage of `Draft` PRs and `do not merge` or `work in progress` labels on PRs:
- Draft PR: not ready for review
- `do not merge` label: ready for review, but not ready to merge

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
