### PR TITLE
feat: add `latency` to supported values of KongIngress upstream.algoritm field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ Adding a new version? You'll need three changes:
   [#4385](https://github.com/Kong/kubernetes-ingress-controller/pull/4385)
   [#4550](https://github.com/Kong/kubernetes-ingress-controller/pull/4550)
   [#4612](https://github.com/Kong/kubernetes-ingress-controller/pull/4612)
+- `KongIngress` CRD now supports `latency` algorithm in its `upstream.algorithm`
+  field. This can be used with Kong Gateway 3.2+.
+  [#4703](https://github.com/Kong/kubernetes-ingress-controller/pull/4703)
 
 ### Changes
 

--- a/config/crd/bases/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongingresses.yaml
@@ -182,6 +182,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-enterprise.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
+++ b/deploy/single/all-in-one-dbless-konnect-enterprise.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless-legacy.yaml
+++ b/deploy/single/all-in-one-dbless-legacy.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-postgres-enterprise.yaml
+++ b/deploy/single/all-in-one-postgres-enterprise.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/deploy/single/all-in-one-postgres.yaml
+++ b/deploy/single/all-in-one-postgres.yaml
@@ -784,6 +784,7 @@ spec:
                 - round-robin
                 - consistent-hashing
                 - least-connections
+                - latency
                 type: string
               hash_fallback:
                 description: 'HashFallback defines What to use as hashing input if

--- a/pkg/apis/configuration/v1/kongingress_types.go
+++ b/pkg/apis/configuration/v1/kongingress_types.go
@@ -162,7 +162,7 @@ type KongIngressUpstream struct {
 	HostHeader *string `json:"host_header,omitempty" yaml:"host_header,omitempty"`
 
 	// Algorithm is the load balancing algorithm to use.
-	// +kubebuilder:validation:Enum=round-robin;consistent-hashing;least-connections
+	// +kubebuilder:validation:Enum=round-robin;consistent-hashing;least-connections;latency
 	Algorithm *string `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
 
 	// Slots is the number of slots in the load balancer algorithm.


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds `latency` as a supported value for `KongIngress` `upstream.algorithm` field.

This is only support in Kong Gateway 3.2+

With this change users will be able to use it as such:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    konghq.com/override: algo
  name: svc
spec:
...
---
apiVersion: configuration.konghq.com/v1
kind: KongIngress
metadata:
  name: algo
upstream:
  algorithm: latency
```

**Which issue this PR fixes**:

Closes #4616.

**Special notes for your reviewer**:

Is `konghq.com/override` the only way to specify this? I believe we wanted to go away from using that, OTOH though [docs](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/#konghqcomoverride) mention that `upstream` field related config is not deprecated.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
