### PR TITLE
build: update golangci-lint config with Gateway API v1 and KIC v1 modules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,12 +82,12 @@ linters-settings:
       alias: metav1
     - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
       alias: gateway${1}
-    - pkg: github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/(v[\w\d]+)
+    - pkg: github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/(v[\w\d]+)
       alias: kong${1}
   forbidigo:
     exclude-godoc-examples: false
     forbid:
-      - 'gatewayv1alpha2|gatewayv1beta1(# use internal/gatewayapi aliases instead)?'
+      - 'gatewayv1alpha2|gatewayv1beta1|gatewayv1(# use internal/gatewayapi aliases instead)?'
       - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
       - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'
   gomodguard:
@@ -158,16 +158,16 @@ issues:
       - gosec
     text: "Potential HTTP request made with variable url"
     path: test\.go
-  # Allow using SchemeGroupVersion, GroupVersion, GroupName, AddToScheme, and Install from gatewayv1alpha2 and
-  # gatewayv1beta1 as their values are different between versions, and we can't alias them in internal/gatewayapi/aliases.go.
+  # Allow using SchemeGroupVersion, GroupVersion, GroupName, AddToScheme, and Install from gatewayv1alpha2,
+  # gatewayv1beta1 and gatewayv1 as their values are different between versions, and we can't alias them in internal/gatewayapi/aliases.go.
   - linters:
       - forbidigo
-    text: "use of `(gatewayv1alpha2|gatewayv1beta1)\\.(SchemeGroupVersion|GroupVersion|GroupName|AddToScheme|Install)"
-  # Allow gatewayv1alpha2 and gatewayv1beta1 types references in internal/gatewayapi/aliases.go as that
+    text: "use of `(gatewayv1alpha2|gatewayv1beta1|gatewayv1)\\.(SchemeGroupVersion|GroupVersion|GroupName|AddToScheme|Install)"
+  # Allow gatewayv1alpha2, gatewayv1beta1 and gatewayv1 types references in internal/gatewayapi/aliases.go as that
   # should be the only place where we use them.
   - linters:
       - forbidigo
-    text: "use of `(gatewayv1alpha2|gatewayv1beta1)"
+    text: "use of `(gatewayv1alpha2|gatewayv1beta1|gatewayv1)"
     path: (internal/gatewayapi/aliases.go|pkg/apis/.*/.*\.go)
 
   - linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,7 +82,7 @@ linters-settings:
       alias: metav1
     - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
       alias: gateway${1}
-    - pkg: github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/(v[\w\d]+)
+    - pkg: github.com/kong/kubernetes-ingress-controller/v[\w\d]+/pkg/apis/configuration/(v[\w\d]+)
       alias: kong${1}
   forbidigo:
     exclude-godoc-examples: false

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
@@ -32,12 +32,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
-
-// -----------------------------------------------------------------------------
-// Vars & Consts
-// -----------------------------------------------------------------------------
-
-var gatewayV1Group = gatewayapi.Group(gatewayv1.GroupName)
 
 // -----------------------------------------------------------------------------
 // Gateway Controller - GatewayReconciler
