### PR TITLE
chore(tests): replace image moul/grpcbin with kong/grpcbin

### DIFF
--- a/deploy/manifests/sample-apps/grpc.yaml
+++ b/deploy/manifests/sample-apps/grpc.yaml
@@ -28,7 +28,7 @@ spec:
         app: grpcbin
     spec:
       containers:
-      - image: moul/grpcbin
+      - image: kong/grpcbin
         name: grpcbin
         ports:
         - containerPort: 9001

--- a/examples/gateway-grpcroute.yaml
+++ b/examples/gateway-grpcroute.yaml
@@ -31,7 +31,7 @@ spec:
         app: grpcbin
     spec:
       containers:
-      - image: moul/grpcbin
+      - image: kong/grpcbin
         name: grpcbin
         ports:
         - containerPort: 9001

--- a/test/consts.go
+++ b/test/consts.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	// HTTPBinImage is the container image name we use for deploying the "httpbin" HTTP testing tool.
-	// if you need a simple HTTP server for tests you're writing, use this and check the documentation.
+	// If you need a simple HTTP server for tests you're writing, use this and check the documentation.
 	// See: https://github.com/kong/httpbin
 	HTTPBinImage = "kong/httpbin:0.1.0"
 	HTTPBinPort  = 80
@@ -15,11 +15,16 @@ const (
 	// Running on Pod tcp-echo-58ccd6b78d-hn9t8.
 	// In namespace foo.
 	// With IP address 10.244.0.13.
-	// Read more about it here: http://github.com/kong/go-echo
+	// See: http://github.com/kong/go-echo
 	EchoImage    = "kong/go-echo:0.3.0"
 	EchoTCPPort  = 1025
 	EchoUDPPort  = 1026
 	EchoHTTPPort = 1027
+
+	// GRPCBinImage is the container image name we use for deploying the "grpcbin" GRPC testing tool.
+	// See: https://github.com/Kong/grpcbin
+	GRPCBinImage = "kong/grpcbin:latest"
+	GRPCBinPort  = 9001
 
 	// EnvironmentCleanupTimeout is the amount of time that will be given by the test suite to the
 	// testing environment to perform its cleanup when the test suite is shutting down.

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -157,7 +157,7 @@ func TestGRPCIngressEssentials(t *testing.T) {
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("grpcbin", "moul/grpcbin", 9001)
+	container := generators.NewContainer("grpcbin", test.GRPCBinImage, test.GRPCBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
 	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Instead of using the original, unmaintained one, use the fork maintained by Kong.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3659

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

We still use [github.com/moul/pb](https://github.com/moul/pb) as a client for [github.com/Kong/grpcbin](https://github.com/Kong/grpcbin), it wasn't in the scope of the original issue, and Kong does not mirror this dependency. Maybe is something to consider - mirroring or including it in [github.com/Kong/grpcbin](https://github.com/Kong/grpcbin)

<!-- Here you can add any open questions or notes that you might have for reviewers -->