### PR TITLE
fix: use debug level for readiness checks logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,9 @@ Adding a new version? You'll need three changes:
   deterministically sorted by their creation timestamps, names and internal
   rule orders to `2^12=4096` and number of `GRPCRoutes` can be sorted to `2^8=256`.
   [#5024](https://github.com/Kong/kubernetes-ingress-controller/pull/5024)
+- Error logs emitted from Gateway Discovery readiness checker that should be
+  logged at `debug` level are now logged at that level.
+  [#5029](https://github.com/Kong/kubernetes-ingress-controller/pull/5029)
 
 ### Changed
 

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -105,7 +105,10 @@ func (c DefaultReadinessChecker) checkPendingClient(
 	client, err := c.factory.CreateAdminAPIClient(ctx, pendingClient)
 	if err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.
-		c.logger.V(util.DebugLevel).Info(fmt.Sprintf("pending client for %q is not ready yet", pendingClient.Address), "reason", err.Error())
+		c.logger.V(util.DebugLevel).Info("pending client is not ready yet",
+			"reason", err.Error(),
+			"address", pendingClient.Address,
+		)
 		return nil
 	}
 
@@ -123,7 +126,8 @@ func (c DefaultReadinessChecker) checkAlreadyExistingClients(ctx context.Context
 				// This should never happen, but if it does, we want to log it.
 				c.logger.Error(
 					errors.New("missing pod reference"),
-					fmt.Sprintf("failed to get PodReference for client %q", client.BaseRootURL()),
+					"failed to get PodReference for client",
+					"address", client.BaseRootURL(),
 				)
 				continue
 			}
@@ -149,7 +153,8 @@ func (c DefaultReadinessChecker) checkAlreadyCreatedClient(ctx context.Context, 
 	if err := client.IsReady(ctx); err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.
 		c.logger.V(util.DebugLevel).Info(
-			fmt.Sprintf("already created client for %q is not ready, moving to pending", client.BaseRootURL()),
+			"already created client is not ready, moving to pending",
+			"address", client.BaseRootURL(),
 			"reason", err.Error(),
 		)
 		return false

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -105,7 +105,7 @@ func (c DefaultReadinessChecker) checkPendingClient(
 	client, err := c.factory.CreateAdminAPIClient(ctx, pendingClient)
 	if err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.
-		c.logger.V(util.DebugLevel).Error(err, fmt.Sprintf("pending client for %q is not ready yet", pendingClient.Address))
+		c.logger.V(util.DebugLevel).Info(fmt.Sprintf("pending client for %q is not ready yet", pendingClient.Address), "reason", err.Error())
 		return nil
 	}
 
@@ -148,9 +148,9 @@ func (c DefaultReadinessChecker) checkAlreadyCreatedClient(ctx context.Context, 
 	defer cancel()
 	if err := client.IsReady(ctx); err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.
-		c.logger.V(util.DebugLevel).Error(
-			err,
+		c.logger.V(util.DebugLevel).Info(
 			fmt.Sprintf("already created client for %q is not ready, moving to pending", client.BaseRootURL()),
+			"reason", err.Error(),
 		)
 		return false
 	}

--- a/internal/dataplane/sendconfig/backoff_strategy.go
+++ b/internal/dataplane/sendconfig/backoff_strategy.go
@@ -58,7 +58,7 @@ func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent Con
 
 	err, resourceErrors, resourceErrorsParseErr = s.decorated.Update(ctx, targetContent)
 	if err != nil {
-		s.logger.V(util.DebugLevel).Error(err, "Update failed, registering it for backoff strategy")
+		s.logger.V(util.DebugLevel).Info("Update failed, registering it for backoff strategy", "reason", err.Error())
 		s.backoffStrategy.RegisterUpdateFailure(err, targetContent.Hash)
 	} else {
 		s.backoffStrategy.RegisterUpdateSuccess()


### PR DESCRIPTION
**What this PR does / why we need it**:

It turns out `s.logger.V(util.DebugLevel).Error(err, "...")` doesn't result in a log message with a debug, but an error level. The PR fixes logs that were intended to use debug-level with the error as a log field.

**Which issue this PR fixes**:

Customer reported 

```
{"error":"making HTTP request: Get \"https://172.17.1.180:8444/status\": context deadline exceeded","level":"error","logger":"setup.readiness-checker","msg":"already created client for \"https://172.17.1.180:8444/\" is not ready, moving to pending","time":"2023-10-31T09:52:17Z"}
```

kind of logs presence repeating quite often. Error logs should not be used for that kind of message as they're signaling expected situations that users should not be worried about.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
