### PR TITLE
feat: add KongUpstreamPolicySpec translation

### DIFF
--- a/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
@@ -74,6 +74,10 @@ spec:
                   cookie:
                     description: Cookie is the name of the cookie to use as hash input.
                     type: string
+                  cookiePath:
+                    description: CookiePath is cookie path to set in the response
+                      headers.
+                    type: string
                   header:
                     description: Header is the name of the header to use as hash input.
                     type: string
@@ -93,6 +97,10 @@ spec:
                 properties:
                   cookie:
                     description: Cookie is the name of the cookie to use as hash input.
+                    type: string
+                  cookiePath:
+                    description: CookiePath is cookie path to set in the response
+                      headers.
                     type: string
                   header:
                     description: Header is the name of the header to use as hash input.
@@ -285,7 +293,7 @@ spec:
                       to be considered healthy.
                     type: integer
                 type: object
-              host_header:
+              hostHeader:
                 description: HostHeader is the hostname to be used as Host header
                   when proxying requests through Kong.
                 type: string

--- a/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
@@ -91,7 +91,7 @@ spec:
                     type: string
                 type: object
               hashOnFallback:
-                description: HasOnFallback defines how to calculate hash for consistent-hashing
+                description: HashOnFallback defines how to calculate hash for consistent-hashing
                   load balancing algorithm if the primary hash function fails. Algorithm
                   must be set to "consistent-hashing" for this field to have effect.
                 properties:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -486,6 +486,7 @@ KongUpstreamHash defines how to calculate hash for consistent-hashing load balan
 | --- | --- |
 | `header` _string_ | Header is the name of the header to use as hash input. |
 | `cookie` _string_ | Cookie is the name of the cookie to use as hash input. |
+| `cookiePath` _string_ | CookiePath is cookie path to set in the response headers. |
 | `queryArg` _string_ | QueryArg is the name of the query argument to use as hash input. |
 | `uriCapture` _string_ | URICapture is the name of the URI capture group to use as hash input. |
 
