### PR TITLE
chore(Makefile): Added a help entry to display all options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -691,3 +691,6 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 
 undeploy: ## Undeploy controller from the K8s cluster specified in $KUBECONFIG.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
+
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
There are many options in the current Makefile. If unfamiliar developers need to know which options to execute, they have to read all the documents or go through the entire content of the Makefile. I hope to add a `make help` command to display all available options.

e.g.

```
✗ make help

Usage:
  make <target>
  controller-gen   Download controller-gen locally if necessary.
  kustomize        Download kustomize locally if necessary.
  client-gen       Download client-gen locally if necessary.
  golangci-lint    Download golangci-lint locally if necessary.
  gotestsum        Download gotestsum locally if necessary.
  crd-ref-docs     Download crd-ref-docs locally if necessary.
  dlv              Download dlv locally if necessary.
  setup-envtest    Download setup-envtest locally if necessary.
  skaffold         Download skaffold locally if necessary.
  go-junit-report  Download go-junit-report locally if necessary.
  deploy           Deploy controller to the K8s cluster specified in $KUBECONFIG.
  undeploy         Undeploy controller from the K8s cluster specified in $KUBECONFIG.
  help             Display this help

```


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
