### PR TITLE
fix: use only 46 bits for priorities of Kong routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,15 @@ Adding a new version? You'll need three changes:
   [#4928](https://github.com/Kong/kubernetes-ingress-controller/pull/4928)
 - Fixed a panic when receiving broken configuration from Kong Gateway.
   [#5003](https://github.com/Kong/kubernetes-ingress-controller/pull/5003)
+- Use 46 bits in values of priorities of generated Kong routes when expression
+  rotuer is enabled to limit the priorities to be less than `1e14`. This
+  prevents them to be encoded into scientific notation when dumping 
+  configurations from admin API that brings precision loss and type 
+  inconsistency in decoding JSON/YAML data to `uint64`. 
+  This change will limit number of `HTTPRoute`s that can be 
+  deterministically sorted by their creation timestamps, names and internal
+  rule orders to `2^12=4096` and number of `GRPCRoutes` can be sorted to `2^8=256`.
+  [#5024](https://github.com/Kong/kubernetes-ingress-controller/pull/5024)
 
 ### Changed
 

--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -18,7 +18,7 @@ services:
     id: b23f135f-8d7e-54cb-96eb-f2579ef1608b
     name: grpcroute.default.grpcbin.example.com.0.0
     preserve_host: true
-    priority: 1713055227461631
+    priority: 26766487929087
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -14,7 +14,7 @@ services:
     id: 91833860-2041-5eea-abf8-a1e85b7c64cf
     name: httproute.default.httproute-testing._.0.0
     preserve_host: true
-    priority: 2251808940752895
+    priority: 35184514699263
     strip_path: true
     tags:
     - k8s-name:httproute-testing

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 2bd1c902-4d3c-50ed-9a78-f698cfa0cf37
     name: foo-namespace.foo.foo-svc.example.net.8000
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -48,7 +48,7 @@ services:
     id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 0673ae1f-4318-59dc-96e7-fc17c218022f
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071817
+    priority: 57178899677193
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 45f1e9e4-8096-5cf7-b8e0-c42f8b9b81a0
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071818
+    priority: 57178899677194
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -82,7 +82,7 @@ services:
     id: fc9a8135-0253-5631-b1e0-8712f796a4e2
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -30,7 +30,7 @@ services:
     id: ab6b1505-ec86-5b04-9d39-a95a711564cc
     name: foo-namespace.foo-2.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: bba23c8e-3f3c-55dc-bfca-2fe19de118d1
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     preserve_host: true
-    priority: 3382102062006304
+    priority: 57178899611680
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -15,7 +15,7 @@ services:
     id: 3eee2c18-8fcc-5661-8f84-5c89adfa404f
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/translators/atc_utils.go
+++ b/internal/dataplane/parser/translators/atc_utils.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	// FromResourceKindPriorityShiftBits is the highest 2 bits 51-50 used in priority field of Kong route
+	// FromResourceKindPriorityShiftBits is the highest 2 bits 45-44 used in priority field of Kong route
 	// to note the kind of the resource from which the route is translated.
 	// 11 - routes from Ingress.
 	// 10 - routes from HTTPRoute.
 	// 01 - routes from GRPCRoute.
-	FromResourceKindPriorityShiftBits = 50
+	FromResourceKindPriorityShiftBits = 44
 	// ResourceKindBitsIngress is the value of highest 2 bits for routes from ingresses.
 	ResourceKindBitsIngress = 3
 	// ResourceKindBitsHTTPRoute is the value of highest 2 bits for routes from HTTPRoutes.

--- a/internal/dataplane/parser/translators/grpcroute_atc_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc_test.go
@@ -613,7 +613,7 @@ func TestGRPCRouteTraitsEncodeToPriority(t *testing.T) {
 				HostnameLength:  15,
 				ServiceLength:   7,
 			},
-			exprectedPriority: (1 << 50) | (1 << 49) | (15 << 41) | (7 << 30),
+			exprectedPriority: (1 << 44) | (1 << 43) | (15 << 35) | (7 << 24),
 		},
 		{
 			name: "non precise hostname",
@@ -624,7 +624,7 @@ func TestGRPCRouteTraitsEncodeToPriority(t *testing.T) {
 				MethodLength:    7,
 				HeaderCount:     3,
 			},
-			exprectedPriority: (1 << 50) | (15 << 41) | (7 << 30) | (7 << 19) | (3 << 14),
+			exprectedPriority: (1 << 44) | (15 << 35) | (7 << 24) | (7 << 13) | (3 << 8),
 		},
 	}
 
@@ -647,7 +647,7 @@ func TestAssignRoutePriorityToSplitGRPCRouteMatches(t *testing.T) {
 		matchIndex int
 	}
 	now := time.Now()
-	const maxRelativeOrderPriorityBits = (1 << 14) - 1
+	const maxRelativeOrderPriorityBits = (1 << 8) - 1
 
 	testCases := []struct {
 		name                  string
@@ -1123,14 +1123,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 0,
 				},
-				Priority: 1024,
+				Priority: 1 << 14,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.no-hostname-exact-method._.0.0"),
 					PreserveHost: kong.Bool(true),
 					Expression:   kong.String(`http.path == "/pets/list"`),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64(1 << 14),
 				},
 				ExpressionRoutes: true,
 			},
