### PR TITLE
chore: remove deprecated KongIngress functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ Adding a new version? You'll need three changes:
   [#4749](https://github.com/Kong/kubernetes-ingress-controller/pull/4749)
 - Removed Knative support.
   [#4748](https://github.com/Kong/kubernetes-ingress-controller/pull/4748)
+- Removed support for deprecated `KongIngress` fields: `Proxy` and `Route`. Respective
+  `Service` or `Ingress` annotations should be used instead. See [KIC Annotations reference].
+  [#4760](https://github.com/Kong/kubernetes-ingress-controller/pull/4760)
 
 ### Fixed
 
@@ -98,6 +101,8 @@ Adding a new version? You'll need three changes:
 - Get rid of deprecation warning in logs for unsupported label `global: true` for `KongPlugin`,
   it'll be treated as any other label without a special meaning.
   [#4737](https://github.com/Kong/kubernetes-ingress-controller/pull/4737)
+
+[KIC Annotations reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/
 
 ## 2.12.0
 

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -310,12 +310,12 @@ func (h RequestHandler) handleKongIngress(_ context.Context, request admissionv1
 	responseBuilder = responseBuilder.Allowed(true)
 
 	if kongIngress.Proxy != nil {
-		const warning = "'proxy' is DEPRECATED. Use Service's annotations instead."
+		const warning = "'proxy' is DEPRECATED. It will have no effect. Use Service's annotations instead."
 		responseBuilder = responseBuilder.WithWarning(warning)
 	}
 
 	if kongIngress.Route != nil {
-		const warning = "'route' is DEPRECATED. Use Ingress' annotations instead."
+		const warning = "'route' is DEPRECATED. It will have no effect. Use Ingress' annotations instead."
 		responseBuilder = responseBuilder.WithWarning(warning)
 	}
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -196,30 +196,11 @@ func (ks *KongState) FillConsumerGroups(_ logrus.FieldLogger, s store.Storer) {
 func (ks *KongState) FillOverrides(log logrus.FieldLogger, s store.Storer) {
 	for i := 0; i < len(ks.Services); i++ {
 		// Services
-		kongIngress, err := getKongIngressForServices(s, ks.Services[i].K8sServices)
-		if err != nil {
-			log.WithError(err).
-				Errorf("failed to fetch KongIngress resource for Services %s",
-					PrettyPrintServiceList(ks.Services[i].K8sServices),
-				)
-			continue
-		}
-
-		for _, svc := range ks.Services[i].K8sServices {
-			ks.Services[i].override(log, kongIngress, svc)
-		}
+		ks.Services[i].override()
 
 		// Routes
 		for j := 0; j < len(ks.Services[i].Routes); j++ {
-			kongIngress, err := getKongIngressFromObjectMeta(s, ks.Services[i].Routes[j].Ingress)
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"resource_name":      ks.Services[i].Routes[j].Ingress.Name,
-					"resource_namespace": ks.Services[i].Routes[j].Ingress.Namespace,
-				}).WithError(err).Errorf("failed to fetch KongIngress resource")
-			}
-
-			ks.Services[i].Routes[j].override(log, kongIngress)
+			ks.Services[i].Routes[j].override(log)
 		}
 	}
 

--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
 // Route represents a Kong Route and holds a reference to the Ingress
@@ -250,104 +248,13 @@ func (r *Route) overrideByAnnotation(log logrus.FieldLogger) {
 }
 
 // override sets Route fields by KongIngress first, then by annotation.
-func (r *Route) override(log logrus.FieldLogger, kongIngress *kongv1.KongIngress) {
+func (r *Route) override(log logrus.FieldLogger) {
 	if r == nil {
 		return
 	}
 
-	// Check if we're trying to get KongIngress configuration based on an annotation
-	// on Gateway API object (this would most likely happen for *Route objects but
-	// log a warning for all other Gateway API objects as well since that also should
-	// not happen) and if that's the case then skip it since those should not be
-	// affected by said annotation.
-	if gvk := r.Ingress.GroupVersionKind; gvk.Group == gatewayv1alpha2.GroupName && kongIngress != nil {
-		log.WithFields(logrus.Fields{
-			"resource_name":      r.Ingress.Name,
-			"resource_namespace": r.Ingress.Namespace,
-			"resource_kind":      gvk.Kind,
-		}).Warn("KongIngress annotation is not allowed on Gateway API objects.")
-		return
-	}
-
-	r.overrideByKongIngress(log, kongIngress)
 	r.overrideByAnnotation(log)
 	r.normalizeProtocols()
-}
-
-// overrideByKongIngress sets Route fields by KongIngress.
-func (r *Route) overrideByKongIngress(log logrus.FieldLogger, kongIngress *kongv1.KongIngress) {
-	// disable overriding routes by KongIngress if expression routes is enabled.
-	if r.ExpressionRoutes {
-		return
-	}
-
-	if kongIngress == nil || kongIngress.Route == nil {
-		return
-	}
-
-	ir := kongIngress.Route
-	if len(ir.Methods) != 0 {
-		invalid := false
-		var methods []*string
-		for _, method := range ir.Methods {
-			sanitizedMethod := strings.TrimSpace(strings.ToUpper(*method))
-			if validMethods.MatchString(sanitizedMethod) {
-				methods = append(methods, kong.String(sanitizedMethod))
-			} else {
-				// if any method is invalid (not an uppercase alpha string),
-				// discard everything
-				log.WithFields(logrus.Fields{
-					"ingress_namespace": r.Ingress.Namespace,
-					"ingress_name":      r.Ingress.Name,
-				}).Errorf("ingress contains invalid method: '%v'", *method)
-				invalid = true
-			}
-		}
-		if !invalid {
-			r.Methods = methods
-		}
-	}
-	if len(ir.Headers) != 0 {
-		r.Headers = ir.Headers
-	}
-	if len(ir.Protocols) != 0 {
-		r.Protocols = protocolPointersToStringPointers(ir.Protocols)
-	}
-	if ir.RegexPriority != nil {
-		r.RegexPriority = kong.Int(*ir.RegexPriority)
-	}
-	if ir.StripPath != nil {
-		r.StripPath = kong.Bool(*ir.StripPath)
-	}
-	if ir.PreserveHost != nil {
-		r.PreserveHost = kong.Bool(*ir.PreserveHost)
-	}
-	if ir.HTTPSRedirectStatusCode != nil {
-		r.HTTPSRedirectStatusCode = kong.Int(*ir.HTTPSRedirectStatusCode)
-	}
-	if ir.PathHandling != nil {
-		r.PathHandling = kong.String(*ir.PathHandling)
-	}
-	if len(ir.SNIs) != 0 {
-		var SNIs []*string
-		for _, unsanitizedSNI := range ir.SNIs {
-			SNI := strings.TrimSpace(*unsanitizedSNI)
-			if validSNIs.MatchString(SNI) {
-				SNIs = append(SNIs, kong.String(SNI))
-			} else {
-				// SNI is not a valid hostname
-				log.WithField("kongroute", r.Name).Errorf("invalid SNI: %v", unsanitizedSNI)
-				return
-			}
-		}
-		r.SNIs = SNIs
-	}
-	if ir.RequestBuffering != nil {
-		r.RequestBuffering = kong.Bool(*ir.RequestBuffering)
-	}
-	if ir.ResponseBuffering != nil {
-		r.ResponseBuffering = kong.Bool(*ir.ResponseBuffering)
-	}
 }
 
 // overrideRequestBuffering ensures defaults for the request_buffering option.

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -7,22 +7,23 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 )
 
 func TestOverrideService(t *testing.T) {
-	assert := assert.New(t)
-
-	testTable := []struct {
-		inService      Service
-		inKongIngresss kongv1.KongIngress
-		outService     Service
-		inAnnotation   map[string]string
+	testCases := []struct {
+		name                  string
+		inService             Service
+		k8sServiceAnnotations map[string]string
+		expectedService       Service
 	}{
 		{
-			Service{
+			name: "no overrides",
+			inService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -31,10 +32,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{},
-			},
-			Service{
+			expectedService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -43,10 +41,11 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			map[string]string{},
+			k8sServiceAnnotations: map[string]string{},
 		},
 		{
-			Service{
+			name: "override protocol to https",
+			inService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -55,12 +54,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("https"),
-				},
-			},
-			Service{
+			expectedService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -69,10 +63,13 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			map[string]string{},
+			k8sServiceAnnotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.ProtocolKey: "https",
+			},
 		},
 		{
-			Service{
+			name: "override retries to 0",
+			inService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -81,12 +78,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Retries: kong.Int(0),
-				},
-			},
-			Service{
+			expectedService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -96,10 +88,13 @@ func TestOverrideService(t *testing.T) {
 					Retries:  kong.Int(0),
 				},
 			},
-			map[string]string{},
+			k8sServiceAnnotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.RetriesKey: "0",
+			},
 		},
 		{
-			Service{
+			name: "override retries to 1",
+			inService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -108,38 +103,7 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Path: kong.String("/new-path"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("http"),
-					Path:     kong.String("/new-path"),
-				},
-			},
-			map[string]string{},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("http"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Retries: kong.Int(1),
-				},
-			},
-			Service{
+			expectedService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -149,10 +113,13 @@ func TestOverrideService(t *testing.T) {
 					Retries:  kong.Int(1),
 				},
 			},
-			map[string]string{},
+			k8sServiceAnnotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.RetriesKey: "1",
+			},
 		},
 		{
-			Service{
+			name: "override path",
+			inService: Service{
 				Service: kong.Service{
 					Host:     kong.String("foo.com"),
 					Port:     kong.Int(80),
@@ -161,14 +128,31 @@ func TestOverrideService(t *testing.T) {
 					Path:     kong.String("/"),
 				},
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					ConnectTimeout: kong.Int(100),
-					ReadTimeout:    kong.Int(100),
-					WriteTimeout:   kong.Int(100),
+			expectedService: Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("http"),
+					Path:     kong.String("/new-path"),
 				},
 			},
-			Service{
+			k8sServiceAnnotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.PathKey: "/new-path",
+			},
+		},
+		{
+			name: "override connect timeout, read timeout, write timeout",
+			inService: Service{
+				Service: kong.Service{
+					Host:     kong.String("foo.com"),
+					Port:     kong.Int(80),
+					Name:     kong.String("foo"),
+					Protocol: kong.String("http"),
+					Path:     kong.String("/"),
+				},
+			},
+			expectedService: Service{
 				Service: kong.Service{
 					Host:           kong.String("foo.com"),
 					Port:           kong.Int(80),
@@ -180,206 +164,33 @@ func TestOverrideService(t *testing.T) {
 					WriteTimeout:   kong.Int(100),
 				},
 			},
-			map[string]string{},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpc"),
-					Path:     nil,
-				},
+			k8sServiceAnnotations: map[string]string{
+				annotations.AnnotationPrefix + annotations.ConnectTimeoutKey: "100",
+				annotations.AnnotationPrefix + annotations.ReadTimeoutKey:    "100",
+				annotations.AnnotationPrefix + annotations.WriteTimeoutKey:   "100",
 			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("grpc"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpc"),
-					Path:     nil,
-				},
-			},
-			map[string]string{},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     nil,
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("grpcs"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpcs"),
-					Path:     nil,
-				},
-			},
-			map[string]string{},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("grpcs"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpcs"),
-					Path:     nil,
-				},
-			},
-			map[string]string{"konghq.com/protocol": "grpcs"},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("grpcs"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpc"),
-					Path:     nil,
-				},
-			},
-			map[string]string{"konghq.com/protocol": "grpc"},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("grpcs"),
-					Path:     nil,
-				},
-			},
-			map[string]string{"konghq.com/protocol": "grpcs"},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{
-					Protocol: kong.String("grpcs"),
-				},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			map[string]string{"konghq.com/protocol": "https"},
-		},
-		{
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			kongv1.KongIngress{
-				Proxy: &kongv1.KongIngressService{},
-			},
-			Service{
-				Service: kong.Service{
-					Host:     kong.String("foo.com"),
-					Port:     kong.Int(80),
-					Name:     kong.String("foo"),
-					Protocol: kong.String("https"),
-					Path:     kong.String("/"),
-				},
-			},
-			map[string]string{"konghq.com/protocol": "https"},
 		},
 	}
 
