### PR TITLE
tests: use testenv.ClusterVersion() for cluster version in E2E tests

### DIFF
--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -3,12 +3,6 @@ package e2e
 import "os"
 
 var (
-	// clusterVersionStr indicates the Kubernetes cluster version to use when
-	// generating a testing environment and allows the caller to provide a specific
-	// version. If no version is provided the default version for the cluster
-	// provisioner in the testing framework will be used.
-	clusterVersionStr = os.Getenv("KONG_CLUSTER_VERSION")
-
 	// controllerImageOverride is the controller image to use in lieu of the default.
 	controllerImageOverride = os.Getenv("TEST_KONG_CONTROLLER_IMAGE_OVERRIDE")
 

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/testenv"
 )
 
 // -----------------------------------------------------------------------------
@@ -85,8 +86,8 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Log("building test cluster and environment")
 	clusterBuilder := kind.NewBuilder()
 	clusterBuilder.WithConfigReader(strings.NewReader(webhookKINDConfig))
-	if clusterVersionStr != "" {
-		clusterVersion, err := semver.ParseTolerant(clusterVersionStr)
+	if v := testenv.ClusterVersion(); v != "" {
+		clusterVersion, err := semver.ParseTolerant(v)
 		require.NoError(t, err)
 		t.Logf("k8s cluster version is set to %v", clusterVersion)
 		clusterBuilder.WithClusterVersion(clusterVersion)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -133,7 +133,7 @@ func getEnvironmentBuilder(ctx context.Context, t *testing.T) (*environments.Bui
 	}
 
 	clusterType, clusterName := clusterParts[0], clusterParts[1]
-	if clusterVersionStr != "" {
+	if testenv.ClusterVersion() != "" {
 		return nil, fmt.Errorf("cannot provide cluster version with existing cluster")
 	}
 
@@ -166,8 +166,8 @@ kubeadmConfigPatches:
 
 func createKINDBuilder(t *testing.T) *environments.Builder {
 	clusterBuilder := kind.NewBuilder().WithConfigReader(strings.NewReader(kindConfig))
-	if clusterVersionStr != "" {
-		clusterVersion := semver.MustParse(strings.TrimPrefix(clusterVersionStr, "v"))
+	if v := testenv.ClusterVersion(); v != "" {
+		clusterVersion := semver.MustParse(strings.TrimPrefix(v, "v"))
 		clusterBuilder = clusterBuilder.WithClusterVersion(clusterVersion)
 	}
 	builder := environments.NewBuilder().WithClusterBuilder(clusterBuilder).WithAddons(metallb.New())
@@ -219,14 +219,14 @@ func createGKEBuilder(t *testing.T) (*environments.Builder, error) {
 		WithCreateSubnet(true).
 		WithLabels(gkeTestClusterLabels())
 
-	if clusterVersionStr != "" {
-		k8sVersion, err := semver.Parse(strings.TrimPrefix(clusterVersionStr, "v"))
+	if v := testenv.ClusterVersion(); v != "" {
+		k8sVersion, err := semver.Parse(strings.TrimPrefix(v, "v"))
 		if err != nil {
 			return nil, err
 		}
 
 		t.Logf("creating GKE cluster, with requested version: %s", k8sVersion)
-		clusterBuilder = clusterBuilder.WithClusterMinorVersion(k8sVersion.Major, k8sVersion.Minor)
+		clusterBuilder.WithClusterVersion(k8sVersion)
 	}
 
 	return environments.NewBuilder().WithClusterBuilder(clusterBuilder), nil

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -86,8 +86,12 @@ func KongEnterpriseEnabled() bool {
 	return os.Getenv("TEST_KONG_ENTERPRISE") == "true"
 }
 
-// ClusterVersion indicates the version of Kubernetes to use for the tests
-// (if the cluster was not provided by the caller).
+// ClusterVersion indicates the Kubernetes cluster version to use when
+// generating a testing environment (if the cluster was not provided by the
+// caller). and allows the caller to provide a specific version.
+//
+// If no version is provided the default version for the cluster provisioner in
+// the testing framework will be used.
 func ClusterVersion() string {
 	return os.Getenv("KONG_CLUSTER_VERSION")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `testenv.ClusterVersion()` for cluster version in E2E tests
