### PR TITLE
fix: make `secretKeyRef` a required field in plugins' `configFrom`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ Adding a new version? You'll need three changes:
 
 ### Changed
 
+- `SecretKeyRef` of `ConfigFrom` field in `KongPlugin` and `KongClusterPlugin`
+  are `Required`. When `ConfigFrom` is specified, the validation of there CRDs
+  will require `SecretKeyRef` to be present.
+  [#5103](https://github.com/Kong/kubernetes-ingress-controller/pull/5103)
 - CRD Validation Expressions
   - `KongPlugin` and `KongClusterPlugin` now enforce only one of `config` and `configFrom`
     to be set.

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -84,6 +84,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -44,7 +44,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -151,6 +151,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -151,8 +151,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -80,6 +80,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/pkg/apis/configuration/v1/configsource.go
+++ b/pkg/apis/configuration/v1/configsource.go
@@ -4,37 +4,32 @@ package v1
 // +kubebuilder:object:generate=true
 type ConfigSource struct {
 	// Specifies a name and a key of a secret to refer to. The namespace is implicitly set to the one of referring object.
-	SecretValue SecretValueFromSource `json:"secretKeyRef,omitempty"`
+	SecretValue SecretValueFromSource `json:"secretKeyRef"`
 }
 
 // NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource.
 // +kubebuilder:object:generate=true
 type NamespacedConfigSource struct {
 	// Specifies a name, a namespace, and a key of a secret to refer to.
-	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef,omitempty"`
+	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef"`
 }
 
 // SecretValueFromSource represents the source of a secret value.
 // +kubebuilder:object:generate=true
 type SecretValueFromSource struct {
 	// The secret containing the key.
-	// +kubebuilder:validation:Required
-	Secret string `json:"name,omitempty"`
+	Secret string `json:"name"`
 	// The key containing the value.
-	// +kubebuilder:validation:Required
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 }
 
 // NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace.
 // +kubebuilder:object:generate=true
 type NamespacedSecretValueFromSource struct {
 	// The namespace containing the secret.
-	// +kubebuilder:validation:Required
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace"`
 	// The secret containing the key.
-	// +kubebuilder:validation:Required
-	Secret string `json:"name,omitempty"`
+	Secret string `json:"name"`
 	// The key containing the value.
-	// +kubebuilder:validation:Required
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 }

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -29,7 +29,6 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=kcp,categories=kong-ingress-controller
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Plugin-Type",type=string,JSONPath=`.plugin`,description="Name of the plugin"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
@@ -65,7 +64,7 @@ type KongClusterPlugin struct {
 
 	// PluginName is the name of the plugin to which to apply the config.
 	// +kubebuilder:validation:Required
-	PluginName string `json:"plugin,omitempty"`
+	PluginName string `json:"plugin"`
 
 	// RunOn configures the plugin to run on the first or the second or both
 	// nodes in case of a service mesh deployment.

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -37,7 +37,7 @@ type KongConsumer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Username is a Kong cluster-unique username of the consumer.
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 
 	// CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping
 	// Kong with users in your existing database.

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -26,7 +26,6 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=kc,categories=kong-ingress-controller
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Username",type=string,JSONPath=`.username`,description="Username of a Kong Consumer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
@@ -38,7 +37,7 @@ type KongConsumer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Username is a Kong cluster-unique username of the consumer.
-	Username string `json:"username,omitempty"`
+	Username string `json:"username"`
 
 	// CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping
 	// Kong with users in your existing database.

--- a/pkg/apis/configuration/v1/kongingress_types.go
+++ b/pkg/apis/configuration/v1/kongingress_types.go
@@ -27,7 +27,6 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=ki,categories=kong-ingress-controller
-// +kubebuilder:validation:Optional
 // +kubebuilder:validation:XValidation:rule="!has(self.proxy)", message="'proxy' field is no longer supported, use Service's annotations instead"
 // +kubebuilder:validation:XValidation:rule="!has(self.route)", message="'route' field is no longer supported, use Ingress' annotations instead"
 

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -28,7 +28,6 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=kp,categories=kong-ingress-controller
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Plugin-Type",type=string,JSONPath=`.plugin`,description="Name of the plugin"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
@@ -65,7 +64,7 @@ type KongPlugin struct {
 
 	// PluginName is the name of the plugin to which to apply the config.
 	// +kubebuilder:validation:Required
-	PluginName string `json:"plugin,omitempty"`
+	PluginName string `json:"plugin"`
 
 	// RunOn configures the plugin to run on the first or the second or both
 	// nodes in case of a service mesh deployment.

--- a/pkg/apis/configuration/v1beta1/ingress_rules.go
+++ b/pkg/apis/configuration/v1beta1/ingress_rules.go
@@ -32,6 +32,7 @@ type IngressRule struct {
 	// Port is the port on which to accept TCP or TLS over TCP sessions and
 	// route. It is a required field. If a Host is not specified, the requested
 	// are routed based only on Port.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:validation:Format=int32
@@ -39,16 +40,19 @@ type IngressRule struct {
 
 	// Backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +kubebuilder:validation:Required
 	Backend IngressBackend `json:"backend"`
 }
 
 // IngressBackend describes all endpoints for a given service and port.
 type IngressBackend struct {
 	// Specifies the name of the referenced service.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	ServiceName string `json:"serviceName"`
 
 	// Specifies the port of the referenced service.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:validation:Format=int32

--- a/pkg/apis/configuration/v1beta1/ingress_rules.go
+++ b/pkg/apis/configuration/v1beta1/ingress_rules.go
@@ -1,7 +1,5 @@
 package v1beta1
 
-// +kubebuilder:validation:Optional
-
 // UDPIngressRule represents a rule to apply against incoming requests
 // wherein no Host matching is available for request routing, only the port
 // is used to match requests.
@@ -11,16 +9,12 @@ type UDPIngressRule struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:validation:Format=int32
-	// +kubebuilder:validation:Required
 	Port int `json:"port"`
 
 	// Backend defines the Kubernetes service which accepts traffic from the
 	// listening Port defined above.
-	// +kubebuilder:validation:Required
 	Backend IngressBackend `json:"backend"`
 }
-
-// +kubebuilder:validation:Optional
 
 // IngressRule represents a rule to apply against incoming requests.
 // Matching is performed based on an (optional) SNI and port.
@@ -32,6 +26,7 @@ type IngressRule struct {
 	// If a Host is specified, the protocol must be TLS over TCP.
 	// A plain-text TCP request cannot be routed based on Host. It can only
 	// be routed based on Port.
+	// +kubebuilder:validation:Optional
 	Host string `json:"host,omitempty"`
 
 	// Port is the port on which to accept TCP or TLS over TCP sessions and
@@ -40,21 +35,16 @@ type IngressRule struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:validation:Format=int32
-	// +kubebuilder:validation:Required
-	Port int `json:"port,omitempty"`
+	Port int `json:"port"`
 
 	// Backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +kubebuilder:validation:Required
 	Backend IngressBackend `json:"backend"`
 }
-
-// +kubebuilder:validation:Optional
 
 // IngressBackend describes all endpoints for a given service and port.
 type IngressBackend struct {
 	// Specifies the name of the referenced service.
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	ServiceName string `json:"serviceName"`
 
@@ -62,6 +52,5 @@ type IngressBackend struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:validation:Format=int32
-	// +kubebuilder:validation:Required
 	ServicePort int `json:"servicePort"`
 }

--- a/pkg/apis/configuration/v1beta1/kongconsumergroup_types.go
+++ b/pkg/apis/configuration/v1beta1/kongconsumergroup_types.go
@@ -26,7 +26,6 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=kcg,categories=kong-ingress-controller
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 
@@ -35,7 +34,7 @@ type KongConsumerGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Status represents the current status of the KongConsumer resource.
+	// Status represents the current status of the KongConsumerGroup resource.
 	Status KongConsumerGroupStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/configuration/v1beta1/tcpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/tcpingress_types.go
@@ -27,7 +27,6 @@ import (
 // +kubebuilder:resource:categories=kong-ingress-controller
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.loadBalancer.ingress[*].ip`,description="Address of the load balancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 

--- a/pkg/apis/configuration/v1beta1/udpingress_types.go
+++ b/pkg/apis/configuration/v1beta1/udpingress_types.go
@@ -40,7 +40,6 @@ type UDPIngressList struct {
 // +kubebuilder:resource:categories=kong-ingress-controller
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:validation:Optional
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.loadBalancer.ingress[*].ip`,description="Address of the load balancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -142,6 +142,8 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
@@ -358,7 +360,7 @@ spec:
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -600,6 +602,8 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
+        required:
+        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id
@@ -1054,6 +1058,8 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -602,8 +602,6 @@ spec:
           username:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
-        required:
-        - username
         type: object
         x-kubernetes-validations:
         - message: Need to provide either username or custom_id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

remove the incorrect usage of annotations `// +kubebuilder:validation:Optional` on type defintions and reserve one `// +kubebuilder:validation:Optional` in packages `v1` and `v1beta1` (in file `docs.go`).

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5061 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

The `// +kubebuilder:validation:Optional`  comments above types are first imported in this PR: https://github.com/Kong/kubernetes-ingress-controller/pull/1757/. I do not know the purpose here, but kept the generated CRDs identical to previous versions. @rainest Do you have more context of that PR? 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
