### PR TITLE
chore(refactor): rename translators to subtranslator everywhere

### DIFF
--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 )
 
@@ -195,7 +195,7 @@ func validateWithKongGateway(
 	var kongRoutes []kong.Route
 	var errMsgs []string
 	for _, rule := range httproute.Spec.Rules {
-		translation := translators.KongRouteTranslation{
+		translation := subtranslator.KongRouteTranslation{
 			Name:    "validation-attempt",
 			Matches: rule.Matches,
 			Filters: rule.Filters,

--- a/internal/dataplane/translator/subtranslator/atc_utils.go
+++ b/internal/dataplane/translator/subtranslator/atc_utils.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"strings"

--- a/internal/dataplane/translator/subtranslator/atc_utils_test.go
+++ b/internal/dataplane/translator/subtranslator/atc_utils_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"testing"

--- a/internal/dataplane/translator/subtranslator/grpcroute.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"fmt"

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"fmt"

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"reflect"

--- a/internal/dataplane/translator/subtranslator/grpcroute_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"testing"

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"encoding/json"

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"fmt"

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"strconv"

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"errors"

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"fmt"

--- a/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"fmt"

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"testing"

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"errors"

--- a/internal/dataplane/translator/subtranslator/l4route_atc.go
+++ b/internal/dataplane/translator/subtranslator/l4route_atc.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"github.com/samber/lo"

--- a/internal/dataplane/translator/subtranslator/l4route_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/l4route_atc_test.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	"testing"

--- a/internal/dataplane/translator/subtranslator/portdef.go
+++ b/internal/dataplane/translator/subtranslator/portdef.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import (
 	netv1 "k8s.io/api/networking/v1"

--- a/internal/dataplane/translator/subtranslator/subtranslator_errors.go
+++ b/internal/dataplane/translator/subtranslator/subtranslator_errors.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 import "errors"
 

--- a/internal/dataplane/translator/subtranslator/subtranslator_vars.go
+++ b/internal/dataplane/translator/subtranslator/subtranslator_vars.go
@@ -1,4 +1,4 @@
-package translators
+package subtranslator
 
 const (
 	// KongPathRegexPrefix is the reserved prefix string that instructs Kong 3.0+ to interpret a path as a regex.

--- a/internal/dataplane/translator/translate_grpcroute_test.go
+++ b/internal/dataplane/translator/translate_grpcroute_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
@@ -379,13 +379,13 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						Route: kong.Route{
 							Name:       kong.String("grpcroute.default.grpcroute-no-hostnames-no-matches._.0.0"),
-							Expression: kong.String(translators.CatchAllHTTPExpression),
+							Expression: kong.String(subtranslator.CatchAllHTTPExpression),
 						},
 					},
 				},
 			},
 			expectedFailures: []failures.ResourceFailure{
-				newResourceFailure(t, translators.ErrRouteValidationNoRules.Error(),
+				newResourceFailure(t, subtranslator.ErrRouteValidationNoRules.Error(),
 					&gatewayapi.GRPCRoute{
 						TypeMeta: grpcRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
@@ -86,7 +86,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			},
 			expressionRoutes: false,
-			expectedError:    translators.ErrRouteValidationNoRules,
+			expectedError:    subtranslator.ErrRouteValidationNoRules,
 		},
 		{
 			name: "HTTPRoute with query param match should pass validation with expression routes",
@@ -134,7 +134,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			},
 			expressionRoutes: false,
-			expectedError:    translators.ErrRouteValidationQueryParamMatchesUnsupported,
+			expectedError:    subtranslator.ErrRouteValidationQueryParamMatchesUnsupported,
 		},
 	}
 
@@ -1836,15 +1836,15 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		matchWithPriority   translators.SplitHTTPRouteMatchToKongRoutePriority
+		matchWithPriority   subtranslator.SplitHTTPRouteMatchToKongRoutePriority
 		expectedKongService kongstate.Service
 		expectedKongRoute   kongstate.Route
 		expectedError       error
 	}{
 		{
 			name: "no hostname",
-			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: translators.SplitHTTPRouteMatch{
+			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: subtranslator.SplitHTTPRouteMatch{
 					Source: &gatewayapi.HTTPRoute{
 						TypeMeta: httpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{
@@ -1894,8 +1894,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 		},
 		{
 			name: "precise hostname and filter",
-			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: translators.SplitHTTPRouteMatch{
+			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: subtranslator.SplitHTTPRouteMatch{
 					Source: &gatewayapi.HTTPRoute{
 						TypeMeta: httpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{
@@ -1972,8 +1972,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 		},
 		{
 			name: "wildcard hostname with multiple backends",
-			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: translators.SplitHTTPRouteMatch{
+			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: subtranslator.SplitHTTPRouteMatch{
 					Source: &gatewayapi.HTTPRoute{
 						TypeMeta: httpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{
@@ -2034,8 +2034,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 		},
 		{
 			name: "precise hostname and no match",
-			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: translators.SplitHTTPRouteMatch{
+			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: subtranslator.SplitHTTPRouteMatch{
 					Source: &gatewayapi.HTTPRoute{
 						TypeMeta: httpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{
@@ -2086,8 +2086,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 		},
 		{
 			name: "no hostname and no match",
-			matchWithPriority: translators.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: translators.SplitHTTPRouteMatch{
+			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
+				Match: subtranslator.SplitHTTPRouteMatch{
 					Source: &gatewayapi.HTTPRoute{
 						TypeMeta: httpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{
@@ -2125,7 +2125,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 			expectedKongRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("httproute.default.httproute-1._.0.0"),
-					Expression:   kong.String(translators.CatchAllHTTPExpression),
+					Expression:   kong.String(subtranslator.CatchAllHTTPExpression),
 					PreserveHost: kong.Bool(true),
 					StripPath:    kong.Bool(false),
 					Priority:     kong.Uint64(1024),

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
 
@@ -156,7 +156,7 @@ func TestGetDefaultBackendService(t *testing.T) {
 				route := svc.Routes[0]
 				if tc.expressionRoutes {
 					require.Equal(t, `(http.path ^= "/") && ((net.protocol == "http") || (net.protocol == "https"))`, *route.Expression)
-					require.Equal(t, translators.IngressDefaultBackendPriority, *route.Priority)
+					require.Equal(t, subtranslator.IngressDefaultBackendPriority, *route.Priority)
 				} else {
 					require.Len(t, route.Paths, 1)
 					require.Equal(t, *route.Paths[0], "/")

--- a/internal/dataplane/translator/translate_tcproute.go
+++ b/internal/dataplane/translator/translate_tcproute.go
@@ -3,7 +3,7 @@ package translator
 import (
 	"fmt"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 )
 
@@ -48,7 +48,7 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 func (t *Translator) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewayapi.TCPRoute) error {
 	spec := tcproute.Spec
 	if len(spec.Rules) == 0 {
-		return translators.ErrRouteValidationNoRules
+		return subtranslator.ErrRouteValidationNoRules
 	}
 
 	gwPorts := t.getGatewayListeningPorts(tcproute.Namespace, gatewayapi.TCPProtocolType, spec.CommonRouteSpec.ParentRefs)

--- a/internal/dataplane/translator/translate_tlsroute.go
+++ b/internal/dataplane/translator/translate_tlsroute.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
@@ -57,7 +57,7 @@ func (t *Translator) ingressRulesFromTLSRoute(result *ingressRules, tlsroute *ga
 		return fmt.Errorf("no hostnames provided")
 	}
 	if len(spec.Rules) == 0 {
-		return translators.ErrRouteValidationNoRules
+		return subtranslator.ErrRouteValidationNoRules
 	}
 
 	tlsPassthrough, err := t.isTLSRoutePassthrough(tlsroute)

--- a/internal/dataplane/translator/translate_udproute.go
+++ b/internal/dataplane/translator/translate_udproute.go
@@ -3,7 +3,7 @@ package translator
 import (
 	"fmt"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 )
 
@@ -55,7 +55,7 @@ func (t *Translator) ingressRulesFromUDPRoutes() ingressRules {
 func (t *Translator) ingressRulesFromUDPRoute(result *ingressRules, udproute *gatewayapi.UDPRoute) error {
 	spec := udproute.Spec
 	if len(spec.Rules) == 0 {
-		return translators.ErrRouteValidationNoRules
+		return subtranslator.ErrRouteValidationNoRules
 	}
 
 	gwPorts := t.getGatewayListeningPorts(udproute.Namespace, gatewayapi.UDPProtocolType, spec.CommonRouteSpec.ParentRefs)
@@ -90,11 +90,11 @@ func (t *Translator) ingressRulesFromUDPRoute(result *ingressRules, udproute *ga
 // at least try to provide a helpful message about the situation in the manager logs.
 func validateUDPRoute(udproute *gatewayapi.UDPRoute) error {
 	if len(udproute.Spec.Rules) == 0 {
-		return translators.ErrRouteValidationNoRules
+		return subtranslator.ErrRouteValidationNoRules
 	}
 	for _, rule := range udproute.Spec.Rules {
 		if len(rule.BackendRefs) == 0 {
-			return translators.ErrRotueValidationRuleNoBackendRef
+			return subtranslator.ErrRotueValidationRuleNoBackendRef
 		}
 	}
 	return nil

--- a/internal/dataplane/translator/translate_udproute_test.go
+++ b/internal/dataplane/translator/translate_udproute_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
@@ -434,7 +434,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			},
 			expectedFailures: []failures.ResourceFailure{
 				newResourceFailure(
-					t, translators.ErrRouteValidationNoRules.Error(),
+					t, subtranslator.ErrRouteValidationNoRules.Error(),
 					&gatewayapi.UDPRoute{
 						TypeMeta:   udpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
@@ -896,7 +896,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			},
 			expectedFailures: []failures.ResourceFailure{
 				newResourceFailure(
-					t, translators.ErrRouteValidationNoRules.Error(),
+					t, subtranslator.ErrRouteValidationNoRules.Error(),
 					&gatewayapi.UDPRoute{
 						TypeMeta:   udpRouteTypeMeta,
 						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},

--- a/internal/dataplane/translator/translate_utils.go
+++ b/internal/dataplane/translator/translate_utils.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/translators"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
@@ -161,7 +161,7 @@ func generateKongServiceFromBackendRefWithRuleNumber(
 func applyExpressionToIngressRules(result *ingressRules) {
 	for _, svc := range result.ServiceNameToServices {
 		for i := range svc.Routes {
-			translators.ApplyExpressionToL4KongRoute(&svc.Routes[i])
+			subtranslator.ApplyExpressionToL4KongRoute(&svc.Routes[i])
 			svc.Routes[i].Destinations = nil
 			svc.Routes[i].SNIs = nil
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Package with name`translators` doesn't describe well its purpose, rename it to `subtranslator` to maintain the Go singular naming convention and better describe what it does - provides bits and pieces for translating particular objects. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Continuation of the PR
- #5095

