### PR TITLE
fix(tests): print message instead of controller panic for expected errors

### DIFF
--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -99,7 +99,8 @@ func DeployControllerManagerForCluster(
 		defer os.Remove(kubeconfig.Name())
 		fmt.Fprintf(os.Stderr, "INFO: Starting Controller Manager for Cluster %s with Configuration: %+v\n", cluster.Name(), config)
 		if err := rootcmd.RunWithLogger(ctx, &config, logger); err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "ERROR: Problems with Controller Manager: %s\n", err)
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Before the change, any panic in the controller results in user-facing panic in logs, e.g. for unsupported feature gate

```log
...
2023-10-23T11:00:44+02:00       info    setup   found configuration option for gated feature    {"v": 0, "feature": "ExpressionRoutes", "enabled": true}
2023-10-23T11:00:44+02:00       info    diagnostics server is starting to listen        {"v": 0, "addr": 0}
panic: failed to configure feature gates: XXX is not a valid feature, please see the documentation: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md

goroutine 516 [running]:
github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster.func1()
        /Users/jakub.warczarek@konghq.com/Documents/work/kubernetes-ingress-controller/internal/util/test/controller_manager.go:102 +0x1d8
created by github.com/kong/kubernetes-ingress-controller/v2/internal/util/test.DeployControllerManagerForCluster in goroutine 1
        /Users/jakub.warczarek@konghq.com/Documents/work/kubernetes-ingress-controller/internal/util/test/controller_manager.go:98 +0x968
```
this PR changes the above behavior to

```log
...
2023-10-24T12:37:16+02:00       info    starting diagnostics server     {"v": 0}
2023-10-24T12:37:16+02:00       info    setup   starting controller manager     {"v": 0, "release": "NOT_SET", "repo": "NOT_SET", "commit": "NOT_SET"}
2023-10-24T12:37:16+02:00       info    setup   the ingress class name has been set     {"v": 0, "value": "kongtests"}
2023-10-24T12:37:16+02:00       info    setup   getting enabled options and features    {"v": 0}
2023-10-24T12:37:16+02:00       info    setup   found configuration option for gated feature    {"v": 0, "feature": "XXX", "enabled": true}
ERROR: Problems with Controller Manager: failed to configure feature gates: XXX is not a valid feature, please see the documentation: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md
```

As expected, the application exits with a non-zero status code. 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->



<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
