### PR TITLE
fix: entry in changelog replace --ingress-address with --ingress-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Adding a new version? You'll need three changes:
 - Telemetry now reports the router flavor.
   [#4762](https://github.com/Kong/kubernetes-ingress-controller/pull/4762)
 - The following flags were renamed and marked as deprecated
-  - `--publish-service` to `--ingress-address`
+  - `--publish-service` to `--ingress-service`
   - `--publish-status-address` to `--ingress-address`
   - `--publish-service-udp` to `--ingress-service-udp`
   - `--publish-status-address-udp` to `--ingress-address-udp`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fix the mistake in changelog, `--publish-service` has been replaced with `--ingress-service`, in changelog by mistake `--ingress-address` has been put

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up for 
- https://github.com/Kong/kubernetes-ingress-controller/pull/4765

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
