### PR TITLE
chore: drop unnecessary version field in UpdateStrategyInMemory

### DIFF
--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/file"
 	"github.com/sirupsen/logrus"
 
@@ -35,20 +34,17 @@ type UpdateStrategyInMemory struct {
 	configService   ConfigService
 	configConverter ContentToDBLessConfigConverter
 	log             logrus.FieldLogger
-	version         semver.Version
 }
 
 func NewUpdateStrategyInMemory(
 	configService ConfigService,
 	configConverter ContentToDBLessConfigConverter,
 	log logrus.FieldLogger,
-	version semver.Version,
 ) UpdateStrategyInMemory {
 	return UpdateStrategyInMemory{
 		configService:   configService,
 		configConverter: configConverter,
 		log:             log,
-		version:         version,
 	}
 }
 

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -117,6 +117,5 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(client UpdateClient
 		adminAPIClient,
 		DefaultContentToDBLessConfigConverter{},
 		r.log,
-		r.config.Version,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes unused `UpdateStrategyInMemory.version` field.
