### PR TITLE
tests: fix `TestKongRouterFlavorCompatibility` e2e test and make it test all Kong Gateway flavors

### DIFF
--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -44,6 +44,7 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 			t.Logf("waiting for Kong with %s router to start", rf)
 			ensureGatewayDeployedWithRouterFlavor(ctx, t, env, proxyDeploymentNN, rf)
 			t.Logf("running ingress tests to verify that KIC with %s Kong router works", rf)
+			deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 			verifyIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed during debugging e2e test failures from  https://github.com/Kong/kubernetes-ingress-controller/pull/4934

~Make `TestKongRouterFlavorCompatibility` run tests for all 3 router flavors.~ This was already done as part of #4934. This PR here adds deployment of echo backends (which were not added in #4934) to allow test to pass.

~Previous scaffolding didn't allow to add `expressions` because when a rolling upgrade is performed KIC is not able to transition from 1 router flavor into another.~ This was already done as part of #4934

This also adds cleanup of resources deployed in each subtest so that they can each deploy their own without conflicts.

This will fix failures as in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6654763042/job/18083851340