### PR TITLE
Determine credential type from label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ Adding a new version? You'll need three changes:
   It's nearly identical to `deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml`
   which is used in the official docs.
   [#4873](https://github.com/Kong/kubernetes-ingress-controller/pull/4873)
-- Credentials now use a `konghq.com/credential-type` label to indicate
+- Credentials now use a `konghq.com/credential` label to indicate
   credential type instead of the `kongCredType` field. This allows controller
   compontents to avoid caching unnecessary Secrets. The `kongCredType` field is
   still supported but is now deprecated. A script to generate commands to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,13 @@ Adding a new version? You'll need three changes:
   It's nearly identical to `deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml`
   which is used in the official docs.
   [#4873](https://github.com/Kong/kubernetes-ingress-controller/pull/4873)
+- Credentials now use a `konghq.com/credential-type` label to indicate
+  credential type instead of the `kongCredType` field. This allows controller
+  compontents to avoid caching unnecessary Secrets. The `kongCredType` field is
+  still supported but is now deprecated. A script to generate commands to
+  update Secrets is available at https://github.com/Kong/kubernetes-ingress-controller/issues/2502#issuecomment-1758213596
+  [#4825](https://github.com/Kong/kubernetes-ingress-controller/pull/4825)
+
 
 ### Fixed
 

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -14,6 +14,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
@@ -242,7 +243,14 @@ func (h RequestHandler) handleSecret(
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := secret.Data["kongCredType"]; !ok {
+	// TODO so long as we still handle the deprecated field, this has to remain
+	// once the deprecated field is removed, we must replace this with a label filter in the webhook itself
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4853
+
+	_, labelOk := secret.Labels[labels.LabelPrefix+labels.CredentialKey]
+	_, fieldOk := secret.Data["kongCredType"]
+
+	if !(labelOk || fieldOk) {
 		// secret does not look like a credential resource in Kong
 		return responseBuilder.Allowed(true).Build(), nil
 	}

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -14,7 +14,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 )
@@ -247,10 +247,7 @@ func (h RequestHandler) handleSecret(
 	// once the deprecated field is removed, we must replace this with a label filter in the webhook itself
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4853
 
-	_, labelOk := secret.Labels[labels.LabelPrefix+labels.CredentialKey]
-	_, fieldOk := secret.Data["kongCredType"]
-
-	if !(labelOk || fieldOk) {
+	if _, credentialTypeSource := util.ExtractKongCredentialType(&secret); credentialTypeSource == util.CredentialTypeAbsent {
 		// secret does not look like a credential resource in Kong
 		return responseBuilder.Allowed(true).Build(), nil
 	}

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 )
 
 func TestUniqueConstraintsValidation(t *testing.T) {

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -1,10 +1,14 @@
 package credentials
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUniqueConstraintsValidation(t *testing.T) {
@@ -58,4 +62,111 @@ func TestUniqueConstraintsValidation(t *testing.T) {
 
 	t.Log("verifying that unconstrained keys for types with constraints don't flag as violated")
 	assert.False(t, IsKeyUniqueConstrained("basic-auth", "unconstrained-key"))
+}
+
+func TestValidateCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  *corev1.Secret
+		wantErr error
+	}{
+		{
+			name: "valid credential",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key": []byte("little-rabbits-be-good"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 to be removed after deprecation window
+			name: "valid credential with deprectated field",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key":          []byte("little-rabbits-be-good"),
+					"kongCredType": []byte("key-auth"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "invalid credential type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "bee-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key": []byte("little-rabbits-be-good"),
+				},
+			},
+			wantErr: fmt.Errorf("invalid credential type bee-auth"),
+		},
+		{
+			name: "no credential type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key": []byte("little-rabbits-be-good"),
+				},
+			},
+			wantErr: fmt.Errorf("secret has no credential type, add a %s label", labels.LabelPrefix+labels.CredentialKey),
+		},
+		{
+			name: "missing required field",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"bee": []byte("little-rabbits-be-good"),
+				},
+			},
+			wantErr: fmt.Errorf("missing required field(s): key"),
+		},
+		{
+			name: "empty required field",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key": []byte(""),
+				},
+			},
+			wantErr: fmt.Errorf("some fields were invalid due to missing data: key"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCredentials(tt.secret)
+			require.Equal(t, tt.wantErr, err)
+		})
+	}
 }

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -158,7 +158,6 @@ func (ks *KongState) FillConsumersAndCredentials(
 			if fieldOk && !labelOk {
 				failuresCollector.PushResourceFailure("credential only has deprecated kongCredType field, needs "+
 					"konghq.com/credential label", secret)
-				failuresCollector.PushResourceFailure(fmt.Sprintf("nonexistent consumer group: %q", err), consumer)
 			}
 			if !credentials.SupportedTypes.Has(credType) {
 				pushCredentialResourceFailures(

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -59,6 +59,7 @@ func (ks *KongState) SanitizedCopy() *KongState {
 }
 
 func (ks *KongState) FillConsumersAndCredentials(
+	logger logr.Logger,
 	s store.Storer,
 	failuresCollector *failures.ResourceFailuresCollector,
 ) {
@@ -105,8 +106,9 @@ func (ks *KongState) FillConsumersAndCredentials(
 			// try the label first. if it's present, no need to check the field
 			credType, credTypeSource := util.ExtractKongCredentialType(secret)
 			if credTypeSource == util.CredentialTypeFromField {
-				failuresCollector.PushResourceFailure("credential only has deprecated kongCredType field, needs "+
-					"konghq.com/credential label", secret)
+				logger.Error(nil,
+					fmt.Sprintf("Secret uses deprecated kongCredType field, needs konghq.com/credential=%s label", credType),
+					"namesapce", secret.Namespace, "name", secret.Name)
 			}
 			if !credentials.SupportedTypes.Has(credType) {
 				pushCredentialResourceFailures(

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -651,7 +651,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				},
 			},
 			expectedTranslationFailureMessages: map[k8stypes.NamespacedName]string{
-				{Namespace: "default", Name: "foo"}: fmt.Sprintf("failed to provision credential: unsupported kongCredType: %q", "unsupported"),
+				{Namespace: "default", Name: "foo"}: fmt.Sprintf("failed to provision credential: unsupported credential type: %q", "unsupported"),
 			},
 		},
 		{
@@ -680,7 +680,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				},
 			},
 			expectedTranslationFailureMessages: map[k8stypes.NamespacedName]string{
-				{Namespace: "default", Name: "foo"}: fmt.Sprintf("failed to provision credential: unsupported kongCredType: %q", "bee-auth"),
+				{Namespace: "default", Name: "foo"}: fmt.Sprintf("failed to provision credential: unsupported credential type: %q", "bee-auth"),
 			},
 		},
 		{
@@ -765,7 +765,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			failureCollector := failures.NewResourceFailuresCollector(logger)
 
 			state := KongState{}
-			state.FillConsumersAndCredentials(store, failureCollector)
+			state.FillConsumersAndCredentials(logger, store, failureCollector)
 			// compare translated consumers.
 			require.Len(t, state.Consumers, len(tc.expectedKongStateConsumers))
 			// compare fields. Since we only test for translating a single consumer, we only compare the first one if exists.

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -193,7 +193,7 @@ func (p *Parser) BuildKongConfig() KongConfigBuildingResult {
 	result.FillOverrides(p.logger, p.storer)
 
 	// generate consumers and credentials
-	result.FillConsumersAndCredentials(p.storer, p.failuresCollector)
+	result.FillConsumersAndCredentials(p.logger, p.storer, p.failuresCollector)
 	for i := range result.Consumers {
 		p.registerSuccessfullyParsedObject(&result.Consumers[i].K8sKongConsumer)
 	}

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,11 @@
+package labels
+
+import "github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
+
+const (
+	// LabelPrefix is the string used at the beginning of KIC-specific labels.
+	LabelPrefix = annotations.AnnotationPrefix
+
+	// CredentialKey is the key used to indicate a Secret's credential type.
+	CredentialKey = "/credential" //nolint:gosec
+)

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
+)
+
+// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 remove field handling when no longer supported.
+
+const (
+	// CredentialTypeAbsent indicates that no credential information is present in a Secret.
+	CredentialTypeAbsent = iota
+	// CredentialTypeFromLabel indicates that a Secret's credential type was determined from a label.
+	CredentialTypeFromLabel = iota
+	// CredentialTypeFromField indicates that a Secret's credential type was determined from a data field.
+	CredentialTypeFromField = iota
+)
+
+// ExtractKongCredentialType returns the credential type of a Secret and a code indicating whether the credential type
+// was obtained from a label, field, or not at all. Labels take precedence over fields if both are present.
+func ExtractKongCredentialType(secret *corev1.Secret) (string, int) {
+	credType, labelOk := secret.Labels[labels.LabelPrefix+labels.CredentialKey]
+	if !labelOk {
+		// if no label, fall back to the deprecated field
+		credBytes, fieldOk := secret.Data["kongCredType"]
+		if !fieldOk {
+			return "", CredentialTypeAbsent
+		}
+		return string(credBytes), CredentialTypeFromField
+	}
+	return credType, CredentialTypeFromLabel
+}

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -8,18 +8,21 @@ import (
 
 // TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 remove field handling when no longer supported.
 
+// CredentialTypeSource indicates the source of credential type information (or lack thereof) in a Secret.
+type CredentialTypeSource int
+
 const (
 	// CredentialTypeAbsent indicates that no credential information is present in a Secret.
-	CredentialTypeAbsent = iota
+	CredentialTypeAbsent CredentialTypeSource = iota
 	// CredentialTypeFromLabel indicates that a Secret's credential type was determined from a label.
-	CredentialTypeFromLabel = iota
+	CredentialTypeFromLabel
 	// CredentialTypeFromField indicates that a Secret's credential type was determined from a data field.
-	CredentialTypeFromField = iota
+	CredentialTypeFromField
 )
 
 // ExtractKongCredentialType returns the credential type of a Secret and a code indicating whether the credential type
 // was obtained from a label, field, or not at all. Labels take precedence over fields if both are present.
-func ExtractKongCredentialType(secret *corev1.Secret) (string, int) {
+func ExtractKongCredentialType(secret *corev1.Secret) (string, CredentialTypeSource) {
 	credType, labelOk := secret.Labels[labels.LabelPrefix+labels.CredentialKey]
 	if !labelOk {
 		// if no label, fall back to the deprecated field

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -1,0 +1,93 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractKongCredentialType(t *testing.T) {
+	tests := []struct {
+		name           string
+		secret         *corev1.Secret
+		credType       string
+		credTypeSource int
+	}{
+		{
+			name: "labeled credential",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key": []byte("little-rabbits-be-good"),
+				},
+			},
+			credType:       "key-auth",
+			credTypeSource: CredentialTypeFromLabel,
+		},
+		{
+			// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 to be removed after deprecation window
+			name: "kongCredType field credential",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key":          []byte("little-rabbits-be-good"),
+					"kongCredType": []byte("key-auth"),
+				},
+			},
+			credType:       "key-auth",
+			credTypeSource: CredentialTypeFromField,
+		},
+		{
+			// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 to be removed after deprecation window
+			name: "kongCredType field and labeled credential, label takes precedence",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key":          []byte("little-rabbits-be-good"),
+					"kongCredType": []byte("bee-auth"),
+				},
+			},
+			credType:       "key-auth",
+			credTypeSource: CredentialTypeFromLabel,
+		},
+		{
+			name: "no credential type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key": []byte("little-rabbits-be-good"),
+				},
+			},
+			credType:       "",
+			credTypeSource: CredentialTypeAbsent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credType, credTypeSource := ExtractKongCredentialType(tt.secret)
+			require.Equal(t, tt.credType, credType)
+			require.Equal(t, tt.credTypeSource, credTypeSource)
+		})
+	}
+}

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -3,10 +3,11 @@ package util
 import (
 	"testing"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/labels"
 )
 
 func TestExtractKongCredentialType(t *testing.T) {
@@ -14,7 +15,7 @@ func TestExtractKongCredentialType(t *testing.T) {
 		name           string
 		secret         *corev1.Secret
 		credType       string
-		credTypeSource int
+		credTypeSource CredentialTypeSource
 	}{
 		{
 			name: "labeled credential",

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -98,7 +98,7 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 
 	// KongConsumer name -> event message
 	kongConsumerTranslationFailureMessages := map[string]string{
-		"consumer-empty-cred":  `credential "empty-cred" failure: failed to provision credential: empty secret`,
+		"consumer-empty-cred":  `credential "empty-cred" failure: failed to provision credential: key-auth is invalid: no key`,
 		"consumer-no-username": `no username or custom_id specified`,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a label alternative to the `kongCredType` Secret field. Setting `konghq.com/credential: CREDTYPE` is now equivalent to setting a `kongCredType=CREDTYPE` Secret field.

**Which issue this PR fixes**:

Fix #2502

**Special notes for your reviewer**:

https://github.com/Kong/kubernetes-ingress-controller/issues/2502#issuecomment-1758213596 contains a migration script that will eventually go in docs. There isn't a clear place in 3.x docs to stick an upgrade section, so https://github.com/Kong/kubernetes-ingress-controller/issues/4854 to follow up. As a stopgap, the changelog links to the comment.

Adds new system, does not remove old system. Not sure we want to single release breaking change this; I think we can do the final removal after 3.0 unless we want to bundle as many breaking changes at once, even if they're larger ones that didn't previously have a deprecation period: https://github.com/Kong/kubernetes-ingress-controller/issues/4853

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
