### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -1,26 +1,40 @@
 e2e:
   kind:
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.28.0'
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.27.3'
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.26.6'
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.25.11'
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.24.15'
+    # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.23.17'
   gke:
     - 'v1.26.5'
+
+  # For Istio, we define combinations of Kind and Istio versions that will be
+  # used directly in the test matrix `include` section.
   istio:
-    # For Istio, we define combinations of Kind and Istio versions that will be
-    # used directly in the test matrix `include` section.
     - kind: 'v1.28.0'
-      istio: 'v1.19'
+      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      istio: 'v1.19.0'
     - kind: 'v1.27.3'
-      istio: 'v1.18'
+      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      istio: 'v1.18.0'
     - kind: 'v1.26.6'
-      istio: 'v1.17'
+      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      istio: 'v1.17.0'
     - kind: 'v1.25.11'
-      istio: 'v1.16'
+      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      istio: 'v1.16.0'
 
 integration:
+  # renovate: datasource=docker depName=kindest/node versioning=docker
   kind: 'v1.28.0'
-  kong-oss: '3.4'
-  kong-ee: '3.4'
+  # renovate: datasource=docker depName=kong versioning=docker
+  kong-oss: '3.4.0'
+  # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
+  kong-ee: '3.4.1.0'

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -51,8 +51,8 @@ jobs:
         name: Set versions
         run: |
           echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kind' | jq -c)" >> $GITHUB_OUTPUT
-          echo "kong-ee=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-oss' | jq -c)" >> $GITHUB_OUTPUT
-          echo "kong-oss=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-ee' | jq -c)" >> $GITHUB_OUTPUT
+          echo "kong-ee=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-ee' | jq -c)" >> $GITHUB_OUTPUT
+          echo "kong-oss=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-oss' | jq -c)" >> $GITHUB_OUTPUT
 
   integration-tests:
     name: ${{ matrix.name }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "gomod": {
+    "enabled": false
+  },
+  "kustomize": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": false
+  },
+  "dockerfile": {
+    "enabled": false
+  },
+  "automerge": false,
+  "separateMinorPatch": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.github/test_dependencies.yaml$"],
+      "matchStrings": [
+        "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Renovate configuration along with annotations in `test_dependencies.yaml`. It will have no effect until we enable Renovate GH application. It will make bumps of minors and patches to be posted in separate PRs. It defines a custom manager with a regex `customType` that matches only `.github/test_dependencies.yaml` file and looks for matching dependencies in there with the use of a regex with named groups (as required by Renovate, see [Custom Managers using Regex](https://docs.renovatebot.com/modules/manager/regex/)). 

Custom annotations like `# renovate: datasource=docker depName=istio/istioctl versioning=docker` matching the defined regex are used to mark dependencies that should be updated and extract their metadata (datasource, name, versioning scheme).

It's been tested on my KIC fork: 
- PR bumping kong/kong-gateway: https://github.com/czeslavo/kubernetes-ingress-controller/pull/17
- PR bumping kindest/node: https://github.com/czeslavo/kubernetes-ingress-controller/pull/10

Screenshot from the Renovate dashboard:
<img width="463" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/8835851/b5d58d5c-b3e9-4528-96a2-2403128af93b">

**Which issue this PR fixes**:

Closes #4692.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

