### PR TITLE
chore: remove ConsumerGroupsVersionCutoff check

### DIFF
--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -6,7 +6,7 @@ const (
 	ErrTextConsumerCredentialValidationFailed = "consumer credential failed validation"
 	ErrTextConsumerExists                     = "consumer already exists"
 	ErrTextConsumerUnretrievable              = "failed to fetch consumer from kong"
-	ErrTextConsumerGroupUnsupported           = "consumer group support requires Kong Enterprise 3.4+"
+	ErrTextConsumerGroupUnsupported           = "consumer group support requires Kong Enterprise"
 	ErrTextConsumerGroupUnlicensed            = "consumer group support requires a valid Kong Enterprise license"
 	ErrTextConsumerGroupUnexpected            = "unexpected error during checking support for consumer group"
 	ErrTextConsumerUsernameEmpty              = "username cannot be empty"

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
@@ -185,7 +184,6 @@ func (validator KongHTTPValidator) ValidateConsumerGroup(
 		return true, "", nil
 	}
 
-	// Consumer groups work only for Kong Enterprise >=3.4.
 	infoSvc, ok := validator.AdminAPIServicesProvider.GetInfoService()
 	if !ok {
 		return true, "", nil
@@ -199,8 +197,7 @@ func (validator KongHTTPValidator) ValidateConsumerGroup(
 	if err != nil {
 		validator.Logger.Debugf("failed to parse Kong version: %v", err)
 	} else {
-		kongVer := semver.Version{Major: version.Major(), Minor: version.Minor()}
-		if !version.IsKongGatewayEnterprise() || !kongVer.GTE(versions.ConsumerGroupsVersionCutoff) {
+		if !version.IsKongGatewayEnterprise() {
 			return false, ErrTextConsumerGroupUnsupported, nil
 		}
 	}

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -450,9 +450,9 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name:             "Enterprise version past threshold",
+			name:             "Enterprise version",
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
-			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
+			InfoSvc:          &fakeInfoSvc{version: "3.4.1.0"},
 			args: args{
 				cg: kongv1beta1.KongConsumerGroup{},
 			},
@@ -461,20 +461,9 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:             "Enterprise version below threshold",
-			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
-			InfoSvc:          &fakeInfoSvc{version: "3.2.0.0"},
-			args: args{
-				cg: kongv1beta1.KongConsumerGroup{},
-			},
-			wantOK:      false,
-			wantMessage: ErrTextConsumerGroupUnsupported,
-			wantErr:     false,
-		},
-		{
 			name:             "OSS version",
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: nil},
-			InfoSvc:          &fakeInfoSvc{version: "3.4.0"},
+			InfoSvc:          &fakeInfoSvc{version: "3.4.1"},
 			args: args{
 				cg: kongv1beta1.KongConsumerGroup{},
 			},
@@ -483,9 +472,9 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:             "Enterprise version above threshold, unlicensed",
+			name:             "Enterprise version, unlicensed",
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusForbidden, "no license")},
-			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
+			InfoSvc:          &fakeInfoSvc{version: "3.4.1.0"},
 			args: args{
 				cg: kongv1beta1.KongConsumerGroup{},
 			},
@@ -494,9 +483,9 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:             "Enterprise version above threshold, API somehow missing",
+			name:             "Enterprise version, API somehow missing",
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusNotFound, "well, this is awkward")},
-			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
+			InfoSvc:          &fakeInfoSvc{version: "3.4.1.0"},
 			args: args{
 				cg: kongv1beta1.KongConsumerGroup{},
 			},
@@ -527,9 +516,9 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:             "Enterprise version above threshold, API returning unexpected error",
+			name:             "Enterprise version, API returning unexpected error",
 			ConsumerGroupSvc: &fakeConsumerGroupSvc{err: kong.NewAPIError(http.StatusTeapot, "I'm a teapot")},
-			InfoSvc:          &fakeInfoSvc{version: "3.4.0.0"},
+			InfoSvc:          &fakeInfoSvc{version: "3.4.1.0"},
 			args: args{
 				cg: kongv1beta1.KongConsumerGroup{},
 			},

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -14,9 +14,6 @@ var (
 	// ExplicitRegexPathVersionCutoff is the lowest Kong version requiring the explicit "~" prefixes in regular expression paths.
 	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 
-	// ConsumerGroupsVersionCutoff is the Kong version prior to the addition of Consumer Groups as first class citizens.
-	ConsumerGroupsVersionCutoff = semver.Version{Major: 3, Minor: 4}
-
 	// MTLSCredentialVersionCutoff is the minimum Kong version that support mTLS credentials. This is a patch version
 	// because the original version of the mTLS credential was not compatible with KIC.
 	MTLSCredentialVersionCutoff = semver.Version{Major: 2, Minor: 3, Patch: 2}

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
@@ -32,7 +31,6 @@ import (
 func TestConsumerGroup(t *testing.T) {
 	t.Parallel()
 
-	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.ConsumerGroupsVersionCutoff))
 	RunWhenKongEnterprise(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR removes the redundant version guard - `ConsumerGroupsVersionCutoff`.
PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduced a global check for KIC `3.0.0` that allows only using Kong Gateway in version `>= 3.4.1`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

