### PR TITLE
test: add host to MustHTTPRequest and implement HTTP client with proxy

### DIFF
--- a/test/expressionrouter/generate_test.go
+++ b/test/expressionrouter/generate_test.go
@@ -43,11 +43,11 @@ func TestExpressionRouterGenerateRoutes(t *testing.T) {
 			name:    "exact match on path",
 			matcher: atc.NewPredicateHTTPPath(atc.OpEqual, "/foo"),
 			matchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foo", nil),
 			},
 			unmatchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foobar", nil),
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foo/", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foobar", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foo/", nil),
 			},
 		},
 		{
@@ -57,11 +57,11 @@ func TestExpressionRouterGenerateRoutes(t *testing.T) {
 				atc.NewPrediacteHTTPHost(atc.OpEqual, "a.foo.com"),
 			),
 			matchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foo", nil),
 			},
 			unmatchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foobar", nil),
-				helpers.MustHTTPRequest(t, "GET", "b.foo.com", "foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foobar", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "b.foo.com", "/foo", nil),
 			},
 		},
 		{
@@ -71,12 +71,12 @@ func TestExpressionRouterGenerateRoutes(t *testing.T) {
 				atc.NewPrediacteHTTPHost(atc.OpSuffixMatch, ".foo.com"),
 			),
 			matchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foo", nil),
-				helpers.MustHTTPRequest(t, "GET", "b.foo.com", "foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "b.foo.com", "/foo", nil),
 			},
 			unmatchRequests: []*http.Request{
-				helpers.MustHTTPRequest(t, "GET", "a.foo.com", "foobar", nil),
-				helpers.MustHTTPRequest(t, "GET", "a.bar.com", "foo", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.foo.com", "/foobar", nil),
+				helpers.MustHTTPRequest(t, http.MethodGet, "a.bar.com", "/foo", nil),
 			},
 		},
 	}

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -130,10 +130,10 @@ func TestConsumerGroup(t *testing.T) {
 	t.Log("checking if consumer has plugin configured correctly based on consumer group membership")
 	for _, consumer := range consumers {
 		require.Eventually(t, func() bool {
-			req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL, "/", map[string]string{
+			req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL.Host, "/", map[string]string{
 				"apikey": consumer.Name,
 			})
-			resp, err := helpers.DefaultHTTPClient().Do(req)
+			resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 			if err != nil {
 				t.Logf("WARNING: consumer %q failed to make a request: %v", consumer.Name, err)
 				return false

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -140,9 +140,9 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Logf("validating that consumer has access")
 	assert.Eventually(t, func() bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL, "/test_consumer_credential", nil)
+		req := helpers.MustHTTPRequest(t, "GET", proxyURL.Host, "/test_consumer_credential", nil)
 		req.SetBasicAuth("test_consumer_credential", "test_consumer_credential")
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			return false
 		}
@@ -152,5 +152,5 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_essentials", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_plugin_essentials", ingressWait, waitTick, nil)
 }

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -140,7 +140,7 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Logf("validating that consumer has access")
 	assert.Eventually(t, func() bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL.Host, "/test_consumer_credential", nil)
+		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL.Host, "/test_consumer_credential", nil)
 		req.SetBasicAuth("test_consumer_credential", "test_consumer_credential")
 		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -434,9 +434,9 @@ func TestGatewayFilters(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
-	helpers.EventuallyGETPath(t, proxyURL, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 	t.Log("waiting for routes from HTTPRoute in other namespace to become operational")
-	helpers.EventuallyGETPath(t, proxyURL, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("changing to the same namespace filter")
 	require.Eventually(t, func() bool {
@@ -459,9 +459,9 @@ func TestGatewayFilters(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("confirming other namespace route becomes inaccessible")
-	helpers.EventuallyGETPath(t, proxyURL, "other_test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "other_test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
 	t.Log("confirming same namespace route still operational")
-	helpers.EventuallyGETPath(t, proxyURL, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("changing to a selector filter")
 	require.Eventually(t, func() bool {
@@ -490,7 +490,7 @@ func TestGatewayFilters(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("confirming wrong selector namespace route becomes inaccessible")
-	helpers.EventuallyGETPath(t, proxyURL, "test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test_gateway_filters", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
 	t.Log("confirming right selector namespace route becomes operational")
-	helpers.EventuallyGETPath(t, proxyURL, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "other_test_gateway_filters", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 }

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -155,20 +155,16 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
 		http.StatusOK, "«yoʻq» dan boshqa bir javobimiz yoʻqdir.", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, "2/test-http-route-essentials/regex/999", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, "3/exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, "3/exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "2/test-http-route-essentials/regex/999", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "3/exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "3/exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
 
 	require.Eventually(t, func() bool {
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", proxyURL, "test-http-route-essentials"), nil)
-		if err != nil {
-			t.Logf("WARNING: failed to create HTTP request: %v", err)
-			return false
-		}
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		req := helpers.MustHTTPRequest(t, "GET", proxyURL.Host, "test-http-route-essentials", nil)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, "test-http-route-essentials", err)
 			return false
@@ -197,7 +193,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Log("verifying HTTPRoute header match")
-		helpers.EventuallyGETPath(t, proxyURL, "", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
+		helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
 	})
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True'")
@@ -225,7 +221,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the parentRefs now removed")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the parentRefs back")
 	require.Eventually(t, func() bool {
@@ -241,7 +237,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
 	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
@@ -250,7 +246,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	callback = GetGatewayIsUnlinkedCallback(ctx, t, gatewayClient, gatewayapi.HTTPProtocolType, ns.Name, httpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the GatewayClass now removed")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
 	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -262,7 +258,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
 	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
@@ -272,7 +268,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the Gateway now removed")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
 	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
@@ -285,7 +281,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -296,7 +292,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute does not get orphaned with the GatewayClass and Gateway gone")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("testing port matching....")
 	t.Log("putting the Gateway back")
@@ -472,8 +468,8 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	t.Log("verifying that both backends are ready to receive traffic")
 	httpbinRespContent := "<title>httpbin.org</title>"
 	nginxRespContent := "<title>Welcome to nginx!</title>"
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-multiple-services", http.StatusOK, httpbinRespContent, emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-multiple-services", http.StatusOK, nginxRespContent, emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services", http.StatusOK, httpbinRespContent, emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services", http.StatusOK, nginxRespContent, emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("verifying that both backends receive requests according to weighted distribution")
 	httpbinRespName := "httpbin-resp"
@@ -506,7 +502,7 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	)
 
 	t.Log("verifying that misconfigured service rules are _not_ routed")
-	helpers.EventuallyGETPath(t, proxyURL, "test-http-route-multiple-services-broken", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services-broken", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 }
 
 func TestHTTPRouteFilterHosts(t *testing.T) {
@@ -584,9 +580,8 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	// testGetByHost tries to get the test path with specified host in request,
 	// and returns true if 200 returned.
 	testGetByHost := func(t *testing.T, host string) bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL, "/test-http-route-filter-hosts", nil)
-		req.Host = host
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		req := helpers.MustHTTPRequest(t, "GET", host, "/test-http-route-filter-hosts", nil)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			return false
 		}

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -155,15 +155,15 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	)
 
 	t.Log("waiting for routes from HTTPRoute to become operational")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials/base64/wqt5b8q7ccK7IGRhbiBib3NocWEgYmlyIGphdm9iaW1peiB5b8q7cWRpci4K",
 		http.StatusOK, "«yoʻq» dan boshqa bir javobimiz yoʻqdir.", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "2/test-http-route-essentials/regex/999", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "3/exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "3/exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/2/test-http-route-essentials/regex/999", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/3/exact-test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/3/exact-test-http-route-essentialsNO", http.StatusNotFound, "no Route matched", emptyHeaderSet, ingressWait, waitTick)
 
 	require.Eventually(t, func() bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL.Host, "test-http-route-essentials", nil)
+		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL.Host, "/test-http-route-essentials", nil)
 		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, "test-http-route-essentials", err)
@@ -193,7 +193,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Log("verifying HTTPRoute header match")
-		helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
+		helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/", http.StatusOK, "<title>httpbin.org</title>", map[string]string{"Content-Type": "audio/mp3"}, ingressWait, waitTick)
 	})
 
 	t.Log("verifying that the HTTPRoute has the Condition 'Accepted' set to 'True'")
@@ -221,7 +221,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the parentRefs now removed")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the parentRefs back")
 	require.Eventually(t, func() bool {
@@ -237,7 +237,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
 	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{}))
@@ -246,7 +246,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	callback = GetGatewayIsUnlinkedCallback(ctx, t, gatewayClient, gatewayapi.HTTPProtocolType, ns.Name, httpRoute.Name)
 	require.Eventually(t, callback, ingressWait, waitTick)
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the GatewayClass now removed")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
 	gwc, err = DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -258,7 +258,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
 	require.NoError(t, gatewayClient.GatewayV1beta1().Gateways(ns.Name).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
@@ -268,7 +268,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute gets dropped with the Gateway now removed")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
 	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
@@ -281,7 +281,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of HTTPRoutes and the route becomes available again")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusOK, "<title>httpbin.org</title>", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
 	require.NoError(t, gatewayClient.GatewayV1beta1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -292,7 +292,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	require.Eventually(t, callback, ingressWait, waitTick)
 
 	t.Log("verifying that the data-plane configuration from the HTTPRoute does not get orphaned with the GatewayClass and Gateway gone")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-essentials", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("testing port matching....")
 	t.Log("putting the Gateway back")
@@ -468,8 +468,8 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	t.Log("verifying that both backends are ready to receive traffic")
 	httpbinRespContent := "<title>httpbin.org</title>"
 	nginxRespContent := "<title>Welcome to nginx!</title>"
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services", http.StatusOK, httpbinRespContent, emptyHeaderSet, ingressWait, waitTick)
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services", http.StatusOK, nginxRespContent, emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-multiple-services", http.StatusOK, httpbinRespContent, emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-multiple-services", http.StatusOK, nginxRespContent, emptyHeaderSet, ingressWait, waitTick)
 
 	t.Log("verifying that both backends receive requests according to weighted distribution")
 	httpbinRespName := "httpbin-resp"
@@ -481,6 +481,7 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	}
 	weightedLoadBalancingTestConfig := helpers.CountHTTPResponsesConfig{
 		Method:      http.MethodGet,
+		Host:        proxyURL.Host,
 		Path:        "test-http-route-multiple-services",
 		Headers:     emptyHeaderSet,
 		Duration:    5 * time.Second,
@@ -502,7 +503,7 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 	)
 
 	t.Log("verifying that misconfigured service rules are _not_ routed")
-	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "test-http-route-multiple-services-broken", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, "/test-http-route-multiple-services-broken", http.StatusNotFound, "", emptyHeaderSet, ingressWait, waitTick)
 }
 
 func TestHTTPRouteFilterHosts(t *testing.T) {
@@ -580,7 +581,7 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	// testGetByHost tries to get the test path with specified host in request,
 	// and returns true if 200 returned.
 	testGetByHost := func(t *testing.T, host string) bool {
-		req := helpers.MustHTTPRequest(t, "GET", host, "/test-http-route-filter-hosts", nil)
+		req := helpers.MustHTTPRequest(t, http.MethodGet, host, "/test-http-route-filter-hosts", nil)
 		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			return false

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -134,11 +134,11 @@ func TestIngressRegexMatchPath(t *testing.T) {
 
 			t.Log("testing paths expected to match")
 			for _, path := range tc.matchPaths {
-				helpers.EventuallyGETPath(t, proxyURL, path, http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
+				helpers.EventuallyGETPath(t, proxyURL, proxyURL.Host, path, http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
 			}
 			t.Log("testing paths expected not to match")
 			for _, path := range tc.notMatchPaths {
-				helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, path, ingressWait, waitTick, nil)
+				helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, path, ingressWait, waitTick, nil)
 			}
 		})
 	}
@@ -233,6 +233,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 				helpers.EventuallyGETPath(
 					t,
 					proxyURL,
+					proxyURL.Host,
 					"/",
 					http.StatusOK,
 					"<title>httpbin.org</title>",
@@ -247,6 +248,7 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 				helpers.EventuallyExpectHTTP404WithNoRoute(
 					t,
 					proxyURL,
+					proxyURL.Host,
 					"/",
 					ingressWait,
 					waitTick,

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -1002,7 +1002,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	cleaner.Add(ingress)
 
 	t.Log("try to access the ingress by matching host")
-	req := helpers.MustHTTPRequest(t, "GET", "test.example", "", nil)
+	req := helpers.MustHTTPRequest(t, http.MethodGet, "test.example", "/", nil)
 	require.Eventually(t, func() bool {
 		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
@@ -1021,7 +1021,7 @@ func TestIngressMatchByHost(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("try to access the ingress by unmatching host, should return 404")
-	req = helpers.MustHTTPRequest(t, "GET", "foo.example", "", nil)
+	req = helpers.MustHTTPRequest(t, http.MethodGet, "foo.example", "/", nil)
 	resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -1039,7 +1039,7 @@ func TestIngressMatchByHost(t *testing.T) {
 
 	t.Log("try to access the ingress by matching host")
 
-	req = helpers.MustHTTPRequest(t, "GET", "test0.example", "", nil)
+	req = helpers.MustHTTPRequest(t, http.MethodGet, "test0.example", "/", nil)
 	require.Eventually(t, func() bool {
 		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
@@ -1058,8 +1058,8 @@ func TestIngressMatchByHost(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("try to access the ingress by unmatching host, should return 404")
-	req.Host = "test.another"
-	resp, err = helpers.DefaultHTTPClient().Do(req)
+	req = helpers.MustHTTPRequest(t, http.MethodGet, "test.another", "/", nil)
+	resp, err = helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -111,7 +111,7 @@ func TestIngressEssentials(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("verifying that removing .Spec.IngressClassName %q from ingress causes routes to disconnect", consts.IngressClass)
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingress_essentials", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_ingress_essentials", ingressWait, waitTick, nil)
 
 	t.Logf("putting the .Spec.IngressClassName %q back on ingress", consts.IngressClass)
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -147,7 +147,7 @@ func TestIngressEssentials(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingress_essentials", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_ingress_essentials", ingressWait, waitTick, nil)
 }
 
 func TestGRPCIngressEssentials(t *testing.T) {
@@ -267,7 +267,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("verifying that removing the IngressClassName %q from ingress causes routes to disconnect", consts.IngressClass)
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
 
 	t.Logf("putting the IngressClassName %q back on ingress", consts.IngressClass)
 	err = setIngressClassNameWithRetry(ctx, ns.Name, ingress, kong.String(consts.IngressClass))
@@ -296,7 +296,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_ingressclassname_spec", ingressWait, waitTick, nil)
 }
 
 func TestIngressNamespaces(t *testing.T) {
@@ -1002,10 +1002,9 @@ func TestIngressMatchByHost(t *testing.T) {
 	cleaner.Add(ingress)
 
 	t.Log("try to access the ingress by matching host")
-	req := helpers.MustHTTPRequest(t, "GET", proxyURL, "", nil)
-	req.Host = "test.example"
+	req := helpers.MustHTTPRequest(t, "GET", "test.example", "", nil)
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1022,8 +1021,8 @@ func TestIngressMatchByHost(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("try to access the ingress by unmatching host, should return 404")
-	req.Host = "foo.example"
-	resp, err := helpers.DefaultHTTPClient().Do(req)
+	req = helpers.MustHTTPRequest(t, "GET", "foo.example", "", nil)
+	resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -1040,9 +1039,9 @@ func TestIngressMatchByHost(t *testing.T) {
 
 	t.Log("try to access the ingress by matching host")
 
-	req.Host = "test0.example"
+	req = helpers.MustHTTPRequest(t, "GET", "test0.example", "", nil)
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1103,9 +1102,8 @@ func TestIngressRewriteURI(t *testing.T) {
 	featureGates := testenv.ControllerFeatureGates()
 	if !strings.Contains(featureGates, "RewriteURIsFeature=true") {
 		t.Log("try to access the ingress with rewrite uri disabled")
-		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL, "/foo/jpeg", nil)
-		req.Host = "test.example"
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		req := helpers.MustHTTPRequest(t, http.MethodGet, "test.example", "/foo/jpeg", nil)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -1114,10 +1112,9 @@ func TestIngressRewriteURI(t *testing.T) {
 	}
 
 	t.Log("try to access the ingress with valid capture group")
-	req := helpers.MustHTTPRequest(t, http.MethodGet, proxyURL, "/foo/jpeg", nil)
-	req.Host = "test.example"
+	req := helpers.MustHTTPRequest(t, http.MethodGet, "test.example", "/foo/jpeg", nil)
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1130,9 +1127,8 @@ func TestIngressRewriteURI(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Log("try to access the ingress with invalid capture group, should return 404")
-	req = helpers.MustHTTPRequest(t, http.MethodGet, proxyURL, "/", nil)
-	req.Host = "test.example"
-	resp, err := helpers.DefaultHTTPClient().Do(req)
+	req = helpers.MustHTTPRequest(t, http.MethodGet, "test.example", "/", nil)
+	resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -1148,10 +1144,9 @@ func TestIngressRewriteURI(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("try to access the ingress with new valid capture group")
-	req = helpers.MustHTTPRequest(t, http.MethodGet, proxyURL, "/foo/jpeg/png", nil)
-	req.Host = "test.example"
+	req = helpers.MustHTTPRequest(t, http.MethodGet, "test.exmaple", "/foo/jpeg/png", nil)
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
@@ -1173,7 +1168,7 @@ func TestIngressRewriteURI(t *testing.T) {
 
 	t.Log("try to access the ingress with new rewrite annotation")
 	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Do(req)
+		resp, err := helpers.DefaultHTTPClientWithProxy(proxyURL).Do(req)
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -153,7 +153,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_essentials", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_plugin_essentials", ingressWait, waitTick, nil)
 }
 
 func TestPluginOrdering(t *testing.T) {
@@ -300,5 +300,5 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, "/test_plugin_ordering", ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_plugin_ordering", ingressWait, waitTick, nil)
 }

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -94,7 +94,13 @@ func EventuallyGETPath(
 	waitDuration time.Duration,
 	waitTick time.Duration,
 ) {
-	client := DefaultHTTPClientWithProxy(proxyURL)
+	var client *http.Client
+	if proxyURL != nil {
+		client = DefaultHTTPClientWithProxy(proxyURL)
+
+	} else {
+		client = DefaultHTTPClient()
+	}
 
 	require.Eventually(t, func() bool {
 		req := MustHTTPRequest(t, http.MethodGet, host, path, headers)

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -22,6 +22,16 @@ func DefaultHTTPClient() *http.Client {
 	}
 }
 
+func DefaultHTTPClientWithProxy(proxyURL *url.URL) *http.Client {
+	tr := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   10 * time.Second,
+	}
+}
+
 // RetryableHTTPClient wraps a client with retry logic. That should be used when calling external services that might
 // temporarily fail (e.g. Konnect APIs), and we don't want them to affect the test results.
 func RetryableHTTPClient(base *http.Client) *http.Client {
@@ -36,11 +46,18 @@ func RetryableHTTPClient(base *http.Client) *http.Client {
 
 // MustHTTPRequest creates a request with provided parameters and it fails the
 // test that it was called in when request creation fails.
-func MustHTTPRequest(t *testing.T, method string, proxyURL *url.URL, path string, headers map[string]string) *http.Request {
-	// trim suffix '/'s of proxy URL and prefix '/'s of path to avoid duplicate /s
-	host := strings.TrimRight(proxyURL.String(), "/")
+func MustHTTPRequest(t *testing.T, method string, host, path string, headers map[string]string) *http.Request {
+	scheme := "http"
+	if strings.HasPrefix(host, "https://") {
+		scheme = "https"
+		host = strings.TrimPrefix(host, "https://")
+	} else if strings.HasPrefix(host, "http://") {
+		scheme = "http"
+		host = strings.TrimPrefix(host, "http://")
+	}
+	host = strings.TrimRight(host, "/")
 	path = strings.TrimLeft(path, "/")
-	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", host, path), nil)
+	req, err := http.NewRequest(method, fmt.Sprintf("%s://%s/%s", scheme, host, path), nil)
 	require.NoError(t, err)
 	for header, value := range headers {
 		req.Header.Set(header, value)
@@ -69,6 +86,7 @@ func MustParseURL(t *testing.T, urlStr string) *url.URL {
 func EventuallyGETPath(
 	t *testing.T,
 	proxyURL *url.URL,
+	host string,
 	path string,
 	statusCode int,
 	bodyContents string,
@@ -76,10 +94,10 @@ func EventuallyGETPath(
 	waitDuration time.Duration,
 	waitTick time.Duration,
 ) {
-	client := DefaultHTTPClient()
+	client := DefaultHTTPClientWithProxy(proxyURL)
 
 	require.Eventually(t, func() bool {
-		req := MustHTTPRequest(t, http.MethodGet, proxyURL, path, headers)
+		req := MustHTTPRequest(t, http.MethodGet, host, path, headers)
 		resp, err := client.Do(req)
 		if err != nil {
 			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, path, err)
@@ -104,6 +122,7 @@ func EventuallyGETPath(
 func EventuallyExpectHTTP404WithNoRoute(
 	t *testing.T,
 	proxyURL *url.URL,
+	host string,
 	path string,
 	waitDuration time.Duration,
 	waitTick time.Duration,
@@ -112,6 +131,7 @@ func EventuallyExpectHTTP404WithNoRoute(
 	EventuallyGETPath(
 		t,
 		proxyURL,
+		host,
 		path,
 		http.StatusNotFound,
 		"no Route matched with those values",
@@ -143,6 +163,7 @@ func MatchRespByStatusAndContent(
 
 type CountHTTPResponsesConfig struct {
 	Method      string
+	Host        string
 	Path        string
 	Headers     map[string]string
 	Duration    time.Duration
@@ -155,7 +176,7 @@ func CountHTTPGetResponses(
 	cfg CountHTTPResponsesConfig,
 	matchers ...ResponseMatcher,
 ) (matchedResponseCounter map[string]int) {
-	req := MustHTTPRequest(t, cfg.Method, proxyURL, cfg.Path, cfg.Headers)
+	req := MustHTTPRequest(t, cfg.Method, cfg.Host, cfg.Path, cfg.Headers)
 	matchedResponseCounter = make(map[string]int)
 
 	finished := time.NewTimer(cfg.Duration)
@@ -166,15 +187,15 @@ func CountHTTPGetResponses(
 	for {
 		select {
 		case <-ticker.C:
-			countHTTPGetResponse(t, req, matchedResponseCounter, matchers...)
+			countHTTPGetResponse(t, req, proxyURL, matchedResponseCounter, matchers...)
 		case <-finished.C:
 			return matchedResponseCounter
 		}
 	}
 }
 
-func countHTTPGetResponse(t *testing.T, req *http.Request, matchCounter map[string]int, matchers ...ResponseMatcher) {
-	resp, err := DefaultHTTPClient().Do(req)
+func countHTTPGetResponse(t *testing.T, req *http.Request, proxyURL *url.URL, matchCounter map[string]int, matchers ...ResponseMatcher) {
+	resp, err := DefaultHTTPClientWithProxy(proxyURL).Do(req)
 	if err != nil {
 		return
 	}

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -85,19 +85,18 @@ func MustParseURL(t *testing.T, urlStr string) *url.URL {
 // calling test will fail and stop.
 func EventuallyGETPath(
 	t *testing.T,
-	proxyURL *url.URL,
+	proxyURL *url.URL, // proxyURL is the URL of Kong gateway proxy.
 	host string,
-	path string,
-	statusCode int,
-	bodyContents string,
-	headers map[string]string,
+	path string, // host and path are host and path of the URL in the GET request.
+	statusCode int, // statusCode is the expected status code.
+	bodyContents string, // bodyContents is the expected content to be contained in response body.
+	headers map[string]string, // headers are headers in the request.
 	waitDuration time.Duration,
 	waitTick time.Duration,
 ) {
 	var client *http.Client
 	if proxyURL != nil {
 		client = DefaultHTTPClientWithProxy(proxyURL)
-
 	} else {
 		client = DefaultHTTPClient()
 	}
@@ -106,7 +105,7 @@ func EventuallyGETPath(
 		req := MustHTTPRequest(t, http.MethodGet, host, path, headers)
 		resp, err := client.Do(req)
 		if err != nil {
-			t.Logf("WARNING: http request failed for GET %s/%s: %v", proxyURL, path, err)
+			t.Logf("WARNING: http request failed for GET %s/%s to %s: %v", host, path, proxyURL, err)
 			return false
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
- Add `host` parameter to `MustHTTPRequest` to make it easier to generate an HTTP request with certain host
- Add `DefaultHTTPClientWithProxy` to create a client proxying to Kong gateway
- Modify affected test code

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #3788 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No CHANGELOG required.
