### PR TITLE
Fix inconsistent route order test flake in `TestParserSNI`

### DIFF
--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -2940,6 +2940,18 @@ func TestParserSNI(t *testing.T) {
 		state.Services[0].Routes[0].Route.Tags = nil
 		state.Services[0].Routes[1].Route.Tags = nil
 		assert.Equal(t, kong.Route{
+			Name:              kong.String("default.foo.foo-svc.example.com.80"),
+			StripPath:         kong.Bool(false),
+			RegexPriority:     kong.Int(0),
+			ResponseBuffering: kong.Bool(true),
+			RequestBuffering:  kong.Bool(true),
+			Hosts:             kong.StringSlice("example.com"),
+			PreserveHost:      kong.Bool(true),
+			Paths:             kong.StringSlice("/"),
+			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("99296cc1-ab30-59f8-b204-7b1a45e64cac"),
+		}, state.Services[0].Routes[0].Route)
+		assert.Equal(t, kong.Route{
 			Name:              kong.String("default.foo.foo-svc._.example.com.80"),
 			StripPath:         kong.Bool(false),
 			RegexPriority:     kong.Int(0),
@@ -2951,18 +2963,6 @@ func TestParserSNI(t *testing.T) {
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
 			ID:                kong.String("cbdfe994-15d4-5336-909a-e302ed66e19a"),
-		}, state.Services[0].Routes[0].Route)
-		assert.Equal(t, kong.Route{
-			Name:              kong.String("default.foo.foo-svc.example.com.80"),
-			StripPath:         kong.Bool(false),
-			RegexPriority:     kong.Int(0),
-			ResponseBuffering: kong.Bool(true),
-			RequestBuffering:  kong.Bool(true),
-			Hosts:             kong.StringSlice("example.com"),
-			PreserveHost:      kong.Bool(true),
-			Paths:             kong.StringSlice("/"),
-			Protocols:         kong.StringSlice("http", "https"),
-			ID:                kong.String("99296cc1-ab30-59f8-b204-7b1a45e64cac"),
 		}, state.Services[0].Routes[1].Route)
 	})
 	t.Run("route does not include SNI when TLS info absent", func(t *testing.T) {

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -2940,18 +2940,6 @@ func TestParserSNI(t *testing.T) {
 		state.Services[0].Routes[0].Route.Tags = nil
 		state.Services[0].Routes[1].Route.Tags = nil
 		assert.Equal(t, kong.Route{
-			Name:              kong.String("default.foo.foo-svc.example.com.80"),
-			StripPath:         kong.Bool(false),
-			RegexPriority:     kong.Int(0),
-			ResponseBuffering: kong.Bool(true),
-			RequestBuffering:  kong.Bool(true),
-			Hosts:             kong.StringSlice("example.com"),
-			PreserveHost:      kong.Bool(true),
-			Paths:             kong.StringSlice("/"),
-			Protocols:         kong.StringSlice("http", "https"),
-			ID:                kong.String("99296cc1-ab30-59f8-b204-7b1a45e64cac"),
-		}, state.Services[0].Routes[0].Route)
-		assert.Equal(t, kong.Route{
 			Name:              kong.String("default.foo.foo-svc._.example.com.80"),
 			StripPath:         kong.Bool(false),
 			RegexPriority:     kong.Int(0),
@@ -2963,6 +2951,18 @@ func TestParserSNI(t *testing.T) {
 			Paths:             kong.StringSlice("/"),
 			Protocols:         kong.StringSlice("http", "https"),
 			ID:                kong.String("cbdfe994-15d4-5336-909a-e302ed66e19a"),
+		}, state.Services[0].Routes[0].Route)
+		assert.Equal(t, kong.Route{
+			Name:              kong.String("default.foo.foo-svc.example.com.80"),
+			StripPath:         kong.Bool(false),
+			RegexPriority:     kong.Int(0),
+			ResponseBuffering: kong.Bool(true),
+			RequestBuffering:  kong.Bool(true),
+			Hosts:             kong.StringSlice("example.com"),
+			PreserveHost:      kong.Bool(true),
+			Paths:             kong.StringSlice("/"),
+			Protocols:         kong.StringSlice("http", "https"),
+			ID:                kong.String("99296cc1-ab30-59f8-b204-7b1a45e64cac"),
 		}, state.Services[0].Routes[1].Route)
 	})
 	t.Run("route does not include SNI when TLS info absent", func(t *testing.T) {

--- a/internal/util/stringheap.go
+++ b/internal/util/stringheap.go
@@ -1,0 +1,28 @@
+package util
+
+// StringHeap is an array of strings that implements container/heap.Interface.
+type StringHeap []string
+
+func (h StringHeap) Len() int {
+	return len(h)
+}
+
+func (h StringHeap) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+func (h StringHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *StringHeap) Push(s any) {
+	*h = append(*h, s.(string))
+}
+
+func (h *StringHeap) Pop() any {
+	old := *h
+	n := len(old)
+	s := old[n-1]
+	*h = old[0 : n-1]
+	return s
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use a consistent order for the routes attached to a service in the parser. This makes tests that care about the route index not flaky.

**Which issue this PR fixes**:

TestParserSNI began failing recently, e.g. https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6407581302/job/17394681361

The origin of the flake isn't clear, but https://github.com/Kong/kubernetes-ingress-controller/commit/23de4f571cfb10ded96043b47fc83c28918ef38c seems the most likely candidate for introducing it based on date and affected code.

**Special notes for your reviewer**:

This is, oddly enough, the only parser test that uses multiple indices. We could alternately look up the routes by name for this test and not change anything in the translator. IDK how likely we'd be to add other affected tests in the future, or how much we'd care about the small bit of essentially wasted CPU time to avoid it.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ only fixes tests for an unreleased change
