### PR TITLE
feat: add KongUpstreamPolicy CRD validation rules

### DIFF
--- a/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreampolicies.yaml
@@ -142,6 +142,9 @@ spec:
                             description: HTTPStatuses is a list of HTTP status codes
                               that Kong considers a success.
                             items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
                               type: integer
                             type: array
                           interval:
@@ -197,6 +200,9 @@ spec:
                             description: HTTPStatuses is a list of HTTP status codes
                               that Kong considers a failure.
                             items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
                               type: integer
                             type: array
                           interval:
@@ -228,6 +234,9 @@ spec:
                             description: HTTPStatuses is a list of HTTP status codes
                               that Kong considers a success.
                             items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
                               type: integer
                             type: array
                           interval:
@@ -267,6 +276,9 @@ spec:
                             description: HTTPStatuses is a list of HTTP status codes
                               that Kong considers a failure.
                             items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
                               type: integer
                             type: array
                           interval:
@@ -305,6 +317,29 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Only one of spec.hashOn.(cookie|header|uriCapture|queryArg) can
+            be set.
+          rule: 'has(self.spec.hashOn) ? [has(self.spec.hashOn.cookie), has(self.spec.hashOn.header),
+            has(self.spec.hashOn.uriCapture), has(self.spec.hashOn.queryArg)].filter(fieldSet,
+            fieldSet == true).size() <= 1 : true'
+        - message: Only one of spec.hashOnFallback.(header|uriCapture|queryArg) can
+            be set.
+          rule: 'has(self.spec.hashOnFallback) ? [has(self.spec.hashOnFallback.header),
+            has(self.spec.hashOnFallback.uriCapture), has(self.spec.hashOnFallback.queryArg)].filter(fieldSet,
+            fieldSet == true).size() <= 1 : true'
+        - message: When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? has(self.spec.hashOn.cookiePath)
+            : true'
+        - message: When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookiePath) ? has(self.spec.hashOn.cookie)
+            : true'
+        - message: spec.hashOnFallback.cookie must not be set.
+          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookie)
+            : true'
+        - message: spec.hashOnFallback.cookiePath must not be set.
+          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookiePath)
+            : true'
     served: true
     storage: true
     subresources:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -399,6 +399,20 @@ UDPIngress is the Schema for the udpingresses API.
 
 
 
