### PR TITLE
chore: remove test matrix checkup from release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -16,14 +16,6 @@ body:
   validations:
     required: true
 - type: checkboxes
-  id: release_tests
-  attributes:
-    label: "**For all releases** Github Workflow Test Matrix Checkup"
-    options:
-      - label: Check the testing workflow ([.github/workflows/_integration_tests.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/_integration_tests.yaml)) and ensure that all matrix versions ([.github/workflows/_e2e_tests.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/_e2e_tests.yaml) (for both K8s and Istio with K8s matrix) and [.github/workflows/release.yaml](/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/release.yaml))  are up to date for various component releases. If there have been any new releases (major, minor or patch) of those components since the latest version seen in that configuration make sure the new versions get added before proceeding with the release. Remove any versions that are no longer supported by the environment provider.
-      - label: Kubernetes (via [KIND](https://hub.docker.com/r/kindest/node/tags) and the latest image available when creating a new rapid channel cluster from the GKE new cluster wizard)
-      - label: Istio (via [Istio's releases page](https://istio.io/latest/news/releases))
-- type: checkboxes
   id: gateway_version
   attributes:
     label: "Bump Kong Gateway version in manifests"


### PR DESCRIPTION
**What this PR does / why we need it**:

As https://github.com/Kong/kubernetes-ingress-controller/issues/4692 has introduced automatic updates of the dependencies mentioned in the release template test matrix checkup, we can now remove this step from the template.

**Which issue this PR fixes**:

Effect of https://github.com/Kong/kubernetes-ingress-controller/issues/4692.
