### PR TITLE
tests(envtest): use comming log encoder in envtest suite when printing logs

### DIFF
--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -51,7 +51,7 @@ func MakeLogger(level string, formatter string, output io.Writer) (*zap.Logger, 
 		return lvl >= logLevel
 	})
 
-	encoder, err := getZapEncoding(formatter)
+	encoder, err := GetZapEncoding(formatter)
 	if err != nil {
 		return nil, fmt.Errorf("setting log formatter failed: %w", err)
 	}
@@ -68,7 +68,7 @@ func getZapLevel(level string) (zapcore.Level, error) {
 	return res, nil
 }
 
-func getZapEncoding(typ string) (zapcore.Encoder, error) {
+func GetZapEncoding(typ string) (zapcore.Encoder, error) {
 	switch typ {
 	case "text", "console":
 		return zapcore.NewConsoleEncoder(zapcore.EncoderConfig{

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -184,9 +185,14 @@ func RunManager(
 	t.Cleanup(func() {
 		wg.Wait()
 		if t.Failed() {
+			encoder, err := util.GetZapEncoding("text")
+			require.NoError(t, err)
+
 			t.Logf("manager logs:")
 			for _, entry := range logs.All() {
-				t.Logf("%s - %s", entry.Time, entry.Message)
+				b, err := encoder.EncodeEntry(entry.Entry, entry.Context)
+				assert.NoError(t, err)
+				t.Logf("%s", b.String())
 			}
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the same log encoder for manager logs in `envtest` suite as when running the manager.
