### PR TITLE
fix: validate configPatches for KongClusterPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Adding a new version? You'll need three changes:
   are applied to the raw JSON in `config`. Can only be specified when
   `configFrom` is not present.
   [#5158](https://github.com/Kong/kubernetes-ingress-controller/pull/5158)
+  [#5208](https://github.com/Kong/kubernetes-ingress-controller/pull/5208)
 
 ### Fixed
 
@@ -96,6 +97,11 @@ Adding a new version? You'll need three changes:
   [#5171](https://github.com/Kong/kubernetes-ingress-controller/pull/5171)
 - Using the same Service in one Ingress as a target for ingress rule and default backend works without issues.
   [#5188](https://github.com/Kong/kubernetes-ingress-controller/pull/5188)
+- Validators of `KongPlugin` and `KongClusterPlugin` will not return `500` on
+  failures to parse configurations and failures to retrieve secrets used for
+  configuration. Instead, it will return `400` with message to tell the
+  validation failures.
+  [#5208](https://github.com/Kong/kubernetes-ingress-controller/pull/5208)
 
 
 

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -292,12 +292,12 @@ func (validator KongHTTPValidator) ValidatePlugin(
 		k8sPlugin.ConfigPatches,
 	)
 	if err != nil {
-		return false, ErrTextPluginConfigInvalid, err
+		return false, fmt.Sprintf("%s: %s", ErrTextPluginConfigInvalid, err), nil
 	}
 	if k8sPlugin.ConfigFrom != nil {
 		config, err := kongstate.SecretToConfiguration(validator.SecretGetter, (*k8sPlugin.ConfigFrom).SecretValue, k8sPlugin.Namespace)
 		if err != nil {
-			return false, ErrTextPluginSecretConfigUnretrievable, err
+			return false, fmt.Sprintf("%s: %s", ErrTextPluginSecretConfigUnretrievable, err), nil
 		}
 		plugin.Config = config
 	}
@@ -311,7 +311,6 @@ func (validator KongHTTPValidator) ValidatePlugin(
 	if err != nil || errText != "" {
 		validator.Logger.Info("validate KongPlugin on Kong gateway failed",
 			"plugin", fmt.Sprintf("%s/%s", k8sPlugin.Namespace, k8sPlugin.Name),
-			"config", plugin.Config,
 			"error", err,
 		)
 		return false, errText, err
@@ -336,13 +335,13 @@ func (validator KongHTTPValidator) ValidateClusterPlugin(
 		k8sPlugin.ConfigPatches,
 	)
 	if err != nil {
-		return false, ErrTextPluginConfigInvalid, err
+		return false, fmt.Sprintf("%s: %s", ErrTextPluginConfigInvalid, err), nil
 	}
 
 	if k8sPlugin.ConfigFrom != nil {
 		config, err := kongstate.NamespacedSecretToConfiguration(validator.SecretGetter, k8sPlugin.ConfigFrom.SecretValue)
 		if err != nil {
-			return false, ErrTextPluginSecretConfigUnretrievable, err
+			return false, fmt.Sprintf("%s: %s", ErrTextPluginSecretConfigUnretrievable, err), nil
 		}
 		plugin.Config = config
 	}
@@ -357,7 +356,6 @@ func (validator KongHTTPValidator) ValidateClusterPlugin(
 	if err != nil || errText != "" {
 		validator.Logger.Info("validate KongClusterPlugin on Kong gateway failed",
 			"plugin", k8sPlugin.Name,
-			"config", plugin.Config,
 			"error", err,
 		)
 		return false, errText, err

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -152,7 +152,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigInvalid,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "plugin has valid configPatches",
@@ -204,7 +204,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigInvalid,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "plugin ConfigFrom references non-existent Secret",
@@ -222,7 +222,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginSecretConfigUnretrievable,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "failed to retrieve validation info",
@@ -244,17 +244,21 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 				},
 				ingressClassMatcher: fakeClassMatcher,
 			}
-			got, got1, err := validator.ValidatePlugin(context.Background(), tt.args.plugin)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("KongHTTPValidator.ValidatePlugin() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			gotOK, gotMessage, err := validator.ValidatePlugin(context.Background(), tt.args.plugin)
+			assert.Equalf(t, tt.wantOK, gotOK,
+				"KongHTTPValidator.ValidatePlugin() want OK: %v, got OK: %v",
+				tt.wantOK, gotOK,
+			)
+			if tt.wantMessage != "" {
+				assert.Containsf(t, gotMessage, tt.wantMessage,
+					"KongHTTPValidator.ValidatePlugin() want message: %v, got message: %v",
+					tt.wantMessage, gotMessage,
+				)
 			}
-			if got != tt.wantOK {
-				t.Errorf("KongHTTPValidator.ValidatePlugin() got = %v, want %v", got, tt.wantOK)
-			}
-			if got1 != tt.wantMessage {
-				t.Errorf("KongHTTPValidator.ValidatePlugin() got message = %v, want %v", got1, tt.wantMessage)
-			}
+			assert.Equalf(t, tt.wantErr, err != nil,
+				"KongHTTPValidator.ValidatePlugin() wantErr %v, got error %v",
+				tt.wantErr, err,
+			)
 		})
 	}
 }
@@ -318,7 +322,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigInvalid,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "plugin has valid configPatches",
@@ -372,7 +376,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginConfigInvalid,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "plugin ConfigFrom references non-existent Secret",
@@ -391,7 +395,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 			},
 			wantOK:      false,
 			wantMessage: ErrTextPluginSecretConfigUnretrievable,
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			name:      "failed to retrieve validation info",
@@ -423,17 +427,22 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 				},
 				ingressClassMatcher: fakeClassMatcher,
 			}
-			got, got1, err := validator.ValidateClusterPlugin(context.Background(), tt.args.plugin)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("KongHTTPValidator.ValidateClusterPlugin() error = %v, wantErr %v", err, tt.wantErr)
-				return
+
+			gotOK, gotMessage, err := validator.ValidateClusterPlugin(context.Background(), tt.args.plugin)
+			assert.Equalf(t, tt.wantOK, gotOK,
+				"KongHTTPValidator.ValidateClusterPlugin() want OK: %v, got OK: %v",
+				tt.wantOK, gotOK,
+			)
+			if tt.wantMessage != "" {
+				assert.Containsf(t, gotMessage, tt.wantMessage,
+					"KongHTTPValidator.ValidateClusterPlugin() want message: %v, got message: %v",
+					tt.wantMessage, gotMessage,
+				)
 			}
-			if got != tt.wantOK {
-				t.Errorf("KongHTTPValidator.ValidateClusterPlugin() got = %v, want %v", got, tt.wantOK)
-			}
-			if got1 != tt.wantMessage {
-				t.Errorf("KongHTTPValidator.ValidateClusterPlugin() got message = %v, want %v", got1, tt.wantMessage)
-			}
+			assert.Equalf(t, tt.wantErr, err != nil,
+				"KongHTTPValidator.ValidateClusterPlugin() wantErr %v, got error %v",
+				tt.wantErr, err,
+			)
 		})
 	}
 }

