### PR TITLE
[backport release/2.12.x] fix: Ingress with default backend targeting the same Service (#5188)

### DIFF
--- a/internal/dataplane/parser/translate_ingress.go
+++ b/internal/dataplane/parser/translate_ingress.go
@@ -79,6 +79,11 @@ func (p *Parser) ingressRulesFromIngressV1() ingressRules {
 	// Add a default backend if it exists.
 	defaultBackendService, ok := getDefaultBackendService(allDefaultBackends, p.featureFlags.ExpressionRoutes)
 	if ok {
+		// When such service would overwrite an existing service, merge the routes.
+		if svc, ok := result.ServiceNameToServices[*defaultBackendService.Name]; ok {
+			svc.Routes = append(svc.Routes, defaultBackendService.Routes...)
+			defaultBackendService = svc
+		}
 		result.ServiceNameToServices[*defaultBackendService.Name] = defaultBackendService
 		result.ServiceNameToParent[*defaultBackendService.Name] = defaultBackendService.Parent
 	}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Backport of #5188. The `main` branch contains rename `parser` -> `translator` thus file with a different path is touched in this PR.

It's part of

- https://github.com/Kong/kubernetes-ingress-controller/issues/5198

CHANGELOG.md on `main` will be updated accordingly during the above release.