### PR TITLE
chore: remove TLSPassthroughCutoff leftover

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -18,9 +18,6 @@ var (
 	// because the original version of the mTLS credential was not compatible with KIC.
 	MTLSCredentialVersionCutoff = semver.Version{Major: 2, Minor: 3, Patch: 2}
 
-	// TLSPassthroughCutoff is the lowest Kong version with support for TLS passthrough.
-	TLSPassthroughCutoff = semver.Version{Major: 2, Minor: 7}
-
 	// ExpressionRouterL4Cutoff is the lowest Kong version with support of L4 proxy in expression router.
 	ExpressionRouterL4Cutoff = semver.Version{Major: 3, Minor: 4}
 )


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR removes the redundant version guard - ConsumerGroupsVersionCutoff.
PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduced a global check for KIC 3.0.0 that allows only using Kong Gateway in version >= 3.4.1.

Leftover from 
- https://github.com/Kong/kubernetes-ingress-controller/pull/4795

**Which issue this PR fixes:**

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764