### PR TITLE
feat: set KIC's UserAgent

### DIFF
--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -23,6 +23,7 @@ import (
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config/types"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/flags"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
 )
 
@@ -325,6 +326,8 @@ func (c *Config) GetKubeconfig() (*rest.Config, error) {
 	if c.Impersonate != "" {
 		config.Impersonate.UserName = c.Impersonate
 	}
+
+	config.UserAgent = "kong-ingress-controller/" + metadata.Release
 
 	return config, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This sets KIC's user agent so that it can be easily identified in Kubernetes Audit logs:

```
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Request",
  "auditID": "0f4fafa0-6f44-4c3a-b937-717a9cc6b042",
  "stage": "ResponseStarted",
  "requestURI": "/api/v1/services?allowWatchBookmarks=true&resourceVersion=362177&timeoutSeconds=367&watch=true",
  "verb": "watch",
  "user": {
    "username": "kubernetes-admin",
    "groups": [
      "system:masters",
      "system:authenticated"
    ]
  },
  "sourceIPs": [
    "172.18.0.1"
  ],
  "userAgent": "kubernetes-ingress-controller/v2.12.0-189-g5a4d76638",
  "objectRef": {
    "resource": "services",
    "apiVersion": "v1"
  },
  "responseStatus": {
    "metadata": {},
    "code": 200
  },
  "requestReceivedTimestamp": "2023-10-30T17:16:50.566806Z",
  "stageTimestamp": "2023-10-30T17:16:50.567532Z",
  "annotations": {
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": ""
  }
}
```

Without this change it uses the default user agent: `"main/v0.0.0 (linux/arm64) kubernetes/$Format"`

### Special notes for reviewers

Is `kubernetes-ingress-controller/<VERSION>` something we want or do we want to use something different?