### PR TITLE
feat(ci): add renovate config for kong helm chart

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -37,6 +37,9 @@ e2e:
       istio: '1.16.7'
 
 integration:
+  helm:
+    # renovate: datasource=github-releases depName=kong/charts versioning=semver
+    kong: '2.26.3'
   # renovate: datasource=docker depName=kindest/node versioning=docker
   kind: 'v1.28.0'
   # renovate: datasource=docker depName=kong versioning=docker

--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -4,9 +4,27 @@ on:
   workflow_call: {}
 
 jobs:
+  dependencies-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: set-versions
+        name: Set versions
+        run: |
+          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+
   conformance-tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: dependencies-versions
+    env:
+      TEST_KONG_HELM_CHART_VERSION: ${{ needs.dependencies-versions.outputs.helm-kong }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -86,13 +86,13 @@ jobs:
         name: Set versions
         run: |
           if [ "${{ inputs.all-supported-k8s-versions }}" == "true" ]; then
-            echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.kind' | jq -c)" >> $GITHUB_OUTPUT
+            echo "kind=$(yq -r -ojson '.e2e.kind' < .github/test_dependencies.yaml)" >> $GITHUB_OUTPUT
           else
             # We assume the first version in the list is the latest one.
-            echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.kind' | jq -c '[first]')" >> $GITHUB_OUTPUT
+            echo "kind=$(yq -r -ojson '.e2e.kind' < .github/test_dependencies.yaml | jq '[first]')" >> $GITHUB_OUTPUT
           fi
-          echo "gke=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.gke' | jq -c)" >> $GITHUB_OUTPUT
-          echo "istio=$(cat .github/test_dependencies.yaml | yq -ojson '.e2e.istio' | jq -c)" >> $GITHUB_OUTPUT
+          echo "gke=$(yq -r -ojson '.e2e.gke' < .github/test_dependencies.yaml)" >> $GITHUB_OUTPUT
+          echo "istio=$(yq -r -ojson '.e2e.istio' < .github/test_dependencies.yaml)" >> $GITHUB_OUTPUT
 
   kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -92,7 +92,7 @@ jobs:
             echo "kind=$(yq -r -ojson '.e2e.kind' < .github/test_dependencies.yaml | jq '[first]')" >> $GITHUB_OUTPUT
           fi
           echo "gke=$(yq -r -ojson '.e2e.gke' < .github/test_dependencies.yaml)" >> $GITHUB_OUTPUT
-          echo "istio=$(yq -r -ojson '.e2e.istio' < .github/test_dependencies.yaml)" >> $GITHUB_OUTPUT
+          echo "istio=$(yq -r -ojson '.e2e.istio' < .github/test_dependencies.yaml | jq -c)" >> $GITHUB_OUTPUT
 
   kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "kind=$(yq -ojson -r '.integration.kind' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
           echo "kong-ee=$(yq -ojson -r '.integration.kong-ee' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
           echo "kong-oss=$(yq -ojson -r '.integration.kong-oss' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
-          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_ENV
+          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   integration-tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -41,6 +41,7 @@ jobs:
       kind: ${{ steps.set-versions.outputs.kind }}
       kong-ee: ${{ steps.set-versions.outputs.kong-ee }}
       kong-oss: ${{ steps.set-versions.outputs.kong-oss }}
+      helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
@@ -50,9 +51,10 @@ jobs:
       - id: set-versions
         name: Set versions
         run: |
-          echo "kind=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kind' | jq -c)" >> $GITHUB_OUTPUT
-          echo "kong-ee=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-ee' | jq -c)" >> $GITHUB_OUTPUT
-          echo "kong-oss=$(cat .github/test_dependencies.yaml | yq -ojson '.integration.kong-oss' | jq -c)" >> $GITHUB_OUTPUT
+          echo "kind=$(yq -ojson -r '.integration.kind' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+          echo "kong-ee=$(yq -ojson -r '.integration.kong-ee' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+          echo "kong-oss=$(yq -ojson -r '.integration.kong-oss' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_ENV
 
   integration-tests:
     name: ${{ matrix.name }}
@@ -61,6 +63,7 @@ jobs:
     env:
       KONG_CLUSTER_VERSION: ${{ needs.dependencies-versions.outputs.kind }}
       TEST_KONG_ROUTER_FLAVOR: 'traditional'
+      TEST_KONG_HELM_CHART_VERSION: ${{ needs.dependencies-versions.outputs.helm-kong }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: set kong version
         run: |
           echo "TEST_KONG_IMAGE=kong" >> $GITHUB_ENV
-          echo "TEST_KONG_TAG=$(cat .github/test_dependencies.yaml | yq -ojson -r '.kongintegration.kong-oss')" >> $GITHUB_ENV
+          echo "TEST_KONG_TAG=$(yq -ojson -r '.kongintegration.kong-oss' < .github/test_dependencies.yaml )" >> $GITHUB_ENV
 
       - name: run kong integration tests
         run: make test.kongintegration

--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,8 @@ test.envtest.pretty:
 _check.container.environment:
 	@./scripts/check-container-environment.sh
 
+TEST_KONG_HELM_CHART_VERSION ?= $(shell yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml | )
+
 # Integration tests don't use gotestsum because there's a data race issue
 # when go toolchain is writing to os.Stderr which is being read in go-kong
 # https://github.com/Kong/go-kong/blob/c71247b5c8aae2/kong/client.go#L182
@@ -409,6 +411,7 @@ _check.container.environment:
 .PHONY: _test.integration
 _test.integration: _check.container.environment go-junit-report
 	KONG_CLUSTER_VERSION="$(KONG_CLUSTER_VERSION)" \
+		TEST_KONG_HELM_CHART_VERSION="$(TEST_KONG_HELM_CHART_VERSION)" \
 		TEST_DATABASE_MODE="$(DBMODE)" \
 		GOFLAGS="-tags=$(GOTAGS)" \
 		KONG_CONTROLLER_FEATURE_GATES="$(KONG_CONTROLLER_FEATURE_GATES)" \

--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ test.envtest.pretty:
 _check.container.environment:
 	@./scripts/check-container-environment.sh
 
-TEST_KONG_HELM_CHART_VERSION ?= $(shell yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml | )
+TEST_KONG_HELM_CHART_VERSION ?= $(shell yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml)
 
 # Integration tests don't use gotestsum because there's a data race issue
 # when go toolchain is writing to os.Stderr which is being read in go-kong

--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,24 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^.github/test_dependencies.yaml$"],
+      "fileMatch": [
+        "^.github/test_dependencies.yaml$"
+      ],
       "matchStrings": [
         "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^test/consts/helm.go$"
+      ],
+      "matchStrings": [
+        "//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+\"(?<currentValue>.*)\""
+      ],
+      "extractVersionTemplate": "^kong-?(?<version>.*)$"
     }
+
   ],
   "customDatasources": {
     "gke-rapid": {

--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,10 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^test/consts/helm.go$"
+        "^.github/test_dependencies.yaml$"
       ],
       "matchStrings": [
-        "//\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+\"(?<currentValue>.*)\""
+        "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
       ],
       "extractVersionTemplate": "^kong-?(?<version>.*)$"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,6 @@
       ],
       "extractVersionTemplate": "^kong-?(?<version>.*)$"
     }