-	for _, testcase := range testTable {
-		testcase := testcase
+	for _, tc := range testCases {
+		tc := tc
 		log := logrus.New()
 		log.SetOutput(io.Discard)
 
-		k8sServices := testcase.inService.K8sServices
-		for _, svc := range k8sServices {
-			testcase.inService.override(log, &testcase.inKongIngresss, svc)
-			assert.Equal(testcase.inService, testcase.outService)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			service := tc.inService
+			for _, k8sSvc := range service.K8sServices {
+				service.overrideByAnnotation(k8sSvc.Annotations)
+				require.Equal(t, tc.expectedService.Service, service.Service)
+			}
+		})
 	}
+}
 
-	assert.NotPanics(func() {
-		log := logrus.New()
-		log.SetOutput(io.Discard)
-
+func TestNilServiceOverrideDoesntPanic(t *testing.T) {
+	require.NotPanics(t, func() {
 		var nilService *Service
-		nilService.override(log, nil, nil)
+		nilService.override()
 	})
 }
 
@@ -688,4 +499,38 @@ func TestOverrideRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServiceOverride_DeterministicOrderWhenMoreThan1KubernetesService(t *testing.T) {
+	service := Service{
+		Service: kong.Service{},
+		K8sServices: map[string]*corev1.Service{
+			"default/service-3": {
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.RetriesKey: "3",
+					},
+				},
+			},
+			"default/service-1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.RetriesKey: "1",
+					},
+				},
+			},
+			"default/service-2": {
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.RetriesKey: "2",
+					},
+				},
+			},
+		},
+	}
+
+	// We expect default/service-3 to be the last one to be processed effectively overriding the previous annotations.
+	const expectedRetries = 3
+	service.override()
+	require.Equal(t, expectedRetries, *service.Service.Retries)
 }

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -151,13 +151,6 @@ func kongPluginFromK8SClusterPlugin(
 	}, nil
 }
 
