### PR TITLE
fix(Makefile): target test.golden.update works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ test.unit.pretty:
 
 .PHONY: test.golden.update
 test.golden.update:
-	@go test -v -run TestParser_GoldenTests ./internal/dataplane/translator -update
+	@go test -v -run TestTranslator_GoldenTests ./internal/dataplane/translator -update
 
 
 .PHONY: use-setup-envtest


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

PR https://github.com/Kong/kubernetes-ingress-controller/pull/5095 renamed `parser` to `translator`, it was overlooked in `Makefile` target `test.golden.update`. This PR fixes it.

