### PR TITLE
feat: add KongServiceFacade controller and feature gate

### DIFF
--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -62,12 +62,13 @@ Features that reach GA and over time become stable will be removed from this tab
 
 ### Feature gates for Alpha or Beta features
 
-| Feature      | Default | Stage | Since  | Until |
-|--------------|---------|-------|--------|-------|
-| GatewayAlpha | `false` | Alpha | 2.6.0  | TBD   |
-| FillIDs      | `false` | Alpha | 2.10.0 | 3.0.0 |
-| FillIDs      | `true`  | Beta  | 3.0.0  | TBD   |
-| RewriteURIs  | `false` | Alpha | 2.12.0 | TBD   |
+| Feature       | Default | Stage | Since  | Until |
+|---------------|---------|-------|--------|-------|
+| GatewayAlpha  | `false` | Alpha | 2.6.0  | TBD   |
+| FillIDs       | `false` | Alpha | 2.10.0 | 3.0.0 |
+| FillIDs       | `true`  | Beta  | 3.0.0  | TBD   |
+| RewriteURIs   | `false` | Alpha | 2.12.0 | TBD   |
+| ServiceFacade | `false` | Alpha | 3.1.0  | TBD   |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -194,6 +194,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -24,6 +24,7 @@
 | `--enable-controller-ingress-class-networkingv1` | `bool` | Enable the networking.k8s.io/v1 IngressClass controller. | `true` |
 | `--enable-controller-ingress-class-parameters` | `bool` | Enable the IngressClassParameters controller. | `true` |
 | `--enable-controller-ingress-networkingv1` | `bool` | Enable the networking.k8s.io/v1 Ingress controller. | `true` |
+| `--enable-controller-kong-service-facade` | `bool` | Enable the KongServiceFacade controller. | `true` |
 | `--enable-controller-kong-upstream-policy` | `bool` | Enable the KongUpstreamPolicy controller. | `true` |
 | `--enable-controller-kongclusterplugin` | `bool` | Enable the KongClusterPlugin controller. | `true` |
 | `--enable-controller-kongconsumer` | `bool` | Enable the KongConsumer controller. | `true` |

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -23,6 +23,8 @@ const (
 	kongv1       = "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1  = "github.com/kong/kubernetes-ingress-controller/v3/api/configuration/v1beta1"
 	kongv1alpha1 = "github.com/kong/kubernetes-ingress-controller/v3/api/configuration/v1alpha1"
+
+	incubatorv1alpha1 = "github.com/kong/kubernetes-ingress-controller/v3/api/incubator/v1alpha1"
 )
 
 // inputControllersNeeded is a list of the supported Types for the
@@ -231,6 +233,21 @@ var inputControllersNeeded = &typesNeeded{
 		AcceptsIngressClassNameSpec:       false,
 		RBACVerbs:                         []string{"get", "list", "watch"},
 	},
