### PR TITLE
tests: add `GracefulShutdownTimeout` option to manager to extend it in tests

### DIFF
--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	SyncPeriod                        time.Duration
 	SkipCACertificates                bool
 	CacheSyncTimeout                  time.Duration
+	GracefulShutdownTimeout           *time.Duration
 
 	// Kong Proxy configurations
 	APIServerHost               string

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -65,7 +65,8 @@ func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbm
 
 	// configure the general manager options
 	managerOpts := ctrl.Options{
-		Scheme: scheme,
+		GracefulShutdownTimeout: c.GracefulShutdownTimeout,
+		Scheme:                  scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: c.MetricsAddr,
 		},

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/zapr"
 	"github.com/phayes/freeport"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -64,6 +66,9 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 	cfg.AnonymousReports = false
 	cfg.FeatureGates = featuregates.GetFeatureGatesDefaults()
 	cfg.FeatureGates[featuregates.GatewayFeature] = false
+
+	// Extend the graceful shutdown timeout to prevent flakiness on CI.
+	cfg.GracefulShutdownTimeout = lo.ToPtr(time.Minute)
 
 	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `GracefulShutdownTimeout` option to manager config to allow customizing it in tests.

It doesn't expose this as a CLI flag so there's no user facing change but it will allow to configure this in tests to e.g. extend the graceful timeout on CI where the manager sometimes doesn't manage to shutdown in time (30s is the default timeout).

Example: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6571082626/job/17849593971?pr=4892#step:4:754

```
    run.go:177: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/envtest/run.go:177
        	            				/opt/hostedtoolcache/go/1.21.3/x64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	failed waiting for all runnables to end within grace period of 30s: context deadline exceeded
        	Test:       	TestGatewayReconciliation_MoreThan100Routes
    run.go:182: manager logs:
```

This also extends the timeout from default 30s to 1m in envtest suite.
