### PR TITLE
chore(refactor): simplify API of TCPEchoResponds and tlsEchoResponds

### DIFF
--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -300,12 +300,11 @@ func verifyTCPRoute(ctx context.Context, t *testing.T, env environments.Environm
 
 	t.Logf("waiting for route from TCPRoute to be operational at %s:%d", proxyIP, tcpListenerPort)
 	require.Eventually(t, func() bool {
-		ok, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyIP, tcpListenerPort), "tcpecho-tcproute")
-		if err != nil {
+		if err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyIP, tcpListenerPort), "tcpecho-tcproute"); err != nil {
 			t.Logf("failed to connect to %s:%d, error %v", proxyIP, tcpListenerPort, err)
 			return false
 		}
-		return ok
+		return true
 	}, ingressWait, 5*time.Second,
 	)
 }

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -172,8 +172,7 @@ func TestTCPRouteExample(t *testing.T) {
 
 	t.Log("verifying that TCPRoute becomes routable")
 	require.Eventually(t, func() bool {
-		responds, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest")
-		return err == nil && responds
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest") == nil
 	}, ingressWait, waitTick)
 }
 
@@ -200,9 +199,8 @@ func TestTLSRouteExample(t *testing.T) {
 
 	t.Log("verifying that TLSRoute becomes routable")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
-			"tlsroute-example-manifest", "tlsroute.kong.example", "tlsroute.kong.example", true)
-		return err == nil && responded
+		return tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
+			"tlsroute-example-manifest", "tlsroute.kong.example", "tlsroute.kong.example", true) == nil
 	}, ingressWait, waitTick)
 }
 

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -163,8 +163,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the tcpecho is responding properly")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("removing the parentrefs from the TCPRoute")
@@ -184,14 +183,14 @@ func TestTCPRouteEssentials(t *testing.T) {
 	t.Log("verifying that the tcpecho is no longer responding")
 	defer func() {
 		if t.Failed() {
-			responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-			t.Logf("no longer responding check failure state: responded=%v, eof=%v, reset=%v, err=%v", responded,
+			err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+			t.Logf("no longer responding check failure state: eof=%v, reset=%v, err=%v",
 				errors.Is(err, io.EOF), errors.Is(err, syscall.ECONNRESET), err)
 		}
 	}()
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the parentRefs back")
@@ -209,8 +208,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
@@ -222,8 +220,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the GatewayClass now removed")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
@@ -236,8 +234,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
@@ -249,8 +246,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the Gateway now removed")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
@@ -270,8 +267,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
@@ -284,8 +280,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
@@ -309,8 +305,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("adding an additional backendRef to the TCPRoute")
@@ -339,20 +334,16 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the TCPRoute is now load-balanced between two services")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
@@ -365,8 +356,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 
 	t.Log("testing port matching")
@@ -386,8 +377,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the TCPRoute responds before specifying a port not existent in Gateway")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 
 	t.Log("setting the port in ParentRef which does not have a matching listener in Gateway")
@@ -404,8 +394,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Log("verifying that the TCPRoute does not respond after specifying a port not existent in Gateway")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return responded == false && (errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET))
+		err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
+		return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 	}, ingressWait, waitTick)
 }
 
@@ -543,12 +533,10 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that only the local tcpecho is responding without a ReferenceGrant")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait*2, waitTick)
 	require.Never(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, time.Second*10, time.Second)
 
 	t.Logf("creating a ReferenceGrant that permits tcproute access from %s to services in %s", ns.Name, otherNs.Name)
@@ -589,12 +577,10 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that requests reach both the local and remote namespace echo instances")
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait, waitTick)
 
 	t.Logf("testing specific name references")
@@ -609,8 +595,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err == nil && responded == true
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait*2, waitTick)
 
 	t.Logf("testing incorrect name does not match")
@@ -620,7 +605,6 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2)
-		return err != nil && responded == false
+		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) != nil
 	}, ingressWait, waitTick)
 }

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -248,22 +248,20 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 	proxyAddress := fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort)
 	t.Log("verifying that the tcpecho is responding properly over TLS")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that the tcpecho route can also serve certificates permitted by a ReferenceGrant with a named To")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
-			return false
+			return true
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that using the wrong name in the ReferenceGrant removes the related certificate")
@@ -273,8 +271,7 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true)
-		return err != nil && responded == false
+		return tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true) != nil
 	}, ingressWait, waitTick)
 
 	t.Log("verifying that a Listener has the invalid ref status condition")
