### PR TITLE
chore: use 'control plane' instead of 'runtime group' naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ lint: verify.tidy golangci-lint staticcheck looppointer
 staticcheck: staticcheck.download
 	# Workaround for staticcheck not supporting nolint directives, see: https://github.com/dominikh/go-tools/issues/822.
 	go list ./... | \
-		grep -F -e internal/konnect/runtimegroups -v | \
+		grep -F -e internal/konnect/controlplanes -v | \
 		xargs $(STATICCHECK) -tags envtest,e2e_tests,integration_tests,istio_tests,conformance_tests -f stylish
 
 looppointer: looppointer.download

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -62,7 +62,7 @@
 | `--konnect-license-polling-period` | `duration` | Polling period to be used after the first license is retrieved. | `12h0m0s` |
 | `--konnect-licensing-enabled` | `bool` | Retrieve licenses from Konnect if available. Overrides licenses provided via the environment. | `false` |
 | `--konnect-refresh-node-period` | `duration` | Period of uploading status of KIC and controlled kong gateway instances. | `1m0s` |
-| `--konnect-sync-enabled` | `bool` | Enable synchronization of data plane configuration with a Konnect runtime group. | `false` |
+| `--konnect-sync-enabled` | `bool` | Enable synchronization of data plane configuration with a Konnect control plane. | `false` |
 | `--konnect-tls-client-cert` | `string` | Konnect TLS client certificate. |  |
 | `--konnect-tls-client-cert-file` | `string` | Konnect TLS client certificate file path. |  |
 | `--konnect-tls-client-key` | `string` | Konnect TLS client key. |  |

--- a/hack/cleanup/konnect_runtime_groups.go
+++ b/hack/cleanup/konnect_runtime_groups.go
@@ -10,39 +10,39 @@ import (
 	"github.com/oapi-codegen/runtime/types"
 	"github.com/samber/lo"
 
+	cp "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/controlplanes"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/roles"
-	rg "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroups"
 )
 
 const (
-	konnectRuntimeGroupsBaseURL     = "https://us.kic.api.konghq.tech/v2"
-	konnectRuntimeGroupsLimit       = 100
+	konnectControlPlanesBaseURL     = "https://us.kic.api.konghq.tech/v2"
+	konnectControlPlanesLimit       = 100
 	konnectRolesBaseURL             = "https://global.api.konghq.tech/v2"
-	createdInTestsRuntimeGroupLabel = "created_in_tests"
-	timeUntilRuntimeGroupOrphaned   = time.Hour
+	createdInTestsControlPlaneLabel = "created_in_tests"
+	timeUntilControlPlaneOrphaned   = time.Hour
 )
 
