### PR TITLE
tests(integration): remove clusterVersion and test skipping code for EOLd k8s versions

### DIFF
--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
@@ -197,10 +196,6 @@ func TestGRPCIngressEssentials(t *testing.T) {
 }
 
 func TestIngressClassNameSpec(t *testing.T) {
-	if clusterVersion.Major < uint64(2) && clusterVersion.Minor < uint64(19) {
-		t.Skip("ingress spec tests can not be properly validated against old clusters")
-	}
-
 	t.Parallel()
 	t.Log("locking IngressClass management")
 	ingressClassMutex.Lock()
@@ -351,10 +346,6 @@ func TestIngressNamespaces(t *testing.T) {
 }
 
 func TestIngressStatusUpdatesExtended(t *testing.T) {
-	if clusterVersion.Major == uint64(1) && clusterVersion.Minor < uint64(19) {
-		t.Skip("status test disabled for old cluster versions")
-	}
-
 	t.Parallel()
 
 	ctx := context.Background()
@@ -484,13 +475,6 @@ func TestIngressStatusUpdatesExtended(t *testing.T) {
 // stop working altogether.
 func TestIngressClassRegexToggle(t *testing.T) {
 	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ExplicitRegexPathVersionCutoff), "regex prefixes are only relevant for Kong 3.0+")
-
-	// skip the test if the cluster does not support namespaced ingress class parameter (<=1.21).
-	// since 1.21 is End of Life now.
-	namespacedIngressClassParameterMinKubernetesVersion := semver.MustParse("1.22.0")
-	if clusterVersion.LT(namespacedIngressClassParameterMinKubernetesVersion) {
-		t.Skipf("kubernetes cluster version %s does not support namespaced ingress class parameters", clusterVersion.String())
-	}
 
 	t.Log("locking IngressClass management")
 	ingressClassMutex.Lock()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -101,8 +101,7 @@ func TestMain(m *testing.M) {
 		builder.WithAddons(metallb.New())
 
 		if testenv.ClusterVersion() != "" {
-			var err error
-			clusterVersion, err = semver.Parse(strings.TrimPrefix(testenv.ClusterVersion(), "v"))
+			clusterVersion, err := semver.Parse(strings.TrimPrefix(testenv.ClusterVersion(), "v"))
 			exitOnErr(ctx, err)
 
 			fmt.Printf("INFO: build a new KIND cluster with version %s\n", clusterVersion.String())
@@ -120,9 +119,6 @@ func TestMain(m *testing.M) {
 			fmt.Printf("ERROR: failed cleaning up the cluster: %v\n", err)
 		}
 	}()
-
-	clusterVersion, err = env.Cluster().Version()
-	exitOnErr(ctx, err)
 
 	exitOnErr(ctx, DeployAddonsForCluster(ctx, env.Cluster()))
 	fmt.Printf("INFO: waiting for cluster %s and all addons to become ready\n", env.Cluster().Name())
@@ -230,6 +226,9 @@ func TestMain(m *testing.M) {
 		fmt.Println("WARN: should run these cases separately to prevent config being affected by invalid cases")
 		runInvalidConfigTests = true
 	}
+
+	clusterVersion, err := env.Cluster().Version()
+	exitOnErr(ctx, err)
 
 	fmt.Printf("INFO: testing environment is ready KUBERNETES_VERSION=(%v): running tests\n", clusterVersion)
 	code = m.Run()

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
@@ -32,9 +31,6 @@ var (
 
 	// proxyUDPURL provides access to the UDP API endpoint for the Kong Addon which is deployed to the test environment's cluster.
 	proxyUDPURL *url.URL
-
-	// clusterVersion is a convenience var where the found version of the env.Cluster is stored.
-	clusterVersion semver.Version
 
 	// runInvalidConfigTests is set to true to run the test cases including invalid test cases.
 	runInvalidConfigTests bool


### PR DESCRIPTION
**What this PR does / why we need it**:

Code that was using `clusterVersion` was mostly around skipping tests for k8s `<=1.21` or `<1.19` and since we don't tests on those versions anymore we can get rid of that.