@@ -1175,14 +1175,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 0,
 				},
-				Priority: 1024,
+				Priority: (1 << 31) + 1,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.precise-hostname-regex-method.foo.com.0.0"),
 					Expression:   kong.String(`(http.path ~ "^/name/[a-z0-9]+") && (http.host == "foo.com")`),
 					PreserveHost: kong.Bool(true),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64((1 << 31) + 1),
 				},
 				ExpressionRoutes: true,
 			},
@@ -1244,14 +1244,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 1,
 				},
-				Priority: 1024,
+				Priority: (1 << 42) + 1,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.wildcard-hostname-header-match._.foo.com.0.1"),
 					Expression:   kong.String(`(http.path ^= "/name/") && (http.headers.foo == "bar") && (http.host =^ ".foo.com")`),
 					PreserveHost: kong.Bool(true),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64((1 << 42) + 1),
 				},
 				ExpressionRoutes: true,
 			},

--- a/internal/dataplane/parser/translators/httproute_atc.go
+++ b/internal/dataplane/parser/translators/httproute_atc.go
@@ -380,11 +380,11 @@ func CalculateHTTPRouteMatchPriorityTraits(match SplitHTTPRouteMatch) HTTPRouteP
 
 // EncodeToPriority turns HTTPRoute priority traits into the integer expressed priority.
 //
-//					   4                   3                   2                   1
-//	 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
-//	+-+---------------+-+-+-------------------+-+---------+---------+-----------------------------------+
-//	|P| host len      |E|R|  Path length      |M|Header No|Query No.| relative order                    |
-//	+-+---------------+-+-+-------------------+-+---------+-------- +-----------------------------------+
+//		   4                   3                   2                   1
+//	 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+//	+-+---------------+-+-+-------------------+-+---------+---------+-----------------------+
+//	|P| host len      |E|R|  Path length      |M|Header No|Query No.| relative order        |
+//	+-+---------------+-+-+-------------------+-+---------+-------- +-----------------------+
 //
 // Where:
 // P: set to 1 if the hostname is non-wildcard.
