### PR TITLE
chore(gateway) use dedicated publish annotation

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -69,7 +69,11 @@ const (
 	//
 	// NOTE: it's currently required that this annotation be present on all GatewayClass
 	// resources: "unmanaged" mode is the only supported mode at this time.
-	GatewayClassUnmanagedAnnotationSuffix = "gatewayclass-unmanaged"
+	GatewayClassUnmanagedKey = "/gatewayclass-unmanaged"
+
+	// GatewayPublishServiceKey is an annotation suffix used to indicate the Service(s) a Gateway's routes are
+	// published to.
+	GatewayPublishServiceKey = "/publish-service"
 
 	// DefaultIngressClass defines the default class used
 	// by Kong's ingress controller.
@@ -82,7 +86,7 @@ const (
 
 // GatewayClassUnmanagedAnnotation is the complete annotations for unmanaged mode made by the konhq.com prefix
 // followed by the gatewayclass-unmanaged GatewayClass suffix.
-var GatewayClassUnmanagedAnnotation = fmt.Sprintf("%s/%s", AnnotationPrefix, GatewayClassUnmanagedAnnotationSuffix)
+var GatewayClassUnmanagedAnnotation = fmt.Sprintf("%s%s", AnnotationPrefix, GatewayClassUnmanagedKey)
 
 func validIngress(ingressAnnotationValue, ingressClass string, handling ClassMatching) bool {
 	switch handling {
@@ -342,6 +346,23 @@ func ExtractUnmanagedGatewayClassMode(anns map[string]string) string {
 // UpdateUnmanagedAnnotation updates the value of the annotation konghq.com/gatewayclass-unmanaged.
 func UpdateUnmanagedAnnotation(anns map[string]string, annotationValue string) {
 	anns[GatewayClassUnmanagedAnnotation] = annotationValue
+}
+
+// ExtractGatewayPublishService extracts the value of the gateway publish service annotation.
+func ExtractGatewayPublishService(anns map[string]string) []string {
+	if anns == nil {
+		return []string{}
+	}
+	publish, ok := anns[AnnotationPrefix+GatewayPublishServiceKey]
+	if !ok {
+		return []string{}
+	}
+	return strings.Split(publish, ",")
+}
+
+// UpdateGatewayPublishService updates the value of the annotation konghq.com/gatewayclass-unmanaged.
+func UpdateGatewayPublishService(anns map[string]string, services []string) {
+	anns[AnnotationPrefix+GatewayPublishServiceKey] = strings.Join(services, ",")
 }
 
 // ExtractUserTags extracts a set of tags from a comma-separated string.

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -333,7 +333,7 @@ func TestIsGatewayControlledAndUnmanagedMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "uncontrolled-unmanaged",
 					Annotations: map[string]string{
-						annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+						annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 					},
 				},
 				Spec: gatewayapi.GatewayClassSpec{
@@ -360,7 +360,7 @@ func TestIsGatewayControlledAndUnmanagedMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "controlled-unmanaged",
 					Annotations: map[string]string{
-						annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+						annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 					},
 				},
 				Spec: gatewayapi.GatewayClassSpec{

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -115,7 +115,7 @@ func ensureTestGatewayClassIsUnmanaged(ctx context.Context, k8sClient client.Cli
 	if gwc.Annotations == nil {
 		gwc.Annotations = map[string]string{}
 	}
-	gwc.Annotations[annotations.GatewayClassUnmanagedAnnotation] = annotations.GatewayClassUnmanagedAnnotationValuePlaceholder
+	gwc.Annotations[annotations.AnnotationPrefix+annotations.GatewayClassUnmanagedKey] = annotations.GatewayClassUnmanagedAnnotationValuePlaceholder
 	if err := k8sClient.Update(ctx, gwc); err != nil {
 		return false
 	}

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -142,7 +142,7 @@ func prepareEnvForGatewayConformanceTests(t *testing.T) (c client.Client, gatewa
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+				annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 			},
 		},
 		Spec: gatewayapi.GatewayClassSpec{

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -42,7 +42,7 @@ func deployGateway(ctx context.Context, t *testing.T, env environments.Environme
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
 				// annotate the gatewayclass to unmanaged.
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+				annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 			},
 		},
 		Spec: gatewayapi.GatewayClassSpec{
@@ -106,7 +106,7 @@ func deployGatewayWithTCPListener(ctx context.Context, t *testing.T, env environ
 			Name: uuid.NewString(),
 			Annotations: map[string]string{
 				// annotate the gatewayclass to unmanaged.
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+				annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 			},
 		},
 		Spec: gatewayapi.GatewayClassSpec{

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -191,7 +191,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "unmanaged-gateway-class",
 					Annotations: map[string]string{
-						annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+						annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 					},
 				},
 			},

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -67,7 +67,7 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 	require.Eventually(t, func() bool {
 		gw, err = gatewayClient.GatewayV1beta1().Gateways(ns.Name).Get(ctx, defaultGatewayName, metav1.GetOptions{})
 		require.NoError(t, err)
-		return gw.Annotations[annotations.GatewayClassUnmanagedAnnotation] == strings.Join(
+		return gw.Annotations[annotations.AnnotationPrefix+annotations.GatewayPublishServiceKey] == strings.Join(
 			[]string{
 				fmt.Sprintf("%s/%s", pubsvc.Namespace, pubsvc.Name),
 				fmt.Sprintf("%s/%s", pubsvcUDP.Namespace, pubsvcUDP.Name),

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -69,7 +69,7 @@ func TestGatewayValidationWebhook(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: uuid.NewString(),
 					Annotations: map[string]string{
-						annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+						annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 					},
 				},
 				Spec: gatewayapi.GatewaySpec{

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -44,7 +44,7 @@ func DeployGatewayClass(ctx context.Context, client *gatewayclient.Clientset, ga
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gatewayClassName,
 			Annotations: map[string]string{
-				annotations.GatewayClassUnmanagedAnnotation: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
+				annotations.AnnotationPrefix + annotations.GatewayClassUnmanagedKey: annotations.GatewayClassUnmanagedAnnotationValuePlaceholder,
 			},
 		},
 		Spec: gatewayapi.GatewayClassSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Create a new annotation for indicating the Gateway publish Service.

Add helpers to retrieve and update values from that annotation.

**Which issue this PR fixes**:

Fix #3849

**Special notes for your reviewer**:

This was flagged as a breaking change, but probably has limited impact. This annotation is managed by the controller and there is no user action needed following this change unless you had some other application consuming the annotation. Given its functional area overlap with official spec features (the Gateway status addresses) and our lack of documentation for it I expect that external usage is likely minimal.

This is at odds with https://github.com/Kong/kubernetes-ingress-controller/issues/4518. It uses `publish-service` for the annotation, and `ingress-service` wouldn't be appropriate, since it's not related to an Ingress here. Both refer to the same thing (the Service where routes generated by the controller are served) and consistent terminology for it would be good.

https://github.com/Kong/kubernetes-ingress-controller/issues/4518

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
