### PR TITLE
ci: add errname linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
   - dogsled
   - durationcheck
   - errcheck
+  - errname
   - errorlint
   - exhaustive
   - exportloopref

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ fmt:
 
 .PHONY: lint
 lint: verify.tidy golangci-lint staticcheck looppointer
-	$(GOLANGCI_LINT) run -v
+	$(GOLANGCI_LINT) run --verbose --config $(PROJECT_DIR)/.golangci.yaml
 
 .PHONY: staticcheck
 staticcheck: staticcheck.download

--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -87,14 +87,14 @@ func getKongPluginOrKongClusterPlugin(s store.Storer, namespace, name string) (
 ) {
 	plugin, pluginErr := s.GetKongPlugin(namespace, name)
 	if pluginErr != nil {
-		if !errors.As(pluginErr, &store.ErrNotFound{}) {
+		if !errors.As(pluginErr, &store.NotFoundError{}) {
 			return nil, nil, fmt.Errorf("failed fetching KongPlugin: %w", pluginErr)
 		}
 
 		// If KongPlugin is not found, try to fetch KongClusterPlugin.
 		clusterPlugin, err := s.GetKongClusterPlugin(name)
 		if err != nil {
-			if !errors.As(err, &store.ErrNotFound{}) {
+			if !errors.As(err, &store.NotFoundError{}) {
 				return nil, nil, fmt.Errorf("failed fetching KongClusterPlugin: %w", err)
 			}
 

--- a/internal/dataplane/parser/ingressclassparemeters_test.go
+++ b/internal/dataplane/parser/ingressclassparemeters_test.go
@@ -109,7 +109,7 @@ func TestGetIngressClassParameters(t *testing.T) {
 				Name:      testIcpName,
 			},
 			parameterSpec: defaultIcpSpec,
-			err:           store.ErrNotFound{Message: "IngressClassParameters test-icp not found"},
+			err:           store.NotFoundError{Message: "IngressClassParameters test-icp not found"},
 		},
 		{
 			name: "unmatched-name",
@@ -121,7 +121,7 @@ func TestGetIngressClassParameters(t *testing.T) {
 				Name:      "another-icp",
 			},
 			parameterSpec: defaultIcpSpec,
-			err:           store.ErrNotFound{Message: "IngressClassParameters another-icp not found"},
+			err:           store.NotFoundError{Message: "IngressClassParameters another-icp not found"},
 		},
 	}
 
@@ -152,8 +152,8 @@ func TestGetIngressClassParameters(t *testing.T) {
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())
 
-				if errors.As(tc.err, &store.ErrNotFound{}) {
-					assert.ErrorAs(t, err, &store.ErrNotFound{})
+				if errors.As(tc.err, &store.NotFoundError{}) {
+					assert.ErrorAs(t, err, &store.NotFoundError{})
 				}
 			} else {
 				assert.NoError(t, err)

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -22,7 +22,7 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 	ingressList := p.storer.ListIngressesV1()
 	icp, err := getIngressClassParametersOrDefault(p.storer)
 	if err != nil {
-		if !errors.As(err, &store.ErrNotFound{}) {
+		if !errors.As(err, &store.NotFoundError{}) {
 			// anything else is unexpected
 			p.logger.Errorf("could not find IngressClassParameters, using defaults: %s", err)
 		}

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -124,7 +124,7 @@ func (p *Parser) isTLSRoutePassthrough(tlsroute *gatewayapi.TLSRoute) (bool, err
 
 		gateway, err := p.storer.GetGateway(gatewayNamespace, string(parentRef.Name))
 		if err != nil {
-			if errors.As(err, &store.ErrNotFound{}) {
+			if errors.As(err, &store.NotFoundError{}) {
 				// log an error if the gateway expected to support the TLSRoute is not found in our cache.
 				p.logger.WithError(err).Errorf("gateway %s/%s not found for TLSRoute %s/%s",
 					gatewayNamespace, parentRef.Name, tlsroute.Namespace, tlsroute.Name)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -1,0 +1,14 @@
+package store
+
+// NotFoundError error is returned when a lookup results in no resource.
+// This type is meant to be used for error handling using `errors.As()`.
+type NotFoundError struct {
+	Message string
+}
+
+func (e NotFoundError) Error() string {
+	if e.Message == "" {
+		return "not found"
+	}
+	return e.Message
+}

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -321,7 +321,7 @@ func TestFakeStoreService(t *testing.T) {
 
 	service, err = store.GetService("default", "does-not-exists")
 	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 	assert.Nil(service)
 }
 
@@ -375,7 +375,7 @@ func TestFakeStoreEndpointSlice(t *testing.T) {
 
 	t.Run("Get EndpointSlices for non-existing Service", func(t *testing.T) {
 		c, err := store.GetEndpointSlicesForService("default", "does-not-exist")
-		require.ErrorAs(t, err, &ErrNotFound{})
+		require.ErrorAs(t, err, &NotFoundError{})
 		require.Nil(t, c)
 	})
 }
@@ -406,7 +406,7 @@ func TestFakeStoreConsumer(t *testing.T) {
 	c, err = store.GetKongConsumer("default", "does-not-exist")
 	assert.Nil(c)
 	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 }
 
 func TestFakeStoreConsumerGroup(t *testing.T) {
@@ -435,7 +435,7 @@ func TestFakeStoreConsumerGroup(t *testing.T) {
 	c, err = store.GetKongConsumerGroup("default", "does-not-exist")
 	assert.Nil(c)
 	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 }
 
 func TestFakeStorePlugins(t *testing.T) {
@@ -469,7 +469,7 @@ func TestFakeStorePlugins(t *testing.T) {
 	assert.Len(plugins, 1)
 
 	plugin, err := store.GetKongPlugin("default", "does-not-exist")
-	require.ErrorAs(err, &ErrNotFound{})
+	require.ErrorAs(err, &NotFoundError{})
 	require.Nil(plugin)
 }
 
@@ -531,7 +531,7 @@ func TestFakeStoreClusterPlugins(t *testing.T) {
 
 	plugin, err = store.GetKongClusterPlugin("does-not-exist")
 	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 	assert.Nil(plugin)
 }
 
@@ -557,7 +557,7 @@ func TestFakeStoreSecret(t *testing.T) {
 	secret, err = store.GetSecret("default", "does-not-exist")
 	assert.Nil(secret)
 	assert.NotNil(err)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 }
 
 func TestFakeKongIngress(t *testing.T) {
@@ -582,7 +582,7 @@ func TestFakeKongIngress(t *testing.T) {
 	kingress, err = store.GetKongIngress("default", "does-not-exist")
 	assert.NotNil(err)
 	assert.Nil(kingress)
-	assert.True(errors.As(err, &ErrNotFound{}))
+	assert.True(errors.As(err, &NotFoundError{}))
 }
 
 func TestFakeStore_ListCACerts(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,19 +53,6 @@ const (
 	IngressClassKongController = "ingress-controllers.konghq.com/kong"
 )
 
-// ErrNotFound error is returned when a lookup results in no resource.
-// This type is meant to be used for error handling using `errors.As()`.
-type ErrNotFound struct {
-	Message string
-}
-
-func (e ErrNotFound) Error() string {
-	if e.Message == "" {
-		return "not found"
-	}
-	return e.Message
-}
-
 // Storer is the interface that wraps the required methods to gather information
 // about ingresses, services, secrets and ingress annotations.
 type Storer interface {
@@ -426,7 +413,7 @@ func (s Store) GetSecret(namespace, name string) (*corev1.Secret, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("Secret %v not found", key)}
+		return nil, NotFoundError{fmt.Sprintf("Secret %v not found", key)}
 	}
 	return secret.(*corev1.Secret), nil
 }
@@ -439,7 +426,7 @@ func (s Store) GetService(namespace, name string) (*corev1.Service, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("Service %v not found", key)}
+		return nil, NotFoundError{fmt.Sprintf("Service %v not found", key)}
 	}
 	return service.(*corev1.Service), nil
 }
@@ -704,7 +691,7 @@ func (s Store) GetEndpointSlicesForService(namespace, name string) ([]*discovery
 		return nil, err
 	}
 	if len(endpointSlices) == 0 {
-		return nil, ErrNotFound{fmt.Sprintf("EndpointSlices for Service %s/%s not found", namespace, name)}
+		return nil, NotFoundError{fmt.Sprintf("EndpointSlices for Service %s/%s not found", namespace, name)}
 	}
 	return endpointSlices, nil
 }
@@ -717,7 +704,7 @@ func (s Store) GetKongPlugin(namespace, name string) (*kongv1.KongPlugin, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongPlugin %v not found", key)}
+		return nil, NotFoundError{fmt.Sprintf("KongPlugin %v not found", key)}
 	}
 	return p.(*kongv1.KongPlugin), nil
 }
@@ -729,7 +716,7 @@ func (s Store) GetKongClusterPlugin(name string) (*kongv1.KongClusterPlugin, err
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongClusterPlugin %v not found", name)}
+		return nil, NotFoundError{fmt.Sprintf("KongClusterPlugin %v not found", name)}
 	}
 	return p.(*kongv1.KongClusterPlugin), nil
 }
@@ -742,7 +729,7 @@ func (s Store) GetKongIngress(namespace, name string) (*kongv1.KongIngress, erro
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongIngress %v not found", name)}
+		return nil, NotFoundError{fmt.Sprintf("KongIngress %v not found", name)}
 	}
 	return p.(*kongv1.KongIngress), nil
 }
@@ -755,7 +742,7 @@ func (s Store) GetKongConsumer(namespace, name string) (*kongv1.KongConsumer, er
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongConsumer %v not found", key)}
+		return nil, NotFoundError{fmt.Sprintf("KongConsumer %v not found", key)}
 	}
 	return p.(*kongv1.KongConsumer), nil
 }
@@ -768,7 +755,7 @@ func (s Store) GetKongConsumerGroup(namespace, name string) (*kongv1beta1.KongCo
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("KongConsumerGroup %v not found", key)}
+		return nil, NotFoundError{fmt.Sprintf("KongConsumerGroup %v not found", key)}
 	}
 	return p.(*kongv1beta1.KongConsumerGroup), nil
 }
@@ -784,7 +771,7 @@ func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("IngressClass %v not found", name)}
+		return nil, NotFoundError{fmt.Sprintf("IngressClass %v not found", name)}
 	}
 	return p.(*netv1.IngressClass), nil
 }
@@ -827,7 +814,7 @@ func (s Store) GetIngressClassParametersV1Alpha1(ingressClass *netv1.IngressClas
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("IngressClassParameters %v not found", ingressClass.Spec.Parameters.Name)}
+		return nil, NotFoundError{fmt.Sprintf("IngressClassParameters %v not found", ingressClass.Spec.Parameters.Name)}
 	}
 	return params.(*kongv1alpha1.IngressClassParameters), nil
 }
@@ -840,7 +827,7 @@ func (s Store) GetGateway(namespace string, name string) (*gatewayapi.Gateway, e
 		return nil, err
 	}
 	if !exists {
-		return nil, ErrNotFound{fmt.Sprintf("Gateway %v not found", name)}
+		return nil, NotFoundError{fmt.Sprintf("Gateway %v not found", name)}
 	}
 	return obj.(*gatewayapi.Gateway), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add [`errname`](https://github.com/Antonboom/errname) linter to ensure that the convention:

> Error types end in "Error" and error variables start with "Err" or "err":

is enforced.

https://github.com/golang/go/wiki/Errors#naming
