### PR TITLE
chore: remove feature gate ExpressionRoutes

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -86,7 +86,7 @@ jobs:
             router-flavor: 'traditional_compatible'
           - name: dbless-expression-router
             test: dbless
-            feature_gates: "ExpressionRoutes=true,GatewayAlpha=true"
+            feature_gates: "GatewayAlpha=true"
             router-flavor: "expressions"
           - name: dbless-gateway-alpha
             test: dbless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ Adding a new version? You'll need three changes:
   [#4743](https://github.com/Kong/kubernetes-ingress-controller/pull/4743)
 - Removed feature gate `CombinedRoutes`. The feature is enabled and it can't be changed.
   [#4749](https://github.com/Kong/kubernetes-ingress-controller/pull/4749)
+- Removed featuregate `ExpressionRoutes`. The feature is enabled and it can't be changed.
+  KIC now translates to expression based Kong routes when Kong's router flavor `expressions`.
+  [#4892](https://github.com/Kong/kubernetes-ingress-controller/pull/4892)
 - Removed Knative support.
   [#4748](https://github.com/Kong/kubernetes-ingress-controller/pull/4748)
 - Removed support for the `debug-log-reduce-redundancy` CLI flag.
@@ -143,8 +146,7 @@ Adding a new version? You'll need three changes:
 ### Added
 
 - Added support for expression-based Kong routes for `TLSRoute`. This requires
-  the `ExpressionRoutes` feature gate and a Kong installed with
-  `KONG_ROUTER_FLAVOR=expressions` set in the environment.
+  Kong installed with `KONG_ROUTER_FLAVOR=expressions` set in the environment.
   [#4574](https://github.com/Kong/kubernetes-ingress-controller/pull/4574).
 - The `FillIDs` feature gate is now enabled by default.
   [#4746](https://github.com/Kong/kubernetes-ingress-controller/pull/4746)

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -62,7 +62,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | CombinedRoutes   | `false` | Alpha | 2.4.0   | 3.0.0 |
 | CombinedRoutes   | `true`  | Beta  | 2.8.0   | 3.0.0 |
 | GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
-| ExpressionRoutes | `false` | Alpha | 2.10.0  | TBD   |
+| ExpressionRoutes | `false` | Alpha | 2.10.0  | 3.0.0 |
 | CombinedServices | `false` | Alpha | 2.10.0  | 3.0.0 |
 | CombinedServices | `true`  | Beta  | 2.11.0  | 3.0.0 |
 | FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |

--- a/internal/dataplane/parser/golden_test.go
+++ b/internal/dataplane/parser/golden_test.go
@@ -35,8 +35,7 @@ var (
 			ReportConfiguredKubernetesObjects: false,
 
 			// Feature flags that are directly propagated from the feature gates get their defaults.
-			ExpressionRoutes: featuregates.GetFeatureGatesDefaults()[featuregates.ExpressionRoutesFeature],
-			FillIDs:          featuregates.GetFeatureGatesDefaults()[featuregates.FillIDsFeature],
+			FillIDs: featuregates.GetFeatureGatesDefaults()[featuregates.FillIDsFeature],
 		}
 	}
 )

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -72,7 +72,7 @@ func NewFeatureFlags(
 ) FeatureFlags {
 	return FeatureFlags{
 		ReportConfiguredKubernetesObjects: updateStatusFlag,
-		ExpressionRoutes:                  shouldEnableParserExpressionRoutes(logger, featureGates, routerFlavor),
+		ExpressionRoutes:                  shouldEnableParserExpressionRoutes(logger, routerFlavor),
 		FillIDs:                           featureGates.Enabled(featuregates.FillIDsFeature),
 		RewriteURIs:                       featureGates.Enabled(featuregates.RewriteURIsFeature),
 	}
@@ -80,14 +80,10 @@ func NewFeatureFlags(
 
 func shouldEnableParserExpressionRoutes(
 	logger logr.Logger,
-	featureGates featuregates.FeatureGates,
 	routerFlavor string,
 ) bool {
-	if !featureGates.Enabled(featuregates.ExpressionRoutesFeature) {
-		return false
-	}
 	if routerFlavor != kongRouterFlavorExpressions {
-		logger.V(util.InfoLevel).Info("ExpressionRoutes feature gate enabled but Gateway is running with incompatible router flavor, using that instead", "flavor", routerFlavor)
+		logger.V(util.InfoLevel).Info("Gateway is running with non-expression router flavor", "flavor", routerFlavor)
 		return false
 	}
 	logger.V(util.InfoLevel).Info("expression routes mode enabled")

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/util/builder"
@@ -4522,24 +4521,12 @@ func TestNewFeatureFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "expression routes feature gate enabled and router flavor matches",
-			featureGates: map[string]bool{
-				featuregates.ExpressionRoutesFeature: true,
-			},
+			name:         "expression routes feature gate enabled and router flavor matches",
 			routerFlavor: kongRouterFlavorExpressions,
 			expectedFeatureFlags: FeatureFlags{
 				ExpressionRoutes: true,
 			},
 			expectInfoLog: "expression routes mode enabled",
-		},
-		{
-			name: "expression routes feature gate enabled and router flavor does not match",
-			featureGates: map[string]bool{
-				featuregates.ExpressionRoutesFeature: true,
-			},
-			routerFlavor:         "any_other_router_mode",
-			expectedFeatureFlags: FeatureFlags{},
-			expectInfoLog:        "ExpressionRoutes feature gate enabled but Gateway is running with incompatible router flavor, using that instead",
 		},
 	}
 

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -18,13 +18,6 @@ const (
 	// disabling the Alpha maturity APIs and relevant features for Gateway API.
 	GatewayAlphaFeature = "GatewayAlpha"
 
-	// ExpressionRoutesFeature is the name of the feature-gate for enabling KIC to translate
-	// supported kubernetes objects into expression based routes in kong configrurations
-	// when controlled kong gateway uses expression based router by configuring `router_flavor` to `expressions`.
-	// Note: this feature is experimental and some resources and features may not be supported.
-	// See: https://docs.konghq.com/gateway/latest/key-concepts/routes/expressions/ about expression based routes in Kong 3.0+.
-	ExpressionRoutesFeature = "ExpressionRoutes"
-
 	// FillIDsFeature is the name of the feature-gate that makes KIC fill in the ID fields of Kong entities (Services,
 	// Routes, and Consumers). It ensures that IDs remain stable across restarts of the controller.
 	FillIDsFeature = "FillIDs"
@@ -67,10 +60,9 @@ func (fg FeatureGates) Enabled(feature string) bool {
 // NOTE: if you're adding a new feature gate, it needs to be added here.
 func GetFeatureGatesDefaults() map[string]bool {
 	return map[string]bool{
-		GatewayFeature:          true,
-		GatewayAlphaFeature:     false,
-		ExpressionRoutesFeature: false,
-		FillIDsFeature:          true,
-		RewriteURIsFeature:      false,
+		GatewayFeature:      true,
+		GatewayAlphaFeature: false,
+		FillIDsFeature:      true,
+		RewriteURIsFeature:  false,
 	}
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -125,7 +125,7 @@ func Run(
 		FilterTags:         c.FilterTags,
 		SkipCACertificates: c.SkipCACertificates,
 		EnableReverseSync:  c.EnableReverseSync,
-		ExpressionRoutes:   featureGates.Enabled(featuregates.ExpressionRoutesFeature),
+		// ExpressionRoutes:   featureGates.Enabled(featuregates.ExpressionRoutesFeature),
 	}
 	kongConfig.Init(ctx, setupLog, initialKongClients)
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -125,7 +125,7 @@ func Run(
 		FilterTags:         c.FilterTags,
 		SkipCACertificates: c.SkipCACertificates,
 		EnableReverseSync:  c.EnableReverseSync,
-		// ExpressionRoutes:   featureGates.Enabled(featuregates.ExpressionRoutesFeature),
+		ExpressionRoutes:   routerFlavor == "expressions",
 	}
 	kongConfig.Init(ctx, setupLog, initialKongClients)
 

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -117,9 +117,6 @@ func prepareEnvForGatewayConformanceTests(t *testing.T) (c client.Client, gatewa
 	require.NoError(t, gatewayv1beta1.AddToScheme(client.Scheme()))
 
 	featureGateFlag := fmt.Sprintf("--feature-gates=%s", consts.DefaultFeatureGates)
-	if testenv.ExpressionRoutesEnabled() {
-		featureGateFlag = fmt.Sprintf("--feature-gates=%s", consts.ConformanceExpressionRoutesTestsFeatureGates)
-	}
 
 	t.Log("starting the controller manager")
 	cert, key := certificate.GetKongSystemSelfSignedCerts()

--- a/test/consts/feature_gates.go
+++ b/test/consts/feature_gates.go
@@ -6,8 +6,4 @@ const (
 	// that are innocuous, or otherwise don't actually get triggered unless the
 	// user takes further action.
 	DefaultFeatureGates = "GatewayAlpha=true"
-
-	// ConformanceExpressionRoutesTestsFeatureGates is the set of feature gates to be used
-	// when running conformance tests with expression routes enabled.
-	ConformanceExpressionRoutesTestsFeatureGates = "GatewayAlpha=true,ExpressionRoutes=true"
 )

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -355,7 +355,6 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 		"<14>"+
 			"signal=kic-ping;"+
 			"db=off;"+
-			"feature-expressionroutes=false;"+
 			"feature-fillids=true;"+
 			"feature-gateway-service-discovery=false;"+
 			"feature-gateway=false;"+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

remove feature gate `ExpressionRoutes` and enable KIC to translate k8s objects to expression based Kong routes when Kong gateway is using `expressions` router.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

part of #4719.  

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
 