### PR TITLE
tests: fix logs encoding in envtest suite

### DIFF
--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -18,7 +18,7 @@ jobs:
           go-version-file: go.mod
 
       - name: run envtest tests
-        run: make test.envtest
+        run: make test.envtest.pretty
         env:
           GOTESTSUM_JUNITFILE: envtest-tests.xml
 

--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,9 @@ ENVTEST_TIMEOUT ?= 5m
 _test.envtest: gotestsum setup-envtest use-setup-envtest
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path)" \
 		GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
-		$(GOTESTSUM) -- \
+		$(GOTESTSUM) \
+		--hide-summary output \
+		-- \
 		-race $(GOTESTFLAGS) \
 		-tags envtest \
 		-covermode=atomic \

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -63,12 +63,12 @@ func TestGatewayAPIControllersMayBeDynamicallyStarted(t *testing.T) {
 				if !lo.ContainsBy(loggerHook.All(), func(entry observer.LoggedEntry) bool {
 					return strings.Contains(entry.LoggerName, controller) && strings.Contains(entry.Message, expectedLog)
 				}) {
-					t.Logf("expected log not found for %s controller", controller)
+					t.Logf("expected log %q not found for %s controller", expectedLog, controller)
 					return false
 				}
 			}
 			return true
-		}, time.Minute, time.Millisecond*500)
+		}, 30*time.Second, time.Millisecond*500)
 	}
 
 	const (

--- a/test/envtest/log.go
+++ b/test/envtest/log.go
@@ -1,0 +1,52 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+)
+
+type observerLogs interface {
+	All() []observer.LoggedEntry
+}
+
+// CreateTestLogger creates a logger for use in tests.
+// It returns the logger - which is also added to the context - and the observer
+// which can be used to dump logs if the test fails.
+func CreateTestLogger(ctx context.Context) (context.Context, logr.Logger, observerLogs) {
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zapr.NewLogger(zap.New(core))
+	ctx = ctrl.LoggerInto(ctx, logger)
+	// NOTE: do not use ctrl.SetLogger() because that would prevent the tests to
+	// pass when run with flag -count N with N > 1 because SetLogger() will only
+	// set the logger once.
+	return ctx, logger, logs
+}
+
+// DumpLogsIfTestFailed dumps the provided logs the if the test failed.
+func DumpLogsIfTestFailed(t *testing.T, logs observerLogs) {
+	t.Helper()
+
+	if !t.Failed() {
+		return
+	}
+
+	encoder, err := util.GetZapEncoding("text")
+	require.NoError(t, err)
+
+	t.Logf("Test %s failed: dumping controller logs\n", t.Name())
+	for _, entry := range logs.All() {
+		b, err := encoder.EncodeEntry(entry.Entry, entry.Context)
+		assert.NoError(t, err)
+		t.Logf("%s", b.String())
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR unifies the log dumping mechanism used in `envtest` suite when run using `StartReconcilers` and `RunManager` in a way that log entries are properly encoded using the `text` encoder.

It also changes the Makefile target used on CI so that only the failed tests outputs are printed for easier debugging.

On top of that it doesn't use the `ctrl.SetLogger()` to allow running tests more than once (`-count N` with `N` > 1). Specifically this allows tests like `TestGatewayAPIControllersMayBeDynamicallyStarted` check controller logs when run more than once.

Logs (when test fails) before this change (for tests using `StartReconcilers()`)

```
=== CONT  TestHTTPRouteReconcilerProperlyReactsToReferenceGrant
    httproute_controller_test.go:39: starting envtest environment for test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant...
    httproute_controller_test.go:39: install Kong CRDs from manifests in /Users/patryk.malek@konghq.com/code_/kubernetes-ingress-controller/config/crd/bases
    httproute_controller_test.go:39: envtest environment (v1.28.3) started at https://127.0.0.1:54456/
    controller.go:60: Test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant failed: dumping controller logs
    controller.go:62: 2023-11-03 14:18:04.457221 +0100 CET m=+3.936222084 Starting EventSource
    controller.go:62: 2023-11-03 14:18:04.457306 +0100 CET m=+3.936307709 Starting EventSource
    controller.go:62: 2023-11-03 14:18:04.457318 +0100 CET m=+3.936319834 Starting EventSource
    controller.go:62: 2023-11-03 14:18:04.457332 +0100 CET m=+3.936333709 Starting EventSource
    controller.go:62: 2023-11-03 14:18:04.457365 +0100 CET m=+3.936366834 Starting Controller
    controller.go:62: 2023-11-03 14:18:04.558896 +0100 CET m=+4.037897126 Starting workers
    controller.go:62: 2023-11-03 14:18:06.47303 +0100 CET m=+5.952019001 Stopping and waiting for non leader election runnables
    controller.go:62: 2023-11-03 14:18:06.473135 +0100 CET m=+5.952123793 Stopping and waiting for leader election runnables
    controller.go:62: 2023-11-03 14:18:06.473167 +0100 CET m=+5.952156168 Shutdown signal received, waiting for all workers to finish
    controller.go:62: 2023-11-03 14:18:06.473177 +0100 CET m=+5.952166209 All workers finished
    controller.go:62: 2023-11-03 14:18:06.473194 +0100 CET m=+5.952182334 Stopping and waiting for caches
    controller.go:62: 2023-11-03 14:18:06.474486 +0100 CET m=+5.953474793 Stopping and waiting for webhooks
    controller.go:62: 2023-11-03 14:18:06.474521 +0100 CET m=+5.953509876 Stopping and waiting for HTTP servers
    controller.go:62: 2023-11-03 14:18:06.474543 +0100 CET m=+5.953531626 Wait completed, proceeding to shutdown the manager
    httproute_controller_test.go:39: stopping envtest environment for test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant
--- FAIL: TestHTTPRouteReconcilerProperlyReactsToReferenceGrant (6.57s)

```

After:

```
=== CONT  TestHTTPRouteReconcilerProperlyReactsToReferenceGrant
    httproute_controller_test.go:39: starting envtest environment for test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant...
    httproute_controller_test.go:39: install Kong CRDs from manifests in /Users/patryk.malek@konghq.com/code_/kubernetes-ingress-controller/config/crd/bases
    httproute_controller_test.go:39: envtest environment (v1.28.3) started at https://127.0.0.1:54706/
    httproute_controller_test.go:190: verifying that HTTPRoute has ResolvedRefs set to Status False and Reason RefNotPermitted
    httproute_controller_test.go:226: verifying that HTTPRoute gets accepted by HTTPRouteReconciler after relevant ReferenceGrant gets created
    httproute_controller_test.go:252: verifying that HTTPRoute gets its ResolvedRefs condition to Status False and Reason RefNotPermitted when relevant ReferenceGrant gets deleted
    controller.go:55: Test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant failed: dumping controller logs
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting EventSource    {"source": "kind source: *v1.GatewayClass"}
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting EventSource    {"source": "kind source: *v1.Gateway"}
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting EventSource    {"source": "kind source: *v1beta1.ReferenceGrant"}
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting EventSource    {"source": "kind source: *v1.HTTPRoute"}
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting Controller
    controller.go:55: 2023-11-03T14:19:50+01:00 info    Starting workers        {"worker count": 1}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Processing httproute    {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking deletion timestamp     {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Retrieving GatewayClass and Gateway for route   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking if the httproute's gateways are ready  {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Gateway associations   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Processing httproute    {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking deletion timestamp     {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Retrieving GatewayClass and Gateway for route   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking if the httproute's gateways are ready  {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Gateway associations   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Programmed condition   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 info    HTTPRoute has been configured on the data-plane {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Processing httproute    {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking deletion timestamp     {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Retrieving GatewayClass and Gateway for route   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking if the httproute's gateways are ready  {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Gateway associations   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Processing httproute    {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking deletion timestamp     {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Retrieving GatewayClass and Gateway for route   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Checking if the httproute's gateways are ready  {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Gateway associations   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 debug   Ensuring status contains Programmed condition   {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 info    HTTPRoute has been configured on the data-plane {"GatewayV1HTTPRoute": {"name":"89aa5da1-ae59-4008-bf5b-66b68875f63d","namespace":"67ecbd24-d215-4907-8a5e-4dab18ccddcd"}, "namespace": "67ecbd24-d215-4907-8a5e-4dab18ccddcd", "name": "89aa5da1-ae59-4008-bf5b-66b68875f63d"}
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Stopping and waiting for non leader election runnables
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Stopping and waiting for leader election runnables
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Shutdown signal received, waiting for all workers to finish
    controller.go:55: 2023-11-03T14:19:52+01:00 info    All workers finished
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Stopping and waiting for caches
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Stopping and waiting for webhooks
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Stopping and waiting for HTTP servers
    controller.go:55: 2023-11-03T14:19:52+01:00 info    Wait completed, proceeding to shutdown the manager
    httproute_controller_test.go:39: stopping envtest environment for test TestHTTPRouteReconcilerProperlyReactsToReferenceGrant
--- FAIL: TestHTTPRouteReconcilerProperlyReactsToReferenceGrant (6.17s)
```