### PR TITLE
fix: set proper destination port for TCPRoute and UDPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@ Adding a new version? You'll need three changes:
   [#4813](https://github.com/Kong/kubernetes-ingress-controller/pull/4813)
 - Fixed an incorrect watch, set in UDPRoute controller watching UDProute status updates.
   [#4835](https://github.com/Kong/kubernetes-ingress-controller/pull/4835)
+- Fixed setting proper destination port for TCPRoute and UDPRoute, now field `SectionName`
+  for `TCPRoute` and `UDPRoute` works as expected. It **breaks** some configurations that
+  relied on matching multiple Gateway's listener ports to ports of services automatically.
+  [#4928](https://github.com/Kong/kubernetes-ingress-controller/pull/4928)
 
 ### Changed
 

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -588,6 +588,38 @@ func (p *Parser) getCerts(secretsToSNIs SecretNameToSNIs) []certWrapper {
 	return certs
 }
 
+func (p *Parser) getGatewayListeningPorts(
+	routeNamespace string,
+	protocol gatewayapi.ProtocolType,
+	prs []gatewayapi.ParentReference,
+) []gatewayapi.PortNumber {
+	var gwPorts []gatewayapi.PortNumber
+	for _, pr := range prs {
+		// When namespace is is explicitly specified in the parentRef,
+		// it should be used instead of namespace of the whole Route.
+		ns := string(lo.FromPtr(pr.Namespace))
+		if ns == "" {
+			ns = routeNamespace
+		}
+		gw, err := p.storer.GetGateway(ns, string(pr.Name))
+		if err != nil {
+			continue // Skip when attached Gateway is not found.
+		}
+
+		// Get explicitly referenced Gateway listening ports by ParentReference configuration.
+		// If no sectionName is specified, all ports are used (according to the specification
+		// "When unspecified (empty string), this will reference the entire resource." - see
+		// https://github.com/kubernetes-sigs/gateway-api/blob/ebe9f31ef27819c3b29f698a3e9b91d279453c59/apis/v1/shared_types.go#L107).
+		gwPorts = append(gwPorts, lo.FilterMap(gw.Spec.Listeners, func(l gatewayapi.Listener, i int) (gatewayapi.PortNumber, bool) {
+			if (pr.SectionName == nil || *pr.SectionName == l.Name) && protocol == l.Protocol {
+				return l.Port, true
+			}
+			return 0, false
+		})...)
+	}
+	return gwPorts
+}
+
 func mergeCerts(logger logr.Logger, certLists ...[]certWrapper) []kongstate.Certificate {
 	snisSeen := make(map[string]string)
 	certsSeen := make(map[string]certWrapper)

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -595,7 +595,7 @@ func (p *Parser) getGatewayListeningPorts(
 ) []gatewayapi.PortNumber {
 	var gwPorts []gatewayapi.PortNumber
 	for _, pr := range prs {
-		// When namespace is is explicitly specified in the parentRef,
+		// When namespace is explicitly specified in the parentRef,
 		// it should be used instead of namespace of the whole Route.
 		ns := string(lo.FromPtr(pr.Namespace))
 		if ns == "" {
@@ -610,7 +610,7 @@ func (p *Parser) getGatewayListeningPorts(
 		// If no sectionName is specified, all ports are used (according to the specification
 		// "When unspecified (empty string), this will reference the entire resource." - see
 		// https://github.com/kubernetes-sigs/gateway-api/blob/ebe9f31ef27819c3b29f698a3e9b91d279453c59/apis/v1/shared_types.go#L107).
-		gwPorts = append(gwPorts, lo.FilterMap(gw.Spec.Listeners, func(l gatewayapi.Listener, i int) (gatewayapi.PortNumber, bool) {
+		gwPorts = append(gwPorts, lo.FilterMap(gw.Spec.Listeners, func(l gatewayapi.Listener, _ int) (gatewayapi.PortNumber, bool) {
 			if (pr.SectionName == nil || *pr.SectionName == l.Name) && protocol == l.Protocol {
 				return l.Port, true
 			}

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -38,20 +38,17 @@ func (p *Parser) ingressRulesFromTCPRoutes() ingressRules {
 		applyExpressionToIngressRules(&result)
 	}
 
-	if len(errs) > 0 {
-		for _, err := range errs {
-			p.logger.Error(err, "could not generate route from TCPRoute")
-		}
+	for _, err := range errs {
+		p.logger.Error(err, "could not generate route from TCPRoute")
 	}
 
 	return result
 }
 
 func (p *Parser) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewayapi.TCPRoute) error {
-	// first we grab the spec and gather some metdata about the object
 	spec := tcproute.Spec
 
-	// validation for TCPRoutes will happen at a higher layer, but in spite of that we run
+	// Validation for TCPRoutes will happen at a higher layer, but in spite of that we run
 	// validation at this level as well as a fallback so that if routes are posted which
 	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
 	// at least try to provide a helpful message about the situation in the manager logs.
@@ -59,18 +56,14 @@ func (p *Parser) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewa
 		return translators.ErrRouteValidationNoRules
 	}
 
-	// each rule may represent a different set of backend services that will be accepting
+	gwPorts := p.getGatewayListeningPorts(tcproute.Namespace, gatewayapi.TCPProtocolType, spec.CommonRouteSpec.ParentRefs)
+
+	// Each rule may represent a different set of backend services that will be accepting
 	// traffic, so we make separate routes and Kong services for every present rule.
 	for ruleNumber, rule := range spec.Rules {
-		// TODO: add this to a generic TCPRoute validation, and then we should probably
-		//       simply be calling validation on each tcproute object at the begininning
-		//       of the topmost list.
-		if len(rule.BackendRefs) == 0 {
-			return fmt.Errorf("missing backendRef in rule")
-		}
 
-		// determine the routes needed to route traffic to services for this rule
-		routes, err := generateKongRoutesFromRouteRule(tcproute, ruleNumber, rule)
+		// Determine the routes needed to route traffic to services for this rule.
+		routes, err := generateKongRoutesFromRouteRule(tcproute, gwPorts, ruleNumber, rule)
 		if err != nil {
 			return err
 		}

--- a/internal/dataplane/parser/translate_tcproute.go
+++ b/internal/dataplane/parser/translate_tcproute.go
@@ -47,11 +47,6 @@ func (p *Parser) ingressRulesFromTCPRoutes() ingressRules {
 
 func (p *Parser) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewayapi.TCPRoute) error {
 	spec := tcproute.Spec
-
-	// Validation for TCPRoutes will happen at a higher layer, but in spite of that we run
-	// validation at this level as well as a fallback so that if routes are posted which
-	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
-	// at least try to provide a helpful message about the situation in the manager logs.
 	if len(spec.Rules) == 0 {
 		return translators.ErrRouteValidationNoRules
 	}

--- a/internal/dataplane/parser/translate_tcproute_test.go
+++ b/internal/dataplane/parser/translate_tcproute_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -373,7 +372,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 					routeName := expectedRoute.Name
 					r, ok := kongRouteNameToRoute[*routeName]
 					require.Truef(t, ok, "should find route %s", *routeName)
-					require.Equalf(t, expectedRoute.Expression, r.Expression, fmt.Sprintf("expected >> %s, actual >> %s", *expectedRoute.Expression, *r.Expression))
+					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
 					require.Equal(t, expectedRoute.Protocols, r.Protocols)
 				}
 			}

--- a/internal/dataplane/parser/translate_tlsroute.go
+++ b/internal/dataplane/parser/translate_tlsroute.go
@@ -43,17 +43,14 @@ func (p *Parser) ingressRulesFromTLSRoutes() ingressRules {
 		applyExpressionToIngressRules(&result)
 	}
 
-	if len(errs) > 0 {
-		for _, err := range errs {
-			p.logger.Error(err, "could not generate route from TLSRoute")
-		}
+	for _, err := range errs {
+		p.logger.Error(err, "could not generate route from TLSRoute")
 	}
 
 	return result
 }
 
 func (p *Parser) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *gatewayapi.TLSRoute) error {
-	// first we grab the spec and gather some metdata about the object
 	spec := tlsroute.Spec
 
 	if len(spec.Hostnames) == 0 {
@@ -68,12 +65,13 @@ func (p *Parser) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *gatewa
 		return err
 	}
 
-	// each rule may represent a different set of backend services that will be accepting
+	// Each rule may represent a different set of backend services that will be accepting
 	// traffic, so we make separate routes and Kong services for every present rule.
 	for ruleNumber, rule := range spec.Rules {
-		// determine the routes needed to route traffic to services for this rule
-		routes, err := generateKongRoutesFromRouteRule(tlsroute, ruleNumber, rule)
-		// change protocols in route to tls_passthrough.
+		// Determine the routes needed to route traffic to services for this rule.
+		// TLSRoute matches based on hostname with Gateway listener thus passing gwPorts is pointless.
+		routes, err := generateKongRoutesFromRouteRule(tlsroute, nil, ruleNumber, rule)
+		// Change protocols in route to tls_passthrough.
 		if tlsPassthrough {
 			for i := range routes {
 				routes[i].Protocols = kong.StringSlice("tls_passthrough")

--- a/internal/dataplane/parser/translate_udproute.go
+++ b/internal/dataplane/parser/translate_udproute.go
@@ -54,11 +54,6 @@ func (p *Parser) ingressRulesFromUDPRoutes() ingressRules {
 
 func (p *Parser) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewayapi.UDPRoute) error {
 	spec := udproute.Spec
-
-	// Validation for TCPRoutes will happen at a higher layer, but in spite of that we run
-	// validation at this level as well as a fallback so that if routes are posted which
-	// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
-	// at least try to provide a helpful message about the situation in the manager logs.
 	if len(spec.Rules) == 0 {
 		return translators.ErrRouteValidationNoRules
 	}

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -942,7 +942,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					routeName := expectedRoute.Name
 					r, ok := kongRouteNameToRoute[*routeName]
 					require.Truef(t, ok, "should find route %s", *routeName)
-					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression >>> expected: %q >>> actual: %q", *routeName, *expectedRoute.Expression, *r.Expression)
+					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
 					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
 				}
 			}

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -25,18 +25,49 @@ var udpRouteTypeMeta = metav1.TypeMeta{Kind: "UDPRoute", APIVersion: gatewayv1al
 func TestIngressRulesFromUDPRoutes(t *testing.T) {
 	testCases := []struct {
 		name                 string
+		gateways             []*gatewayapi.Gateway
 		udpRoutes            []*gatewayapi.UDPRoute
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
 	}{
 		{
-			name: "single UDPRoute with single rule",
+			name: "single UDPRoute with single rule, single backendref and Gateway in the same namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("tcp80").WithPort(80).TCP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "single-rule",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name: "gateway-1",
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -76,18 +107,68 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "single UDPRoute with multiple rules",
+			name: "multiple UDPRoute with single rule, different SectionName and Gateway in the same namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp81").WithPort(81).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "multiple-rules", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rule-1",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp80")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
 									builder.NewBackendRef("service1").WithPort(80).Build(),
 								},
 							},
+						},
+					},
+				},
+				{
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rule-2",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp81")),
+								},
+							},
+						},
+						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
 									builder.NewBackendRef("service2").WithPort(81).Build(),
@@ -97,11 +178,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					},
 				},
 			},
-
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name:     kong.String("udproute.default.multiple-rules.0"),
+						Name:     kong.String("udproute.default.rule-1.0"),
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
@@ -113,7 +193,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 				},
 				{
 					Service: kong.Service{
-						Name:     kong.String("udproute.default.multiple-rules.1"),
+						Name:     kong.String("udproute.default.rule-2.0"),
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
@@ -125,10 +205,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"udproute.default.multiple-rules.0": {
+				"udproute.default.rule-1.0": {
 					{
 						Route: kong.Route{
-							Name: kong.String("udproute.default.multiple-rules.0.0"),
+							Name: kong.String("udproute.default.rule-1.0.0"),
 							Destinations: []*kong.CIDRPort{
 								{Port: kong.Int(80)},
 							},
@@ -136,10 +216,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						},
 					},
 				},
-				"udproute.default.multiple-rules.1": {
+				"udproute.default.rule-2.0": {
 					{
 						Route: kong.Route{
-							Name: kong.String("udproute.default.multiple-rules.1.0"),
+							Name: kong.String("udproute.default.rule-2.0.0"),
 							Destinations: []*kong.CIDRPort{
 								{Port: kong.Int(81)},
 							},
@@ -150,12 +230,43 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "single UDPRoute with single rule and multiple backendRefs",
+			name: "single UDPRoute with single rule and multiple backendRefs and Gateway in a different namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp81").WithPort(81).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "multiple-backends", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multiple-backends",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:      "gateway-1",
+									Namespace: lo.ToPtr(gatewayapi.Namespace("test-1")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -201,12 +312,40 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple udproutes with translation errors",
+			name: "multiple UDPRoutes with translation errors",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp8080").WithPort(8080).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
 					TypeMeta:   udpRouteTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp80")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -220,6 +359,14 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					TypeMeta:   udpRouteTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: "single-rule-2", Namespace: "default"},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp8080")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -301,6 +448,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				Gateways:  tc.gateways,
 				UDPRoutes: tc.udpRoutes,
 			})
 			require.NoError(t, err)
@@ -352,18 +500,48 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 	testCases := []struct {
 		name                 string
+		gateways             []*gatewayapi.Gateway
 		udpRoutes            []*gatewayapi.UDPRoute
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
 	}{
 		{
-			name: "single UDPRoute with single rule",
+			name: "UDPRoute with single rule, single backendref and Gateway in the same namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "single-rule",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name: "gateway-1",
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -401,21 +579,73 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "single UDPRoute with multiple rules",
+			name: "UDPRoute with single rule, multiple backendrefs and Gateway in a different namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp81").WithPort(81).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "multiple-rules", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rule-1",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									Namespace:   lo.ToPtr(gatewayapi.Namespace("test-1")),
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp80")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
-									builder.NewBackendRef("service1").WithPort(80).Build(),
+									builder.NewBackendRef("service1").WithPort(8080).Build(),
 								},
 							},
+						},
+					},
+				},
+				{
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rule-2",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									Namespace:   lo.ToPtr(gatewayapi.Namespace("test-1")),
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp81")),
+								},
+							},
+						},
+						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
-									builder.NewBackendRef("service2").WithPort(81).Build(),
+									builder.NewBackendRef("service2").WithPort(8181).Build(),
 								},
 							},
 						},
