### PR TITLE
fix(tests) only require chart version if provided

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -66,7 +66,9 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pin the Helm chart version.
-	kongbuilder.WithHelmChartVersion(testenv.KongHelmChartVersion())
+	if v := os.Getenv("TEST_KONG_HELM_CHART_VERSION"); v != "" {
+		kongbuilder.WithHelmChartVersion(testenv.KongHelmChartVersion())
+	}
 
 	kongAddon := kongbuilder.Build()
 	builder := environments.NewBuilder().WithAddons(kongAddon)


### PR DESCRIPTION
**What this PR does / why we need it**:

If no chart version is specified for integration tests, use the default environment version instead of failing.

**Which issue this PR fixes**:

Running tests locally, I'm usually fine running whatever chart version I have available, since it's probably close to latest. I don't want to have to always specify the exact version.

**Special notes for your reviewer**:

This is a bit a question about the intended purpose of `testenv.KongHelmChartVersion()`. As-is, it blocks any test run without an explicit version.

IMO it makes more sense to use the version if provided (`if os.Getenv("TEST_KONG_HELM_CHART_VERSION") != "" { kongbuilder.WithHelmChartVersion(os.Getenv("TEST_KONG_HELM_CHART_VERSION")) }` and not fail if it's not available.

AFAIK the renovate stuff in CI will always provide a `TEST_KONG_HELM_CHART_VERSION` value, and will thus use that explicit version, but I'm not sure what the intended workflow was outside of CI (or if invoking tests without the make targets). Do we need to preserve the failure in some situations, or would this be fine with an entirely opportunistic "use version if given, do nothing and use defaults otherwise" approach?