### PR TITLE
chore: fix GatewayClass controller and logger names after v1 GW API migration

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -143,7 +144,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// start the required gatewayclass controller as well
 	gwcCTRL := &GatewayClassReconciler{
 		Client:           r.Client,
-		Log:              r.Log.WithName("V1Beta1GatewayClass"),
+		Log:              r.Log.WithName(strings.ToUpper(gatewayapi.V1GroupVersion) + "GatewayClass"),
 		Scheme:           r.Scheme,
 		CacheSyncTimeout: r.CacheSyncTimeout,
 	}

--- a/internal/controllers/gateway/gatewayclass_controller.go
+++ b/internal/controllers/gateway/gatewayclass_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,7 +64,8 @@ type GatewayClassReconciler struct { //nolint:revive
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	c, err := controller.New("V1Beta1GatewayClass", mgr, controller.Options{
+	name := strings.ToUpper(gatewayapi.V1GroupVersion) + "GatewayClass"
+	c, err := controller.New(name, mgr, controller.Options{
 		Reconciler: r,
 		LogConstructor: func(_ *reconcile.Request) logr.Logger {
 			return r.Log

--- a/internal/gatewayapi/consts.go
+++ b/internal/gatewayapi/consts.go
@@ -4,4 +4,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-const V1Group = Group(gatewayv1.GroupName)
+const (
+	V1Group = Group(gatewayv1.GroupName)
+)
+
+var V1GroupVersion = gatewayv1.GroupVersion.Version


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix an outdated reference to v1beta1 version after the migration to v1.

