### PR TITLE
chore(ci): commit only generated files

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
-          git add . 
+          git add ./deploy/single
           git diff-index --quiet HEAD || \
           git commit -m "chore: regenerate manifests" && \
           git push origin ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
**What this PR does / why we need it**:

`git adds` only the generated manifests directory to prevent unwanted files from being committed.
