### PR TITLE
chore(deps): auto-regenerate manifests on Renovate manifests bumps

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -24,6 +24,13 @@ jobs:
       - name: regenerate
         run: make manifests
 
-      - uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
+      - name: commit and push (if changes detected)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          git add . 
+          git diff-index --quiet HEAD || \
+          git commit -m "chore: regenerate manifests" && \
+          git push origin ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -1,0 +1,29 @@
+# This workflow will regenerate the manifests, commit&push them on a PR labeled with `renovate/auto-regenerate`.
+# It's to make sure that Renovate-created PRs that update kustomize dependencies also update the manifests.
+name: Regenerate on deps bump
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  regenerate:
+    if: contains(github.event.*.labels.*.name, 'renovate/auto-regenerate')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: regenerate
+        run: make manifests
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,11 @@
       "matchUpdateTypes": ["minor"],
       "matchDepPatterns": [".*@only-patch"],
       "enabled": false
+    },
+    {
+      "description": "Add 'renovate/auto-regenerate' label to a PR if it changes kustomize files to trigger regenerate_on_deps_bump.yaml workflow.",
+      "matchManagers": ["kustomize"],
+      "addLabels": ["renovate/auto-regenerate"]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovates is capable of bumping `kustomize` images, but we cannot force it to regenerate manifests. This PR adds Renovate config `packageRule` that will add a `renovate/auto-regenerate` label to every `kustomize` manager-triggered PR, and a workflow that will regenerate manifests for PRs with this label. 

Tested with my fork: https://github.com/czeslavo/kubernetes-ingress-controller/pull/32

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4836.
