### PR TITLE
chore: remove MTLSCredentialVersionCutoff check

### DIFF
--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -3,10 +3,8 @@ package kongstate
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
@@ -69,7 +67,7 @@ func (c *Consumer) SanitizedCopy() *Consumer {
 	}
 }
 
-func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags []*string, kongVersion semver.Version) error {
+func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags []*string) error {
 	switch credType {
 	case "key-auth", "keyauth_credential":
 		cred, err := NewKeyAuth(credConfig)
@@ -114,9 +112,6 @@ func (c *Consumer) SetCredential(credType string, credConfig interface{}, tags [
 		cred.Tags = tags
 		c.ACLGroups = append(c.ACLGroups, cred)
 	case "mtls-auth":
-		if !kongVersion.GTE(versions.MTLSCredentialVersionCutoff) {
-			return fmt.Errorf("controller cannot support mtls-auth below version %v", versions.MTLSCredentialVersionCutoff)
-		}
 		cred, err := NewMTLSAuth(credConfig)
 		if err != nil {
 			return err

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -3,12 +3,9 @@ package kongstate
 import (
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/versions"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 )
 
@@ -86,9 +83,6 @@ func TestConsumer_SetCredential(t *testing.T) {
 		result  *Consumer
 		wantErr bool
 	}
-
-	v, err := semver.Parse("2.2.0") // version prior to MTLSCredentialVersionCutoff
-	require.NoError(t, err)
 
 	tests := []Case{
 		{
@@ -445,20 +439,10 @@ func TestConsumer_SetCredential(t *testing.T) {
 			result:  &Consumer{Consumer: kong.Consumer{Username: &username, Tags: []*string{}}},
 			wantErr: true,
 		},
-		{
-			name: "mtls-auth on unsupported version",
-			args: args{
-				credType:   "mtls-auth",
-				consumer:   &Consumer{Consumer: kong.Consumer{Username: &username, Tags: []*string{}}},
-				credConfig: map[string]string{"subject_name": "foo@example.com"},
-			},
-			result:  &Consumer{Consumer: kong.Consumer{Username: &username, Tags: []*string{}}},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.args.consumer.SetCredential(tt.args.credType, tt.args.credConfig, []*string{}, v)
+			err := tt.args.consumer.SetCredential(tt.args.credType, tt.args.credConfig, []*string{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("processCredential() error = %v, wantErr %v",
 					err, tt.wantErr)
@@ -510,8 +494,7 @@ func TestConsumer_SetCredential(t *testing.T) {
 
 	for _, tt := range mtlsSupportedTests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := versions.MTLSCredentialVersionCutoff // minimum version for mtls-auths with tags
-			err := tt.args.consumer.SetCredential(tt.args.credType, tt.args.credConfig, []*string{}, v)
+			err := tt.args.consumer.SetCredential(tt.args.credType, tt.args.credConfig, []*string{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("processCredential() error = %v, wantErr %v",
 					err, tt.wantErr)

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -62,7 +61,6 @@ func (ks *KongState) SanitizedCopy() *KongState {
 func (ks *KongState) FillConsumersAndCredentials(
 	s store.Storer,
 	failuresCollector *failures.ResourceFailuresCollector,
-	kongVersion semver.Version,
 ) {
 	consumerIndex := make(map[string]Consumer)
 
@@ -163,8 +161,7 @@ func (ks *KongState) FillConsumersAndCredentials(
 				continue
 			}
 			credTags := util.GenerateTagsForObject(secret)
-			err = c.SetCredential(credType, credConfig, credTags, kongVersion)
-			if err != nil {
+			if err := c.SetCredential(credType, credConfig, credTags); err != nil {
 				pushCredentialResourceFailures(
 					fmt.Sprintf("failed to provision credential: %v", err),
 				)

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -631,7 +630,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			require.NoError(t, err)
 
 			state := KongState{}
-			state.FillConsumersAndCredentials(store, failureCollector, semver.MustParse("2.3.2"))
+			state.FillConsumersAndCredentials(store, failureCollector)
 			// compare translated consumers.
 			require.Len(t, state.Consumers, len(tc.expectedKongStateConsumers))
 			// compare fields. Since we only test for translating a single consumer, we only compare the first one if exists.

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -209,7 +209,7 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 	result.FillOverrides(p.logger, p.storer)
 
 	// generate consumers and credentials
-	result.FillConsumersAndCredentials(p.storer, p.failuresCollector, p.kongVersion)
+	result.FillConsumersAndCredentials(p.storer, p.failuresCollector)
 	for i := range result.Consumers {
 		p.registerSuccessfullyParsedObject(&result.Consumers[i].K8sKongConsumer)
 	}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -11,10 +11,6 @@ var (
 	// ExplicitRegexPathVersionCutoff is the lowest Kong version requiring the explicit "~" prefixes in regular expression paths.
 	ExplicitRegexPathVersionCutoff = semver.Version{Major: 3, Minor: 0}
 
-	// MTLSCredentialVersionCutoff is the minimum Kong version that support mTLS credentials. This is a patch version
-	// because the original version of the mTLS credential was not compatible with KIC.
-	MTLSCredentialVersionCutoff = semver.Version{Major: 2, Minor: 3, Patch: 2}
-
 	// ExpressionRouterL4Cutoff is the lowest Kong version with support of L4 proxy in expression router.
 	ExpressionRouterL4Cutoff = semver.Version{Major: 3, Minor: 4}
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR removes the redundant version guard - `MTLSCredentialVersionCutoff`.
PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduced a global check for KIC `3.0.0` that allows only using Kong Gateway in version `>= 3.4.1`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

