### PR TITLE
chore: graduate feature gate FillIDs to Beta and set to true by default

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -74,10 +74,10 @@ jobs:
             router-flavor: "expressions"
           - name: dbless-fill-ids
             test: dbless
-            feature_gates: "GatewayAlpha=true,FillIDs=true"
+            feature_gates: "GatewayAlpha=true"
           - name: postgres-fill-ids
             test: postgres
-            feature_gates: "GatewayAlpha=true,FillIDs=true"
+            feature_gates: "GatewayAlpha=true"
           - name: dbless-rewrite-uris
             test: dbless
             feature_gates: "GatewayAlpha=true,RewriteURIs=true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ Adding a new version? You'll need three changes:
 - No more "log.SetLogger(...) was never called..." log entry during shutdown of KIC
   [#4738](https://github.com/Kong/kubernetes-ingress-controller/pull/4738)
 
+### Added
+
+- The `FillIDs` feature gate is now enabled by default.
+  [#4746](https://github.com/Kong/kubernetes-ingress-controller/pull/4746)
+  
+
 ## 2.12.0
 
 > Release date: 2023-09-25

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -66,6 +66,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | CombinedServices | `false` | Alpha | 2.10.0  | 3.0.0 |
 | CombinedServices | `true`  | Beta  | 2.11.0  | 3.0.0 |
 | FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |
+| FillIDs          | `true`  | Beta  | 3.0.0   | TBD   |
 | RewriteURIs      | `false` | Alpha | 2.12.0  | TBD   |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -490,7 +490,7 @@ func (ks *KongState) FillIDs(logger logrus.FieldLogger) {
 
 	for consumerIndex, consumer := range ks.Consumers {
 		if err := consumer.FillID(); err != nil {
-			logger.WithError(err).Errorf("failed to fill ID for consumer %s", *consumer.Username)
+			logger.WithError(err).Errorf("failed to fill ID for consumer %s", consumer.FriendlyName())
 		} else {
 			ks.Consumers[consumerIndex] = consumer
 		}

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -5080,12 +5080,12 @@ func TestNewFeatureFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "fill ids enabled",
+			name: "fill ids disabled",
 			featureGates: map[string]bool{
-				featuregates.FillIDsFeature: true,
+				featuregates.FillIDsFeature: false,
 			},
 			expectedFeatureFlags: FeatureFlags{
-				FillIDs: true,
+				FillIDs: false,
 			},
 		},
 	}

--- a/internal/dataplane/parser/testdata/golden/consumer-group-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/consumer-group-example/default_golden.yaml
@@ -1,12 +1,14 @@
 _format_version: "3.0"
 consumer_groups:
-- name: consumer-group-2
+- id: 876a1c78-f75a-570e-a918-26506344add0
+  name: consumer-group-2
   tags:
   - k8s-name:consumer-group-2
   - k8s-kind:KongConsumerGroup
   - k8s-group:configuration.konghq.com
   - k8s-version:v1beta1
-- name: consumer-group-1
+- id: dc176b3e-97a3-55b5-935a-b6edda29067d
+  name: consumer-group-1
   tags:
   - k8s-name:consumer-group-1
   - k8s-kind:KongConsumerGroup
@@ -16,6 +18,7 @@ consumers:
 - groups:
   - name: consumer-group-1
   - name: consumer-group-2
+  id: 71168e5f-1d0b-5465-8bb9-a3b032fbc4c4
   tags:
   - k8s-name:consumer-2
   - k8s-kind:KongConsumer
@@ -24,6 +27,7 @@ consumers:
   username: consumer-2
 - groups:
   - name: consumer-group-1
+  id: e23d9ef8-1cc4-5b55-abd1-db89aa90346c
   tags:
   - k8s-name:consumer-1
   - k8s-kind:KongConsumer

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: grpcroute.default.grpcbin.0
+  id: 21a5e729-c47e-5086-a236-0551b9a11bda
   name: grpcroute.default.grpcbin.0
   plugins:
   - config:
@@ -15,6 +16,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: c28a0082-bf9d-5577-bd96-c82519503d53
     name: grpcroute.default.grpcbin.0.0
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: grpcroute.default.grpcbin.example.com.0
+  id: e3750232-74d7-5496-bf14-1c266ec17184
   name: grpcroute.default.grpcbin.example.com.0
   plugins:
   - config:
@@ -14,6 +15,7 @@ services:
   routes:
   - expression: (http.path == "/grpcbin.GRPCBin/DummyUnary") && (http.host == "example.com")
     https_redirect_status_code: 426
+    id: b23f135f-8d7e-54cb-96eb-f2579ef1608b
     name: grpcroute.default.grpcbin.example.com.0.0
     preserve_host: true
     priority: 1713055227461631

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/regex-path-prefix-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: grpcroute.default.grpcbin.0
+  id: 21a5e729-c47e-5086-a236-0551b9a11bda
   name: grpcroute.default.grpcbin.0
   plugins:
   - config:
@@ -15,6 +16,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: c28a0082-bf9d-5577-bd96-c82519503d53
     name: grpcroute.default.grpcbin.0.0
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: httproute..httproute-testing.0
+  id: 58104a2b-77b7-59e4-aeee-7453dcf61b31
   name: httproute..httproute-testing.0
   port: 8080
   protocol: http
@@ -9,6 +10,7 @@ services:
   retries: 5
   routes:
   - https_redirect_status_code: 426
+    id: c2ee1eba-4c06-5753-88d6-1a96d54329ac
     name: httproute..httproute-testing.0.0
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: httproute..httproute-testing._.0
+  id: 8c2128fd-fd7f-5124-be47-5f398496c564
   name: httproute..httproute-testing._.0
   port: 8080
   protocol: http
@@ -10,6 +11,7 @@ services:
   routes:
   - expression: (http.path == "/httproute-testing") || (http.path ^= "/httproute-testing/")
     https_redirect_status_code: 426
+    id: 6ed3cb3b-9fde-540a-9e9d-0a8c13762a84
     name: httproute..httproute-testing._.0.0
     preserve_host: true
     priority: 2251808940752895

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/combined-routes-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: cd111d84-e443-5591-a27e-9c33e18f6309
   name: foo-namespace.foo-svc.pnum-80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 1d9c6ccc-b13f-5a88-ae11-549f290dcd8b
     name: foo-namespace.foo.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062006273

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ingress-class-annotation/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/combined-routes-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.8000.svc
+  id: 1372d85f-0631-5525-b30a-42755b57f643
   name: foo-namespace.foo-svc.pnum-8000
   path: /
   port: 8000
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.net
     https_redirect_status_code: 426
+    id: 0ddab388-38bb-5d0b-9555-7c4838807989
     name: foo-namespace.foo.10
     path_handling: v0
     paths:
@@ -38,6 +40,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: cd111d84-e443-5591-a27e-9c33e18f6309
   name: foo-namespace.foo-svc.pnum-80
   path: /
   port: 80
@@ -48,6 +51,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 1d9c6ccc-b13f-5a88-ae11-549f290dcd8b
     name: foo-namespace.foo.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.8000.svc
+  id: 8c1ded2c-3f68-5845-bc85-f4c4c318829a
   name: foo-namespace.foo-svc.8000
   path: /
   port: 8000
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.net
     https_redirect_status_code: 426
+    id: 2bd1c902-4d3c-50ed-9a78-f698cfa0cf37
     name: foo-namespace.foo.foo-svc.example.net.8000
     path_handling: v0
     paths:
@@ -38,6 +40,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -48,6 +51,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.8000.svc
+  id: 8c1ded2c-3f68-5845-bc85-f4c4c318829a
   name: foo-namespace.foo-svc.8000
   path: /
   port: 8000
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.net") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: 2bd1c902-4d3c-50ed-9a78-f698cfa0cf37
     name: foo-namespace.foo.foo-svc.example.net.8000
     preserve_host: true
     priority: 3382102062006273
@@ -31,6 +33,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -40,6 +43,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062006273

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/combined-routes-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.http.svc
+  id: 50053427-d5bf-52de-afbd-63786ec6bfb3
   name: foo-namespace.foo-svc.pname-http
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 37cc7b45-776c-5005-a36b-73fa84d68b13
     name: foo-namespace.regex-prefix.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.http.svc
+  id: bc2b75ab-9763-539c-a251-d6a2730a964b
   name: foo-namespace.foo-svc.http
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 0673ae1f-4318-59dc-96e7-fc17c218022f
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.http.svc
+  id: bc2b75ab-9763-539c-a251-d6a2730a964b
   name: foo-namespace.foo-svc.http
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: 0673ae1f-4318-59dc-96e7-fc17c218022f
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     preserve_host: true
     priority: 3382102062006273

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path == "/whatever")
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071817

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/regex-path-prefix-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/regex-path-prefix-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 45f1e9e4-8096-5cf7-b8e0-c42f8b9b81a0
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ~ "^/foo/\\d{3}")
     https_redirect_status_code: 426
