### PR TITLE
chore(tests): for DB backed use traditional_compatible router

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -97,12 +97,14 @@ jobs:
           - name: postgres-gateway-alpha
             test: postgres
             feature_gates: "GatewayAlpha=true"
+            router-flavor: 'traditional_compatible'
           - name: dbless-rewrite-uris
             test: dbless
             feature_gates: "GatewayAlpha=true,RewriteURIs=true"
           - name: postgres-rewrite-uris
             test: postgres
             feature_gates: "GatewayAlpha=true,RewriteURIs=true"
+            router-flavor: 'traditional_compatible'
           - name: dbless-invalid-config
             test: dbless
             run_invalid_config: "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Comment https://github.com/Kong/kubernetes-ingress-controller/pull/4934#issuecomment-1777350228 from the issue that update router default says that for DB mode `traditional_compatible` router should be used. This PR fixes overlooked integration tests, from a run e.g. 
- [postgres-gateway-alpha](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6890333836/job/18743265341#step:6:6)
- [postgres-rewrite-uris](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/6890333836/job/18743265719#step:6:6)

that used to use `expressions` router.

**Special notes for your reviewer**:

There is a hope that it may resolve the flake mentioned in https://github.com/Kong/kubernetes-ingress-controller/pull/5171#issuecomment-1814372198