### PR TITLE
feat: don't configure Kong Gateways with incompatible router flavor

### DIFF
--- a/internal/dataplane/configuration/router_flavor.go
+++ b/internal/dataplane/configuration/router_flavor.go
@@ -1,0 +1,15 @@
+package configuration
+
+// RouterFlavor is the type for Kong Gateway router flavors.
+// Ref: https://docs.konghq.com/kubernetes-ingress-controller/latest/references/supported-router-flavors
+type RouterFlavor string
+
+const (
+	// RouterFlavorTraditional is one of Kong Gateway router flavors.
+	RouterFlavorTraditional RouterFlavor = "traditional"
+	// RouterFlavorTraditionalCompatible is one of Kong Gateway router flavors.
+	RouterFlavorTraditionalCompatible RouterFlavor = "traditional_compatible"
+	// RouterFlavorExpressions is one of Kong Gateway router flavors.
+	// Ref: https://docs.konghq.com/gateway/latest/reference/router-expressions-language/
+	RouterFlavorExpressions RouterFlavor = "expressions"
+)

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
@@ -36,10 +37,6 @@ import (
 
 const (
 	KindGateway = gatewayapi.Kind("Gateway")
-
-	// kongRouterFlavorExpressions is the value used in router_flavor of kong configuration
-	// to enable expression based router of kong.
-	kongRouterFlavorExpressions = "expressions"
 )
 
 // -----------------------------------------------------------------------------
@@ -67,7 +64,7 @@ type FeatureFlags struct {
 func NewFeatureFlags(
 	logger logr.Logger,
 	featureGates featuregates.FeatureGates,
-	routerFlavor string,
+	routerFlavor configuration.RouterFlavor,
 	updateStatusFlag bool,
 ) FeatureFlags {
 	return FeatureFlags{
@@ -80,9 +77,9 @@ func NewFeatureFlags(
 
 func shouldEnableParserExpressionRoutes(
 	logger logr.Logger,
-	routerFlavor string,
+	routerFlavor configuration.RouterFlavor,
 ) bool {
-	if routerFlavor != kongRouterFlavorExpressions {
+	if routerFlavor != configuration.RouterFlavorExpressions {
 		logger.V(util.InfoLevel).Info("Gateway is running with non-expression router flavor", "flavor", routerFlavor)
 		return false
 	}

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
@@ -4505,7 +4506,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		name string
 
 		featureGates     map[string]bool
-		routerFlavor     string
+		routerFlavor     configuration.RouterFlavor
 		updateStatusFlag bool
 
 		expectedFeatureFlags FeatureFlags
@@ -4514,7 +4515,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		{
 			name:             "default",
 			featureGates:     map[string]bool{},
-			routerFlavor:     "traditional",
+			routerFlavor:     configuration.RouterFlavorTraditional,
 			updateStatusFlag: true,
 			expectedFeatureFlags: FeatureFlags{
 				ReportConfiguredKubernetesObjects: true,
@@ -4522,7 +4523,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		},
 		{
 			name:         "expression routes feature gate enabled and router flavor matches",
-			routerFlavor: kongRouterFlavorExpressions,
+			routerFlavor: configuration.RouterFlavorExpressions,
 			expectedFeatureFlags: FeatureFlags{
 				ExpressionRoutes: true,
 			},

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
+	"github.com/samber/mo"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -148,6 +149,9 @@ func Run(
 		logger,
 		initialKongClients,
 		readinessChecker,
+		clients.WithClientRequirements(clients.ClientRequirements{
+			RouterFlavor: mo.Some(routerFlavor),
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create AdminAPIClientsManager: %w", err)

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -14,13 +14,14 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 )
 
 // KongStartUpOptions includes start up configurations of Kong that could change behavior of Kong Ingress Controller.
 // The fields are extracted from results of Kong gateway configuration root.
 type KongStartUpOptions struct {
 	DBMode       string
-	RouterFlavor string
+	RouterFlavor configuration.RouterFlavor
 	Version      kong.Version
 }
 
@@ -94,7 +95,7 @@ func DBModeFromRoot(r Root) (string, error) {
 	return dbModeStr, nil
 }
 
-func RouterFlavorFromRoot(r Root) (string, error) {
+func RouterFlavorFromRoot(r Root) (configuration.RouterFlavor, error) {
 	rootConfig, err := extractConfigurationFromRoot(r)
 	if err != nil {
 		return "", err
@@ -109,7 +110,7 @@ func RouterFlavorFromRoot(r Root) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("invalid %q type, expected a string, got %T", routerFlavorKey, routerFlavor)
 	}
-	return routerFlavorStr, nil
+	return configuration.RouterFlavor(routerFlavorStr), nil
 }
 
 func KongVersionFromRoot(r Root) (kong.Version, error) {

--- a/internal/manager/utils/kongconfig/root_test.go
+++ b/internal/manager/utils/kongconfig/root_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
@@ -22,14 +23,14 @@ func TestValidateRoots(t *testing.T) {
 		name                 string
 		configStr            string
 		expectedDBMode       string
-		expectedRouterFlavor string
+		expectedRouterFlavor configuration.RouterFlavor
 		expectedKongVersion  string
 	}{
 		{
 			name:                 "dbless config with version 3.4.1",
 			configStr:            dblessConfigJSON3_4_1,
 			expectedDBMode:       "off",
-			expectedRouterFlavor: "traditional_compatible",
+			expectedRouterFlavor: configuration.RouterFlavorTraditionalCompatible,
 			expectedKongVersion:  versions.KICv3VersionCutoff.String(),
 		},
 	}

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
@@ -101,12 +102,12 @@ func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) string {
 	return dbmode
 }
 
-func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) string {
+func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) configuration.RouterFlavor {
 	t.Helper()
 
 	var (
 		err          error
-		routerFlavor string
+		routerFlavor configuration.RouterFlavor
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
@@ -86,7 +87,7 @@ func GetKongDBMode(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword
 }
 
 // GetKongRouterFlavor gets router flavor of Kong using the provided Admin API URL.
-func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (string, error) {
+func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (configuration.RouterFlavor, error) {
 	jsonResp, err := GetKongRootConfig(ctx, proxyAdminURL, kongTestPassword)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What this PR does / why we need it**:

Warn users in logs when Kong Gateway with incompatible router is detected and reject the client for that Gateway when sending out the configuration.

**Which issue this PR fixes**:

Related: #5018 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