-func protocolPointersToStringPointers(protocols []*kongv1.KongProtocol) (res []*string) {
-	for _, protocol := range protocols {
-		res = append(res, kong.String(string(*protocol)))
-	}
-	return
-}
-
 func protocolsToStrings(protocols []kongv1.KongProtocol) (res []string) {
 	for _, protocol := range protocols {
 		res = append(res, string(protocol))

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -9,24 +9,20 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
-func TestKongIngressEssentials(t *testing.T) {
+func TestServiceOverrides(t *testing.T) {
 	skipTestForExpressionRouter(t)
 	ctx := context.Background()
 
@@ -45,10 +41,10 @@ func TestKongIngressEssentials(t *testing.T) {
 	}()
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
-	c, err := clientset.NewForConfig(env.Cluster().Config())
-	assert.NoError(t, err)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	service.Annotations = map[string]string{"konghq.com/override": testName}
+	service.Annotations = map[string]string{
+		annotations.AnnotationPrefix + annotations.ReadTimeoutKey: "1000",
+	}
 	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -69,33 +65,7 @@ func TestKongIngressEssentials(t *testing.T) {
 		assert.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
 	}()
 
-	t.Logf("applying service overrides to Service %s via KongIngress", service.Name)
-	king := &kongv1.KongIngress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: ns.Name,
-			Annotations: map[string]string{
-				annotations.IngressClassKey: consts.IngressClass,
-			},
-		},
-		Proxy: &kongv1.KongIngressService{
-			ReadTimeout: kong.Int(1000),
-		},
-	}
-	king, err = c.ConfigurationV1().KongIngresses(ns.Name).Create(ctx, king, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	defer func() {
-		t.Logf("ensuring that KongIngress %s is cleaned up", king.Name)
-		if err := c.ConfigurationV1().KongIngresses(ns.Name).Delete(ctx, king.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				require.NoError(t, err)
-			}
-		}
-	}()
-
 	t.Log("waiting for routes from Ingress to be operational and that overrides are in place")
-
 	assert.Eventually(t, func() bool {
 		// Even though the HTTP client has a timeout of 10s, it should never be hit,
 		// we expect a 504 from the proxy within 1000ms
@@ -111,7 +81,7 @@ func TestKongIngressEssentials(t *testing.T) {
 	svc, err := env.Cluster().Client().CoreV1().Services(ns.Name).Get(ctx, service.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	anns := svc.GetAnnotations()
-	delete(anns, "konghq.com/override")
+	delete(anns, annotations.AnnotationPrefix+annotations.ReadTimeoutKey)
 	svc.SetAnnotations(anns)
 	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Update(ctx, svc, metav1.UpdateOptions{})
 	assert.NoError(t, err)

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -79,8 +79,8 @@ func TestKongIngressValidationWebhook(t *testing.T) {
 		assert.NoError(t, result.Error())
 		require.Len(t, result.Warnings(), 2)
 		expectedWarnings := []string{
-			"'route' is DEPRECATED. Use Ingress' annotations instead.",
-			"'proxy' is DEPRECATED. Use Service's annotations instead.",
+			"'route' is DEPRECATED. It will have no effect. Use Ingress' annotations instead.",
+			"'proxy' is DEPRECATED. It will have no effect. Use Service's annotations instead.",
 		}
 		receivedWarnings := lo.Map(result.Warnings(), func(item net.WarningHeader, index int) string {
 			return item.Text


### PR DESCRIPTION
**What this PR does / why we need it**:

Stops respecting deprecated `KongIngress` `Proxy` and `Route` fields and aligns tests to use annotations in favor of `KongIngress`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3018 and https://github.com/Kong/kubernetes-ingress-controller/issues/4740.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