@@ -425,43 +655,43 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name:     kong.String("udproute.default.multiple-rules.0"),
+						Name:     kong.String("udproute.default.rule-1.0"),
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						{
 							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
 						},
 					},
 				},
 				{
 					Service: kong.Service{
-						Name:     kong.String("udproute.default.multiple-rules.1"),
+						Name:     kong.String("udproute.default.rule-2.0"),
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						{
 							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
+							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8181)},
 						},
 					},
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"udproute.default.multiple-rules.0": {
+				"udproute.default.rule-1.0": {
 					{
 						Route: kong.Route{
-							Name:       kong.String("udproute.default.multiple-rules.0.0"),
+							Name:       kong.String("udproute.default.rule-1.0.0"),
 							Expression: kong.String("net.dst.port == 80"),
 							Protocols:  kong.StringSlice("udp"),
 						},
 					},
 				},
-				"udproute.default.multiple-rules.1": {
+				"udproute.default.rule-2.0": {
 					{
 						Route: kong.Route{
-							Name:       kong.String("udproute.default.multiple-rules.1.0"),
+							Name:       kong.String("udproute.default.rule-2.0.0"),
 							Expression: kong.String("net.dst.port == 81"),
 							Protocols:  kong.StringSlice("udp"),
 						},
@@ -471,11 +701,41 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 		},
 		{
 			name: "single UDPRoute with single rule and multiple backendRefs",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp81").WithPort(81).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
-					TypeMeta:   udpRouteTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{Name: "multiple-backends", Namespace: "default"},
+					TypeMeta: udpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multiple-backends",
+						Namespace: "default",
+					},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name: "gateway-1",
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -518,12 +778,40 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple udproutes with translation errors",
+			name: "multiple UDPRoutes with translation errors",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+							builder.NewListener("udp8080").WithPort(8080).UDP().Build(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "test-1",
+					},
+				},
+			},
 			udpRoutes: []*gatewayapi.UDPRoute{
 				{
 					TypeMeta:   udpRouteTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp80")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -537,6 +825,14 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					TypeMeta:   udpRouteTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: "single-rule-2", Namespace: "default"},
 					Spec: gatewayapi.UDPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: lo.ToPtr(gatewayapi.SectionName("udp8080")),
+								},
+							},
+						},
 						Rules: []gatewayapi.UDPRouteRule{
 							{
 								BackendRefs: []gatewayapi.BackendRef{
@@ -614,6 +910,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				Gateways:  tc.gateways,
 				UDPRoutes: tc.udpRoutes,
 			})
 			require.NoError(t, err)
@@ -645,7 +942,8 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					routeName := expectedRoute.Name
 					r, ok := kongRouteNameToRoute[*routeName]
 					require.Truef(t, ok, "should find route %s", *routeName)
-					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
+					// require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
+					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression >>> expected: %q >>> actual: %q", *routeName, *expectedRoute.Expression, *r.Expression)
 					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
 				}
 			}