-// cleanupKonnectRuntimeGroups deletes orphaned runtime groups created by the tests and their roles.
-func cleanupKonnectRuntimeGroups(ctx context.Context) error {
-	rgClient, err := rg.NewClientWithResponses(konnectRuntimeGroupsBaseURL, rg.WithRequestEditorFn(
+// cleanupKonnectControlPlanes deletes orphaned control planes created by the tests and their roles.
+func cleanupKonnectControlPlanes(ctx context.Context) error {
+	cpClient, err := cp.NewClientWithResponses(konnectControlPlanesBaseURL, cp.WithRequestEditorFn(
 		func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
 			return nil
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create runtime groups client: %w", err)
+		return fmt.Errorf("failed to create control planes client: %w", err)
 	}
 
-	orphanedRGs, err := findOrphanedRuntimeGroups(ctx, rgClient)
+	orphanedCPs, err := findOrphanedControlPlanes(ctx, cpClient)
 	if err != nil {
-		return fmt.Errorf("failed to find orphaned runtime groups: %w", err)
+		return fmt.Errorf("failed to find orphaned control planes: %w", err)
 	}
-	if err := deleteRuntimeGroups(ctx, orphanedRGs, rgClient); err != nil {
-		return fmt.Errorf("failed to delete runtime groups: %w", err)
+	if err := deleteControlPlanes(ctx, orphanedCPs, cpClient); err != nil {
+		return fmt.Errorf("failed to delete control planes: %w", err)
 	}
 
-	// We have to manually delete roles created for the runtime group because Konnect doesn't do it automatically.
+	// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
 	// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
 	// because of a performance issue when there's too many roles for the account
 	// (see https://konghq.atlassian.net/browse/TPS-1319).
@@ -50,88 +50,88 @@ func cleanupKonnectRuntimeGroups(ctx context.Context) error {
 	// We can drop this once the automated cleanup is implemented on Konnect side:
 	// https://konghq.atlassian.net/browse/TPS-1453.
 	rolesClient := roles.NewClient(&http.Client{}, konnectRolesBaseURL, konnectAccessToken)
-	rolesToDelete, err := findOrphanedRolesToDelete(ctx, orphanedRGs, rolesClient)
+	rolesToDelete, err := findOrphanedRolesToDelete(ctx, orphanedCPs, rolesClient)
 	if err != nil {
-		return fmt.Errorf("failed to list runtime group roles to delete: %w", err)
+		return fmt.Errorf("failed to list control plane roles to delete: %w", err)
 	}
 	if err := deleteRoles(ctx, rolesToDelete, rolesClient); err != nil {
-		return fmt.Errorf("failed to delete runtime group roles: %w", err)
+		return fmt.Errorf("failed to delete control plane roles: %w", err)
 	}
 
 	return nil
 }
 
-// findOrphanedRuntimeGroups finds runtime groups that were created by the tests and are older than timeUntilRuntimeGroupOrphaned.
-func findOrphanedRuntimeGroups(ctx context.Context, c *rg.ClientWithResponses) ([]types.UUID, error) {
-	response, err := c.ListRuntimeGroupsWithResponse(ctx, &rg.ListRuntimeGroupsParams{
-		PageSize: lo.ToPtr(konnectRuntimeGroupsLimit),
+// findOrphanedControlPlanes finds control planes that were created by the tests and are older than timeUntilControlPlaneOrphaned.
+func findOrphanedControlPlanes(ctx context.Context, c *cp.ClientWithResponses) ([]types.UUID, error) {
+	response, err := c.ListControlPlanesWithResponse(ctx, &cp.ListControlPlanesParams{
+		PageSize: lo.ToPtr(konnectControlPlanesLimit),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list runtime groups: %w", err)
+		return nil, fmt.Errorf("failed to list control planes: %w", err)
 	}
 	if response.JSON200 == nil {
-		return nil, fmt.Errorf("failed to list runtime groups, status: %s, body: %s", response.Status(), string(response.Body))
+		return nil, fmt.Errorf("failed to list control planes, status: %s, body: %s", response.Status(), string(response.Body))
 	}
 	if response.JSON200 == nil || response.JSON200.Data == nil {
 		return nil, fmt.Errorf("no data in the response, status: %s, body: %s", response.Status(), string(response.Body))
 	}
 
-	var orphanedRuntimeGroups []types.UUID
-	for _, runtimeGroup := range *response.JSON200.Data {
-		if runtimeGroup.Labels == nil || (*runtimeGroup.Labels)[createdInTestsRuntimeGroupLabel] != "true" {
-			log.Infof("runtime group %s was not created by the tests, skipping\n", *runtimeGroup.Name)
+	var orphanedControlPlanes []types.UUID
+	for _, ControlPlane := range *response.JSON200.Data {
+		if ControlPlane.Labels == nil || (*ControlPlane.Labels)[createdInTestsControlPlaneLabel] != "true" {
+			log.Infof("control plane %s was not created by the tests, skipping\n", *ControlPlane.Name)
 			continue
 		}
-		if runtimeGroup.CreatedAt == nil {
-			log.Infof("runtime group %s has no creation timestamp, skipping\n", *runtimeGroup.Name)
+		if ControlPlane.CreatedAt == nil {
+			log.Infof("control plane %s has no creation timestamp, skipping\n", *ControlPlane.Name)
 			continue
 		}
-		orphanedAfter := (*runtimeGroup.CreatedAt).Add(timeUntilRuntimeGroupOrphaned)
+		orphanedAfter := (*ControlPlane.CreatedAt).Add(timeUntilControlPlaneOrphaned)
 		if !time.Now().After(orphanedAfter) {
-			log.Infof("runtime group %s is not old enough to be considered orphaned, created at %s, skipping\n", *runtimeGroup.Name, *runtimeGroup.CreatedAt)
+			log.Infof("control plane %s is not old enough to be considered orphaned, created at %s, skipping\n", *ControlPlane.Name, *ControlPlane.CreatedAt)
 			continue
 		}
-		orphanedRuntimeGroups = append(orphanedRuntimeGroups, *runtimeGroup.Id)
+		orphanedControlPlanes = append(orphanedControlPlanes, *ControlPlane.Id)
 	}
-	return orphanedRuntimeGroups, nil
+	return orphanedControlPlanes, nil
 }
 
-// deleteRuntimeGroups deletes runtime groups by their IDs.
-func deleteRuntimeGroups(ctx context.Context, rgsIDs []types.UUID, c *rg.ClientWithResponses) error {
-	if len(rgsIDs) < 1 {
-		log.Info("no runtime groups to clean up")
+// deleteControlPlanes deletes control planes by their IDs.
+func deleteControlPlanes(ctx context.Context, cpsIDs []types.UUID, c *cp.ClientWithResponses) error {
+	if len(cpsIDs) < 1 {
+		log.Info("no control planes to clean up")
 		return nil
 	}
 
 	var errs []error
-	for _, rgID := range rgsIDs {
-		log.Infof("deleting runtime group %s\n", rgID)
-		if _, err := c.DeleteRuntimeGroupWithResponse(ctx, rgID); err != nil {
-			errs = append(errs, fmt.Errorf("failed to delete runtime group %s: %w", rgID, err))
+	for _, cpID := range cpsIDs {
+		log.Infof("deleting control plane %s\n", cpID)
+		if _, err := c.DeleteControlPlaneWithResponse(ctx, cpID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete control plane %s: %w", cpID, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// findOrphanedRolesToDelete gets a list of roles that belong to the orphaned runtime groups.
-func findOrphanedRolesToDelete(ctx context.Context, orphanedRGsIDs []types.UUID, rolesClient *roles.Client) ([]string, error) {
-	if len(orphanedRGsIDs) < 1 {
-		log.Info("no runtime groups to clean up, skipping listing roles")
+// findOrphanedRolesToDelete gets a list of roles that belong to the orphaned control planes.
+func findOrphanedRolesToDelete(ctx context.Context, orphanedCPsIDs []types.UUID, rolesClient *roles.Client) ([]string, error) {
+	if len(orphanedCPsIDs) < 1 {
+		log.Info("no control planes to clean up, skipping listing roles")
 		return nil, nil
 	}
 
-	existingRoles, err := rolesClient.ListRuntimeGroupsRoles(ctx)
+	existingRoles, err := rolesClient.ListControlPlanesRoles(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list runtime group roles: %w", err)
+		return nil, fmt.Errorf("failed to list control plane roles: %w", err)
 	}
 
 	var rolesIDsToDelete []string
 	for _, role := range existingRoles {
-		belongsToOrphanedRuntimeGroup := lo.ContainsBy(orphanedRGsIDs, func(rgID types.UUID) bool {
-			return rgID.String() == role.EntityID
+		belongsToOrphanedControlPlane := lo.ContainsBy(orphanedCPsIDs, func(cpID types.UUID) bool {
+			return cpID.String() == role.EntityID
 		})
-		if !belongsToOrphanedRuntimeGroup {
-			log.Infof("role %s is not assigned to an orphaned runtime group, skipping\n", role.ID)
+		if !belongsToOrphanedControlPlane {
+			log.Infof("role %s is not assigned to an orphaned control plane, skipping\n", role.ID)
 			continue
 		}
 		rolesIDsToDelete = append(rolesIDsToDelete, role.ID)

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -9,15 +9,15 @@
 // 1. Its name begins with a predefined prefix (`gke-e2e-`).
 // 2. It was created more than 1h ago.
 //
-// A runtime group is considered orphaned when all conditions are satisfied:
+// A control plane is considered orphaned when all conditions are satisfied:
 // 1. It has a label `created_in_tests` with value `true`.
 // 2. It was created more than 1h ago.
 //
 // Usage: `go run ./hack/cleanup [mode]`
 // Where `mode` is one of:
-// - `all` (default): clean up both GKE clusters and Konnect runtime groups
+// - `all` (default): clean up both GKE clusters and Konnect control planes
 // - `gke`: clean up only GKE clusters
-// - `konnect`: clean up only Konnect runtime groups
+// - `konnect`: clean up only Konnect control planes
 package main
 
 import (
@@ -90,12 +90,12 @@ func resolveCleanupFuncs(mode string) []func(context.Context) error {
 		}
 	case cleanupModeKonnect:
 		return []func(context.Context) error{
-			cleanupKonnectRuntimeGroups,
+			cleanupKonnectControlPlanes,
 		}
 	default:
 		return []func(context.Context) error{
 			cleanupGKEClusters,
-			cleanupKonnectRuntimeGroups,
+			cleanupKonnectControlPlanes,
 		}
 	}
 }

--- a/internal/adminapi/backoff_strategy_konnect.go
+++ b/internal/adminapi/backoff_strategy_konnect.go
@@ -34,7 +34,7 @@ type Clock interface {
 //
 // It's important to note that KonnectBackoffStrategy can use the latter (config hash)
 // because of the nature of the one-directional integration where KIC is the only
-// component responsible for populating configuration of Konnect's Runtime Group.
+// component responsible for populating configuration of Konnect's Control Plane.
 // In case that changes in the future (e.g. manual modifications to parts of the
 // configuration are allowed on Konnect side for some reason), we might have to
 // drop this part of the backoff strategy.

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -23,7 +23,7 @@ type Client struct {
 	adminAPIClient      *kong.Client
 	pluginSchemaStore   *util.PluginSchemaStore
 	isKonnect           bool
-	konnectRuntimeGroup string
+	konnectControlPlane string
 	lastConfigSHA       []byte
 
 	// podRef (optional) describes the Pod that the Client communicates with.
@@ -53,13 +53,13 @@ type KonnectClient struct {
 	backoffStrategy UpdateBackoffStrategy
 }
 
-// NewKonnectClient creates an Admin API client that is to be used with a Konnect Runtime Group Admin API.
-func NewKonnectClient(c *kong.Client, runtimeGroup string) *KonnectClient {
+// NewKonnectClient creates an Admin API client that is to be used with a Konnect Control Plane Admin API.
+func NewKonnectClient(c *kong.Client, controlPlane string) *KonnectClient {
 	return &KonnectClient{
 		Client: Client{
 			adminAPIClient:      c,
 			isKonnect:           true,
-			konnectRuntimeGroup: runtimeGroup,
+			konnectControlPlane: controlPlane,
 			pluginSchemaStore:   util.NewPluginSchemaStore(c),
 		},
 		backoffStrategy: NewKonnectBackoffStrategy(clock.System{}),
@@ -139,19 +139,19 @@ func (c *Client) PluginSchemaStore() *util.PluginSchemaStore {
 	return c.pluginSchemaStore
 }
 
-// IsKonnect tells if a client is used for communication with Konnect Runtime Group Admin API.
+// IsKonnect tells if a client is used for communication with Konnect Control Plane Admin API.
 func (c *Client) IsKonnect() bool {
 	return c.isKonnect
 }
 
-// KonnectRuntimeGroup gets a unique identifier of a Konnect's Runtime Group that config should
+// KonnectControlPlane gets a unique identifier of a Konnect's Control Plane that config should
 // be synchronised with. Empty in case of non-Konnect clients.
-func (c *Client) KonnectRuntimeGroup() string {
+func (c *Client) KonnectControlPlane() string {
 	if !c.isKonnect {
 		return ""
 	}
 
-	return c.konnectRuntimeGroup
+	return c.konnectControlPlane
 }
 
 // SetLastConfigSHA overrides last config SHA.

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -31,7 +31,7 @@ type KonnectConfig struct {
 	LicensePollingPeriod          time.Duration
 }
 
-func NewKongClientForKonnectRuntimeGroup(c KonnectConfig) (*KonnectClient, error) {
+func NewKongClientForKonnectControlPlane(c KonnectConfig) (*KonnectClient, error) {
 	clientCertificate, err := tlsutil.ExtractClientCertificates(
 		[]byte(c.TLSClient.Cert),
 		c.TLSClient.CertFile,
@@ -100,7 +100,7 @@ func EnsureKonnectConnection(ctx context.Context, client *kong.Client, logger lo
 }
 
 // tagsStub replaces a default Tags service in the go-kong's Client for Konnect clients.
-// It will always tell tags are supported, which is true for Konnect Runtime Group Admin API.
+// It will always tell tags are supported, which is true for Konnect Control Plane Admin API.
 type tagsStub struct{}
 
 func (t tagsStub) Exists(context.Context) (bool, error) {

--- a/internal/adminapi/konnect_test.go
+++ b/internal/adminapi/konnect_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 )
 
-func TestNewKongClientForKonnectRuntimeGroup(t *testing.T) {
+func TestNewKongClientForKonnectControlPlane(t *testing.T) {
 	t.Skip("There's no infrastructure for Konnect tests yet")
 
 	ctx := context.Background()
-	const runtimeGroupID = "adf78c28-5763-4394-a9a4-a9436a1bea7d"
+	const controlPlaneID = "adf78c28-5763-4394-a9a4-a9436a1bea7d"
 
-	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
 		ConfigSynchronizationEnabled: true,
-		ControlPlaneID:               runtimeGroupID,
+		ControlPlaneID:               controlPlaneID,
 		Address:                      "https://us.kic.api.konghq.tech",
 		TLSClient: adminapi.TLSClientConfig{
 			Cert: os.Getenv("KONG_TEST_KONNECT_TLS_CLIENT_CERT"),
@@ -30,7 +30,7 @@ func TestNewKongClientForKonnectRuntimeGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, c.IsKonnect())
-	require.Equal(t, runtimeGroupID, c.KonnectRuntimeGroup())
+	require.Equal(t, controlPlaneID, c.KonnectControlPlane())
 
 	_, err = c.AdminAPIClient().Services.ListAll(ctx)
 	require.NoError(t, err)

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -66,7 +66,7 @@ type AdminAPIClientsManager struct {
 	readinessReconciliationTicker Ticker
 
 	// konnectClient represents a special-case of the data-plane which is Konnect cloud.
-	// This client is used to synchronise configuration with Konnect's Runtime Group Admin API.
+	// This client is used to synchronise configuration with Konnect's Control Plane Admin API.
 	konnectClient *adminapi.KonnectClient
 
 	// lock prevents concurrent access to the manager's fields.
@@ -150,7 +150,7 @@ func (c *AdminAPIClientsManager) Notify(discoveredAPIs []adminapi.DiscoveredAdmi
 	}
 }
 
-// SetKonnectClient sets a client that will be used to communicate with Konnect Runtime Group Admin API.
+// SetKonnectClient sets a client that will be used to communicate with Konnect Control Plane Admin API.
 // If called multiple times, it will override the client.
 func (c *AdminAPIClientsManager) SetKonnectClient(client *adminapi.KonnectClient) {
 	c.lock.Lock()

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -555,7 +555,7 @@ func (c *KongClient) sendToClient(
 }
 
 // SetConfigStatusNotifier sets a notifier which notifies subscribers about configuration sending results.
-// Currently it is used for uploading the node status to konnect runtime group.
+// Currently it is used for uploading the node status to konnect control plane.
 func (c *KongClient) SetConfigStatusNotifier(n clients.ConfigStatusNotifier) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -34,7 +34,7 @@ type AdminAPIClient interface {
 	PluginSchemaStore() *util.PluginSchemaStore
 
 	IsKonnect() bool
-	KonnectRuntimeGroup() string
+	KonnectControlPlane() string
 }
 
 // PerformUpdate writes `targetContent` to Kong Admin API specified by `kongConfig`.

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -36,7 +36,7 @@ type UpdateStrategy interface {
 
 type UpdateClient interface {
 	IsKonnect() bool
-	KonnectRuntimeGroup() string
+	KonnectControlPlane() string
 	AdminAPIClient() *kong.Client
 }
 
@@ -94,7 +94,7 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(client UpdateClient
 			adminAPIClient,
 			dump.Config{
 				SkipCACerts:         true,
-				KonnectControlPlane: client.KonnectRuntimeGroup(),
+				KonnectControlPlane: client.KonnectControlPlane(),
 			},
 			r.config.Version,
 			r.config.Concurrency,

--- a/internal/dataplane/sendconfig/strategy_test.go
+++ b/internal/dataplane/sendconfig/strategy_test.go
@@ -17,7 +17,7 @@ import (
 type clientMock struct {
 	isKonnect bool
 
-	konnectRuntimeGroupWasCalled bool
+	konnectControlPlaneWasCalled bool
 	adminAPIClientWasCalled      bool
 }
 
@@ -25,8 +25,8 @@ func (c *clientMock) IsKonnect() bool {
 	return c.isKonnect
 }
 
-func (c *clientMock) KonnectRuntimeGroup() string {
-	c.konnectRuntimeGroupWasCalled = true
+func (c *clientMock) KonnectControlPlane() string {
+	c.konnectControlPlaneWasCalled = true
 	return uuid.NewString()
 }
 
@@ -48,19 +48,19 @@ func TestDefaultUpdateStrategyResolver_ResolveUpdateStrategy(t *testing.T) {
 		isKonnect                     bool
 		inMemory                      bool
 		expectedStrategyType          string
-		expectKonnectRuntimeGroupCall bool
+		expectKonnectControlPlaneCall bool
 	}{
 		{
 			isKonnect:                     true,
 			inMemory:                      false,
 			expectedStrategyType:          "WithBackoff(DBMode)",
-			expectKonnectRuntimeGroupCall: true,
+			expectKonnectControlPlaneCall: true,
 		},
 		{
 			isKonnect:                     true,
 			inMemory:                      true,
 			expectedStrategyType:          "WithBackoff(DBMode)",
-			expectKonnectRuntimeGroupCall: true,
+			expectKonnectControlPlaneCall: true,
 		},
 		{
 			isKonnect:            false,
@@ -94,7 +94,7 @@ func TestDefaultUpdateStrategyResolver_ResolveUpdateStrategy(t *testing.T) {
 			strategy := resolver.ResolveUpdateStrategy(updateClient)
 			require.Equal(t, tc.expectedStrategyType, strategy.Type())
 			assert.True(t, client.adminAPIClientWasCalled)
-			assert.Equal(t, tc.expectKonnectRuntimeGroupCall, client.konnectRuntimeGroupWasCalled)
+			assert.Equal(t, tc.expectKonnectControlPlaneCall, client.konnectControlPlaneWasCalled)
 		})
 	}
 }

--- a/internal/konnect/controlplanes/client.go
+++ b/internal/konnect/controlplanes/client.go
@@ -5,7 +5,7 @@
 // until we have a proper Konnect API Go SDK: https://github.com/Kong/kubernetes-ingress-controller/issues/3550.
 
 //nolint:all
-package runtimegroups
+package controlplanes
 
 import (
 	"bytes"
@@ -79,22 +79,22 @@ type AdditionalErrorInformation_Item struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// CreateRuntimeGroupRequest The request schema for the create runtime group request.
-type CreateRuntimeGroupRequest struct {
-	// Description The description of the runtime group in Konnect.
+// CreateControlPlaneRequest The request schema for the create control plane request.
+type CreateControlPlaneRequest struct {
+	// Description The description of the control plane in Konnect.
 	Description *string `json:"description,omitempty"`
 
-	// Labels Labels to facilitate tagged search on runtime groups. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
+	// Labels Labels to facilitate tagged search on control planes. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
 	Labels *Labels `json:"labels,omitempty"`
 
-	// Name The name of the runtime group.
+	// Name The name of the control plane.
 	Name string `json:"name"`
 
-	// ClusterType is the type of cluster this runtime group is associated with.
+	// ClusterType is the type of cluster this control plane is associated with.
 	ClusterType ClusterType `json:"cluster_type,omitempty"`
 }
 
-// Labels Labels to facilitate tagged search on runtime groups. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
+// Labels Labels to facilitate tagged search on control planes. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
 type Labels map[string]string
 
 // PaginatedMeta Returns pagination information
@@ -112,8 +112,8 @@ type PaginatedMeta struct {
 	} `json:"page,omitempty"`
 }
 
-// RuntimeGroup The runtime group object contains information about a Kong control plane.
-type RuntimeGroup struct {
+// ControlPlane The control plane object contains information about a Kong control plane.
+type ControlPlane struct {
 	// Config CP configuration object for related access endpoints.
 	Config *struct {
 		// ControlPlaneEndpoint Control Plane Endpoint.
@@ -123,22 +123,22 @@ type RuntimeGroup struct {
 		TelemetryEndpoint *string `json:"telemetry_endpoint,omitempty"`
 	} `json:"config,omitempty"`
 
-	// CreatedAt An ISO-8604 timestamp representation of runtime group creation date.
+	// CreatedAt An ISO-8604 timestamp representation of control plane creation date.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 
-	// Description The description of the runtime group in Konnect.
+	// Description The description of the control plane in Konnect.
 	Description *string `json:"description,omitempty"`
 
-	// Id The runtime group ID.
+	// Id The control plane ID.
 	Id *openapi_types.UUID `json:"id,omitempty"`
 
-	// Labels Labels to facilitate tagged search on runtime groups. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
+	// Labels Labels to facilitate tagged search on control planes. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
 	Labels *Labels `json:"labels,omitempty"`
 
-	// Name The name of the runtime group.
+	// Name The name of the control plane.
 	Name *string `json:"name,omitempty"`
 
-	// UpdatedAt An ISO-8604 timestamp representation of runtime group update date.
+	// UpdatedAt An ISO-8604 timestamp representation of control plane update date.
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
@@ -163,15 +163,15 @@ type Status500 int
 // Status503 The HTTP status code.
 type Status503 int
 
-// UpdateRuntimeGroupRequest The request schema for the update runtime group request.
-type UpdateRuntimeGroupRequest struct {
-	// Description The description of the runtime group in Konnect.
+// UpdateControlPlaneRequest The request schema for the update control plane request.
+type UpdateControlPlaneRequest struct {
+	// Description The description of the control plane in Konnect.
 	Description *string `json:"description,omitempty"`
 
-	// Labels Labels to facilitate tagged search on runtime groups. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
+	// Labels Labels to facilitate tagged search on control planes. Keys must be of length 1-63 characters, and cannot start with 'kong', 'konnect', 'mesh', 'kic', or '_'.
 	Labels *Labels `json:"labels,omitempty"`
 
-	// Name The name of the runtime group.
+	// Name The name of the control plane.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -190,25 +190,25 @@ type PageNumber = int
 // PageSize defines model for PageSize.
 type PageSize = int
 
-// CreateRuntimeGroupResponse The runtime group object contains information about a Kong control plane.
-type CreateRuntimeGroupResponse = RuntimeGroup
+// CreateControlPlaneResponse The control plane object contains information about a Kong control plane.
+type CreateControlPlaneResponse = ControlPlane
 
-// ListRuntimeGroupsResponse defines model for ListRuntimeGroupsResponse.
-type ListRuntimeGroupsResponse struct {
-	Data *[]RuntimeGroup `json:"data,omitempty"`
+// ListControlPlanesResponse defines model for ListControlPlanesResponse.
+type ListControlPlanesResponse struct {
+	Data *[]ControlPlane `json:"data,omitempty"`
 
 	// Meta Returns pagination information
 	Meta *PaginatedMeta `json:"meta,omitempty"`
 }
 
-// RetrieveRuntimeGroupResponse The runtime group object contains information about a Kong control plane.
-type RetrieveRuntimeGroupResponse = RuntimeGroup
+// RetrieveControlPlaneResponse The control plane object contains information about a Kong control plane.
+type RetrieveControlPlaneResponse = ControlPlane
 
-// UpdateRuntimeGroupResponse The runtime group object contains information about a Kong control plane.
-type UpdateRuntimeGroupResponse = RuntimeGroup
+// UpdateControlPlaneResponse The control plane object contains information about a Kong control plane.
+type UpdateControlPlaneResponse = ControlPlane
 
-// ListRuntimeGroupsParams defines parameters for ListRuntimeGroups.
-type ListRuntimeGroupsParams struct {
+// ListControlPlanesParams defines parameters for ListControlPlanes.
+type ListControlPlanesParams struct {
 	// PageSize How many items to include in a page.
 	PageSize *PageSize `form:"page[size],omitempty" json:"page[size],omitempty"`
 
@@ -225,11 +225,11 @@ type ListRuntimeGroupsParams struct {
 	FilterNameContains *FilterByNameContains `form:"filter[name][contains],omitempty" json:"filter[name][contains],omitempty"`
 }
 
-// CreateRuntimeGroupJSONRequestBody defines body for CreateRuntimeGroup for application/json ContentType.
-type CreateRuntimeGroupJSONRequestBody = CreateRuntimeGroupRequest
+// CreateControlPlaneJSONRequestBody defines body for CreateControlPlane for application/json ContentType.
+type CreateControlPlaneJSONRequestBody = CreateControlPlaneRequest
 
-// UpdateRuntimeGroupJSONRequestBody defines body for UpdateRuntimeGroup for application/json ContentType.
-type UpdateRuntimeGroupJSONRequestBody = UpdateRuntimeGroupRequest
+// UpdateControlPlaneJSONRequestBody defines body for UpdateControlPlane for application/json ContentType.
+type UpdateControlPlaneJSONRequestBody = UpdateControlPlaneRequest
 
 // Getter for additional properties for AdditionalErrorInformation_Item. Returns the specified
 // element and whether it was found
@@ -402,28 +402,28 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
-	// ListRuntimeGroups request
-	ListRuntimeGroups(ctx context.Context, params *ListRuntimeGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListControlPlanes request
+	ListControlPlanes(ctx context.Context, params *ListControlPlanesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateRuntimeGroup request with any body
-	CreateRuntimeGroupWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateControlPlane request with any body
+	CreateControlPlaneWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateRuntimeGroup(ctx context.Context, body CreateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateControlPlane(ctx context.Context, body CreateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteRuntimeGroup request
-	DeleteRuntimeGroup(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteControlPlane request
+	DeleteControlPlane(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetRuntimeGroup request
-	GetRuntimeGroup(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetControlPlane request
+	GetControlPlane(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UpdateRuntimeGroup request with any body
-	UpdateRuntimeGroupWithBody(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UpdateControlPlane request with any body
+	UpdateControlPlaneWithBody(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpdateRuntimeGroup(ctx context.Context, id openapi_types.UUID, body UpdateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateControlPlane(ctx context.Context, id openapi_types.UUID, body UpdateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) ListRuntimeGroups(ctx context.Context, params *ListRuntimeGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRuntimeGroupsRequest(c.Server, params)
+func (c *Client) ListControlPlanes(ctx context.Context, params *ListControlPlanesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListControlPlanesRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -434,8 +434,8 @@ func (c *Client) ListRuntimeGroups(ctx context.Context, params *ListRuntimeGroup
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateRuntimeGroupWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateRuntimeGroupRequestWithBody(c.Server, contentType, body)
+func (c *Client) CreateControlPlaneWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateControlPlaneRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -446,8 +446,8 @@ func (c *Client) CreateRuntimeGroupWithBody(ctx context.Context, contentType str
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateRuntimeGroup(ctx context.Context, body CreateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateRuntimeGroupRequest(c.Server, body)
+func (c *Client) CreateControlPlane(ctx context.Context, body CreateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateControlPlaneRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -458,8 +458,8 @@ func (c *Client) CreateRuntimeGroup(ctx context.Context, body CreateRuntimeGroup
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteRuntimeGroup(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteRuntimeGroupRequest(c.Server, id)
+func (c *Client) DeleteControlPlane(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteControlPlaneRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -470,8 +470,8 @@ func (c *Client) DeleteRuntimeGroup(ctx context.Context, id openapi_types.UUID, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetRuntimeGroup(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetRuntimeGroupRequest(c.Server, id)
+func (c *Client) GetControlPlane(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetControlPlaneRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -482,8 +482,8 @@ func (c *Client) GetRuntimeGroup(ctx context.Context, id openapi_types.UUID, req
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateRuntimeGroupWithBody(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateRuntimeGroupRequestWithBody(c.Server, id, contentType, body)
+func (c *Client) UpdateControlPlaneWithBody(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateControlPlaneRequestWithBody(c.Server, id, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -494,8 +494,8 @@ func (c *Client) UpdateRuntimeGroupWithBody(ctx context.Context, id openapi_type
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateRuntimeGroup(ctx context.Context, id openapi_types.UUID, body UpdateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateRuntimeGroupRequest(c.Server, id, body)
+func (c *Client) UpdateControlPlane(ctx context.Context, id openapi_types.UUID, body UpdateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateControlPlaneRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -506,8 +506,8 @@ func (c *Client) UpdateRuntimeGroup(ctx context.Context, id openapi_types.UUID, 
 	return c.Client.Do(req)
 }
 
-// NewListRuntimeGroupsRequest generates requests for ListRuntimeGroups
-func NewListRuntimeGroupsRequest(server string, params *ListRuntimeGroupsParams) (*http.Request, error) {
+// NewListControlPlanesRequest generates requests for ListControlPlanes
+func NewListControlPlanesRequest(server string, params *ListControlPlanesParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -515,7 +515,7 @@ func NewListRuntimeGroupsRequest(server string, params *ListRuntimeGroupsParams)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/runtime-groups")
+	operationPath := fmt.Sprintf("/control-planes")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -617,19 +617,19 @@ func NewListRuntimeGroupsRequest(server string, params *ListRuntimeGroupsParams)
 	return req, nil
 }
 
-// NewCreateRuntimeGroupRequest calls the generic CreateRuntimeGroup builder with application/json body
-func NewCreateRuntimeGroupRequest(server string, body CreateRuntimeGroupJSONRequestBody) (*http.Request, error) {
+// NewCreateControlPlaneRequest calls the generic CreateControlPlane builder with application/json body
+func NewCreateControlPlaneRequest(server string, body CreateControlPlaneJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateRuntimeGroupRequestWithBody(server, "application/json", bodyReader)
+	return NewCreateControlPlaneRequestWithBody(server, "application/json", bodyReader)
 }
 
-// NewCreateRuntimeGroupRequestWithBody generates requests for CreateRuntimeGroup with any type of body
-func NewCreateRuntimeGroupRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateControlPlaneRequestWithBody generates requests for CreateControlPlane with any type of body
+func NewCreateControlPlaneRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -637,7 +637,7 @@ func NewCreateRuntimeGroupRequestWithBody(server string, contentType string, bod
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/runtime-groups")
+	operationPath := fmt.Sprintf("/control-planes")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -657,8 +657,8 @@ func NewCreateRuntimeGroupRequestWithBody(server string, contentType string, bod
 	return req, nil
 }
 
-// NewDeleteRuntimeGroupRequest generates requests for DeleteRuntimeGroup
-func NewDeleteRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.Request, error) {
+// NewDeleteControlPlaneRequest generates requests for DeleteControlPlane
+func NewDeleteControlPlaneRequest(server string, id openapi_types.UUID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -673,7 +673,7 @@ func NewDeleteRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.R
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/runtime-groups/%s", pathParam0)
+	operationPath := fmt.Sprintf("/control-planes/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -691,8 +691,8 @@ func NewDeleteRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.R
 	return req, nil
 }
 
-// NewGetRuntimeGroupRequest generates requests for GetRuntimeGroup
-func NewGetRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.Request, error) {
+// NewGetControlPlaneRequest generates requests for GetControlPlane
+func NewGetControlPlaneRequest(server string, id openapi_types.UUID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -707,7 +707,7 @@ func NewGetRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.Requ
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/runtime-groups/%s", pathParam0)
+	operationPath := fmt.Sprintf("/control-planes/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -725,19 +725,19 @@ func NewGetRuntimeGroupRequest(server string, id openapi_types.UUID) (*http.Requ
 	return req, nil
 }
 
-// NewUpdateRuntimeGroupRequest calls the generic UpdateRuntimeGroup builder with application/json body
-func NewUpdateRuntimeGroupRequest(server string, id openapi_types.UUID, body UpdateRuntimeGroupJSONRequestBody) (*http.Request, error) {
+// NewUpdateControlPlaneRequest calls the generic UpdateControlPlane builder with application/json body
+func NewUpdateControlPlaneRequest(server string, id openapi_types.UUID, body UpdateControlPlaneJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewUpdateRuntimeGroupRequestWithBody(server, id, "application/json", bodyReader)
+	return NewUpdateControlPlaneRequestWithBody(server, id, "application/json", bodyReader)
 }
 
-// NewUpdateRuntimeGroupRequestWithBody generates requests for UpdateRuntimeGroup with any type of body
-func NewUpdateRuntimeGroupRequestWithBody(server string, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+// NewUpdateControlPlaneRequestWithBody generates requests for UpdateControlPlane with any type of body
+func NewUpdateControlPlaneRequestWithBody(server string, id openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -752,7 +752,7 @@ func NewUpdateRuntimeGroupRequestWithBody(server string, id openapi_types.UUID, 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/runtime-groups/%s", pathParam0)
+	operationPath := fmt.Sprintf("/control-planes/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -815,31 +815,31 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
-	// ListRuntimeGroups request
-	ListRuntimeGroupsWithResponse(ctx context.Context, params *ListRuntimeGroupsParams, reqEditors ...RequestEditorFn) (*ListRuntimeGroupsHTTPResponse, error)
+	// ListControlPlanes request
+	ListControlPlanesWithResponse(ctx context.Context, params *ListControlPlanesParams, reqEditors ...RequestEditorFn) (*ListControlPlanesHTTPResponse, error)
 
-	// CreateRuntimeGroup request with any body
-	CreateRuntimeGroupWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRuntimeGroupHTTPResponse, error)
+	// CreateControlPlane request with any body
+	CreateControlPlaneWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateControlPlaneHTTPResponse, error)
 
-	CreateRuntimeGroupWithResponse(ctx context.Context, body CreateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateRuntimeGroupHTTPResponse, error)
+	CreateControlPlaneWithResponse(ctx context.Context, body CreateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateControlPlaneHTTPResponse, error)
 
-	// DeleteRuntimeGroup request
-	DeleteRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteRuntimeGroupHTTPResponse, error)
+	// DeleteControlPlane request
+	DeleteControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteControlPlaneHTTPResponse, error)
 
-	// GetRuntimeGroup request
-	GetRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetRuntimeGroupHTTPResponse, error)
+	// GetControlPlane request
+	GetControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetControlPlaneHTTPResponse, error)
 
-	// UpdateRuntimeGroup request with any body
-	UpdateRuntimeGroupWithBodyWithResponse(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRuntimeGroupHTTPResponse, error)
+	// UpdateControlPlane request with any body
+	UpdateControlPlaneWithBodyWithResponse(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateControlPlaneHTTPResponse, error)
 
-	UpdateRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, body UpdateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRuntimeGroupHTTPResponse, error)
+	UpdateControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, body UpdateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateControlPlaneHTTPResponse, error)
 }
 
-type ListRuntimeGroupsHTTPResponse struct {
+type ListControlPlanesHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		Data *[]RuntimeGroup `json:"data,omitempty"`
+		Data *[]ControlPlane `json:"data,omitempty"`
 
 		// Meta Returns pagination information
 		Meta *PaginatedMeta `json:"meta,omitempty"`
@@ -902,7 +902,7 @@ type ListRuntimeGroupsHTTPResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListRuntimeGroupsHTTPResponse) Status() string {
+func (r ListControlPlanesHTTPResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -910,17 +910,17 @@ func (r ListRuntimeGroupsHTTPResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListRuntimeGroupsHTTPResponse) StatusCode() int {
+func (r ListControlPlanesHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateRuntimeGroupHTTPResponse struct {
+type CreateControlPlaneHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *RuntimeGroup
+	JSON201      *ControlPlane
 	JSON400      *struct {
 		// Detail Information about the error response.
 		Detail *string `json:"detail,omitempty"`
@@ -1005,7 +1005,7 @@ type CreateRuntimeGroupHTTPResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateRuntimeGroupHTTPResponse) Status() string {
+func (r CreateControlPlaneHTTPResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1013,14 +1013,14 @@ func (r CreateRuntimeGroupHTTPResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateRuntimeGroupHTTPResponse) StatusCode() int {
+func (r CreateControlPlaneHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type DeleteRuntimeGroupHTTPResponse struct {
+type DeleteControlPlaneHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *struct {
@@ -1107,7 +1107,7 @@ type DeleteRuntimeGroupHTTPResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteRuntimeGroupHTTPResponse) Status() string {
+func (r DeleteControlPlaneHTTPResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1115,17 +1115,17 @@ func (r DeleteRuntimeGroupHTTPResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteRuntimeGroupHTTPResponse) StatusCode() int {
+func (r DeleteControlPlaneHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetRuntimeGroupHTTPResponse struct {
+type GetControlPlaneHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *RuntimeGroup
+	JSON200      *ControlPlane
 	JSON400      *struct {
 		// Detail Information about the error response.
 		Detail *string `json:"detail,omitempty"`
@@ -1197,7 +1197,7 @@ type GetRuntimeGroupHTTPResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetRuntimeGroupHTTPResponse) Status() string {
+func (r GetControlPlaneHTTPResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1205,17 +1205,17 @@ func (r GetRuntimeGroupHTTPResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetRuntimeGroupHTTPResponse) StatusCode() int {
+func (r GetControlPlaneHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type UpdateRuntimeGroupHTTPResponse struct {
+type UpdateControlPlaneHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *RuntimeGroup
+	JSON200      *ControlPlane
 	JSON400      *struct {
 		// Detail Information about the error response.
 		Detail *string `json:"detail,omitempty"`
@@ -1300,7 +1300,7 @@ type UpdateRuntimeGroupHTTPResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r UpdateRuntimeGroupHTTPResponse) Status() string {
+func (r UpdateControlPlaneHTTPResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1308,83 +1308,83 @@ func (r UpdateRuntimeGroupHTTPResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r UpdateRuntimeGroupHTTPResponse) StatusCode() int {
+func (r UpdateControlPlaneHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ListRuntimeGroupsWithResponse request returning *ListRuntimeGroupsHTTPResponse
-func (c *ClientWithResponses) ListRuntimeGroupsWithResponse(ctx context.Context, params *ListRuntimeGroupsParams, reqEditors ...RequestEditorFn) (*ListRuntimeGroupsHTTPResponse, error) {
-	rsp, err := c.ListRuntimeGroups(ctx, params, reqEditors...)
+// ListControlPlanesWithResponse request returning *ListControlPlanesHTTPResponse
+func (c *ClientWithResponses) ListControlPlanesWithResponse(ctx context.Context, params *ListControlPlanesParams, reqEditors ...RequestEditorFn) (*ListControlPlanesHTTPResponse, error) {
+	rsp, err := c.ListControlPlanes(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListRuntimeGroupsHTTPResponse(rsp)
+	return ParseListControlPlanesHTTPResponse(rsp)
 }
 
-// CreateRuntimeGroupWithBodyWithResponse request with arbitrary body returning *CreateRuntimeGroupHTTPResponse
-func (c *ClientWithResponses) CreateRuntimeGroupWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.CreateRuntimeGroupWithBody(ctx, contentType, body, reqEditors...)
+// CreateControlPlaneWithBodyWithResponse request with arbitrary body returning *CreateControlPlaneHTTPResponse
+func (c *ClientWithResponses) CreateControlPlaneWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateControlPlaneHTTPResponse, error) {
+	rsp, err := c.CreateControlPlaneWithBody(ctx, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateRuntimeGroupHTTPResponse(rsp)
+	return ParseCreateControlPlaneHTTPResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateRuntimeGroupWithResponse(ctx context.Context, body CreateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.CreateRuntimeGroup(ctx, body, reqEditors...)
+func (c *ClientWithResponses) CreateControlPlaneWithResponse(ctx context.Context, body CreateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateControlPlaneHTTPResponse, error) {
+	rsp, err := c.CreateControlPlane(ctx, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateRuntimeGroupHTTPResponse(rsp)
+	return ParseCreateControlPlaneHTTPResponse(rsp)
 }
 
-// DeleteRuntimeGroupWithResponse request returning *DeleteRuntimeGroupHTTPResponse
-func (c *ClientWithResponses) DeleteRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.DeleteRuntimeGroup(ctx, id, reqEditors...)
+// DeleteControlPlaneWithResponse request returning *DeleteControlPlaneHTTPResponse
+func (c *ClientWithResponses) DeleteControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*DeleteControlPlaneHTTPResponse, error) {
+	rsp, err := c.DeleteControlPlane(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteRuntimeGroupHTTPResponse(rsp)
+	return ParseDeleteControlPlaneHTTPResponse(rsp)
 }
 
-// GetRuntimeGroupWithResponse request returning *GetRuntimeGroupHTTPResponse
-func (c *ClientWithResponses) GetRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.GetRuntimeGroup(ctx, id, reqEditors...)
+// GetControlPlaneWithResponse request returning *GetControlPlaneHTTPResponse
+func (c *ClientWithResponses) GetControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*GetControlPlaneHTTPResponse, error) {
+	rsp, err := c.GetControlPlane(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetRuntimeGroupHTTPResponse(rsp)
+	return ParseGetControlPlaneHTTPResponse(rsp)
 }
 
-// UpdateRuntimeGroupWithBodyWithResponse request with arbitrary body returning *UpdateRuntimeGroupHTTPResponse
-func (c *ClientWithResponses) UpdateRuntimeGroupWithBodyWithResponse(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.UpdateRuntimeGroupWithBody(ctx, id, contentType, body, reqEditors...)
+// UpdateControlPlaneWithBodyWithResponse request with arbitrary body returning *UpdateControlPlaneHTTPResponse
+func (c *ClientWithResponses) UpdateControlPlaneWithBodyWithResponse(ctx context.Context, id openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateControlPlaneHTTPResponse, error) {
+	rsp, err := c.UpdateControlPlaneWithBody(ctx, id, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUpdateRuntimeGroupHTTPResponse(rsp)
+	return ParseUpdateControlPlaneHTTPResponse(rsp)
 }
 
-func (c *ClientWithResponses) UpdateRuntimeGroupWithResponse(ctx context.Context, id openapi_types.UUID, body UpdateRuntimeGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRuntimeGroupHTTPResponse, error) {
-	rsp, err := c.UpdateRuntimeGroup(ctx, id, body, reqEditors...)
+func (c *ClientWithResponses) UpdateControlPlaneWithResponse(ctx context.Context, id openapi_types.UUID, body UpdateControlPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateControlPlaneHTTPResponse, error) {
+	rsp, err := c.UpdateControlPlane(ctx, id, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUpdateRuntimeGroupHTTPResponse(rsp)
+	return ParseUpdateControlPlaneHTTPResponse(rsp)
 }
 
-// ParseListRuntimeGroupsHTTPResponse parses an HTTP response from a ListRuntimeGroupsWithResponse call
-func ParseListRuntimeGroupsHTTPResponse(rsp *http.Response) (*ListRuntimeGroupsHTTPResponse, error) {
+// ParseListControlPlanesHTTPResponse parses an HTTP response from a ListControlPlanesWithResponse call
+func ParseListControlPlanesHTTPResponse(rsp *http.Response) (*ListControlPlanesHTTPResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListRuntimeGroupsHTTPResponse{
+	response := &ListControlPlanesHTTPResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1392,7 +1392,7 @@ func ParseListRuntimeGroupsHTTPResponse(rsp *http.Response) (*ListRuntimeGroupsH
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			Data *[]RuntimeGroup `json:"data,omitempty"`
+			Data *[]ControlPlane `json:"data,omitempty"`
 
 			// Meta Returns pagination information
 			Meta *PaginatedMeta `json:"meta,omitempty"`
@@ -1486,22 +1486,22 @@ func ParseListRuntimeGroupsHTTPResponse(rsp *http.Response) (*ListRuntimeGroupsH
 	return response, nil
 }
 
-// ParseCreateRuntimeGroupHTTPResponse parses an HTTP response from a CreateRuntimeGroupWithResponse call
-func ParseCreateRuntimeGroupHTTPResponse(rsp *http.Response) (*CreateRuntimeGroupHTTPResponse, error) {
+// ParseCreateControlPlaneHTTPResponse parses an HTTP response from a CreateControlPlaneWithResponse call
+func ParseCreateControlPlaneHTTPResponse(rsp *http.Response) (*CreateControlPlaneHTTPResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateRuntimeGroupHTTPResponse{
+	response := &CreateControlPlaneHTTPResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest RuntimeGroup
+		var dest ControlPlane
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1629,15 +1629,15 @@ func ParseCreateRuntimeGroupHTTPResponse(rsp *http.Response) (*CreateRuntimeGrou
 	return response, nil
 }
 
-// ParseDeleteRuntimeGroupHTTPResponse parses an HTTP response from a DeleteRuntimeGroupWithResponse call
-func ParseDeleteRuntimeGroupHTTPResponse(rsp *http.Response) (*DeleteRuntimeGroupHTTPResponse, error) {
+// ParseDeleteControlPlaneHTTPResponse parses an HTTP response from a DeleteControlPlaneWithResponse call
+func ParseDeleteControlPlaneHTTPResponse(rsp *http.Response) (*DeleteControlPlaneHTTPResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteRuntimeGroupHTTPResponse{
+	response := &DeleteControlPlaneHTTPResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1765,22 +1765,22 @@ func ParseDeleteRuntimeGroupHTTPResponse(rsp *http.Response) (*DeleteRuntimeGrou
 	return response, nil
 }
 
-// ParseGetRuntimeGroupHTTPResponse parses an HTTP response from a GetRuntimeGroupWithResponse call
-func ParseGetRuntimeGroupHTTPResponse(rsp *http.Response) (*GetRuntimeGroupHTTPResponse, error) {
+// ParseGetControlPlaneHTTPResponse parses an HTTP response from a GetControlPlaneWithResponse call
+func ParseGetControlPlaneHTTPResponse(rsp *http.Response) (*GetControlPlaneHTTPResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetRuntimeGroupHTTPResponse{
+	response := &GetControlPlaneHTTPResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest RuntimeGroup
+		var dest ControlPlane
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1889,22 +1889,22 @@ func ParseGetRuntimeGroupHTTPResponse(rsp *http.Response) (*GetRuntimeGroupHTTPR
 	return response, nil
 }
 
-// ParseUpdateRuntimeGroupHTTPResponse parses an HTTP response from a UpdateRuntimeGroupWithResponse call
-func ParseUpdateRuntimeGroupHTTPResponse(rsp *http.Response) (*UpdateRuntimeGroupHTTPResponse, error) {
+// ParseUpdateControlPlaneHTTPResponse parses an HTTP response from a UpdateControlPlaneWithResponse call
+func ParseUpdateControlPlaneHTTPResponse(rsp *http.Response) (*UpdateControlPlaneHTTPResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UpdateRuntimeGroupHTTPResponse{
+	response := &UpdateControlPlaneHTTPResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest RuntimeGroup
+		var dest ControlPlane
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/konnect/controlplanesconfig/client.go
+++ b/internal/konnect/controlplanesconfig/client.go
@@ -5,7 +5,7 @@
 // until we have a proper Konnect API Go SDK: https://github.com/Kong/kubernetes-ingress-controller/issues/3550.
 
 //nolint:all
-package runtimegroupsconfig
+package controlplanesconfig
 
 import (
 	"bytes"
@@ -45,13 +45,13 @@ type GetDpClientCert struct {
 
 // GetExpectedConfigHash defines model for get-expected-config-hash.
 type GetExpectedConfigHash struct {
-	// CreatedAt Date the runtime group configuration was created.
+	// CreatedAt Date the control plane configuration was created.
 	CreatedAt *int `json:"created_at,omitempty"`
 
 	// ExpectedHash The expected configuration hash.
 	ExpectedHash *string `json:"expected_hash,omitempty"`
 
-	// UpdatedAt Date the runtime group configuration was last updated.
+	// UpdatedAt Date the control plane configuration was last updated.
 	UpdatedAt *int `json:"updated_at,omitempty"`
 }
 
@@ -1180,13 +1180,13 @@ type GetExpectedConfigHashHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		// CreatedAt Date the runtime group configuration was created.
+		// CreatedAt Date the control plane configuration was created.
 		CreatedAt *int `json:"created_at,omitempty"`
 
 		// ExpectedHash The expected configuration hash.
 		ExpectedHash *string `json:"expected_hash,omitempty"`
 
-		// UpdatedAt Date the runtime group configuration was last updated.
+		// UpdatedAt Date the control plane configuration was last updated.
 		UpdatedAt *int `json:"updated_at,omitempty"`
 	}
 }
@@ -1638,13 +1638,13 @@ func ParseGetExpectedConfigHashHTTPResponse(rsp *http.Response) (*GetExpectedCon
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			// CreatedAt Date the runtime group configuration was created.
+			// CreatedAt Date the control plane configuration was created.
 			CreatedAt *int `json:"created_at,omitempty"`
 
 			// ExpectedHash The expected configuration hash.
 			ExpectedHash *string `json:"expected_hash,omitempty"`
 
-			// UpdatedAt Date the runtime group configuration was last updated.
+			// UpdatedAt Date the control plane configuration was last updated.
 			UpdatedAt *int `json:"updated_at,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -21,7 +21,7 @@ import (
 // Client interacts with the Konnect license API.
 type Client struct {
 	address        string
-	runtimeGroupID string
+	controlPlaneID string
 	httpClient     *http.Client
 }
 
@@ -48,13 +48,13 @@ func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
 
 	return &Client{
 		address:        cfg.Address,
-		runtimeGroupID: cfg.ControlPlaneID,
+		controlPlaneID: cfg.ControlPlaneID,
 		httpClient:     c,
 	}, nil
 }
 
 func (c *Client) kicLicenseAPIEndpoint() string {
-	return fmt.Sprintf(KICLicenseAPIPathPattern, c.address, c.runtimeGroupID)
+	return fmt.Sprintf(KICLicenseAPIPathPattern, c.address, c.controlPlaneID)
 }
 
 func (c *Client) Get(ctx context.Context) (mo.Option[license.KonnectLicense], error) {

--- a/internal/konnect/node_agent.go
+++ b/internal/konnect/node_agent.go
@@ -43,7 +43,7 @@ type ManagerInstanceIDProvider interface {
 	GetID() uuid.UUID
 }
 
-// NodeClient is the interface to Konnect Runtime Group Node API.
+// NodeClient is the interface to Konnect Control Plane Node API.
 type NodeClient interface {
 	CreateNode(ctx context.Context, req *nodes.CreateNodeRequest) (*nodes.CreateNodeResponse, error)
 	UpdateNode(ctx context.Context, nodeID string, req *nodes.UpdateNodeRequest) (*nodes.UpdateNodeResponse, error)
@@ -237,7 +237,7 @@ func (a *NodeAgent) updateKICNode(ctx context.Context, existingNodes []*nodes.No
 			// save all nodes with same name as current KIC node, update the latest one and delete others.
 			nodesWithSameName = append(nodesWithSameName, node)
 		} else {
-			// delete the nodes with different name of the current node, since only on KIC node is allowed in the runtime group.
+			// delete the nodes with different name of the current node, since only on KIC node is allowed in the control plane.
 			a.logger.V(util.DebugLevel).Info("remove outdated KIC node", "node_id", node.ID, "hostname", node.Hostname)
 			err := a.nodeClient.DeleteNode(ctx, node.ID)
 			if err != nil {

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -283,7 +283,7 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 				// Notify gateway clients changes.
 				gatewayClientsChangesNotifier.Notify()
 
-				// Check number of nodes in RG.
+				// Check number of nodes in CP.
 				ns := nodeClient.MustAllNodes()
 				if len(ns) != tc.numNodes {
 					t.Logf("expected %d nodes, got %d", tc.numNodes, len(ns))

--- a/internal/konnect/nodes/client.go
+++ b/internal/konnect/nodes/client.go
@@ -18,10 +18,10 @@ import (
 )
 
 // Client is used for sending requests to Konnect Node API.
-// It can be used to register Nodes in Konnect's Runtime Groups.
+// It can be used to register Nodes in Konnect's Control Planes.
 type Client struct {
 	address        string
-	runtimeGroupID string
+	controlPlaneID string
 	httpClient     *http.Client
 }
 
@@ -48,17 +48,17 @@ func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
 
 	return &Client{
 		address:        cfg.Address,
-		runtimeGroupID: cfg.ControlPlaneID,
+		controlPlaneID: cfg.ControlPlaneID,
 		httpClient:     c,
 	}, nil
 }
 
 func (c *Client) kicNodeAPIEndpoint() string {
-	return fmt.Sprintf(KicNodeAPIPathPattern, c.address, c.runtimeGroupID)
+	return fmt.Sprintf(KicNodeAPIPathPattern, c.address, c.controlPlaneID)
 }
 
 func (c *Client) kicNodeAPIEndpointWithNodeID(nodeID string) string {
-	return fmt.Sprintf(KicNodeAPIPathPattern, c.address, c.runtimeGroupID) + "/" + nodeID
+	return fmt.Sprintf(KicNodeAPIPathPattern, c.address, c.controlPlaneID) + "/" + nodeID
 }
 
 func (c *Client) CreateNode(ctx context.Context, req *CreateNodeRequest) (*CreateNodeResponse, error) {
@@ -131,7 +131,7 @@ func (c *Client) UpdateNode(ctx context.Context, nodeID string, req *UpdateNodeR
 	return resp, nil
 }
 
-// ListAllNodes call ListNodes() repeatedly to get all nodes in a runtime group.
+// ListAllNodes call ListNodes() repeatedly to get all nodes in a control plane.
 func (c *Client) ListAllNodes(ctx context.Context) ([]*NodeItem, error) {
 	nodes := []*NodeItem{}
 	pageNum := 0

--- a/internal/konnect/roles/client.go
+++ b/internal/konnect/roles/client.go
@@ -25,7 +25,7 @@ type Role struct {
 	// ID is the role ID.
 	ID string
 
-	// EntityID is the ID of the entity the role is assigned to (e.g. Runtime Group).
+	// EntityID is the ID of the entity the role is assigned to (e.g. Control Plane).
 	EntityID string
 }
 
@@ -50,8 +50,8 @@ func NewClient(httpClient *http.Client, baseURL string, personalAccessToken stri
 	}
 }
 
-// ListRuntimeGroupsRoles lists all roles assigned to the current user for Runtime Groups.
-func (c *Client) ListRuntimeGroupsRoles(ctx context.Context) ([]Role, error) {
+// ListControlPlanesRoles lists all roles assigned to the current user for Control Planes.
+func (c *Client) ListControlPlanesRoles(ctx context.Context) ([]Role, error) {
 	currentUserID, err := c.getCurrentUserID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current user ID: %w", err)

--- a/internal/konnect/roles/client_test.go
+++ b/internal/konnect/roles/client_test.go
@@ -60,14 +60,14 @@ func newMockRolesServer(t *testing.T) *httptest.Server {
 		           "id": "24ac168d-4ffb-46ec-8dd6-5a26b5ec6f0b",
 		           "role_name": "Admin",
 		           "entity_region": "us",
-		           "entity_type_name": "Runtime Groups",
+		           "entity_type_name": "Control Planes",
 		           "entity_id": "e3f155ec-1786-4017-98d0-b0a0f5e179c3"
 		       },
 		       {
 		           "id": "7edaf68b-8f07-4827-b540-fce06e45429e",
 		           "role_name": "Admin",
 		           "entity_region": "us",
-		           "entity_type_name": "Runtime Groups",
+		           "entity_type_name": "Control Planes",
 		           "entity_id": "c486f518-9fc8-461f-af0a-2bc85b70e492"
 		       }
 		   ]
@@ -87,7 +87,7 @@ func TestRolesClient(t *testing.T) {
 	server := newMockRolesServer(t)
 	c := roles.NewClient(&http.Client{}, server.URL, testToken)
 
-	rgRoles, err := c.ListRuntimeGroupsRoles(ctx)
+	rgRoles, err := c.ListControlPlanesRoles(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(rgRoles))
 	role := rgRoles[0]

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -254,7 +254,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.DurationVar(&c.TermDelay, "term-delay", time.Second*0, "The time delay to sleep before SIGTERM or SIGINT will shut down the Ingress Controller")
 
 	// Konnect
-	flagSet.BoolVar(&c.Konnect.ConfigSynchronizationEnabled, "konnect-sync-enabled", false, "Enable synchronization of data plane configuration with a Konnect runtime group.")
+	flagSet.BoolVar(&c.Konnect.ConfigSynchronizationEnabled, "konnect-sync-enabled", false, "Enable synchronization of data plane configuration with a Konnect control plane.")
 	flagSet.BoolVar(&c.Konnect.LicenseSynchronizationEnabled, "konnect-licensing-enabled", false, "Retrieve licenses from Konnect if available. Overrides licenses provided via the environment.")
 	flagSet.DurationVar(&c.Konnect.InitialLicensePollingPeriod, "konnect-initial-license-polling-period", license.DefaultInitialPollingPeriod, "Polling period to be used before the first license is retrieved.")
 	flagSet.DurationVar(&c.Konnect.LicensePollingPeriod, "konnect-license-polling-period", license.DefaultPollingPeriod, "Polling period to be used after the first license is retrieved.")

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -261,7 +261,7 @@ func TestConfigValidate(t *testing.T) {
 			require.NoError(t, c.Validate())
 		})
 
-		t.Run("enabled with no runtime group is rejected", func(t *testing.T) {
+		t.Run("enabled with no control plane is rejected", func(t *testing.T) {
 			c := validEnabled()
 			c.Konnect.ControlPlaneID = ""
 			require.ErrorContains(t, c.Validate(), "control plane not specified")

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -424,9 +424,9 @@ func setupKonnectAdminAPIClientWithClientsMgr(
 	clientsManager *clients.AdminAPIClientsManager,
 	logger logr.Logger,
 ) {
-	konnectAdminAPIClient, err := adminapi.NewKongClientForKonnectRuntimeGroup(config)
+	konnectAdminAPIClient, err := adminapi.NewKongClientForKonnectControlPlane(config)
 	if err != nil {
-		logger.Error(err, "Failed creating Konnect Runtime Group Admin API client, skipping synchronisation")
+		logger.Error(err, "Failed creating Konnect Control Plane Admin API client, skipping synchronisation")
 		return
 	}
 	if err := adminapi.EnsureKonnectConnection(ctx, konnectAdminAPIClient.AdminAPIClient(), logger); err != nil {

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -29,18 +29,18 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect"
+	cp "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/controlplanes"
+	cpc "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/controlplanesconfig"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/nodes"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/roles"
-	rg "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroups"
-	rgc "github.com/kong/kubernetes-ingress-controller/v2/internal/konnect/runtimegroupsconfig"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
 
 const (
-	konnectRuntimeGroupsBaseURL          = "https://us.kic.api.konghq.tech/v2"
-	konnectRuntimeGroupsConfigBaseURLFmt = "https://us.api.konghq.tech/v2/control-planes/%s/"
-	konnectRuntimeGroupAdminAPIBaseURL   = "https://us.kic.api.konghq.tech"
+	konnectControlPlanesBaseURL          = "https://us.kic.api.konghq.tech/v2"
+	konnectControlPlanesConfigBaseURLFmt = "https://us.api.konghq.tech/v2/control-planes/%s/"
+	konnectControlPlaneAdminAPIBaseURL   = "https://us.kic.api.konghq.tech"
 	konnectRolesBaseURL                  = "https://global.api.konghq.tech/v2"
 
 	konnectNodeRegistrationTimeout = 5 * time.Minute
@@ -56,9 +56,9 @@ func TestKonnectConfigPush(t *testing.T) {
 
 	ctx, env := setupE2ETest(t)
 
-	rgID := createTestRuntimeGroup(ctx, t)
-	cert, key := createClientCertificate(ctx, t, rgID)
-	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
+	cpID := createTestControlPlane(ctx, t)
+	cert, key := createClientCertificate(ctx, t, cpID)
+	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, cpID)
 
 	deployments := deployAllInOneKonnectManifest(ctx, t, env)
 
@@ -66,13 +66,13 @@ func TestKonnectConfigPush(t *testing.T) {
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 	verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 
-	t.Log("ensuring ingress resources are correctly populated in Konnect Runtime Group's Admin API")
-	konnectAdminAPIClient := createKonnectAdminAPIClient(t, rgID, cert, key)
+	t.Log("ensuring ingress resources are correctly populated in Konnect Control Plane's Admin API")
+	konnectAdminAPIClient := createKonnectAdminAPIClient(t, cpID, cert, key)
 	verifyIngressWithEchoBackendsInAdminAPI(ctx, t, konnectAdminAPIClient.AdminAPIClient(), numberOfEchoBackends)
 
-	t.Log("ensuring KIC nodes and controlled kong gateway nodes are present in konnect runtime group")
-	requireKonnectNodesConsistentWithK8s(ctx, t, env, deployments, rgID, cert, key)
-	requireAllProxyReplicasIDsConsistentWithKonnect(ctx, t, env, deployments.ProxyNN, rgID, cert, key)
+	t.Log("ensuring KIC nodes and controlled kong gateway nodes are present in konnect control plane")
+	requireKonnectNodesConsistentWithK8s(ctx, t, env, deployments, cpID, cert, key)
+	requireAllProxyReplicasIDsConsistentWithKonnect(ctx, t, env, deployments.ProxyNN, cpID, cert, key)
 }
 
 func TestKonnectLicenseActivation(t *testing.T) {
@@ -82,7 +82,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 
 	ctx, env := setupE2ETest(t)
 
-	rgID := createTestRuntimeGroup(ctx, t)
+	rgID := createTestControlPlane(ctx, t)
 	cert, key := createClientCertificate(ctx, t, rgID)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
@@ -146,11 +146,11 @@ func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	skipTestIfControllerVersionBelow(t, gatewayDiscoveryMinimalVersion)
 	ctx, env := setupE2ETest(t)
 
-	rgID := createTestRuntimeGroup(ctx, t)
+	rgID := createTestControlPlane(ctx, t)
 	cert, key := createClientCertificate(ctx, t, rgID)
 
-	// create a Konnect client secret and config map with a non-existing runtime group ID to simulate misconfiguration
-	notExistingRgID := "not-existing-rg-id"
+	// create a Konnect client secret and config map with a non-existing control plane ID to simulate misconfiguration
+	notExistingRgID := "not-existing-cp-id"
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, notExistingRgID)
 
 	deployAllInOneKonnectManifest(ctx, t, env)
@@ -175,10 +175,10 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	return ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 }
 
-func generateTestKonnectRuntimeGroupDescription(t *testing.T) string {
+func generateTestKonnectControlPlaneDescription(t *testing.T) string {
 	t.Helper()
 
-	desc := fmt.Sprintf("runtime group for test %s", t.Name())
+	desc := fmt.Sprintf("control plane for test %s", t.Name())
 	if githubServerURL != "" && githubRepo != "" && githubRunID != "" {
 		githubRunURL := fmt.Sprintf("%s/%s/actions/runs/%s",
 			githubServerURL, githubRepo, githubRunID)
@@ -188,11 +188,11 @@ func generateTestKonnectRuntimeGroupDescription(t *testing.T) string {
 	return desc
 }
 
-// createTestRuntimeGroup creates a runtime group to be used in tests. It returns the created runtime group's ID.
+// createTestControlPlane creates a control plane to be used in tests. It returns the created control plane's ID.
 // It also sets up a cleanup function for it to be deleted.
-func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
+func createTestControlPlane(ctx context.Context, t *testing.T) string {
 	t.Helper()
-	rgClient, err := rg.NewClientWithResponses(konnectRuntimeGroupsBaseURL, rg.WithRequestEditorFn(
+	rgClient, err := cp.NewClientWithResponses(konnectControlPlanesBaseURL, cp.WithRequestEditorFn(
 		func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
 			return nil
@@ -208,22 +208,22 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 	var rgID uuid.UUID
 	createRgErr := retry.Do(func() error {
 		rgName := uuid.NewString()
-		createRgResp, err := rgClient.CreateRuntimeGroupWithResponse(ctx, rg.CreateRuntimeGroupRequest{
-			Description: lo.ToPtr(generateTestKonnectRuntimeGroupDescription(t)),
-			Labels: &rg.Labels{
+		createRgResp, err := rgClient.CreateControlPlaneWithResponse(ctx, cp.CreateControlPlaneRequest{
+			Description: lo.ToPtr(generateTestKonnectControlPlaneDescription(t)),
+			Labels: &cp.Labels{
 				"created_in_tests": "true",
 			},
 			Name:        rgName,
-			ClusterType: rg.ClusterTypeKubernetesIngressController,
+			ClusterType: cp.ClusterTypeKubernetesIngressController,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to create runtime group: %w", err)
+			return fmt.Errorf("failed to create control plane: %w", err)
 		}
 		if createRgResp.StatusCode() != http.StatusCreated {
 			return fmt.Errorf("failed to create RG: code %d, message %s", createRgResp.StatusCode(), string(createRgResp.Body))
 		}
 		if createRgResp.JSON201 == nil || createRgResp.JSON201.Id == nil {
-			return errors.New("No runtime group ID in response")
+			return errors.New("No control plane ID in response")
 		}
 
 		rgID = *createRgResp.JSON201.Id
@@ -232,56 +232,56 @@ func createTestRuntimeGroup(ctx context.Context, t *testing.T) string {
 	require.NoError(t, createRgErr)
 
 	t.Cleanup(func() {
-		t.Logf("deleting test Konnect Runtime Group: %q", rgID)
+		t.Logf("deleting test Konnect Control Plane: %q", rgID)
 		err := retry.Do(
 			func() error {
-				_, err := rgClient.DeleteRuntimeGroupWithResponse(ctx, rgID)
+				_, err := rgClient.DeleteControlPlaneWithResponse(ctx, rgID)
 				return err
 			},
 			retry.Attempts(5), retry.Delay(time.Second),
 		)
-		assert.NoErrorf(t, err, "failed to cleanup a runtime group: %q", rgID)
+		assert.NoErrorf(t, err, "failed to cleanup a control plane: %q", rgID)
 
-		// We have to manually delete roles created for the runtime group because Konnect doesn't do it automatically.
+		// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
 		// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
 		// because of a performance issue when there's too many roles for the account
 		// (see https://konghq.atlassian.net/browse/TPS-1319).
 		//
 		// We can drop this once the automated cleanup is implemented on Konnect side:
 		// https://konghq.atlassian.net/browse/TPS-1453.
-		rgRoles, err := rolesClient.ListRuntimeGroupsRoles(ctx)
-		require.NoErrorf(t, err, "failed to list runtime group roles for cleanup: %q", rgID)
+		rgRoles, err := rolesClient.ListControlPlanesRoles(ctx)
+		require.NoErrorf(t, err, "failed to list control plane roles for cleanup: %q", rgID)
 		for _, role := range rgRoles {
-			if role.EntityID == rgID.String() { // Delete only roles created for the runtime group.
-				t.Logf("deleting test Konnect Runtime Group role: %q", role.ID)
+			if role.EntityID == rgID.String() { // Delete only roles created for the control plane.
+				t.Logf("deleting test Konnect Control Plane role: %q", role.ID)
 				err := rolesClient.DeleteRole(ctx, role.ID)
-				assert.NoErrorf(t, err, "failed to cleanup a runtime group role: %q", role.ID)
+				assert.NoErrorf(t, err, "failed to cleanup a control plane role: %q", role.ID)
 			}
 		}
 	})
 
-	t.Logf("created test Konnect Runtime Group: %q", rgID.String())
+	t.Logf("created test Konnect Control Plane: %q", rgID.String())
 	return rgID.String()
 }
 
-// createClientCertificate creates a TLS client certificate and POSTs it to Konnect Runtime Group configuration API
+// createClientCertificate creates a TLS client certificate and POSTs it to Konnect Control Plane configuration API
 // so that KIC can use the certificates to authenticate against Konnect Admin API.
 func createClientCertificate(ctx context.Context, t *testing.T, rgID string) (certPEM string, keyPEM string) {
 	t.Helper()
 
-	rgConfigClient, err := rgc.NewClientWithResponses(fmt.Sprintf(konnectRuntimeGroupsConfigBaseURLFmt, rgID), rgc.WithRequestEditorFn(
+	rgConfigClient, err := cpc.NewClientWithResponses(fmt.Sprintf(konnectControlPlanesConfigBaseURLFmt, rgID), cpc.WithRequestEditorFn(
 		func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer "+konnectAccessToken)
 			return nil
 		}),
-		rgc.WithHTTPClient(helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())),
+		cpc.WithHTTPClient(helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())),
 	)
 	require.NoError(t, err)
 
 	cert, key := certificate.MustGenerateSelfSignedCertPEMFormat()
 
 	t.Log("creating client certificate in Konnect")
-	resp, err := rgConfigClient.PostDpClientCertificatesWithResponse(ctx, rgc.PostDpClientCertificatesJSONRequestBody{
+	resp, err := rgConfigClient.PostDpClientCertificatesWithResponse(ctx, cpc.PostDpClientCertificatesJSONRequestBody{
 		Cert: string(cert),
 	})
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func createClientCertificate(ctx context.Context, t *testing.T, rgID string) (ce
 }
 
 // createKonnectClientSecretAndConfigMap creates a Secret with client TLS certificate that is used by KIC to communicate
-// with Konnect Admin API. It also creates a ConfigMap that specifies a Runtime Group ID and Konnect Admin API URL.
+// with Konnect Admin API. It also creates a ConfigMap that specifies a Control Plane ID and Konnect Admin API URL.
 // Both Secret and ConfigMap are used by all-in-one-dbless-konnect.yaml manifest and need to be populated before
 // deploying it.
 func createKonnectClientSecretAndConfigMap(ctx context.Context, t *testing.T, env environment.Environment, tlsCert, tlsKey, rgID string) {
@@ -325,19 +325,19 @@ func createKonnectClientSecretAndConfigMap(ctx context.Context, t *testing.T, en
 		},
 		Data: map[string]string{
 			"CONTROLLER_KONNECT_CONTROL_PLANE_ID": rgID,
-			"CONTROLLER_KONNECT_ADDRESS":          konnectRuntimeGroupAdminAPIBaseURL,
+			"CONTROLLER_KONNECT_ADDRESS":          konnectControlPlaneAdminAPIBaseURL,
 		},
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 }
 
-// createKonnectAdminAPIClient creates an *kong.Client that will communicate with Konnect Runtime Group's Admin API.
+// createKonnectAdminAPIClient creates an *kong.Client that will communicate with Konnect Control Plane's Admin API.
 func createKonnectAdminAPIClient(t *testing.T, rgID, cert, key string) *adminapi.KonnectClient {
 	t.Helper()
 
-	c, err := adminapi.NewKongClientForKonnectRuntimeGroup(adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
 		ControlPlaneID: rgID,
-		Address:        konnectRuntimeGroupAdminAPIBaseURL,
+		Address:        konnectControlPlaneAdminAPIBaseURL,
 		TLSClient: adminapi.TLSClientConfig{
 			Cert: cert,
 			Key:  key,
@@ -347,12 +347,12 @@ func createKonnectAdminAPIClient(t *testing.T, rgID, cert, key string) *adminapi
 	return c
 }
 
-// createKonnectNodeClient creates a konnect.NodeClient to get nodes in konnect runtime group.
+// createKonnectNodeClient creates a konnect.NodeClient to get nodes in konnect control plane.
 func createKonnectNodeClient(t *testing.T, rgID, cert, key string) *nodes.Client {
 	cfg := adminapi.KonnectConfig{
 		ConfigSynchronizationEnabled: true,
 		ControlPlaneID:               rgID,
-		Address:                      konnectRuntimeGroupAdminAPIBaseURL,
+		Address:                      konnectControlPlaneAdminAPIBaseURL,
 		RefreshNodePeriod:            konnect.MinRefreshNodePeriod,
 		TLSClient: adminapi.TLSClientConfig{
 			Cert: cert,


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors non-user-facing code to use `control plane` instead of `runtime group` naming for Konnect control planes.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4466.