+### HTTPStatus
+
+_Underlying type:_ `integer`
+
+HTTPStatus is an HTTP status code.
+
+
+
+
+
+_Appears in:_
+- [KongUpstreamHealthcheckHealthy](#kongupstreamhealthcheckhealthy)
+- [KongUpstreamHealthcheckUnhealthy](#kongupstreamhealthcheckunhealthy)
+
 ### IngressBackend
 
 
@@ -526,7 +540,7 @@ KongUpstreamHealthcheckHealthy configures thresholds and HTTP status codes to ma
 
 | Field | Description |
 | --- | --- |
-| `httpStatuses` _integer array_ | HTTPStatuses is a list of HTTP status codes that Kong considers a success. |
+| `httpStatuses` _[HTTPStatus](#httpstatus) array_ | HTTPStatuses is a list of HTTP status codes that Kong considers a success. |
 | `interval` _integer_ | Interval is the interval between active health checks for an upstream in seconds when in a healthy state. |
 | `successes` _integer_ | Successes is the number of successes to consider a target healthy. |
 
@@ -546,7 +560,7 @@ KongUpstreamHealthcheckUnhealthy configures thresholds and HTTP status codes to 
 | Field | Description |
 | --- | --- |
 | `httpFailures` _integer_ | HTTPFailures is the number of failures to consider a target unhealthy. |
-| `httpStatuses` _integer array_ | HTTPStatuses is a list of HTTP status codes that Kong considers a failure. |
+| `httpStatuses` _[HTTPStatus](#httpstatus) array_ | HTTPStatuses is a list of HTTP status codes that Kong considers a failure. |
 | `tcpFailures` _integer_ | TCPFailures is the number of TCP failures in a row to consider a target unhealthy. |
 | `timeouts` _integer_ | Timeouts is the number of timeouts in a row to consider a target unhealthy. |
 | `interval` _integer_ | Interval is the interval between active health checks for an upstream in seconds when in an unhealthy state. |

--- a/internal/dataplane/parser/translators/kongupstreampolicy_test.go
+++ b/internal/dataplane/parser/translators/kongupstreampolicy_test.go
@@ -93,13 +93,13 @@ func TestTranslateKongUpstreamPolicy(t *testing.T) {
 						Type:        lo.ToPtr("http"),
 						Concurrency: lo.ToPtr(10),
 						Healthy: &kongv1beta1.KongUpstreamHealthcheckHealthy{
-							HTTPStatuses: []int{200},
+							HTTPStatuses: []kongv1beta1.HTTPStatus{200},
 							Interval:     lo.ToPtr(20),
 							Successes:    lo.ToPtr(30),
 						},
 						Unhealthy: &kongv1beta1.KongUpstreamHealthcheckUnhealthy{
 							HTTPFailures: lo.ToPtr(40),
-							HTTPStatuses: []int{500},
+							HTTPStatuses: []kongv1beta1.HTTPStatus{500},
 							Timeouts:     lo.ToPtr(60),
 							Interval:     lo.ToPtr(70),
 						},

--- a/pkg/apis/configuration/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/configuration/v1beta1/zz_generated.deepcopy.go
@@ -302,7 +302,7 @@ func (in *KongUpstreamHealthcheckHealthy) DeepCopyInto(out *KongUpstreamHealthch
 	*out = *in
 	if in.HTTPStatuses != nil {
 		in, out := &in.HTTPStatuses, &out.HTTPStatuses
-		*out = make([]int, len(*in))
+		*out = make([]HTTPStatus, len(*in))
 		copy(*out, *in)
 	}
 	if in.Interval != nil {
@@ -337,7 +337,7 @@ func (in *KongUpstreamHealthcheckUnhealthy) DeepCopyInto(out *KongUpstreamHealth
 	}
 	if in.HTTPStatuses != nil {
 		in, out := &in.HTTPStatuses, &out.HTTPStatuses
-		*out = make([]int, len(*in))
+		*out = make([]HTTPStatus, len(*in))
 		copy(*out, *in)
 	}
 	if in.TCPFailures != nil {

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -4,6 +4,7 @@ package envtest
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
@@ -109,7 +111,7 @@ func TestCRDValidations(t *testing.T) {
 	ctx := context.Background()
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
-	client := NewControllerClient(t, scheme, envcfg)
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	testCases := []struct {
 		name     string
@@ -175,12 +177,130 @@ func TestCRDValidations(t *testing.T) {
 				require.ErrorContains(t, err, "spec.rules[0].port")
 			},
 		},
+		{
+			name: "KongUpstreamPolicy - only one of spec.hashOn.(cookie|header|uriCapture|queryArg) can be set",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				for i, invalidHashOn := range generateInvalidHashOns() {
+					invalidHashOn := invalidHashOn
+					t.Run(fmt.Sprintf("invalidHashOn[%d]", i), func(t *testing.T) {
+						err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+							HashOn: &invalidHashOn,
+						})
+						require.ErrorContains(t, err, "Only one of spec.hashOn.(cookie|header|uriCapture|queryArg) can be set.")
+					})
+				}
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - only one of spec.hashOnFallback.(header|uriCapture|queryArg) can be set",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				invalidHashOns := lo.Reject(generateInvalidHashOns(), func(hashOn kongv1beta1.KongUpstreamHash, _ int) bool {
+					// Filter out Cookie which is not allowed in spec.hashOnFallback.
+					return hashOn.Cookie != nil
+				})
+				for i, invalidHashOn := range invalidHashOns {
+					invalidHashOn := invalidHashOn
+					t.Run(fmt.Sprintf("invalidHashOn[%d]", i), func(t *testing.T) {
+						err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+							HashOnFallback: &invalidHashOn,
+						})
+						require.ErrorContains(t, err, "Only one of spec.hashOnFallback.(header|uriCapture|queryArg) can be set.")
+					})
+				}
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - spec.hashOn.cookie and spec.hashOn.cookiePath are set",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					HashOn: &kongv1beta1.KongUpstreamHash{
+						Cookie:     lo.ToPtr("cookie-name"),
+						CookiePath: lo.ToPtr("/"),
+					},
+				})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - spec.hashOn.cookie is set, spec.hashOn.cookiePath is required",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					HashOn: &kongv1beta1.KongUpstreamHash{
+						Cookie: lo.ToPtr("cookie-name"),
+					},
+				})
+				require.ErrorContains(t, err, "When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required.")
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - spec.hashOn.cookiePath is set, spec.hashOn.cookie is required",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					HashOn: &kongv1beta1.KongUpstreamHash{
+						CookiePath: lo.ToPtr("/"),
+					},
+				})
+				require.ErrorContains(t, err, "When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required.")
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - spec.hashOnFallback.cookie must not be set",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					HashOnFallback: &kongv1beta1.KongUpstreamHash{
+						CookiePath: lo.ToPtr("/"),
+					},
+				})
+				require.ErrorContains(t, err, "spec.hashOnFallback.cookiePath must not be set.")
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - spec.hashOnFallback.cookiePath must not be set",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					HashOnFallback: &kongv1beta1.KongUpstreamHash{
+						CookiePath: lo.ToPtr("/"),
+					},
+				})
+				require.ErrorContains(t, err, "spec.hashOnFallback.cookiePath must not be set.")
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - healthchecks.active.healthy.httpStatuses contains invalid HTTP status code",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					Healthchecks: &kongv1beta1.KongUpstreamHealthcheck{
+						Active: &kongv1beta1.KongUpstreamActiveHealthcheck{
+							Healthy: &kongv1beta1.KongUpstreamHealthcheckHealthy{
+								HTTPStatuses: []kongv1beta1.HTTPStatus{600},
+							},
+						},
+					},
+				})
+				require.ErrorContains(t, err, "should be less than or equal to 599")
+			},
+		},
+		{
+			name: "KongUpstreamPolicy - healthchecks.active.unhealthy.httpStatuses contains invalid HTTP status code",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
+					Healthchecks: &kongv1beta1.KongUpstreamHealthcheck{
+						Active: &kongv1beta1.KongUpstreamActiveHealthcheck{
+							Unhealthy: &kongv1beta1.KongUpstreamHealthcheckUnhealthy{
+								HTTPStatuses: []kongv1beta1.HTTPStatus{99},
+							},
+						},
+					},
+				})
+				require.ErrorContains(t, err, "should be greater than or equal to 100")
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ns := CreateNamespace(ctx, t, client)
+			ns := CreateNamespace(ctx, t, ctrlClient)
 			tc.scenario(ctx, t, ns.Name)
 		})
 	}
