### PR TITLE
chore: add CLI flags for enabling and disabling Gateway API controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,8 @@ test.golden.update:
 use-setup-envtest:
 	$(SETUP_ENVTEST) use
 
+ENVTEST_TIMEOUT ?= 5m
+
 .PHONY: _test.envtest
 .ONESHELL: _test.envtest
 _test.envtest: gotestsum setup-envtest use-setup-envtest
@@ -386,6 +388,7 @@ _test.envtest: gotestsum setup-envtest use-setup-envtest
 		-race $(GOTESTFLAGS) \
 		-tags envtest \
 		-covermode=atomic \
+		-timeout $(ENVTEST_TIMEOUT) \
 		-coverpkg=$(PKG_LIST) \
 		-coverprofile=coverage.envtest.out \
 		./test/envtest/...

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -18,6 +18,9 @@
 | `--dump-sensitive-config` | `bool` | Include credentials and TLS secrets in configs exposed with --dump-config. | `false` |
 | `--election-id` | `string` | Election id to use for status update. | `5b374a9e.konghq.com` |
 | `--election-namespace` | `string` | Leader election namespace to use when running outside a cluster. |  |
+| `--enable-controller-gwapi-gateway` | `bool` | Enable the Gateway API Gateway controller. | `true` |
+| `--enable-controller-gwapi-httproute` | `bool` | Enable the Gateway API HTTPRoute controller. | `true` |
+| `--enable-controller-gwapi-reference-grant` | `bool` | Enable the Gateway API ReferenceGrant controller. | `true` |
 | `--enable-controller-ingress-class-networkingv1` | `bool` | Enable the networking.k8s.io/v1 IngressClass controller. | `true` |
 | `--enable-controller-ingress-class-parameters` | `bool` | Enable the IngressClassParameters controller. | `true` |
 | `--enable-controller-ingress-networkingv1` | `bool` | Enable the networking.k8s.io/v1 Ingress controller. | `true` |

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -105,7 +105,7 @@ type Config struct {
 	KongPluginEnabled             bool
 	KongConsumerEnabled           bool
 	ServiceEnabled                bool
-	// Gateway API toggling
+	// Gateway API toggling.
 	GatewayAPIGatewayController        bool
 	GatewayAPIHTTPRouteController      bool
 	GatewayAPIReferenceGrantController bool

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -105,6 +105,10 @@ type Config struct {
 	KongPluginEnabled             bool
 	KongConsumerEnabled           bool
 	ServiceEnabled                bool
+	// Gateway API toggling
+	GatewayAPIGatewayController        bool
+	GatewayAPIHTTPRouteController      bool
+	GatewayAPIReferenceGrantController bool
 
 	// Admission Webhook server config
 	AdmissionServer admission.ServerConfig
@@ -228,6 +232,9 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.KongPluginEnabled, "enable-controller-kongplugin", true, "Enable the KongPlugin controller.")
 	flagSet.BoolVar(&c.KongConsumerEnabled, "enable-controller-kongconsumer", true, "Enable the KongConsumer controller. ")
 	flagSet.BoolVar(&c.ServiceEnabled, "enable-controller-service", true, "Enable the Service controller.")
+	flagSet.BoolVar(&c.GatewayAPIGatewayController, "enable-controller-gwapi-gateway", true, "Enable the Gateway API Gateway controller.")
+	flagSet.BoolVar(&c.GatewayAPIHTTPRouteController, "enable-controller-gwapi-httproute", true, "Enable the Gateway API HTTPRoute controller.")
+	flagSet.BoolVar(&c.GatewayAPIReferenceGrantController, "enable-controller-gwapi-reference-grant", true, "Enable the Gateway API ReferenceGrant controller.")
 
 	// Admission Webhook server config
 	flagSet.StringVar(&c.AdmissionServer.ListenAddr, "admission-webhook-listen", "off",

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -255,7 +255,7 @@ func setupControllers(
 		// Gateway API Controllers - Beta APIs
 		// ---------------------------------------------------------------------------
 		{
-			Enabled: featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIGatewayController && featureGates[featuregates.GatewayFeature],
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/Gateway"),
@@ -275,7 +275,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIHTTPRouteController && featureGates[featuregates.GatewayFeature],
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/HTTPRoute"),
@@ -296,7 +296,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[featuregates.GatewayFeature],
+			Enabled: c.GatewayAPIReferenceGrantController && featureGates[featuregates.GatewayFeature],
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/ReferenceGrant"),

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -252,7 +252,7 @@ func setupControllers(
 			},
 		},
 		// ---------------------------------------------------------------------------
-		// Gateway API Controllers - Beta APIs
+		// Gateway API Controllers
 		// ---------------------------------------------------------------------------
 		{
 			Enabled: c.GatewayAPIGatewayController && featureGates[featuregates.GatewayFeature],

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -39,9 +39,10 @@ func TestGatewayAPIControllersMayBeDynamicallyStarted(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	loggerHook := RunManager(ctx, t, envcfg,
+	_, loggerHook := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithGatewayFeatureEnabled,
+		WithGatewayAPIControllers(),
 		WithPublishService("ns"),
 	)
 

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -27,6 +27,11 @@ import (
 func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 	t.Parallel()
 
+	const (
+		waitTime = time.Minute
+		tickTime = 500 * time.Millisecond
+	)
+
 	scheme := Scheme(t, WithGatewayAPI, WithKong)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
@@ -38,6 +43,7 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 		AdminAPIOptFns(),
 		WithPublishService(gw.Namespace),
 		WithGatewayFeatureEnabled,
+		WithGatewayAPIControllers(),
 	)
 
 	const numOfRoutes = 120
@@ -61,7 +67,7 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 			return false
 		}
 		return true
-	}, 3*time.Minute, time.Second, "failed to reconcile all HTTPRoutes")
+	}, waitTime, tickTime, "failed to reconcile all HTTPRoutes")
 }
 
 // createHTTPRoutes creates a number of dummy HTTPRoutes for the given Gateway.

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -33,6 +33,7 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 		AdminAPIOptFns(),
 		WithPublishService(gw.Namespace),
 		WithGatewayFeatureEnabled,
