### PR TITLE
chore(admission): don't check Gateway's gatewayClassName in admission webhook

### DIFF
--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -346,11 +346,6 @@ func (validator KongHTTPValidator) ValidateClusterPlugin(
 func (validator KongHTTPValidator) ValidateGateway(
 	ctx context.Context, gateway gatewayapi.Gateway,
 ) (bool, string, error) {
-	// check if the gateway declares a gateway class
-	if gateway.Spec.GatewayClassName == "" {
-		return true, "", nil
-	}
-
 	// validate the gatewayclass reference
 	gwc := gatewayapi.GatewayClass{}
 	if err := validator.ManagerClient.Get(ctx, client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, &gwc); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't check `Gateway`'s `gatewayClassName` because that's already enforced at the Gateway API field level: `Gateway`'s `GatewayClassName` field is of type `ObjectName` which cannot be empty:

https://github.com/kubernetes-sigs/gateway-api/blob/faba2585346ef0806585f8ce2ee458e9cd70ec7b/apis/v1/shared_types.go#L578-L584
