### PR TITLE
fix: fix a panic when receiving a broken config from Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@ Adding a new version? You'll need three changes:
   for `TCPRoute` and `UDPRoute` works as expected. It **breaks** some configurations that
   relied on matching multiple Gateway's listener ports to ports of services automatically.
   [#4928](https://github.com/Kong/kubernetes-ingress-controller/pull/4928)
+- Fixed a panic when receiving broken configuration from Kong Gateway.
+  [#5003](https://github.com/Kong/kubernetes-ingress-controller/pull/5003)
 
 ### Changed
 

--- a/internal/dataplane/configfetcher/config_fetcher.go
+++ b/internal/dataplane/configfetcher/config_fetcher.go
@@ -3,6 +3,7 @@ package configfetcher
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/deck/dump"
@@ -70,6 +71,10 @@ func (cf *DefaultKongLastGoodConfigFetcher) TryFetchingValidConfigFromGateways(
 		rs, err := cf.getKongRawState(ctx, client.AdminAPIClient())
 		if err != nil {
 			errs = errors.Join(errs, err)
+		}
+		if rs == nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to fetch configuration from %q, got nil kong raw state", client.BaseRootURL()))
+			continue
 		}
 		status, err := cf.getKongStatus(ctx, client.AdminAPIClient())
 		if err != nil {

--- a/internal/dataplane/configfetcher/kongrawstate.go
+++ b/internal/dataplane/configfetcher/kongrawstate.go
@@ -14,6 +14,9 @@ import (
 // KongRawStateToKongState converts a Deck kongRawState to a KIC KongState.
 func KongRawStateToKongState(rawstate *utils.KongRawState) *kongstate.KongState {
 	kongState := &kongstate.KongState{}
+	if rawstate == nil {
+		return kongState
+	}
 
 	routes := make(map[string][]*kong.Route)
 	for _, r := range rawstate.Routes {


### PR DESCRIPTION
**What this PR does / why we need it**:

When KIC receives a broken config from Gateway (e.g. like the one described in https://github.com/Kong/kubernetes-ingress-controller/issues/4990) with route's priority in scientific notation:

```
routes:
  - request_buffering: true
    expression: ((http.path == "/echo") || (http.path ^= "/echo/")) && (http.method == "GET")
    preserve_host: true
    name: default.echo.echo..1027
    response_buffering: true
    updated_at: 1698340425
    https_redirect_status_code: 426
    ws_id: 0dc6f45b-8f8d-40d2-a504-473544ee190b
    id: 6ece5df4-2c97-5372-a840-47e222d4ea9d
    created_at: 1698340425
    tags:
      - k8s-name:echo
      - k8s-namespace:default
      - k8s-kind:Ingress
      - k8s-uid:6eb54997-0c70-4a68-918b-935a356f14cd
      - k8s-group:networking.k8s.io
      - k8s-version:v1
    priority: 3.3820977671045e+15 # <- this
    service: 4a3125fc-7d51-5575-b0f3-978d9a44a49b
    protocols:
      - http
      - https
    strip_path: true
```

then it cannot handle an unparsed configuration and it panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1037d8a34]

goroutine 138 [running]:
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/configfetcher.KongRawStateToKongState(0x0)
        kubernetes-ingress-controller/internal/dataplane/configfetcher/kongrawstate.go:19 +0x84
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/configfetcher.(*DefaultKongLastGoodConfigFetcher).TryFetchingValidConfigFromGateways(0x14000aad1d0, {0x1040464d0, 0x14000aacff0}, {{0x104049b88?, 0x140000db230?}, 0x0?}, {0x14000bd3100, 0x2, 0x0?})
        kubernetes-ingress-controller/internal/dataplane/configfetcher/config_fetcher.go:85 +0x438
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*KongClient).Update(0x140009ec1e0, {0x1040464d0, 0x14000aacff0})
        kubernetes-ingress-controller/internal/dataplane/kong_client.go:397 +0x124
github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*Synchronizer).startUpdateServer(0x14000579340, {0x1040464d0, 0x14000aacff0})
        kubernetes-ingress-controller/internal/dataplane/synchronizer.go:183 +0xa0
created by github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane.(*Synchronizer).Start in goroutine 136
        kubernetes-ingress-controller/internal/dataplane/synchronizer.go:120 +0x1c8
```

This PR allows KIC to handle this error and print a log about it:

```
2023-10-27T19:52:11+02:00     error   failed to fetch last good configuration from gateways   {"error": "routes: json: cannot unmarshal number 3.379898743849e+15 into Go struct field Route.priority of type int\nfailed to fetch configuration from \"https://10.244.0.241:8444\", got nil kong raw state\nroutes: json: cannot unmarshal number 3.379898743849e+15 into Go struct field Route.priority of type int\nfailed to fetch configuration from \"https://10.244.0.242:8444\", got nil kong raw state"}
```

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
