### PR TITLE
chore: remove RegexHeaderVersionCutoff check

### DIFF
--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
@@ -30,7 +29,6 @@ func ValidateHTTPRoute(
 	ctx context.Context,
 	routesValidator routeValidator,
 	parserFeatures parser.FeatureFlags,
-	kongVersion semver.Version,
 	httproute *gatewayapi.HTTPRoute,
 	attachedGateways ...*gatewayapi.Gateway,
 ) (bool, string, error) {
@@ -64,7 +62,7 @@ func ValidateHTTPRoute(
 		}
 	}
 
-	return validateWithKongGateway(ctx, routesValidator, parserFeatures, kongVersion, httproute)
+	return validateWithKongGateway(ctx, routesValidator, parserFeatures, httproute)
 }
 
 // -----------------------------------------------------------------------------
@@ -188,7 +186,7 @@ func getListenersForHTTPRouteValidation(sectionName *gatewayapi.SectionName, gat
 }
 
 func validateWithKongGateway(
-	ctx context.Context, routesValidator routeValidator, parserFeatures parser.FeatureFlags, kongVersion semver.Version, httproute *gatewayapi.HTTPRoute,
+	ctx context.Context, routesValidator routeValidator, parserFeatures parser.FeatureFlags, httproute *gatewayapi.HTTPRoute,
 ) (bool, string, error) {
 	// Translate HTTPRoute to Kong Route object(s) that can be sent directly to the Admin API for validation.
 	// Use KIC parser that works both for traditional and expressions based routes.
@@ -201,7 +199,7 @@ func validateWithKongGateway(
 			Filters: rule.Filters,
 		}
 		routes, err := parser.GenerateKongRouteFromTranslation(
-			httproute, translation, parserFeatures.RegexPathPrefix, parserFeatures.ExpressionRoutes, kongVersion,
+			httproute, translation, parserFeatures.RegexPathPrefix, parserFeatures.ExpressionRoutes,
 		)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -373,9 +372,9 @@ func TestValidateHTTPRoute(t *testing.T) {
 			err:           fmt.Errorf("Pod is not a supported kind for httproute backendRefs, only Service is supported"),
 		},
 	} {
-		// Passed Kong version and routesValidator are irrelevant for the above test cases.
+		// Passed routesValidator is irrelevant for the above test cases.
 		valid, validMsg, err := ValidateHTTPRoute(
-			context.Background(), mockRoutesValidator{}, parser.FeatureFlags{}, semver.MustParse("3.0.0"), tt.route, tt.gateways...,
+			context.Background(), mockRoutesValidator{}, parser.FeatureFlags{}, tt.route, tt.gateways...,
 		)
 		assert.Equal(t, tt.valid, valid, tt.msg)
 		assert.Equal(t, tt.validationMsg, validMsg, tt.msg)

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -433,7 +433,7 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 		routeValidator = routesSvc
 	}
 	return gatewayvalidation.ValidateHTTPRoute(
-		ctx, routeValidator, validator.ParserFeatures, validator.KongVersion, &httproute, managedGateways...,
+		ctx, routeValidator, validator.ParserFeatures, &httproute, managedGateways...,
 	)
 }
 

