### PR TITLE
fix: fix typo in UDPRoute controller's watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ Adding a new version? You'll need three changes:
   will be included in the message reported in `KongConfigurationApplyFailed` Kubernetes event
   generated for it.
   [#4813](https://github.com/Kong/kubernetes-ingress-controller/pull/4813)
+- Fixed an incorrect watch, set in UDPRoute controller watching UDProute status updates.
+  [#4835](https://github.com/Kong/kubernetes-ingress-controller/pull/4835)
 
 ### Changed
 

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -91,7 +91,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
 				Group:   gatewayv1alpha2.GroupVersion.Group,
 				Version: gatewayv1alpha2.GroupVersion.Version,
-				Kind:    "TCPRoute",
+				Kind:    "UDPRoute",
 			})},
 			&handler.EnqueueRequestForObject{},
 		); err != nil {
@@ -380,7 +380,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		if configurationStatus == k8sobj.ConfigurationStatusFailed {
-			debug(log, udproute, "tcproute configuration failed")
+			debug(log, udproute, "udproute configuration failed")
 			statusUpdated, err := ensureParentsProgrammedCondition(ctx, r.Status(), udproute, udproute.Status.Parents, gateways, metav1.Condition{
 				Status: metav1.ConditionFalse,
 				Reason: string(ConditionReasonTranslationError),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in UDPRoute controller's watch which is set to watch status updates.

**Special notes for your reviewer**:

This should fail a test or 2, how come this didn't 🤔 ?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
