### PR TITLE
Fix: add `kong-effective-version` input in validate Kong image tests and skip enterprise cases if enterprise not enabled

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -173,6 +173,7 @@ jobs:
           TEST_KONG_LOAD_IMAGES: ${{ inputs.load-local-image }}
           TEST_KONG_IMAGE: ${{ steps.split.outputs.kong-image }}
           TEST_KONG_TAG: ${{ steps.split.outputs.kong-tag }}
+          TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           GOTESTSUM_JUNITFILE: "e2e-${{ matrix.test }}${{ matrix.kubernetes-version }}-tests.xml"

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -14,6 +14,10 @@ on:
         type: string
         required: true
         default: "latest"
+      kong-effective-version:
+        description: Effective semantic version of Kong Gateway Docker image. If not given, the semantic version will be parsed from the image tag.
+        type: string
+        required: false 
       e2e-controller-image-repo:
         description: KIC Docker image for E2E tests (repository).
         type: string
@@ -68,11 +72,13 @@ jobs:
     with:
       kong-container-repo: ${{ github.event.inputs.kong-image-repo }}
       kong-container-tag: ${{ github.event.inputs.kong-image-tag }}
+      kong-oss-effective-version: ${{ github.event.inputs.kong-effective-version }}
       # We're passing the same image twice, because the integration tests need to know the image
       # for Enterprise variant of tests separately.
       # That makes this workflow usable only for Enterprise images.
       kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
       kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}
+      kong-enterprise-effective-version: ${{ github.event.inputs.kong-effective-version }}
 
   on-finish-comment-or-close-issue:
     needs:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

- Support specifying effective semantic version of tested Kong gateway image to avoid "failed to parse semver" error.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

part of #5045 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

expected to fix partial integration tests. For e2e tests, I used `3.0.0-rc1` KIC image and most cases passed: 
https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6741008630
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
