### PR TITLE
chore: bump gateway APIs to 1.0.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,9 +152,10 @@ Adding a new version? You'll need three changes:
 - Docker images now use UID and GID 1000 to match Kong images. This should have
   no user-facing effect.
   [#4911](https://github.com/Kong/kubernetes-ingress-controller/pull/4911)
-- Bump version of gateway API to `1.0.0-rc1` and support `Gateway`, `GatewayClass`
+- Bump version of gateway API to `1.0.0-rc2` and support `Gateway`, `GatewayClass`
   and `HTTPRoute` in API version `gateway.networking.k8s.io/v1`.
   [#4893](https://github.com/Kong/kubernetes-ingress-controller/pull/4893)
+  [#4981](https://github.com/Kong/kubernetes-ingress-controller/pull/4981)
 - Update `Gateway`s, `GatewayClass`es and `HTTPRoute`s in examples to API
   version `gateway.networking.k8s.io/v1`.
   [#4935](https://github.com/Kong/kubernetes-ingress-controller/pull/4935)

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	k8s.io/client-go v0.28.3
 	k8s.io/component-base v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
-	sigs.k8s.io/gateway-api v1.0.0-rc1
+	sigs.k8s.io/gateway-api v1.0.0-rc2
 	sigs.k8s.io/kustomize/api v0.15.0
 	sigs.k8s.io/kustomize/kyaml v0.15.0
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSn
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
-sigs.k8s.io/gateway-api v1.0.0-rc1 h1:v7N9fWTcQxox5aP2IrViDw6imeUHMAt2WFjI4BYo0sw=
-sigs.k8s.io/gateway-api v1.0.0-rc1/go.mod h1:+QpYENjk9s31/abu2Pv5BpK2v88UQDK2aeQCwCvy6ck=
+sigs.k8s.io/gateway-api v1.0.0-rc2 h1:+7rq7j5fehUkMkgnJyL90mtXrVnz8aj5SXsRqIEW3Mk=
+sigs.k8s.io/gateway-api v1.0.0-rc2/go.mod h1:+QpYENjk9s31/abu2Pv5BpK2v88UQDK2aeQCwCvy6ck=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -21,6 +21,7 @@ import (
 
 var commonSkippedTests = []string{
 	// core conformance
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4982
 	tests.GatewayWithAttachedRoutes.ShortName,
 
 	// extended conformance
@@ -42,8 +43,9 @@ var commonSkippedTests = []string{
 	tests.HTTPRouteTimeoutBackendRequest.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4915
 	tests.HTTPRouteTimeoutRequest.ShortName,
-
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4983
 	tests.HTTPRouteBackendProtocolH2C.ShortName,
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/4984
 	tests.HTTPRouteBackendProtocolWebSocket.ShortName,
 
 	// experimental conformance

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -21,8 +21,7 @@ import (
 
 var commonSkippedTests = []string{
 	// core conformance
-	// https://github.com/Kong/kubernetes-ingress-controller/issues/4916
-	tests.GatewaySecretInvalidReferenceGrant.ShortName,
+	tests.GatewayWithAttachedRoutes.ShortName,
 
 	// extended conformance
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4563
@@ -43,6 +42,9 @@ var commonSkippedTests = []string{
 	tests.HTTPRouteTimeoutBackendRequest.ShortName,
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/4915
 	tests.HTTPRouteTimeoutRequest.ShortName,
+
+	tests.HTTPRouteBackendProtocolH2C.ShortName,
+	tests.HTTPRouteBackendProtocolWebSocket.ShortName,
 
 	// experimental conformance
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/3684

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -4,8 +4,8 @@
 package consts
 
 const (
-	GatewayAPIVersion                   = "v1.0.0-rc1"
-	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.0.0-rc1"
-	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0-rc1"
-	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0-rc1"
+	GatewayAPIVersion                   = "v1.0.0-rc2"
+	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.0.0-rc2"
+	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0-rc2"
+	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0-rc2"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

bump gateway API to `1.0.0-rc2` and set skip of conformance tests in 1.0.0-rc2.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #4916 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

related conformance failures (skips):
- #4982 
- #4983 
- #4984 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
