### PR TITLE
feat(expression router) add validation to creating predicates

### DIFF
--- a/internal/dataplane/parser/atc/expression_test.go
+++ b/internal/dataplane/parser/atc/expression_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustNewPredicate(t *testing.T, lhs LHS, op BinaryOperator, rhs Literal) Predicate {
+	t.Helper()
+
+	predicate, err := NewPredicate(lhs, op, rhs)
+	require.NoError(t, err)
+	return predicate
+}
+
 func TestGenerateExpression(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -24,7 +32,8 @@ func TestGenerateExpression(t *testing.T) {
 		},
 		{
 			name: "simple predicate with lower() transformer",
-			matcher: NewPredicate(
+			matcher: mustNewPredicate(
+				t,
 				NewTransformerLower(FieldHTTPMethod),
 				OpEqual,
 				StringLiteral("get"),

--- a/internal/dataplane/parser/atc/predicate.go
+++ b/internal/dataplane/parser/atc/predicate.go
@@ -117,28 +117,28 @@ func (p Predicate) IsEmpty() bool {
 }
 
 var (
-	ErrorTypeNotMatch    = errors.New("type does not match on sides of predicate")
-	ErrorOperatorInvalid = errors.New("operator is not valid for the types of sides of predicate")
+	ErrTypeNotMatch    = errors.New("type does not match on sides of predicate")
+	ErrOperatorInvalid = errors.New("operator is not valid for the types of sides of predicate")
 )
 
 // NewPredicate generates a single predicate.
 func NewPredicate(lhs LHS, op BinaryOperator, rhs Literal) (Predicate, error) {
-	// check for predicates on string fields
+	// Check for predicates on string fields.
 	if lhs.FieldType() == FieldTypeString {
 		if rhs.Type() != LiteralTypeString {
-			return Predicate{}, ErrorTypeNotMatch
+			return Predicate{}, ErrTypeNotMatch
 		}
 		if op == OpGreaterThan || op == OpGreaterEqual || op == OpLessThan || op == OpLessEqual {
-			return Predicate{}, ErrorOperatorInvalid
+			return Predicate{}, ErrOperatorInvalid
 		}
 	}
-	// check for predicates on integer fields
+	// Check for predicates on integer fields.
 	if lhs.FieldType() == FieldTypeInt {
 		if rhs.Type() != LiteralTypeInt {
-			return Predicate{}, ErrorTypeNotMatch
+			return Predicate{}, ErrTypeNotMatch
 		}
 		if op == OpContains || op == OpPrefixMatch || op == OpSuffixMatch || op == OpRegexMatch {
-			return Predicate{}, ErrorOperatorInvalid
+			return Predicate{}, ErrOperatorInvalid
 		}
 	}
 	return Predicate{

--- a/internal/dataplane/parser/atc/predicate.go
+++ b/internal/dataplane/parser/atc/predicate.go
@@ -1,6 +1,7 @@
 package atc
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -115,15 +116,36 @@ func (p Predicate) IsEmpty() bool {
 	return p.value == nil
 }
 
+var (
+	ErrorTypeNotMatch    = errors.New("type does not match on sides of predicate")
+	ErrorOperatorInvalid = errors.New("operator is not valid for the types of sides of predicate")
+)
+
 // NewPredicate generates a single predicate.
-// TODO: check validity of LHS, op and RHS:
-// https://github.com/Kong/kubernetes-ingress-controller/issues/3822.
-func NewPredicate(lhs LHS, op BinaryOperator, rhs Literal) Predicate {
+func NewPredicate(lhs LHS, op BinaryOperator, rhs Literal) (Predicate, error) {
+	// check for predicates on string fields
+	if lhs.FieldType() == FieldTypeString {
+		if rhs.Type() != LiteralTypeString {
+			return Predicate{}, ErrorTypeNotMatch
+		}
+		if op == OpGreaterThan || op == OpGreaterEqual || op == OpLessThan || op == OpLessEqual {
+			return Predicate{}, ErrorOperatorInvalid
+		}
+	}
+	// check for predicates on integer fields
+	if lhs.FieldType() == FieldTypeInt {
+		if rhs.Type() != LiteralTypeInt {
+			return Predicate{}, ErrorTypeNotMatch
+		}
+		if op == OpContains || op == OpPrefixMatch || op == OpSuffixMatch || op == OpRegexMatch {
+			return Predicate{}, ErrorOperatorInvalid
+		}
+	}
 	return Predicate{
 		field: lhs,
 		op:    op,
 		value: rhs,
-	}
+	}, nil
 }
 
 func NewPredicateNetProtocol(op BinaryOperator, value string) Predicate {

--- a/internal/dataplane/parser/atc/predicate_test.go
+++ b/internal/dataplane/parser/atc/predicate_test.go
@@ -1,0 +1,74 @@
+package atc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPredicate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		lhs           LHS
+		op            BinaryOperator
+		rhs           Literal
+		expectedError error
+		expression    string
+	}{
+		{
+			name:       "predicate for string field (http.path)",
+			lhs:        FieldHTTPPath,
+			op:         OpEqual,
+			rhs:        StringLiteral("/path"),
+			expression: `http.path == "/path"`,
+		},
+		{
+			name:       "predicate for integer field (net.dst.port)",
+			lhs:        FieldNetDstPort,
+			op:         OpGreaterEqual,
+			rhs:        IntLiteral(1024),
+			expression: `net.dst.port >= 1024`,
+		},
+		{
+			name:          "unmatched types (LHS string RHS integer)",
+			lhs:           FieldHTTPPath,
+			op:            OpEqual,
+			rhs:           IntLiteral(80),
+			expectedError: ErrTypeNotMatch,
+		},
+		{
+			name:          "unmatched types (LHS integer RHS string)",
+			lhs:           FieldNetPort,
+			op:            OpEqual,
+			rhs:           StringLiteral("/"),
+			expectedError: ErrTypeNotMatch,
+		},
+		{
+			name:          "invalid operator (contains for integer)",
+			lhs:           FieldNetPort,
+			op:            OpContains,
+			rhs:           IntLiteral(10),
+			expectedError: ErrOperatorInvalid,
+		},
+		{
+			name:          "invalid operator (less than for string)",
+			lhs:           FieldHTTPPath,
+			op:            OpLessThan,
+			rhs:           StringLiteral("/v1"),
+			expectedError: ErrOperatorInvalid,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			predicate, err := NewPredicate(tc.lhs, tc.op, tc.rhs)
+			if tc.expectedError == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.expression, predicate.Expression())
+			} else {
+				require.EqualError(t, err, tc.expectedError.Error())
+			}
+		})
+	}
+}

--- a/internal/dataplane/parser/translators/l4route_atc.go
+++ b/internal/dataplane/parser/translators/l4route_atc.go
@@ -27,7 +27,8 @@ func ApplyExpressionToL4KongRoute(r *kongstate.Route) {
 	//
 	// Neither GWAPI Routes nor TCP/UDPIngress support sources either, so this only adds destinations.
 	for _, dst := range r.Destinations {
-		portMatchers = append(portMatchers, atc.NewPredicate(atc.FieldNetDstPort, atc.OpEqual, atc.IntLiteral(*dst.Port)))
+		portMatcher, _ := atc.NewPredicate(atc.FieldNetDstPort, atc.OpEqual, atc.IntLiteral(*dst.Port))
+		portMatchers = append(portMatchers, portMatcher)
 	}
 	matchers = append(matchers, atc.Or(portMatchers...))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Adds validation on creating ATC predicates in `NewPredicate`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #3822.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No user facing part changed.
