### PR TITLE
ci: add ref to generate name for conformance report workflow

### DIFF
--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -1,16 +1,16 @@
 name: Generate Kubernetes Gateway API conformance tests report
+run-name: "Generate Kubernetes Gateway API conformance tests report ${{ format('ref:{0}', github.event.inputs.tag) }}"
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: The version of code (e.g. v1.2.3 or commit hash)
+        description: The version of code to checkout (e.g. v1.2.3 or commit hash)
         required: false
         default: main
 
 jobs:
   generate-report:
-    name:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a ref to generate name for the conformance report generation workflow so that it's easy to see which ref the report was generated for.