### PR TITLE
feat: provide Kong admin token via file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Adding a new version? You'll need three changes:
   [#4766](https://github.com/Kong/kubernetes-ingress-controller/pull/4766)
 - Added `--kong-admin-token-file` flag to provide the Kong admin token via file
   [Providing Kong admin token via file](https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1120).
-  [#4789](https://github.com/Kong/kubernetes-ingress-controller/issues/2341)
+  [#4808](https://github.com/Kong/kubernetes-ingress-controller/pull/4808)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ Adding a new version? You'll need three changes:
 - Only Kong Gateway in version >= 3.4.1 is supported. The controller will refuse to start
   if the version is lower, also won't discover such Kong Gateways.
   [#4766](https://github.com/Kong/kubernetes-ingress-controller/pull/4766)
+- Added `--kong-admin-token-file` flag to provide the Kong admin token via file
+  [Providing Kong admin token via file](https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1120).
+  [#4789](https://github.com/Kong/kubernetes-ingress-controller/issues/2341)
+
 
 ### Fixed
 

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -54,6 +54,7 @@
 | `--kong-admin-tls-server-name` | `string` | SNI name to use to verify the certificate presented by Kong in TLS. |  |
 | `--kong-admin-tls-skip-verify` | `bool` | Disable verification of TLS certificate of Kong's Admin endpoint. | `false` |
 | `--kong-admin-token` | `string` | The Kong Enterprise RBAC token used by the controller. |  |
+| `--kong-admin-token-file` | `string` | Path to the Kong Enterprise RBAC token file used by the controller. |  |
 | `--kong-admin-url` | `stringSlice` | Kong Admin URL(s) to connect to in the format "protocol://address:port". More than 1 URL can be provided, in such case the flag should be used multiple times or a corresponding env variable should use comma delimited addresses. | `[http://localhost:8001]` |
 | `--kong-workspace` | `string` | Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces. |  |
 | `--konnect-address` | `string` | Base address of Konnect API. | `https://us.kic.api.konghq.com` |

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -287,15 +287,14 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	return flagSet
 }
 
+// Resolve the Config item(s) value from file, when provided.
 func (c *Config) Resolve() error {
-	if c.KongAdminToken == "" {
-		if c.KongAdminTokenPath != "" {
-			token, err := os.ReadFile(c.KongAdminTokenPath)
-			if err != nil {
-				return fmt.Errorf("failed to read --kong-admin-token-file from path '%s': %w", c.KongAdminTokenPath, err)
-			}
-			c.KongAdminToken = string(token)
+	if c.KongAdminTokenPath != "" {
+		token, err := os.ReadFile(c.KongAdminTokenPath)
+		if err != nil {
+			return fmt.Errorf("failed to read --kong-admin-token-file from path '%s': %w", c.KongAdminTokenPath, err)
 		}
+		c.KongAdminToken = string(token)
 	}
 	return nil
 }

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -1,11 +1,12 @@
 package manager_test
 
 import (
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 )
 
 func TestConfigResolve(t *testing.T) {

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -1,0 +1,28 @@
+package manager_test
+
+import (
+	"os"
+	"testing"
+
+)
+
+func TestConfigResolve(t *testing.T) {
+	t.Run("Admin Token Path", func(t *testing.T) {
+		validWithTokenPath := func() manager.Config {
+			tempDir := t.TempDir()
+			tokenFile, err := os.CreateTemp(tempDir, "kong.token")
+			require.NoError(t, err)
+			_, err = tokenFile.Write([]byte("non-empty-token"))
+			require.NoError(t, err)
+			return manager.Config{
+				KongAdminTokenPath: tokenFile.Name(),
+			}
+		}
+
+		t.Run("admin token path accepted", func(t *testing.T) {
+			c := validWithTokenPath()
+			require.NoError(t, c.Resolve())
+			require.Equal(t, c.KongAdminToken, "non-empty-token")
+		})
+	})
+}

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -1,6 +1,8 @@
 package manager_test
 
 import (
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -61,6 +61,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("can't set both --kong-admin-svc and --kong-admin-url")
 		}
 	}
+	if c.KongAdminToken != "" && c.KongAdminTokenPath != "" {
+		return errors.New("both admin token and admin token file specified, only one allowed")
+	}
 
 	if err := c.validateKonnect(); err != nil {
 		return fmt.Errorf("invalid konnect configuration: %w", err)

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -359,8 +359,7 @@ func TestConfigValidate(t *testing.T) {
 			_, err = tokenFile.Write([]byte("non-empty-token"))
 			require.NoError(t, err)
 			return manager.Config{
-				KongAdminTokenPath: tokenFile.Name()
-				,
+				KongAdminTokenPath: tokenFile.Name(),
 			}
 		}
 
@@ -376,9 +375,7 @@ func TestConfigValidate(t *testing.T) {
 			c.KongAdminToken = "non-empty-token"
 			require.ErrorContains(t, c.Validate(), "both admin token and admin token file specified, only one allowed")
 		})
-
 	})
-
 }
 
 func TestConfigValidateGatewayDiscovery(t *testing.T) {

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -3,7 +3,6 @@ package manager_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/samber/mo"
@@ -347,28 +346,15 @@ func TestConfigValidate(t *testing.T) {
 		t.Run("admin token accepted", func(t *testing.T) {
 			c := validWithToken()
 			require.NoError(t, c.Validate())
-			require.NoError(t, c.Resolve())
 		})
 	})
 
 	t.Run("Admin Token Path", func(t *testing.T) {
 		validWithTokenPath := func() manager.Config {
-			tempDir := t.TempDir()
-			tokenFile, err := os.CreateTemp(tempDir, "kong.token")
-			require.NoError(t, err)
-			_, err = tokenFile.Write([]byte("non-empty-token"))
-			require.NoError(t, err)
 			return manager.Config{
-				KongAdminTokenPath: tokenFile.Name(),
+				KongAdminTokenPath: "non-empty-token-path",
 			}
 		}
-
-		t.Run("admin token path accepted", func(t *testing.T) {
-			c := validWithTokenPath()
-			require.NoError(t, c.Validate())
-			require.NoError(t, c.Resolve())
-			require.Equal(t, c.KongAdminToken, "non-empty-token")
-		})
 
 		t.Run("admin token and token path rejected", func(t *testing.T) {
 			c := validWithTokenPath()

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -76,6 +76,11 @@ func Run(ctx context.Context, c *Config, diagnostic util.ConfigDumpDiagnostic, d
 		return fmt.Errorf("failed to create admin apis discoverer: %w", err)
 	}
 
+	err = c.Resolve()
+	if err != nil {
+		return fmt.Errorf("failed to resolve configuration: %w", err)
+	}
+
 	adminAPIClientsFactory := adminapi.NewClientFactoryForWorkspace(c.KongWorkspace, c.KongAdminAPIConfig, c.KongAdminToken)
 
 	setupLog.Info("getting the kong admin api client configuration")


### PR DESCRIPTION
**What this PR does / why we need it**:

When deploying Kong Enterprise in Kubernetes we need another option to secure the Kong admin token. The existing feature to provide the kong-admin-token via the environment variable CONTROLLER_KONG_ADMIN_TOKEN which can be backed as a Kubernetes secret does not fit for us.

**Which issue this PR fixes**:

Providing Kong admin token via file #4789

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
