### PR TITLE
reintegrate 2.12.x into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ Adding a new version? You'll need three changes:
 
 > Release date: 2023-09-25
 
+### Deprecated
+
+- Knative Ingress is deprecated and will be removed in KIC 3.0. [#2813](https://github.com/Kong/kubernetes-ingress-controller/issues/2813)
+- `KongIngress` for `Service` and `Route` parameters has been deprecated since KIC 2.8 and will be removed in KIC 3.0.
+    - We expect to eventually deprecate `KongIngress` also for `Upstream` parameters as described in [#3174](https://github.com/Kong/kubernetes-ingress-controller/issues/3174)
+- Existing Kustomize (`deploy/manifests/`) and `deploy/single/` YAML manifests as a method of installing KIC.
+    - The `deploy/single/` and `deploy/manifests/` directories will no longer work with KIC 3.0+. You should use the [Helm chart](https://docs.konghq.com/kubernetes-ingress-controller/latest/deployment/k4k8s/#helm) or [Kong Gateway Operator](https://docs.konghq.com/gateway-operator/latest/) instead.
+- DB-less deployments of Kong running with KIC as a sidecar. The [Gateway Discovery](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-gateway-discovery/) feature added in KIC 2.9 should be used instead.
+    - The mode where Kong runs with a database (Postgres) is not affected by the migration to Gateway Discovery yet, but likely will be in the future [#4751](https://github.com/Kong/kubernetes-ingress-controller/issues/4751)
+
 ### Added
 
 - `konghq.com/rewrite` annotation has been introduced to manage URI rewriting.


### PR DESCRIPTION
Technical reintegrate PR - adds the changelog updates to `main`

Part of #4699 

Do not merge from GitHub UI - to be merged from the CLI to preserve the release branch