### PR TITLE
feat(admission): validate labeled credentials

### DIFF
--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -237,8 +237,7 @@ func (validator KongHTTPValidator) ValidateCredential(
 	secret corev1.Secret,
 ) (bool, string, error) {
 	// If the secret doesn't contain a type key it's not a credentials secret.
-	_, ok := secret.Data[credsvalidation.TypeKey]
-	if !ok {
+	if _, s := util.ExtractKongCredentialType(&secret); s == util.CredentialTypeAbsent {
 		return true, "", nil
 	}
 

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -568,6 +568,35 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 		wantErrContains string
 	}{
 		{
+			name: "labeled valid key-auth credential with no consumers gets accepted",
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"konghq.com/credential": "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					"key": []byte("my-key"),
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "labeled invalid key-auth credential with no consumers gets rejected",
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"konghq.com/credential": "key-auth",
+					},
+				},
+				Data: map[string][]byte{
+					// missing key
+				},
+			},
+			wantOK:      false,
+			wantMessage: fmt.Sprintf("%s: %s", ErrTextConsumerCredentialValidationFailed, "missing required field(s): key"),
+		},
+		{
 			name: "valid key-auth credential with no consumers gets accepted",
 			secret: corev1.Secret{
 				Data: map[string][]byte{
@@ -586,7 +615,7 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 				},
 			},
 			wantOK:      false,
-			wantMessage: fmt.Sprintf("%s: %s", ErrTextConsumerCredentialValidationFailed, "invalid credentials secret, no data present"),
+			wantMessage: fmt.Sprintf("%s: %s", ErrTextConsumerCredentialValidationFailed, "missing required field(s): key"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `util.ExtractKongCredentialType` to determine the credential type in the validation handler. Otherwise, we'd validate only secrets that include `kongCredType` key.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #2502.
