### PR TITLE
chore: remove redundant entries from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,6 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- Using an Ingress with annotation `konghq.com/rewrite` and another Ingress without it pointing to the same Service,
-  will no longer cause synchronization loop and random request failures due to incorrect routing.
-  [#5171](https://github.com/Kong/kubernetes-ingress-controller/pull/5171)
-- Using the same Service in one Ingress as a target for ingress rule and default backend works without issues.
-  [#5188](https://github.com/Kong/kubernetes-ingress-controller/pull/5188)
 - Validators of `KongPlugin` and `KongClusterPlugin` will not return `500` on
   failures to parse configurations and failures to retrieve secrets used for
   configuration. Instead, it will return `400` with message to tell the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It removes from the section **Unreleased** two entries that have been already released and mentioned in [3.0.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#301)

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
