### PR TITLE
chore: update features gates for v3, remove Gateway feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,6 @@ Adding a new version? You'll need three changes:
   update Secrets is available at https://github.com/Kong/kubernetes-ingress-controller/issues/2502#issuecomment-1758213596
   [#4825](https://github.com/Kong/kubernetes-ingress-controller/pull/4825)
 
-
 ### Fixed
 
 - No more "log.SetLogger(...) was never called..." log entry during shutdown of KIC
@@ -163,6 +162,15 @@ Adding a new version? You'll need three changes:
   the controller resides in a separate Deployment. This allows the controller
   to manage its own mTLS negotiation.
   [#4942](https://github.com/Kong/kubernetes-ingress-controller/pull/4942)
+- Remove `Gateway` feature flag for Gateway API.
+  [#4968](https://github.com/Kong/kubernetes-ingress-controller/pull/4968)
+
+  It was enabled by default since 2.6.0 so the default behavior doesn't change.
+  If users want to disable related functionality, they still can by disabling
+  related Gateway API controllers via setting the following flags to `false`:
+  - `--enable-controller-gwapi-gateway`
+  - `--enable-controller-gwapi-httproute`
+  - `--enable-controller-gwapi-reference-grant`
 
 ### Added
 

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -44,8 +44,16 @@ Once a feature graduates from `Alpha` to `Beta` maturity these preview docs will
 
 ### Feature gates for graduated or deprecated features
 
-| Feature                    | Default | Stage      | Since | Until |
-|----------------------------|---------|------------|-------|-------|
+| Feature          | Default | Stage | Since  | Until |
+|------------------|---------|-------|--------|-------|
+| Gateway          | `false` | Alpha | 2.2.0  | 2.6.0 |
+| Gateway          | `true`  | Beta  | 2.6.0  | 3.0.0 |
+| CombinedRoutes   | `false` | Alpha | 2.4.0  | 3.0.0 |
+| CombinedRoutes   | `true`  | Beta  | 2.8.0  | 3.0.0 |
+| CombinedServices | `false` | Alpha | 2.10.0 | 3.0.0 |
+| CombinedServices | `true`  | Beta  | 2.11.0 | 3.0.0 |
+| ExpressionRoutes | `false` | Alpha | 2.10.0 | 3.0.0 |
+| Knative          | `false` | Alpha | 0.8.0  | 3.0.0 |
 
 Features that reach GA and over time become stable will be removed from this table, they can be found in the main [KIC CRD Documentation][specs] and [Guides][guides].
 
@@ -54,20 +62,12 @@ Features that reach GA and over time become stable will be removed from this tab
 
 ### Feature gates for Alpha or Beta features
 
-| Feature          | Default | Stage | Since   | Until |
-|------------------|---------|-------|---------|-------|
-| Knative          | `false` | Alpha | 0.8.0   | 3.0.0 |
-| Gateway          | `false` | Alpha | 2.2.0   | TBD   |
-| Gateway          | `true`  | Beta  | 2.6.0   | TBD   |
-| CombinedRoutes   | `false` | Alpha | 2.4.0   | 3.0.0 |
-| CombinedRoutes   | `true`  | Beta  | 2.8.0   | 3.0.0 |
-| GatewayAlpha     | `false` | Alpha | 2.6.0   | TBD   |
-| ExpressionRoutes | `false` | Alpha | 2.10.0  | 3.0.0 |
-| CombinedServices | `false` | Alpha | 2.10.0  | 3.0.0 |
-| CombinedServices | `true`  | Beta  | 2.11.0  | 3.0.0 |
-| FillIDs          | `false` | Alpha | 2.10.0  | 3.0.0 |
-| FillIDs          | `true`  | Beta  | 3.0.0   | TBD   |
-| RewriteURIs      | `false` | Alpha | 2.12.0  | TBD   |
+| Feature      | Default | Stage | Since  | Until |
+|--------------|---------|-------|--------|-------|
+| GatewayAlpha | `false` | Alpha | 2.6.0  | TBD   |
+| FillIDs      | `false` | Alpha | 2.10.0 | 3.0.0 |
+| FillIDs      | `true`  | Beta  | 3.0.0  | TBD   |
+| RewriteURIs  | `false` | Alpha | 2.12.0 | TBD   |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -265,7 +265,7 @@ func setupControllers(
 		// Gateway API Controllers
 		// ---------------------------------------------------------------------------
 		{
-			Enabled: c.GatewayAPIGatewayController && featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIGatewayController,
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/Gateway"),
@@ -285,7 +285,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: c.GatewayAPIHTTPRouteController && featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIHTTPRouteController,
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/HTTPRoute"),
@@ -306,7 +306,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: c.GatewayAPIReferenceGrantController && featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIReferenceGrantController,
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/ReferenceGrant"),

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -11,9 +11,6 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	// GatewayFeature is the name of the feature-gate for enabling/disabling GatewayFeature APIs.
-	GatewayFeature = "Gateway"
-
 	// GatewayAlphaFeature is the name of the feature-gate for enabling or
 	// disabling the Alpha maturity APIs and relevant features for Gateway API.
 	GatewayAlphaFeature = "GatewayAlpha"
@@ -60,7 +57,6 @@ func (fg FeatureGates) Enabled(feature string) bool {
 // NOTE: if you're adding a new feature gate, it needs to be added here.
 func GetFeatureGatesDefaults() map[string]bool {
 	return map[string]bool{
-		GatewayFeature:      true,
 		GatewayAlphaFeature: false,
 		FillIDsFeature:      true,
 		RewriteURIsFeature:  false,

--- a/internal/manager/featuregates/feature_gates_test.go
+++ b/internal/manager/featuregates/feature_gates_test.go
@@ -18,10 +18,10 @@ func TestFeatureGates(t *testing.T) {
 	assert.Len(t, fgs, len(GetFeatureGatesDefaults()))
 
 	t.Log("verifying feature gates setup results when valid feature gates options are present")
-	featureGates := map[string]bool{GatewayFeature: true}
+	featureGates := map[string]bool{GatewayAlphaFeature: true}
 	fgs, err = New(setupLog, featureGates)
 	assert.NoError(t, err)
-	assert.True(t, fgs[GatewayFeature])
+	assert.True(t, fgs[GatewayAlphaFeature])
 
 	t.Log("configuring several invalid feature gates options")
 	featureGates = map[string]bool{"invalidGateway": true}

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -50,7 +50,7 @@ func TestCreateManager(t *testing.T) {
 			"kv": "3.1.1",
 		}
 		featureGates = map[string]bool{
-			"gateway": true,
+			"gatewayalpha": true,
 		}
 		publishService = k8stypes.NamespacedName{
 			Namespace: "kong",
@@ -119,7 +119,7 @@ func TestCreateManager(t *testing.T) {
 						"signal=test-signal;"+
 						"db=off;"+
 						"feature-gateway-service-discovery=true;"+
-						"feature-gateway=true;"+
+						"feature-gatewayalpha=true;"+
 						"feature-konnect-sync=true;"+
 						"hn=%s;"+
 						"kv=3.1.1;"+

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -66,7 +66,6 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 	cfg.Konnect.LicenseSynchronizationEnabled = false
 	cfg.AnonymousReports = false
 	cfg.FeatureGates = featuregates.GetFeatureGatesDefaults()
-	cfg.FeatureGates[featuregates.GatewayFeature] = false
 
 	// Extend the graceful shutdown timeout to prevent flakiness on CI.
 	cfg.GracefulShutdownTimeout = lo.ToPtr(time.Minute)
@@ -82,7 +81,6 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 type ModifyManagerConfigFn func(cfg *manager.Config)
 
 func WithGatewayFeatureEnabled(cfg *manager.Config) {
-	cfg.FeatureGates[featuregates.GatewayFeature] = true
 	cfg.FeatureGates[featuregates.GatewayAlphaFeature] = true
 }
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -357,7 +357,6 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"db=off;"+
 			"feature-fillids=true;"+
 			"feature-gateway-service-discovery=false;"+
-			"feature-gateway=false;"+
 			"feature-gatewayalpha=false;"+
 			"feature-konnect-sync=false;"+
 			"feature-rewriteuris=false;"+


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

- Removes the `Gateway` feature gate. It was enabled by default for a while now, 3.0 is a good opportunity to remove it.
- Updates the https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md
- Moves the graduated or removed features gates from https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md#feature-gates-for-alpha-or-beta-features to https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md#feature-gates-for-graduated-or-deprecated-features


**Special notes for your reviewer**:

We do not have CLI flags for enabling/disabling Gateway API controllers. We only did that with the feature flags up until now hence this PR flips the enable criteria on those controllers to `true`, i.e. always enabled.

Do we want to introduce those?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