+		WithGatewayAPIControllers(),
 		func(cfg *manager.Config) {
 			// Enable status updates and change the queue's buffer size to 0 to
 			// ensure that the status update notifications do not block the
@@ -115,6 +116,11 @@ func httpRouteGetsProgrammed(ctx context.Context, t *testing.T, cl client.Client
 func Test_WatchNamespaces(t *testing.T) {
 	t.Parallel()
 
+	const (
+		waitTime = 10 * time.Second
+		tickTime = 100 * time.Millisecond
+	)
+
 	scheme := Scheme(t, WithGatewayAPI)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
@@ -127,6 +133,7 @@ func Test_WatchNamespaces(t *testing.T) {
 		AdminAPIOptFns(),
 		WithPublishService(gw.Namespace),
 		WithGatewayFeatureEnabled,
+		WithGatewayAPIControllers(),
 		func(cfg *manager.Config) {
 			// Enable status updates and change the queue's buffer size to 0 to
 			// ensure that the status update notifications do not block the
@@ -194,7 +201,7 @@ func Test_WatchNamespaces(t *testing.T) {
 	t.Cleanup(func() { _ = ctrlClient.Delete(ctx, &hiddenRoute) })
 
 	require.Eventually(t, httpRouteGetsProgrammed(ctx, t, ctrlClient, httpRoute),
-		time.Second*10, time.Millisecond*50)
+		waitTime, tickTime)
 
 	require.Never(t, func() bool {
 		if err := ctrlClient.Get(ctx, client.ObjectKeyFromObject(&hiddenRoute), &hiddenRoute); err != nil {
@@ -205,5 +212,5 @@ func Test_WatchNamespaces(t *testing.T) {
 			return true
 		}
 		return false
-	}, time.Second*10, time.Second)
+	}, waitTime, tickTime)
 }

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -21,6 +21,11 @@ import (
 func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	t.Parallel()
 
+	const (
+		waitTime = 10 * time.Second
+		tickTime = 100 * time.Millisecond
+	)
+
 	scheme := Scheme(t, WithKong)
 	cfg := Setup(t, scheme)
 	client := NewControllerClient(t, scheme, cfg)
@@ -102,7 +107,7 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 		"consumer-no-username": `no username or custom_id specified`,
 	}
 
-	RunManager(ctx, t, cfg, AdminAPIOptFns())
+	RunManager(ctx, t, cfg, AdminAPIOptFns(), WithProxySyncSeconds(0.5))
 
 	require.Eventually(t, func() bool {
 		events := &corev1.EventList{}
@@ -126,5 +131,5 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 			}
 		}
 		return true
-	}, time.Minute, time.Second)
+	}, waitTime, tickTime)
 }

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -43,7 +43,7 @@ func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
 	t.Log("Replacing Kubernetes API server address with the proxy address")
 	envcfg.Host = fmt.Sprintf("https://%s", apiServerProxy.Address())
 
