### PR TITLE
test: skip enterprise tests when image is enterprise but TEST_KONG_ENTERPRISE not enabled

### DIFF
--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
 func RunWhenKongVersion(t *testing.T, vRangeStr string, msg ...any) {
@@ -54,6 +55,10 @@ func RunWhenKongDBMode(t *testing.T, dbmode dpconf.DBMode, msg ...any) {
 
 func RunWhenKongEnterprise(t *testing.T) {
 	t.Helper()
+
+	if !testenv.KongEnterpriseEnabled() {
+		t.Skipf("skipping because Kong enterprise is not enabled")
+	}
 
 	version := eventuallyGetKongVersion(t, proxyAdminURL)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Skip the test cases requiring enterprise features when `TEST_KONG_ENTERPRISE ` is not set to `true`. This prevents the enterprise test cases to run if enterprise version of Kong image used, but  `TEST_KONG_ENTERPRISE ` is not set thus fails on the tests, because license is not initialized in such case.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #5045 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ CHANGELOG not required
