### PR TITLE
chore(ci): remove k8s 1.23 from testing matrix

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -10,8 +10,6 @@ e2e:
     - 'v1.25.11'
     # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.24.15'
-    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
-    - 'v1.23.17'
   gke:
     # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
     - '1.28.2'


### PR DESCRIPTION
**What this PR does / why we need it**:

According to https://endoflife.date/kubernetes and other sources 1.23 is already unsupported for several months now.

The latest version available in GKE is 1.24 so leaving this kind version in for now. (even though [we test on GKE 1.28.2](https://github.com/Kong/kubernetes-ingress-controller/blob/b6809f5ff9a6ee58fb52b6411dfb63ffb5eeca0a/.github/test_dependencies.yaml#L13-L15))