### PR TITLE
chore(test): bump kind version to v0.20.0

### DIFF
--- a/scripts/check-container-environment.sh
+++ b/scripts/check-container-environment.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-KIND_VERSION="v0.14.0"
+KIND_VERSION="v0.20.0"
 
 # ensure docker command is accessible
 if ! command -v docker &> /dev/null


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
There are some incompatibilities between different versions of kind and the old version can't work with Kubernetes v1.28.

We have not encountered any issues because the GitHub Actions environment has already upgraded kind to the latest version by default.

https://github.com/actions/runner-images/pull/7747



**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:
<s>
- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
</s>

Since this change does not affect to  user/devs, I will not update the CHANGELOG.md file.