+    id: 45f1e9e4-8096-5cf7-b8e0-c42f8b9b81a0
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071818

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/combined-routes-off_golden.yaml
@@ -69,6 +69,7 @@ certificates:
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc
+  id: d5e3ab34-7de0-53a1-98f3-2d893817c584
   name: bar-namespace.foo-svc.pnum-80
   path: /
   port: 80
@@ -79,6 +80,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: f719d0b1-93bb-598b-a4d5-2afcca11fe2d
     name: bar-namespace.ing-with-tls.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -69,6 +69,7 @@ certificates:
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc
+  id: edc1d53e-73b4-5932-9455-0e01f0d53e3f
   name: bar-namespace.foo-svc.80
   path: /
   port: 80
@@ -79,6 +80,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: fc9a8135-0253-5631-b1e0-8712f796a4e2
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -69,6 +69,7 @@ certificates:
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc
+  id: edc1d53e-73b4-5932-9455-0e01f0d53e3f
   name: bar-namespace.foo-svc.80
   path: /
   port: 80
@@ -78,6 +79,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path == "/")
     https_redirect_status_code: 426
+    id: fc9a8135-0253-5631-b1e0-8712f796a4e2
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071809

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/combined-routes-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: cd111d84-e443-5591-a27e-9c33e18f6309
   name: foo-namespace.foo-svc.pnum-80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 1d9c6ccc-b13f-5a88-ae11-549f290dcd8b
     name: foo-namespace.foo.00
     path_handling: v0
     paths:
