### PR TITLE
build: expand golangci-lint config to verify comments etc

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -129,6 +129,21 @@ linters-settings:
 issues:
   fix: true
   max-same-issues: 0
+  exclude-use-default: false
+  exclude:
+   # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+   - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+   # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
+   - (should have( a package)? comment)
+   # EXC0007 gosec: Too many false-positives for parametrized shell calls
+   - Subprocess launch(ed with variable|ing should be audited)
+   # EXC0008 gosec: Duplicated errcheck checks
+   - (G104)
+   # EXC0009 gosec: Too many issues in popular repos
+   - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+   # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+   - Potential file inclusion via variable
+
   exclude-rules:
   # Ignore insecure TLS in tests and hardcoded credentials
   - path: _test\.go

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ client-gen: ## Download client-gen locally if necessary.
 	@$(MAKE) _download_tool TOOL=client-gen
 
 GOLANGCI_LINT = $(PROJECT_DIR)/bin/golangci-lint
-.PHONY: golangci-lint
-golangci-lint: ## Download golangci-lint locally if necessary.
+.PHONY: golangci-lint.download
+golangci-lint.download: ## Download golangci-lint locally if necessary.
 	@$(MAKE) _download_tool TOOL=golangci-lint
 
 GOTESTSUM = $(PROJECT_DIR)/bin/gotestsum
@@ -157,6 +157,9 @@ fmt:
 
 .PHONY: lint
 lint: verify.tidy golangci-lint staticcheck looppointer
+
+.PHONY: golangci-lint
+golangci-lint: golangci-lint.download
 	$(GOLANGCI_LINT) run --verbose --config $(PROJECT_DIR)/.golangci.yaml
 
 .PHONY: staticcheck

--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -10,7 +10,7 @@ const (
 	ErrTextConsumerGroupUnlicensed            = "consumer group support requires a valid Kong Enterprise license"
 	ErrTextConsumerGroupUnexpected            = "unexpected error during checking support for consumer group"
 	ErrTextConsumerUsernameEmpty              = "username cannot be empty"
-	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernetes API" //nolint:gosec
+	ErrTextFailedToRetrieveSecret             = "could not retrieve secrets from the kubernetes API" //nolint:revive,gosec
 	ErrTextPluginConfigInvalid                = "could not parse plugin configuration"
 	ErrTextPluginConfigValidationFailed       = "unable to validate plugin schema"
 	ErrTextPluginConfigViolatesSchema         = "plugin failed schema validation: %s"

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -63,7 +63,7 @@ const (
 	UserTagKey           = "/tags"
 	RewriteURIKey        = "/rewrite"
 
-	// GatewayClassUnmanagedAnnotationSuffix is an annotation used on a Gateway resource to
+	// GatewayClassUnmanagedKey is an annotation used on a Gateway resource to
 	// indicate that the GatewayClass should be reconciled according to unmanaged
 	// mode.
 	//
@@ -79,7 +79,7 @@ const (
 	// by Kong's ingress controller.
 	DefaultIngressClass = "kong"
 
-	// GatewayClassUnmanagedAnnotationPlaceholder is intended to be used as placeholder value for the
+	// GatewayClassUnmanagedAnnotationValuePlaceholder is intended to be used as placeholder value for the
 	// GatewayClassUnmanagedAnnotation annotation.
 	GatewayClassUnmanagedAnnotationValuePlaceholder = "true"
 )

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	// KongConfugurationApplySucceededEvnetReason defines an event reason to tell the updating of Kong configuration succeeded.
+	// KongConfigurationApplySucceededEventReason defines an event reason to tell the updating of Kong configuration succeeded.
 	KongConfigurationApplySucceededEventReason = "KongConfigurationSucceeded"
 	// KongConfigurationTranslationFailedEventReason defines an event reason used for creating all translation resource failure events.
 	KongConfigurationTranslationFailedEventReason = "KongConfigurationTranslationFailed"

--- a/internal/dataplane/kongstate/types.go
+++ b/internal/dataplane/kongstate/types.go
@@ -13,9 +13,9 @@ const (
 	// PortModeImplicit means that the Ingress does not specify the Kubernetes Service port, and that KIC should expect
 	// the Service to have only one port defined.
 	PortModeImplicit PortMode = iota
-	// PortModeNumber means that the Ingress specifies the Service port by raw port number.
+	// PortModeByNumber means that the Ingress specifies the Service port by raw port number.
 	PortModeByNumber PortMode = iota
-	// PortModeNumber means that the Ingress specifies the Service port by its name field.
+	// PortModeByName means that the Ingress specifies the Service port by its name field.
 	PortModeByName PortMode = iota
 )
 

--- a/internal/dataplane/parser/atc/predicate.go
+++ b/internal/dataplane/parser/atc/predicate.go
@@ -48,6 +48,8 @@ type LiteralType int
 const (
 	LiteralTypeInt LiteralType = iota
 	LiteralTypeString
+	// LiteralTypeIP is a type that represents a literal of a single IP address or an IP CIDR.
+	//
 	// TODO: define subtypes of IP literals(IPv4/IPv6;single IP/IP CIDR).
 	LiteralTypeIP
 )

--- a/test/consts/exit_codes.go
+++ b/test/consts/exit_codes.go
@@ -29,7 +29,7 @@ const (
 	// problems setting up the testing environment and/or cluster.
 	ExitCodeEnvSetupFailed = 104
 
-	// ExitCodeCentCreateLogger is a POSIX compliant exit code for the test suite to indicate
+	// ExitCodeCantCreateLogger is a POSIX compliant exit code for the test suite to indicate
 	// that a failure occurred when trying to create a logger for the test suite.
 	ExitCodeCantCreateLogger = 105
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This config change removes some unused defaults (by disabling the `--exclude-use-default`) and hence enforces correct comments and some more.
