### PR TITLE
[backport] fix: use only 46 bits for priorities of Kong routes (#5024)

### DIFF
--- a/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -16,7 +16,7 @@ services:
     https_redirect_status_code: 426
     name: grpcroute.default.grpcbin.example.com.0.0
     preserve_host: true
-    priority: 1713055227461631
+    priority: 26766487929087
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default

--- a/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -12,7 +12,7 @@ services:
     https_redirect_status_code: 426
     name: httproute..httproute-testing._.0.0
     preserve_host: true
-    priority: 2251808940752895
+    priority: 35184514699263
     strip_path: true
     tags:
     - k8s-name:httproute-testing

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.net.8000
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -42,7 +42,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     preserve_host: true
-    priority: 3382102062006273
+    priority: 57178899611649
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071817
+    priority: 57178899677193
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071818
+    priority: 57178899677194
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -80,7 +80,7 @@ services:
     https_redirect_status_code: 426
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -27,7 +27,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo-2.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     preserve_host: true
-    priority: 3382102062006304
+    priority: 57178899611680
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/internal/dataplane/parser/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -13,7 +13,7 @@ services:
     https_redirect_status_code: 426
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
-    priority: 3382102062071809
+    priority: 57178899677185
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/parser/translators/atc_utils.go
+++ b/internal/dataplane/parser/translators/atc_utils.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	// FromResourceKindPriorityShiftBits is the highest 2 bits 51-50 used in priority field of Kong route
+	// FromResourceKindPriorityShiftBits is the highest 2 bits 45-44 used in priority field of Kong route
 	// to note the kind of the resource from which the route is translated.
 	// 11 - routes from Ingress.
 	// 10 - routes from HTTPRoute.
 	// 01 - routes from GRPCRoute.
-	FromResourceKindPriorityShiftBits = 50
+	FromResourceKindPriorityShiftBits = 44
 	// ResourceKindBitsIngress is the value of highest 2 bits for routes from ingresses.
 	ResourceKindBitsIngress = 3
 	// ResourceKindBitsHTTPRoute is the value of highest 2 bits for routes from HTTPRoutes.

--- a/internal/dataplane/parser/translators/grpcroute_atc.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc.go
@@ -286,11 +286,11 @@ func CalculateGRCPRouteMatchPriorityTraits(match SplitGRPCRouteMatch) GRPCRouteP
 
 // EncodeToPriority turns GRPCRoute priority traits into the integer expressed priority.
 //
-//					   4                   3                   2                   1
-//	 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
-//	+-+---------------+---------------------+---------------------+---------+---------------------------+
-//	|P| host len      | GRPC service length | GRPC method length  |Header No| relative order            |
-//	+-+---------------+---------------------+---------------------+---------+---------------------------+
+//		   4                   3                   2                   1
+//	 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+//	+-+---------------+---------------------+---------------------+---------+----------------+
+//	|P| host len      | GRPC service length | GRPC method length  |Header No| relative order |
+//	+-+---------------+---------------------+---------------------+---------+----------------+
 //
 // Where:
 // P: set to 1 if the hostname is non-wildcard.
@@ -304,17 +304,17 @@ func CalculateGRCPRouteMatchPriorityTraits(match SplitGRPCRouteMatch) GRPCRouteP
 // to assign higher priority for method match with `Exact` match?
 func (t GRPCRoutePriorityTraits) EncodeToPriority() RoutePriorityType {
 	const (
-		// PreciseHostnameShiftBits assigns bit 49 for marking if the hostname is non-wildcard.
-		PreciseHostnameShiftBits = 49
-		// HostnameLengthShiftBits assigns bits 41-48 for the length of hostname.
-		HostnameLengthShiftBits = 41
-		// ServiceLengthShiftBits assigns bits 30-40 for the length of `Service` in method match.
-		ServiceLengthShiftBits = 30
-		// MethodLengthShiftBits assigns bits 19-29 for the length of `Method` in method match.
-		MethodLengthShiftBits = 19
-		// HeaderCountShiftBits assigns bits 14-18 for the number of header matches.
-		HeaderCountShiftBits = 14
-		// bits 0-13 are used for relative order of creation timestamp, namespace/name, and internal order of rules and matches.
+		// PreciseHostnameShiftBits assigns bit 43 for marking if the hostname is non-wildcard.
+		PreciseHostnameShiftBits = 43
+		// HostnameLengthShiftBits assigns bits 35-42 for the length of hostname.
+		HostnameLengthShiftBits = 35
+		// ServiceLengthShiftBits assigns bits 24-34 for the length of `Service` in method match.
+		ServiceLengthShiftBits = 24
+		// MethodLengthShiftBits assigns bits 13-23 for the length of `Method` in method match.
+		MethodLengthShiftBits = 13
+		// HeaderCountShiftBits assigns bits 8-12 for the number of header matches.
+		HeaderCountShiftBits = 8
+		// bits 0-7 are used for relative order of creation timestamp, namespace/name, and internal order of rules and matches.
 		// the bits are calculated by sorting GRPCRoutes with the same priority calculated from the fields above
 		// and start from all 1s, then decrease by one for each GRPCRoute.
 	)
@@ -366,11 +366,11 @@ func AssignRoutePriorityToSplitGRPCRouteMatches(
 
 	splitGRPCRoutesToPriority := make([]SplitGRPCRouteMatchToPriority, 0, len(splitGRPCouteMatches))
 
-	// Bits 0-13 (14 bits) are assigned for relative order of GRPCRoutes.
+	// Bits 0-7 (8 bits) are assigned for relative order of GRPCRoutes.
 	// If multiple GRPCRoutes are assigned to the same priority in the previous step,
-	// sort them then starts with 2^14 -1 and decrease by one for each GRPCRoute;
+	// sort them then starts with 2^8 -1 and decrease by one for each GRPCRoute;
 	// If only one GRPCRoute occupies the priority, fill the relative order bits with all 1s.
-	const relativeOrderAssignedBits = 14
+	const relativeOrderAssignedBits = 8
 	const defaultRelativeOrderPriorityBits RoutePriorityType = (1 << relativeOrderAssignedBits) - 1
 
 	for priority, matches := range priorityToSplitGRPCRouteMatches {
@@ -389,7 +389,7 @@ func AssignRoutePriorityToSplitGRPCRouteMatches(
 
 		for i, match := range matches {
 			relativeOrderBits := defaultRelativeOrderPriorityBits - RoutePriorityType(i)
-			// Although it is very unlikely that there are 2^14 = 16384 GRPCRoutes
+			// Although it is very unlikely that there are 2^8 = 256 GRPCRoutes
 			// should be given priority by their relative order, here we limit the
 			// relativeOrderBits to be at least 0.
 			if relativeOrderBits <= 0 {
@@ -401,10 +401,10 @@ func AssignRoutePriorityToSplitGRPCRouteMatches(
 			})
 		}
 
-		// Just in case, log a very unlikely scenario where we have more than 2^14 routes with the same base
+		// Just in case, log a very unlikely scenario where we have more than 2^8 routes with the same base
 		// priority and we have no bit space for them to be deterministically ordered.
-		if len(matches) > (1 << 14) {
-			logger.V(util.WarnLevel).Info("Too many GRPCRoute matches to be deterministically ordered", "grpcroute_number", len(matches))
+		if len(matches) > (1 << 8) {
+			logger.Error(nil, "Too many GRPCRoute matches to be deterministically ordered", "grpcroute_number", len(matches))
 		}
 	}
 

--- a/internal/dataplane/parser/translators/grpcroute_atc_test.go
+++ b/internal/dataplane/parser/translators/grpcroute_atc_test.go
@@ -614,7 +614,7 @@ func TestGRPCRouteTraitsEncodeToPriority(t *testing.T) {
 				HostnameLength:  15,
 				ServiceLength:   7,
 			},
-			exprectedPriority: (1 << 50) | (1 << 49) | (15 << 41) | (7 << 30),
+			exprectedPriority: (1 << 44) | (1 << 43) | (15 << 35) | (7 << 24),
 		},
 		{
 			name: "non precise hostname",
@@ -625,7 +625,7 @@ func TestGRPCRouteTraitsEncodeToPriority(t *testing.T) {
 				MethodLength:    7,
 				HeaderCount:     3,
 			},
-			exprectedPriority: (1 << 50) | (15 << 41) | (7 << 30) | (7 << 19) | (3 << 14),
+			exprectedPriority: (1 << 44) | (15 << 35) | (7 << 24) | (7 << 13) | (3 << 8),
 		},
 	}
 
@@ -648,7 +648,7 @@ func TestAssignRoutePriorityToSplitGRPCRouteMatches(t *testing.T) {
 		matchIndex int
 	}
 	now := time.Now()
-	const maxRelativeOrderPriorityBits = (1 << 14) - 1
+	const maxRelativeOrderPriorityBits = (1 << 8) - 1
 
 	testCases := []struct {
 		name                  string
@@ -1124,14 +1124,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 0,
 				},
-				Priority: 1024,
+				Priority: 1 << 14,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.no-hostname-exact-method._.0.0"),
 					PreserveHost: kong.Bool(true),
 					Expression:   kong.String(`http.path == "/pets/list"`),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64(1 << 14),
 				},
 				ExpressionRoutes: true,
 			},
@@ -1176,14 +1176,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 0,
 				},