@@ -584,7 +585,7 @@ KongUpstreamPolicySpec contains the specification for KongUpstreamPolicy.
 | `hashOn` _[KongUpstreamHash](#kongupstreamhash)_ | HashOn defines how to calculate hash for consistent-hashing load balancing algorithm. Algorithm must be set to "consistent-hashing" for this field to have effect. |
 | `hashOnFallback` _[KongUpstreamHash](#kongupstreamhash)_ | HasOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash function fails. Algorithm must be set to "consistent-hashing" for this field to have effect. |
 | `healthchecks` _[KongUpstreamHealthcheck](#kongupstreamhealthcheck)_ | Healthchecks defines the health check configurations in Kong. |
-| `host_header` _string_ | HostHeader is the hostname to be used as Host header when proxying requests through Kong. |
+| `hostHeader` _string_ | HostHeader is the hostname to be used as Host header when proxying requests through Kong. |
 
 
 _Appears in:_

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -583,7 +583,7 @@ KongUpstreamPolicySpec contains the specification for KongUpstreamPolicy.
 | `algorithm` _string_ | Algorithm is the load balancing algorithm to use. Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency". |
 | `slots` _integer_ | Slots is the number of slots in the load balancer algorithm. If not set, the default value in Kong for the algorithm is used. |
 | `hashOn` _[KongUpstreamHash](#kongupstreamhash)_ | HashOn defines how to calculate hash for consistent-hashing load balancing algorithm. Algorithm must be set to "consistent-hashing" for this field to have effect. |
-| `hashOnFallback` _[KongUpstreamHash](#kongupstreamhash)_ | HasOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash function fails. Algorithm must be set to "consistent-hashing" for this field to have effect. |
+| `hashOnFallback` _[KongUpstreamHash](#kongupstreamhash)_ | HashOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash function fails. Algorithm must be set to "consistent-hashing" for this field to have effect. |
 | `healthchecks` _[KongUpstreamHealthcheck](#kongupstreamhealthcheck)_ | Healthchecks defines the health check configurations in Kong. |
 | `hostHeader` _string_ | HostHeader is the hostname to be used as Host header when proxying requests through Kong. |
 

--- a/internal/dataplane/parser/translators/kongupstreampolicy.go
+++ b/internal/dataplane/parser/translators/kongupstreampolicy.go
@@ -1,0 +1,147 @@
+package translators
+
+import (
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+)
+
+// TranslateKongUpstreamPolicy translates KongUpstreamPolicySpec to kong.Upstream. It makes assumption that
+// KongUpstreamPolicySpec has been validated on the API level.
+func TranslateKongUpstreamPolicy(policy kongv1beta1.KongUpstreamPolicySpec) *kong.Upstream {
+	return &kong.Upstream{
+		Algorithm:    policy.Algorithm,
+		Slots:        policy.Slots,
+		Healthchecks: translateHealthchecks(policy.Healthchecks),
+		HostHeader:   policy.HostHeader,
+
+		HashOn:           translateHashOn(policy.HashOn),
+		HashOnHeader:     translateHashOnHeader(policy.HashOn),
+		HashOnURICapture: translateHashOnURICapture(policy.HashOn),
+		HashOnCookie:     translateHashOnCookie(policy.HashOn),
+		HashOnCookiePath: translateHashOnCookiePath(policy.HashOn),
+		HashOnQueryArg:   translateHashOnQueryArg(policy.HashOn),
+
+		HashFallback:           translateHashOn(policy.HashOnFallback),
+		HashFallbackHeader:     translateHashOnHeader(policy.HashOnFallback),
+		HashFallbackURICapture: translateHashOnURICapture(policy.HashOnFallback),
+		HashFallbackQueryArg:   translateHashOnQueryArg(policy.HashOnFallback),
+	}
+}
+
+func translateHashOn(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
+		return nil
+	}
+	// Only one of hashOn fields can be set.
+	switch {
+	case hashOn.Header != nil:
+		return lo.ToPtr("header")
+	case hashOn.Cookie != nil:
+		return lo.ToPtr("cookie")
+	case hashOn.QueryArg != nil:
+		return lo.ToPtr("query_arg")
+	case hashOn.URICapture != nil:
+		return lo.ToPtr("uri_capture")
+	default:
+		return nil
+	}
+}
+
+func translateHashOnHeader(hasOn *kongv1beta1.KongUpstreamHash) *string {
+	if hasOn == nil {
+		return nil
+	}
+	return hasOn.Header
+}
+
+func translateHashOnCookie(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
+		return nil
+	}
+	return hashOn.Cookie
+}
+
+func translateHashOnQueryArg(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
+		return nil
+	}
+	return hashOn.QueryArg
+}
+
+func translateHashOnURICapture(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
+		return nil
+	}
+	return hashOn.URICapture
+}
+
+func translateHashOnCookiePath(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
+		return nil
+	}
+	return hashOn.CookiePath
+}
+
+func translateHealthchecks(healthchecks *kongv1beta1.KongUpstreamHealthcheck) *kong.Healthcheck {
+	if healthchecks == nil {
+		return nil
+	}
+	return &kong.Healthcheck{
+		Active:  translateActiveHealthcheck(healthchecks.Active),
+		Passive: translatePassiveHealthcheck(healthchecks.Passive),
+	}
+}
+
+func translateActiveHealthcheck(healthcheck *kongv1beta1.KongUpstreamActiveHealthcheck) *kong.ActiveHealthcheck {
+	if healthcheck == nil {
+		return nil
+	}
+	return &kong.ActiveHealthcheck{
+		Concurrency:            healthcheck.Concurrency,
+		HTTPPath:               healthcheck.HTTPPath,
+		HTTPSSni:               healthcheck.HTTPSSNI,
+		HTTPSVerifyCertificate: healthcheck.HTTPSVerifyCertificate,
+		Type:                   healthcheck.Type,
+		Timeout:                healthcheck.Timeout,
+		Headers:                healthcheck.Headers,
+		Healthy:                translateHealthy(healthcheck.Healthy),
+		Unhealthy:              translateUnhealthy(healthcheck.Unhealthy),
+	}
+}
+
+func translatePassiveHealthcheck(healthcheck *kongv1beta1.KongUpstreamPassiveHealthcheck) *kong.PassiveHealthcheck {
+	if healthcheck == nil {
+		return nil
+	}
+	return &kong.PassiveHealthcheck{
+		Type:      healthcheck.Type,
+		Healthy:   translateHealthy(healthcheck.Healthy),
+		Unhealthy: translateUnhealthy(healthcheck.Unhealthy),
+	}
+}
+
+func translateHealthy(healthy *kongv1beta1.KongUpstreamHealthcheckHealthy) *kong.Healthy {
+	if healthy == nil {
+		return nil
+	}
+	return &kong.Healthy{
+		HTTPStatuses: healthy.HTTPStatuses,
+		Interval:     healthy.Interval,
+		Successes:    healthy.Successes,
+	}
+}
+
+func translateUnhealthy(unhealthy *kongv1beta1.KongUpstreamHealthcheckUnhealthy) *kong.Unhealthy {
+	if unhealthy == nil {
+		return nil
+	}
+	return &kong.Unhealthy{
+		HTTPFailures: unhealthy.HTTPFailures,
+		HTTPStatuses: unhealthy.HTTPStatuses,
+		TCPFailures:  unhealthy.TCPFailures,
+		Timeouts:     unhealthy.Timeouts,
+		Interval:     unhealthy.Interval,
+	}
+}

--- a/internal/dataplane/parser/translators/kongupstreampolicy.go
+++ b/internal/dataplane/parser/translators/kongupstreampolicy.go
@@ -34,7 +34,8 @@ func translateHashOn(hashOn *kongv1beta1.KongUpstreamHash) *string {
 	if hashOn == nil {
 		return nil
 	}
-	// Only one of hashOn fields can be set.
+	// CRD validations will ensure only one of hashOn fields can be set, therefore the order doesn't matter.
+	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/4951
 	switch {
 	case hashOn.Header != nil:
 		return lo.ToPtr("header")
@@ -49,11 +50,11 @@ func translateHashOn(hashOn *kongv1beta1.KongUpstreamHash) *string {
 	}
 }
 
-func translateHashOnHeader(hasOn *kongv1beta1.KongUpstreamHash) *string {
-	if hasOn == nil {
+func translateHashOnHeader(hashOn *kongv1beta1.KongUpstreamHash) *string {
+	if hashOn == nil {
 		return nil
 	}
-	return hasOn.Header
+	return hashOn.Header
 }
 
 func translateHashOnCookie(hashOn *kongv1beta1.KongUpstreamHash) *string {

--- a/internal/dataplane/parser/translators/kongupstreampolicy_test.go
+++ b/internal/dataplane/parser/translators/kongupstreampolicy_test.go
@@ -1,0 +1,171 @@
+package translators_test
+
+import (
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/parser/translators"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
+)
+
+func TestTranslateKongUpstreamPolicy(t *testing.T) {
+	testCases := []struct {
+		name             string
+		policySpec       kongv1beta1.KongUpstreamPolicySpec
+		expectedUpstream *kong.Upstream
+	}{
+		{
+			name: "KongUpstreamPolicySpec with no hash-on or hash-fallback",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				HostHeader: lo.ToPtr("foo"),
+				Algorithm:  lo.ToPtr("least-connections"),
+				Slots:      lo.ToPtr(10),
+			},
+			expectedUpstream: &kong.Upstream{
+				HostHeader: lo.ToPtr("foo"),
+				Algorithm:  lo.ToPtr("least-connections"),
+				Slots:      lo.ToPtr(10),
+			},
+		},
+		{
+			name: "KongUpstreamPolicySpec with hash-on header",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				HashOn: &kongv1beta1.KongUpstreamHash{
+					Header: lo.ToPtr("foo"),
+				},
+				HashOnFallback: &kongv1beta1.KongUpstreamHash{
+					Header: lo.ToPtr("bar"),
+				},
+			},
+			expectedUpstream: &kong.Upstream{
+				HashOn:             lo.ToPtr("header"),
+				HashOnHeader:       lo.ToPtr("foo"),
+				HashFallback:       lo.ToPtr("header"),
+				HashFallbackHeader: lo.ToPtr("bar"),
+			},
+		},
+		{
+			name: "KongUpstreamPolicySpec with hash-on cookie",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				HashOn: &kongv1beta1.KongUpstreamHash{
+					Cookie:     lo.ToPtr("foo"),
+					CookiePath: lo.ToPtr("/"),
+				},
+			},
+			expectedUpstream: &kong.Upstream{
+				HashOn:           lo.ToPtr("cookie"),
+				HashOnCookie:     lo.ToPtr("foo"),
+				HashOnCookiePath: lo.ToPtr("/"),
+			},
+		},
+		{
+			name: "KongUpstreamPolicySpec with hash-on query-arg",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				HashOn: &kongv1beta1.KongUpstreamHash{
+					QueryArg: lo.ToPtr("foo"),
+				},
+			},
+			expectedUpstream: &kong.Upstream{
+				HashOn:         lo.ToPtr("query_arg"),
+				HashOnQueryArg: lo.ToPtr("foo"),
+			},
+		},
+		{
+			name: "KongUpstreamPolicySpec with hash-on uri-capture",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				HashOn: &kongv1beta1.KongUpstreamHash{
+					URICapture: lo.ToPtr("foo"),
+				},
+			},
+			expectedUpstream: &kong.Upstream{
+				HashOn:           lo.ToPtr("uri_capture"),
+				HashOnURICapture: lo.ToPtr("foo"),
+			},
+		},
+		{
+			name: "KongUpstreamPolicySpec with healthchecks",
+			policySpec: kongv1beta1.KongUpstreamPolicySpec{
+				Healthchecks: &kongv1beta1.KongUpstreamHealthcheck{
+					Active: &kongv1beta1.KongUpstreamActiveHealthcheck{
+						Type:        lo.ToPtr("http"),
+						Concurrency: lo.ToPtr(10),
+						Healthy: &kongv1beta1.KongUpstreamHealthcheckHealthy{
+							HTTPStatuses: []int{200},
+							Interval:     lo.ToPtr(20),
+							Successes:    lo.ToPtr(30),
+						},
+						Unhealthy: &kongv1beta1.KongUpstreamHealthcheckUnhealthy{
+							HTTPFailures: lo.ToPtr(40),
+							HTTPStatuses: []int{500},
+							Timeouts:     lo.ToPtr(60),
+							Interval:     lo.ToPtr(70),
+						},
+						HTTPPath:               lo.ToPtr("/foo"),
+						HTTPSSNI:               lo.ToPtr("foo.com"),
+						HTTPSVerifyCertificate: lo.ToPtr(true),
+						Timeout:                lo.ToPtr(80),
+						Headers:                map[string][]string{"foo": {"bar"}},
+					},
+					Passive: &kongv1beta1.KongUpstreamPassiveHealthcheck{
+						Type: lo.ToPtr("tcp"),
+						Healthy: &kongv1beta1.KongUpstreamHealthcheckHealthy{
+							Interval:  lo.ToPtr(90),
+							Successes: lo.ToPtr(100),
+						},
+						Unhealthy: &kongv1beta1.KongUpstreamHealthcheckUnhealthy{
+							TCPFailures: lo.ToPtr(110),
+							Timeouts:    lo.ToPtr(120),
+							Interval:    lo.ToPtr(130),
+						},
+					},
+					Threshold: lo.ToPtr(140),
+				},
+			},
+			expectedUpstream: &kong.Upstream{
+				Healthchecks: &kong.Healthcheck{
+					Active: &kong.ActiveHealthcheck{
+						Type:        lo.ToPtr("http"),
+						Concurrency: lo.ToPtr(10),
+						Healthy: &kong.Healthy{
+							HTTPStatuses: []int{200},
+							Interval:     lo.ToPtr(20),
+							Successes:    lo.ToPtr(30),
+						},
+						Unhealthy: &kong.Unhealthy{
+							HTTPFailures: lo.ToPtr(40),
+							HTTPStatuses: []int{500},
+							Timeouts:     lo.ToPtr(60),
+							Interval:     lo.ToPtr(70),
+						},
+						HTTPPath:               lo.ToPtr("/foo"),
+						HTTPSSni:               lo.ToPtr("foo.com"),
+						HTTPSVerifyCertificate: lo.ToPtr(true),
+						Headers:                map[string][]string{"foo": {"bar"}},
+						Timeout:                lo.ToPtr(80),
+					},
+					Passive: &kong.PassiveHealthcheck{
+						Type: lo.ToPtr("tcp"),
+						Healthy: &kong.Healthy{
+							Interval:  lo.ToPtr(90),
+							Successes: lo.ToPtr(100),
+						},
+						Unhealthy: &kong.Unhealthy{
+							TCPFailures: lo.ToPtr(110),
+							Timeouts:    lo.ToPtr(120),
+							Interval:    lo.ToPtr(130),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualUpstream := translators.TranslateKongUpstreamPolicy(tc.policySpec)
+			require.Equal(t, tc.expectedUpstream, actualUpstream)
+		})
+	}
+}

--- a/pkg/apis/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/pkg/apis/configuration/v1beta1/kongupstreampolicy_types.go
@@ -79,7 +79,7 @@ type KongUpstreamPolicySpec struct {
 	Healthchecks *KongUpstreamHealthcheck `json:"healthchecks,omitempty"`
 
 	// HostHeader is the hostname to be used as Host header when proxying requests through Kong.
-	HostHeader *string `json:"host_header,omitempty"`
+	HostHeader *string `json:"hostHeader,omitempty"`
 }
 
 // KongUpstreamHash defines how to calculate hash for consistent-hashing load balancing algorithm.
@@ -90,6 +90,9 @@ type KongUpstreamHash struct {
 
 	// Cookie is the name of the cookie to use as hash input.
 	Cookie *string `json:"cookie,omitempty"`
+
+	// CookiePath is cookie path to set in the response headers.
+	CookiePath *string `json:"cookiePath,omitempty"`
 
 	// QueryArg is the name of the query argument to use as hash input.
 	QueryArg *string `json:"queryArg,omitempty"`

--- a/pkg/apis/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/pkg/apis/configuration/v1beta1/kongupstreampolicy_types.go
@@ -70,7 +70,7 @@ type KongUpstreamPolicySpec struct {
 	// Algorithm must be set to "consistent-hashing" for this field to have effect.
 	HashOn *KongUpstreamHash `json:"hashOn,omitempty"`
 
-	// HasOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash
+	// HashOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash
 	// function fails.
 	// Algorithm must be set to "consistent-hashing" for this field to have effect.
 	HashOnFallback *KongUpstreamHash `json:"hashOnFallback,omitempty"`

--- a/pkg/apis/configuration/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/configuration/v1beta1/zz_generated.deepcopy.go
@@ -240,6 +240,11 @@ func (in *KongUpstreamHash) DeepCopyInto(out *KongUpstreamHash) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CookiePath != nil {
+		in, out := &in.CookiePath, &out.CookiePath
+		*out = new(string)
+		**out = **in
+	}
 	if in.QueryArg != nil {
 		in, out := &in.QueryArg, &out.QueryArg
 		*out = new(string)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongUpstreamPolicySpec` -> `kong.Upstream` translation function along with unit tests. 

Also, changes `hostHeader`'s JSON tag to match convention and adds missing `cookiePath` field.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #4929.
