### PR TITLE
chore: setup GKE Renovate custom datasource

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -13,7 +13,8 @@ e2e:
     # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.23.17'
   gke:
-    - 'v1.26.5'
+    # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
+    - '1.26.5'
 
   # For Istio, we define combinations of Kind and Istio versions that will be
   # used directly in the test matrix `include` section.

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,11 @@
         "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
       ]
     }
-  ]
+  ],
+  "customDatasources": {
+    "gke-rapid": {
+      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/kong/gke-renovate-datasource/main/static/rapid.json",
+      "format": "json"
+    }
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets up a [Custom Datasource](https://docs.renovatebot.com/modules/datasource/custom/) using https://github.com/Kong/gke-renovate-datasource that will make Renovate automatically update GKE versions.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4692.
