### PR TITLE
chore(linter): in switch case default signifies exhaustive match

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,6 +47,8 @@ linters:
   - unused
   - wastedassign
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   gci:
     sections:
     - standard

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -140,7 +140,7 @@ func (h RequestHandler) handleKongConsumer(
 		return nil, err
 	}
 
-	switch request.Operation { //nolint:exhaustive
+	switch request.Operation {
 	case admissionv1.Create:
 		ok, msg, err := h.Validator.ValidateConsumer(ctx, consumer)
 		if err != nil {
@@ -241,7 +241,7 @@ func (h RequestHandler) handleSecret(
 		return responseBuilder.Allowed(true).Build(), nil
 	}
 
-	switch request.Operation { //nolint:exhaustive
+	switch request.Operation {
 	case admissionv1.Update, admissionv1.Create:
 		ok, message, err := h.Validator.ValidateCredential(ctx, secret)
 		if err != nil {

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -466,7 +466,7 @@ func getListenerStatus(
 		if len(conflictReason) > 0 {
 			for _, cond := range statuses[listener.Name].Conditions {
 				// shut up linter, there's a default
-				switch gatewayapi.ListenerConditionType(cond.Type) { //nolint:exhaustive
+				switch gatewayapi.ListenerConditionType(cond.Type) {
 				case gatewayapi.ListenerConditionProgrammed, gatewayapi.ListenerConditionConflicted:
 					continue
 				default:

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -246,7 +246,7 @@ func generateAddressFinderGetter(mgrc client.Client, ingressServiceNN k8stypes.N
 		}
 
 		var addrs []string
-		switch svc.Spec.Type { //nolint:exhaustive
+		switch svc.Spec.Type {
 		case corev1.ServiceTypeLoadBalancer:
 			for _, lbaddr := range svc.Status.LoadBalancer.Ingress {
 				if lbaddr.IP != "" {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -221,7 +221,7 @@ func getKongProxyIP(ctx context.Context, t *testing.T, env environments.Environm
 	svc := refreshService()
 	require.NotEqual(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "ClusterIP service is not supported")
 
-	switch svc.Spec.Type { //nolint:exhaustive
+	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		return getKongProxyLoadBalancerIP(t, refreshService)
 	case corev1.ServiceTypeNodePort:

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -262,7 +262,7 @@ func gatewayLinkStatusMatches(
 	namespace, name string,
 ) bool {
 	// gather a fresh copy of the route, given the specific protocol type
-	switch protocolType { //nolint:exhaustive
+	switch protocolType {
 	case gatewayapi.HTTPProtocolType:
 		route, err := c.GatewayV1().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		groute, gerr := c.GatewayV1alpha2().GRPCRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -346,7 +346,7 @@ func verifyProgrammedConditionStatus(t *testing.T,
 	ctx := context.Background()
 
 	// gather a fresh copy of the route, given the specific protocol type
-	switch protocolType { //nolint:exhaustive
+	switch protocolType {
 	case gatewayapi.HTTPProtocolType:
 		route, err := c.GatewayV1().HTTPRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		groute, gerr := c.GatewayV1alpha2().GRPCRoutes(namespace).Get(ctx, name, metav1.GetOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR adjusts configuration of golangci-lint, to get rid of `//nolint:exhaustive`. It is sensible to always treat `switch` statements that include case `default` as exhaustive 
