### PR TITLE
chore: add changelog entry for KongUpstreamPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,8 +200,21 @@ Adding a new version? You'll need three changes:
   that prefer to mount a file over binding a Secret to an environment variable
   value. Only one of the two options can be used.
   [#4808](https://github.com/Kong/kubernetes-ingress-controller/pull/4808)
+- New `KongUpstreamPolicy` CRD superseding `KongIngress.Upstream` was introduced.
+  It allows overriding Kong Upstream settings generated for a specific `Service` used
+  in an `Ingress` or Gateway API `*Route`. A policy can be applied to a `Service` by
+  setting `konghq.com/upstream-policy: <policy-name>` annotation on the `Service` object.
+  Read more in [KIC CRDs reference].
+  [#4880](https://github.com/Kong/kubernetes-ingress-controller/pull/4880)
+  [#4943](https://github.com/Kong/kubernetes-ingress-controller/pull/4943)
+  [#4955](https://github.com/Kong/kubernetes-ingress-controller/pull/4955)
+  [#4957](https://github.com/Kong/kubernetes-ingress-controller/pull/4957)
+  [#4969](https://github.com/Kong/kubernetes-ingress-controller/pull/4969)
+  [#4979](https://github.com/Kong/kubernetes-ingress-controller/pull/4979)
+  [#4989](https://github.com/Kong/kubernetes-ingress-controller/pull/4989)
 
 [KIC Annotations reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/
+[KIC CRDs reference]: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/
 
 ## 2.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,7 @@ Adding a new version? You'll need three changes:
   [#4808](https://github.com/Kong/kubernetes-ingress-controller/pull/4808)
 - New `KongUpstreamPolicy` CRD superseding `KongIngress.Upstream` was introduced.
   It allows overriding Kong Upstream settings generated for a specific `Service` used
-  in an `Ingress` or Gateway API `*Route`. A policy can be applied to a `Service` by
+  in an `Ingress` or Gateway API `Route`. A policy can be applied to a `Service` by
   setting `konghq.com/upstream-policy: <policy-name>` annotation on the `Service` object.
   Read more in [KIC CRDs reference].
   [#4880](https://github.com/Kong/kubernetes-ingress-controller/pull/4880)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a single changelog entry for `KongUpstreamPolicy`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3174.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
