### PR TITLE
fix: use HTTPS port name for HTTPS port

### DIFF
--- a/config/variants/multi-gw-postgres/gateway_admin_service.yaml
+++ b/config/variants/multi-gw-postgres/gateway_admin_service.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     app: proxy-kong
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     targetPort: 8444
     protocol: TCP

--- a/config/variants/multi-gw/base/gateway_admin_service.yaml
+++ b/config/variants/multi-gw/base/gateway_admin_service.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     app: proxy-kong
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     targetPort: 8444
     protocol: TCP

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2403,7 +2403,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     protocol: TCP
     targetPort: 8444

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2403,7 +2403,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     protocol: TCP
     targetPort: 8444

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2403,7 +2403,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     protocol: TCP
     targetPort: 8444

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2403,7 +2403,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     protocol: TCP
     targetPort: 8444

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2403,7 +2403,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: admin
+  - name: admin-tls
     port: 8444
     protocol: TCP
     targetPort: 8444


### PR DESCRIPTION
Ports in the test manifests used HTTP names although they were HTTPS. After 
https://github.com/Kong/kubernetes-ingress-controller/pull/5043 port names must reflect their protocol, as discovery will not attempt to connect to non-HTTPS ports and uses the port name to determine the protocol.