@@ -300,12 +297,11 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteExtraHostname, tlsRouteExtraHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 }
 
@@ -451,12 +447,11 @@ func TestTLSRoutePassthrough(t *testing.T) {
 	proxyAddress := fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort)
 	t.Log("verifying that the tcpecho is responding properly over TLS")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("removing the parentrefs from the TLSRoute")
@@ -475,9 +470,9 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that the tcpecho is no longer responding")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
+		err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
 			testUUID, tlsRouteHostname, tlsRouteHostname, false)
-		return responded == false && errors.Is(err, io.EOF)
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the parentRefs back")
@@ -495,12 +490,11 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the GatewayClass")
@@ -512,8 +506,8 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute gets dropped with the GatewayClass now removed")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		return responded == false && errors.Is(err, io.EOF)
+		err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the GatewayClass back")
@@ -526,12 +520,11 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that creating the GatewayClass again triggers reconciliation of TLSRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("deleting the Gateway")
@@ -543,8 +536,8 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute gets dropped with the Gateway now removed")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		return responded == false && errors.Is(err, io.EOF)
+		err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the Gateway back")
@@ -576,12 +569,11 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that creating the Gateway again triggers reconciliation of TLSRoutes and the route becomes available again")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("adding an additional backendRef to the TLSRoute")
@@ -610,20 +602,18 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that the TLSRoute is now load-balanced between two services")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID2, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("deleting both GatewayClass and Gateway rapidly")
@@ -636,9 +626,9 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("verifying that the data-plane configuration from the TLSRoute does not get orphaned with the GatewayClass and Gateway gone")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
+		err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
 			testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		return responded == false && errors.Is(err, io.EOF)
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 
 	t.Log("testing port matching")
@@ -670,12 +660,11 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("ensuring tls echo responds after recreating gateway and gateway class")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		if err != nil {
+		if err := tlsEchoResponds(proxyAddress, testUUID, tlsRouteHostname, tlsRouteHostname, true); err != nil {
 			t.Logf("failed accessing tcpecho at %s, err: %v", proxyAddress, err)
 			return false
 		}
-		return err == nil && responded == true
+		return true
 	}, ingressWait, waitTick)
 
 	t.Log("setting the port in ParentRef which does not have a matching listener in Gateway")
@@ -692,19 +681,20 @@ func TestTLSRoutePassthrough(t *testing.T) {
 
 	t.Log("ensuring tls echo does not respond after using not existing port")
 	require.Eventually(t, func() bool {
-		responded, err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
+		err := tlsEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTLSServicePort),
 			testUUID, tlsRouteHostname, tlsRouteHostname, true)
-		return responded == false && errors.Is(err, io.EOF)
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 }
 
