### PR TITLE
fix: annotation konghq.com/rewrite for multiple Ingresses routing to the same Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+### Fixed
+
+- Using an Ingress with annotation `konghq.com/rewrite` and another Ingress without it pointing to the same Service,
+  will no longer cause synchronization loop and random request failures due to incorrect routing.
+  [#5171](https://github.com/Kong/kubernetes-ingress-controller/pull/5171)
+
 ### Changed
 
 - `SecretKeyRef` of `ConfigFrom` field in `KongPlugin` and `KongClusterPlugin`

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -1675,12 +1675,14 @@ func TestMaybeRewriteURI(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := MaybeRewriteURI(&tc.service, true)
 			require.Equal(t, tc.expectedError, err)
-			require.Equal(t, tc.expectedPlugins, tc.service.Plugins)
+			for _, route := range tc.service.Routes {
+				require.Equal(t, tc.expectedPlugins, route.Plugins)
+			}
 		})
 	}
 }

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -222,16 +222,18 @@ func TestRewriteURIAnnotation(t *testing.T) {
 		require.Len(t, rules, 1)
 
 		for _, svc := range rules {
-			require.Equal(t, []kong.Plugin{
-				{
-					Name: kong.String("request-transformer"),
-					Config: kong.Configuration{
-						"replace": map[string]string{
-							"uri": "/rewrite/$(uri_captures[1])/xx",
+			for _, route := range svc.Routes {
+				require.Equal(t, []kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						Config: kong.Configuration{
+							"replace": map[string]string{
+								"uri": "/rewrite/$(uri_captures[1])/xx",
+							},
 						},
 					},
-				},
-			}, svc.Plugins)
+				}, route.Plugins)
+			}
 		}
 
 		errs := p.failuresCollector.PopResourceFailures()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fixes misbehavior when multiple Ingresses point to the Same service, some of them have `konghq.com/rewrite` and some do not (or a different path specified in it):

- commit 1cfe0285be86be497f69975cf45416ce37fa84f8 improves integration test `TestIngressRewriteURI` to catch situation reported in https://github.com/Kong/kubernetes-ingress-controller/issues/5021
- commit 857cdbb4507ac86311ac3bb05f1ceeb95b7a3070 contains fix - `request-transformer` is attached to the Kong route instead of Kong service



<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5021

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

One case that is not covered by a test is `Ingress` which uses only the default backend and annotation `konghq.com/rewrite` is specified. It will be covered in a separate PR after merging it. 

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
