### PR TITLE
tests(integration): run invalid confg tests in parallel with all other

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -77,6 +77,10 @@ jobs:
           - name: postgres-rewrite-uris
             test: postgres
             feature_gates: "GatewayAlpha=true,RewriteURIs=true"
+          - name: dbless-invalid-config
+            test: dbless
+            run_invalid_config: "true"
+            go_test_flags: -run=TestIngressRecoverFromInvalidPath
 
     steps:
       - uses: Kong/kong-license@master
@@ -113,18 +117,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
-          JUNIT_REPORT: "integration-tests-${{ matrix.name }}.xml"
+          JUNIT_REPORT: integration-tests-${{ matrix.name }}.xml
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
-
-      - name: run ${{ matrix.name }} - invalid config
-        run: make test.integration.${{ matrix.test }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
-          JUNIT_REPORT: "integration-tests-invalid-config-${{ matrix.name }}.xml"
-          GOTESTFLAGS: "-run=TestIngressRecoverFromInvalidPath"
-          TEST_RUN_INVALID_CONFIG_CASES: "true"
+          TEST_RUN_INVALID_CONFIG_CASES: ${{ matrix.run_invalid_config }}
+          GOTESTFLAGS: "${{ matrix.go_test_flags }}"
 
       - name: collect test coverage
         if: ${{ !cancelled() }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Save around 3 minutes of integration tests run time by pulling the invalid config test suite into a separate integration tests matrix entry.

Currently running with default `traditional` router flavour. That's right isn't it? Before this change it was running with all routers in all [matrix entries](https://github.com/Kong/kubernetes-ingress-controller/blob/edfd7e2b1c2f7e2b9866c3ca7dd08c956a4a0866/.github/workflows/_integration_tests.yaml#L48-L79) but that should really be the case.