### PR TITLE
fix(tests): fix setting GKE cluster version setting

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -226,7 +226,7 @@ func createGKEBuilder(t *testing.T) (*environments.Builder, error) {
 		}
 
 		t.Logf("creating GKE cluster, with requested version: %s", k8sVersion)
-		clusterBuilder = clusterBuilder.WithClusterMinorVersion(k8sVersion.Major, k8sVersion.Minor)
+		clusterBuilder.WithClusterVersion(k8sVersion)
 	}
 
 	return environments.NewBuilder().WithClusterBuilder(clusterBuilder), nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the full version when selecting GKE cluster version in E2E tests.

This prevents issues like specifying 1.28.1 in test dependencies matrix https://github.com/Kong/kubernetes-ingress-controller/blob/2089f87b924a0d4c7faff6a074f8426792bbe588/.github/test_dependencies.yaml#L17 and then shortening it to 1.28.0 by not specifying the patch version via `clusterBuilder.WithClusterMinorVersion()`