### PR TITLE
chore: use k8s team GH PAT in regenerate on deps bump

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: commit and push (if changes detected)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses k8s team bot's PAT instead of a default one to make sure the commit will trigger CI checks.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes problems with https://github.com/Kong/kubernetes-ingress-controller/pull/5113 alike that hasn't its checks run after the GH actions' `chore: regenerate manifests`.
