### PR TITLE
chore: remove everything related obsolete global KongPlugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ Adding a new version? You'll need three changes:
 
 - The `FillIDs` feature gate is now enabled by default.
   [#4746](https://github.com/Kong/kubernetes-ingress-controller/pull/4746)
-  
+- Get rid of deprecation warning in logs for unsupported label `global: true` for `KongPlugin`,
+  it'll be treated as any other label without a special meaning.
+  [#4737](https://github.com/Kong/kubernetes-ingress-controller/pull/4737)
 
 ## 2.12.0
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -390,28 +390,17 @@ func buildPlugins(
 		}
 	}
 
-	globalPlugins, err := globalPlugins(log, s)
+	gKCPs, err := globalKongClusterPlugins(log, s)
 	if err != nil {
-		log.WithError(err).Error("failed to fetch global plugins")
+		log.WithError(err).Error("failed to fetch global Kong Cluster plugins")
 	}
 	// global plugins have no instance_name transform as they can only be applied once
-	plugins = append(plugins, globalPlugins...)
+	plugins = append(plugins, gKCPs...)
 
 	return plugins
 }
 
-func globalPlugins(log logrus.FieldLogger, s store.Storer) ([]Plugin, error) {
-	// removed as of 0.10.0
-	// only retrieved now to warn users
-	globalPlugins, err := s.ListGlobalKongPlugins()
-	if err != nil {
-		return nil, fmt.Errorf("error listing global KongPlugins: %w", err)
-	}
-	if len(globalPlugins) > 0 {
-		log.Warning("global KongPlugins found. These are no longer applied and",
-			" must be replaced with KongClusterPlugins.",
-			" Please run \"kubectl get kongplugin -l global=true --all-namespaces\" to list existing plugins")
-	}
+func globalKongClusterPlugins(log logrus.FieldLogger, s store.Storer) ([]Plugin, error) {
 	res := make(map[string]Plugin)
 	var duplicates []string // keep track of duplicate
 	// TODO respect the oldest CRD

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -541,14 +541,12 @@ func TestFakeStorePlugins(t *testing.T) {
 	store, err = NewFakeStore(FakeObjects{KongPlugins: plugins})
 	require.Nil(err)
 	require.NotNil(store)
-	plugins, err = store.ListGlobalKongPlugins()
-	assert.NoError(err)
-	assert.Len(plugins, 0)
+	plugins = store.ListKongPlugins()
+	assert.Len(plugins, 1)
 
 	plugin, err := store.GetKongPlugin("default", "does-not-exist")
-	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
-	assert.Nil(plugin)
+	require.ErrorAs(err, &ErrNotFound{})
+	require.Nil(plugin)
 }
 
 func TestFakeStoreClusterPlugins(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -95,7 +95,6 @@ type Storer interface {
 	ListTCPIngresses() ([]*kongv1beta1.TCPIngress, error)
 	ListUDPIngresses() ([]*kongv1beta1.UDPIngress, error)
 	ListKnativeIngresses() ([]*knative.Ingress, error)
-	ListGlobalKongPlugins() ([]*kongv1.KongPlugin, error)
 	ListGlobalKongClusterPlugins() ([]*kongv1.KongClusterPlugin, error)
 	ListKongPlugins() []*kongv1.KongPlugin
 	ListKongClusterPlugins() []*kongv1.KongClusterPlugin
@@ -925,31 +924,6 @@ func (s Store) ListKongConsumerGroups() []*kongv1beta1.KongConsumerGroup {
 	}
 
 	return consumerGroups
-}
-
-// ListGlobalKongPlugins returns all KongPlugin resources
-// filtered by the ingress.class annotation and with the
-// label global:"true".
-// Support for these global namespaced KongPlugins was removed in 0.10.0
-// This function remains only to provide warnings to users with old configuration.
-func (s Store) ListGlobalKongPlugins() ([]*kongv1.KongPlugin, error) {
-	var plugins []*kongv1.KongPlugin
-	req, err := labels.NewRequirement("global", selection.Equals, []string{"true"})
-	if err != nil {
-		return nil, err
-	}
-	err = cache.ListAll(s.stores.Plugin,
-		labels.NewSelector().Add(*req),
-		func(ob interface{}) {
-			p, ok := ob.(*kongv1.KongPlugin)
-			if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.IngressClassKey, s.getIngressClassHandling()) {
-				plugins = append(plugins, p)
-			}
-		})
-	if err != nil {
-		return nil, err
-	}
-	return plugins, nil
 }
 
 // ListGlobalKongClusterPlugins returns all KongClusterPlugin resources


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

`KongClusterPlugin` supports the label `global: true`, [see the docs](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kongplugin-resource/#configuring-global-plugins) and it is not changed.

For a long time (since `KIC v0.10.0`) for `KongPlugin` with the label `global: true` KIC logs a warning about unsupporting. This PR gets rid of everything related to the support of label `global` for `KongPlugin`, including a warning.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3873

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
