### PR TITLE
chore: pull Helm test version from Renovate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/ssgelm/cookiejarparser v1.0.1 // indirect
-	github.com/tidwall/gjson v1.17.0 // indirect
+	github.com/tidwall/gjson v1.17.0
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to read the Helm chart test version from the Renovate file if none is specified via the environment. Proceed with no version (effectively using whatever's installed on the machine running the test) if both fail.

**Which issue this PR fixes**:

Alternative to https://github.com/Kong/kubernetes-ingress-controller/pull/4867 that tries for greater consistency.

**Special notes for your reviewer**:

This forces tests on older release branches to whatever chart version they had unless you override it to another version. This may not be desirable.

The path is relative to the `test/integration` directory and won't work if tests are invoked on another directory. However, `test/integration` currently has a flat file structure, and the failure is graceful.

Without `TEST_KONG_HELM_CHART_VERSION`:

```
INFO: setting up test environment
INFO: pulled version  from environment
INFO: pulled version 2.30.0 from dependency file
INFO: using kong/kong chart version 2.30.0
```

With `TEST_KONG_HELM_CHART_VERSION=2.29.0`:
```
INFO: setting up test environment
INFO: pulled version 2.29.0 from environment
INFO: using kong/kong chart version 2.29.0
```

With an intentionally broken file path:
```
INFO: setting up test environment
WARN: could not get kong/kong chart dependency version: could not open .github/test_dependencies.yaml: open .github/test_dependencies.yaml: no such file or directory165 <nil>
WARN: will use whatever kong/kong chart version is installed locally
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
