### PR TITLE
tests: use `ingressClass` spec field instead of a deprecated `kubernetes.io/ingress.class` annotation

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
@@ -451,7 +452,7 @@ func TestDefaultIngressClass(t *testing.T) {
 
 	t.Logf("creating a classless ingress for service %s", service.Name)
 	ingress := generators.NewIngressForService("/abbosiysaltanati", map[string]string{
-		"konghq.com/strip-path": "true",
+		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 	}, service)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), kongDeployment.Namespace, ingress))
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 	"github.com/kong/deck/dump"
-	gokong "github.com/kong/go-kong/kong"
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/loadimage"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
@@ -428,10 +428,10 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
 	ingress := generators.NewIngressForService(echoPath, map[string]string{
-		annotations.IngressClassKey:                             ingressClass,
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 		annotations.AnnotationPrefix + annotations.MethodsKey:   http.MethodGet,
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(ingressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
 	return ingress
 }
@@ -516,7 +516,7 @@ func verifyIngressWithEchoBackendsPath(
 func verifyIngressWithEchoBackendsInAdminAPI(
 	ctx context.Context,
 	t *testing.T,
-	kongClient *gokong.Client,
+	kongClient *kong.Client,
 	noReplicas int,
 ) {
 	t.Helper()

--- a/test/integration/config_error_event_test.go
+++ b/test/integration/config_error_event_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -54,11 +54,11 @@ func TestConfigErrorEventGeneration(t *testing.T) {
 	t.Logf("creating an ingress for service %s with invalid configuration", service.Name)
 	// GRPC routes cannot have methods, only HTTP, and we don't catch this as a translation error
 	ingress := generators.NewIngressForService("/bar", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
-		"konghq.com/protocols":      "grpcs",
-		"konghq.com/methods":        "GET",
+		"konghq.com/strip-path": "true",
+		"konghq.com/protocols":  "grpcs",
+		"konghq.com/methods":    "GET",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 
 	t.Log("deploying ingress")
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/require"
@@ -196,10 +197,10 @@ func deployMinimalSvcWithKeyAuth(
 
 	t.Logf("creating an ingress for service %q with plugin %q attached", service.Name, pluginKeyAuthName)
 	ingress := generators.NewIngressForService("/", map[string]string{
-		annotations.IngressClassKey:                             consts.IngressClass,
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 		annotations.AnnotationPrefix + annotations.PluginsKey:   pluginKeyAuthName,
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), namespace, ingress))
 	return deployment, service, ingress, pluginKeyAuth
 }

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
@@ -47,9 +48,9 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
 	ingress := generators.NewIngressForService("/test_consumer_credential", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)
 

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
@@ -53,10 +53,10 @@ func TestHTTPSRedirect(t *testing.T) {
 
 	t.Logf("exposing Service %s via Ingress", service.Name)
 	ingress := generators.NewIngressForService("/test_https_redirect", map[string]string{
-		annotations.IngressClassKey:             consts.IngressClass,
 		"konghq.com/protocols":                  "https",
 		"konghq.com/https-redirect-status-code": "301",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	assert.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)
 
@@ -122,13 +122,13 @@ func TestHTTPSIngress(t *testing.T) {
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
 	ingress1 := generators.NewIngressForService("/foo", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress1.Spec.IngressClassName = kong.String(consts.IngressClass)
 	ingress2 := generators.NewIngressForService("/bar", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress2.Spec.IngressClassName = kong.String(consts.IngressClass)
 
 	t.Log("configuring ingress tls spec")
 	ingress1.Spec.TLS = []netv1.IngressTLS{{SecretName: "secret1", Hosts: []string{"foo.example"}}}

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/assert"
@@ -55,9 +56,9 @@ func TestServiceOverrides(t *testing.T) {
 
 	t.Logf("routing to service %s via Ingress", service.Name)
 	ingress := generators.NewIngressForService("/test_kongingress_essentials", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 
 	defer func() {

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -49,9 +49,9 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
 	ingress := generators.NewIngressForService("/test_plugin_essentials", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)
 
@@ -181,9 +181,9 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
 	ingress := generators.NewIngressForService("/test_plugin_ordering", map[string]string{
-		annotations.IngressClassKey: consts.IngressClass,
-		"konghq.com/strip-path":     "true",
+		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)
 

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -413,11 +413,9 @@ func ingressWithPathBackedByService(service *corev1.Service) *netv1.Ingress {
 	return &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testutils.RandomName(testTranslationFailuresObjectsPrefix),
-			Annotations: map[string]string{
-				annotations.IngressClassKey: consts.IngressClass,
-			},
 		},
 		Spec: netv1.IngressSpec{
+			IngressClassName: kong.String(consts.IngressClass),
 			Rules: []netv1.IngressRule{
 				{
 					IngressRuleValue: netv1.IngressRuleValue{


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent warning logs like:

```
W1002 22:46:30.055335   14658 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

which are prevalent in integration and e2e tests let's use the spec field which has the same behaviour and is the recommended (not-deprecated) way of setting the ingress class on a net v1 `Ingress`.
