### PR TITLE
chore: fix typos in log entry and function identifier, reuse helper in test

### DIFF
--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -375,7 +375,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(grpcroute)
 		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
 			// requeue until grpcroute is configured.
-			debug(log, grpcroute, "GRPCRoute not configured,requeueing")
+			debug(log, grpcroute, "GRPCRoute not configured, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -456,7 +456,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(httproute)
 		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
 			// requeue until httproute is configured.
-			debug(log, httproute, "HTTPRoute not configured,requeueing")
+			debug(log, httproute, "HTTPRoute not configured, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -382,7 +382,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(tcproute)
 		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
 			// requeue until tcproute is configured.
-			debug(log, tcproute, "TCPRoute not configured,requeueing")
+			debug(log, tcproute, "TCPRoute not configured, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -371,7 +371,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(tlsroute)
 		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
 			// requeue until tlsroute is configured.
-			debug(log, tlsroute, "TLSRoute not configured,requeueing")
+			debug(log, tlsroute, "TLSRoute not configured, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -376,7 +376,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(udproute)
 		if configurationStatus == k8sobj.ConfigurationStatusUnknown {
 			// requeue until udproute is configured.
-			debug(log, udproute, "UDPRoute not configured,requeueing")
+			debug(log, udproute, "UDPRoute not configured, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -45,7 +45,7 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		}
 		hostnames := getGRPCRouteHostnamesAsSliceOfStrings(grpcroute)
 		// assign an empty match to generate matchers by only hostnames and annotations.
-		matcher := generateMathcherFromGRPCMatch(gatewayapi.GRPCRouteMatch{}, hostnames, ingressObjectInfo.Annotations)
+		matcher := generateMatcherFromGRPCMatch(gatewayapi.GRPCRouteMatch{}, hostnames, ingressObjectInfo.Annotations)
 		atc.ApplyExpression(&r.Route, matcher, 1)
 		return []kongstate.Route{r}
 	}
@@ -68,7 +68,7 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		}
 
 		hostnames := getGRPCRouteHostnamesAsSliceOfStrings(grpcroute)
-		matcher := generateMathcherFromGRPCMatch(match, hostnames, ingressObjectInfo.Annotations)
+		matcher := generateMatcherFromGRPCMatch(match, hostnames, ingressObjectInfo.Annotations)
 
 		atc.ApplyExpression(&r.Route, matcher, 1)
 		routes = append(routes, r)
@@ -77,7 +77,7 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 	return routes
 }
 
-func generateMathcherFromGRPCMatch(match gatewayapi.GRPCRouteMatch, hostnames []string, metaAnnotations map[string]string) atc.Matcher {
+func generateMatcherFromGRPCMatch(match gatewayapi.GRPCRouteMatch, hostnames []string, metaAnnotations map[string]string) atc.Matcher {
 	routeMatcher := atc.And()
 
 	if match.Method != nil {
@@ -479,7 +479,7 @@ func KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(
 	}
 
 	grpcMatch := matchWithPriority.Match.Match
-	matcher := generateMathcherFromGRPCMatch(
+	matcher := generateMatcherFromGRPCMatch(
 		grpcMatch,
 		[]string{hostname},
 		grpcRoute.Annotations,

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -49,7 +49,7 @@ func TestHTTPRouteExample(t *testing.T) {
 	cleaner.AddManifest(string(b))
 
 	t.Logf("verifying that the Gateway receives listen addresses")
-	var gatewayAddr string
+	var gatewayIP string
 	require.Eventually(t, func() bool {
 		obj, err := gwc.GatewayV1().Gateways(corev1.NamespaceDefault).Get(ctx, "kong", metav1.GetOptions{})
 		if err != nil {
@@ -58,7 +58,7 @@ func TestHTTPRouteExample(t *testing.T) {
 
 		for _, addr := range obj.Status.Addresses {
 			if addr.Type != nil && *addr.Type == gatewayapi.IPAddressType {
-				gatewayAddr = addr.Value
+				gatewayIP = addr.Value
 				return true
 			}
 		}
@@ -66,39 +66,16 @@ func TestHTTPRouteExample(t *testing.T) {
 		return false
 	}, gatewayUpdateWaitTime, waitTick)
 
+	require.NoError(t, err)
 	t.Logf("verifying that the HTTPRoute becomes routable")
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
-			return strings.Contains(b.String(), "<title>httpbin.org</title>")
-		}
-		return false
-	}, ingressWait, waitTick)
+	helpers.EventuallyGETPath(
+		t, nil, gatewayIP, "/httproute-testing", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick,
+	)
 
 	t.Logf("verifying that the backendRefs are being loadbalanced")
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(fmt.Sprintf("http://%s/httproute-testing", gatewayAddr))
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
-			return strings.Contains(b.String(), "<title>Welcome to nginx!</title>")
-		}
-		return false
-	}, ingressWait, waitTick)
+	helpers.EventuallyGETPath(
+		t, nil, gatewayIP, "/httproute-testing", http.StatusOK, "<title>Welcome to nginx!</title>", nil, ingressWait, waitTick,
+	)
 }
 
 func TestUDPRouteExample(t *testing.T) {

--- a/test/integration/grpcroute_test.go
+++ b/test/integration/grpcroute_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
-func grpcbinClient(ctx context.Context, url, hostname string) (pb.GRPCBinClient, func() error, error) {
+func grpcBinClient(ctx context.Context, url, hostname string) (pb.GRPCBinClient, func() error, error) {
 	conn, err := grpc.DialContext(ctx, url,
 		grpc.WithTransportCredentials(credentials.NewTLS(
 			&tls.Config{
@@ -48,7 +48,7 @@ func grpcbinClient(ctx context.Context, url, hostname string) (pb.GRPCBinClient,
 }
 
 func grpcEchoResponds(ctx context.Context, url, hostname, input string) error {
-	client, closeConn, err := grpcbinClient(ctx, url, hostname)
+	client, closeConn, err := grpcBinClient(ctx, url, hostname)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func TestGRPCRouteEssentials(t *testing.T) {
 		return err == nil
 	}, ingressWait, waitTick)
 
-	client, closeGrpcConn, err := grpcbinClient(ctx, grpcAddr, testHostname)
+	client, closeGrpcConn, err := grpcBinClient(ctx, grpcAddr, testHostname)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := closeGrpcConn()

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -78,19 +78,20 @@ func MustParseURL(t *testing.T, urlStr string) *url.URL {
 
 // EventuallyGETPath makes a GET request to the Kong proxy multiple times until
 // either the request starts to respond with the given status code and contents
-// present in the response body, or until timeout occurrs according to
-// ingressWait time limits. This uses only the path of for the request and does
-// not pay attention to hostname or other routing rules. This uses a "require"
-// for the desired conditions so if this request doesn't eventually succeed the
-// calling test will fail and stop.
+// present in the response body, or until timeout occurs according to ingressWait
+// time limits. This uses a "require" for the desired conditions so if this request
+// doesn't eventually succeed the calling test will fail and stop.
+// Parameter proxyURL is the URL of Kong Gateway proxy (set nil when it's not different
+// from parameter host). Parameter host, path and headers are used to make the GET request.
+// Response is expected to have the given statusCode and contain the passed bodyContents.
 func EventuallyGETPath(
 	t *testing.T,
-	proxyURL *url.URL, // proxyURL is the URL of Kong gateway proxy.
+	proxyURL *url.URL,
 	host string,
-	path string, // host and path are host and path of the URL in the GET request.
-	statusCode int, // statusCode is the expected status code.
-	bodyContents string, // bodyContents is the expected content to be contained in response body.
-	headers map[string]string, // headers are headers in the request.
+	path string,
+	statusCode int,
+	bodyContents string,
+	headers map[string]string,
 	waitDuration time.Duration,
 	waitTick time.Duration,
 ) {


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Small improvements:
- add space after `,` for debug-level log messages about requeueing
- fix typo in function name `generateMathcherFromGRPCMatch` -> `generateMatcherFromGRPCMatch`
- reuse `helpers.EventuallyGETPath(...)` in `TestHTTPRouteExample`
- improve docs for `helpers.EventuallyGETPath(...)`, comments next to arguments are not displayed by VSCode. Golang doesn't have a convention for documenting arguments, so I just described them.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Opportunistic improvements spotted during the work on 

- https://github.com/Kong/kubernetes-ingress-controller/issues/4273

extracted to this PR for clarity.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

