### PR TITLE
fix(controllers) expand TypeMeta population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ Adding a new version? You'll need three changes:
 
 - No more "log.SetLogger(...) was never called..." log entry during shutdown of KIC
   [#4738](https://github.com/Kong/kubernetes-ingress-controller/pull/4738)
+- Changes to referenced Secrets are now tracked independent of their referent.
+  [#4758](https://github.com/Kong/kubernetes-ingress-controller/pull/4758)
 
 ### Added
 

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -87,6 +87,11 @@ func (r *KongAdminAPIServiceReconciler) SetLogger(l logr.Logger) {
 }
 
 func (r *KongAdminAPIServiceReconciler) shouldReconcileEndpointSlice(obj client.Object) bool {
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 	endpoints, ok := obj.(*discoveryv1.EndpointSlice)
 	if !ok {
 		return false

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -77,6 +77,11 @@ func (r *CoreV1SecretReconciler) SetLogger(l logr.Logger) {
 // - the secret has label: konghq.com/ca-cert:true
 // - or the secret is referred by objects we care (service, ingress, gateway, ...)
 func (r *CoreV1SecretReconciler) shouldReconcileSecret(obj client.Object) bool {
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		return false
@@ -113,6 +118,13 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(secret)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", secret.GetNamespace(), "name", secret.GetName())
+	}
+
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -77,12 +77,16 @@ func (r *CoreV1SecretReconciler) SetLogger(l logr.Logger) {
 // - the secret has label: konghq.com/ca-cert:true
 // - or the secret is referred by objects we care (service, ingress, gateway, ...)
 func (r *CoreV1SecretReconciler) shouldReconcileSecret(obj client.Object) bool {
-	err := util.PopulateTypeMeta(obj)
+	// TypeMeta is necessary to generate the correct key for references, but we can't use the original object
+	// controller-runtime's client provides the same object to both predicates and the admission webhook, and can result
+	// in a race condition if this uses the original
+	o := obj.DeepCopyObject()
+	err := util.PopulateTypeMeta(o)
 	if err != nil {
 		r.Log.Error(err, "could not set resource TypeMeta",
 			"namespace", obj.GetNamespace(), "name", obj.GetName())
 	}
-	secret, ok := obj.(*corev1.Secret)
+	secret, ok := o.(*corev1.Secret)
 	if !ok {
 		return false
 	}

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -28,7 +28,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -100,11 +99,6 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// get the relevant object
 	obj := new(corev1.Service)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: corev1.SchemeGroupVersion.String(),
-		Kind:       "Service",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -121,6 +115,11 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -209,11 +208,6 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 
 	// get the relevant object
 	obj := new(discoveryv1.EndpointSlice)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: discoveryv1.SchemeGroupVersion.String(),
-		Kind:       "EndpointSlice",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -225,6 +219,11 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -352,11 +351,6 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// get the relevant object
 	obj := new(netv1.Ingress)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: netv1.SchemeGroupVersion.String(),
-		Kind:       "Ingress",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -373,6 +367,11 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -506,11 +505,6 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// get the relevant object
 	obj := new(netv1.IngressClass)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: netv1.SchemeGroupVersion.String(),
-		Kind:       "IngressClass",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -522,6 +516,11 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -596,11 +595,6 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// get the relevant object
 	obj := new(kongv1.KongIngress)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind:       "KongIngress",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -612,6 +606,11 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -687,11 +686,6 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// get the relevant object
 	obj := new(kongv1.KongPlugin)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind:       "KongPlugin",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -708,6 +702,11 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -834,11 +833,6 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 
 	// get the relevant object
 	obj := new(kongv1.KongClusterPlugin)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind:       "KongClusterPlugin",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -855,6 +849,11 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1015,11 +1014,6 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// get the relevant object
 	obj := new(kongv1.KongConsumer)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1.SchemeGroupVersion.String(),
-		Kind:       "KongConsumer",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1036,6 +1030,11 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1207,11 +1206,6 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 
 	// get the relevant object
 	obj := new(kongv1beta1.KongConsumerGroup)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind:       "KongConsumerGroup",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1228,6 +1222,11 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1401,11 +1400,6 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// get the relevant object
 	obj := new(kongv1beta1.TCPIngress)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind:       "TCPIngress",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1422,6 +1416,11 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1608,11 +1607,6 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// get the relevant object
 	obj := new(kongv1beta1.UDPIngress)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1beta1.SchemeGroupVersion.String(),
-		Kind:       "UDPIngress",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1624,6 +1618,11 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1742,11 +1741,6 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 
 	// get the relevant object
 	obj := new(kongv1alpha1.IngressClassParameters)
-	// set type meta to the object
-	obj.TypeMeta = metav1.TypeMeta{
-		APIVersion: kongv1alpha1.SchemeGroupVersion.String(),
-		Kind:       "IngressClassParameters",
-	}
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1758,6 +1752,11 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	err := util.PopulateTypeMeta(obj)
+	if err != nil {
+		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
+	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -41,10 +41,6 @@ import (
 var (
 	ErrUnmanagedAnnotation = errors.New("invalid unmanaged annotation value")
 	gatewayV1beta1Group    = gatewayv1beta1.Group(gatewayv1beta1.GroupName)
-	gatewayTypeMeta        = metav1.TypeMeta{
-		APIVersion: gatewayv1beta1.GroupVersion.String(),
-		Kind:       "Gateway",
-	}
 )
 
 // -----------------------------------------------------------------------------
@@ -343,7 +339,6 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// gather the gateway object based on the reconciliation trigger. It's possible for the object
 	// to be gone at this point in which case it will be ignored.
 	gateway := new(gatewayv1beta1.Gateway)
-	gateway.TypeMeta = gatewayTypeMeta
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if apierrors.IsNotFound(err) {
 			gateway.Namespace = req.Namespace
@@ -358,6 +353,13 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		return ctrl.Result{Requeue: true}, err
 	}
+
+	err := util.PopulateTypeMeta(gateway)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", gateway.GetNamespace(), "name", gateway.GetName())
+	}
+
 	debug(log, gateway, "processing gateway")
 
 	// though our watch configuration eliminates reconciliation of unsupported gateways it's

--- a/internal/controllers/gateway/gatewayclass_controller.go
+++ b/internal/controllers/gateway/gatewayclass_controller.go
@@ -120,6 +120,13 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(gwc)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", gwc.GetNamespace(), "name", gwc.GetName())
+	}
+
 	log.V(util.DebugLevel).Info("processing gatewayclass", "name", req.Name)
 
 	if isGatewayClassControlledAndUnmanaged(gwc) {

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -272,6 +272,13 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(grpcroute)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", grpcroute.GetNamespace(), "name", grpcroute.GetName())
+	}
+
 	debug(log, grpcroute, "processing grpcroute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -345,6 +345,13 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(httproute)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", httproute.GetNamespace(), "name", httproute.GetName())
+	}
+
 	debug(log, httproute, "processing httproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/referencegrant_controller.go
+++ b/internal/controllers/gateway/referencegrant_controller.go
@@ -32,6 +32,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 // ReferenceGrantReconciler reconciles a ReferenceGrant object.
@@ -84,6 +85,13 @@ func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(grant)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", grant.GetNamespace(), "name", grant.GetName())
+	}
+
 	debug(log, grant, "processing referencegrant")
 
 	debug(log, grant, "checking deletion timestamp")

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -268,6 +268,13 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(tcproute)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", tcproute.GetNamespace(), "name", tcproute.GetName())
+	}
+
 	debug(log, tcproute, "processing tcproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -268,6 +268,13 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(tlsroute)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", tlsroute.GetNamespace(), "name", tlsroute.GetName())
+	}
+
 	debug(log, tlsroute, "processing tlsroute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -268,6 +268,13 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
 	}
+
+	err := util.PopulateTypeMeta(udproute)
+	if err != nil {
+		r.Log.Error(err, "could not set resource TypeMeta",
+			"namespace", udproute.GetNamespace(), "name", udproute.GetName())
+	}
+
 	debug(log, udproute, "processing udproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/manager/scheme/scheme.go
+++ b/internal/manager/scheme/scheme.go
@@ -7,15 +7,13 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
 
-// Get returns the scheme for the manager, enabling all the default schemes and
-// those that were enabled via the feature flags.
-func Get(fg map[string]bool) (*runtime.Scheme, error) {
+// Get returns a scheme aware of all types the manager can interact with.
+func Get() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 
 	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
@@ -36,15 +34,12 @@ func Get(fg map[string]bool) (*runtime.Scheme, error) {
 		return nil, err
 	}
 
-	if v, ok := fg[featuregates.GatewayAlphaFeature]; ok && v {
-		if err := gatewayv1alpha2.Install(scheme); err != nil {
-			return nil, err
-		}
+	if err := gatewayv1alpha2.Install(scheme); err != nil {
+		return nil, err
 	}
-	if v, ok := fg[featuregates.GatewayFeature]; ok && v {
-		if err := gatewayv1beta1.Install(scheme); err != nil {
-			return nil, err
-		}
+
+	if err := gatewayv1beta1.Install(scheme); err != nil {
+		return nil, err
 	}
 
 	return scheme, nil

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -66,7 +66,7 @@ func SetupLoggers(c *Config, output io.Writer) (logrus.FieldLogger, logr.Logger,
 
 func setupControllerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode string, featureGates map[string]bool) (ctrl.Options, error) {
 	logger.Info("building the manager runtime scheme and loading apis into the scheme")
-	scheme, err := scheme.Get(featureGates)
+	scheme, err := scheme.Get()
 	if err != nil {
 		return ctrl.Options{}, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -983,94 +983,51 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	// Kubernetes Core APIs
 	// ----------------------------------------------------------------------------
 	case netv1.SchemeGroupVersion.WithKind("Ingress"):
-		return &netv1.Ingress{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &netv1.Ingress{}, nil
 	case corev1.SchemeGroupVersion.WithKind("Service"):
-		return &corev1.Service{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &corev1.Service{}, nil
 	case corev1.SchemeGroupVersion.WithKind("Secret"):
-		return &corev1.Secret{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &corev1.Secret{}, nil
 	// ----------------------------------------------------------------------------
 	// Kubernetes Discovery APIs
 	// ----------------------------------------------------------------------------
 	case discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice"):
-		return &discoveryv1.EndpointSlice{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &discoveryv1.EndpointSlice{}, nil
 	// ----------------------------------------------------------------------------
 	// Kubernetes Gateway APIs
 	// ----------------------------------------------------------------------------
 	case gatewayv1beta1.SchemeGroupVersion.WithKind("HTTPRoute"):
-		return &gatewayv1beta1.HTTPRoute{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1beta1.HTTPRoute{}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("GRPCRoute"):
-		return &gatewayv1alpha2.GRPCRoute{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1alpha2.GRPCRoute{}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"):
-		return &gatewayv1alpha2.TCPRoute{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1alpha2.TCPRoute{}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"):
-		return &gatewayv1alpha2.UDPRoute{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1alpha2.UDPRoute{}, nil
 	case gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"):
-		return &gatewayv1alpha2.TLSRoute{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1alpha2.TLSRoute{}, nil
 	case gatewayv1beta1.SchemeGroupVersion.WithKind("ReferenceGrant"):
-		return &gatewayv1beta1.ReferenceGrant{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &gatewayv1beta1.ReferenceGrant{}, nil
 	// ----------------------------------------------------------------------------
 	// Kong APIs
 	// ----------------------------------------------------------------------------
 	case kongv1.SchemeGroupVersion.WithKind("KongIngress"):
-		return &kongv1.KongIngress{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1.KongIngress{}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("UDPIngress"):
-		return &kongv1beta1.UDPIngress{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1beta1.UDPIngress{}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("TCPIngress"):
-		return &kongv1beta1.TCPIngress{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1beta1.TCPIngress{}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongPlugin"):
-		return &kongv1.KongPlugin{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1.KongPlugin{}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongClusterPlugin"):
-		return &kongv1.KongClusterPlugin{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1.KongClusterPlugin{}, nil
 	case kongv1.SchemeGroupVersion.WithKind("KongConsumer"):
-		return &kongv1.KongConsumer{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1.KongConsumer{}, nil
 	case kongv1beta1.SchemeGroupVersion.WithKind("KongConsumerGroup"):
-		return &kongv1beta1.KongConsumerGroup{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1beta1.KongConsumerGroup{}, nil
 	case kongv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"):
-		return &kongv1alpha1.IngressClassParameters{
-			TypeMeta: typeMetaFromGVK(gvk),
-		}, nil
+		return &kongv1alpha1.IngressClassParameters{}, nil
 	default:
 		return nil, fmt.Errorf("%s is not a supported runtime.Object", gvk)
-	}
-}
-
-func typeMetaFromGVK(gvk schema.GroupVersionKind) metav1.TypeMeta {
-	return metav1.TypeMeta{
-		APIVersion: gvk.GroupVersion().String(),
-		Kind:       gvk.Kind,
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -71,15 +71,22 @@ spec:
 	assert.NoError(t, err)
 	assert.False(t, exists)
 
+	var got interface{}
 	t.Log("ensuring that we can Get() the objects back out of the cache store")
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "httpbin-deployment"}}
 	ing := &netv1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "httpbin-ingress"}}
-	_, exists, err = cs.Get(svc)
+	got, exists, err = cs.Get(svc)
 	assert.NoError(t, err)
 	assert.True(t, exists)
-	_, exists, err = cs.Get(ing)
+	gotSvc, ok := got.(*corev1.Service)
+	require.True(t, ok)
+	require.NotEmpty(t, gotSvc.TypeMeta.Kind)
+	got, exists, err = cs.Get(ing)
 	assert.NoError(t, err)
 	assert.True(t, exists)
+	gotIng, ok := got.(*netv1.Ingress)
+	require.True(t, ok)
+	require.NotEmpty(t, gotIng.TypeMeta.Kind)
 }
 
 func TestGetIngressClassHandling(t *testing.T) {

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +16,49 @@ limitations under the License.
 
 package util
 
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/scheme"
+)
+
 // Endpoint describes a kubernetes endpoint, same as a target in Kong.
 type Endpoint struct {
 	// Address IP address of the endpoint
 	Address string `json:"address"`
 	// Port number of the TCP port
 	Port string `json:"port"`
+}
+
+// TypeMeta is stripped after unmarshaling into Go struct due to the issue described in
+// https://github.com/kubernetes/kubernetes/issues/3030, but we need it for various purposes.
+
+// This function is adopted from https://github.com/kubernetes/cli-runtime/blob/v0.28.2/pkg/printers/typesetter.go#L39-L72
+// It has been modified to remove the io.Writer output and to use the scheme package directly instead of the Typer helper.
+
+// PopulateTypeMeta adds GVK information to a runtime.Object that may not have it available in the object TypeMeta.
+func PopulateTypeMeta(obj runtime.Object) error {
+	s, err := scheme.Get()
+	if err != nil {
+		return fmt.Errorf("could not build scheme: %w", err)
+	}
+	gvks, _, err := s.ObjectKinds(obj)
+	if err != nil {
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %v", err)
+	}
+
+	for _, gvk := range gvks {
+		if len(gvk.Kind) == 0 {
+			continue
+		}
+		if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Expands TypeMeta population (see [earlier work](https://github.com/Kong/kubernetes-ingress-controller/commit/663ed219c48c1e02b07d624e3439ab20332510a9)). Predicting where we'll need this isn't always easy, so just stuffing it in every controller to be safe.

Add TypeMeta population to controller reference predicates.

Use a scheme-based helper to populate TypeMeta from a runtime.object instead of local GVK helpers or pre-defined objects.

Adds a test to confirm credentials update properly.

**Which issue this PR fixes**:

The added test breaks without the predicate changes. Updating a credential Secret (and presumably other referenced Secrets) after its initial load would not modify Kong configuration.

We [add referent Secrets directly to the store](https://github.com/Kong/kubernetes-ingress-controller/blob/v2.12.0/internal/controllers/reference/reference.go#L52-L54) from reference updaters, This populates the Secret initially, but future updates need to run through the Secret reconciler. The reconciler predicate was not building the reference key properly without TypeMeta and would never reconcile Secrets with references.

**Special notes for your reviewer**:

Ideally we could centralize TypeMeta injection, but I don't think we can (barring an upstream fix). I initially tried adding it to `store.Add()`, but this doesn't work for anything that might need it in the reconciler. AFAIK there's nowhere in controller-runtime that'd let us add a global preprocessing step.

Trying to load manager configuration outside the manager results in a package import loop that I'm not particularly inclined to untangle. Removing feature gates for the scheme builder should be fine, since simply being aware of types doesn't do anything on its own.

This came out of research on https://github.com/Kong/kubernetes-ingress-controller/issues/4672, but I'm still not fully sure why outdated CRDs trigger this. I suspect that the issue is somewhere in [the reference builder store update](https://github.com/Kong/kubernetes-ingress-controller/blob/v2.12.0/internal/controllers/reference/reference.go#L52-L54) since the predicate was never working, and that updater is seemingly the only way into the store that bypasses the reconciler.

Sadly, my reproduction steps (disable CRD installation in the test harness, `helm install wat kong/kong --version 2.13.1; helm delete` to get the old CRDs, install consumer group CRD and GWAPI) stopped reproducing the issue after I located this second store insert path, so I wasn't able to explore it fully.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
