### PR TITLE
tests(integration): log setup failure reason

### DIFF
--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -48,9 +48,11 @@ func exitOnErrWithCode(ctx context.Context, err error, exitCode int) {
 		return
 	}
 
-	fmt.Println("WARNING: failure occurred, performing test cleanup")
-	if rmErr := helpers.RemoveCluster(ctx, env.Cluster()); rmErr != nil {
-		err = fmt.Errorf("cleanup failed after test failure occurred CLEANUP_FAILURE=(%w): %w", rmErr, err)
+	fmt.Printf("WARNING: failure occurred: %v\n", err)
+	if env != nil {
+		if rmErr := helpers.RemoveCluster(ctx, env.Cluster()); rmErr != nil {
+			err = fmt.Errorf("cleanup failed after test failure occurred CLEANUP_FAILURE=(%w): %w", rmErr, err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "Error: tests failed: %s\n", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes it so that integration tests will log the setup error when the cleanup logic is run but fails (which up until now didn't print anything).

This also prevents failures in dereferencing the `env` fields/methods when it's still unset.