### PR TITLE
disable HTTP/2 of admin api in e2e if Kong < 3.0.0

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -280,19 +280,6 @@ func (d ManifestDeploy) Run(ctx context.Context, t *testing.T, env environments.
 	t.Log("waiting for controller to be ready")
 	deployments := getManifestDeployments(d.Path)
 
-	if !d.SkipTestPatches {
-		adminAPINoHTTP2Range := kong.MustNewRange("<" + adminAPIHTTP2MinimalKongVersion.String())
-		kongVersion, err := getKongVersionFromOverrideImageTag()
-		if err == nil && adminAPINoHTTP2Range(kongVersion) {
-			t.Logf(
-				"Kong version %s is below %s, should disable HTTP/2 on admin API",
-				kongVersion.String(), adminAPIHTTP2MinimalKongVersion.String(),
-			)
-			removeAdminListenHTTP2(ctx, t, env, deployments.ProxyNN)
-		}
-
-	}
-
 	waitForDeploymentRollout(ctx, t, env, deployments.ControllerNN.Namespace, deployments.ControllerNN.Name)
 	waitForDeploymentRollout(ctx, t, env, deployments.ProxyNN.Namespace, deployments.ProxyNN.Name)
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -280,14 +280,17 @@ func (d ManifestDeploy) Run(ctx context.Context, t *testing.T, env environments.
 	t.Log("waiting for controller to be ready")
 	deployments := getManifestDeployments(d.Path)
 
-	adminAPINoHTTP2Range := kong.MustNewRange("<" + adminAPIHTTP2MinimalKongVersion.String())
-	kongVersion, err := getKongVersionFromOverrideImageTag()
-	if err == nil && adminAPINoHTTP2Range(kongVersion) {
-		t.Logf(
-			"Kong version %s is below %s, should disable HTTP/2 on admin API",
-			kongVersion.String(), adminAPIHTTP2MinimalKongVersion.String(),
-		)
-		removeAdminListenHTTP2(ctx, t, env, deployments.ProxyNN)
+	if !d.SkipTestPatches {
+		adminAPINoHTTP2Range := kong.MustNewRange("<" + adminAPIHTTP2MinimalKongVersion.String())
+		kongVersion, err := getKongVersionFromOverrideImageTag()
+		if err == nil && adminAPINoHTTP2Range(kongVersion) {
+			t.Logf(
+				"Kong version %s is below %s, should disable HTTP/2 on admin API",
+				kongVersion.String(), adminAPIHTTP2MinimalKongVersion.String(),
+			)
+			removeAdminListenHTTP2(ctx, t, env, deployments.ProxyNN)
+		}
+
 	}
 
 	waitForDeploymentRollout(ctx, t, env, deployments.ControllerNN.Namespace, deployments.ControllerNN.Name)

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -47,6 +47,9 @@ var (
 	gatewayDiscoveryMinimalVersion = semver.Version{Major: 2, Minor: 9} // 2.9.0
 	// adminAPIHTTP2MinimalKongVersion is the minimal version of Kong gateway version that supports `http2` on admin APIs.
 	adminAPIHTTP2MinimalKongVersion = semver.Version{Major: 3, Minor: 0} // 3.0.0
+	// upgradeTestMinimalKongVersion is the minimal version of Kong gateway version that enables `TestDeployAndUpgrade*` test cases.
+	// Since the source Kong version used in TestDeployAndUpgrade* is 3.3, we should enable the test for Kong 3.0.x and above.
+	upgradeTestMinimalKongVersion = semver.Version{Major: 3, Minor: 0} // 3.0.0
 	// statusReadyProbeMinimalKongVersion is the minimal version of kong gateway version that enables /status/ready probe.
 	statusReadyProbeMinimalKongVersion = semver.Version{Major: 3, Minor: 3} // 3.3.0
 )

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -186,7 +186,6 @@ func getTestManifest(t *testing.T, baseManifestPath string, skipTestPatches bool
 				t.Logf("configure Kong admin API to non-HTTP2 listen because Kong version %s is below %s",
 					kongVersion.String(), adminAPIHTTP2MinimalKongVersion.String(),
 				)
-				// REVIEW: replace to `0.0.0.0:8001, 0.0.0.0:8444` or extract the value then remove the `http2` as the new value?
 				manifestsReader, err = patchKongAdminAPIListen(manifestsReader, deployments.ProxyNN,
 					"0.0.0.0:8001, 0.0.0.0:8444 ssl",
 				)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Since we still need to test 2.12 against Kong 2.8.x, we need to update the proxy deployments if Kong gateway version < 3.0.0.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #5212.
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
