### PR TITLE
chore(deps): enable kustomize manager in Renovate

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -16,16 +16,6 @@ body:
   validations:
     required: true
 - type: checkboxes
-  id: gateway_version
-  attributes:
-    label: "Bump Kong Gateway version in manifests"
-    options:
-      - label: "Note: it might be possible that the latest Gateway version is not compatible with KIC and code changes are required. In such case, a decision whether to release with no compliance with the latest Gateway version should be made on a team level."
-      - label: Check the latest minor Kong Gateway release in [Kong releases](https://github.com/Kong/kong/releases).
-      - label: Make sure the image tag in [config/image/enterprise/kustomization.yaml](/Kong/kubernetes-ingress-controller/blob/main/config/image/enterprise/kustomization.yaml) and [config/image/oss/kustomization.yaml](/Kong/kubernetes-ingress-controller/blob/main/config/image/oss/kustomization.yaml) is updated accordingly.
-      - label: Run `make manifests` to regenerate manifests using the modified kustomizations and open a PR with the changes (similarly to [this PR](https://github.com/Kong/kubernetes-ingress-controller/pull/3288)).
-      - label: "Make sure that effective versions configured in manifests of github workflows updated, including these files:  .github.com/workflows/e2e_nightly.yaml, .github/workflows/test_nightly.yaml."
-- type: checkboxes
   id: release_branch
   attributes:
     label: "**For major/minor releases** Create `release/<MAJOR>.<MINOR>.x` Branch"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "configMigration": true,
-  "enabledManagers": ["regex"],
+  "enabledManagers": ["regex", "kustomize"],
   "automerge": false,
   "separateMinorPatch": true,
   "labels": ["dependencies"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables `renovate` manager in Kustomize that will handle image updates in `config/image/(enterprise|oss)/kustomize.yaml`. That allows dropping the manual step of updating those from the release issue template.

Tested on fork, created PRs:
- https://github.com/czeslavo/kubernetes-ingress-controller/pull/27 
- https://github.com/czeslavo/kubernetes-ingress-controller/pull/26

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4836.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

