### PR TITLE
tests: migrate `TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames` integration tests to envtest suite

### DIFF
--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -34,7 +34,7 @@ func RunWithLogger(ctx context.Context, c *manager.Config, deprecatedLogger logr
 		return fmt.Errorf("config invalid: %w", err)
 	}
 
-	diag, err := StartDiagnosticsServer(ctx, manager.DiagnosticsPort, c, logger)
+	diag, err := StartDiagnosticsServer(ctx, c.DiagnosticServerPort, c, logger)
 	if err != nil {
 		return fmt.Errorf("failed to start diagnostics server: %w", err)
 	}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -108,9 +108,10 @@ type Config struct {
 	AdmissionServer admission.ServerConfig
 
 	// Diagnostics and performance
-	EnableProfiling     bool
-	EnableConfigDumps   bool
-	DumpSensitiveConfig bool
+	EnableProfiling      bool
+	EnableConfigDumps    bool
+	DumpSensitiveConfig  bool
+	DiagnosticServerPort int
 
 	// Feature Gates
 	FeatureGates map[string]bool

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -1,0 +1,195 @@
+//go:build envtest
+
+package envtest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	gojson "github.com/goccy/go-json"
+	"github.com/google/uuid"
+	"github.com/kong/deck/file"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/phayes/freeport"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
+)
+
+func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
+	t.Parallel()
+
+	const (
+		waitTime = 10 * time.Second
+		tickTime = 10 * time.Millisecond
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add Gateway API Schema because its controllers are enabled by default.
+	scheme := Scheme(t, WithGatewayAPI)
+	envcfg := Setup(t, scheme)
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
+	ingressClassName := "kongenvtest"
+	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
+
+	diagPort, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	ns := CreateNamespace(ctx, t, ctrlClient)
+	RunManager(ctx, t, envcfg,
+		WithIngressService(ns.Name),
+		WithIngressClass(ingressClassName),
+		WithProxySyncSeconds(0.01),
+		WithDiagnosticsServer(diagPort),
+	)
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment.Spec.Template.Spec.Containers[0].Ports[0].Name = "http"
+	deployment.Namespace = ns.Name
+	require.NoError(t, ctrlClient.Create(ctx, deployment))
+
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Namespace = ns.Name
+	t.Logf("exposing deployment %s via service %s", deployment.Name, service.Name)
+	require.NoError(t, ctrlClient.Create(ctx, service))
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"app": "httpbin",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				func() corev1.Container {
+					c := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
+					c.Ports[0].Name = "http"
+					return c
+				}(),
+			},
+		},
+	}
+	require.NoError(t, ctrlClient.Create(ctx, &pod))
+
+	es := discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uuid.NewString(),
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": service.Name,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       lo.ToPtr(true),
+					Terminating: lo.ToPtr(false),
+				},
+				TargetRef: testPodReference("pod-1", ns.Name),
+			},
+		},
+		Ports: builder.NewEndpointPort(80).WithName("http").IntoSlice(),
+	}
+	require.NoError(t, ctrlClient.Create(ctx, &es))
+
+	ingress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: ns.Name,
+			Annotations: map[string]string{
+				"konghq.com/strip-path": "true",
+			},
+		},
+		Spec: netv1.IngressSpec{
+			IngressClassName: lo.ToPtr(ingressClassName),
+			Rules: []netv1.IngressRule{
+				{
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: lo.ToPtr(netv1.PathTypePrefix),
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: service.Name,
+											Port: netv1.ServiceBackendPort{
+												Name: service.Spec.Ports[0].Name,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Logf("creating ingress %s for service %s", ingress.Name, service.Name)
+	require.NoError(t, ctrlClient.Create(ctx, ingress))
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/config/successful", diagPort))
+		if err != nil {
+			t.Logf("WARNING: error while getting config: %v", err)
+			return false
+		}
+		defer resp.Body.Close()
+
+		var (
+			config file.Content
+			buff   bytes.Buffer
+		)
+
+		if err := gojson.NewDecoder(io.TeeReader(resp.Body, &buff)).Decode(&config); err != nil {
+			t.Logf("WARNING: error while decoding config: %+v, response: %s", err, buff.String())
+			return false
+		}
+
+		if len(config.Services) != 1 {
+			t.Logf("WARNING: expected 1 service in config: %+v", config)
+			return false
+		}
+		if len(config.Services[0].Routes) != 1 {
+			t.Logf("WARNING: expected 1 route for service in config: %+v", config)
+			return false
+		}
+
+		if len(config.Upstreams) != 1 {
+			t.Logf("WARNING: expected 1 upstream in config: %+v", config)
+			return false
+		}
+
+		if len(config.Upstreams[0].Targets) != 1 {
+			t.Logf("WARNING: expected 1 target in config: %+v", config)
+			return false
+		}
+
+		target := config.Upstreams[0].Targets[0].Target.Target
+		if target == nil || *target != "10.0.0.1:80" {
+			t.Logf("WARNING: expected target to be equal to %s%d: actual %s", es.Endpoints[0].Addresses[0], *es.Ports[0].Port, *target)
+			return false
+		}
+
+		return true
+	}, waitTime, tickTime)
+}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -1065,90 +1064,6 @@ func TestIngressMatchByHost(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)
-}
-
-func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ns, cleaner := helpers.Setup(ctx, t, env)
-
-	client := env.Cluster().Client()
-
-	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
-	deployment := generators.NewDeploymentForContainer(container)
-	deployment.Spec.Template.Spec.Containers[0].Ports[0].Name = "http"
-	deployment, err := client.AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(deployment)
-
-	t.Logf("exposing deployment %s via service", deployment.Name)
-	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(service)
-
-	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
-
-	// TODO: create a similar helper to generators.NewIngressForServiceWithClusterVersion()
-	// which will accept a param to parametrize the port name or number.
-	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: service.Name,
-			Annotations: map[string]string{
-				"konghq.com/strip-path": "true",
-			},
-		},
-		Spec: netv1.IngressSpec{
-			IngressClassName: kong.String(consts.IngressClass),
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/",
-									PathType: lo.ToPtr(netv1.PathTypePrefix),
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: service.Name,
-											Port: netv1.ServiceBackendPort{
-												Name: service.Spec.Ports[0].Name,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	_, err = client.NetworkingV1().Ingresses(ns.Name).Create(ctx, ingress, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(ingress)
-
-	t.Log("waiting for routes from Ingress to be operational")
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(proxyURL.String())
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
-			// Expected: "<title>httpbin.org</title>"
-			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
-			return strings.Contains(b.String(), "<title>httpbin.org</title>")
-		}
-		return false
-	}, ingressWait, waitTick)
 }
 
 func TestIngressRewriteURI(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This migrates the `TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames` integration test to `envtest` suite.

It also performs some refactoring in the `envtest` suite to ensure all tests pass, among others

- it adds holding the config by the API mocks and returning it in subsequent `GET /config` requests
- it disables the diagnostics server and profiling by default in `envtest` suite
- adds several test configuration functions like `WithProxySyncSeconds`, `WithDiagnosticsServer`
- it makes `TestDebugEndpoints` use the `RunManager` to start the controller manager instead of using hand rolled code for that
- adds `t.Logf("got config: %v", string(b))` log to Admin API mock to print the received config
