### PR TITLE
fix: set router flavor to traditional_compatible in konnect related manifests

### DIFF
--- a/config/components/konnect/manager.yaml
+++ b/config/components/konnect/manager.yaml
@@ -27,3 +27,18 @@ spec:
               secretKeyRef:
                 name: konnect-client-tls
                 key: tls.key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-kong
+  namespace: kong
+spec:
+  template:
+    spec:
+      containers:
+        - name: proxy
+          env:
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional_compatible
+

--- a/config/variants/konnect/base/manager.yaml
+++ b/config/variants/konnect/base/manager.yaml
@@ -27,3 +27,18 @@ spec:
               secretKeyRef:
                 name: konnect-client-tls
                 key: tls.key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-kong
+  namespace: kong
+spec:
+  template:
+    spec:
+      containers:
+        - name: proxy
+          env:
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional_compatible
+

--- a/config/variants/konnect/debug/manager_debug.yaml
+++ b/config/variants/konnect/debug/manager_debug.yaml
@@ -30,3 +30,17 @@ spec:
             - name: CONTROLLER_KONNECT_ADDRESS
               value: https://us.kic.api.konghq.tech
           image: kic-placeholder:placeholder
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-kong
+  namespace: kong
+spec:
+  template:
+    spec:
+      containers:
+        - name: proxy
+          env:
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional_compatible

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2572,6 +2572,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional_compatible
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
             backlog=16384
@@ -2593,8 +2595,6 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_ROUTER_FLAVOR
-          value: expressions
         image: kong/kong-gateway:3.4
         lifecycle:
           preStop:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2574,6 +2574,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: KONG_ROUTER_FLAVOR
+          value: traditional_compatible
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
             backlog=16384
@@ -2595,8 +2597,6 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        - name: KONG_ROUTER_FLAVOR
-          value: expressions
         image: kong:3.4
         lifecycle:
           preStop:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Konnect seems not to support expression routes. We need to set router flavor to `traditional_compatible` to pass e2e tests for integration with Konnect.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #4993 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
