### PR TITLE
chore(deps): make Renovate bump kind/istio minors only for latest

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -2,15 +2,15 @@ e2e:
   kind:
     # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.28.0'
-    # renovate: datasource=docker depName=kindest/node versioning=docker
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.27.3'
-    # renovate: datasource=docker depName=kindest/node versioning=docker
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.26.6'
-    # renovate: datasource=docker depName=kindest/node versioning=docker
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.25.11'
-    # renovate: datasource=docker depName=kindest/node versioning=docker
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.24.15'
-    # renovate: datasource=docker depName=kindest/node versioning=docker
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.23.17'
   gke:
     # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
@@ -23,22 +23,22 @@ e2e:
       kind: 'v1.28.0'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: '1.19.3'
-    - # renovate: datasource=docker depName=kindest/node versioning=docker
+    - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.27.3'
-      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      # renovate: datasource=docker depName=istio/istioctl@only-patch packageName=istio/istioctl versioning=docker
       istio: '1.18.5'
-    - # renovate: datasource=docker depName=kindest/node versioning=docker
+    - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.26.6'
-      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      # renovate: datasource=docker depName=istio/istioctl@only-patch packageName=istio/istioctl versioning=docker
       istio: '1.17.8'
-    - # renovate: datasource=docker depName=kindest/node versioning=docker
+    - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.25.11'
-      # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      # renovate: datasource=docker depName=istio/istioctl@only-patch packageName=istio/istioctl versioning=docker
       istio: '1.16.7'
 
 integration:
   helm:
-    # renovate: datasource=github-releases depName=kong/charts versioning=semver
+    # renovate: datasource=helm depName=kong registryUrl=https://charts.konghq.com versioning=helm
     kong: '2.29.0'
   # renovate: datasource=docker depName=kindest/node versioning=docker
   kind: 'v1.28.0'

--- a/renovate.json
+++ b/renovate.json
@@ -6,25 +6,19 @@
   "separateMinorPatch": true,
   "labels": ["dependencies"],
   "schedule": "before 5am every weekday",
+  "registryAliases": {
+    "kong": "https://charts.konghq.com"
+  },
   "customManagers": [
     {
+      "description": "Match dependencies in .github/test_dependencies.yaml that are properly annotated with `# renovate: datasource={} depName={} [packageName={}] [registryUrl={}] versioning={}.`",
       "customType": "regex",
       "fileMatch": [
         "^.github/test_dependencies.yaml$"
       ],
       "matchStrings": [
-        "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
+        "#\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?(registryUrl=(?<registryUrl>.*)\\s+)?versioning=(?<versioning>.*?)\\n.+'(?<currentValue>.*?)'"
       ]
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^.github/test_dependencies.yaml$"
-      ],
-      "matchStrings": [
-        "#\\s+renovate:\\s+datasource=(?<datasource>.*)\\s+depName=(?<depName>.*)\\s+versioning=(?<versioning>.*)\\n.+'(?<currentValue>.*)'"
-      ],
-      "extractVersionTemplate": "^kong-?(?<version>.*)$"
     }
   ],
   "customDatasources": {
@@ -32,5 +26,13 @@
       "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/kong/gke-renovate-datasource/main/static/rapid.json",
       "format": "json"
     }
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Ignore minor updates if depName has `@only-patch` suffix.",
+      "matchUpdateTypes": ["minor"],
+      "matchDepPatterns": [".*@only-patch"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures Renovate to bump minors only for the entries that we'd like it to update (typically only one entry in the test matrix that is treated as the latest version we want to test against). 

It builds on Renovate's [`packageRules`](https://docs.renovatebot.com/configuration-options/#packagerules) where we can specify various matches (`matchUpdateTypes`, `matchDatasource`, etc.) and settings that should apply to their matches (e.g. `enabled: false`).

In our case, we match `updateTypes=minor` with depNames pattern `.*@only-patch` and disable minor updates for those. We can explicitly specify another `depName` in the annotation (e.g. `depName=kindest/node@only-patch`) to make an entry match this rule. `depName` can be treated as a "display name", while `packageName` is the name used for actual lookups of the dependency's versions ([source](https://github.com/renovatebot/renovate/discussions/14885#discussioncomment-2482898)). By specifying a custom `depName` in the annotation, we can make an entry to match the rule. By specifying a `packageName` equal to a proper dependency name, we make Renovate know what name should be looked up.

Merges custom manager for helm chart version with the general custom manager for `test_dependencies.yaml` by using `helm` datasource and optional `registryUrl` param in the annotation. A registry alias for `kong` registry had to be added.

It also adds descriptions to `customManagers` and `packageRules` for context.

Tested on my KIC fork (intentionally downgraded helm to see if the registry stuff works as expected): 
![image](https://github.com/Kong/kubernetes-ingress-controller/assets/8835851/f4a99353-5169-4856-8442-c2606266d2d2)


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Makes sure undesired PRs like https://github.com/Kong/kubernetes-ingress-controller/pull/4870 and https://github.com/Kong/kubernetes-ingress-controller/pull/4869 are no longer created.