@@ -647,8 +641,8 @@ func (r *GatewayReconciler) determineL4ListenersFromService(
 	addresses := make([]gatewayapi.GatewayAddress, 0, len(svc.Spec.ClusterIPs))
 	listeners := make([]gatewayapi.Listener, 0, len(svc.Spec.Ports))
 	protocolToRouteGroupKind := map[corev1.Protocol]gatewayapi.RouteGroupKind{
-		corev1.ProtocolTCP: {Group: &gatewayV1Group, Kind: gatewayapi.Kind("TCPRoute")},
-		corev1.ProtocolUDP: {Group: &gatewayV1Group, Kind: gatewayapi.Kind("UDPRoute")},
+		corev1.ProtocolTCP: {Group: lo.ToPtr(gatewayapi.V1Group), Kind: gatewayapi.Kind("TCPRoute")},
+		corev1.ProtocolUDP: {Group: lo.ToPtr(gatewayapi.V1Group), Kind: gatewayapi.Kind("UDPRoute")},
 	}
 
 	for _, port := range svc.Spec.Ports {
@@ -743,7 +737,7 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 				listener.Protocol = gatewayapi.TLSProtocolType
 				listener.AllowedRoutes = &gatewayapi.AllowedRoutes{
 					Kinds: []gatewayapi.RouteGroupKind{
-						{Group: &gatewayV1Group, Kind: (gatewayapi.Kind)("TLSRoute")},
+						{Group: lo.ToPtr(gatewayapi.V1Group), Kind: (gatewayapi.Kind)("TLSRoute")},
 					},
 				}
 			}
@@ -753,14 +747,14 @@ func (r *GatewayReconciler) determineListenersFromDataPlane(
 				listener.Protocol = gatewayapi.HTTPSProtocolType
 				listener.AllowedRoutes = &gatewayapi.AllowedRoutes{
 					Kinds: []gatewayapi.RouteGroupKind{
-						{Group: &gatewayV1Group, Kind: (gatewayapi.Kind)("HTTPRoute")},
+						{Group: lo.ToPtr(gatewayapi.V1Group), Kind: (gatewayapi.Kind)("HTTPRoute")},
 					},
 				}
 			} else {
 				listener.Protocol = gatewayapi.HTTPProtocolType
 				listener.AllowedRoutes = &gatewayapi.AllowedRoutes{
 					Kinds: []gatewayapi.RouteGroupKind{
-						{Group: &gatewayV1Group, Kind: (gatewayapi.Kind)("HTTPRoute")},
+						{Group: lo.ToPtr(gatewayapi.V1Group), Kind: (gatewayapi.Kind)("HTTPRoute")},
 					},
 				}
 			}

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -418,7 +418,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 					Spec: gatewayapi.ReferenceGrantSpec{
 						From: []gatewayapi.ReferenceGrantFrom{
 							{
-								Group:     gatewayV1Group,
+								Group:     gatewayapi.V1Group,
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -468,7 +468,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 							},
 							// good entry
 							{
-								Group:     gatewayV1Group,
+								Group:     gatewayapi.V1Group,
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -500,7 +500,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 					Spec: gatewayapi.ReferenceGrantSpec{
 						From: []gatewayapi.ReferenceGrantFrom{
 							{
-								Group:     gatewayV1Group,
+								Group:     gatewayapi.V1Group,
 								Kind:      "Gateway",
 								Namespace: "test",
 							},

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -543,7 +543,7 @@ func getReferenceGrantConditionReason(
 		}
 		for _, from := range grant.Spec.From {
 			// we are interested only in grants for gateways that want to reference secrets
-			if from.Group != gatewayV1Group || from.Kind != "Gateway" {
+			if from.Group != gatewayapi.V1Group || from.Kind != "Gateway" {
 				continue
 			}
 			if from.Namespace == gatewayapi.Namespace(gatewayNamespace) {
@@ -672,7 +672,7 @@ func routeAcceptedByGateways(routeNamespace string, parentStatuses []gatewayapi.
 	for _, routeParentStatus := range parentStatuses {
 		gatewayNamespace := routeNamespace
 		parentRef := routeParentStatus.ParentRef
-		if (parentRef.Group != nil && *parentRef.Group != gatewayV1Group) ||
+		if (parentRef.Group != nil && *parentRef.Group != gatewayapi.V1Group) ||
 			(parentRef.Kind != nil && *parentRef.Kind != "Gateway") {
 			continue
 		}
@@ -706,7 +706,7 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 		route := route
 		acceptedByGateway := lo.ContainsBy(route.Status.Parents, func(parentStatus gatewayapi.RouteParentStatus) bool {
 			parentRef := parentStatus.ParentRef
-			if parentRef.Group != nil && *parentRef.Group != gatewayV1Group {
+			if parentRef.Group != nil && *parentRef.Group != gatewayapi.V1Group {
 				return false
 			}
 			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -6,6 +6,8 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
+var InstallV1 = gatewayv1.Install
+
 // This file contains aliases for types and consts from the Gateway API.  Its purpose is to allow easy migration from
 // one version of the Gateway API to another with minimal changes to the codebase.
 

--- a/internal/gatewayapi/consts.go
+++ b/internal/gatewayapi/consts.go
@@ -1,0 +1,7 @@
+package gatewayapi
+
+import (
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const V1Group = Group(gatewayv1.GroupName)


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds KIC v3 module and Gateway API v1 into golangci-lint config to enforce the same rules as previously but on mentioned modules
