### PR TITLE
[release/2.12] fix: provide descriptive error for known bug with conflicting Kong Routes naming

### DIFF
--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -227,7 +227,9 @@ func ingressV1ToKongServiceLegacy(
 func routeName(failuresCollector *failures.ResourceFailuresCollector, objIngress client.Object, ruleIndex, pathIndex int) *string {
 	// Since there is no separator between the rule and path index in the traditional Ingress -> route name pattern,
 	// the controller can generate multiple routes with the same name if there are multiple rules where the pattern
-	// results in the same sequence of digits. For example, rule 1 path 11 and rule 11 path 1 both result in suffix111
+	// results in the same sequence of digits. For example, rule 1 path 11 and rule 11 path 1 both result in suffix111.
+	// Detecting only the first problematic case is enough, because indexes are in ascending order, thus without hitting
+	// the first problematic case, the second one will not be hit either.
 	if ruleIndex == 1 && pathIndex == 11 || ruleIndex == 11 && pathIndex == 1 {
 		failuresCollector.PushResourceFailure(
 			fmt.Sprint(

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -225,8 +225,9 @@ func ingressV1ToKongServiceLegacy(
 
 // routeName generates a name for a Kong Route based on the Ingress name, namespace and rule index and path index.
 func routeName(failuresCollector *failures.ResourceFailuresCollector, objIngress client.Object, ruleIndex, pathIndex int) *string {
-	// Indexes are expected to be ascending (starts from 0), hence the first conflict is expected to be
-	// for the below condition - both will be `111`. Register failure with a hint for user.
+	// Since there is no separator between the rule and path index in the traditional Ingress -> route name pattern,
+	// the controller can generate multiple routes with the same name if there are multiple rules where the pattern
+	// results in the same sequence of digits. For example, rule 1 path 11 and rule 11 path 1 both result in suffix111
 	if ruleIndex == 1 && pathIndex == 11 || ruleIndex == 11 && pathIndex == 1 {
 		failuresCollector.PushResourceFailure(
 			fmt.Sprint(

--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -233,7 +233,7 @@ func routeNamer(failuresCollector *failures.ResourceFailuresCollector, objIngres
 		if _, conflicting := uniqueRouteNames[*routeName]; conflicting {
 			failuresCollector.PushResourceFailure(
 				fmt.Sprint(
-					"ERROR: Kong route with conflicting name: ", *routeName, " ",
+					"Kong route with conflicting name: ", *routeName, " ",
 					"use feature gate CombinedRoutes=true ",
 					"or update Kong Kubernetes Ingress Controller version to 3.0.0 or above ",
 					"(both remediation changes naming schema of Kong routes)",

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -339,7 +339,7 @@ func TestIngressGeneratingKongRoutesWithConflictingNames(t *testing.T) {
 		})
 
 		// Just check couple of them, other follows the same pattern.
-		const expectedErrMsg = "ERROR: Kong route with conflicting name: %s use feature gate CombinedRoutes=true or update Kong Kubernetes Ingress Controller version to 3.0.0 or above (both remediation changes naming schema of Kong routes)"
+		const expectedErrMsg = "Kong route with conflicting name: %s use feature gate CombinedRoutes=true or update Kong Kubernetes Ingress Controller version to 3.0.0 or above (both remediation changes naming schema of Kong routes)"
 		for _, conflictingName := range []string{
 			"foo-namespace.conflicting-one-11-11.110",
 			"foo-namespace.conflicting-one-11-11.111",

--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -275,7 +275,7 @@ func TestRewriteURIAnnotation(t *testing.T) {
 	})
 }
 
-func TestConflictingNames(t *testing.T) {
+func TestIngressGeneratingKongRoutesWithConflictingNames(t *testing.T) {
 	createIngress := func(noRules, noPaths int) *netv1.Ingress {
 		var ingresRules []netv1.IngressRule
 		for i := 0; i <= noRules; i++ {
@@ -329,7 +329,7 @@ func TestConflictingNames(t *testing.T) {
 	require.NoError(t, err)
 	p := mustNewParser(t, s)
 
-	t.Run("Ingress rule with conflicting names - CombinedRoutes=false", func(t *testing.T) {
+	t.Run("more than 11 rules and paths in Ingress and CombinedRoutes=false warns about conflicts", func(t *testing.T) {
 		p.featureFlags.CombinedServiceRoutes = false
 		_ = p.ingressRulesFromIngressV1()
 		errs := p.failuresCollector.PopResourceFailures()
@@ -350,7 +350,7 @@ func TestConflictingNames(t *testing.T) {
 		}
 	})
 
-	t.Run("Ingress rule with conflicting names - CombinedRoutes=true", func(t *testing.T) {
+	t.Run("more than 11 rules and paths in Ingress and CombinedRoutes=true gives no conflicts and no warnings", func(t *testing.T) {
 		p.featureFlags.CombinedServiceRoutes = true
 		_ = p.ingressRulesFromIngressV1()
 		errs := p.failuresCollector.PopResourceFailures()

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -73,7 +73,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),
 					Route: kong.Route{
-						Name:              kong.String(fmt.Sprintf("%s.%s.%d%d", ingress.Namespace, ingress.Name, i, j)),
+						Name:              routeName(p.failuresCollector, ingress, i, j),
 						Paths:             kong.StringSlice(path),
 						StripPath:         kong.Bool(false),
 						PreserveHost:      kong.Bool(true),

--- a/internal/dataplane/parser/translate_knative.go
+++ b/internal/dataplane/parser/translate_knative.go
@@ -57,6 +57,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 
 		secretToSNIs.addFromIngressV1TLS(knativeIngressToNetworkingTLS(ingress.Spec.TLS), ingress)
 
+		routeName := routeNamer(p.failuresCollector, ingress)
 		var objectSuccessfullyParsed bool
 		for i, rule := range ingressSpec.Rules {
 			hosts := rule.Hosts
@@ -73,7 +74,7 @@ func (p *Parser) ingressRulesFromKnativeIngress() ingressRules {
 				r := kongstate.Route{
 					Ingress: util.FromK8sObject(ingress),
 					Route: kong.Route{
-						Name:              routeName(p.failuresCollector, ingress, i, j),
+						Name:              routeName(i, j),
 						Paths:             kong.StringSlice(path),
 						StripPath:         kong.Bool(false),
 						PreserveHost:      kong.Bool(true),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since KIC 2.12 is an LTS release provide a fix for the bug described in https://github.com/Kong/kubernetes-ingress-controller/issues/3942. It only occurs when `CombinedRoutes` feature gate is not set to `true`. For KIC >=3.0 bug does not exist, because `CombinedRoutes` is enabled by default and it can't be changed.

Users may rely on a naming scheme of Kong routes, hence only provide descriptive message with remediation instead of changing it with this fix.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3942

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

It's part of 

- https://github.com/Kong/kubernetes-ingress-controller/issues/5198

`CHANGELOG.md` on `main` will be updated accordingly during the above release.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