-	loggerHook := RunManager(ctx, t, envcfg, AdminAPIOptFns())
+	_, loggerHook := RunManager(ctx, t, envcfg, AdminAPIOptFns())
 	hasLog := func(expectedLog string) bool {
 		return lo.ContainsBy(loggerHook.All(), func(entry observer.LoggedEntry) bool {
 			return strings.Contains(entry.Message, expectedLog)

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -5,49 +5,35 @@ package envtest
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v2/internal/metrics"
-	"github.com/kong/kubernetes-ingress-controller/v2/internal/util"
-	"github.com/kong/kubernetes-ingress-controller/v2/pkg/clientset/scheme"
 )
 
 func TestMetricsAreServed(t *testing.T) {
 	t.Parallel()
 
 	const (
-		waitTime = 30 * time.Second
+		waitTime = 200 * time.Second
 		tickTime = 10 * time.Millisecond
+		maxDelay = 500 * time.Millisecond
 	)
 
-	envcfg := Setup(t, scheme.Scheme)
-	cfg := ConfigForEnvConfig(t, envcfg)
-	cfg.EnableProfiling = false
-	cfg.EnableConfigDumps = false
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), waitTime)
 	defer cancel()
 
-	go func(ctx context.Context) {
-		// NOTE: We're not running rootcmd.Run() or rootcmd.RunWithLogger() here
-		// hecause that sets up signal handling and that in turn uses a mutex to ensure
-		// only one signal handler is running at a time.
-		// We could try to work around this but that code calls os.Exit(1) whenever
-		// the root context is cancelled and that not what we want to test here.
-
-		logger, err := manager.SetupLoggers(&cfg, io.Discard)
-		require.NoError(t, err)
-
-		err = manager.Run(ctx, &cfg, util.ConfigDumpDiagnostic{}, logger)
-		require.NoError(t, err)
-	}(ctx)
+	cfg, _ := RunManager(ctx, t, envcfg,
+		AdminAPIOptFns(),
+	)
 
 	wantMetrics := []string{
 		metrics.MetricNameConfigPushCount,
@@ -64,31 +50,42 @@ func TestMetricsAreServed(t *testing.T) {
 	for _, metric := range wantMetrics {
 		metric := metric
 		t.Run(metric, func(t *testing.T) {
-			require.Eventually(t, func() bool {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					t.Logf("err %v checking %q", err, metricsURL)
-					return false
-				}
+			require.NoError(t,
+				retry.Do(func() error {
+					resp, err := http.Get(metricsURL)
+					if err != nil {
+						return fmt.Errorf("error %w checking %q", err, metricsURL)
+					}
 
-				defer resp.Body.Close()
-				if http.StatusOK != resp.StatusCode {
-					t.Logf("status code %v", resp.StatusCode)
-					return false
-				}
+					defer resp.Body.Close()
+					if http.StatusOK != resp.StatusCode {
+						return fmt.Errorf("status code %v not as expected (200)", resp.StatusCode)
+					}
 
-				var parser expfmt.TextParser
-				mf, err := parser.TextToMetricFamilies(resp.Body)
-				if err != nil {
-					t.Logf("err %v parsing %q", err, metricsURL)
-					return false
-				}
+					var parser expfmt.TextParser
+					mf, err := parser.TextToMetricFamilies(resp.Body)
+					if err != nil {
+						return fmt.Errorf("error %w parsing %q", err, metricsURL)
+					}
 
-				if _, ok := mf[metric]; !ok {
-					return false
-				}
-				return true
-			}, waitTime, tickTime)
+					if _, ok := mf[metric]; !ok {
+						return fmt.Errorf("metric %q not present yet", metric)
+					}
+					return nil
+				},
+					retry.Context(ctx),
+					retry.Delay(tickTime),
+					retry.MaxDelay(maxDelay),
+					retry.MaxJitter(maxDelay),
+					retry.DelayType(retry.BackOffDelay),
+					retry.Attempts(0), // We're using a context with timeout, so we don't need to limit the number of attempts.
+					retry.LastErrorOnly(true),
+					retry.OnRetry(func(n uint, err error) {
+						t.Logf("metric %s not present yet, err: %v", metric, err.Error())
+					}),
+				),
+			)
+
 			t.Logf("metric %q is present at /metrics", metric)
 		})
 	}

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -22,17 +22,19 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
-	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
+	ns := CreateNamespace(ctx, t, ctrlClient)
+
 	RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithUpdateStatus(),
-		WithIngressAddress("http://localhost:8080"),
+		WithPublishService(ns.Name),
+		WithPublishStatusAddress("http://localhost:8080"),
 	)
-
-	ns := CreateNamespace(ctx, t, ctrlClient)
 
 	testCases := []struct {
 		name                        string

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -71,6 +71,11 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 	// Extend the graceful shutdown timeout to prevent flakiness on CI.
 	cfg.GracefulShutdownTimeout = lo.ToPtr(time.Minute)
 
+	// Disable Gateway API controllers, enable those only in tests that use them.
+	cfg.GatewayAPIGatewayController = false
+	cfg.GatewayAPIHTTPRouteController = false
+	cfg.GatewayAPIReferenceGrantController = false
+
 	return cfg
 }
 
@@ -79,6 +84,14 @@ type ModifyManagerConfigFn func(cfg *manager.Config)
 func WithGatewayFeatureEnabled(cfg *manager.Config) {
 	cfg.FeatureGates[featuregates.GatewayFeature] = true
 	cfg.FeatureGates[featuregates.GatewayAlphaFeature] = true
+}
+
+func WithGatewayAPIControllers() func(cfg *manager.Config) {
+	return func(cfg *manager.Config) {
+		cfg.GatewayAPIGatewayController = true
+		cfg.GatewayAPIHTTPRouteController = true
+		cfg.GatewayAPIReferenceGrantController = true
+	}
 }
 
 func WithPublishService(namespace string) func(cfg *manager.Config) {
@@ -91,7 +104,7 @@ func WithPublishService(namespace string) func(cfg *manager.Config) {
 	}
 }
 
-func WithIngressAddress(address string) func(cfg *manager.Config) {
+func WithPublishStatusAddress(address string) func(cfg *manager.Config) {
 	return func(cfg *manager.Config) {
 		cfg.PublishStatusAddress = []string{address}
 	}
@@ -154,8 +167,8 @@ func RunManager(
 	envcfg *rest.Config,
 	adminAPIOpts []mocks.AdminAPIHandlerOpt,
 	modifyCfgFns ...func(cfg *manager.Config),
-) (loggerHook *observer.ObservedLogs) {
-	cfg := ConfigForEnvConfig(t, envcfg, adminAPIOpts...)
+) (cfg manager.Config, loggerHook *observer.ObservedLogs) {
+	cfg = ConfigForEnvConfig(t, envcfg, adminAPIOpts...)
 
 	for _, modifyCfgFn := range modifyCfgFns {
 		modifyCfgFn(&cfg)
@@ -197,5 +210,5 @@ func RunManager(
 		}
 	})
 
-	return logs
+	return cfg, logs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This introduces 3 new CLI flags for enabling/disabling Gateway API controllers:

```
      --enable-controller-gwapi-gateway                   Enable the Gateway API Gateway controller. (default true)
      --enable-controller-gwapi-httproute                 Enable the Gateway API HTTPRoute controller. (default true)
      --enable-controller-gwapi-reference-grant           Enable the Gateway API ReferenceGrant controller. (default true)
```

It's needed for https://github.com/Kong/kubernetes-ingress-controller/pull/4968 which will remove the `Gateway` feature flag (the only way of controlling whether the Gateway API controllers are enabled as of today).

Additionally it adjusts the `envtest` suite.

In #4968 the controller enablement conditions 

```
Enabled: c.GatewayAPIHTTPRouteController && featureGates[featuregates.GatewayFeature]
```

will look like this

```
Enabled: c.GatewayAPIHTTPRouteController
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
