### PR TITLE
test(integration): remove skipTestForExpressionRouter helper in tests

### DIFF
--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -177,7 +177,6 @@ func TestTCPRouteExample(t *testing.T) {
 }
 
 func TestTLSRouteExample(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()
 	t.Cleanup(func() {
@@ -279,7 +278,6 @@ func TestIngressExample(t *testing.T) {
 }
 
 func TestUDPIngressExample(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	t.Log("locking UDP port")
 	udpMutex.Lock()
 	t.Cleanup(func() {

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -141,7 +141,6 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 }
 
 func TestGatewayListenerConflicts(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	ctx := context.Background()
 
 	var gw *gatewayapi.Gateway
@@ -334,7 +333,6 @@ func TestGatewayListenerConflicts(t *testing.T) {
 }
 
 func TestGatewayFilters(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	ctx := context.Background()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestServiceOverrides(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	skipTestForRouterFlavors(t, expressions)
 	ctx := context.Background()
 
 	t.Parallel()

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,12 +20,9 @@ import (
 )
 
 func TestKongIngressValidationWebhook(t *testing.T) {
-	skipTestForExpressionRouter(t)
+	skipTestForNonKindCluster(t)
+	skipTestForRouterFlavors(t, expressions)
 	ctx := context.Background()
-
-	if env.Cluster().Type() != kind.KindClusterType {
-		t.Skip("webhook tests are only available on KIND clusters currently")
-	}
 
 	ns, _ := helpers.Setup(ctx, t, env)
 

--- a/test/integration/skip_helpers_test.go
+++ b/test/integration/skip_helpers_test.go
@@ -26,15 +26,6 @@ func skipTestForRouterFlavors(t *testing.T, flavor ...routerFlavor) {
 	}
 }
 
-// Expression router is not supported for some objects and features.
-// For example, KongIngress is intentionally unsupported.
-// TCPRoute is not supported because Kong (< 3.4) does not support expression router on stream proxy.
-// When the test case depends on the object or feature not supported, we skip it if expression router is used.
-func skipTestForExpressionRouter(t *testing.T) {
-	t.Helper()
-	skipTestForRouterFlavors(t, expressions)
-}
-
 func skipTestForNonKindCluster(t *testing.T) {
 	t.Helper()
 	if env.Cluster().Type() != kind.KindClusterType {

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -303,11 +303,6 @@ func TestTCPIngressTLS(t *testing.T) {
 
 func TestTCPIngressTLSPassthrough(t *testing.T) {
 	t.Parallel()
-	skipTestForExpressionRouter(t)
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4540
-	// Kong does not currently recognize these requests even though the expression looks correct. This should be enabled
-	// after determining why the gateway is discarding these requests and applying any necessary fixes.
-	// RunWhenKongExpressionRouter(t)
 
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -37,7 +37,6 @@ const testTranslationFailuresObjectsPrefix = "translation-failures-"
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
-	skipTestForExpressionRouter(t)
 	ctx := context.Background()
 
 	type expectedTranslationFailure struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

use `skipTestForRouterFlavors` instead of `skipTestForExpressionRouter` to skip tests not expected to run with expression router, and remove the skip for unnecessary cases.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

part of #4719 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
