### PR TITLE
chore: use current generated doc path

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -55,7 +55,7 @@ body:
       - label: Ensure a draft PR is created in [docs.konghq.com](https://github.com/Kong/docs.konghq.com/pulls) repository.
       - label: If you are adding a new CRD, add a new description file under `app/_includes/md/kic/crd-ref/`. This is a brief description injected into the CRD reference page.
       - label: Update articles in the new version as needed.
-      - label: Update `references/version-compatibility.md` to include the new versions (make sure you capture any new Kubernetes/Istio versions that have been tested)
+      - label: Update `reference/version-compatibility.md` to include the new versions (make sure you capture any new Kubernetes/Istio versions that have been tested)
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.
       - label: Make sure that `app/_data/docs_nav_kic_NEWVERSION.yml` links to the latest generated `custom-resources-X.X.X.md`.
       - label: Add a section to `app/_data/kong_versions.yml` for your version.

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -33,12 +33,12 @@ jobs:
       - name: Generate CRDs reference
         run: |
           ./scripts/apidocs-gen/post-process-for-konghq.sh \
-          docs.konghq.com/app/_src/kubernetes-ingress-controller/references/custom-resources-${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.x.md
+          docs.konghq.com/app/_src/kubernetes-ingress-controller/reference/custom-resources-${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.x.md
 
       - name: Generate flags reference
         run: |
           ./scripts/cli-arguments-docs-gen/post-process-for-konghq.sh \
-          docs.konghq.com/app/_src/kubernetes-ingress-controller/references/cli-arguments-${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.x.md
+          docs.konghq.com/app/_src/kubernetes-ingress-controller/reference/cli-arguments-${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.x.md
 
       - name: Detect changes
         id: detect-changes


### PR DESCRIPTION
The 3.0 doc reorg dropped the `s` from `references`:

https://github.com/Kong/docs.konghq.com/blob/main/app/_src/kubernetes-ingress-controller/reference/cli-arguments.md

https://github.com/Kong/docs.konghq.com/blob/main/app/_src/kubernetes-ingress-controller/reference/custom-resources-3.0.x.md

Unclear how the update was run for the initial 3.0 rollout, but those do appear up to date (`--konnect-control-plane-id` and `KongUpstreamPolicy` are indeed present), and AFAIK we do not need to run this workflow after.