@@ -398,23 +398,23 @@ func CalculateHTTPRouteMatchPriorityTraits(match SplitHTTPRouteMatch) HTTPRouteP
 // relative order: relative order of creation timestamp, namespace and name and internal rule/match order between different (split) HTTPRoutes.
 func (t HTTPRoutePriorityTraits) EncodeToPriority() RoutePriorityType {
 	const (
-		// PreciseHostnameShiftBits assigns bit 49 for marking if the hostname is non-wildcard.
-		PreciseHostnameShiftBits = 49
-		// HostnameLengthShiftBits assigns bits 41-48 for the length of hostname.
-		HostnameLengthShiftBits = 41
-		// ExactPathShiftBits assigns bit 40 to mark if the match is exact path match.
-		ExactPathShiftBits = 40
-		// RegularExpressionPathShiftBits assigns bit 39 to mark if the match is regex path match.
-		RegularExpressionPathShiftBits = 39
-		// PathLengthShiftBits assigns bits 29-38 to path length. (max length = 1024, but must start with /)
-		PathLengthShiftBits = 29
-		// MethodMatchShiftBits assigns bit 28 to mark if method is specified.
-		MethodMatchShiftBits = 28
-		// HeaderNumberShiftBits assign bits 23-27 to number of headers. (max number of headers = 16)
-		HeaderNumberShiftBits = 23
-		// QueryParamNumberShiftBits makes bits 18-22 used for number of query params (max number of query params = 16)
-		QueryParamNumberShiftBits = 18
-		// bits 0-17 are used for relative order of creation timestamp, namespace/name, and internal order of rules and matches.
+		// PreciseHostnameShiftBits assigns bit 43 for marking if the hostname is non-wildcard.
+		PreciseHostnameShiftBits = 43
+		// HostnameLengthShiftBits assigns bits 35-42 for the length of hostname.
+		HostnameLengthShiftBits = 35
+		// ExactPathShiftBits assigns bit 34 to mark if the match is exact path match.
+		ExactPathShiftBits = 34
+		// RegularExpressionPathShiftBits assigns bit 33 to mark if the match is regex path match.
+		RegularExpressionPathShiftBits = 33
+		// PathLengthShiftBits assigns bits 23-32 to path length. (max length = 1024, but must start with /)
+		PathLengthShiftBits = 23
+		// MethodMatchShiftBits assigns bit 22 to mark if method is specified.
+		MethodMatchShiftBits = 22
+		// HeaderNumberShiftBits assign bits 17-21 to number of headers. (max number of headers = 16)
+		HeaderNumberShiftBits = 17
+		// QueryParamNumberShiftBits makes bits 12-16 used for number of query params (max number of query params = 16)
+		QueryParamNumberShiftBits = 12
+		// bits 0-11 are used for relative order of creation timestamp, namespace/name, and internal order of rules and matches.
 		// the bits are calculated by sorting HTTPRoutes with the same priority calculated from the fields above
 		// and start from all 1s, then decrease by one for each HTTPRoute.
 	)
@@ -467,11 +467,11 @@ func AssignRoutePriorityToSplitHTTPRouteMatches(
 
 	httpRouteMatchesToPriorities := make([]SplitHTTPRouteMatchToKongRoutePriority, 0, len(splitHTTPRouteMatches))
 
-	// Bits 0-17 (18 bits) are assigned for relative order of matches.
+	// Bits 0-11 (12 bits) are assigned for relative order of matches.
 	// If multiple matches are assigned to the same priority in the previous step,
-	// sort them then starts with 2^18 -1 and decrease by one for each HTTPRoute;
+	// sort them then starts with 2^12 -1 and decrease by one for each HTTPRoute;
 	// If only one match occupies the priority, fill the relative order bits with all 1s.
-	const RelativeOrderAssignedBits = 18
+	const RelativeOrderAssignedBits = 12
 	const defaultRelativeOrderPriorityBits = (uint64(1) << RelativeOrderAssignedBits) - 1
 	for priority, matches := range priorityToSplitHTTPRouteMatches {
 		if len(matches) == 1 {
@@ -488,7 +488,7 @@ func AssignRoutePriorityToSplitHTTPRouteMatches(
 
 		for i, match := range matches {
 			relativeOrderBits := defaultRelativeOrderPriorityBits - RoutePriorityType(i)
-			// Although it is very unlikely that there are 2^18 = 262144 HTTPRoutes
+			// Although it is very unlikely that there are 2^12 = 4096 HTTPRoutes
 			// should be given priority by their relative order, here we limit the
 			// relativeOrderBits to be at least 0.
 			if relativeOrderBits <= 0 {
@@ -499,9 +499,9 @@ func AssignRoutePriorityToSplitHTTPRouteMatches(
 				Priority: priority + relativeOrderBits,
 			})
 		}
-		// Just in case, log a very unlikely scenario where we have more than 2^18 matches with the same base
+		// Just in case, log a very unlikely scenario where we have more than 2^12 matches with the same base
 		// priority and we have no bit space for them to be deterministically ordered.
-		if len(matches) > (1 << 18) {
+		if len(matches) > (1 << 12) {
 			logger.Error(nil, "Too many HTTPRoute matches to be deterministically ordered", "match_number", len(matches))
 		}
 	}

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -483,7 +483,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathType:        gatewayapi.PathMatchExact,
 				PathLength:      4,
 			},
-			expectedPriority: (2 << 50) | (1 << 49) | (7 << 41) | (1 << 40) | (3 << 29),
+			expectedPriority: (2 << 44) | (1 << 43) | (7 << 35) | (1 << 34) | (3 << 23),
 		},
 		{
 			name: "wildcard hostname and prefix path",
@@ -493,7 +493,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathType:        gatewayapi.PathMatchPathPrefix,
 				PathLength:      5,
 			},
-			expectedPriority: (2 << 50) | (7 << 41) | (4 << 29),
+			expectedPriority: (2 << 44) | (7 << 35) | (4 << 23),
 		},
 		{
 			name: "no hostname and regex path, with header matches",
@@ -502,7 +502,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathLength:  5,
 				HeaderCount: 2,
 			},
-			expectedPriority: (2 << 50) | (1 << 39) | (4 << 29) | (2 << 23),
+			expectedPriority: (2 << 44) | (1 << 33) | (4 << 23) | (2 << 17),
 		},
 		{
 			name: "no hostname and exact path, with method match and query parameter matches",
@@ -512,7 +512,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				HasMethodMatch:  true,
 				QueryParamCount: 1,
 			},
-			expectedPriority: (2 << 50) | (1 << 40) | (4 << 29) | (1 << 28) | (1 << 18),
+			expectedPriority: (2 << 44) | (1 << 34) | (4 << 23) | (1 << 22) | (1 << 12),
 		},
 	}
 
