### PR TITLE
test: check existence of input KIC image and use it if exists in gke tests

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -224,6 +224,8 @@ jobs:
       - name: check availability of KIC image
         id: check_kic_image
         if: ${{ inputs.kic-image != '' }}
+        # We have to check whether the image passed in inputs is available in the docker hub. 
+        # If it's not, we'll fall back to a nightly image later.
         run: (docker manifest inspect ${{ inputs.kic-image }} && echo "kic_image=${{ inputs.kic-image }}" >> $GITHUB_OUTPUT) || true
 
       - name: split image and tag
@@ -244,11 +246,11 @@ jobs:
             echo "kic-image=$kic_image_repo" >> $GITHUB_OUTPUT
             echo "kic-tag=$kic_image_tag" >> $GITHUB_OUTPUT  
           else
+            # See the https://github.com/Kong/kubernetes-testing-framework/issues/587 TODO below.
+            # If we add local image GKE support, we can get rid of this fallback.
             echo "kic-image=kong/nightly-ingress-controller" >> $GITHUB_OUTPUT
             echo "kic-tag=nightly" >> $GITHUB_OUTPUT
           fi
-          # see the https://github.com/Kong/kubernetes-testing-framework/issues/587 TODO below
-          # if we add local image GKE support, we probably need to split it into components here
 
       - name: run ${{ matrix.test }}
         run: make test.e2e

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -221,6 +221,11 @@ jobs:
         with:
           password: ${{ secrets.PULP_PASSWORD }}
 
+      - name: check availability of KIC image
+        id: check_kic_image
+        if: ${{ inputs.kic-image != '' }}
+        run: (docker manifest inspect ${{ inputs.kic-image }} && echo "kic_image=${{ inputs.kic-image }}" >> $GITHUB_OUTPUT) || true
+
       - name: split image and tag
         id: split
         env:
@@ -233,6 +238,15 @@ jobs:
             echo "kong-image=$kong_image" >> $GITHUB_OUTPUT
             echo "kong-tag=$kong_tag" >> $GITHUB_OUTPUT
           fi
+          if [ "${{ steps.check_kic_image.outputs.kic_image }}" != "" ]; then
+            export kic_image_repo=$(echo ${{ steps.check_kic_image.outputs.kic_image }} | awk '{split($0,a,":"); print a[1]}')
+            export kic_image_tag=$(echo ${{ steps.check_kic_image.outputs.kic_image }} | awk '{split($0,a,":"); print a[2]}')
+            echo "kic-image=$kic_image_repo" >> $GITHUB_OUTPUT
+            echo "kic-tag=$kic_image_tag" >> $GITHUB_OUTPUT  
+          else
+            echo "kic-image=kong/nightly-ingress-controller" >> $GITHUB_OUTPUT
+            echo "kic-tag=nightly" >> $GITHUB_OUTPUT
+          fi
           # see the https://github.com/Kong/kubernetes-testing-framework/issues/587 TODO below
           # if we add local image GKE support, we probably need to split it into components here
 
@@ -243,8 +257,8 @@ jobs:
           # therefore we need to use the nightly one.
           # TODO: Once we have a way to load images into GKE, we can use the local image.
           # KTF issue that should enable it: https://github.com/Kong/kubernetes-testing-framework/issues/587
-          TEST_CONTROLLER_IMAGE: "kong/nightly-ingress-controller"
-          TEST_CONTROLLER_TAG: "nightly"
+          TEST_CONTROLLER_IMAGE: ${{ steps.split.outputs.kic-image }}
+          TEST_CONTROLLER_TAG: ${{ steps.split.outputs.kic-tag }}
           TEST_KONG_IMAGE: ${{ steps.split.outputs.kong-image }}
           TEST_KONG_TAG: ${{ steps.split.outputs.kong-tag }}
           TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Enable changing KIC image for e2e tests run on GKE. This is required for running validation test against Kong 2.8.x, because we need to use KIC 2.12.x in the tests.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #5228 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
