### PR TITLE
feat(telemetry) add Kong router flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ Adding a new version? You'll need three changes:
 - Get rid of deprecation warning in logs for unsupported label `global: true` for `KongPlugin`,
   it'll be treated as any other label without a special meaning.
   [#4737](https://github.com/Kong/kubernetes-ingress-controller/pull/4737)
+- Telemetry now reports the router flavor.
+  [#4762](https://github.com/Kong/kubernetes-ingress-controller/pull/4762)
 
 [KIC Annotations reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/
 

--- a/internal/manager/telemetry/reports.go
+++ b/internal/manager/telemetry/reports.go
@@ -78,11 +78,17 @@ func SetupAnonymousReports(
 	if !ok {
 		return nil, fmt.Errorf("malformed database configuration found in Kong client root")
 	}
+	routerFlavor, ok := cfg["router_flavor"].(string)
+	if !ok {
+		// version to old to use router flavor, de facto traditional
+		routerFlavor = "traditional"
+	}
 
 	fixedPayload := Payload{
 		"v":  metadata.Release,
 		"kv": kongVersion,
 		"db": kongDB,
+		"rf": routerFlavor,
 		"id": instanceIDProvider.GetID(), // universal unique identifier for this system
 	}
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -361,6 +361,7 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"feature-rewriteuris=false;"+
 			"hn=%s;"+
 			"kv=3.3.0;"+
+			"rf=traditional;"+
 			"v=NOT_SET;"+
 			"k8s_arch=%s;"+
 			"k8s_provider=UNKNOWN;"+

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -79,14 +79,14 @@ func TestTelemetry(t *testing.T) {
 		waitTime = 3 * time.Second
 		tickTime = 10 * time.Millisecond
 	)
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
 		select {
 		case report := <-reportChan:
 			return verifyTelemetryReport(t, k8sVersion, string(report))
 		case <-time.After(tickTime):
 			return false
 		}
-	}, waitTime, tickTime)
+	}, waitTime, tickTime, "telemetry report never matched expected value")
 }
 
 func configForEnvTestTelemetry(t *testing.T, envcfg *rest.Config, splunkEndpoint string, telemetryPeriod time.Duration) manager.Config {
@@ -340,7 +340,8 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 	for _, s := range []string{"id", "uptime"} {
 		report, err = removeStanzaFromReport(report, s)
 		if err != nil {
-			t.Logf("failed to remove stanza %q from report: %s", s, err)
+			// this normally happens during shutdown, when the report is an empty string
+			// no point in proceeding if so
 			return false
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes the router flavor in reports.

**Special notes for your reviewer**:

Tests normally can't run telemetry against a real instance, so an example with that flipped in `KONG_TEST_EXPRESSION_ROUTES=true KONG_TEST_CLUSTER=kind:kind GOFLAGS="-tags=integration_tests" dlv test ./test/integration`

```
(dlv) p cfg["router_flavor"]
interface {}(string) "traditional"
(dlv) n
> github.com/kong/kubernetes-ingress-controller/v2/internal/manager/telemetry.SetupAnonymousReports() ./internal/manager/telemetry/reports.go:82 (PC: 0x3e0a70a)
    77:		kongDB, ok := cfg["database"].(string)
    78:		if !ok {
    79:			return nil, fmt.Errorf("malformed database configuration found in Kong client root")
    80:		}
    81:		routerFlavor, ok := cfg["router_flavor"].(string)
=>  82:		if !ok {
    83:			// version to old to use router flavor, de facto traditional
    84:			routerFlavor = "traditional"
    85:		}
    86:	
    87:		fixedPayload := Payload{
(dlv) p ok
true
...
(dlv) p fixedPayload
github.com/kong/kubernetes-telemetry/pkg/types.ProviderReport [
	"v": "NOT_SET", 
	"kv": "3.3.1", 
	"db": "off", 
	"r": "traditional", 
	"id": github.com/google/uuid.UUID [100,208,215,11,47,138,78,62,175,54,171,192,93,253,54,188], 
]
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
