### PR TITLE
fix: no more "log.SetLogger(...) was never called..." log entry during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- No more "log.SetLogger(...) was never called..." log entry during shutdown of KIC
+  [#4738](https://github.com/Kong/kubernetes-ingress-controller/pull/4738)
+
 ## 2.12.0
 
 > Release date: 2023-09-25
@@ -140,7 +147,7 @@ Adding a new version? You'll need three changes:
   [#4641](https://github.com/Kong/kubernetes-ingress-controller/issues/4641)
   [#4643](https://github.com/Kong/kubernetes-ingress-controller/issues/4643)
 - Fix `Licenses` and `ConsumerGroups` missing in sanitized copies of Kong configuration.
-  [#4710](https://github.com/Kong/kubernetes-ingress-controller/pull/4710
+  [#4710](https://github.com/Kong/kubernetes-ingress-controller/pull/4710)
 
 ## [2.11.1]
 

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -19,6 +19,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -55,6 +56,10 @@ func SetupLoggers(c *Config, output io.Writer) (logrus.FieldLogger, logr.Logger,
 		// disable deck's per-change diff output
 		cprint.DisableOutput = true
 	}
+
+	// Prevents controller-runtime from logging
+	// [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
+	ctrllog.SetLogger(logger)
 
 	return deprecatedLogger, logger, nil
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Getting rid of the message that complains about a missing call to `SetLogger()` when KIC is killed or shutdown.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4736

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Unfortunately, controller-runtime expects it to be called always, it was spotted in tests, and the fix was provided
- https://github.com/Kong/kubernetes-ingress-controller/pull/4661

but only in the test helper. Now it is in both places. Efforts relating to streamlining logging in KIC may help us with having all the configurations in one place. 

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
