### PR TITLE
review suggestion: move types to `internal/dataplane/config`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -84,6 +84,8 @@ linters-settings:
       alias: gateway${1}
     - pkg: github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/(v[\w\d]+)
       alias: kong${1}
+    - pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config
+      alias: dpconf
   forbidigo:
     exclude-godoc-examples: false
     forbid:

--- a/internal/dataplane/client.go
+++ b/internal/dataplane/client.go
@@ -3,7 +3,7 @@ package dataplane
 import (
 	"context"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -26,7 +26,7 @@ const (
 type Client interface {
 	// DBMode informs the caller which DB mode the data-plane has employed
 	// (e.g. "off" (dbless) or "postgres").
-	DBMode() dataplane.DBMode
+	DBMode() dpconf.DBMode
 
 	// Update the data-plane by parsing the current configuring and applying
 	// it to the backend API.

--- a/internal/dataplane/config/dbmode.go
+++ b/internal/dataplane/config/dbmode.go
@@ -1,4 +1,4 @@
-package dataplane
+package config
 
 import "fmt"
 
@@ -20,24 +20,12 @@ func NewDBMode(mode string) (DBMode, error) {
 }
 
 // IsDBLessMode can be used to detect the proxy mode (db or dbless).
-func IsDBLessMode(mode DBMode) bool {
-	return mode == "" || mode == DBModeOff
+func (m DBMode) IsDBLessMode() bool {
+	return m == "" || m == DBModeOff
 }
 
 // DBBacked returns true if the gateway is DB backed.
 // reverse of IsDBLessMode for readability.
-func DBBacked(mode DBMode) bool {
-	return !IsDBLessMode(mode)
-}
-
-type RouterFlavor string
-
-const (
-	RouterFlavorTraditional           RouterFlavor = "traditional"
-	RouterFlavorTraditionalCompatible RouterFlavor = "traditional_compatible"
-	RouterFlavorExpressions           RouterFlavor = "expressions"
-)
-
-func ShouldEnableExpressionRoutes(rf RouterFlavor) bool {
-	return rf == RouterFlavorExpressions
+func (m DBMode) DBBacked() bool {
+	return !m.IsDBLessMode()
 }

--- a/internal/dataplane/config/router.go
+++ b/internal/dataplane/config/router.go
@@ -1,0 +1,13 @@
+package config
+
+type RouterFlavor string
+
+const (
+	RouterFlavorTraditional           RouterFlavor = "traditional"
+	RouterFlavorTraditionalCompatible RouterFlavor = "traditional_compatible"
+	RouterFlavorExpressions           RouterFlavor = "expressions"
+)
+
+func ShouldEnableExpressionRoutes(rf RouterFlavor) bool {
+	return rf == RouterFlavorExpressions
+}

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configfetcher"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckgen"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
@@ -38,7 +39,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
@@ -144,7 +144,7 @@ var (
 type mockGatewayClientsProvider struct {
 	gatewayClients []*adminapi.Client
 	konnectClient  *adminapi.KonnectClient
-	dbMode         dataplaneutil.DBMode
+	dbMode         dpconf.DBMode
 }
 
 func (p mockGatewayClientsProvider) KonnectClient() *adminapi.KonnectClient {
@@ -156,7 +156,7 @@ func (p mockGatewayClientsProvider) GatewayClients() []*adminapi.Client {
 }
 
 func (p mockGatewayClientsProvider) GatewayClientsToConfigure() []*adminapi.Client {
-	if dataplaneutil.IsDBLessMode(p.dbMode) {
+	if p.dbMode.IsDBLessMode() {
 		return p.gatewayClients
 	}
 	if len(p.gatewayClients) == 0 {
@@ -692,7 +692,7 @@ func setupTestKongClient(
 		diagnostic,
 		config,
 		eventRecorder,
-		dataplaneutil.DBModeOff,
+		dpconf.DBModeOff,
 		clientsProvider,
 		updateStrategyResolver,
 		configChangeDetector,

--- a/internal/dataplane/parser/parser.go
+++ b/internal/dataplane/parser/parser.go
@@ -20,13 +20,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 )
@@ -61,12 +61,12 @@ type FeatureFlags struct {
 
 func NewFeatureFlags(
 	featureGates featuregates.FeatureGates,
-	routerFlavor dataplaneutil.RouterFlavor,
+	routerFlavor dpconf.RouterFlavor,
 	updateStatusFlag bool,
 ) FeatureFlags {
 	return FeatureFlags{
 		ReportConfiguredKubernetesObjects: updateStatusFlag,
-		ExpressionRoutes:                  dataplaneutil.ShouldEnableExpressionRoutes(routerFlavor),
+		ExpressionRoutes:                  dpconf.ShouldEnableExpressionRoutes(routerFlavor),
 		FillIDs:                           featureGates.Enabled(featuregates.FillIDsFeature),
 		RewriteURIs:                       featureGates.Enabled(featuregates.RewriteURIsFeature),
 	}

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -24,11 +24,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
@@ -4504,7 +4504,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		name string
 
 		featureGates     map[string]bool
-		routerFlavor     dataplaneutil.RouterFlavor
+		routerFlavor     dpconf.RouterFlavor
 		updateStatusFlag bool
 
 		expectedFeatureFlags FeatureFlags
@@ -4512,7 +4512,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		{
 			name:             "traditional compatible router and update status enabled",
 			featureGates:     map[string]bool{},
-			routerFlavor:     dataplaneutil.RouterFlavorTraditionalCompatible,
+			routerFlavor:     dpconf.RouterFlavorTraditionalCompatible,
 			updateStatusFlag: true,
 			expectedFeatureFlags: FeatureFlags{
 				ReportConfiguredKubernetesObjects: true,
@@ -4520,7 +4520,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		},
 		{
 			name:         "expression router and update status disabled",
-			routerFlavor: dataplaneutil.RouterFlavorExpressions,
+			routerFlavor: dpconf.RouterFlavorExpressions,
 			expectedFeatureFlags: FeatureFlags{
 				ExpressionRoutes: true,
 			},

--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -42,7 +42,7 @@ type Synchronizer struct {
 
 	// dataplane client to send updates to the Kong Admin API
 	dataplaneClient Client
-	dbMode          dataplaneutil.DBMode
+	dbMode          dpconf.DBMode
 
 	// server configuration, flow control, channels and utility attributes
 	stagger         time.Duration
@@ -140,7 +140,7 @@ func (p *Synchronizer) IsReady() bool {
 	defer p.lock.RUnlock()
 	// If the proxy is has no database, it is only ready after a successful sync
 	// Otherwise, it has no configuration loaded
-	if dataplaneutil.IsDBLessMode(p.dbMode) {
+	if p.dbMode.IsDBLessMode() {
 		return p.configApplied
 	}
 	// If the proxy has a database, it is ready immediately

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 )
 
 const testSynchronizerTick = time.Millisecond * 10
@@ -24,7 +24,7 @@ func TestSynchronizer(t *testing.T) {
 	}
 
 	t.Log("setting up a fake dataplane client to test the synchronizer")
-	c := &fakeDataplaneClient{dbmode: dataplaneutil.DBModePostgres}
+	c := &fakeDataplaneClient{dbmode: dpconf.DBModePostgres}
 
 	t.Log("configuring the dataplane synchronizer")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,9 +92,9 @@ func TestSynchronizer(t *testing.T) {
 }
 
 func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
-	for _, dbMode := range []dataplaneutil.DBMode{
-		dataplaneutil.DBModeOff,
-		dataplaneutil.DBModePostgres,
+	for _, dbMode := range []dpconf.DBMode{
+		dpconf.DBModeOff,
+		dpconf.DBModePostgres,
 	} {
 		dbMode := dbMode
 		t.Run(fmt.Sprintf("dbmode=%s", dbMode), func(t *testing.T) {
@@ -131,14 +131,14 @@ func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
 // fakeDataplaneClient fakes the dataplane.Client interface so that we can
 // unit test the dataplane.Synchronizer.
 type fakeDataplaneClient struct {
-	dbmode                  dataplaneutil.DBMode
+	dbmode                  dpconf.DBMode
 	updateCount             atomic.Uint64
 	lock                    sync.RWMutex
 	clientCallBlockDuration time.Duration
 	t                       *testing.T
 }
 
-func (c *fakeDataplaneClient) DBMode() dataplaneutil.DBMode {
+func (c *fakeDataplaneClient) DBMode() dpconf.DBMode {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if c.clientCallBlockDuration > 0 {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configfetcher"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
@@ -36,7 +37,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
 )
 
@@ -115,12 +115,12 @@ func Run(
 
 	kongConfig := sendconfig.Config{
 		Version:            kongSemVersion,
-		InMemory:           dataplaneutil.IsDBLessMode(dbMode),
+		InMemory:           dbMode.IsDBLessMode(),
 		Concurrency:        c.Concurrency,
 		FilterTags:         c.FilterTags,
 		SkipCACertificates: c.SkipCACertificates,
 		EnableReverseSync:  c.EnableReverseSync,
-		ExpressionRoutes:   dataplaneutil.ShouldEnableExpressionRoutes(routerFlavor),
+		ExpressionRoutes:   dpconf.ShouldEnableExpressionRoutes(routerFlavor),
 	}
 	kongConfig.Init(ctx, setupLog, initialKongClients)
 

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -26,10 +26,10 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/parser"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 )
 
 // -----------------------------------------------------------------------------
@@ -56,7 +56,7 @@ func SetupLoggers(c *Config, output io.Writer) (logr.Logger, error) {
 	return logger, nil
 }
 
-func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode dataplaneutil.DBMode) (ctrl.Options, error) {
+func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode dpconf.DBMode) (ctrl.Options, error) {
 	logger.Info("Building the manager runtime scheme and loading apis into the scheme")
 	scheme, err := scheme.Get()
 	if err != nil {
@@ -113,13 +113,13 @@ func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbm
 	return managerOpts, nil
 }
 
-func leaderElectionEnabled(logger logr.Logger, c *Config, dbmode dataplaneutil.DBMode) bool {
+func leaderElectionEnabled(logger logr.Logger, c *Config, dbmode dpconf.DBMode) bool {
 	if c.Konnect.ConfigSynchronizationEnabled {
 		logger.Info("Konnect config synchronisation enabled, enabling leader election")
 		return true
 	}
 
-	if dataplaneutil.IsDBLessMode(dbmode) {
+	if dbmode.IsDBLessMode() {
 		if c.KongAdminSvc.IsPresent() {
 			logger.Info("DB-less mode detected with service detection, enabling leader election")
 			return true

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -14,14 +14,14 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 )
 
 // KongStartUpOptions includes start up configurations of Kong that could change behavior of Kong Ingress Controller.
 // The fields are extracted from results of Kong gateway configuration root.
 type KongStartUpOptions struct {
-	DBMode       dataplaneutil.DBMode
-	RouterFlavor dataplaneutil.RouterFlavor
+	DBMode       dpconf.DBMode
+	RouterFlavor dpconf.RouterFlavor
 	Version      kong.Version
 }
 
@@ -76,7 +76,7 @@ func extractConfigurationFromRoot(r Root) (map[string]any, error) {
 	return rootConfig, nil
 }
 
-func DBModeFromRoot(r Root) (dataplaneutil.DBMode, error) {
+func DBModeFromRoot(r Root) (dpconf.DBMode, error) {
 	rootConfig, err := extractConfigurationFromRoot(r)
 	if err != nil {
 		return "", err
@@ -92,10 +92,10 @@ func DBModeFromRoot(r Root) (dataplaneutil.DBMode, error) {
 		return "", fmt.Errorf("invalid %q type, expected a string, got %T", dbModeKey, dbMode)
 	}
 
-	return dataplaneutil.NewDBMode(dbModeStr)
+	return dpconf.NewDBMode(dbModeStr)
 }
 
-func RouterFlavorFromRoot(r Root) (dataplaneutil.RouterFlavor, error) {
+func RouterFlavorFromRoot(r Root) (dpconf.RouterFlavor, error) {
 	rootConfig, err := extractConfigurationFromRoot(r)
 	if err != nil {
 		return "", err
@@ -110,7 +110,7 @@ func RouterFlavorFromRoot(r Root) (dataplaneutil.RouterFlavor, error) {
 	if !ok {
 		return "", fmt.Errorf("invalid %q type, expected a string, got %T", routerFlavorKey, routerFlavor)
 	}
-	return dataplaneutil.RouterFlavor(routerFlavorStr), nil
+	return dpconf.RouterFlavor(routerFlavorStr), nil
 }
 
 func KongVersionFromRoot(r Root) (kong.Version, error) {
@@ -171,13 +171,13 @@ func getRootKeyFunc(skipCACerts bool) func(Root) string {
 }
 
 // validateDBMode validates the provided dbMode string.
-func validateDBMode(dbMode dataplaneutil.DBMode, skipCACerts bool) error {
+func validateDBMode(dbMode dpconf.DBMode, skipCACerts bool) error {
 	switch dbMode {
-	case "", dataplaneutil.DBModeOff:
+	case "", dpconf.DBModeOff:
 		if skipCACerts {
 			return fmt.Errorf("--skip-ca-certificates is not available for use with DB-less Kong instances")
 		}
-	case dataplaneutil.DBModePostgres:
+	case dpconf.DBModePostgres:
 		return nil
 	default:
 		return fmt.Errorf("%s is not a supported database backend", dbMode)

--- a/internal/manager/utils/kongconfig/root_test.go
+++ b/internal/manager/utils/kongconfig/root_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
@@ -22,15 +22,15 @@ func TestValidateRoots(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		configStr            string
-		expectedDBMode       dataplaneutil.DBMode
-		expectedRouterFlavor dataplaneutil.RouterFlavor
+		expectedDBMode       dpconf.DBMode
+		expectedRouterFlavor dpconf.RouterFlavor
 		expectedKongVersion  string
 	}{
 		{
 			name:                 "dbless config with version 3.4.1",
 			configStr:            dblessConfigJSON3_4_1,
-			expectedDBMode:       dataplaneutil.DBModeOff,
-			expectedRouterFlavor: dataplaneutil.RouterFlavorTraditionalCompatible,
+			expectedDBMode:       dpconf.DBModeOff,
+			expectedRouterFlavor: dpconf.RouterFlavorTraditionalCompatible,
 			expectedKongVersion:  versions.KICv3VersionCutoff.String(),
 		},
 	}

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
@@ -39,7 +39,7 @@ func RunWhenKongVersion(t *testing.T, vRangeStr string, msg ...any) {
 	}
 }
 
-func RunWhenKongDBMode(t *testing.T, dbmode dataplaneutil.DBMode, msg ...any) {
+func RunWhenKongDBMode(t *testing.T, dbmode dpconf.DBMode, msg ...any) {
 	t.Helper()
 
 	actual := eventuallyGetKongDBMode(t, proxyAdminURL)
@@ -85,12 +85,12 @@ func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
 	return version
 }
 
-func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) dataplaneutil.DBMode {
+func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) dpconf.DBMode {
 	t.Helper()
 
 	var (
 		err    error
-		dbmode dataplaneutil.DBMode
+		dbmode dpconf.DBMode
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
@@ -102,12 +102,12 @@ func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) dataplaneutil.DBMo
 	return dbmode
 }
 
-func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) dataplaneutil.RouterFlavor {
+func eventuallyGetKongRouterFlavor(t *testing.T, adminURL *url.URL) dpconf.RouterFlavor {
 	t.Helper()
 
 	var (
 		err          error
-		routerFlavor dataplaneutil.RouterFlavor
+		routerFlavor dpconf.RouterFlavor
 	)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -11,8 +11,8 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
-	dataplaneutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
@@ -74,7 +74,7 @@ func (e TooOldKongGatewayError) Error() string {
 }
 
 // GetKongDBMode returns kong dbmode using the provided Admin API URL.
-func GetKongDBMode(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (dataplaneutil.DBMode, error) {
+func GetKongDBMode(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (dpconf.DBMode, error) {
 	jsonResp, err := GetKongRootConfig(ctx, proxyAdminURL, kongTestPassword)
 	if err != nil {
 		return "", err
@@ -87,7 +87,7 @@ func GetKongDBMode(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword
 }
 
 // GetKongRouterFlavor gets router flavor of Kong using the provided Admin API URL.
-func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (dataplaneutil.RouterFlavor, error) {
+func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (dpconf.RouterFlavor, error) {
 	jsonResp, err := GetKongRootConfig(ctx, proxyAdminURL, kongTestPassword)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Review suggestion to #5092.

- Moved DBMode and RouterFlavor enums from internal/util/dataplane to internal/dataplane/config.
- Added a linter rule for internal/dataplane/config alias to be enforced to dpconf
- Changed DBMode's helper functions to methods