### PR TITLE
feat(expression router): implement query parameter match of HTTPRoute

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -49,6 +49,9 @@ jobs:
         env:
           JUNIT_REPORT: "conformance-tests.xml"
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
+          # TODO: remove this until we use kong:3.4 as default in Kong Addon of KTF
+          TEST_KONG_IMAGE: kong
+          TEST_KONG_TAG: "3.4"
 
       - name: collect test report
         if: ${{ always() }}

--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -49,9 +49,6 @@ jobs:
         env:
           JUNIT_REPORT: "conformance-tests.xml"
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
-          # TODO: remove this until we use kong:3.4 as default in Kong Addon of KTF
-          TEST_KONG_IMAGE: kong
-          TEST_KONG_TAG: "3.4"
 
       - name: collect test report
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,8 +159,7 @@ Adding a new version? You'll need three changes:
   - `--publish-service-udp` to `--ingress-service-udp`
   - `--publish-status-address-udp` to `--ingress-address-udp`
   [#4765](https://github.com/Kong/kubernetes-ingress-controller/pull/4765)
-- Support Query Parameter matching of `HTTPRoute` with Kong 3.4.1 and above and
-  expression router enabled.
+- Support Query Parameter matching of `HTTPRoute` when expression router enabled.
   [#4780](https://github.com/Kong/kubernetes-ingress-controller/pull/4780)
 
 [KIC Annotations reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,9 @@ Adding a new version? You'll need three changes:
   - `--publish-service-udp` to `--ingress-service-udp`
   - `--publish-status-address-udp` to `--ingress-address-udp`
   [#4765](https://github.com/Kong/kubernetes-ingress-controller/pull/4765)
+- Support Query Parameter matching of `HTTPRoute` with Kong 3.4.1 and above and
+  expression router enabled.
+  [#4780](https://github.com/Kong/kubernetes-ingress-controller/pull/4780)
 
 [KIC Annotations reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/
 

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -33,7 +33,7 @@ func ValidateHTTPRoute(
 	attachedGateways ...*gatewayapi.Gateway,
 ) (bool, string, error) {
 	// validate that no unsupported features are in use
-	if err := validateHTTPRouteFeatures(httproute); err != nil {
+	if err := validateHTTPRouteFeatures(httproute, parserFeatures); err != nil {
 		return false, "httproute spec did not pass validation", err
 	}
 
@@ -95,13 +95,15 @@ func validateHTTPRouteListener(listener *gatewayapi.Listener) error {
 // validateHTTPRouteFeatures checks for features that are not supported by this
 // HTTPRoute implementation and validates that the provided object is not using
 // any of those unsupported features.
-func validateHTTPRouteFeatures(httproute *gatewayapi.HTTPRoute) error {
+func validateHTTPRouteFeatures(httproute *gatewayapi.HTTPRoute, parserFeatures parser.FeatureFlags) error {
 	for _, rule := range httproute.Spec.Rules {
 		for _, match := range rule.Matches {
 			// We don't support query parameters matching rules yet
 			// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 			if len(match.QueryParams) != 0 {
-				return fmt.Errorf("queryparam matching is not yet supported for httproute")
+				if !parserFeatures.ExpressionRoutes {
+					return fmt.Errorf("queryparam matching is not supported with expression router only")
+				}
 			}
 		}
 		// We don't support any backendRef types except Kubernetes Services.

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -99,7 +99,6 @@ func validateHTTPRouteFeatures(httproute *gatewayapi.HTTPRoute, parserFeatures p
 	for _, rule := range httproute.Spec.Rules {
 		for _, match := range rule.Matches {
 			// We support query parameters matching rules only with expression router.
-			// See: https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 			if len(match.QueryParams) != 0 {
 				if !parserFeatures.ExpressionRoutes {
 					return fmt.Errorf("queryparam matching is supported with expression router only")

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -98,11 +98,11 @@ func validateHTTPRouteListener(listener *gatewayapi.Listener) error {
 func validateHTTPRouteFeatures(httproute *gatewayapi.HTTPRoute, parserFeatures parser.FeatureFlags) error {
 	for _, rule := range httproute.Spec.Rules {
 		for _, match := range rule.Matches {
-			// We don't support query parameters matching rules yet
-			// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3679
+			// We support query parameters matching rules only with expression router.
+			// See: https://github.com/Kong/kubernetes-ingress-controller/issues/3679
 			if len(match.QueryParams) != 0 {
 				if !parserFeatures.ExpressionRoutes {
-					return fmt.Errorf("queryparam matching is not supported with expression router only")
+					return fmt.Errorf("queryparam matching is supported with expression router only")
 				}
 			}
 		}

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 func TestValidateHTTPRoute(t *testing.T) {
@@ -254,7 +255,8 @@ func TestValidateHTTPRoute(t *testing.T) {
 			}},
 			valid:         false,
 			validationMsg: "httproute spec did not pass validation",
-			err:           fmt.Errorf("queryparam matching is not yet supported for httproute"),
+			err: fmt.Errorf("queryparam matching is only supported for httproute with Kong %s and expression router",
+				versions.QueryParameterVersionCutoff),
 		},
 		{
 			msg: "we don't support any group except core kubernetes for backendRefs",

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 func TestValidateHTTPRoute(t *testing.T) {
@@ -205,7 +204,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 			err:           fmt.Errorf("HTTPRoute not supported by listener http-alternate"),
 		},
 		{
-			msg: "if an HTTPRoute is using queryparams matching it fails validation due to lack of support",
+			msg: "if an HTTPRoute is using queryparams matching it fails validation due to only supporting expression router",
 			route: &gatewayapi.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: corev1.NamespaceDefault,
@@ -255,8 +254,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 			}},
 			valid:         false,
 			validationMsg: "httproute spec did not pass validation",
-			err: fmt.Errorf("queryparam matching is only supported for httproute with Kong %s and expression router",
-				versions.QueryParameterVersionCutoff),
+			err:           fmt.Errorf("queryparam matching is supported with expression router only"),
 		},
 		{
 			msg: "we don't support any group except core kubernetes for backendRefs",

--- a/internal/dataplane/parser/atc/field.go
+++ b/internal/dataplane/parser/atc/field.go
@@ -80,3 +80,17 @@ func (f HTTPHeaderField) FieldType() FieldType {
 func (f HTTPHeaderField) String() string {
 	return "http.headers." + strings.ToLower(strings.ReplaceAll(f.HeaderName, "-", "_"))
 }
+
+// HTTPQueryField extracts the value of an HTTP query string from the request.
+// available since Kong 3.4.1.
+type HTTPQueryField struct {
+	QueryParamName string
+}
+
+func (f HTTPQueryField) FieldType() FieldType {
+	return FieldTypeString
+}
+
+func (f HTTPQueryField) String() string {
+	return "http.queries." + f.QueryParamName
+}

--- a/internal/dataplane/parser/atc/field.go
+++ b/internal/dataplane/parser/atc/field.go
@@ -81,8 +81,7 @@ func (f HTTPHeaderField) String() string {
 	return "http.headers." + strings.ToLower(strings.ReplaceAll(f.HeaderName, "-", "_"))
 }
 
-// HTTPQueryField extracts the value of an HTTP query string from the request.
-// available since Kong 3.4.1.
+// HTTPQueryField extracts the value of an HTTP query parameter from the query string of the request.
 type HTTPQueryField struct {
 	QueryParamName string
 }

--- a/internal/dataplane/parser/atc/predicate.go
+++ b/internal/dataplane/parser/atc/predicate.go
@@ -197,3 +197,13 @@ func NewPredicateTLSSNI(op BinaryOperator, value string) Predicate {
 		value: StringLiteral(value),
 	}
 }
+
+func NewPredicateHTTPQuery(key string, op BinaryOperator, value string) Predicate {
+	return Predicate{
+		field: HTTPQueryField{
+			QueryParamName: key,
+		},
+		op:    op,
+		value: StringLiteral(value),
+	}
+}

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -202,7 +202,7 @@ func GenerateKongRouteFromTranslation(
 	)
 }
 
-// generateKongRoutesFromHTTPRouteMatches converts an HTTPRouteMatches to a slice of Kong Route objects.
+// generateKongRoutesFromHTTPRouteMatches converts an HTTPRouteMatches to a slice of Kong Route objects with traditional routes.
 // This function assumes that the HTTPRouteMatches share the query params, headers and methods.
 func generateKongRoutesFromHTTPRouteMatches(
 	routeName string,
@@ -232,8 +232,9 @@ func generateKongRoutesFromHTTPRouteMatches(
 		return []kongstate.Route{r}, nil
 	}
 
-	// Kong starts to support query parameter match since 3.4.1 with expression router
-	// so with traditional/traditional compatible router, we do not support query parameter match.
+	// Kong starts to support query parameter match since 3.4.1 with expression router.
+	// This function is only called for Kong with traditional/traditional compatible router,
+	// so we do not support query parameter match here.
 	if len(matches[0].QueryParams) > 0 {
 		return []kongstate.Route{}, translators.ErrRouteValidationQueryParamMatchesUnsupported
 	}

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -232,7 +232,8 @@ func generateKongRoutesFromHTTPRouteMatches(
 		return []kongstate.Route{r}, nil
 	}
 
-	// TODO: implement query param matches (https://github.com/Kong/kubernetes-ingress-controller/issues/2778)
+	// Kong starts to support query parameter match since 3.4.1 with expression router
+	// so with traditional/traditional compatible router, we do not support query parameter match.
 	if len(matches[0].QueryParams) > 0 {
 		return []kongstate.Route{}, translators.ErrRouteValidationQueryParamMatchesUnsupported
 	}

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -232,7 +232,7 @@ func generateKongRoutesFromHTTPRouteMatches(
 		return []kongstate.Route{r}, nil
 	}
 
-	// Kong starts to support query parameter match since 3.4.1 with expression router.
+	// Kong supports query parameter match only with expression router.
 	// This function is only called for Kong with traditional/traditional compatible router,
 	// so we do not support query parameter match here.
 	if len(matches[0].QueryParams) > 0 {

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -226,7 +226,7 @@ func queryParamMatcherFromHTTPQueryParamMatch(queryParamMatch gatewayapi.HTTPQue
 }
 
 func queryParamMatcherFromHTTPQueryParamMatches(queryParamMatches []gatewayapi.HTTPQueryParamMatch) atc.Matcher {
-	// sort queryParamMatches by names to generate a stable output.
+	// Sort queryParamMatches by names to generate a stable output.
 	sort.Slice(queryParamMatches, func(i, j int) bool {
 		return string(queryParamMatches[i].Name) < string(queryParamMatches[j].Name)
 	})

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -134,6 +134,7 @@ func generateMatcherFromHTTPRouteMatch(match gatewayapi.HTTPRouteMatch) atc.Matc
 		matcher.And(headerMatcher)
 	}
 
+	// REVIEW: Since KIC 3.0.0 only support Kong 3.4.1 and above, could we omit the check of Kong version here?
 	if len(match.QueryParams) > 0 {
 		queryMatcher := queryParamMatcherFromHTTPQueryParamMatches(match.QueryParams)
 		matcher.And(queryMatcher)

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -134,7 +134,6 @@ func generateMatcherFromHTTPRouteMatch(match gatewayapi.HTTPRouteMatch) atc.Matc
 		matcher.And(headerMatcher)
 	}
 
-	// REVIEW: Since KIC 3.0.0 only support Kong 3.4.1 and above, could we omit the check of Kong version here?
 	if len(match.QueryParams) > 0 {
 		queryMatcher := queryParamMatcherFromHTTPQueryParamMatches(match.QueryParams)
 		matcher.And(queryMatcher)

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -318,6 +318,14 @@ func TestGenerateMatcherFromHTTPRouteMatch(t *testing.T) {
 				Build(),
 			expression: `((http.path == "/prefix/0") || (http.path ^= "/prefix/0/")) && ((http.headers.hash ~ "[0-9A-Fa-f]{32}") && (http.headers.x_foo == "Bar"))`,
 		},
+		{
+			name: "prefix path match and multiple query params",
+			match: builder.NewHTTPRouteMatch().WithPathPrefix("/prefix/0").
+				WithQueryParam("foo", "bar").
+				WithQueryParamRegex("id", "[0-9a-z-]+").
+				Build(),
+			expression: `((http.path == "/prefix/0") || (http.path ^= "/prefix/0/")) && ((http.queries.foo == "bar") && (http.queries.id ~ "[0-9a-z-]+"))`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -140,6 +140,8 @@ const (
 	PathMatchExact                        = gatewayv1beta1.PathMatchExact
 	PathMatchPathPrefix                   = gatewayv1beta1.PathMatchPathPrefix
 	PathMatchRegularExpression            = gatewayv1beta1.PathMatchRegularExpression
+	QueryParamMatchExact                  = gatewayv1beta1.QueryParamMatchExact
+	QueryParamMatchRegularExpression      = gatewayv1beta1.QueryParamMatchRegularExpression
 	RouteConditionAccepted                = gatewayv1beta1.RouteConditionAccepted
 	RouteConditionResolvedRefs            = gatewayv1beta1.RouteConditionResolvedRefs
 	RouteReasonAccepted                   = gatewayv1beta1.RouteReasonAccepted

--- a/internal/util/builder/httproutematch.go
+++ b/internal/util/builder/httproutematch.go
@@ -56,6 +56,15 @@ func (b *HTTPRouteMatchBuilder) WithQueryParam(name, value string) *HTTPRouteMat
 	return b
 }
 
+func (b *HTTPRouteMatchBuilder) WithQueryParamRegex(name, value string) *HTTPRouteMatchBuilder {
+	b.httpRouteMatch.QueryParams = append(b.httpRouteMatch.QueryParams, gatewayapi.HTTPQueryParamMatch{
+		Type:  lo.ToPtr(gatewayapi.QueryParamMatchRegularExpression),
+		Name:  gatewayapi.HTTPHeaderName(name),
+		Value: value,
+	})
+	return b
+}
+
 func (b *HTTPRouteMatchBuilder) WithMethod(method gatewayapi.HTTPMethod) *HTTPRouteMatchBuilder {
 	b.httpRouteMatch.Method = &method
 	return b

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -25,8 +25,6 @@ var commonSkippedTests = []string{
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4563
 	tests.GatewayWithAttachedRoutesWithPort8080.ShortName,
 	tests.HTTPRouteRedirectPortAndScheme.ShortName,
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/3679
-	tests.HTTPRouteQueryParamMatching.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3681
 	tests.HTTPRouteRedirectPort.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3682
@@ -62,6 +60,8 @@ var (
 		// cannot support the path > method > header precedence,
 		// but no way to omit individual cases.
 		tests.HTTPRouteMethodMatching.ShortName,
+		// only expression router supports query param matches
+		tests.HTTPRouteQueryParamMatching.ShortName,
 	)
 )
 

--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -43,6 +43,7 @@ func TestGatewayExperimentalConformance(t *testing.T) {
 				SupportedFeatures: sets.New(
 					suite.SupportHTTPRouteMethodMatching,
 					suite.SupportHTTPResponseHeaderModification,
+					suite.SupportHTTPRouteQueryParamMatching,
 				),
 			},
 			ConformanceProfiles: sets.New(

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -200,7 +199,6 @@ func TestHTTPRouteEssentials(t *testing.T) {
 
 	t.Run("HTTPRoute query param match", func(t *testing.T) {
 		RunWhenKongExpressionRouter(t)
-		RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.QueryParameterVersionCutoff))
 
 		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -198,7 +198,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	})
 
 	t.Run("HTTPRoute query param match", func(t *testing.T) {
-		RunWhenKongExpressionRouter(t)
+		RunWhenKongExpressionRouter(t) //nolint:contextcheck
 
 		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Log("verifying HTTPRoute query param match")
-		helpers.EventuallyGETPath(t, proxyURL, "?foo=bar", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
+		helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/?foo=bar", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
 	})
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True'")

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -194,6 +196,29 @@ func TestHTTPRouteEssentials(t *testing.T) {
 
 		t.Log("verifying HTTPRoute header match")
 		helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
+	})
+
+	t.Run("HTTPRoute query param match", func(t *testing.T) {
+		RunWhenKongExpressionRouter(t)
+		RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.QueryParameterVersionCutoff))
+
+		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		httpRoute.Spec.Rules[0].Matches = append(httpRoute.Spec.Rules[0].Matches, gatewayapi.HTTPRouteMatch{
+			QueryParams: []gatewayapi.HTTPQueryParamMatch{
+				{
+					Type:  lo.ToPtr(gatewayapi.QueryParamMatchExact),
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+		})
+		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		t.Log("verifying HTTPRoute query param match")
+		helpers.EventuallyGETPath(t, proxyURL, "?foo=bar", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
 	})
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True'")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

implement query parameter matching in `HTTPRoute`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3679 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
