### PR TITLE
chore: extract test dependencies to a separate file

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -1,0 +1,26 @@
+e2e:
+  kind:
+    - 'v1.28.0'
+    - 'v1.27.0'
+    - 'v1.26.3'
+    - 'v1.25.10'
+    - 'v1.24.11'
+    - 'v1.23.12'
+  gke:
+    - 'v1.26.5'
+  istio:
+    # For Istio, we define combinations of Kind and Istio versions that will be
+    # used directly in the test matrix `include` section.
+    - kind: 'v1.28.0'
+      istio: 'v1.19'
+    - kind: 'v1.27.3'
+      istio: 'v1.18'
+    - kind: 'v1.26.6'
+      istio: 'v1.17'
+    - kind: 'v1.25.11'
+      istio: 'v1.16'
+
+integration:
+  kind: 'v1.28.0'
+  kong-oss: '3.4'
+  kong-ee: '3.4'

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -70,22 +70,30 @@ jobs:
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 
-  # TODO: extract this as a separate workflow reading the dependencies versions from a file (not only Kind, but also
-  # GKE, Istio, Kong, etc.)
-  # https://github.com/Kong/kubernetes-ingress-controller/issues/3349
   dependencies-versions:
     runs-on: ubuntu-latest
     outputs:
-      kind-versions: ${{ steps.set-kind-versions.outputs.kind-versions }}
+      kind: ${{ steps.set-versions.outputs.kind }}
+      gke: ${{ steps.set-versions.outputs.gke }}
+      istio: ${{ steps.set-versions.outputs.istio }}
     steps:
-      - id: set-kind-versions
-        name: Set Kind versions
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: set-versions
+        name: Set versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind-versions=[\"1.23.17\", \"1.24.15\", \"1.25.11\", \"1.26.6\", \"1.27.3\", \"1.28.0\"]" >> $GITHUB_OUTPUT
+            echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.kind' | jq -c)" >> $GITHUB_OUTPUT
           else
-            echo "kind-versions=[\"1.28.0\"]" >> $GITHUB_OUTPUT
+            # We assume the first version in the list is the latest one.
+            echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.kind' | jq -c '[first]')" >> $GITHUB_OUTPUT
           fi
+          echo "gke=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.gke' | jq -c)" >> $GITHUB_OUTPUT
+          echo "istio=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.istio' | jq -c)" >> $GITHUB_OUTPUT
+
   kind:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
@@ -95,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ${{ fromJSON(needs.dependencies-versions.outputs.kind-versions) }}
+        kubernetes-version: ${{ fromJSON(needs.dependencies-versions.outputs.kind) }}
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: Download built image artifact
@@ -172,8 +180,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version:
-          - 'v1.26.5'
+        kubernetes-version: ${{ fromJSON(needs.dependencies-versions.outputs.gke) }}
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
       - name: checkout repository
@@ -229,18 +236,11 @@ jobs:
   istio:
     if: ${{ inputs.run-istio }}
     runs-on: ubuntu-latest
+    needs: dependencies-versions
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - kubernetes-version: 'v1.28.0'
-            istio-version: 'v1.19'
-          - kubernetes-version: 'v1.27.3'
-            istio-version: 'v1.18'
-          - kubernetes-version: 'v1.26.6'
-            istio-version: 'v1.17'
-          - kubernetes-version: 'v1.25.11'
-            istio-version: 'v1.16'
+        include: ${{ fromJSON(needs.dependencies-versions.outputs.istio) }}
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
@@ -277,8 +277,8 @@ jobs:
           TEST_KONG_LOAD_IMAGES: ${{ inputs.load-local-image }}
           TEST_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
-          ISTIO_VERSION: ${{ matrix.istio-version }}
+          KONG_CLUSTER_VERSION: ${{ matrix.kind }}
+          ISTIO_VERSION: ${{ matrix.istio }}
           NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
           # multiple kind clusters within a single job, so only 1 is allowed at a time.
           GOTESTSUM_JUNITFILE: "istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml"

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         # TODO: Consider changing to "kong:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.4"
+        default: "<from_test_dependencies.yaml>"
         required: false
       kong-oss-effective-version:
         # specifies effective semver of Kong gateway OSS when tag is not a valid semver (like 'nightly').
@@ -26,7 +26,7 @@ on:
         type: string
         # TODO: Consider changing to "kong/kong-gateway:latest"
         # See https://github.com/Kong/kubernetes-testing-framework/issues/542
-        default: "3.4"
+        default: "<from_test_dependencies.yaml>"
         required: false
       kong-enterprise-effective-version:
         # specifies effective semver of Kong gateway enterprise when tag is not a valid semver (like 'nightly').
@@ -35,11 +35,31 @@ on:
         required: false
 
 jobs:
+  dependencies-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      kind: ${{ steps.set-versions.outputs.kind }}
+      kong-ee: ${{ steps.set-versions.outputs.kong-ee }}
+      kong-oss: ${{ steps.set-versions.outputs.kong-oss }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: set-versions
+        name: Set versions
+        run: |
+          echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kind' | jq -c)" >> $GITHUB_OUTPUT
+          echo "kong-ee=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-oss' | jq -c)" >> $GITHUB_OUTPUT
+          echo "kong-oss=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-ee' | jq -c)" >> $GITHUB_OUTPUT
+
   integration-tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: dependencies-versions
     env:
-      KONG_CLUSTER_VERSION: 'v1.28.0'
+      KONG_CLUSTER_VERSION: ${{ needs.dependencies-versions.outputs.kind }}
       TEST_KONG_ROUTER_FLAVOR: 'traditional'
     strategy:
       fail-fast: false
@@ -91,13 +111,22 @@ jobs:
       - name: Set image of Kong
         id: set_kong_image
         run: |
+          kong_ee_tag="${{ inputs.kong-enterprise-container-tag }}"
+          if [ "${{ inputs.kong-enterprise-container-tag }}" == "<from_test_dependencies.yaml>" ]; then
+            kong_ee_tag=${{ needs.dependencies-versions.outputs.kong-ee }}
+          fi
+          kong_oss_tag="${{ inputs.kong-container-tag }}"
+          if [ "${{ inputs.kong-container-tag }}" == "<from_test_dependencies.yaml>" ]; then
+              kong_oss_tag=${{ needs.dependencies-versions.outputs.kong-oss }}
+          fi
+
           if [ "${{ matrix.enterprise }}" == "true" ]; then
             echo "TEST_KONG_IMAGE=${{ inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ inputs.kong-enterprise-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${kong_ee_tag}" >> $GITHUB_ENV
             echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-enterprise-effective-version }}" >> $GITHUB_ENV
           else
             echo "TEST_KONG_IMAGE=${{ inputs.kong-container-repo }}" >> $GITHUB_ENV
-            echo "TEST_KONG_TAG=${{ inputs.kong-container-tag }}" >> $GITHUB_ENV
+            echo "TEST_KONG_TAG=${kong_oss_tag}" >> $GITHUB_ENV
             echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-oss-effective-version }}" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts `Kind`, `GKE` and `Istio` versions definitions to a separate file: `.github/test_dependencies.yaml`. Uses `yq` and `jq` to extract versions from the file in workflows.

There was an [alternative attempt](https://github.com/Kong/kubernetes-ingress-controller/compare/main...chore/test-deps-file) not using `jq` nor `yq` but a separate dedicated Go script but I think it's better to keep it simple - `jq` gives us enough flexibility to extract values we're interested in for the workflows.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4691.

