### PR TITLE
fix: log KongIngress deprecation errors only when needed

### DIFF
--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -491,11 +491,11 @@ func (ks *KongState) FillIDs(logger logr.Logger) {
 // is annotated with `konghq.com/override` annotation.
 func maybeLogKongIngressDeprecationError(logger logr.Logger, services []*corev1.Service) {
 	for _, svc := range services {
-		_, kongUpstreamPolicyAnnotated := annotations.ExtractUpstreamPolicy(svc.Annotations)
-		kongIngressAnnotated := annotations.ExtractConfigurationName(svc.Annotations) != ""
+		_, upstreamPolicyAnnotationSet := annotations.ExtractUpstreamPolicy(svc.Annotations)
+		kongOverrideAnnotationSet := annotations.ExtractConfigurationName(svc.Annotations) != ""
 
 		// If both `konghq.com/override` and `konghq.com/upstream-policy` are set, we should log a more specific error.
-		if kongIngressAnnotated && kongUpstreamPolicyAnnotated {
+		if kongOverrideAnnotationSet && upstreamPolicyAnnotationSet {
 			logger.Error(nil, fmt.Sprintf("Service uses both %s and %s annotations, should use only %s annotation. Settings "+
 				"from %s will take precedence",
 				annotations.AnnotationPrefix+annotations.ConfigurationKey,
@@ -507,7 +507,7 @@ func maybeLogKongIngressDeprecationError(logger logr.Logger, services []*corev1.
 		}
 
 		// In case it's just `konghq.com/override` set, we should log a deprecation error.
-		if kongIngressAnnotated {
+		if kongOverrideAnnotationSet {
 			logger.Error(nil, fmt.Sprintf(
 				"Service uses deprecated %s annotation and KongIngress, migrate to %s and KongUpstreamPolicy",
 				annotations.AnnotationPrefix+annotations.ConfigurationKey,

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -216,39 +216,23 @@ func (ks *KongState) FillUpstreamOverrides(
 		servicesGroup := lo.Values(ks.Upstreams[i].Service.K8sServices)
 		servicesAsObjects := func(svc *corev1.Service, _ int) client.Object { return svc }
 
+		// In case `konghq.com/override` annotation is set on any of the services, we should log a deprecation error.
+		maybeLogKongIngressDeprecationError(logger, servicesGroup)
+
 		kongIngress, err := getKongIngressForServices(s, servicesGroup)
 		if err != nil {
 			failuresCollector.PushResourceFailure(err.Error(), lo.Map(servicesGroup, servicesAsObjects)...)
 		} else {
-			for _, svc := range ks.Upstreams[i].Service.K8sServices {
+			for _, svc := range servicesGroup {
 				ks.Upstreams[i].override(kongIngress, svc)
-				logger.Error(nil, fmt.Sprintf(
-					"Service uses deprecated %s annotation and KongIngress, migrate to %s and KongUpstreamPolicy",
-					annotations.AnnotationPrefix+annotations.ConfigurationKey,
-					kongv1beta1.KongUpstreamPolicyAnnotationKey),
-					"namespace", svc.Namespace, "name", svc.Name)
 			}
 		}
 
 		kongUpstreamPolicy, err := GetKongUpstreamPolicyForServices(s, servicesGroup)
 		if err != nil {
 			failuresCollector.PushResourceFailure(err.Error(), lo.Map(servicesGroup, servicesAsObjects)...)
-		} else {
-			if kongUpstreamPolicy != nil {
-				if kongIngress != nil {
-					for _, svc := range servicesGroup {
-						logger.Error(nil,
-							fmt.Sprintf("Service uses both %s and %s annotations, should use only %s annotation. Settings "+
-								"from %s will take precedence",
-								annotations.AnnotationPrefix+annotations.ConfigurationKey,
-								kongv1beta1.KongUpstreamPolicyAnnotationKey,
-								kongv1beta1.KongUpstreamPolicyAnnotationKey,
-								kongv1beta1.KongUpstreamPolicyAnnotationKey),
-							"namespace", svc.Namespace, "name", svc.Name)
-					}
-				}
-				ks.Upstreams[i].overrideByKongUpstreamPolicy(kongUpstreamPolicy)
-			}
+		} else if kongUpstreamPolicy != nil {
+			ks.Upstreams[i].overrideByKongUpstreamPolicy(kongUpstreamPolicy)
 		}
 	}
 }
@@ -499,6 +483,37 @@ func (ks *KongState) FillIDs(logger logr.Logger) {
 			logger.Error(err, "failed to fill ID for consumer group", "consumer_group_name", *consumerGroup.Name)
 		} else {
 			ks.ConsumerGroups[consumerGroupIndex] = consumerGroup
+		}
+	}
+}
+
+// maybeLogKongIngressDeprecationError iterates over services and logs a deprecation error if a service
+// is annotated with `konghq.com/override` annotation.
+func maybeLogKongIngressDeprecationError(logger logr.Logger, services []*corev1.Service) {
+	for _, svc := range services {
+		_, kongUpstreamPolicyAnnotated := annotations.ExtractUpstreamPolicy(svc.Annotations)
+		kongIngressAnnotated := annotations.ExtractConfigurationName(svc.Annotations) != ""
+
+		// If both `konghq.com/override` and `konghq.com/upstream-policy` are set, we should log a more specific error.
+		if kongIngressAnnotated && kongUpstreamPolicyAnnotated {
+			logger.Error(nil, fmt.Sprintf("Service uses both %s and %s annotations, should use only %s annotation. Settings "+
+				"from %s will take precedence",
+				annotations.AnnotationPrefix+annotations.ConfigurationKey,
+				kongv1beta1.KongUpstreamPolicyAnnotationKey,
+				kongv1beta1.KongUpstreamPolicyAnnotationKey,
+				kongv1beta1.KongUpstreamPolicyAnnotationKey),
+				"namespace", svc.Namespace, "name", svc.Name,
+			)
+		}
+
+		// In case it's just `konghq.com/override` set, we should log a deprecation error.
+		if kongIngressAnnotated {
+			logger.Error(nil, fmt.Sprintf(
+				"Service uses deprecated %s annotation and KongIngress, migrate to %s and KongUpstreamPolicy",
+				annotations.AnnotationPrefix+annotations.ConfigurationKey,
+				kongv1beta1.KongUpstreamPolicyAnnotationKey),
+				"namespace", svc.Namespace, "name", svc.Name,
+			)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It will make sure that a log entry is emitted for every Service that's annotated with deprecated `konghq.com/override`, but not when it's not.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #5056.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No need for changelog entry as that wasn't released yet.
