### PR TITLE
fix: remove HTTP ports from discovery config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,12 @@ Adding a new version? You'll need three changes:
 - Count `HTTPRoute` to gateway's number of attached route if the gateway is
   present in its `status.parents`, even if the gateway has unresolved refs.
   [#4987](https://github.com/Kong/kubernetes-ingress-controller/pull/4987)
+- The default value for `--kong-admin-svc-port-names` is now `"admin-tls,kong-admin-tls"`
+  instead of `"admin,admin-tls,kong-admin,kong-admin-tls"`. HTTP port names
+  have been removed as discovery does not support plaintext HTTP connections.
+  Instances configured with both HTTP and HTTPS admin ports resulted in
+  discovery unsuccessfully trying to use HTTPS to talk to HTTP ports.
+  [#5043](https://github.com/Kong/kubernetes-ingress-controller/pull/5043)
 
 ### Added
 

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -46,7 +46,7 @@
 | `--kong-admin-init-retries` | `uint` | Number of attempts that will be made initially on controller startup to connect to the Kong Admin API. | `60` |
 | `--kong-admin-init-retry-delay` | `duration` | The time delay between every attempt (on controller startup) to connect to the Kong Admin API. | `1s` |
 | `--kong-admin-svc` | `namespaced-name` | Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery. |  |
-| `--kong-admin-svc-port-names` | `strings` | Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery. | `[admin,admin-tls,kong-admin,kong-admin-tls]` |
+| `--kong-admin-svc-port-names` | `strings` | Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery. | `[admin-tls,kong-admin-tls]` |
 | `--kong-admin-tls-client-cert` | `string` | Mutual TLS (mTLS) client certificate for authentication. Mutually exclusive with --kong-admin-tls-client-cert-file. |  |
 | `--kong-admin-tls-client-cert-file` | `string` | Mutual TLS (mTLS) client certificate file for authentication. Mutually exclusive with --kong-admin-tls-client-cert. |  |
 | `--kong-admin-tls-client-key` | `string` | Mutual TLS (mTLS) client key for authentication. Mutually exclusive with --kong-admin-tls-client-key-file. |  |

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -183,7 +183,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		`Kong Admin URL(s) in comma-separated format (or specify this flag multiple times) to connect to in the format "protocol://address:port".`)
 	flagSet.Var(flags.NewValidatedValue(&c.KongAdminSvc, namespacedNameFromFlagValue, nnTypeNameOverride), "kong-admin-svc",
 		`Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery.`)
-	flagSet.StringSliceVar(&c.KongAdminSvcPortNames, "kong-admin-svc-port-names", []string{"admin", "admin-tls", "kong-admin", "kong-admin-tls"},
+	flagSet.StringSliceVar(&c.KongAdminSvcPortNames, "kong-admin-svc-port-names", []string{"admin-tls", "kong-admin-tls"},
 		"Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery.")
 	flagSet.Var(flags.NewValidatedValue(&c.GatewayDiscoveryDNSStrategy, dnsStrategyFromFlagValue, flags.WithDefault(cfgtypes.IPDNSStrategy), flags.WithTypeNameOverride[cfgtypes.DNSStrategy]("dns-strategy")),
 		"gateway-discovery-dns-strategy", "DNS strategy to use when creating Gateway's Admin API addresses. One of: ip, service, pod.")


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the HTTP port names from the default list of accepted Service ports for discovery. 

**Which issue this PR fixes**:

Discovery is [hard-coded to support HTTPS only](https://github.com/Kong/kubernetes-ingress-controller/blob/513db87cbf94ce66207f74365b502e8cde841357/internal/adminapi/endpoints.go#L186), and would unsuccessfully attempt to use HTTP ports when available. The client generator code [builds clients for all admissable port names](https://github.com/Kong/kubernetes-ingress-controller/blob/c102cea90961347259846b134c958a4f155b2af3/internal/adminapi/endpoints.go#L101-L151) and has no filters by protocol.

In DB mode this could prevent the controller from talking to Kong at all if it chose an HTTP port from the list, as it only selects a single client from the list (at least as of the current draft in https://github.com/Kong/kubernetes-ingress-controller/pull/4828).

**Special notes for your reviewer**:

AFAIK there should not be any reason to add HTTP support for discovery. I had only been using it to simplify manual requests in a debugging session.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