-				Priority: 1024,
+				Priority: (1 << 31) + 1,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.precise-hostname-regex-method.foo.com.0.0"),
 					Expression:   kong.String(`(http.path ~ "^/name/[a-z0-9]+") && (http.host == "foo.com")`),
 					PreserveHost: kong.Bool(true),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64((1 << 31) + 1),
 				},
 				ExpressionRoutes: true,
 			},
@@ -1245,14 +1245,14 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 					RuleIndex:  0,
 					MatchIndex: 1,
 				},
-				Priority: 1024,
+				Priority: (1 << 42) + 1,
 			},
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.wildcard-hostname-header-match._.foo.com.0.1"),
 					Expression:   kong.String(`(http.path ^= "/name/") && (http.headers.foo == "bar") && (http.host =^ ".foo.com")`),
 					PreserveHost: kong.Bool(true),
-					Priority:     kong.Uint64(1024),
+					Priority:     kong.Uint64((1 << 42) + 1),
 				},
 				ExpressionRoutes: true,
 			},

--- a/internal/dataplane/parser/translators/httproute_atc_test.go
+++ b/internal/dataplane/parser/translators/httproute_atc_test.go
@@ -478,7 +478,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathType:        gatewayv1beta1.PathMatchExact,
 				PathLength:      4,
 			},
