### PR TITLE
chore: remove unused KongClient's ingressClass field

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -63,11 +63,6 @@ type KongConfigBuilder interface {
 type KongClient struct {
 	logger logr.Logger
 
-	// ingressClass indicates the Kubernetes ingress class that should be
-	// used to qualify support for any given Kubernetes object to be parsed
-	// into data-plane configuration.
-	ingressClass string
-
 	// requestTimeout is the maximum amount of time that should be waited for
 	// requests to the data-plane to receive a response.
 	requestTimeout time.Duration
@@ -152,7 +147,6 @@ type KongClient struct {
 func NewKongClient(
 	logger logr.Logger,
 	timeout time.Duration,
-	ingressClass string,
 	diagnostic util.ConfigDumpDiagnostic,
 	kongConfig sendconfig.Config,
 	eventRecorder record.EventRecorder,
@@ -166,7 +160,6 @@ func NewKongClient(
 ) (*KongClient, error) {
 	c := &KongClient{
 		logger:                 logger,
-		ingressClass:           ingressClass,
 		requestTimeout:         timeout,
 		diagnostic:             diagnostic,
 		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -667,7 +667,6 @@ func setupTestKongClient(
 ) *KongClient {
 	logger := zapr.NewLogger(zap.NewNop())
 	timeout := time.Second
-	ingressClass := "kong"
 	diagnostic := util.ConfigDumpDiagnostic{}
 	config := sendconfig.Config{}
 	dbMode := "off"
@@ -679,7 +678,6 @@ func setupTestKongClient(
 	kongClient, err := NewKongClient(
 		logger,
 		timeout,
-		ingressClass,
 		diagnostic,
 		config,
 		eventRecorder,

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -190,7 +190,6 @@ func Run(
 	dataplaneClient, err := dataplane.NewKongClient(
 		logger,
 		time.Duration(c.ProxyTimeoutSeconds*float32(time.Second)),
-		c.IngressClassName,
 		diagnostic,
 		kongConfig,
 		eventRecorder,


### PR DESCRIPTION
**What this PR does / why we need it**:

Seems that this is unused to remove it.