### PR TITLE
test(e2e): include istio 1.19, drop istio 1.15

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -234,13 +234,13 @@ jobs:
       matrix:
         include:
           - kubernetes-version: 'v1.27.3'
+            istio-version: 'v1.19'
+          - kubernetes-version: 'v1.27.3'
             istio-version: 'v1.18'
           - kubernetes-version: 'v1.26.6'
             istio-version: 'v1.17'
           - kubernetes-version: 'v1.25.11'
             istio-version: 'v1.16'
-          - kubernetes-version: 'v1.25.11'
-            istio-version: 'v1.15'
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -233,7 +233,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kubernetes-version: 'v1.27.3'
+          - kubernetes-version: 'v1.28.0'
             istio-version: 'v1.19'
           - kubernetes-version: 'v1.27.3'
             istio-version: 'v1.18'


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps istio in the E2E test, per the release instructions in #4699

**Which issue this PR fixes**:

Part of #4699

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
