### PR TITLE
ci: use restricted GITHUB_TOKEN istead of GITHUB PAT for issue state check

### DIFF
--- a/.github/workflows/check_fixed_issues_references.yaml
+++ b/.github/workflows/check_fixed_issues_references.yaml
@@ -8,8 +8,10 @@ on:
 jobs:
     check_issues_state:
       runs-on: ubuntu-latest
+      permissions:
+        issues: read
       env:
-        GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       steps:
         - name: checkout repository
           uses: actions/checkout@v4


### PR DESCRIPTION
**What this PR does / why we need it**:

Limit the scope of the GITHUB_TOKEN used in issue status check to `issues`  read-only.
Ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token


Example workflow run: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6746666425
