### PR TITLE
fix: bound IPv6 addresses for discovery

### DIFF
--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -110,6 +110,34 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 			dnsStrategy: cfgtypes.IPDNSStrategy,
 		},
 		{
+			name: "basic IPDNSStrategy IPv6",
+			endpoints: discoveryv1.EndpointSlice{
+				ObjectMeta:  endpointsSliceObjectMeta,
+				AddressType: discoveryv1.AddressTypeIPv6,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"fe80::cae2:65ff:fe7b:2852", "fe80::cae2:65ff:fe7b:2853"},
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       lo.ToPtr(true),
+							Terminating: lo.ToPtr(false),
+						},
+						TargetRef: testPodReference(namespaceName, "pod-1"),
+					},
+				},
+				Ports: builder.NewEndpointPort(8444).WithName("admin").IntoSlice(),
+			},
+			portNames: sets.New("admin"),
+			want: sets.New(
+				DiscoveredAdminAPI{
+					Address: "https://[fe80::cae2:65ff:fe7b:2852]:8444",
+					PodRef: k8stypes.NamespacedName{
+						Name: "pod-1", Namespace: namespaceName,
+					},
+				},
+			),
+			dnsStrategy: cfgtypes.IPDNSStrategy,
+		},
+		{
 			name: "basic",
 			endpoints: discoveryv1.EndpointSlice{
 				ObjectMeta:  endpointsSliceObjectMeta,


### PR DESCRIPTION
**What this PR does / why we need it**:

Include IPv6 address bound markers in discovery so as not to incorrectly include the port as part of the address.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5138 for the IP strategy.

**Special notes for your reviewer**:

IDK what's needed to fix the hostname strategies. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 is not very helpful for IPv6 address records despite the mention of AAAA records. They presumably do not use `[` and `]` because hostnames.

Integration tests lack the ability to test discovery behavior at present, and we don't do an IPv6 test run to boot, so only a unit. Building an image and running it through the configuration that [found  the issue](https://github.com/Kong/kubernetes-ingress-controller/issues/5138#issuecomment-1804660545) indicated that it did clear this.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
