### PR TITLE
fix: Ingress with default backend targeting the same Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ Adding a new version? You'll need three changes:
 - Using an Ingress with annotation `konghq.com/rewrite` and another Ingress without it pointing to the same Service,
   will no longer cause synchronization loop and random request failures due to incorrect routing.
   [#5171](https://github.com/Kong/kubernetes-ingress-controller/pull/5171)
+- Using the same Service in one Ingress as a target for ingress rule and default backend works without issues.
+  [#5188](https://github.com/Kong/kubernetes-ingress-controller/pull/5188)
+
 
 ### Changed
 

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -64,6 +64,11 @@ func (t *Translator) ingressRulesFromIngressV1() ingressRules {
 	// Add a default backend if it exists.
 	defaultBackendService, ok := getDefaultBackendService(allDefaultBackends, t.featureFlags.ExpressionRoutes)
 	if ok {
+		// When such service would overwrite an existing service, merge the routes.
+		if svc, ok := result.ServiceNameToServices[*defaultBackendService.Name]; ok {
+			svc.Routes = append(svc.Routes, defaultBackendService.Routes...)
+			defaultBackendService = svc
+		}
 		result.ServiceNameToServices[*defaultBackendService.Name] = defaultBackendService
 		result.ServiceNameToParent[*defaultBackendService.Name] = defaultBackendService.Parent
 	}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -151,6 +151,48 @@ func TestIngressEssentials(t *testing.T) {
 	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyURL, proxyURL.Host, "/test_ingress_essentials", ingressWait, waitTick, nil)
 }
 
+func TestIngressDefaultBackend(t *testing.T) {
+	ctx := context.Background()
+	ns, cleaner := helpers.Setup(ctx, t, env)
+
+	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err := env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(deployment)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(service)
+
+	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
+	ingress := generators.NewIngressForService("/test", map[string]string{
+		"konghq.com/strip-path": "true",
+	}, service)
+	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
+	ingress.Spec.DefaultBackend = &netv1.IngressBackend{
+		Service: &netv1.IngressServiceBackend{
+			Name: service.Name,
+			Port: netv1.ServiceBackendPort{
+				Number: service.Spec.Ports[0].Port,
+			},
+		},
+	}
+	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
+	cleaner.Add(ingress)
+
+	t.Log("matching path")
+	helpers.EventuallyGETPath(t, nil, proxyURL.String(), "/test", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
+
+	t.Log("non matching path - use default backend")
+	helpers.EventuallyGETPath(
+		t, nil, proxyURL.String(), fmt.Sprintf("/status/%d", http.StatusTeapot), http.StatusTeapot, "", nil, ingressWait, waitTick,
+	)
+}
+
 func TestGRPCIngressEssentials(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -169,7 +169,7 @@ func TestIngressDefaultBackend(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
-	ingress := generators.NewIngressForService("/test", map[string]string{
+	ingress := generators.NewIngressForService("/foo", map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
@@ -185,7 +185,7 @@ func TestIngressDefaultBackend(t *testing.T) {
 	cleaner.Add(ingress)
 
 	t.Log("matching path")
-	helpers.EventuallyGETPath(t, nil, proxyURL.String(), "/test", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, nil, proxyURL.String(), "/foo", http.StatusOK, "<title>httpbin.org</title>", nil, ingressWait, waitTick)
 
 	t.Log("non matching path - use default backend")
 	helpers.EventuallyGETPath(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It covers Ingress's default backend with integration test and fixes behavior when the same Service is used in a routing rule and as the default backend. Although rather such config doesn't have much practical application, when someone configures something like that it should work as expected.  

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Spotted during work on https://github.com/Kong/kubernetes-ingress-controller/pull/5171

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

For a default backend `konghq.com/rewrite` annotation does not have meaning, because it works on the level of capture groups specified in the URL path used in an ingress rule. [See the docs](https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/annotations/#konghqcomrewrite).

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