-			expectedPriority: (2 << 50) | (1 << 49) | (7 << 41) | (1 << 40) | (3 << 29),
+			expectedPriority: (2 << 44) | (1 << 43) | (7 << 35) | (1 << 34) | (3 << 23),
 		},
 		{
 			name: "wildcard hostname and prefix path",
@@ -488,7 +488,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathType:        gatewayv1beta1.PathMatchPathPrefix,
 				PathLength:      5,
 			},
-			expectedPriority: (2 << 50) | (7 << 41) | (4 << 29),
+			expectedPriority: (2 << 44) | (7 << 35) | (4 << 23),
 		},
 		{
 			name: "no hostname and regex path, with header matches",
@@ -497,7 +497,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				PathLength:  5,
 				HeaderCount: 2,
 			},
-			expectedPriority: (2 << 50) | (1 << 39) | (4 << 29) | (2 << 23),
+			expectedPriority: (2 << 44) | (1 << 33) | (4 << 23) | (2 << 17),
 		},
 		{
 			name: "no hostname and exact path, with method match and query parameter matches",
@@ -507,7 +507,7 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 				HasMethodMatch:  true,
 				QueryParamCount: 1,
 			},
-			expectedPriority: (2 << 50) | (1 << 40) | (4 << 29) | (1 << 28) | (1 << 18),
+			expectedPriority: (2 << 44) | (1 << 34) | (4 << 23) | (1 << 22) | (1 << 12),
 		},
 	}
 
@@ -728,7 +728,7 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 		matchIndex int
 	}
 	now := time.Now()
-	const maxRelativeOrderPriorityBits = (1 << 18) - 1
+	const maxRelativeOrderPriorityBits = (1 << 12) - 1
 
 	testCases := []struct {
 		name    string

--- a/internal/dataplane/parser/translators/ingress_atc_test.go
+++ b/internal/dataplane/parser/translators/ingress_atc_test.go
@@ -432,7 +432,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  false,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (1 << 32) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (1 << 32) | 5,
 		},
 		{
 			name: "plain host false regex path true",
@@ -443,7 +443,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  true,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (2 << 33) | (1 << 16) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (2 << 33) | (1 << 16) | 5,
 		},
 		{
 			name: "header number exceed limit",
@@ -454,7 +454,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				MaxPathLength: 5,
 				HasRegexPath:  true,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (255 << 33) | (1 << 16) | 5,
+			expectedPriority: (3 << 44) | (2 << 41) | (255 << 33) | (1 << 16) | 5,
 		},
 		{
 			name: "path length exceed limit",
@@ -463,7 +463,7 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 				PlainHostOnly: true,
 				MaxPathLength: 100000,
 			},
-			expectedPriority: (3 << 50) | (2 << 41) | (1 << 32) | 65535,
+			expectedPriority: (3 << 44) | (2 << 41) | (1 << 32) | 65535,
 		},
 	}
 


### PR DESCRIPTION
(cherry picked from commit b2475f344850bf9b6722d0cac508a8a2866b8fee)
