### PR TITLE
feat: add CRD validation expression for `KongPlugin` and `KongClusterPlugin` `config` and `configFrom` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,11 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
-TBD
+### Changed
+
+- `KongPlugin` and `KongClusterPlugin` now enforce only one of `config` and `configFrom`
+  to be set using the CRD validation expressions
+  [#5119](https://github.com/Kong/kubernetes-ingress-controller/pull/5119)
 
 ## [3.0.0]
 

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -246,7 +246,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin can only have one of config or configFrom set
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
           rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
             !has(self.configFrom))
     served: true

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -247,8 +247,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -245,6 +245,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin can only have one of config or configFrom set
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongclusterplugins.yaml
@@ -246,7 +246,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -241,7 +241,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -242,8 +242,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongplugins.yaml
@@ -240,6 +240,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/internal/admission/errors.go
+++ b/internal/admission/errors.go
@@ -16,7 +16,6 @@ const (
 	ErrTextPluginConfigViolatesSchema         = "plugin failed schema validation: %s"
 	ErrTextPluginNameEmpty                    = "plugin name cannot be empty"
 	ErrTextPluginSecretConfigUnretrievable    = "could not load secret plugin configuration"
-	ErrTextPluginUsesBothConfigTypes          = "plugin cannot use both Config and ConfigFrom"
 )
 
 const (

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -298,6 +298,10 @@ func (validator KongHTTPValidator) ValidatePlugin(
 	}
 	if k8sPlugin.ConfigFrom != nil {
 		if len(plugin.Config) > 0 {
+			// TODO: remove when KIC supports only Kubernetes 1.25+ and this no
+			// longer needs to be done in admission webhook.
+			// CRD validation expression is already in place since
+			// https://github.com/Kong/kubernetes-ingress-controller/pull/5119
 			return false, ErrTextPluginUsesBothConfigTypes, nil
 		}
 		config, err := kongstate.SecretToConfiguration(validator.SecretGetter, (*k8sPlugin.ConfigFrom).SecretValue, k8sPlugin.Namespace)

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -297,13 +297,6 @@ func (validator KongHTTPValidator) ValidatePlugin(
 		return false, ErrTextPluginConfigInvalid, err
 	}
 	if k8sPlugin.ConfigFrom != nil {
-		if len(plugin.Config) > 0 {
-			// TODO: remove when KIC supports only Kubernetes 1.25+ and this no
-			// longer needs to be done in admission webhook.
-			// CRD validation expression is already in place since
-			// https://github.com/Kong/kubernetes-ingress-controller/pull/5119
-			return false, ErrTextPluginUsesBothConfigTypes, nil
-		}
 		config, err := kongstate.SecretToConfiguration(validator.SecretGetter, (*k8sPlugin.ConfigFrom).SecretValue, k8sPlugin.Namespace)
 		if err != nil {
 			return false, ErrTextPluginSecretConfigUnretrievable, err

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -152,27 +152,6 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:      "plugin has both Config and ConfigFrom",
-			PluginSvc: &fakePluginSvc{},
-			args: args{
-				plugin: kongv1.KongPlugin{
-					PluginName: "key-auth",
-					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"key_names": "whatever"}`),
-					},
-					ConfigFrom: &kongv1.ConfigSource{
-						SecretValue: kongv1.SecretValueFromSource{
-							Key:    "key-auth-config",
-							Secret: "conf-secret",
-						},
-					},
-				},
-			},
-			wantOK:      false,
-			wantMessage: ErrTextPluginUsesBothConfigTypes,
-			wantErr:     false,
-		},
-		{
 			name:      "plugin ConfigFrom references non-existent Secret",
 			PluginSvc: &fakePluginSvc{},
 			args: args{
@@ -282,28 +261,6 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigInvalid,
 			wantErr:     true,
-		},
-		{
-			name:      "plugin has both Config and ConfigFrom",
-			PluginSvc: &fakePluginSvc{},
-			args: args{
-				plugin: kongv1.KongClusterPlugin{
-					PluginName: "key-auth",
-					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"key_names": "whatever"}`),
-					},
-					ConfigFrom: &kongv1.NamespacedConfigSource{
-						SecretValue: kongv1.NamespacedSecretValueFromSource{
-							Key:       "key-auth-config",
-							Secret:    "conf-secret",
-							Namespace: "default",
-						},
-					},
-				},
-			},
-			wantOK:      false,
-			wantMessage: ErrTextPluginUsesBothConfigTypes,
-			wantErr:     false,
 		},
 		{
 			name:      "plugin ConfigFrom references non-existent Secret",

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
-// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="KongClusterPlugin cannot use both Config and ConfigFrom"
+// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="Using both config and configFrom fields is not allowed."
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API.
 type KongClusterPlugin struct {

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
+// +kubebuilder:validation:XValidation:rule="(!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))", message="KongClusterPlugin cannot use both Config and ConfigFrom"
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API.
 type KongClusterPlugin struct {

--- a/pkg/apis/configuration/v1/kongclusterplugin_types.go
+++ b/pkg/apis/configuration/v1/kongclusterplugin_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
-// +kubebuilder:validation:XValidation:rule="(!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))", message="KongClusterPlugin cannot use both Config and ConfigFrom"
+// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="KongClusterPlugin cannot use both Config and ConfigFrom"
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API.
 type KongClusterPlugin struct {

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
-// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="KongPlugin cannot use both Config and ConfigFrom"
+// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="Using both config and configFrom fields is not allowed."
 
 // KongPlugin is the Schema for the kongplugins API.
 type KongPlugin struct {

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
-// +kubebuilder:validation:XValidation:rule="(!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))", message="KongPlugin cannot use both Config and ConfigFrom"
+// +kubebuilder:validation:XValidation:rule="(has(self.config) || has(self.configFrom)) ? ((!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))) : true", message="KongPlugin cannot use both Config and ConfigFrom"
 
 // KongPlugin is the Schema for the kongplugins API.
 type KongPlugin struct {

--- a/pkg/apis/configuration/v1/kongplugin_types.go
+++ b/pkg/apis/configuration/v1/kongplugin_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Disabled",type=boolean,JSONPath=`.disabled`,description="Indicates if the plugin is disabled",priority=1
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.config`,description="Configuration of the plugin",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
+// +kubebuilder:validation:XValidation:rule="(!has(self.config) && has(self.configFrom)) || (has(self.config) && !has(self.configFrom))", message="KongPlugin cannot use both Config and ConfigFrom"
 
 // KongPlugin is the Schema for the kongplugins API.
 type KongPlugin struct {

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -304,7 +304,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'
@@ -1212,7 +1212,7 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - message: KongPlugin cannot use both Config and ConfigFrom
+        - message: Using both config and configFrom fields is not allowed.
           rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
             && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
             : true'

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -303,6 +303,10 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: KongClusterPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:
@@ -1207,7 +1211,9 @@ spec:
         - plugin
         type: object
         x-kubernetes-validations:
-        - rule: has(self.config) && !has(self.configFrom)
+        - message: KongPlugin cannot use both Config and ConfigFrom
+          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
+            !has(self.configFrom))
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -305,8 +305,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongClusterPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:
@@ -1212,8 +1213,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: KongPlugin cannot use both Config and ConfigFrom
-          rule: (!has(self.config) && has(self.configFrom)) || (has(self.config) &&
-            !has(self.configFrom))
+          rule: '(has(self.config) || has(self.configFrom)) ? ((!has(self.config)
+            && has(self.configFrom)) || (has(self.config) && !has(self.configFrom)))
+            : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -1206,6 +1206,8 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - rule: has(self.config) && !has(self.configFrom)
     served: true
     storage: true
     subresources:

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -533,7 +533,7 @@ func TestCRDValidations(t *testing.T) {
 					},
 				})
 				assert.Error(t, err)
-				assert.ErrorContains(t, err, "KongPlugin cannot use both Config and ConfigFrom")
+				assert.ErrorContains(t, err, "Using both config and configFrom fields is not allowed.")
 			},
 		},
 		{
@@ -590,7 +590,7 @@ func TestCRDValidations(t *testing.T) {
 					},
 				})
 				assert.Error(t, err)
-				assert.ErrorContains(t, err, "KongClusterPlugin cannot use both Config and ConfigFrom")
+				assert.ErrorContains(t, err, "Using both config and configFrom fields is not allowed.")
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds CRD validation expression to `KongPlugin` and `KongClusterPlugin` to enforce only one of `config` and `configFrom` fields to be set using the CRD validation expressions.

**Which issue this PR fixes**:

Related to #5062 (just a small part of it).

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
