### PR TITLE
chore: remove unused PortDefFromIntStr

### DIFF
--- a/internal/dataplane/parser/translators/portdef.go
+++ b/internal/dataplane/parser/translators/portdef.go
@@ -2,7 +2,6 @@ package translators
 
 import (
 	netv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
 )
@@ -16,11 +15,4 @@ func PortDefFromServiceBackendPort(sbp *netv1.ServiceBackendPort) kongstate.Port
 	default:
 		return kongstate.PortDef{Mode: kongstate.PortModeImplicit}
 	}
-}
-
-func PortDefFromIntStr(is intstr.IntOrString) kongstate.PortDef {
-	if is.Type == intstr.String {
-		return kongstate.PortDef{Mode: kongstate.PortModeByName, Name: is.StrVal}
-	}
-	return kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: is.IntVal}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`PortDefFromIntStr` is unused (an in `internal/`) so remove it