-
   ],
   "customDatasources": {
     "gke-rapid": {

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -79,7 +79,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pin the Helm chart version.
-	kongBuilder.WithHelmChartVersion(consts.KongHelmChartVersion)
+	kongBuilder.WithHelmChartVersion(testenv.KongHelmChartVersion())
 
 	kongAddon := kongBuilder.Build()
 	builder := environments.NewBuilder().WithAddons(metallb.New(), kongAddon)

--- a/test/consts/helm.go
+++ b/test/consts/helm.go
@@ -1,4 +1,5 @@
 package consts
 
 // KongHelmChartVersion is the version of the Kong Helm chart to use in tests.
+// renovate: datasource=github-releases depName=kong/charts versioning=semver
 const KongHelmChartVersion = "2.26.3"

--- a/test/consts/helm.go
+++ b/test/consts/helm.go
@@ -1,5 +1,0 @@
-package consts
-
-// KongHelmChartVersion is the version of the Kong Helm chart to use in tests.
-// renovate: datasource=github-releases depName=kong/charts versioning=semver
-const KongHelmChartVersion = "2.26.3"

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pin the Helm chart version.
-	kongbuilder.WithHelmChartVersion(consts.KongHelmChartVersion)
+	kongbuilder.WithHelmChartVersion(testenv.KongHelmChartVersion())
 
 	kongAddon := kongbuilder.Build()
 	builder := environments.NewBuilder().WithAddons(kongAddon)

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -46,6 +46,15 @@ func KongEffectiveVersion() string {
 	return os.Getenv("TEST_KONG_EFFECTIVE_VERSION")
 }
 
+// KongHelmChartVersion is the 'kong' helm chart version to use in tests.
+func KongHelmChartVersion() string {
+	v := os.Getenv("TEST_KONG_HELM_CHART_VERSION")
+	if v == "" {
+		os.Exit(1)
+	}
+	return v
+}
+
 // KongRouterFlavor returns router mode of Kong in tests. Currently supports:
 // - `traditional`
 // - `traditional_compatible`.

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -1,6 +1,7 @@
 package testenv
 
 import (
+	"fmt"
 	"os"
 	"time"
 )
@@ -50,6 +51,7 @@ func KongEffectiveVersion() string {
 func KongHelmChartVersion() string {
 	v := os.Getenv("TEST_KONG_HELM_CHART_VERSION")
 	if v == "" {
+		fmt.Println("ERROR: missing required TEST_KONG_HELM_CHART_VERSION")
 		os.Exit(1)
 	}
 	return v


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Renovate config for helm chart

Based on

- https://docs.renovatebot.com/user-stories/maintaining-aur-packages-with-renovate/#updating-versions-with-renovate
- https://docs.renovatebot.com/modules/datasource/gitlab-releases/

Exemplar working PR: https://github.com/pmalek/kubernetes-ingress-controller/pull/1