### PR TITLE
fix: fix webhook validation of `KongConsumer`s referring Secrets with `konghq.com/credential` label

### DIFF
--- a/examples/kong-consumer-key-auth.yaml
+++ b/examples/kong-consumer-key-auth.yaml
@@ -1,0 +1,82 @@
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: consumer1
+  annotations:
+      kubernetes.io/ingress.class: kong
+username: consumer1
+credentials:
+- consumer1-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer1-auth
+  labels:
+    konghq.com/credential: key-auth
+type: Opaque
+stringData:
+  key: password
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin-deployment
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+      - name: httpbin
+        image: kong/httpbin:0.1.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: httpbin
+  name: httpbin-deployment
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: httpbin
+  type: ClusterIP
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: key-auth-1
+plugin: key-auth
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin-ingress
+  annotations:
+    konghq.com/strip-path: "true"
+    konghq.com/plugins: key-auth-1
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: httpbin-deployment
+            port:
+              number: 80

--- a/internal/admission/validation/consumers/credentials/validation.go
+++ b/internal/admission/validation/consumers/credentials/validation.go
@@ -112,12 +112,13 @@ type Index map[string]map[string]map[string]struct{}
 // and will validate it for both normal structure validation and for
 // unique key constraint violations.
 func (cs Index) ValidateCredentialsForUniqueKeyConstraints(secret *corev1.Secret) error {
-	// the indication of credential type is required to be present on all credentials.
-	credentialTypeB, ok := secret.Data[TypeKey]
-	if !ok {
-		return fmt.Errorf("missing required key %s", TypeKey)
+	credentialType, credentialSource := util.ExtractKongCredentialType(secret)
+	if credentialSource == util.CredentialTypeAbsent {
+		return fmt.Errorf(
+			"secret has no credential type, add a %s label",
+			labels.LabelPrefix+labels.CredentialKey,
+		)
 	}
-	credentialType := string(credentialTypeB)
 
 	// the additional key/values are optional, but must be validated
 	// for unique constraint violations. Using an index of credentials


### PR DESCRIPTION
**What this PR does / why we need it**:

After introducing credential type labels in https://github.com/Kong/kubernetes-ingress-controller/pull/4825, it seems that webhook wasn't checked for letting the Secrets with only said label (where it should).

This PR fixes it by fixing the webhook logic in `KongHTTPValidator.ValidateCredential`.

**Which issue this PR fixes**:

Fixes: https://github.com/Kong/kubernetes-ingress-controller/issues/5069

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

No CHANGELOG entry since the change regarding `keyCredType` wasn't released yet.

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
