### PR TITLE
[backport release/3.0.x] fix: annotation konghq.com/rewrite for multiple Ingresses routing to the same Service (#5171)

### DIFF
--- a/internal/dataplane/parser/translate_ingress_test.go
+++ b/internal/dataplane/parser/translate_ingress_test.go
@@ -223,16 +223,18 @@ func TestRewriteURIAnnotation(t *testing.T) {
 		require.Len(t, rules, 1)
 
 		for _, svc := range rules {
-			require.Equal(t, []kong.Plugin{
-				{
-					Name: kong.String("request-transformer"),
-					Config: kong.Configuration{
-						"replace": map[string]string{
-							"uri": "/rewrite/$(uri_captures[1])/xx",
+			for _, route := range svc.Routes {
+				require.Equal(t, []kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						Config: kong.Configuration{
+							"replace": map[string]string{
+								"uri": "/rewrite/$(uri_captures[1])/xx",
+							},
 						},
 					},
-				},
-			}, svc.Plugins)
+				}, route.Plugins)
+			}
 		}
 
 		errs := p.failuresCollector.PopResourceFailures()

--- a/internal/dataplane/parser/translators/ingress_test.go
+++ b/internal/dataplane/parser/translators/ingress_test.go
@@ -1675,12 +1675,14 @@ func TestMaybeRewriteURI(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := MaybeRewriteURI(&tc.service, true)
 			require.Equal(t, tc.expectedError, err)
-			require.Equal(t, tc.expectedPlugins, tc.service.Plugins)
+			for _, route := range tc.service.Routes {
+				require.Equal(t, tc.expectedPlugins, route.Plugins)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Backport of #5171.

It's part of

- https://github.com/Kong/kubernetes-ingress-controller/issues/5196

CHANGELOG.md on `main` will be updated accordingly during the above release.
