### PR TITLE
chore(tests): enforce Kong Gateway in the version >= 3.4.1

### DIFF
--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
@@ -96,7 +97,7 @@ func TestGatewayConformance(t *testing.T) {
 	// test order execution.
 	go require.Eventually(t, func() bool {
 		return ensureTestGatewayClassIsUnmanaged(ctx, k8sClient)
-	}, 10*time.Minute, 10*time.Second)
+	}, 10*time.Minute, test.RequestTimeout)
 
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:

--- a/test/consts.go
+++ b/test/consts.go
@@ -28,5 +28,8 @@ const (
 
 	// EnvironmentCleanupTimeout is the amount of time that will be given by the test suite to the
 	// testing environment to perform its cleanup when the test suite is shutting down.
-	EnvironmentCleanupTimeout = time.Minute * 3
+	EnvironmentCleanupTimeout = 3 * time.Minute
+
+	// RequestTimeout is the amount of time that will be given to any request to complete.
+	RequestTimeout = 10 * time.Second
 )

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/conditions"
 )
 
@@ -315,7 +316,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 					return false
 				}
 				return true
-			}, 10*time.Second, 50*time.Millisecond)
+			}, test.RequestTimeout, 50*time.Millisecond)
 		})
 	}
 }

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -613,7 +613,7 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 			return false
 		}
 		return true
-	}, 10*time.Second, 100*time.Millisecond)
+	}, test.RequestTimeout, 100*time.Millisecond)
 	t.Logf("test host matched hostname in listeners")
 	require.Eventually(t, func() bool {
 		return testGetByHost(t, "test.specific.io")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -138,11 +139,11 @@ func TestMain(m *testing.M) {
 		ctx,
 		retry.Do(
 			func() error {
-				version, err := helpers.GetKongVersion(proxyAdminURL, consts.KongTestPassword)
+				kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(proxyAdminURL, consts.KongTestPassword)
 				if err != nil {
 					return err
 				}
-				fmt.Printf("INFO: using Kong instance (version: %s) reachable at %s\n", version, proxyAdminURL)
+				fmt.Printf("INFO: using Kong instance (version: %q) reachable at %s\n", kongVersion, proxyAdminURL)
 				return nil
 			},
 			retry.OnRetry(
@@ -150,7 +151,9 @@ func TestMain(m *testing.M) {
 					fmt.Printf("WARNING: try to get Kong Gateway version attempt %d/10 - error: %s\n", n+1, err)
 				},
 			),
-			retry.LastErrorOnly(true),
+			retry.LastErrorOnly(true), retry.RetryIf(func(err error) bool {
+				return !errors.As(err, &helpers.TooOldKongGatewayError{})
+			}),
 		))
 
 	if v := os.Getenv("KONG_BRING_MY_OWN_KIC"); v == "true" {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -139,7 +139,9 @@ func TestMain(m *testing.M) {
 		ctx,
 		retry.Do(
 			func() error {
-				kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(proxyAdminURL, consts.KongTestPassword)
+				reqCtx, cancel := context.WithTimeout(ctx, test.RequestTimeout)
+				defer cancel()
+				kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(reqCtx, proxyAdminURL, consts.KongTestPassword)
 				if err != nil {
 					return err
 				}

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"context"
 	"net/url"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
@@ -74,7 +76,9 @@ func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		version, err = helpers.GetKongVersion(adminURL, consts.KongTestPassword)
+		ctx, cancel := context.WithTimeout(context.Background(), test.RequestTimeout)
+		defer cancel()
+		version, err = helpers.GetKongVersion(ctx, adminURL, consts.KongTestPassword)
 		assert.NoError(t, err)
 	}, time.Minute, time.Second)
 	return version
@@ -89,7 +93,9 @@ func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) string {
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		dbmode, err = helpers.GetKongDBMode(adminURL, consts.KongTestPassword)
+		ctx, cancel := context.WithTimeout(context.Background(), test.RequestTimeout)
+		defer cancel()
+		dbmode, err = helpers.GetKongDBMode(ctx, adminURL, consts.KongTestPassword)
 		assert.NoError(t, err)
 	}, time.Minute, time.Second)
 	return dbmode
@@ -104,7 +110,9 @@ func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) string {
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		routerFlavor, err = helpers.GetKongRouterFlavor(adminURL, consts.KongTestPassword)
+		ctx, cancel := context.WithTimeout(context.Background(), test.RequestTimeout)
+		defer cancel()
+		routerFlavor, err = helpers.GetKongRouterFlavor(ctx, adminURL, consts.KongTestPassword)
 		assert.NoError(t, err)
 	}, time.Minute, time.Second)
 	return routerFlavor

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -28,6 +28,7 @@ import (
 	testutils "github.com/kong/kubernetes-ingress-controller/v2/internal/util/test"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
@@ -669,7 +670,7 @@ func ensureWebhookServiceIsConnective(ctx context.Context, t *testing.T, configR
 	defer cancel()
 	require.NoError(
 		t,
-		networking.WaitForConnectionOnServicePort(waitCtx, env.Cluster().Client(), consts.ControllerNamespace, svcName, svcPort, 10*time.Second),
+		networking.WaitForConnectionOnServicePort(waitCtx, env.Cluster().Client(), consts.ControllerNamespace, svcName, svcPort, test.RequestTimeout),
 	)
 }
 

--- a/test/kongintegration/containers/kong.go
+++ b/test/kongintegration/containers/kong.go
@@ -11,6 +11,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
@@ -67,7 +68,9 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 	adminURL, err := url.Parse(kong.AdminURL(ctx, t))
 	require.NoError(t, err)
 
-	kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(adminURL, consts.KongTestPassword) //nolint:contextcheck
+	reqCtx, cancel := context.WithTimeout(ctx, test.RequestTimeout)
+	defer cancel()
+	kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(reqCtx, adminURL, consts.KongTestPassword)
 	require.NoError(t, err)
 	fmt.Printf("INFO: using Kong instance (version: %q) reachable at %s\n", kongVersion, adminURL)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

PR https://github.com/Kong/kubernetes-ingress-controller/pull/4766 introduces a global check on KIC startup for the Kong Gateway version to allow only `>= 3.4.1`. Tests that use Kong Gateway are run in separation (and do not include the aforementioned check), hence let's enforce during test environment creation Kong Gateway in version `3.4.1` to be consistent everywhere. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4764

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The update of the Helm chart version should be handled automatically by #4846 (which will put this into `.github/test_dependencies.yaml`), so after it and rebase tests should pass. The Helm chart version will be `2.29.0` (it includes Kong Gateway in version `3.4.1` instead of the current `2.26.0`.

This PR doesn't touch e2e tests, because they will be heavily  reworked during
- https://github.com/Kong/kubernetes-ingress-controller/issues/4712

after this, a similar check should be introduced. 