+	typeNeeded{
+		Group:                             "incubator.konghq.com",
+		Version:                           "v1alpha1",
+		Kind:                              "KongServiceFacade",
+		PackageImportAlias:                "incubatorv1alpha1",
+		PackageAlias:                      "IncubatorV1Alpha1",
+		Package:                           incubatorv1alpha1,
+		Plural:                            "kongservicefacades",
+		CacheType:                         "KongServiceFacade",
+		NeedsStatusPermissions:            true,
+		ConfigStatusNotificationsEnabled:  true,
+		ProgrammedConditionUpdatesEnabled: true,
+		AcceptsIngressClassNameAnnotation: true,
+		RBACVerbs:                         []string{"get", "list", "watch"},
+	},
 }
 
 var inputRBACPermissionsNeeded = &rbacsNeeded{
@@ -429,6 +446,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 `
 

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -48,6 +48,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 // -----------------------------------------------------------------------------
@@ -1803,6 +1804,172 @@ func (r *KongV1Alpha1IngressClassParametersReconciler) Reconcile(ctx context.Con
 	// update the kong Admin API with the changes
 	if err := r.DataplaneClient.UpdateObject(obj); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// -----------------------------------------------------------------------------
+// IncubatorV1Alpha1 KongServiceFacade - Reconciler
+// -----------------------------------------------------------------------------
+
+// IncubatorV1Alpha1KongServiceFacadeReconciler reconciles KongServiceFacade resources
+type IncubatorV1Alpha1KongServiceFacadeReconciler struct {
+	client.Client
+
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
+	CacheSyncTimeout time.Duration
+	StatusQueue      *status.Queue
+
+	IngressClassName           string
+	DisableIngressClassLookups bool
+}
+
+var _ controllers.Reconciler = &IncubatorV1Alpha1KongServiceFacadeReconciler{}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("IncubatorV1Alpha1KongServiceFacade", mgr, controller.Options{
+		Reconciler: r,
+		LogConstructor: func(_ *reconcile.Request) logr.Logger {
+			return r.Log
+		},
+		CacheSyncTimeout: r.CacheSyncTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	// if configured, start the status updater controller
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   "incubator.konghq.com",
+				Version: "v1alpha1",
+				Kind:    "KongServiceFacade",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
+	}
+	if !r.DisableIngressClassLookups {
+		err = c.Watch(
+			source.Kind(mgr.GetCache(), &netv1.IngressClass{}),
+			handler.EnqueueRequestsFromMapFunc(r.listClassless),
+			predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
+	return c.Watch(
+		source.Kind(mgr.GetCache(), &incubatorv1alpha1.KongServiceFacade{}),
+		&handler.EnqueueRequestForObject{},
+		preds,
+	)
+}
+
+// listClassless finds and reconciles all objects without ingress class information
+func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) listClassless(ctx context.Context, obj client.Object) []reconcile.Request {
+	resourceList := &incubatorv1alpha1.KongServiceFacadeList{}
+	if err := r.Client.List(ctx, resourceList); err != nil {
+		r.Log.Error(err, "Failed to list classless kongservicefacades")
+		return nil
+	}
+	var recs []reconcile.Request
+	for i, resource := range resourceList.Items {
+		if ctrlutils.IsIngressClassEmpty(&resourceList.Items[i]) {
+			recs = append(recs, reconcile.Request{
+				NamespacedName: k8stypes.NamespacedName{
+					Namespace: resource.Namespace,
+					Name:      resource.Name,
+				},
+			})
+		}
+	}
+	return recs
+}
+
+// SetLogger sets the logger.
+func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) SetLogger(l logr.Logger) {
+	r.Log = l
+}
+
+//+kubebuilder:rbac:groups=incubator.konghq.com,resources=kongservicefacades,verbs=get;list;watch
+//+kubebuilder:rbac:groups=incubator.konghq.com,resources=kongservicefacades/status,verbs=get;update;patch
+
+// Reconcile processes the watched objects
+func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("IncubatorV1Alpha1KongServiceFacade", req.NamespacedName)
+
+	// get the relevant object
+	obj := new(incubatorv1alpha1.KongServiceFacade)
+
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			obj.Namespace = req.Namespace
+			obj.Name = req.Name
+
+			return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
+		}
+		return ctrl.Result{}, err
+	}
+	log.V(util.DebugLevel).Info("Reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	// clean the object up if it's being deleted
+	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
+		log.V(util.DebugLevel).Info("Resource is being deleted, its configuration will be removed", "type", "KongServiceFacade", "namespace", req.Namespace, "name", req.Name)
+
+		objectExistsInCache, err := r.DataplaneClient.ObjectExists(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.DataplaneClient.DeleteObject(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
+		return ctrl.Result{}, nil
+	}
+
+	class := new(netv1.IngressClass)
+	if !r.DisableIngressClassLookups {
+		if err := r.Get(ctx, k8stypes.NamespacedName{Name: r.IngressClassName}, class); err != nil {
+			// we log this without taking action to support legacy configurations that only set ingressClassName or
+			// used the class annotation and did not create a corresponding IngressClass. We only need this to determine
+			// if the IngressClass is default or to configure default settings, and can assume no/no additional defaults
+			// if none exists.
+			log.V(util.DebugLevel).Info("Could not retrieve IngressClass", "ingressclass", r.IngressClassName)
+		}
+	}
+	// if the object is not configured with our ingress.class, then we need to ensure it's removed from the cache
+	if !ctrlutils.MatchesIngressClass(obj, r.IngressClassName, ctrlutils.IsDefaultIngressClass(class)) {
+		log.V(util.DebugLevel).Info("Object missing ingress class, ensuring it's removed from configuration",
+			"namespace", req.Namespace, "name", req.Name, "class", r.IngressClassName)
+		return ctrl.Result{}, r.DataplaneClient.DeleteObject(obj)
+	} else {
+		log.V(util.DebugLevel).Info("Object has matching ingress class", "namespace", req.Namespace, "name", req.Name,
+			"class", r.IngressClassName)
+	}
+
+	// update the kong Admin API with the changes
+	if err := r.DataplaneClient.UpdateObject(obj); err != nil {
+		return ctrl.Result{}, err
+	}
+	// if status updates are enabled report the status for the object
+	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
+		log.V(util.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
+		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(configurationStatus, obj.Generation, obj.Status.Conditions)
+		obj.Status.Conditions = conditions
+		if updateNeeded {
+			return ctrl.Result{}, r.Status().Update(ctx, obj)
+		}
+		log.V(util.DebugLevel).Info("Status update not needed", "namespace", req.Namespace, "name", req.Name)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	KongConsumerEnabled           bool
 	ServiceEnabled                bool
 	KongUpstreamPolicyEnabled     bool
+	KongServiceFacadeEnabled      bool
 
 	// Gateway API toggling.
 	GatewayAPIGatewayController        bool
@@ -244,6 +245,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.GatewayAPIGatewayController, "enable-controller-gwapi-gateway", true, "Enable the Gateway API Gateway controller.")
 	flagSet.BoolVar(&c.GatewayAPIHTTPRouteController, "enable-controller-gwapi-httproute", true, "Enable the Gateway API HTTPRoute controller.")
 	flagSet.BoolVar(&c.GatewayAPIReferenceGrantController, "enable-controller-gwapi-reference-grant", true, "Enable the Gateway API ReferenceGrant controller.")
+	flagSet.BoolVar(&c.KongServiceFacadeEnabled, "enable-controller-kong-service-facade", true, "Enable the KongServiceFacade controller.")
 
 	// Admission Webhook server config
 	flagSet.StringVar(&c.AdmissionServer.ListenAddr, "admission-webhook-listen", "off",

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -62,7 +62,7 @@ func setupControllers(
 	udpDataplaneAddressFinder *dataplane.AddressFinder,
 	kubernetesStatusQueue *status.Queue,
 	c *Config,
-	featureGates map[string]bool,
+	featureGates featuregates.FeatureGates,
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
 ) []ControllerDef {
@@ -261,6 +261,19 @@ func setupControllers(
 				CacheSyncTimeout: c.CacheSyncTimeout,
 			},
 		},
+		{
+			Enabled: featureGates.Enabled(featuregates.ServiceFacade) && c.KongServiceFacadeEnabled,
+			Controller: &configuration.IncubatorV1Alpha1KongServiceFacadeReconciler{
+				Client:                     mgr.GetClient(),
+				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongServiceFacade"),
+				Scheme:                     mgr.GetScheme(),
+				DataplaneClient:            dataplaneClient,
+				CacheSyncTimeout:           c.CacheSyncTimeout,
+				IngressClassName:           c.IngressClassName,
+				DisableIngressClassLookups: !c.IngressClassNetV1Enabled,
+				StatusQueue:                kubernetesStatusQueue,
+			},
+		},
 		// ---------------------------------------------------------------------------
 		// Gateway API Controllers
 		// ---------------------------------------------------------------------------
@@ -329,7 +342,7 @@ func setupControllers(
 		// Gateway API Controllers - Alpha APIs
 		// ---------------------------------------------------------------------------
 		{
-			Enabled: featureGates[featuregates.GatewayAlphaFeature],
+			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/UDPRoute"),
@@ -350,7 +363,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[featuregates.GatewayAlphaFeature],
+			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/TCPRoute"),
@@ -371,7 +384,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[featuregates.GatewayAlphaFeature],
+			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/TLSRoute"),
@@ -392,7 +405,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates[featuregates.GatewayAlphaFeature],
+			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/GRPCRoute"),

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -22,6 +22,9 @@ const (
 	// RewriteURIsFeature is the name of the feature-gate for enabling/disabling konghq.com/rewrite annotation.
 	RewriteURIsFeature = "RewriteURIs"
 
+	// ServiceFacade is the name of the feature-gate for enabling KongServiceFacade CR reconciliation.
+	ServiceFacade = "ServiceFacade"
+
 	// DocsURL provides a link to the documentation for feature gates in the KIC repository.
 	DocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
 )
@@ -60,5 +63,6 @@ func GetFeatureGatesDefaults() map[string]bool {
 		GatewayAlphaFeature: false,
 		FillIDsFeature:      true,
 		RewriteURIsFeature:  false,
+		ServiceFacade:       false,
 	}
 }

--- a/internal/store/cache_stores.go
+++ b/internal/store/cache_stores.go
@@ -17,6 +17,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 // CacheStores stores cache.Store for all Kinds of k8s objects that
@@ -48,6 +49,7 @@ type CacheStores struct {
 	UDPIngress                     cache.Store
 	KongUpstreamPolicy             cache.Store
 	IngressClassParametersV1alpha1 cache.Store
+	KongServiceFacade              cache.Store
 
 	l *sync.RWMutex
 }
@@ -79,6 +81,7 @@ func NewCacheStores() CacheStores {
 		UDPIngress:                     cache.NewStore(keyFunc),
 		KongUpstreamPolicy:             cache.NewStore(keyFunc),
 		IngressClassParametersV1alpha1: cache.NewStore(keyFunc),
+		KongServiceFacade:              cache.NewStore(keyFunc),
 
 		l: &sync.RWMutex{},
 	}
@@ -183,6 +186,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.KongUpstreamPolicy.Get(obj)
 	case *kongv1alpha1.IngressClassParameters:
 		return c.IngressClassParametersV1alpha1.Get(obj)
+	case *incubatorv1alpha1.KongServiceFacade:
+		return c.KongServiceFacade.Get(obj)
 	}
 	return nil, false, fmt.Errorf("%T is not a supported cache object type", obj)
 }
@@ -245,6 +250,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.KongUpstreamPolicy.Add(obj)
 	case *kongv1alpha1.IngressClassParameters:
 		return c.IngressClassParametersV1alpha1.Add(obj)
+	case *incubatorv1alpha1.KongServiceFacade:
+		return c.KongServiceFacade.Add(obj)
 	default:
 		return fmt.Errorf("cannot add unsupported kind %q to the store", obj.GetObjectKind().GroupVersionKind())
 	}
@@ -308,6 +315,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.KongUpstreamPolicy.Delete(obj)
 	case *kongv1alpha1.IngressClassParameters:
 		return c.IngressClassParametersV1alpha1.Delete(obj)
+	case *incubatorv1alpha1.KongServiceFacade:
+		return c.KongServiceFacade.Delete(obj)
 	default:
 		return fmt.Errorf("cannot delete unsupported kind %q from the store", obj.GetObjectKind().GroupVersionKind())
 	}

--- a/internal/store/cache_stores_test.go
+++ b/internal/store/cache_stores_test.go
@@ -6,43 +6,64 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 func TestCacheStores(t *testing.T) {
-	t.Run("KongUpstreamPolicy", func(t *testing.T) {
-		s := store.NewCacheStores()
-		upstreamPolicy := &kongv1beta1.KongUpstreamPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "upstream-policy",
-				Namespace: "default",
+	testCases := []struct {
+		name          string
+		objectToStore client.Object
+	}{
+		{
+			name: "KongUpstreamPolicy",
+			objectToStore: &kongv1beta1.KongUpstreamPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "upstream-policy",
+					Namespace: "default",
+				},
+				Spec: kongv1beta1.KongUpstreamPolicySpec{
+					Algorithm: lo.ToPtr("least-connections"),
+				},
 			},
-			Spec: kongv1beta1.KongUpstreamPolicySpec{
-				Algorithm: lo.ToPtr("least-connections"),
+		},
+		{
+			name: "KongServiceFacade",
+			objectToStore: &incubatorv1alpha1.KongServiceFacade{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-facade",
+					Namespace: "default",
+				},
+				Spec: incubatorv1alpha1.KongServiceFacadeSpec{
+					Backend: incubatorv1alpha1.KongServiceFacadeBackend{
+						Name: "backend",
+						Port: 80,
+					},
+				},
 			},
-		}
+		},
+	}
 
-		err := s.Add(upstreamPolicy)
-		require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.NewCacheStores()
+			err := s.Add(tc.objectToStore)
+			require.NoError(t, err)
 
-		objKey := &kongv1beta1.KongUpstreamPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "upstream-policy",
-				Namespace: "default",
-			},
-		}
-		storedObj, ok, err := s.Get(objKey)
-		require.NoError(t, err)
-		require.True(t, ok)
-		require.Equal(t, upstreamPolicy, storedObj)
+			storedObj, ok, err := s.Get(tc.objectToStore)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, tc.objectToStore, storedObj)
 
-		err = s.Delete(objKey)
-		require.NoError(t, err)
+			err = s.Delete(tc.objectToStore)
+			require.NoError(t, err)
 
-		_, ok, err = s.Get(objKey)
-		require.NoError(t, err, err)
-		require.False(t, ok)
-	})
+			_, ok, err = s.Get(tc.objectToStore)
+			require.NoError(t, err, err)
+			require.False(t, ok)
+		})
+	}
 }

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -25,6 +25,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 func keyFunc(obj interface{}) (string, error) {
@@ -62,6 +63,7 @@ type FakeObjects struct {
 	KongConsumers                  []*kongv1.KongConsumer
 	KongConsumerGroups             []*kongv1beta1.KongConsumerGroup
 	KongUpstreamPolicies           []*kongv1beta1.KongUpstreamPolicy
+	KongServiceFacades             []*incubatorv1alpha1.KongServiceFacade
 }
 
 // NewFakeStore creates a store backed by the objects passed in as arguments.
@@ -209,6 +211,13 @@ func NewFakeStore(
 			return nil, err
 		}
 	}
+	kongServiceFacade := cache.NewStore(keyFunc)
+	for _, s := range objects.KongServiceFacades {
+		err := kongServiceFacade.Add(s)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	s = Store{
 		stores: CacheStores{
@@ -233,6 +242,7 @@ func NewFakeStore(
 			KongIngress:                    kongIngressStore,
 			IngressClassParametersV1alpha1: IngressClassParametersV1alpha1Store,
 			KongUpstreamPolicy:             kongUpstreamPolicyStore,
+			KongServiceFacade:              kongServiceFacade,
 		},
 		ingressClass:          annotations.DefaultIngressClass,
 		isValidIngressClass:   annotations.IngressClassValidatorFuncFromObjectMeta(annotations.DefaultIngressClass),

--- a/internal/store/fake_store_test.go
+++ b/internal/store/fake_store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 func TestKeyFunc(t *testing.T) {
@@ -815,4 +816,30 @@ func TestFakeStore_KongUpstreamPolicy(t *testing.T) {
 	storedPolicy, err := store.GetKongUpstreamPolicy("default", "foo")
 	require.NoError(t, err)
 	require.Equal(t, fakeObjects.KongUpstreamPolicies[0], storedPolicy)
+}
+
+func TestFakeStore_KongServiceFacade(t *testing.T) {
+	fakeObjects := FakeObjects{
+		KongServiceFacades: []*incubatorv1alpha1.KongServiceFacade{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: incubatorv1alpha1.KongServiceFacadeSpec{
+					Backend: incubatorv1alpha1.KongServiceFacadeBackend{
+						Name: "service-name",
+						Port: 80,
+					},
+				},
+			},
+		},
+	}
+
+	store, err := NewFakeStore(fakeObjects)
+	require.NoError(t, err)
+
+	storedFacade, err := store.GetKongServiceFacade("default", "foo")
+	require.NoError(t, err)
+	require.Equal(t, fakeObjects.KongServiceFacades[0], storedFacade)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,6 +43,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 const (
@@ -67,6 +68,7 @@ type Storer interface {
 	GetIngressClassParametersV1Alpha1(ingressClass *netv1.IngressClass) (*kongv1alpha1.IngressClassParameters, error)
 	GetGateway(namespace string, name string) (*gatewayapi.Gateway, error)
 	GetKongUpstreamPolicy(namespace, name string) (*kongv1beta1.KongUpstreamPolicy, error)
+	GetKongServiceFacade(namespace, name string) (*incubatorv1alpha1.KongServiceFacade, error)
 
 	ListIngressesV1() []*netv1.Ingress
 	ListIngressClassesV1() []*netv1.IngressClass
@@ -499,6 +501,18 @@ func (s Store) GetKongUpstreamPolicy(namespace, name string) (*kongv1beta1.KongU
 		return nil, NotFoundError{fmt.Sprintf("KongUpstreamPolicy %v not found", key)}
 	}
 	return p.(*kongv1beta1.KongUpstreamPolicy), nil
+}
+
+func (s Store) GetKongServiceFacade(namespace, name string) (*incubatorv1alpha1.KongServiceFacade, error) {
+	key := fmt.Sprintf("%v/%v", namespace, name)
+	p, exists, err := s.stores.KongServiceFacade.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, NotFoundError{fmt.Sprintf("KongServiceFacade %v not found", key)}
+	}
+	return p.(*incubatorv1alpha1.KongServiceFacade), nil
 }
 
 // GetIngressClassParametersV1Alpha1 returns IngressClassParameters for provided

--- a/pkg/apis/incubator/doc.go
+++ b/pkg/apis/incubator/doc.go
@@ -1,4 +1,8 @@
 // Package incubator contains API Schema definitions for the incubator.konghq.com API group.
 // This group is for APIs that are highly experimental and may not be supported in the future.
 // It's not distributed by default and has to be installed separately.
+//
+// CRDs in this group are not going to graduate to beta or GA in scope of the group.
+// They're unlikely to be promoted to the `configuration.konghq.com` group, but if they do,
+// this will be the way for them to be promoted to beta or GA.
 package incubator

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2279,6 +2279,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -360,6 +360,7 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"feature-gatewayalpha=false;"+
 			"feature-konnect-sync=false;"+
 			"feature-rewriteuris=false;"+
+			"feature-servicefacade=false;"+
 			"hn=%s;"+
 			"kv=3.4.1;"+
 			"rf=traditional;"+


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongServiceFacade` controller along with the CLI flag and feature gate enabling it. Also extends stores to handle the new CRD appropriately.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5152.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
