### PR TITLE
chore(ci): increase lint timeout to prevent CI failures

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
   build-tags:
   - integration_tests
   - e2e_tests


### PR DESCRIPTION
**What this PR does / why we need it**:

Extended `golangci-lint` timeout from 5m to 10m to prevent CI failures like: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6642225481/job/18046592773?pr=4975

```
Wed, 25 Oct 2023 15:01:09 GMT
/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/bin/golangci-lint run --verbose --config /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/.golangci.yaml
Wed, 25 Oct 2023 15:01:09 GMT
level=info msg="[config_reader] Used config file .golangci.yaml"
Wed, 25 Oct 2023 15:01:09 GMT
level=info msg="[lintersdb] Active 36 linters: [asasalint asciicheck bodyclose contextcheck dogsled durationcheck errcheck errname errorlint exhaustive exportloopref forbidigo gci godot gofmt gofumpt goimports gomodguard gosec gosimple govet importas ineffassign loggercheck misspell nakedret nilerr nolintlint predeclared revive staticcheck tenv unconvert unparam unused wastedassign]"
Wed, 25 Oct 2023 15:01:09 GMT
level=info msg="[loader] Using build tags: [integration_tests e2e_tests conformance_tests istio_tests envtest]"
Wed, 25 Oct 2023 15:03:37 GMT
level=info msg="[loader] Go packages loading at mode 575 (compiled_files|imports|types_sizes|deps|exports_file|files|name) took 2m28.167865866s"
Wed, 25 Oct 2023 15:03:37 GMT
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 115.501915ms"
Wed, 25 Oct 2023 15:06:09 GMT
level=info msg="Memory: 3001 samples, avg is 834.3MB, max is 2668.8MB"
Wed, 25 Oct 2023 15:06:09 GMT
level=info msg="Execution took 5m0.006988123s"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[linters_context/goanalysis] analyzers took 11m33.573989814s with top 10 stages: buildir: 4m22.782293755s, buildssa: 3m30.121877762s, wastedassign: 50.17804453s, the_only_name: 26.277057935s, goimports: 16.219876378s, unconvert: 13.736766649s, gci: 9.067290661s, gofumpt: 8.724957159s, nilness: 6.835713314s, exhaustive: 6.065443963s"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[runner] fixer took 0s with no stages"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[runner] Issues before processing: 1337, after processing: 0"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[runner] Processors filtering stat (out/in): filename_unadjuster: 1337/1337, path_prettifier: 1337/1337, autogenerated_exclude: 1198/1337, exclude: 447/1198, nolint: 0/282, skip_files: 1337/1337, identifier_marker: 1198/1198, cgo: 1337/1337, skip_dirs: 1337/1337, exclude-rules: 282/447"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[runner] processing took 83.68898ms with stages: nolint: 26.669476ms, identifier_marker: 25.808264ms, exclude: 15.57272ms, path_prettifier: 5.65848ms, autogenerated_exclude: 5.223274ms, exclude-rules: 3.042843ms, skip_dirs: 1.235417ms, cgo: 243.203µs, filename_unadjuster: 199.403µs, fixer: 31.5µs, max_same_issues: 1.3µs, uniq_by_line: 600ns, diff: 400ns, severity-rules: 400ns, skip_files: 300ns, sort_results: 300ns, source_code: 300ns, max_per_file_from_linter: 200ns, path_shortener: 200ns, path_prefixer: 200ns, max_from_linter: 200ns"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="[runner] linters took 2m51.163[635](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6642225481/job/18046592773?pr=4975#step:4:636)233s with stages: goanalysis_metalinter: 2m51.079835651s"
Wed, 25 Oct 2023 15:06:28 GMT
level=info msg="File cache stats: 461 entries of total size 3.3MiB"
Wed, 25 Oct 2023 15:06:28 GMT
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
Wed, 25 Oct 2023 15:06:28 GMT
make: *** [Makefile:163: golangci-lint] Error 4
```