### PR TITLE
tests(conformance): for experimental enable test and change report name

### DIFF
--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -44,9 +44,6 @@ func TestGatewayExperimentalConformance(t *testing.T) {
 					suite.SupportHTTPRouteMethodMatching,
 					suite.SupportHTTPResponseHeaderModification,
 				),
-				SkipTests: []string{
-					tests.GatewayClassObservedGenerationBump.ShortName,
-				},
 			},
 			ConformanceProfiles: sets.New(
 				suite.HTTPConformanceProfileName,
@@ -71,7 +68,7 @@ func TestGatewayExperimentalConformance(t *testing.T) {
 	//cSuite.Run(t, []suite.ConformanceTest{tests.HTTPRouteRedirectPortAndScheme})
 	require.NoError(t, cSuite.Run(t, tests.ConformanceTests))
 
-	const reportFileName = "conformance-tests-report.yaml"
+	const reportFileName = "kong-kubernetes-ingress-controller.yaml"
 	t.Log("saving the gateway conformance test report to file:", reportFileName)
 	report, err := cSuite.Report()
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since the report in [gateway-api](https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports/v0.7.1) is expected to have be named `kong-kubernetes-ingress-controller.yaml` change to it to reduce friction.

Enable test `GatewayClassObservedGenerationBump` as it has been fixed in 
- #4645 

[Related run](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6301443503) of CI workflow for generating a report.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

