### PR TITLE
[backport release/2.12.x] fix: run basic credentials validation despite relation with consumers (#4887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,12 +124,12 @@ Adding a new version? You'll need three changes:
   [#4608](https://github.com/Kong/kubernetes-ingress-controller/pull/4608)
 - Do not parse error body when failed to get response from reloading declarative
   configurations to produce proper error log in such situations,
-  [#4666](https://github.com/Kong/kubernetes-ingress-controller/pull/4666) 
+  [#4666](https://github.com/Kong/kubernetes-ingress-controller/pull/4666)
 - Set type meta of objects when adding them to caches and reference indexers
   to ensure that indexes of objects in reference indexers have correct object
-  kind. This ensures referece relations of objects are stored and indexed 
+  kind. This ensures referece relations of objects are stored and indexed
   correctly.
-  [#4663](https://github.com/Kong/kubernetes-ingress-controller/pull/4663) 
+  [#4663](https://github.com/Kong/kubernetes-ingress-controller/pull/4663)
 - Display Service ports on generated Kong services, instead of a static default
   value. This change is cosmetic only.
   [#4503](https://github.com/Kong/kubernetes-ingress-controller/pull/4503)
@@ -150,7 +150,7 @@ Adding a new version? You'll need three changes:
   [#4641](https://github.com/Kong/kubernetes-ingress-controller/issues/4641)
   [#4643](https://github.com/Kong/kubernetes-ingress-controller/issues/4643)
 - Fix `Licenses` and `ConsumerGroups` missing in sanitized copies of Kong configuration.
-  [#4710](https://github.com/Kong/kubernetes-ingress-controller/pull/4710
+  [#4710](https://github.com/Kong/kubernetes-ingress-controller/pull/4710)
 
 ## [2.11.1]
 
@@ -203,7 +203,7 @@ Adding a new version? You'll need three changes:
   [#4211](https://github.com/Kong/kubernetes-ingress-controller/pull/4211)
 - Assign priorities to routes translated from Ingresses when parser translate
   them to expression based Kong routes. The assigning method is basically the
-  same as in Kong gateway's `traditional_compatible` router, except that 
+  same as in Kong gateway's `traditional_compatible` router, except that
   `regex_priority` field in Kong traditional route is not supported. This
   method is adopted to keep the compatibility with traditional router on
   maximum effort.
@@ -213,7 +213,7 @@ Adding a new version? You'll need three changes:
   [specification on priorities of matches in `HTTPRoute`][httproute-specification].
   [#4296](https://github.com/Kong/kubernetes-ingress-controller/pull/4296)
   [#4434](https://github.com/Kong/kubernetes-ingress-controller/pull/4434)
-- Assign priorities to routes translated from GRPCRoutes when the parser translates 
+- Assign priorities to routes translated from GRPCRoutes when the parser translates
   them to expression based Kong routes. The priority order follows the
   [specification on match priorities in GRPCRoute][grpcroute-specification].
   [#4364](https://github.com/Kong/kubernetes-ingress-controller/pull/4364)
@@ -230,7 +230,7 @@ Adding a new version? You'll need three changes:
   in terms of accepting data-plane traffic, but are ready to accept configuration
   updates. The controller will now send configuration to such Gateways and will
   actively monitor their readiness for accepting configuration updates.
-  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368)
 - `KongConsumer`, `KongConsumerGroup` `KongPlugin`, and `KongClusterPlugin` CRDs were extended with
   `Status.Conditions` field. It will contain the `Programmed` condition describing
   whether an object was successfully translated into Kong entities and sent to Kong.
@@ -265,11 +265,11 @@ Adding a new version? You'll need three changes:
 - Changed the Gateway's readiness probe in all-in-one manifests from `/status`
   to `/status/ready`. Gateways will be considered ready only after an initial
   configuration is applied by the controller.
-  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368
-- When translating to expression based Kong routes, annotations to specify 
+  [#4368](https://github.com/Kong/kubernetes-ingress-controller/pull/4368)
+- When translating to expression based Kong routes, annotations to specify
   protocols are translated to `protocols` field of the result Kong route,
-  instead of putting the conditions to match protocols inside expressions. 
-  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422) 
+  instead of putting the conditions to match protocols inside expressions.
+  [#4422](https://github.com/Kong/kubernetes-ingress-controller/pull/4422)
 
 ### Fixed
 
@@ -285,7 +285,7 @@ Adding a new version? You'll need three changes:
 - `Gateway` can now correctly update `AttachedRoutes` even if there are more
   than 100 `HttpRoute`s.
   [#4458](https://github.com/Kong/kubernetes-ingress-controller/pull/4458)
- 
+
 [gojson]: https://github.com/goccy/go-json
 [httproute-specification]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
 [grpcroute-specification]:  https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteRule

--- a/hack/deploy-admission-controller.sh
+++ b/hack/deploy-admission-controller.sh
@@ -58,6 +58,7 @@ webhooks:
     apiVersions:
     - 'v1'
     operations:
+    - CREATE
     - UPDATE
     resources:
     - secrets

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -246,13 +246,8 @@ func (h RequestHandler) handleSecret(
 		return responseBuilder.Allowed(true).Build(), nil
 	}
 
-	// secrets are only validated on update because they must be referenced by a
-	// managed consumer in order for us to validate them, and because credentials
-	// validation also happens at the consumer side of the reference so a
-	// credentials secret can not be referenced without being validated.
-
 	switch request.Operation { //nolint:exhaustive
-	case admissionv1.Update:
+	case admissionv1.Update, admissionv1.Create:
 		ok, message, err := h.Validator.ValidateCredential(ctx, secret)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #4887 to release/2.12.x.