### PR TITLE
fix(ci): change path for regeneration of manifests for e2e tests

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
-          git add ./deploy/single
+          git add ./test/e2e/manifests
           git diff-index --quiet HEAD || \
           git commit -m "chore: regenerate manifests" && \
           git push origin ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

The location of all-in-one manifests used for tests changed in https://github.com/Kong/kubernetes-ingress-controller/pull/4970, hence the path for committing regenerated ones in `.github/workflows/regenerate_on_deps_bump.yaml` needs adjustment. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

