### PR TITLE
tests: run envtest suite in parallel, add test.envtest.pretty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ _test.envtest: gotestsum setup-envtest use-setup-envtest
 test.envtest:
 	$(MAKE) _test.envtest GOTESTSUM_FORMAT=standard-verbose
 
-.PHONY: test.envtes.pretty
+.PHONY: test.envtest.pretty
 test.envtest.pretty:
 	$(MAKE) _test.envtest GOTESTSUM_FORMAT=testname
 

--- a/Makefile
+++ b/Makefile
@@ -369,10 +369,14 @@ test.unit.pretty:
 test.golden.update:
 	@go test -v -run TestParser_GoldenTests ./internal/dataplane/parser -update
 
-.PHONY: test.envtest
-.ONESHELL: test.envtest
-test.envtest: gotestsum setup-envtest
+
+.PHONY: use-setup-envtest
+use-setup-envtest:
 	$(SETUP_ENVTEST) use
+
+.PHONY: _test.envtest
+.ONESHELL: _test.envtest
+_test.envtest: gotestsum setup-envtest use-setup-envtest
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) -- \
@@ -382,6 +386,14 @@ test.envtest: gotestsum setup-envtest
 		-coverpkg=$(PKG_LIST) \
 		-coverprofile=coverage.envtest.out \
 		./test/envtest/...
+
+.PHONY: test.envtest
+test.envtest:
+	$(MAKE) _test.envtest GOTESTSUM_FORMAT=standard-verbose
+
+.PHONY: test.envtes.pretty
+test.envtest.pretty:
+	$(MAKE) _test.envtest GOTESTSUM_FORMAT=testname
 
 .PHONY: _check.container.environment
 _check.container.environment:

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -30,6 +30,8 @@ import (
 // TestGatewayAPIControllersMayBeDynamicallyStarted ensures that in case of missing CRDs installation in the
 // cluster, specific controllers are not started until the CRDs are installed.
 func TestGatewayAPIControllersMayBeDynamicallyStarted(t *testing.T) {
+	t.Parallel()
+
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme, WithInstallGatewayCRDs(false))
 
@@ -83,6 +85,8 @@ func TestGatewayAPIControllersMayBeDynamicallyStarted(t *testing.T) {
 // TestNoKongCRDsInstalledIsFatal ensures that in case of missing Kong CRDs installation, the manager Run() eventually
 // returns an error due to cache synchronisation timeout.
 func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
+	t.Parallel()
+
 	scheme := Scheme(t)
 	envcfg := Setup(t, scheme, WithInstallKongCRDs(false))
 
@@ -101,6 +105,8 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 }
 
 func TestCRDValidations(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -25,6 +25,8 @@ import (
 // Gateway's listener.
 // It reproduces https://github.com/Kong/kubernetes-ingress-controller/issues/4456.
 func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
+	t.Parallel()
+
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -21,6 +21,8 @@ import (
 // TestManagerDoesntStartUntilKubernetesAPIReachable ensures that the manager and its Runnables are not start until the
 // Kubernetes API server is reachable.
 func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
+	t.Parallel()
+
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestTelemetry(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring TLS listener - server for telemetry data")
 	cert := certificate.MustGenerateSelfSignedCert()
 	telemetryServerListener, err := tls.Listen("tcp", "localhost:0", &tls.Config{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the tests in `envtest` suite run in parallel.

Additionally it adds the `test.envtest.pretty` which prints only the test names and test output logs only when those fail.