@@ -258,4 +378,58 @@ func validUDPIngress() *kongv1beta1.UDPIngress {
 			},
 		},
 	}
+}
+
+func createKongUpstreamPolicy(ctx context.Context, client client.Client, ns string, spec kongv1beta1.KongUpstreamPolicySpec) error {
+	return client.Create(ctx, &kongv1beta1.KongUpstreamPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    ns,
+		},
+		Spec: spec,
+	})
+}
+
+// generateInvalidHashOns generates a list of KongUpstreamHash objects with all possible invalid fields pairs.
+func generateInvalidHashOns() []kongv1beta1.KongUpstreamHash {
+	fieldSetFns := []func(h *kongv1beta1.KongUpstreamHash){
+		func(h *kongv1beta1.KongUpstreamHash) {
+			h.Cookie = lo.ToPtr("cookie-name")
+			h.CookiePath = lo.ToPtr("/")
+		},
+		func(h *kongv1beta1.KongUpstreamHash) {
+			h.Header = lo.ToPtr("header-name")
+		},
+		func(h *kongv1beta1.KongUpstreamHash) {
+			h.URICapture = lo.ToPtr("uri-capture")
+		},
+		func(h *kongv1beta1.KongUpstreamHash) {
+			h.QueryArg = lo.ToPtr("query-arg")
+		},
+	}
+
+	var invalidHashOns []kongv1beta1.KongUpstreamHash
+	for outerIdx, fieldSetFn := range fieldSetFns {
+		hashOn := kongv1beta1.KongUpstreamHash{}
+		fieldSetFn(&hashOn)
+
+		for innerIdx, innerFieldSetFn := range fieldSetFns {
+			if outerIdx == innerIdx {
+				continue
+			}
+			invalidHashOn := hashOn.DeepCopy()
+			innerFieldSetFn(invalidHashOn)
+			invalidHashOns = append(invalidHashOns, *invalidHashOn)
+		}
+	}
+
+	optStr := func(s *string) string {
+		if s == nil {
+			return "<nil>"
+		}
+		return *s
+	}
+	return lo.UniqBy(invalidHashOns, func(h kongv1beta1.KongUpstreamHash) string {
+		return fmt.Sprintf("%s.%s.%s.%s", optStr(h.Cookie), optStr(h.Header), optStr(h.URICapture), optStr(h.QueryArg))
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongUpstreamPolicy` CRD validations (both CEL rules as well as regular min/max for HTTP status codes). It will allow us to make assumptions on data validity in the controller.

**Which issue this PR fixes**:

Closes #4951.