-// tlsEchoResponds takes a TLS address URL and a Pod name and checks if a
-// go-echo instance is running on that Pod at that address using hostname for SNI.
-// It compares an expected message and its length against an expected message, returning true
-// if it is and false and an error explanation if it is not.
+// tlsEchoResponds takes a TLS address URL and a Pod name and checks if a go-echo
+// instance is running on that Pod at that address using hostname for SNI. It sends
+// a message and checks if returned one matches. It returns an error with
+// an explanation if it is not (typical network related errors like io.EOF or
+// syscall.ECONNRESET are returned directly).
 func tlsEchoResponds(
 	url string, podName string, hostname, certHostname string, passthrough bool,
-) (bool, error) {
+) error {
 	dialer := net.Dialer{Timeout: time.Second * 10}
 	conn, err := tls.DialWithDialer(&dialer,
 		"tcp",
@@ -714,13 +704,13 @@ func tlsEchoResponds(
 			InsecureSkipVerify: true,
 		})
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer conn.Close()
 
 	cert := conn.ConnectionState().PeerCertificates[0]
 	if cert.Subject.CommonName != certHostname {
-		return false, fmt.Errorf("expected certificate with cn=%s, got cn=%s", certHostname, cert.Subject.CommonName)
+		return fmt.Errorf("expected certificate with cn=%s, got cn=%s", certHostname, cert.Subject.CommonName)
 	}
 
 	header := []byte(fmt.Sprintf("Running on Pod %s.", podName))
@@ -733,46 +723,46 @@ func tlsEchoResponds(
 
 	wrote, err := conn.Write(message)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if wrote != len(message) {
-		return false, fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
+		return fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
 	}
 
 	if err := conn.SetDeadline(time.Now().Add(time.Second * 5)); err != nil {
-		return false, err
+		return err
 	}
 
 	headerResponse := make([]byte, len(header)+1)
 	read, err := conn.Read(headerResponse)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if read != len(header)+1 { // add 1 for newline
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
+		return fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
 	}
 
 	if !bytes.Contains(headerResponse, header) {
-		return false, fmt.Errorf(`expected header response "%s", received: "%s"`, string(header), string(headerResponse))
+		return fmt.Errorf(`expected header response "%s", received: "%s"`, string(header), string(headerResponse))
 	}
 
 	messageResponse := make([]byte, wrote+1)
 	read, err = conn.Read(messageResponse)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if read != len(message) {
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(message))
+		return fmt.Errorf("read %d bytes but expected %d", read, len(message))
 	}
 
 	if !bytes.Contains(messageResponse, message) {
-		return false, fmt.Errorf(`expected message response "%s", received: "%s"`, string(message), string(messageResponse))
+		return fmt.Errorf(`expected message response "%s", received: "%s"`, string(message), string(messageResponse))
 	}
 
-	return true, nil
+	return nil
 }
 
 func createTLSEchoContainer(tlsEchoPort int32, sendMsg string) corev1.Container { //nolint:unparam

--- a/test/tcp_utils.go
+++ b/test/tcp_utils.go
@@ -7,15 +7,16 @@ import (
 	"time"
 )
 
-// TCPEchoResponds takes a TCP address URL and a Pod name and checks if a
-// go-echo instance is running on that Pod at that address. It compares an
-// expected message and its length against an expected message, returning true
-// if it is and false and an error explanation if it is not.
-func TCPEchoResponds(url string, podName string) (bool, error) {
-	dialer := net.Dialer{Timeout: time.Second * 10}
+// TCPEchoResponds takes a TCP address URL and a Pod name and checks if
+// a go-echo instance is running on that Pod at that address. It sends
+// a message and checks if returned one matches. It returns an error with
+// an explanation if it is not (typical network related errors like
+// io.EOF or syscall.ECONNRESET are returned directly).
+func TCPEchoResponds(url string, podName string) error {
+	dialer := net.Dialer{Timeout: RequestTimeout}
 	conn, err := dialer.Dial("tcp", url)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	header := []byte(fmt.Sprintf("Running on Pod %s.", podName))
@@ -23,44 +24,44 @@ func TCPEchoResponds(url string, podName string) (bool, error) {
 
 	wrote, err := conn.Write(message)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if wrote != len(message) {
-		return false, fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
+		return fmt.Errorf("wrote message of size %d, expected %d", wrote, len(message))
 	}
 
 	if err := conn.SetDeadline(time.Now().Add(time.Second * 5)); err != nil {
-		return false, err
+		return err
 	}
 
 	headerResponse := make([]byte, len(header)+1)
 	read, err := conn.Read(headerResponse)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if read != len(header)+1 { // add 1 for newline
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
+		return fmt.Errorf("read %d bytes but expected %d", read, len(header)+1)
 	}
 
 	if !bytes.Contains(headerResponse, header) {
-		return false, fmt.Errorf(`expected header response "%s", received: "%s"`, string(header), string(headerResponse))
+		return fmt.Errorf(`expected header response "%s", received: "%s"`, header, headerResponse)
 	}
 
 	messageResponse := make([]byte, wrote+1)
 	read, err = conn.Read(messageResponse)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if read != len(message) {
-		return false, fmt.Errorf("read %d bytes but expected %d", read, len(message))
+		return fmt.Errorf("read %d bytes but expected %d", read, len(message))
 	}
 
 	if !bytes.Contains(messageResponse, message) {
-		return false, fmt.Errorf(`expected message response "%s", received: "%s"`, string(message), string(messageResponse))
+		return fmt.Errorf(`expected message response "%s", received: "%s"`, message, messageResponse)
 	}
 
-	return true, nil
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Simplify API of helpers `TCPEchoResponds` and `tlsEchoResponds`, returning an error is enough, the boolean value was redundant. Furthermore inspecting any returned value when a returned error is not nil is considered mostly as a bad practice in Go. Moreover they are consistent with `grpcEchoResponds` now.

