### PR TITLE
chore: remove PluginOrderingVersionCutoff & TLSPassthroughCutoff checks

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -14,9 +14,6 @@ var (
 	// ExplicitRegexPathVersionCutoff is the lowest Kong version requiring the explicit "~" prefixes in regular expression paths.
 	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 
-	// PluginOrderingVersionCutoff is the Kong version prior to the addition of plugin ordering.
-	PluginOrderingVersionCutoff = semver.Version{Major: 3}
-
 	// ConsumerGroupsVersionCutoff is the Kong version prior to the addition of Consumer Groups as first class citizens.
 	ConsumerGroupsVersionCutoff = semver.Version{Major: 3, Minor: 4}
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -160,7 +159,6 @@ func TestPluginEssentials(t *testing.T) {
 func TestPluginOrdering(t *testing.T) {
 	t.Parallel()
 
-	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.PluginOrderingVersionCutoff))
 	RunWhenKongEnterprise(t)
 
 	ctx := context.Background()

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
@@ -309,8 +308,6 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 	// Kong does not currently recognize these requests even though the expression looks correct. This should be enabled
 	// after determining why the gateway is discarding these requests and applying any necessary fixes.
 	// RunWhenKongExpressionRouter(t)
-
-	RunWhenKongVersion(t, fmt.Sprintf(">=%s", versions.TLSPassthroughCutoff))
 
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR removes the redundant version guard - `PluginOrderingVersionCutoff` and `TLSPassthroughCutoff` (they are used only in tests).
PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduced a global check for KIC `3.0.0` that allows only using Kong Gateway in version `>= 3.4.1`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