@@ -733,7 +733,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 		matchIndex int
 	}
 	now := time.Now()
-	const maxRelativeOrderPriorityBits = (1 << 18) - 1
+	const maxRelativeOrderPriorityBits = (1 << 12) - 1
 
 	testCases := []struct {
 		name    string

--- a/internal/dataplane/parser/translators/ingress_atc_test.go
+++ b/internal/dataplane/parser/translators/ingress_atc_test.go
@@ -430,7 +430,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  false,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (1 << 32) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (1 << 32) | 5,
 		},
 		{
 			name: "plain host false regex path true",
@@ -441,7 +441,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  true,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (2 << 33) | (1 << 16) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (2 << 33) | (1 << 16) | 5,
 		},
 		{
 			name: "header number exceed limit",
@@ -452,7 +452,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  true,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (255 << 33) | (1 << 16) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (255 << 33) | (1 << 16) | 5,
 		},
 		{
 			name: "path length exceed limit",
@@ -461,7 +461,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				PlainHostOnly: true,
 				MaxPathLength: 100000,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (1 << 32) | 65535,
+			expectedPriority: (3 << 44) | (2 << 41) | (1 << 32) | 65535,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Use only 46 bits in calculated `priority` of generated Kong routes when expression router is enabled. This prevent Kong gateway to decode it to scientific notation that will cause precision loss in dumping and comparing the configurations.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5009 and also #4990.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

Review on changelog: should this change be notated as a `Breaking change`?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
