### PR TITLE
tests(kongintegration): make kong version retrieval run in .Eventually()

### DIFF
--- a/test/kongintegration/containers/kong.go
+++ b/test/kongintegration/containers/kong.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -69,29 +70,43 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 	}
 	adminURL, err := url.Parse(kong.AdminURL(ctx, t))
 	require.NoError(t, err)
-
-	const (
-		waitTime = time.Minute
-		tickTime = 100 * time.Millisecond
-	)
-	require.Eventually(t, func() bool {
-		reqCtx, cancel := context.WithTimeout(ctx, test.RequestTimeout)
-		defer cancel()
-		kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(reqCtx, adminURL, consts.KongTestPassword)
-		if err != nil {
-			if !errors.As(err, &helpers.TooOldKongGatewayError{}) {
-				t.Logf("failed validating Kong version: %v", err)
-				return false
-			}
-		}
-
-		t.Logf("using Kong instance (version: %q) reachable at %s\n", kongVersion, adminURL)
-		return true
-	}, waitTime, tickTime)
-
 	t.Cleanup(func() {
 		assert.NoError(t, kongC.Terminate(ctx))
 	})
+
+	const (
+		tickTime = 100 * time.Millisecond
+		waitTime = time.Minute
+	)
+	versionCtx, cancel := context.WithTimeout(ctx, waitTime)
+	defer cancel()
+
+	require.NoError(t,
+		retry.Do(
+			func() error {
+				reqCtx, cancel := context.WithTimeout(ctx, test.RequestTimeout)
+				defer cancel()
+				kongVersion, err := helpers.ValidateMinimalSupportedKongVersion(reqCtx, adminURL, consts.KongTestPassword)
+				if err != nil {
+					return err
+				}
+
+				t.Logf("using Kong instance (version: %q) reachable at %s\n", kongVersion, adminURL)
+				return nil
+			},
+			retry.Context(versionCtx),
+			retry.Attempts(0),
+			retry.Delay(tickTime),
+			retry.DelayType(retry.FixedDelay),
+			retry.LastErrorOnly(true),
+			retry.OnRetry(func(n uint, err error) {
+				t.Logf("failed validating Kong version: %v", err)
+			}),
+			retry.RetryIf(func(err error) bool {
+				return !errors.As(err, &helpers.TooOldKongGatewayError{})
+			}),
+		),
+	)
 
 	return kong
 }

--- a/test/kongintegration/containers/kong.go
+++ b/test/kongintegration/containers/kong.go
@@ -91,7 +91,7 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 					return err
 				}
 
-				t.Logf("using Kong instance (version: %q) reachable at %s\n", kongVersion, adminURL)
+				t.Logf("using Kong instance (version: %q) reachable at %s", kongVersion, adminURL)
 				return nil
 			},
 			retry.Context(versionCtx),


### PR DESCRIPTION
**What this PR does / why we need it**:

Run code that retrieves the kong version in `.Eventually()`.

This should fix e.g. https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6528638258/job/17725109637?pr=4859#step:5:580

```
    kong.go:74: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/kongintegration/containers/kong.go:74
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/kongintegration/parser_golden_tests_outputs_test.go:86
        	Error:      	Received unexpected error:
        	            	making HTTP request: Get "http://localhost:32772/": read tcp [::1]:44440->[::1]:32772: read: connection reset by peer
        	Test:       	TestParsersGoldenTestsOutputs/default
```
