### PR TITLE
chore: bump GWAPI to 1.0, fix target test.conformance-experimental

### DIFF
--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -10,8 +10,26 @@ on:
         default: main
 
 jobs:
+  dependencies-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.inputs.tag }}
+
+      - id: set-versions
+        name: Set versions
+        run: |
+          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+
   generate-report:
     runs-on: ubuntu-latest
+    needs: dependencies-versions
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
@@ -26,13 +44,16 @@ jobs:
           go-version-file: go.mod
 
       - name: Run conformance experimental tests
+        env:
+          TEST_KONG_HELM_CHART_VERSION: ${{ needs.dependencies-versions.outputs.helm-kong }}
         run: make test.conformance-experimental
 
       # Generated report should be submitted to
       # https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports
       # in future when experimental becomes stable autamate creating PR (add to release workflow).
+      # See: https://github.com/Kong/kubernetes-ingress-controller/issues/4654
       - name: Collect conformance tests report
         uses: actions/upload-artifact@v3
         with:
           name: kong-kubernetes-ingress-controller.yaml
-          path: conformance-tests-report.yaml
+          path: kong-kubernetes-ingress-controller.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,9 @@ e2e-tests
 *.out
 *.out.*
 
-# for this repo only
+# For this repo only
 kong-ingress-controller
-conformance-tests-report.yaml
+kong-kubernetes-ingress-controller.yaml
 
 # ignore vendor tree
 vendor

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ test.all: test.unit test.envtest test.integration test.conformance
 .PHONY: test.conformance
 test.conformance: _check.container.environment go-junit-report
 	@TEST_DATABASE_MODE="off" \
+		TEST_KONG_HELM_CHART_VERSION="$(TEST_KONG_HELM_CHART_VERSION)" \
 		GOFLAGS="-tags=conformance_tests" \
 		go test \
 		-v \
@@ -327,6 +328,7 @@ test.conformance: _check.container.environment go-junit-report
 .PHONY: test.conformance-experimental
 test.conformance-experimental: _check.container.environment go-junit-report
 	@TEST_DATABASE_MODE="off" \
+		TEST_KONG_HELM_CHART_VERSION="$(TEST_KONG_HELM_CHART_VERSION)" \
 		GOFLAGS="-tags=conformance_tests" \
 		KONG_TEST_EXPRESSION_ROUTES="true" \
 		TEST_EXPERIMENTAL_CONFORMANCE="true" \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codecov](https://codecov.io/gh/Kong/kubernetes-ingress-controller/branch/main/graph/badge.svg?token=S1aqcXiGEo)](https://codecov.io/gh/Kong/kubernetes-ingress-controller)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v0.8.1-Kong%20Ingress%20Controller%202.12-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.8.1/kong-kubernetes-ingress-controller.yaml)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.0.0-Kong%20Ingress%20Controller%203.0-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller.yaml)
 
 # Kong Ingress Controller for Kubernetes (KIC)
 
@@ -17,7 +17,7 @@ Custom Resource Definitions (CRDs) and Kubernetes-native tooling.
 
 ## Features
 
-- **Gateway API support (beta, soon GA)**
+- **Gateway API support**
   Use [Gateway API][gwapi] resources (official successor of [Ingress][ingress] resources) to configure Kong.
   Native support for TCP, UDP, TLS, gRPC and HTTP/HTTPS traffic, reuse the same gateway for multiple protocols and namespaces.
 - **Ingress support**
@@ -43,7 +43,7 @@ Setting up Kong for Kubernetes is as simple as:
 
 ```shell
 # Install the Gateway API CRDs before installing Kong Ingress Controller.
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0-rc2/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
 # Install the Kong Ingress Controller with Helm.
 helm install kong --namespace kong --create-namespace --repo https://charts.konghq.com ingress
 ```

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	k8s.io/client-go v0.28.3
 	k8s.io/component-base v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
-	sigs.k8s.io/gateway-api v1.0.0-rc2
+	sigs.k8s.io/gateway-api v1.0.0
 	sigs.k8s.io/kustomize/api v0.15.0
 	sigs.k8s.io/kustomize/kyaml v0.15.0
 	sigs.k8s.io/yaml v1.4.0
@@ -219,5 +219,3 @@ require (
 	sigs.k8s.io/kind v0.20.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 )
-
-replace sigs.k8s.io/gateway-api v1.0.0-rc2 => sigs.k8s.io/gateway-api v1.0.0-rc2.0.20231030133349-8f1b718543ca

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSn
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
-sigs.k8s.io/gateway-api v1.0.0-rc2.0.20231030133349-8f1b718543ca h1:mDbkOf1Dr1cyEmhq+sotpsW/7RSkZ336hNrw80KFS7U=
-sigs.k8s.io/gateway-api v1.0.0-rc2.0.20231030133349-8f1b718543ca/go.mod h1:4cUgr0Lnp5FZ0Cdq8FdRwCvpiWws7LVhLHGIudLlf4c=
+sigs.k8s.io/gateway-api v1.0.0 h1:iPTStSv41+d9p0xFydll6d7f7MOBGuqXM6p2/zVYMAs=
+sigs.k8s.io/gateway-api v1.0.0/go.mod h1:4cUgr0Lnp5FZ0Cdq8FdRwCvpiWws7LVhLHGIudLlf4c=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=

--- a/test/conformance/gateway_expermimental_conformance_test.go
+++ b/test/conformance/gateway_expermimental_conformance_test.go
@@ -63,6 +63,9 @@ func TestGatewayExperimentalConformance(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("starting the gateway conformance test suite")
 	cSuite.Setup(t)
+
+	go patchGatewayClassToPassTestGatewayClassObservedGenerationBump(ctx, t, client)
+
 	// To work with individual tests only, you can disable the normal Run call and construct a slice containing a
 	// single test only, e.g.:
 	//

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -4,8 +4,8 @@
 package consts
 
 const (
-	GatewayAPIVersion                   = "v1.0.0-rc2"
-	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.0.0-rc2"
-	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0-rc2"
-	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0-rc2"
+	GatewayAPIVersion                   = "v1.0.0"
+	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.0.0"
+	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0"
+	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Bump gateway-api to the release 1.0.0 and all related stuff
- gateway-api bump
- fix `Makefile` targets `test.conformance` and `test.conformance-experimental` (for now maintain both, because experimental doesn't become the default one with the release of GWAPI 1.0.0)
- reuse hack for passing test `GatewayClassObservedGenerationBump` for experimental-conformance
- adjust versions in README.md (for now link to the conformance report is broken until submitting it to GWAPI repo)
- reflect in `.gitignore` changing the generated report name (introduced in https://github.com/Kong/kubernetes-ingress-controller/pull/4726)

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4998
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

In issue https://github.com/Kong/kubernetes-ingress-controller/issues/4998 acceptance criteria mention submitting the report, but generating and submitting the report is a part of the release process, it is documented in. It should be done on the tag `v3.0.0` to use the same code as for release artifacts. Thus here I only fixed tests, and pipeline and tried whether it works see the [CI run](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6710727460)
