### PR TITLE
chore: add missing kind renovate annotations

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -18,16 +18,20 @@ e2e:
   # For Istio, we define combinations of Kind and Istio versions that will be
   # used directly in the test matrix `include` section.
   istio:
-    - kind: 'v1.28.0'
+    - # renovate: datasource=docker depName=kindest/node versioning=docker
+      kind: 'v1.28.0'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: 'v1.19.0'
-    - kind: 'v1.27.3'
+    - # renovate: datasource=docker depName=kindest/node versioning=docker
+      kind: 'v1.27.3'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: 'v1.18.0'
-    - kind: 'v1.26.6'
+    - # renovate: datasource=docker depName=kindest/node versioning=docker
+      kind: 'v1.26.6'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: 'v1.17.0'
-    - kind: 'v1.25.11'
+    - # renovate: datasource=docker depName=kindest/node versioning=docker
+      kind: 'v1.25.11'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: 'v1.16.0'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/Kong/kubernetes-ingress-controller/pull/4822 I missed adding Renovate annotations for Kind in Istio test matrix.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4692.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
