### PR TITLE
chore: remove redundant if statements

### DIFF
--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -115,11 +115,9 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 					raw.Problems[fmt.Sprintf("%s:%s", ee.Type, ee.Name)] = p.Message
 				}
 			}
-			if len(p.Messages) > 0 {
-				for i, message := range p.Messages {
-					if len(message) > 0 {
-						raw.Problems[fmt.Sprintf("%s[%d]", p.Field, i)] = message
-					}
+			for i, message := range p.Messages {
+				if len(message) > 0 {
+					raw.Problems[fmt.Sprintf("%s[%d]", p.Field, i)] = message
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

In `ingressRulesFromGRPCRoute(...)` branch for expression router is redundant, because it's already checked in line `26`. Iterating over `nil` or 0 elements length slice is safe, not precheck is required. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
Opportunistic improvements spotted during the work on 

- https://github.com/Kong/kubernetes-ingress-controller/issues/4273

extracted to this PR for clarity.
