### PR TITLE
fix(admission): use `Ignore` failure policy in tests (same as charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,13 @@ Nothing yet.
   They must be migrated to annotations. `upstream` field is deprecated - it's recommended
   to migrate its settings to the new `KongUpstreamPolicy` resource.
   [#5022](https://github.com/Kong/kubernetes-ingress-controller/pull/5022)
+- Fixed `HTTPRoute` and `KongConsumer` admission webhook validators to properly
+  signal validation failures, resulting in returning responses with `AdmissionResponse`
+  filled instead of 500 status codes. It will make them work as expected in cases where
+  the `ValidatingWebhookConfiguration` has `failurePolicy: Ignore`.
+  This will enable validations of `HTTPRoute` and `KongConsumer` that were previously only
+  accidentally effective with `failurePolicy: Fail`, thus it can be considered a breaking change.
+  [#5063](https://github.com/Kong/kubernetes-ingress-controller/pull/5063)
 
 ### Fixed
 
@@ -173,11 +180,6 @@ Nothing yet.
 - Error logs emitted from Gateway Discovery readiness checker that should be
   logged at `debug` level are now logged at that level.
   [#5029](https://github.com/Kong/kubernetes-ingress-controller/pull/5029)
-- Fixed `HTTPRoute` and `KongConsumer` admission webhook validators to properly
-  signal validation failures, resulting in returning responses with `AdmissionResponse`
-  filled instead of 500 status codes. It will make them work as expected in cases where
-  the `ValidatingWebhookConfiguration` has `failurePolicy: Ignore`.
-  [#5063](https://github.com/Kong/kubernetes-ingress-controller/pull/5063)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,9 @@ Nothing yet.
   [#5029](https://github.com/Kong/kubernetes-ingress-controller/pull/5029)
 - Fixed `HTTPRoute` and `KongConsumer` admission webhook validators to properly
   signal validation failures, resulting in returning responses with `AdmissionResponse`
-  filled instead of 500 status codes. It will make them work as expected in cases where the 
-  `ValidatingWebhookConfiguration` is configured with `failurePolicy: Ignore`.
+  filled instead of 500 status codes. It will make them work as expected in cases where
+  the `ValidatingWebhookConfiguration` has `failurePolicy: Ignore`.
+  [#5063](https://github.com/Kong/kubernetes-ingress-controller/pull/5063)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,10 @@ Nothing yet.
 - Error logs emitted from Gateway Discovery readiness checker that should be
   logged at `debug` level are now logged at that level.
   [#5029](https://github.com/Kong/kubernetes-ingress-controller/pull/5029)
+- Fixed `HTTPRoute` and `KongConsumer` admission webhook validators to properly
+  signal validation failures, resulting in returning responses with `AdmissionResponse`
+  filled instead of 500 status codes. It will make them work as expected in cases where the 
+  `ValidatingWebhookConfiguration` is configured with `failurePolicy: Ignore`.
 
 ### Changed
 

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -290,7 +290,6 @@ func (h RequestHandler) handleHTTPRoute(
 	if err != nil {
 		return nil, err
 	}
-
 	return responseBuilder.Allowed(ok).WithMessage(message).Build(), nil
 }
 

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -251,10 +251,7 @@ func (h RequestHandler) handleSecret(
 
 	switch request.Operation {
 	case admissionv1.Update, admissionv1.Create:
-		ok, message, err := h.Validator.ValidateCredential(ctx, secret)
-		if err != nil {
-			return nil, err
-		}
+		ok, message := h.Validator.ValidateCredential(ctx, secret)
 		return responseBuilder.Allowed(ok).WithMessage(message).Build(), nil
 	default:
 		return nil, fmt.Errorf("unknown operation %q", string(request.Operation))

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -59,8 +59,8 @@ func (v KongFakeValidator) ValidateClusterPlugin(
 	return v.Result, v.Message, v.Error
 }
 
-func (v KongFakeValidator) ValidateCredential(_ context.Context, _ corev1.Secret) (bool, string, error) {
-	return v.Result, v.Message, v.Error
+func (v KongFakeValidator) ValidateCredential(ctx context.Context, secret corev1.Secret) (bool, string) {
+	return v.Result, v.Message
 }
 
 func (v KongFakeValidator) ValidateGateway(_ context.Context, _ gatewayapi.Gateway) (bool, string, error) {

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -59,7 +59,7 @@ func (v KongFakeValidator) ValidateClusterPlugin(
 	return v.Result, v.Message, v.Error
 }
 
-func (v KongFakeValidator) ValidateCredential(ctx context.Context, secret corev1.Secret) (bool, string) {
+func (v KongFakeValidator) ValidateCredential(context.Context, corev1.Secret) (bool, string) {
 	return v.Result, v.Message
 }
 

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -59,8 +58,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "Couldn't determine parentRefs for httproute",
-			err:           fmt.Errorf("no parentRef matched gateway default/testing-gateway"),
+			validationMsg: "Couldn't determine parentRefs for httproute: no parentRef matched gateway default/testing-gateway",
 		},
 		{
 			msg: "if you use sectionname to attach to a non-existent gateway listener, it fails validation",
@@ -98,8 +96,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "Couldn't find gateway listeners for httproute",
-			err:           fmt.Errorf("sectionname referenced listener listener-that-doesnt-exist was not found on gateway default/testing-gateway"),
+			validationMsg: "Couldn't find gateway listeners for httproute: sectionname referenced listener listener-that-doesnt-exist was not found on gateway default/testing-gateway",
 		},
 		{
 			msg: "if the provided gateway has NO listeners, the HTTPRoute fails validation",
@@ -126,8 +123,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "Couldn't find gateway listeners for httproute",
-			err:           fmt.Errorf("no listeners could be found for gateway default/testing-gateway"),
+			validationMsg: "Couldn't find gateway listeners for httproute: no listeners could be found for gateway default/testing-gateway",
 		},
 		{
 			msg: "parentRefs which omit the namespace pass validation in the same namespace",
@@ -200,8 +196,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "HTTPRoute linked Gateway listeners did not pass validation",
-			err:           fmt.Errorf("HTTPRoute not supported by listener http-alternate"),
+			validationMsg: "HTTPRoute linked Gateway listeners did not pass validation: HTTPRoute not supported by listener http-alternate",
 		},
 		{
 			msg: "if an HTTPRoute is using queryparams matching it fails validation due to only supporting expression router",
@@ -253,8 +248,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "HTTPRoute spec did not pass validation",
-			err:           fmt.Errorf("queryparam matching is supported with expression router only"),
+			validationMsg: "HTTPRoute spec did not pass validation: queryparam matching is supported with expression router only",
 		},
 		{
 			msg: "we don't support any group except core kubernetes for backendRefs",
@@ -311,8 +305,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "HTTPRoute spec did not pass validation",
-			err:           fmt.Errorf("example is not a supported group for httproute backendRefs, only core is supported"),
+			validationMsg: "HTTPRoute spec did not pass validation: example is not a supported group for httproute backendRefs, only core is supported",
 		},
 		{
 			msg: "we don't support any core kind except Service for backendRefs",
@@ -368,17 +361,18 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 			valid:         false,
-			validationMsg: "HTTPRoute spec did not pass validation",
-			err:           fmt.Errorf("Pod is not a supported kind for httproute backendRefs, only Service is supported"),
+			validationMsg: "HTTPRoute spec did not pass validation: Pod is not a supported kind for httproute backendRefs, only Service is supported",
 		},
 	} {
-		// Passed routesValidator is irrelevant for the above test cases.
-		valid, validMsg, err := ValidateHTTPRoute(
-			context.Background(), mockRoutesValidator{}, parser.FeatureFlags{}, tt.route, tt.gateways...,
-		)
-		assert.Equal(t, tt.valid, valid, tt.msg)
-		assert.Equal(t, tt.validationMsg, validMsg, tt.msg)
-		assert.Equal(t, tt.err, err, tt.msg)
+		t.Run(tt.msg, func(t *testing.T) {
+			// Passed routesValidator is irrelevant for the above test cases.
+			valid, validMsg, err := ValidateHTTPRoute(
+				context.Background(), mockRoutesValidator{}, parser.FeatureFlags{}, tt.route, tt.gateways...,
+			)
+			assert.Equal(t, tt.valid, valid, tt.msg)
+			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)
+			assert.Equal(t, tt.err, err, tt.msg)
+		})
 	}
 }
 

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -125,7 +125,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 	// credentials so that the consumers credentials references can be validated.
 	managedConsumers, err := validator.listManagedConsumers(ctx)
 	if err != nil {
-		return false, ErrTextConsumerUnretrievable, err
+		return false, fmt.Sprintf("failed to fetch managed KongConsumers from cache: %s", err), nil
 	}
 
 	// retrieve the consumer's credentials secrets to validate them with the index
@@ -136,7 +136,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 		secret, err := validator.SecretGetter.GetSecret(consumer.Namespace, secretName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, ErrTextConsumerCredentialSecretNotFound, err
+				return false, fmt.Sprintf("%s: %s", ErrTextConsumerCredentialSecretNotFound, err), nil
 			}
 			return false, ErrTextFailedToRetrieveSecret, err
 		}
@@ -248,7 +248,7 @@ func (validator KongHTTPValidator) ValidateCredential(ctx context.Context, secre
 	// if the credentials are referenced.
 	managedConsumers, err := validator.listManagedConsumers(ctx)
 	if err != nil {
-		return false, fmt.Sprintf("failed to list managed KongConsumers: %s", err)
+		return false, fmt.Sprintf("failed to fetch managed KongConsumers from cache: %s", err)
 	}
 
 	// Verify whether this secret is referenced by any managed consumer.
@@ -402,7 +402,7 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 			Name:      string(parentRef.Name),
 		}, &gateway); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, fmt.Sprintf("Referenced gateway %s/%s not found", namespace, parentRef.Name), nil
+				return false, fmt.Sprintf("referenced gateway %s/%s not found", namespace, parentRef.Name), nil
 			}
 			return false, "", err
 		}
@@ -411,7 +411,7 @@ func (validator KongHTTPValidator) ValidateHTTPRoute(
 		gatewayClass := gatewayapi.GatewayClass{}
 		if err := validator.ManagerClient.Get(ctx, client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, &gatewayClass); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, fmt.Sprintf("Referenced gatewayclass %s not found", gateway.Spec.GatewayClassName), nil
+				return false, fmt.Sprintf("referenced gatewayclass %s not found", gateway.Spec.GatewayClassName), nil
 			}
 			return false, "", err
 		}

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -164,7 +164,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 	// testing them against themselves.
 	credentialsIndex, err := globalValidationIndexForCredentials(ctx, validator.ManagerClient, managedConsumers, ignoredSecrets)
 	if err != nil {
-		return false, ErrTextConsumerCredentialValidationFailed, err
+		return false, fmt.Sprintf("%s: %s", ErrTextConsumerCredentialValidationFailed, err), nil
 	}
 
 	// validate the consumer's credentials against the index of all managed
@@ -172,7 +172,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 	for _, secret := range credentials {
 		// do the unique constraints validation of the credentials using the credentials index
 		if err := credentialsIndex.ValidateCredentialsForUniqueKeyConstraints(secret); err != nil {
-			return false, ErrTextConsumerCredentialValidationFailed, err
+			return false, fmt.Sprintf("%s: %s", ErrTextConsumerCredentialValidationFailed, err), nil
 		}
 	}
 

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -664,8 +664,7 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 				Logger:                   logr.Discard(),
 			}
 
-			ok, msg, err := validator.ValidateCredential(context.Background(), tc.secret)
-			require.NoError(t, err)
+			ok, msg := validator.ValidateCredential(context.Background(), tc.secret)
 			assert.Equal(t, tc.wantOK, ok)
 			assert.Equal(t, tc.wantMessage, msg)
 		})

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -62,7 +62,7 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErrSubstring: `Referenced gateway a6587a40-b3c6-4433-9232-216f9acf833a/fake-gateway not found`,
+			WantCreateErrSubstring: `fake-gateway not found`,
 		},
 		{
 			Name: "an invalid httproute will pass validation if it's not linked to a managed controller (it's not ours)",

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -62,7 +62,7 @@ func commonHTTPRouteValidationTestCases(
 					},
 				},
 			},
