### PR TITLE
chore: remove a non user facing CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,7 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
-### Changed
-
-- use `req.Clone` improve RoundTrip function.
-  [#5089](https://github.com/Kong/kubernetes-ingress-controller/pull/5089)
+TBD
 
 ## [3.0.0]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove non user facing changelog entry as discussed in https://github.com/Kong/kubernetes-ingress-controller/pull/5089/files/a17fb1ae74bf3601e38ea18215177f637701ff98#r1383038333