### PR TITLE
feat: add validation on secrets on generated plugin cofigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,12 +104,19 @@ Adding a new version? You'll need three changes:
 - Added support for GRPC over HTTP (without TLS) in Gateway API.
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)
   [#5283](https://github.com/Kong/kubernetes-ingress-controller/pull/5283)
-- Added `-init-cache-sync-duration` CLI flag. This flag configures how long the controller waits for Kubernetes resources to populate at startup before generating the initial Kong configuration. It also fixes a bug that removed the default 5 second wait period.
+- Added `--init-cache-sync-duration` CLI flag. This flag configures how long the
+  controller waits for Kubernetes resources to populate at startup before
+  generating the initial Kong configuration. It also fixes a bug that removed
+  the default 5 second wait period.
   [#5238](https://github.com/Kong/kubernetes-ingress-controller/pull/5238)
 - Added `--emit-kubernetes-events` CLI flag to disable the creation of events
   in translating and applying configurations to Kong.
   [#5296](https://github.com/Kong/kubernetes-ingress-controller/pull/5296)
   [#5299](https://github.com/Kong/kubernetes-ingress-controller/pull/5299)
+ - Added validation on `Secret`s to reject the change if it will genereate
+   invalid confiugration of plugins for `KongPlugin`s or `KongClusterPlugin`s
+   referencing to the secret.
+   [#5203](https://github.com/Kong/kubernetes-ingress-controller/pull/5203)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ Adding a new version? You'll need three changes:
   in translating and applying configurations to Kong.
   [#5296](https://github.com/Kong/kubernetes-ingress-controller/pull/5296)
   [#5299](https://github.com/Kong/kubernetes-ingress-controller/pull/5299)
- - Added validation on `Secret`s to reject the change if it will genereate
+ - Added validation on `Secret`s to reject the change if it will generate
    invalid confiugration of plugins for `KongPlugin`s or `KongClusterPlugin`s
    referencing to the secret.
    [#5203](https://github.com/Kong/kubernetes-ingress-controller/pull/5203)

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -288,9 +288,7 @@ func (h RequestHandler) checkReferrersOfSecret(ctx context.Context, secret *core
 
 	for _, obj := range referrers {
 		gvk := obj.GetObjectKind().GroupVersionKind()
-		// REVIEW: Should we check version here? Seems that we do not need to support KongPlugin and KongClusterPlugin in other versions.
-		if gvk.Group == kongv1.GroupVersion.Group && gvk.Kind == KindKongPlugin {
-			// REVIEW: run type check here to avoid panic, although it should be unlikely to happen after checking the GVK?
+		if gvk.Group == kongv1.GroupVersion.Group && gvk.Version == kongv1.GroupVersion.Version && gvk.Kind == KindKongPlugin {
 			plugin := obj.(*kongv1.KongPlugin)
 			ok, message, err := h.Validator.ValidatePlugin(ctx, *plugin, []*corev1.Secret{secret})
 			if err != nil {
@@ -305,7 +303,7 @@ func (h RequestHandler) checkReferrersOfSecret(ctx context.Context, secret *core
 					), nil
 			}
 		}
-		if gvk.Group == kongv1.GroupVersion.Group && gvk.Kind == KindKongClusterPlugin {
+		if gvk.Group == kongv1.GroupVersion.Group && gvk.Version == kongv1.GroupVersion.Version && gvk.Kind == KindKongClusterPlugin {
 			plugin := obj.(*kongv1.KongClusterPlugin)
 			ok, message, err := h.Validator.ValidateClusterPlugin(ctx, *plugin, []*corev1.Secret{secret})
 			if err != nil {

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -48,6 +48,7 @@ func (v KongFakeValidator) ValidateConsumerGroup(
 func (v KongFakeValidator) ValidatePlugin(
 	_ context.Context,
 	_ kongv1.KongPlugin,
+	_ []*corev1.Secret,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }
@@ -55,6 +56,7 @@ func (v KongFakeValidator) ValidatePlugin(
 func (v KongFakeValidator) ValidateClusterPlugin(
 	_ context.Context,
 	_ kongv1.KongClusterPlugin,
+	_ []*corev1.Secret,
 ) (bool, string, error) {
 	return v.Result, v.Message, v.Error
 }

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -249,7 +249,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 				},
 				ingressClassMatcher: fakeClassMatcher,
 			}
-			gotOK, gotMessage, err := validator.ValidatePlugin(context.Background(), tt.args.plugin)
+			gotOK, gotMessage, err := validator.ValidatePlugin(context.Background(), tt.args.plugin, nil)
 			assert.Equalf(t, tt.wantOK, gotOK,
 				"KongHTTPValidator.ValidatePlugin() want OK: %v, got OK: %v",
 				tt.wantOK, gotOK,
@@ -433,7 +433,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 				ingressClassMatcher: fakeClassMatcher,
 			}
 
-			gotOK, gotMessage, err := validator.ValidateClusterPlugin(context.Background(), tt.args.plugin)
+			gotOK, gotMessage, err := validator.ValidateClusterPlugin(context.Background(), tt.args.plugin, nil)
 			assert.Equalf(t, tt.wantOK, gotOK,
 				"KongHTTPValidator.ValidateClusterPlugin() want OK: %v, got OK: %v",
 				tt.wantOK, gotOK,

--- a/internal/controllers/configuration/object_references.go
+++ b/internal/controllers/configuration/object_references.go
@@ -103,7 +103,7 @@ func listKongPluginReferredSecrets(plugin *kongv1.KongPlugin) []k8stypes.Namespa
 }
 
 func listKongClusterPluginReferredSecrets(plugin *kongv1.KongClusterPlugin) []k8stypes.NamespacedName {
-	referredSecretNames := make([]k8stypes.NamespacedName, 0, 1)
+	referredSecretNames := make([]k8stypes.NamespacedName, 0, len(plugin.ConfigPatches)+1)
 	if plugin.ConfigFrom != nil {
 		nsName := k8stypes.NamespacedName{
 			Namespace: plugin.ConfigFrom.SecretValue.Namespace,
@@ -114,7 +114,7 @@ func listKongClusterPluginReferredSecrets(plugin *kongv1.KongClusterPlugin) []k8
 
 	for _, patch := range plugin.ConfigPatches {
 		nsName := k8stypes.NamespacedName{
-			Namespace: plugin.Namespace,
+			Namespace: patch.ValueFrom.SecretValue.Namespace,
 			Name:      patch.ValueFrom.SecretValue.Secret,
 		}
 		referredSecretNames = append(referredSecretNames, nsName)

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -267,6 +267,7 @@ func (c CacheIndexers) ListReferredObjects(referrer client.Object) ([]client.Obj
 	return objs, nil
 }
 
+// ListReferrerObjectsByReferent lists all objects that refers to the same referent.
 func (c CacheIndexers) ListReferrerObjectsByReferent(referent client.Object) ([]client.Object, error) {
 	refs, err := c.ListReferencesByReferent(referent)
 	if err != nil {

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -194,11 +194,11 @@ func (c CacheIndexers) ListReferencesByReferrer(referrer client.Object) ([]*Obje
 
 // ListReferencesByReferent lists all reference records referring to the same referent.
 func (c CacheIndexers) ListReferencesByReferent(referent client.Object) ([]*ObjectReference, error) {
-	referenctKey, err := objectKeyFunc(referent)
+	referentKey, err := objectKeyFunc(referent)
 	if err != nil {
 		return nil, err
 	}
-	refList, err := c.indexer.ByIndex(IndexNameReferent, referenctKey)
+	refList, err := c.indexer.ByIndex(IndexNameReferent, referentKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/reference/indexer_test.go
+++ b/internal/controllers/reference/indexer_test.go
@@ -263,7 +263,7 @@ func TestDeleteReferencesByReferrer(t *testing.T) {
 	}
 }
 
-func TestListReferencesByReferent(t *testing.T) {
+func TestListReferrerObjectsByReferent(t *testing.T) {
 	testCases := []struct {
 		name          string
 		addReferrer   client.Object

--- a/internal/controllers/reference/indexer_test.go
+++ b/internal/controllers/reference/indexer_test.go
@@ -262,3 +262,41 @@ func TestDeleteReferencesByReferrer(t *testing.T) {
 		})
 	}
 }
+
+func TestListReferencesByReferent(t *testing.T) {
+	testCases := []struct {
+		name          string
+		addReferrer   client.Object
+		addReferent   client.Object
+		checkReferent client.Object
+		objectNum     int
+	}{
+		{
+			name:          "has_referring_objects",
+			addReferrer:   testRefService1,
+			addReferent:   testRefSecret1,
+			checkReferent: testRefSecret1,
+			objectNum:     1,
+		},
+		{
+			name:          "has_no_referring_objects",
+			addReferrer:   testRefService1,
+			addReferent:   testRefSecret1,
+			checkReferent: testRefSecret2,
+			objectNum:     0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCacheIndexers(logr.Discard())
+			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
+			require.NoError(t, err, "should not return error on setting reference")
+
+			referrers, err := c.ListReferrerObjectsByReferent(tc.checkReferent)
+			require.NoError(t, err)
+			require.Len(t, referrers, tc.objectNum)
+		})
+	}
+}

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -58,6 +58,7 @@ func setupControllers(
 	ctx context.Context,
 	mgr manager.Manager,
 	dataplaneClient controllers.DataPlane,
+	referenceIndexers ctrlref.CacheIndexers,
 	dataplaneAddressFinder *dataplane.AddressFinder,
 	udpDataplaneAddressFinder *dataplane.AddressFinder,
 	kubernetesStatusQueue *status.Queue,
@@ -66,8 +67,6 @@ func setupControllers(
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
 ) []ControllerDef {
-	referenceIndexers := ctrlref.NewCacheIndexers(ctrl.LoggerFrom(ctx).WithName("controllers").WithName("reference-indexers"))
-
 	controllers := []ControllerDef{
 		// ---------------------------------------------------------------------------
 		// Kong Gateway Admin API Service discovery

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
+	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configfetcher"
@@ -174,6 +175,7 @@ func Run(
 		c.UpdateStatus,
 	)
 
+	referenceIndexers := ctrlref.NewCacheIndexers(setupLog.WithName("reference-indexers"))
 	cache := store.NewCacheStores()
 	storer := store.New(cache, c.IngressClassName, logger)
 	configTranslator, err := translator.NewTranslator(
@@ -186,7 +188,7 @@ func Run(
 	}
 
 	setupLog.Info("Starting Admission Server")
-	if err := setupAdmissionServer(ctx, c, clientsManager, mgr.GetClient(), logger, translatorFeatureFlags, storer); err != nil {
+	if err := setupAdmissionServer(ctx, c, clientsManager, referenceIndexers, mgr.GetClient(), logger, translatorFeatureFlags, storer); err != nil {
 		return err
 	}
 
@@ -237,6 +239,7 @@ func Run(
 		ctx,
 		mgr,
 		dataplaneClient,
+		referenceIndexers,
 		dataplaneAddressFinder,
 		udpDataplaneAddressFinder,
 		kubernetesStatusQueue,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -171,7 +171,6 @@ func setupAdmissionServer(
 	ctx context.Context,
 	managerConfig *Config,
 	clientsManager *clients.AdminAPIClientsManager,
-	// REVIEW: where to add it? More general: where to add new args in constructors, all append to the last?
 	referenceIndexers ctrlref.CacheIndexers,
 	managerClient client.Client,
 	logger logr.Logger,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
@@ -170,6 +171,8 @@ func setupAdmissionServer(
 	ctx context.Context,
 	managerConfig *Config,
 	clientsManager *clients.AdminAPIClientsManager,
+	// REVIEW: where to add it? More general: where to add new args in constructors, all append to the last?
+	referenceIndexers ctrlref.CacheIndexers,
 	managerClient client.Client,
 	logger logr.Logger,
 	translatorFeatures translator.FeatureFlags,
@@ -192,7 +195,8 @@ func setupAdmissionServer(
 			translatorFeatures,
 			storer,
 		),
-		Logger: admissionLogger,
+		ReferenceIndexers: referenceIndexers,
+		Logger:            admissionLogger,
 	}, admissionLogger)
 	if err != nil {
 		return err

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -19,6 +19,7 @@ import (
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -547,18 +548,19 @@ func TestValidationWebhook(t *testing.T) {
 		secretBefore  *corev1.Secret
 		secretAfter   *corev1.Secret
 		errorOnUpdate bool
+		errorContains string
 	}{
 		{
-			name: "should fail the validation if secret produces invalid plugin configuration",
+			name: "should fail the validation if secret used in ConfigFrom of KongPlugin generates invalid plugin configuration",
 			KongPlugin: &kongv1.KongPlugin{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns.Name,
-					Name:      "rate-limiting",
+					Name:      "rate-limiting-invalid-config-from",
 				},
 				PluginName: "rate-limiting",
 				ConfigFrom: &kongv1.ConfigSource{
 					SecretValue: kongv1.SecretValueFromSource{
-						Secret: "conf-secret",
+						Secret: "conf-secret-invalid-config",
 						Key:    "rate-limiting-config",
 					},
 				},
@@ -566,7 +568,7 @@ func TestValidationWebhook(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns.Name,
-					Name:      "conf-secret",
+					Name:      "conf-secret-invalid-config",
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
@@ -575,13 +577,101 @@ func TestValidationWebhook(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns.Name,
-					Name:      "conf-secret",
+					Name:      "conf-secret-invalid-config",
 				},
 				Data: map[string][]byte{
-					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local"}`),
+					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":"5"}`),
 				},
 			},
 			errorOnUpdate: true,
+			errorContains: "Change on secret will generate invalid configuration for KongPlugin",
+		},
+		{
+			name: "should fail the validation if the secret is used in ConfigPatches of KongPlugin and generates invalid config",
+			KongPlugin: &kongv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "rate-limiting-invalid-config-patches",
+				},
+				PluginName: "rate-limiting",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"limit_by":"consumer","policy":"local"}`),
+				},
+				ConfigPatches: []kongv1.ConfigPatch{
+					{
+						Path: "/minute",
+						ValueFrom: kongv1.ConfigSource{
+							SecretValue: kongv1.SecretValueFromSource{
+								Secret: "conf-secret-invalid-field",
+								Key:    "rate-limiting-config-minutes",
+							},
+						},
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "conf-secret-invalid-field",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config-minutes": []byte("10"),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "conf-secret-invalid-field",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config-minutes": []byte(`"10"`),
+				},
+			},
+			errorOnUpdate: true,
+			errorContains: "Change on secret will generate invalid configuration for KongPlugin",
+		},
+		{
+			name: "should pass the validation if the secret used in ConfigPatches of KongPlugin and generates valid config",
+			KongPlugin: &kongv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "rate-limiting-valid-config",
+				},
+				PluginName: "rate-limiting",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"limit_by":"consumer","policy":"local"}`),
+				},
+				ConfigPatches: []kongv1.ConfigPatch{
+					{
+						Path: "/minute",
+						ValueFrom: kongv1.ConfigSource{
+							SecretValue: kongv1.SecretValueFromSource{
+								Secret: "conf-secret-valid-field",
+								Key:    "rate-limiting-config-minutes",
+							},
+						},
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "conf-secret-valid-field",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config-minutes": []byte(`10`),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "conf-secret-valid-field",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config-minutes": []byte(`15`),
+				},
+			},
+			errorOnUpdate: false,
 		},
 	} {
 		tt := tt
@@ -595,9 +685,211 @@ func TestValidationWebhook(t *testing.T) {
 				require.NoError(t, err)
 			}()
 
-			_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, tt.secretAfter, metav1.CreateOptions{})
+			_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Update(ctx, tt.secretAfter, metav1.UpdateOptions{})
 			if tt.errorOnUpdate {
 				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Log("verifying that the validation fails when secret generates invalid plugin configuration for KongClusterPlugin")
+	for _, tt := range []struct {
+		name              string
+		kongClusterPlugin *kongv1.KongClusterPlugin
+		secretBefore      *corev1.Secret
+		secretAfter       *corev1.Secret
+		errorOnUpdate     bool
+		errorContains     string
+	}{
+		{
+			name: "should pass the validation if the secret used in ConfigFrom of KongClusterPlugin generates valid configuration",
+			kongClusterPlugin: &kongv1.KongClusterPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-rate-limiting-valid",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				PluginName: "rate-limiting",
+				ConfigFrom: &kongv1.NamespacedConfigSource{
+					SecretValue: kongv1.NamespacedSecretValueFromSource{
+						Namespace: ns.Name,
+						Secret:    "cluster-conf-secret-valid",
+						Key:       "rate-limiting-config",
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-valid",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-valid",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":10}`),
+				},
+			},
+			errorOnUpdate: false,
+		},
+		{
+			name: "should fail the validation if the secret in ConfigFrom of KongClusterPlugin generates invalid configuration",
+			kongClusterPlugin: &kongv1.KongClusterPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-rate-limiting-invalid",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				PluginName: "rate-limiting",
+				ConfigFrom: &kongv1.NamespacedConfigSource{
+					SecretValue: kongv1.NamespacedSecretValueFromSource{
+						Namespace: ns.Name,
+						Secret:    "cluster-conf-secret-invalid",
+						Key:       "rate-limiting-config",
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-invalid",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-invalid",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":"5"}`),
+				},
+			},
+			errorOnUpdate: true,
+			errorContains: "Change on secret will generate invalid configuration for KongClusterPlugin",
+		},
+		{
+			name: "should pass the validation if the secret in ConfigPatches generates valid configuration",
+			kongClusterPlugin: &kongv1.KongClusterPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-rate-limiting-valid-config-patches",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				PluginName: "rate-limiting",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"limit_by":"consumer","policy":"local"}`),
+				},
+				ConfigPatches: []kongv1.NamespacedConfigPatch{
+					{
+						Path: "/minute",
+						ValueFrom: kongv1.NamespacedConfigSource{
+							SecretValue: kongv1.NamespacedSecretValueFromSource{
+								Namespace: ns.Namespace,
+								Secret:    "cluster-conf-secret-valid-patch",
+								Key:       "rate-limiting-minute",
+							},
+						},
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-valid-patch",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-minute": []byte(`5`),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-valid-patch",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-minute": []byte(`10`),
+				},
+			},
+			errorOnUpdate: false,
+		},
+		{
+			name: "should pass the validation if the secret in ConfigPatches generates invalid configuration",
+			kongClusterPlugin: &kongv1.KongClusterPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-rate-limiting-invalid-config-patches",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: consts.IngressClass,
+					},
+				},
+				PluginName: "rate-limiting",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"limit_by":"consumer","policy":"local"}`),
+				},
+				ConfigPatches: []kongv1.NamespacedConfigPatch{
+					{
+						Path: "/minute",
+						ValueFrom: kongv1.NamespacedConfigSource{
+							SecretValue: kongv1.NamespacedSecretValueFromSource{
+								Namespace: ns.Name,
+								Secret:    "cluster-conf-secret-invalid-patch",
+								Key:       "rate-limiting-minute",
+							},
+						},
+					},
+				},
+			},
+			secretBefore: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-invalid-patch",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-minute": []byte(`5`),
+				},
+			},
+			secretAfter: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "cluster-conf-secret-invalid-patch",
+				},
+				Data: map[string][]byte{
+					"rate-limiting-minute": []byte(`"10"`),
+				},
+			},
+			errorOnUpdate: true,
+			errorContains: "Change on secret will generate invalid configuration for KongClusterPlugin",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, tt.secretBefore, metav1.CreateOptions{})
+			require.NoError(t, err)
+			_, err = kongClient.ConfigurationV1().KongClusterPlugins().Create(ctx, tt.kongClusterPlugin, metav1.CreateOptions{})
+			require.NoError(t, err)
+			defer func() {
+				err := kongClient.ConfigurationV1().KongClusterPlugins().Delete(ctx, tt.kongClusterPlugin.Name, metav1.DeleteOptions{})
+				require.NoError(t, err)
+			}()
+
+			_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Update(ctx, tt.secretAfter, metav1.UpdateOptions{})
+			if tt.errorOnUpdate {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

validates secrets when they are referred by `KongPlugin` and `KongClusterPlugin` to check if they generate invalid Kong plugin configurations.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #5190

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
