### PR TITLE
docs: align auto-generated references with konghq.com

### DIFF
--- a/scripts/apidocs-gen/post-process-for-konghq.sh
+++ b/scripts/apidocs-gen/post-process-for-konghq.sh
@@ -28,5 +28,5 @@ echo "<!-- vale on -->" >> "${POST_PROCESSED_DOC}"
 
 # Replace all description placeholders with proper include directives
 sed -i -r \
-  's/<!-- (.*) description placeholder -->/{% include_cached md\/kic\/crd-ref\/\1_description.md kong_version=page.kong_version %}/' \
+  's/<!-- \(.*\) description placeholder -->/{% include md\/kic\/crd-ref\/\1_description.md kong_version=page.kong_version %}/' \
   "${POST_PROCESSED_DOC}"

--- a/scripts/cli-arguments-docs-gen/post-process-for-konghq.sh
+++ b/scripts/cli-arguments-docs-gen/post-process-for-konghq.sh
@@ -19,7 +19,7 @@ echo '---
 title: CLI Arguments
 ---
 
-Various settings and configurations of the controller can be tweaked
+Learn about the various settings and configurations of the controller can be tweaked
 using CLI flags.
 
 ## Environment variables
@@ -35,7 +35,7 @@ environment variable:
 CONTROLLER_INGRESS_CLASS=kong-foobar
 ```
 
-It is recommended that all the configuration is done via environment variables
+It is recommended that all the configuration is done through environment variables
 and not CLI flags.
 
 <!-- vale off -->


### PR DESCRIPTION
**What this PR does / why we need it**:

Aligns the autogenerated references for CLI arguments and CRDs API with what konghq.com docs use now:

- use `include` directive instead of `include_cached`
- align wording

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
