### PR TITLE
fix: fix `KongUpstreamPolicy` example manifests

### DIFF
--- a/examples/kong-upstream-policy-httproute.yaml
+++ b/examples/kong-upstream-policy-httproute.yaml
@@ -141,8 +141,7 @@ spec:
   slots: 100
   hashOn:
     cookie: session-id
-  hashOnFallback:
-    header: Authorization
+    cookiePath: cookie-path
   healthchecks:
     active:
       type: tcp
@@ -159,4 +158,3 @@ spec:
         successes: 5
       unhealthy:
         timeouts: 10
-        interval: 10

--- a/examples/kong-upstream-policy-ingress.yaml
+++ b/examples/kong-upstream-policy-ingress.yaml
@@ -31,10 +31,12 @@ metadata:
     konghq.com/upstream-policy: httpbin-upstream-policy
 spec:
   ports:
-    - port: 80
+    - name: http1
+      port: 80
       protocol: TCP
       targetPort: 80
-    - port: 8080
+    - name: http2
+      port: 8080
       protocol: TCP
       targetPort: 8080
   selector:
@@ -92,8 +94,7 @@ spec:
   slots: 100
   hashOn:
     cookie: session-id
-  hashOnFallback:
-    header: Authorization
+    cookiePath: cookie-path
   healthchecks:
     active:
       type: tcp
@@ -110,4 +111,3 @@ spec:
         successes: 5
       unhealthy:
         timeouts: 10
-        interval: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `KongUpstreamPolicy` example manifests so that they pass CRD validation.
