### PR TITLE
review: decorate client instead of calling multiple times

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -566,11 +566,6 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) Reconcile(ctx context.Context, re
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
-
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "{{.Kind}}", "namespace", req.Namespace, "name", req.Name)

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -87,11 +87,6 @@ func (r *KongAdminAPIServiceReconciler) SetLogger(l logr.Logger) {
 }
 
 func (r *KongAdminAPIServiceReconciler) shouldReconcileEndpointSlice(obj client.Object) bool {
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 	endpoints, ok := obj.(*discoveryv1.EndpointSlice)
 	if !ok {
 		return false

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -114,12 +114,6 @@ func (r *CoreV1SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(secret)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", secret.GetNamespace(), "name", secret.GetName())
-	}
-
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
 	// clean the object up if it's being deleted

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -116,11 +116,6 @@ func (r *CoreV1ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
-
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "Service", "namespace", req.Namespace, "name", req.Name)
@@ -219,11 +214,6 @@ func (r *DiscoveryV1EndpointSliceReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -367,11 +357,6 @@ func (r *NetV1IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -517,11 +502,6 @@ func (r *NetV1IngressClassReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
-
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "IngressClass", "namespace", req.Namespace, "name", req.Name)
@@ -606,11 +586,6 @@ func (r *KongV1KongIngressReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -702,11 +677,6 @@ func (r *KongV1KongPluginReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -849,11 +819,6 @@ func (r *KongV1KongClusterPluginReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1030,11 +995,6 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1222,11 +1182,6 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1416,11 +1371,6 @@ func (r *KongV1Beta1TCPIngressReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
@@ -1619,11 +1569,6 @@ func (r *KongV1Beta1UDPIngressReconciler) Reconcile(ctx context.Context, req ctr
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
 
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
-
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
 		log.V(util.DebugLevel).Info("resource is being deleted, its configuration will be removed", "type", "UDPIngress", "namespace", req.Namespace, "name", req.Name)
@@ -1752,11 +1697,6 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 		return ctrl.Result{}, err
 	}
 	log.V(util.DebugLevel).Info("reconciling resource", "namespace", req.Namespace, "name", req.Name)
-
-	err := util.PopulateTypeMeta(obj)
-	if err != nil {
-		log.WithValues().Error(err, "could not set resource TypeMeta", "namespace", obj.GetNamespace(), "name", obj.GetName())
-	}
 
 	// clean the object up if it's being deleted
 	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -350,12 +350,6 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	err := util.PopulateTypeMeta(gateway)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", gateway.GetNamespace(), "name", gateway.GetName())
-	}
-
 	debug(log, gateway, "processing gateway")
 
 	// though our watch configuration eliminates reconciliation of unsupported gateways it's

--- a/internal/controllers/gateway/gatewayclass_controller.go
+++ b/internal/controllers/gateway/gatewayclass_controller.go
@@ -121,12 +121,6 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(gwc)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", gwc.GetNamespace(), "name", gwc.GetName())
-	}
-
 	log.V(util.DebugLevel).Info("processing gatewayclass", "name", req.Name)
 
 	if isGatewayClassControlledAndUnmanaged(gwc) {

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -273,12 +273,6 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(grpcroute)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", grpcroute.GetNamespace(), "name", grpcroute.GetName())
-	}
-
 	debug(log, grpcroute, "processing grpcroute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -347,12 +347,6 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(httproute)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", httproute.GetNamespace(), "name", httproute.GetName())
-	}
-
 	debug(log, httproute, "processing httproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/referencegrant_controller.go
+++ b/internal/controllers/gateway/referencegrant_controller.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/controllers"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 )
 
 // ReferenceGrantReconciler reconciles a ReferenceGrant object.
@@ -84,12 +83,6 @@ func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
-	}
-
-	err := util.PopulateTypeMeta(grant)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", grant.GetNamespace(), "name", grant.GetName())
 	}
 
 	debug(log, grant, "processing referencegrant")

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -270,12 +270,6 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(tcproute)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", tcproute.GetNamespace(), "name", tcproute.GetName())
-	}
-
 	debug(log, tcproute, "processing tcproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -269,12 +269,6 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(tlsroute)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", tlsroute.GetNamespace(), "name", tlsroute.GetName())
-	}
-
 	debug(log, tlsroute, "processing tlsroute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -269,12 +269,6 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	err := util.PopulateTypeMeta(udproute)
-	if err != nil {
-		r.Log.Error(err, "could not set resource TypeMeta",
-			"namespace", udproute.GetNamespace(), "name", udproute.GetName())
-	}
-
 	debug(log, udproute, "processing udproute")
 
 	// if there's a present deletion timestamp then we need to update the proxy cache

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -38,10 +38,6 @@ func objectKeyFunc(obj client.Object) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("could not convert %s/%s back to client Object", obj.GetNamespace(), obj.GetName())
 	}
-	err := util.PopulateTypeMeta(o)
-	if err != nil {
-		return "", fmt.Errorf("could not populate %s/%s metadata: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
 	return metaObj.GetObjectKind().GroupVersionKind().String() + "/" +
 		metaObj.GetNamespace() + "/" + metaObj.GetName(), nil
 }

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -67,6 +67,7 @@ func setupControllers(
 ) []ControllerDef {
 	referenceIndexers := ctrlref.NewCacheIndexers(ctrl.LoggerFrom(ctx).WithName("controllers").WithName("reference-indexers"))
 
+	client := NewTypeMetaSettingClient(mgr.GetClient())
 	controllers := []ControllerDef{
 		// ---------------------------------------------------------------------------
 		// Kong Gateway Admin API Service discovery
@@ -74,7 +75,7 @@ func setupControllers(
 		{
 			Enabled: c.KongAdminSvc.IsPresent(),
 			Controller: &configuration.KongAdminAPIServiceReconciler{
-				Client:              mgr.GetClient(),
+				Client:              client,
 				ServiceNN:           c.KongAdminSvc.OrEmpty(),
 				Log:                 ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongAdminAPIService"),
 				CacheSyncTimeout:    c.CacheSyncTimeout,
@@ -88,7 +89,7 @@ func setupControllers(
 		{
 			Enabled: c.IngressClassNetV1Enabled,
 			Controller: &configuration.NetV1IngressClassReconciler{
-				Client:           mgr.GetClient(),
+				Client:           client,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("IngressClass").WithName("netv1"),
 				DataplaneClient:  dataplaneClient,
 				Scheme:           mgr.GetScheme(),
@@ -98,7 +99,7 @@ func setupControllers(
 		{
 			Enabled: c.IngressNetV1Enabled,
 			Controller: &configuration.NetV1IngressReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Ingress").WithName("netv1"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -113,7 +114,7 @@ func setupControllers(
 		{
 			Enabled: c.ServiceEnabled,
 			Controller: &configuration.CoreV1ServiceReconciler{
-				Client:            mgr.GetClient(),
+				Client:            client,
 				Log:               ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Service"),
 				Scheme:            mgr.GetScheme(),
 				DataplaneClient:   dataplaneClient,
@@ -124,7 +125,7 @@ func setupControllers(
 		{
 			Enabled: c.ServiceEnabled,
 			Controller: &configuration.DiscoveryV1EndpointSliceReconciler{
-				Client:           mgr.GetClient(),
+				Client:           client,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("EndpointSlice"),
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
@@ -134,7 +135,7 @@ func setupControllers(
 		{
 			Enabled: true,
 			Controller: &configuration.CoreV1SecretReconciler{
-				Client:            mgr.GetClient(),
+				Client:            client,
 				Log:               ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Secrets"),
 				Scheme:            mgr.GetScheme(),
 				DataplaneClient:   dataplaneClient,
@@ -148,7 +149,7 @@ func setupControllers(
 		{
 			Enabled: c.UDPIngressEnabled,
 			Controller: &configuration.KongV1Beta1UDPIngressReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("UDPIngress"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -162,7 +163,7 @@ func setupControllers(
 		{
 			Enabled: c.TCPIngressEnabled,
 			Controller: &configuration.KongV1Beta1TCPIngressReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("TCPIngress"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -177,7 +178,7 @@ func setupControllers(
 		{
 			Enabled: c.KongIngressEnabled,
 			Controller: &configuration.KongV1KongIngressReconciler{
-				Client:           mgr.GetClient(),
+				Client:           client,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongIngress"),
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
@@ -187,7 +188,7 @@ func setupControllers(
 		{
 			Enabled: c.IngressClassParametersEnabled,
 			Controller: &configuration.KongV1Alpha1IngressClassParametersReconciler{
-				Client:           mgr.GetClient(),
+				Client:           client,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("IngressClassParameters"),
 				Scheme:           mgr.GetScheme(),
 				DataplaneClient:  dataplaneClient,
@@ -197,7 +198,7 @@ func setupControllers(
 		{
 			Enabled: c.KongPluginEnabled,
 			Controller: &configuration.KongV1KongPluginReconciler{
-				Client:            mgr.GetClient(),
+				Client:            client,
 				Log:               ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongPlugin"),
 				Scheme:            mgr.GetScheme(),
 				DataplaneClient:   dataplaneClient,
@@ -210,7 +211,7 @@ func setupControllers(
 		{
 			Enabled: c.KongConsumerEnabled,
 			Controller: &configuration.KongV1KongConsumerReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongConsumer"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -224,7 +225,7 @@ func setupControllers(
 		{
 			Enabled: c.KongConsumerEnabled,
 			Controller: &configuration.KongV1Beta1KongConsumerGroupReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongConsumerGroup"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -238,7 +239,7 @@ func setupControllers(
 		{
 			Enabled: c.KongClusterPluginEnabled,
 			Controller: &configuration.KongV1KongClusterPluginReconciler{
-				Client:                     mgr.GetClient(),
+				Client:                     client,
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongClusterPlugin"),
 				Scheme:                     mgr.GetScheme(),
 				DataplaneClient:            dataplaneClient,
@@ -261,7 +262,7 @@ func setupControllers(
 				CacheSyncTimeout: c.CacheSyncTimeout,
 				RequiredCRDs:     baseGatewayCRDs(),
 				Controller: &gateway.GatewayReconciler{
-					Client:               mgr.GetClient(),
+					Client:               client,
 					Log:                  ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Gateway"),
 					Scheme:               mgr.GetScheme(),
 					DataplaneClient:      dataplaneClient,
@@ -285,7 +286,7 @@ func setupControllers(
 					Resource: "httproutes",
 				}),
 				Controller: &gateway.HTTPRouteReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("HTTPRoute"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,
@@ -309,7 +310,7 @@ func setupControllers(
 					Resource: "referencegrants",
 				}),
 				Controller: &gateway.ReferenceGrantReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("ReferenceGrant"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,
@@ -329,7 +330,7 @@ func setupControllers(
 					Resource: "udproutes",
 				}),
 				Controller: &gateway.UDPRouteReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("UDPRoute"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,
@@ -350,7 +351,7 @@ func setupControllers(
 					Resource: "tcproutes",
 				}),
 				Controller: &gateway.TCPRouteReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("TCPRoute"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,
@@ -371,7 +372,7 @@ func setupControllers(
 					Resource: "tlsroutes",
 				}),
 				Controller: &gateway.TLSRouteReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("TLSRoute"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,
@@ -392,7 +393,7 @@ func setupControllers(
 					Resource: "grpcroutes",
 				}),
 				Controller: &gateway.GRPCRouteReconciler{
-					Client:           mgr.GetClient(),
+					Client:           client,
 					Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("GRPCRoute"),
 					Scheme:           mgr.GetScheme(),
 					DataplaneClient:  dataplaneClient,

--- a/internal/manager/type_meta_setting_client.go
+++ b/internal/manager/type_meta_setting_client.go
@@ -1,0 +1,36 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
+)
+
+// TypeMetaSettingClient decorates client.Client so that it populates the TypeMeta field of the
+// object after fetching it from the API server.
+type TypeMetaSettingClient struct {
+	client.Client
+}
+
+func NewTypeMetaSettingClient(c client.Client) TypeMetaSettingClient {
+	return TypeMetaSettingClient{Client: c}
+}
+
+// Get retrieves an object from the Kubernetes API server and populates the TypeMeta field of the object.
+func (c TypeMetaSettingClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if err := util.PopulateTypeMeta(obj, c.Client.Scheme()); err != nil {
+		return fmt.Errorf("failed to populate type meta: %w", err)
+	}
+	return nil
+}

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/scheme"
 )
 
 // Endpoint describes a kubernetes endpoint, same as a target in Kong.
@@ -39,11 +37,7 @@ type Endpoint struct {
 // It has been modified to remove the io.Writer output and to use the scheme package directly instead of the Typer helper.
 
 // PopulateTypeMeta adds GVK information to a runtime.Object that may not have it available in the object TypeMeta.
-func PopulateTypeMeta(obj runtime.Object) error {
-	s, err := scheme.Get()
-	if err != nil {
-		return fmt.Errorf("could not build scheme: %w", err)
-	}
+func PopulateTypeMeta(obj runtime.Object, s *runtime.Scheme) error {
 	gvks, _, err := s.ObjectKinds(obj)
 	if err != nil {
 		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)

--- a/internal/util/types_test.go
+++ b/internal/util/types_test.go
@@ -3,9 +3,12 @@ package util
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/scheme"
 )
 
 func TestPopulateTypeMeta(t *testing.T) {
@@ -22,7 +25,7 @@ func TestPopulateTypeMeta(t *testing.T) {
 
 	require.Empty(t, credential.GetObjectKind().GroupVersionKind().Kind)
 
-	err := PopulateTypeMeta(credential)
+	err := PopulateTypeMeta(credential, lo.Must(scheme.Get()))
 
 	require.NoError(t, err)
 	require.NotEmpty(t, credential.GetObjectKind().GroupVersionKind().Kind)

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -157,7 +157,7 @@ func TestConsumerCredential(t *testing.T) {
 	_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Update(ctx, credential, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	assert.Eventually(t, func() bool {
-		req := helpers.MustHTTPRequest(t, "GET", proxyURL.Host, "/test_consumer_credential", nil)
+		req := helpers.MustHTTPRequest(t, "GET", proxyURL.String(), "/test_consumer_credential", nil)
 		req.SetBasicAuth("new_consumer_credential", "test_consumer_credential")
 		resp, err := helpers.DefaultHTTPClient().Do(req)
 		if err != nil {


### PR DESCRIPTION
Review suggestion: instead of having to remember to call `util.PopulateTypeMeta` in every controller, we can decorate the client to always do it. Also, use the client's schema instead of building it on every call.