### PR TITLE
chore(docs): update feature preview docs by removing mention to alpha Gatway API

### DIFF
--- a/FEATURE_PREVIEW_DOCUMENTATION.md
+++ b/FEATURE_PREVIEW_DOCUMENTATION.md
@@ -9,7 +9,3 @@ As features mature to `BETA` or `GA` state this documentation will be grown and 
 [fg]:/FEATURE_GATES.md
 [fg-alpha]:/FEATURE_GATES.md#feature-gates-for-alpha-or-beta-features
 [kong-docs]:https://github.com/Kong/docs.konghq.com
-
-## Feature Preview: Gateway APIs
-
-The documentation for this `alpha` feature is available in the standard Kong documentation: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-gateway-api/


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the feature preview doc by removing Gateway API