### PR TITLE
feat(GWAPI): support extended field `Spec.CommonRouteSpec.ParentRefs[*].Port` in TCPRoute & UDPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ Adding a new version? You'll need three changes:
   - `KongConsumer` now enforces that at least one of `username` or `custom_id` is provided.
     [#5137](https://github.com/Kong/kubernetes-ingress-controller/pull/5137)
 
+### Added
+
+- Added support for extended field `Spec.CommonRouteSpec.ParentRefs[*].Port` in TCPRoute & UDPRoute.
+  When both Port and SectionName are specified, the name and port of the selected listener
+  must match both specified values.
+  [#5147](https://github.com/Kong/kubernetes-ingress-controller/pull/5147)
+
+
 ## [3.0.0]
 
 > Release date: 2023-11-03

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -594,7 +594,7 @@ func (t *Translator) getGatewayListeningPorts(
 		// https://github.com/kubernetes-sigs/gateway-api/blob/ebe9f31ef27819c3b29f698a3e9b91d279453c59/apis/v1/shared_types.go#L107).
 		//
 		// When the parent resource is a Gateway, this targets all listeners
-		// listening on the specified port that also support this kind of Route(and
+		// listening on the specified port that also supports this kind of Route (and
 		// select this Route). It's not recommended to set `Port` unless the
 		// networking behaviors specified in a Route must apply to a specific port
 		// as opposed to a listener(s) whose port(s) may be changed. When both Port


### PR DESCRIPTION




<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values.

ref:

https://github.com/kubernetes-sigs/gateway-api/blob/e2f02aa0fc9dfa27be271397801f52f4e0a78acc/apis/v1/shared_types.go#L124C1-L130C38
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:
fixes: https://github.com/Kong/kubernetes-ingress-controller/issues/4958
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:



<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
