### PR TITLE
chore(kustomize): resolve Warning: 'patchesJson6902' is deprecated.

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: kong
 resources:
 - namespace.yaml
@@ -12,4 +14,4 @@ resources:
 - kong-ingress-dbless.yaml
 
 components:
-  - ../image/oss
+- ../image/oss

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -13,7 +15,6 @@ resources:
 - bases/configuration.konghq.com_kongupstreampolicies.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_tcpingresses.yaml

--- a/config/variants/enterprise-postgres/kustomization.yaml
+++ b/config/variants/enterprise-postgres/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../postgres
 - enterprise-resources.yaml
@@ -7,4 +9,4 @@ patches:
 - path: kong-enterprise-job.yaml
 
 components:
-  - ../../image/enterprise/
+- ../../image/enterprise/

--- a/config/variants/enterprise/kustomization.yaml
+++ b/config/variants/enterprise/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../multi-gw/base
 
@@ -5,4 +7,4 @@ patches:
 - path: kong-enterprise.yaml
 
 components:
-  - ../../image/enterprise/
+- ../../image/enterprise/

--- a/config/variants/multi-gw-postgres/base/kustomization.yaml
+++ b/config/variants/multi-gw-postgres/base/kustomization.yaml
@@ -9,16 +9,14 @@ resources:
 - gateway_deployment.yaml
 
 components:
-  - ../../../image/oss
+- ../../../image/oss
 
 patches:
 - path: manager_multi_gateway_patch.yaml
 - path: gateway_service_patch.yaml
-
-patchesJson6902:
-- target:
+- path: ./remove_proxy_container.yaml
+  target:
     group: apps
-    version: v1
     kind: Deployment
     name: ingress-kong
-  path: ./remove_proxy_container.yaml
+    version: v1

--- a/config/variants/multi-gw-postgres/oss/kustomization.yaml
+++ b/config/variants/multi-gw-postgres/oss/kustomization.yaml
@@ -5,18 +5,18 @@ resources:
 - ../base
 
 components:
-  - ../../../image/oss
+- ../../../image/oss
 
 patches:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: ingress-kong
-  patch: |-
+- patch: |-
     - op: add
       path: /spec/template/metadata/annotations/traffic.kuma.io~1exclude-outbound-ports
       value: "8444"
     - op: add
       path: /spec/template/metadata/annotations/traffic.sidecar.istio.io~1excludeOutboundPorts
       value: "8444"
+  target:
+    group: apps
+    kind: Deployment
+    name: ingress-kong
+    version: v1

--- a/config/variants/multi-gw/oss/kustomization.yaml
+++ b/config/variants/multi-gw/oss/kustomization.yaml
@@ -5,18 +5,18 @@ resources:
 - ../base
 
 components:
-  - ../../../image/oss
+- ../../../image/oss
 
 patches:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: ingress-kong
-  patch: |-
+- patch: |-
     - op: add
       path: /spec/template/metadata/annotations/traffic.kuma.io~1exclude-outbound-ports
       value: "8444"
     - op: add
       path: /spec/template/metadata/annotations/traffic.sidecar.istio.io~1excludeOutboundPorts
       value: "8444"
+  target:
+    group: apps
+    kind: Deployment
+    name: ingress-kong
+    version: v1

--- a/config/variants/postgres/kustomization.yaml
+++ b/config/variants/postgres/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../../base/
 - migration.yaml


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

When I run `make manifest`, I receive the following warnings:

```
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```



<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The content is generated automatically via `kustomize edit fix`
<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

<s>
- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
</s>