-			WantCreateErrSubstring: `Gateway.gateway.networking.k8s.io \"fake-gateway\" not found`,
+			WantCreateErrSubstring: `Referenced gateway a6587a40-b3c6-4433-9232-216f9acf833a/fake-gateway not found`,
 		},
 		{
 			Name: "an invalid httproute will pass validation if it's not linked to a managed controller (it's not ours)",

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -611,7 +611,7 @@ func ensureAdmissionRegistration(ctx context.Context, t *testing.T, namespace, c
 			Webhooks: []admregv1.ValidatingWebhook{
 				{
 					Name:                    "validations.kong.konghq.com",
-					FailurePolicy:           lo.ToPtr(admregv1.Fail),
+					FailurePolicy:           lo.ToPtr(admregv1.Ignore),
 					SideEffects:             lo.ToPtr(admregv1.SideEffectClassNone),
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					Rules:                   rules,


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses the same failure policy (`Ignore`) in the test admission webhook configuration as the one used in [charts](https://github.com/Kong/charts/blob/179f76c1757747396b023c1b0b6ad32946a34257/charts/kong/values.yaml#L565) and [deploy-admission-controller.sh](https://github.com/Kong/kubernetes-ingress-controller/blob/2fccacbaeae94467fa381c8b952c0c2f016c97dc/hack/deploy-admission-controller.sh#L45) script. 

The policy tells Kubernetes what to do in case status 500 is returned from the webhook:
- `Ignore` - accept the object. 
- `Fail` - do not accept the object.

Given that we're using `Ignore` in production, we should use the same in tests. Without that, we may have test cases where we expect an object to be rejected, but we returned status 500, which in production would still accept the object.

What validations will this bring back to life for installations using default `failurePolicy`:

- `HTTPRoute`:
  - queryparam matching is supported with expression router only
  - group is not a supported group for httproute backendRefs, only core is supported
  - kind is not a supported kind for httproute backendRefs, only Service is supported
  - no parentRef matched gateway
  - sectionname referenced listener was not found on gateway
  - no listeners could be found for gateway
  - HTTPRoute not supported by listener
  - HTTPRoute failed schema validation (route could not be generated in parser)
  - referenced gateway not found
  - referenced gatewayclass not found
- `KongConsumer`:
  - failed to fetch managed KongConsumers from cache
  - consumer referenced non-existent credentials secret
  - consumer credential failed validation

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/4680

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
