### PR TITLE
fix: include Licenses and ConsumerGroups in sanitized copies of config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ Adding a new version? You'll need three changes:
 - KongPlugins used on multiple resources will no longer result in
   `instance_name` collisions.
   [#4588](https://github.com/Kong/kubernetes-ingress-controller/issues/4588)
-- Fix `panic` when last known configuratino fetcher gets a `nil` Status when requesting
+- Fix `panic` when last known configuration fetcher gets a `nil` Status when requesting
   `/status` from Kong Gateway.
   This happens when Gateway is responding with a 50x HTTP status code.
   [#4627](https://github.com/Kong/kubernetes-ingress-controller/issues/4627)
@@ -137,6 +137,8 @@ Adding a new version? You'll need three changes:
   deleting existing configuration during an API server restart.
   [#4641](https://github.com/Kong/kubernetes-ingress-controller/issues/4641)
   [#4643](https://github.com/Kong/kubernetes-ingress-controller/issues/4643)
+- Fix `Licenses` and `ConsumerGroups` missing in sanitized copies of Kong configuration.
+  [#4710](https://github.com/Kong/kubernetes-ingress-controller/pull/4710
 
 ## [2.11.1]
 

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -147,7 +147,7 @@ func ToDeckContent(
 
 	for _, c := range k8sState.Licenses {
 		content.Licenses = append(content.Licenses,
-			file.FLicense{License: c})
+			file.FLicense{License: c.License})
 	}
 
 	sort.SliceStable(content.Licenses, func(i, j int) bool {

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -24,7 +24,7 @@ type KongState struct {
 	Upstreams      []Upstream
 	Certificates   []Certificate
 	CACertificates []kong.CACertificate
-	Licenses       []kong.License
+	Licenses       []License
 	Plugins        []Plugin
 	Consumers      []Consumer
 	ConsumerGroups []ConsumerGroup
@@ -49,6 +49,13 @@ func (ks *KongState) SanitizedCopy() *KongState {
 			}
 			return
 		}(),
+		Licenses: func() (res []License) {
+			for _, v := range ks.Licenses {
+				res = append(res, *v.SanitizedCopy())
+			}
+			return
+		}(),
+		ConsumerGroups: ks.ConsumerGroups,
 	}
 }
 

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -108,7 +108,7 @@ func ensureAllKongStateFieldsAreCoveredInTest(t *testing.T, testedFields []strin
 
 	// Meta test - ensure we have testcases covering all fields in KongState.
 	for _, field := range allKongStateFields {
-		assert.True(t, lo.Contains(testedFields, field), "field %s wasn't tested", field)
+		require.Containsf(t, testedFields, field, "field %s wasn't tested", field)
 	}
 }
 

--- a/internal/dataplane/kongstate/license.go
+++ b/internal/dataplane/kongstate/license.go
@@ -1,0 +1,20 @@
+package kongstate
+
+import "github.com/kong/go-kong/kong"
+
+// License represents the license object in Kong.
+type License struct {
+	kong.License
+}
+
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (l License) SanitizedCopy() *License {
+	return &License{
+		License: kong.License{
+			ID:        l.ID,
+			Payload:   redactedString,
+			CreatedAt: l.CreatedAt,
+			UpdatedAt: l.UpdatedAt,
+		},
+	}
+}

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -264,7 +264,7 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 	if p.licenseGetter != nil {
 		optionalLicense := p.licenseGetter.GetLicense()
 		if l, ok := optionalLicense.Get(); ok {
-			result.Licenses = append(result.Licenses, l)
+			result.Licenses = append(result.Licenses, kongstate.License{License: l})
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We missed adding `Licenses` and `ConsumerGroups` to the sanitized copies. This PR adds them, as well as improves tests to catch such cases in the future automatically.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
