### PR TITLE
chore: remove temp go-get-gatewayapi and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,10 +174,11 @@ Adding a new version? You'll need three changes:
 - Docker images now use UID and GID 1000 to match Kong images. This should have
   no user-facing effect.
   [#4911](https://github.com/Kong/kubernetes-ingress-controller/pull/4911)
-- Bump version of gateway API to `1.0.0-rc2` and support `Gateway`, `GatewayClass`
+- Bump version of gateway API to `1.0.0` and support `Gateway`, `GatewayClass`
   and `HTTPRoute` in API version `gateway.networking.k8s.io/v1`.
   [#4893](https://github.com/Kong/kubernetes-ingress-controller/pull/4893)
   [#4981](https://github.com/Kong/kubernetes-ingress-controller/pull/4981)
+  [#5041](https://github.com/Kong/kubernetes-ingress-controller/pull/5041)
 - Update `Gateway`s, `GatewayClass`es and `HTTPRoute`s in examples to API
   version `gateway.networking.k8s.io/v1`.
   [#4935](https://github.com/Kong/kubernetes-ingress-controller/pull/4935)

--- a/Makefile
+++ b/Makefile
@@ -382,14 +382,9 @@ use-setup-envtest:
 
 ENVTEST_TIMEOUT ?= 5m
 
-# TODO: remove when Gateway API v1 gets released and updated in go.mod
-.PHONY: go-get-gateway-api
-go-get-gateway-api:
-	go mod download -x $(GATEWAY_API_PACKAGE)@v1.0.0-rc2
-
 .PHONY: _test.envtest
 .ONESHELL: _test.envtest
-_test.envtest: gotestsum setup-envtest use-setup-envtest go-get-gateway-api
+_test.envtest: gotestsum setup-envtest use-setup-envtest
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) -- \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
- remove the temporary `go-get-gatewayapi` in `Makefile`
- Add changelog entry for bumping gateway api to 1.0.0

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