@@ -33,6 +35,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3f5f2f77-2dab-5665-939a-cea3820df7f4
     name: foo-namespace.foo-2.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:
@@ -33,6 +35,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: ab6b1505-ec86-5b04-9d39-a95a711564cc
     name: foo-namespace.foo-2.foo-svc.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071809
@@ -25,6 +27,7 @@ services:
     - k8s-version:v1
   - expression: (http.host == "example.com") && (http.path ^= "/")
     https_redirect_status_code: 426
+    id: ab6b1505-ec86-5b04-9d39-a95a711564cc
     name: foo-namespace.foo-2.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071809

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/combined-routes-off_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/combined-routes-off_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: cert-manager-solver-pod.foo-namespace.80.svc
+  id: 53a98821-7879-5a65-bf53-1688f4df6814
   name: foo-namespace.cert-manager-solver-pod.pnum-80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 1d9c6ccc-b13f-5a88-ae11-549f290dcd8b
     name: foo-namespace.foo.00
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: cert-manager-solver-pod.foo-namespace.80.svc
+  id: ffc0fc8a-f989-521b-af6d-d236a9cbcb76
   name: foo-namespace.cert-manager-solver-pod.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: bba23c8e-3f3c-55dc-bfca-2fe19de118d1
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: cert-manager-solver-pod.foo-namespace.80.svc
+  id: ffc0fc8a-f989-521b-af6d-d236a9cbcb76
   name: foo-namespace.cert-manager-solver-pod.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path ^= "/.well-known/acme-challenge/yolo")
     https_redirect_status_code: 426
+    id: bba23c8e-3f3c-55dc-bfca-2fe19de118d1
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     preserve_host: true
     priority: 3382102062006304

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -12,6 +13,7 @@ services:
   - hosts:
     - example.com
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     path_handling: v0
     paths:
@@ -38,6 +40,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: default-svc.bar-namespace.80.svc
+  id: 65ebeec1-01a0-5211-85c9-9f688a182c88
   name: bar-namespace.default-svc.80
   port: 80
   protocol: http
@@ -45,6 +48,7 @@ services:
   retries: 5
   routes:
   - https_redirect_status_code: 426
+    id: 01c21dd4-41c1-57b6-a417-66c80b8ad22b
     name: bar-namespace.ing-with-default-backend
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: foo-svc.foo-namespace.80.svc
+  id: fe1e2edc-5479-52fe-b0f4-b90d8d5f83ba
   name: foo-namespace.foo-svc.80
   path: /
   port: 80
@@ -11,6 +12,7 @@ services:
   routes:
   - expression: (http.host == "example.com") && (http.path == "/")
     https_redirect_status_code: 426
+    id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 3382102062071809
@@ -31,6 +33,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: default-svc.bar-namespace.80.svc
+  id: 65ebeec1-01a0-5211-85c9-9f688a182c88
   name: bar-namespace.default-svc.80
   port: 80
   protocol: http
@@ -40,6 +43,7 @@ services:
   - expression: (http.path ^= "/") && ((net.protocol == "http") || (net.protocol ==
       "https"))
     https_redirect_status_code: 426