--- a/internal/dataplane/parser/translate_udproute_test.go
+++ b/internal/dataplane/parser/translate_udproute_test.go
@@ -942,7 +942,6 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					routeName := expectedRoute.Name
 					r, ok := kongRouteNameToRoute[*routeName]
 					require.Truef(t, ok, "should find route %s", *routeName)
-					// require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
 					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression >>> expected: %q >>> actual: %q", *routeName, *expectedRoute.Expression, *r.Expression)
 					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
 				}

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -111,7 +111,9 @@ func TestTCPRouteEssentials(t *testing.T) {
 	cleaner.Add(service1)
 
 	t.Logf("exposing deployment %s/%s via service", deployment2.Namespace, deployment2.Name)
-	const service2Port = 8080 // Use a different port that listening on the Gateway for TCP.
+	// Configure service to expose a different port than Gateway's TCP listener port (ktfkong.DefaultTCPServicePort)
+	// to check whether traffic will be routed correctly.
+	const service2Port = 8080
 	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
 	service2.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tcp",

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +27,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v2/test"
 	"github.com/kong/kubernetes-ingress-controller/v2/test/internal/helpers"
 )
+
+const gatewayTCPPortName = "tcp"
 
 func TestTCPRouteEssentials(t *testing.T) {
 	ctx := context.Background()
@@ -49,12 +52,12 @@ func TestTCPRouteEssentials(t *testing.T) {
 	require.NoError(t, err)
 	cleaner.Add(gwc)
 
-	t.Log("deploying a gateway to the test cluster using unmanaged gateway mode and port 8888")
+	t.Logf("deploying a gateway to the test cluster using unmanaged gateway mode and port %d", ktfkong.DefaultTCPServicePort)
 	gatewayName := uuid.NewString()
 	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
 		gw.Name = gatewayName
 		gw.Spec.Listeners = []gatewayapi.Listener{{
-			Name:     "tcp",
+			Name:     gatewayTCPPortName,
 			Protocol: gatewayapi.TCPProtocolType,
 			Port:     gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
@@ -94,15 +97,13 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 	t.Logf("exposing deployment %s/%s via service", deployment1.Namespace, deployment1.Name)
 	service1 := generators.NewServiceForDeployment(deployment1, corev1.ServiceTypeLoadBalancer)
-	// we have to override the ports so that we can map the default TCP port from
-	// the Kong Gateway deployment to the tcpecho port, as this is what will be
-	// used to route the traffic at the Gateway (at the time of writing, the
-	// Kong Gateway doesn't support an API for dynamically adding these ports. The
-	// ports must be added manually to the config or ENV).
+	// Use the same port as the default TCP port from the Kong Gateway deployment
+	// to the tcpecho port, as this is what will be used to route the traffic at the Gateway.
+	const service1Port = ktfkong.DefaultTCPServicePort
 	service1.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
-		Port:       ktfkong.DefaultTCPServicePort,
+		Port:       service1Port,
 		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service1, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service1, metav1.CreateOptions{})
@@ -110,24 +111,19 @@ func TestTCPRouteEssentials(t *testing.T) {
 	cleaner.Add(service1)
 
 	t.Logf("exposing deployment %s/%s via service", deployment2.Namespace, deployment2.Name)
+	const service2Port = 8080 // Use a different port that listening on the Gateway for TCP.
 	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
-	// we have to override the ports so that we can map the default TCP port from
-	// the Kong Gateway deployment to the tcpecho port, as this is what will be
-	// used to route the traffic at the Gateway (at the time of writing, the
-	// Kong Gateway doesn't support an API for dynamically adding these ports. The
-	// ports must be added manually to the config or ENV).
 	service2.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
-		Port:       ktfkong.DefaultTCPServicePort,
+		Port:       service2Port,
 		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service2, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service2, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	cleaner.Add(service2)
 
-	t.Logf("creating a tcproute to access deployment %s via kong", deployment1.Name)
-	tcpPortDefault := gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort)
+	t.Logf("creating a TCPRoute to access deployment %s via kong", deployment1.Name)
 	tcpRoute := &gatewayapi.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
@@ -135,14 +131,15 @@ func TestTCPRouteEssentials(t *testing.T) {
 		Spec: gatewayapi.TCPRouteSpec{
 			CommonRouteSpec: gatewayapi.CommonRouteSpec{
 				ParentRefs: []gatewayapi.ParentReference{{
-					Name: gatewayapi.ObjectName(gatewayName),
+					Name:        gatewayapi.ObjectName(gatewayName),
+					SectionName: lo.ToPtr(gatewayapi.SectionName(gatewayTCPPortName)),
 				}},
 			},
 			Rules: []gatewayapi.TCPRouteRule{{
 				BackendRefs: []gatewayapi.BackendRef{{
 					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Name: gatewayapi.ObjectName(service1.Name),
-						Port: &tcpPortDefault,
+						Port: lo.ToPtr(gatewayapi.PortNumber(service1Port)),
 					},
 				}},
 			}},
@@ -254,7 +251,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
 		gw.Name = gatewayName
 		gw.Spec.Listeners = []gatewayapi.Listener{{
-			Name:     "tcp",
+			Name:     gatewayTCPPortName,
 			Protocol: gatewayapi.TCPProtocolType,
 			Port:     gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
@@ -292,7 +289,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	gateway, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
 		gw.Name = gatewayName
 		gw.Spec.Listeners = []gatewayapi.Listener{{
-			Name:     "tcp",
+			Name:     gatewayTCPPortName,
 			Protocol: gatewayapi.TCPProtocolType,
 			Port:     gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
@@ -317,13 +314,13 @@ func TestTCPRouteEssentials(t *testing.T) {
 			{
 				BackendObjectReference: gatewayapi.BackendObjectReference{
 					Name: gatewayapi.ObjectName(service1.Name),
-					Port: &tcpPortDefault,
+					Port: lo.ToPtr(gatewayapi.PortNumber(service1Port)),
 				},
 			},
 			{
 				BackendObjectReference: gatewayapi.BackendObjectReference{
 					Name: gatewayapi.ObjectName(service2.Name),
-					Port: &tcpPortDefault,
+					Port: lo.ToPtr(gatewayapi.PortNumber(service2Port)),
 				},
 			},
 		}
@@ -365,7 +362,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 	_, err = DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
 		gw.Name = gatewayName
 		gw.Spec.Listeners = []gatewayapi.Listener{{
-			Name:     "tcp",
+			Name:     gatewayTCPPortName,
 			Protocol: gatewayapi.TCPProtocolType,
 			Port:     gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
@@ -428,7 +425,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	gateway, err := DeployGateway(ctx, gatewayClient, ns.Name, gatewayClassName, func(gw *gatewayapi.Gateway) {
 		gw.Name = gatewayName
 		gw.Spec.Listeners = []gatewayapi.Listener{{
-			Name:     "tcp",
+			Name:     gatewayTCPPortName,
 			Protocol: gatewayapi.TCPProtocolType,
 			Port:     gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort),
 		}}
@@ -468,15 +465,13 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Logf("exposing deployment %s/%s via service", deployment1.Namespace, deployment1.Name)
 	service1 := generators.NewServiceForDeployment(deployment1, corev1.ServiceTypeLoadBalancer)
-	// we have to override the ports so that we can map the default TCP port from
-	// the Kong Gateway deployment to the tcpecho port, as this is what will be
-	// used to route the traffic at the Gateway (at the time of writing, the
-	// Kong Gateway doesn't support an API for dynamically adding these ports. The
-	// ports must be added manually to the config or ENV).
+	// Use the same port as the default TCP port from the Kong Gateway deployment
+	// to the tcpecho port, as this is what will be used to route the traffic at the Gateway.
+	const service1Port = ktfkong.DefaultTCPServicePort
 	service1.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
-		Port:       ktfkong.DefaultTCPServicePort,
+		Port:       service1Port,
 		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service1, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service1, metav1.CreateOptions{})
@@ -484,11 +479,12 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(service1)
 
 	t.Logf("exposing deployment %s/%s via service", deployment2.Namespace, deployment2.Name)
+	const service2Port = 8080 // Use a different port that listening on the Gateway for TCP.
 	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
 	service2.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tcp",
 		Protocol:   corev1.ProtocolTCP,
-		Port:       ktfkong.DefaultTCPServicePort,
+		Port:       service2Port,
 		TargetPort: intstr.FromInt(test.EchoTCPPort),
 	}}
 	service2, err = env.Cluster().Client().CoreV1().Services(otherNs.Name).Create(ctx, service2, metav1.CreateOptions{})
@@ -496,7 +492,6 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	cleaner.Add(service2)
 
 	t.Logf("creating a tcproute to access deployment %s via kong", deployment1.Name)
-	tcpPortDefault := gatewayapi.PortNumber(ktfkong.DefaultTCPServicePort)
 	remoteNamespace := gatewayapi.Namespace(otherNs.Name)
 	tcproute := &gatewayapi.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -505,7 +500,8 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 		Spec: gatewayapi.TCPRouteSpec{
 			CommonRouteSpec: gatewayapi.CommonRouteSpec{
 				ParentRefs: []gatewayapi.ParentReference{{
-					Name: gatewayapi.ObjectName(gatewayName),
+					Name:        gatewayapi.ObjectName(gatewayName),
+					SectionName: lo.ToPtr(gatewayapi.SectionName(gatewayTCPPortName)),
 				}},
 			},
 			Rules: []gatewayapi.TCPRouteRule{{
@@ -513,14 +509,14 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 					{
 						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Name: gatewayapi.ObjectName(service1.Name),
-							Port: &tcpPortDefault,
+							Port: lo.ToPtr(gatewayapi.PortNumber(service1Port)),
 						},
 					},
 					{
 						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Name:      gatewayapi.ObjectName(service2.Name),
 							Namespace: &remoteNamespace,
-							Port:      &tcpPortDefault,
+							Port:      lo.ToPtr(gatewayapi.PortNumber(service2Port)),
 						},
 					},
 				},

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -206,7 +206,9 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("exposing deployment %s/%s via service", deployment2.Namespace, deployment2.Name)
-	const service2Port = 8443 // Use a different port that listening on the Gateway for TLS.
+	// Configure service to expose a different port than Gateway's TLS listener port (ktfkong.DefaultTLSServicePort)
+	// to check whether traffic will be routed correctly.
+	const service2Port = 8443
 	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
 	service2.Spec.Ports = []corev1.ServicePort{{
 		Name:       "tls",

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/gatewayapi"
@@ -204,7 +206,14 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("exposing deployment %s/%s via service", deployment2.Namespace, deployment2.Name)
+	const service2Port = 8443 // Use a different port that listening on the Gateway for TLS.
 	service2 := generators.NewServiceForDeployment(deployment2, corev1.ServiceTypeLoadBalancer)
+	service2.Spec.Ports = []corev1.ServicePort{{
+		Name:       "tls",
+		Protocol:   corev1.ProtocolTCP,
+		Port:       service2Port,
+		TargetPort: intstr.FromInt(tlsEchoPort),
+	}}
 	service2, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(service2)
@@ -233,7 +242,7 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 					{
 						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Name: gatewayapi.ObjectName(service2.Name),
-							Port: &backendTLSPort,
+							Port: lo.ToPtr(gatewayapi.PortNumber(service2Port)),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
As described in https://github.com/Kong/kubernetes-ingress-controller/issues/4864 `TCPRoute` sets the incorrect destinations port on the Routes it creates (sets the desired backend service port instead of the listener port). The same happens for `UDPRoute`. It ignores the port set by specifying `SectionName`, it always requires the same port for the backend service as for the listener.

This PR fixes it for both cases. When `SectionName` is specified take config from it. Otherwise, it works now as described (a little bit vague) in spec 
> When unspecified (empty string), this will reference the entire resource. ([src](https://github.com/kubernetes-sigs/gateway-api/blob/ebe9f31ef27819c3b29f698a3e9b91d279453c59/apis/v1/shared_types.go#L107))

so every listener that matches the protocol (UDP or TCP) is used. 

<ins>It breaks current behavior that automatically matches ports by number from target services to listening ports on Gateway with the same numbers.</ins>

It is interesting that no conformance test from `gateway-api` catches that problem - a test for this should exist in `gateway-api` project.

There is also another field for this purpose [PortNumber](https://github.com/kubernetes-sigs/gateway-api/blob/ebe9f31ef27819c3b29f698a3e9b91d279453c59/apis/v1/shared_types.go#L121-L154) it is part of experimental and extended `gateway-api`, currently KIC doesn't care about it at all. A separate issue has been created to provide support for it and will be prioritized accordingly see

- https://github.com/Kong/kubernetes-ingress-controller/issues/4958



**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/4864

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The first commit 1100749e4f6f12cd1845714317a429e36d76ec77 introduces adjustments for `TCPRoute` and `TLSRoute` integration tests to check such a scenario. Test for `TCPRoute` does not pass, for `TLSRoute` bug doesn't exist because matching is done with hostname. 

The second commit b385f15f9102301d066428b1740a3f37472ad607 introduces actual fix and unit test cases, also for `UDPRoute`. Integration test for `UDPRoute` requires refactoring (to make it similar to TCP one) which is not in the scope of this PR due to a major rework of it in PR https://github.com/Kong/kubernetes-ingress-controller/pull/4823. After it should be adjusted to test changes introduced in this PR too.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
