### PR TITLE
chore: use upstream RouteReasonNoMatchingParent

### DIFF
--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -121,18 +121,6 @@ func parentRefsForRoute[T types.RouteT](route T) ([]ParentReference, error) {
 	}
 }
 
-const (
-	// This reason is used with the "Accepted" condition when there are
-	// no matching Parents. In the case of Gateways, this can occur when
-	// a Route ParentRef specifies a Port and/or SectionName that does not
-	// match any Listeners in the Gateway.
-	//
-	// NOTE: This is already in uptsream, albeit unreleased:
-	// https://github.com/kubernetes-sigs/gateway-api/pull/1516
-	// TODO: swap this out with upstream const when released.
-	RouteReasonNoMatchingParent gatewayv1beta1.RouteConditionReason = "NoMatchingParent"
-)
-
 // getSupportedGatewayForRoute will retrieve the Gateway and GatewayClass object for any
 // Gateway APIs route object (e.g. HTTPRoute, TCPRoute, e.t.c.) from the provided cached
 // client if they match this controller. If there are no gateways present for this route
@@ -285,7 +273,7 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			// We failed to match a listener with this route
 
 			// This will also catch a case of not matching listener/section name.
-			reason := RouteReasonNoMatchingParent
+			reason := gatewayv1beta1.RouteReasonNoMatchingParent
 
 			if matchingHostname != nil && *matchingHostname == metav1.ConditionFalse {
 				// If there is no matchingHostname, the gateway Status Condition Accepted
@@ -294,11 +282,11 @@ func getSupportedGatewayForRoute[T types.RouteT](ctx context.Context, mgrc clien
 			} else if (parentRef.SectionName) != nil && !allowedByListenerName {
 				// If ParentRef specified listener names but none of the listeners matches the name,
 				// the gateway Status Condition Accepted must be set to False with reason RouteReasonNoMatchingParent.
-				reason = RouteReasonNoMatchingParent
+				reason = gatewayv1beta1.RouteReasonNoMatchingParent
 			} else if (parentRef.Port != nil) && !portMatched {
 				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
 				// Condition Accepted must be set to False with reason NoMatchingListenerPort
-				reason = RouteReasonNoMatchingParent
+				reason = gatewayv1beta1.RouteReasonNoMatchingParent
 			} else if !allowedByAllowedRoutes || !allowedBySupportedKinds {
 				reason = gatewayv1beta1.RouteReasonNotAllowedByListeners
 			}

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -415,7 +415,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: []expected{
 					{
-						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 					},
 				},
 			},
@@ -532,7 +532,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: []expected{
 					{
-						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 					},
 				},
 			},
@@ -695,7 +695,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					namespace,
 				},
 				expected: expected{
-					condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+					condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 				},
 			},
 			{
@@ -741,7 +741,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: expected{
 					listenerName: "unknown-listener",
-					condition:    routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+					condition:    routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 				},
 			},
 		}
@@ -892,7 +892,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					namespace,
 				},
 				expected: expected{
-					condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+					condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 				},
 			},
 			{
@@ -928,7 +928,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: expected{
 					listenerName: "unknown-listener",
-					condition:    routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+					condition:    routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 				},
 			},
 		}
@@ -1060,7 +1060,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: []expected{
 					{
-						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 					},
 				},
 			},
@@ -1114,7 +1114,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 				expected: []expected{
 					{
-						condition: routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+						condition: routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 					},
 				},
 			},
@@ -1155,7 +1155,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				expected: []expected{
 					{
 						listenerName: "unknown-listener",
-						condition:    routeConditionAccepted(metav1.ConditionFalse, RouteReasonNoMatchingParent),
+						condition:    routeConditionAccepted(metav1.ConditionFalse, gatewayv1beta1.RouteReasonNoMatchingParent),
 					},
 				},
 			},

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -329,7 +329,7 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 	svc := refreshService()
 	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "ClusterIP service is not supported")
 
-	switch svc.Spec.Type { //nolint: exhaustive
+	switch svc.Spec.Type { //nolint:exhaustive
 	case corev1.ServiceTypeLoadBalancer:
 		return getKongProxyLoadBalancerIP(t, refreshService)
 	case corev1.ServiceTypeNodePort:

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -22,7 +22,6 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	gatewaypkg "github.com/kong/kubernetes-ingress-controller/v2/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
@@ -323,7 +322,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'False' when it specified a port not existent in Gateway")
-	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, false, gatewaypkg.RouteReasonNoMatchingParent), statusWait, waitTick)
+	require.Eventually(t, HTTPRouteMatchesAcceptedCallback(t, gatewayClient, httpRoute, false, gatewayv1beta1.RouteReasonNoMatchingParent), statusWait, waitTick)
 }
 
 func TestHTTPRouteMultipleServices(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `RouteReasonNoMatchingParent` const and uses the one from upstream.