+    id: 01c21dd4-41c1-57b6-a417-66c80b8ad22b
     name: bar-namespace.ing-with-default-backend
     preserve_host: true
     priority: 0

--- a/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/kongplugin-instance-name/default_golden.yaml
@@ -33,6 +33,7 @@ plugins:
 services:
 - connect_timeout: 60000
   host: httpbin..80.svc
+  id: 84eb138f-d0f8-5200-a393-15b772b4b616
   name: .httpbin.80
   path: /
   port: 80
@@ -41,6 +42,7 @@ services:
   retries: 5
   routes:
   - https_redirect_status_code: 426
+    id: 0e0a5206-3e46-52e9-adab-943b1752a6c7
     name: .httpbin.httpbin..80
     path_handling: v0
     paths:
@@ -59,6 +61,7 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   - https_redirect_status_code: 426
+    id: a45af20a-d4fd-5695-a7b6-363eade3150c
     name: .httpbin-other.httpbin..80
     path_handling: v0
     paths:
@@ -83,6 +86,7 @@ services:
   write_timeout: 60000
 - connect_timeout: 60000
   host: httpbin-other..80.svc
+  id: 13b20b54-10d5-5fd5-b453-38bdd73beb42
   name: .httpbin-other.80
   path: /
   port: 80
@@ -91,6 +95,7 @@ services:
   retries: 5
   routes:
   - https_redirect_status_code: 426
+    id: f1c0dac6-309d-5939-8182-fdfbf92d7d0b
     name: .httpbin-other.httpbin-other..80
     path_handling: v0
     paths:

--- a/internal/dataplane/parser/testdata/golden/same-name-services-single-backend/default_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/same-name-services-single-backend/default_golden.yaml
@@ -2,6 +2,7 @@ _format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: httproute.default.test.0
+  id: 5879d21c-33ed-5355-be10-f0911e04d397
   name: httproute.default.test.0
   port: 80
   protocol: http
@@ -9,6 +10,7 @@ services:
   retries: 5
   routes:
   - https_redirect_status_code: 426
+    id: f78c2a62-d9bc-5b80-a16a-d19f4dea4fbe
     name: httproute.default.test.0.0
     path_handling: v0
     paths:

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -80,7 +80,7 @@ func GetFeatureGatesDefaults() map[string]bool {
 		GatewayAlphaFeature:     false,
 		CombinedRoutesFeature:   true,
 		ExpressionRoutesFeature: false,
-		FillIDsFeature:          false,
+		FillIDsFeature:          true,
 		RewriteURIsFeature:      false,
 	}
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -42,19 +42,6 @@ func TestDeployAndUpgradeAllInOnePostgres(t *testing.T) {
 	})
 }
 
-func TestDeployAndUpgradeAllInOnePostgres_FeatureGates(t *testing.T) {
-	testManifestsUpgrade(t, manifestsUpgradeTestParams{
-		fromManifestURL:   fmt.Sprintf(postgresURLTemplate, upgradeTestFromTag),
-		toManifestPath:    postgresPath,
-		beforeUpgradeHook: postgresBeforeUpgradeHook,
-		// We want to test that nothing breaks when enabling FillIDs feature gate to prevent regressions like
-		// https://github.com/Kong/kubernetes-ingress-controller/issues/4025.
-		// In 2.10.0 this is disabled by default, so we need a separate test for this.
-		// TODO: remove this test when FillIDs is enabled by default.
-		controllerFeatureGates: "FillIDs=true",
-	})
-}
-
 func postgresBeforeUpgradeHook(ctx context.Context, t *testing.T, env environments.Environment) {
 	// Injecting a beforeUpgradeHook to delete the old migrations job before the upgrade. This is necessary because it's
 	// not allowed to modify the existing job's spec.

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -355,7 +355,7 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"db=off;"+
 			"feature-combinedroutes=true;"+
 			"feature-expressionroutes=false;"+
-			"feature-fillids=false;"+
+			"feature-fillids=true;"+
 			"feature-gateway-service-discovery=false;"+
 			"feature-gateway=false;"+
 			"feature-gatewayalpha=false;"+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Graduate feature gate `FillIDs` to Beta and set to `true` by default. Adjust code, tests (regenerate golden tests tests cases), CI, etc. Mention it in `CHANGELOG.MD` and `FEATURE_GATES.md`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4739

**Special notes for your reviewer:**

Dereferencing any field in `KongConsumer` is risky, because each one is a pointer, thus when an error is returned (it was the case for envtests that don't care about it) panic occurred. Using `FriendlyName(...)` is always safe

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