--- a/internal/dataplane/parser/translate_httproute.go
+++ b/internal/dataplane/parser/translate_httproute.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -70,7 +69,7 @@ func (p *Parser) ingressRulesFromHTTPRoute(result *ingressRules, httproute *gate
 
 		// generate the routes for the service and attach them to the service
 		for _, kongRouteTranslation := range kongServiceTranslation.KongRoutes {
-			routes, err := GenerateKongRouteFromTranslation(httproute, kongRouteTranslation, p.featureFlags.RegexPathPrefix, p.featureFlags.ExpressionRoutes, p.kongVersion)
+			routes, err := GenerateKongRouteFromTranslation(httproute, kongRouteTranslation, p.featureFlags.RegexPathPrefix, p.featureFlags.ExpressionRoutes)
 			if err != nil {
 				return err
 			}
@@ -175,7 +174,6 @@ func GenerateKongRouteFromTranslation(
 	translation translators.KongRouteTranslation,
 	addRegexPrefix bool,
 	expressionRoutes bool,
-	kongVersion semver.Version,
 ) ([]kongstate.Route, error) {
 	// gather the k8s object information and hostnames from the httproute
 	objectInfo := util.FromK8sObject(httproute)
@@ -204,7 +202,6 @@ func GenerateKongRouteFromTranslation(
 		hostnames,
 		addRegexPrefix,
 		tags,
-		kongVersion,
 	)
 }
 
@@ -218,7 +215,6 @@ func generateKongRoutesFromHTTPRouteMatches(
 	hostnames []*string,
 	addRegexPrefix bool,
 	tags []*string,
-	kongVersion semver.Version,
 ) ([]kongstate.Route, error) {
 	if len(matches) == 0 {
 		// it's acceptable for an HTTPRoute to have no matches in the rulesets,
@@ -249,7 +245,7 @@ func generateKongRoutesFromHTTPRouteMatches(
 	r.Tags = tags
 
 	// convert header matching from HTTPRoute to Route format
-	headers, err := convertGatewayMatchHeadersToKongRouteMatchHeaders(matches[0].Headers, kongVersion)
+	headers, err := convertGatewayMatchHeadersToKongRouteMatchHeaders(matches[0].Headers)
 	if err != nil {
 		return []kongstate.Route{}, err
 	}

--- a/internal/dataplane/parser/translate_utils.go
+++ b/internal/dataplane/parser/translate_utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,7 +12,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -22,7 +20,7 @@ import (
 
 // convertGatewayMatchHeadersToKongRouteMatchHeaders takes an input list of Gateway APIs HTTPHeaderMatch
 // and converts these header matching rules to the format expected by go-kong.
-func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayapi.HTTPHeaderMatch, kongVersion semver.Version) (map[string][]string, error) {
+func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayapi.HTTPHeaderMatch) (map[string][]string, error) {
 	// iterate through each provided header match checking for invalid
 	// options and otherwise converting to kong type format.
 	convertedHeaders := make(map[string][]string)
@@ -32,9 +30,6 @@ func convertGatewayMatchHeadersToKongRouteMatchHeaders(headers []gatewayapi.HTTP
 				string(header.Name))
 		}
 		if header.Type != nil && *header.Type == gatewayapi.HeaderMatchRegularExpression {
-			if kongVersion.LT(versions.RegexHeaderVersionCutoff) {
-				return nil, fmt.Errorf("Kong version %s does not support HeaderMatchRegularExpression", kongVersion)
-			}
 			convertedHeaders[string(header.Name)] = []string{kongHeaderRegexPrefix + header.Value}
 		} else if header.Type == nil || *header.Type == gatewayapi.HeaderMatchExact {
 			convertedHeaders[string(header.Name)] = []string{header.Value}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -8,9 +8,6 @@ var (
 	// KICv3VersionCutoff is the lowest version version of Kong Gateway supported by KIC >=v3.0.0.
 	KICv3VersionCutoff = semver.Version{Major: 3, Minor: 4, Patch: 1}
 
-	// RegexHeaderVersionCutoff is the Kong version prior to the addition of support for regular expression for matching headers.
-	RegexHeaderVersionCutoff = semver.Version{Major: 2, Minor: 8}
-
 	// ExplicitRegexPathVersionCutoff is the lowest Kong version requiring the explicit "~" prefixes in regular expression paths.
 	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -182,8 +181,6 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	}, ingressWait, waitTick)
 
 	t.Run("", func(t *testing.T) {
-		RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.RegexHeaderVersionCutoff))
-
 		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -180,7 +180,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 		return false
 	}, ingressWait, waitTick)
 
-	t.Run("", func(t *testing.T) {
+	t.Run("header regex match", func(t *testing.T) {
 		httpRoute, err = gatewayClient.GatewayV1beta1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR removes the redundant version guard - `RegexHeaderVersionCutoff`.
PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduced a global check for KIC `3.0.0` that allows only using Kong Gateway in version `>= 3.4.1`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