--- a/internal/dataplane/kongstate/plugin.go
+++ b/internal/dataplane/kongstate/plugin.go
@@ -272,7 +272,7 @@ func rawConfigToConfiguration(raw []byte) (kong.Configuration, error) {
 
 // NamespacedSecretToConfiguration fetches specified value from given namespace, secret and key,
 // then parse the value to Kong plugin configurations.
-// Export it for using in validators.
+// Exported primarily to be used in admission validators.
 func NamespacedSecretToConfiguration(
 	s SecretGetter,
 	reference kongv1.NamespacedSecretValueFromSource) (
@@ -291,7 +291,7 @@ type SecretGetter interface {
 
 // SecretToConfiguration fetches specified value from secret and key in the namespace,
 // then parse the value to Kong plugin configurations.
-// Export it for using in validators.
+// Exported primarily to be used in admission validators.
 func SecretToConfiguration(
 	s SecretGetter,
 	reference kongv1.SecretValueFromSource, namespace string) (

--- a/internal/dataplane/kongstate/plugin.go
+++ b/internal/dataplane/kongstate/plugin.go
@@ -67,7 +67,7 @@ func kongPluginFromK8SClusterPlugin(
 	}
 	if k8sPlugin.ConfigFrom != nil {
 		var err error
-		config, err = namespacedSecretToConfiguration(
+		config, err = NamespacedSecretToConfiguration(
 			s,
 			(*k8sPlugin.ConfigFrom).SecretValue)
 		if err != nil {
@@ -270,8 +270,11 @@ func rawConfigToConfiguration(raw []byte) (kong.Configuration, error) {
 	return kongConfig, nil
 }
 
-func namespacedSecretToConfiguration(
-	s store.Storer,
+// NamespacedSecretToConfiguration fetches specified value from given namespace, secret and key,
+// then parse the value to Kong plugin configurations.
+// Export it for using in validators.
+func NamespacedSecretToConfiguration(
+	s SecretGetter,
 	reference kongv1.NamespacedSecretValueFromSource) (
 	kong.Configuration, error,
 ) {
@@ -286,6 +289,9 @@ type SecretGetter interface {
 	GetSecret(namespace, name string) (*corev1.Secret, error)
 }
 
+// SecretToConfiguration fetches specified value from secret and key in the namespace,
+// then parse the value to Kong plugin configurations.
+// Export it for using in validators.
 func SecretToConfiguration(
 	s SecretGetter,
 	reference kongv1.SecretValueFromSource, namespace string) (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
- Fix the validation of `KongClusterPlugin` to generate configuration using `configPatches`
- Do not share code of `ValidateKongPlugin` in `ValidateKongClusterPlugin`

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes the problem of validator for `KongClusterPlugin` in #5158.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
REVIEW: how do we write changelog here? This is a fix on a not yet released feature.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
