### PR TITLE
chore: exclude admin API comms from mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,10 +154,14 @@ Adding a new version? You'll need three changes:
   [#4911](https://github.com/Kong/kubernetes-ingress-controller/pull/4911)
 - Bump version of gateway API to `1.0.0-rc1` and support `Gateway`, `GatewayClass`
   and `HTTPRoute` in API version `gateway.networking.k8s.io/v1`.
-[#4893](https://github.com/Kong/kubernetes-ingress-controller/pull/4893)
+  [#4893](https://github.com/Kong/kubernetes-ingress-controller/pull/4893)
 - Update `Gateway`s, `GatewayClass`es and `HTTPRoute`s in examples to API
   version `gateway.networking.k8s.io/v1`.
-[#4935](https://github.com/Kong/kubernetes-ingress-controller/pull/4935)
+  [#4935](https://github.com/Kong/kubernetes-ingress-controller/pull/4935)
+- Controller to admin API communications are exempted from mesh proxies when
+  the controller resides in a separate Deployment. This allows the controller
+  to manage its own mTLS negotiation.
+  [#4942](https://github.com/Kong/kubernetes-ingress-controller/pull/4942)
 
 
 ### Added

--- a/config/variants/multi-gw/oss/kustomization.yaml
+++ b/config/variants/multi-gw/oss/kustomization.yaml
@@ -6,3 +6,17 @@ resources:
 
 components:
   - ../../../image/oss
+
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: ingress-kong
+  patch: |-
+    - op: add
+      path: /spec/template/metadata/annotations/traffic.kuma.io~1exclude-outbound-ports
+      value: "8444"
+    - op: add
+      path: /spec/template/metadata/annotations/traffic.sidecar.istio.io~1excludeOutboundPorts
+      value: "8444"

--- a/deploy/single/all-in-one-dbless-konnect.yaml
+++ b/deploy/single/all-in-one-dbless-konnect.yaml
@@ -2059,6 +2059,8 @@ spec:
       annotations:
         kuma.io/gateway: enabled
         kuma.io/service-account-token-volume: kong-serviceaccount-token
+        traffic.kuma.io/exclude-outbound-ports: "8444"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong

--- a/deploy/single/all-in-one-dbless.yaml
+++ b/deploy/single/all-in-one-dbless.yaml
@@ -2059,6 +2059,8 @@ spec:
       annotations:
         kuma.io/gateway: enabled
         kuma.io/service-account-token-volume: kong-serviceaccount-token
+        traffic.kuma.io/exclude-outbound-ports: "8444"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong


### PR DESCRIPTION
**What this PR does / why we need it**:

Excludes controller->admin API comms from meshes.

**Which issue this PR fixes**:

Part of #4698 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
