### PR TITLE
chore: unskip TestTCPIngressTLSPassthrough integration test

### DIFF
--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -303,11 +303,7 @@ func TestTCPIngressTLS(t *testing.T) {
 
 func TestTCPIngressTLSPassthrough(t *testing.T) {
 	t.Parallel()
-	skipTestForExpressionRouter(t)
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4540
-	// Kong does not currently recognize these requests even though the expression looks correct. This should be enabled
-	// after determining why the gateway is discarding these requests and applying any necessary fixes.
-	// RunWhenKongExpressionRouter(t)
+	RunWhenKongExpressionRouter(t)
 
 	t.Log("locking Gateway TLS ports")
 	tlsMutex.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/Kong/kubernetes-ingress-controller/issues/4540 was resolved `TestTCPIngressTLSPassthrough` should pass already.

