### PR TITLE
chore(tests): re-enable gateway config (bug fixed in upstream)

### DIFF
--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -244,21 +244,17 @@ func TestGatewayListenerConflicts(t *testing.T) {
 	httpsHost := gatewayv1beta1.Hostname("https.example")
 	httphostHost := gatewayv1beta1.Hostname("http.example")
 
-	// this tests compatibility to the extent that we can with Kong listens. it does not support the full range
+	// This tests compatibility to the extent that we can with Kong listens. it does not support the full range
 	// of compatible Gateway Routes. Gateway permits TLS and HTTPS routes to coexist on the same port so long
 	// as all use unique hostnames. Kong, however, requires that TLS routes go through a TLS stream listen, so
 	// the binds are separate and we cannot combine them. attempting to do so (e.g. setting the tls port to 443 here)
-	// will result in ListenerReasonPortUnavailable
+	// will result in ListenerReasonPortUnavailable.
 	gw.Spec.Listeners = []gatewayv1beta1.Listener{
-		// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4597
-		// This is disabled pending an apparent upstream bug in GWAPI v0.8.0.
-		// We need to confirm with upstream and either re-enable it after a fixed GWAPI release
-		// or remove it (or httphost).
-		//{
-		//	Name:     "http",
-		//	Protocol: gatewayv1beta1.HTTPProtocolType,
-		//	Port:     gatewayv1beta1.PortNumber(80),
-		//},
+		{
+			Name:     "http",
+			Protocol: gatewayv1beta1.HTTPProtocolType,
+			Port:     gatewayv1beta1.PortNumber(80),
+		},
 		{
 			Name:     "tls",
 			Protocol: gatewayv1beta1.TLSProtocolType,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since `gateway-api` is in version `0.8.1` the bug has been fixed in upstream
- https://github.com/kubernetes-sigs/gateway-api/pull/2370
thus previously problematic configuration can be re-enabled in our tests. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

closes https://github.com/Kong/kubernetes-ingress-controller/issues/4597
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

