### PR TITLE
enable setting KIC image for e2e on GKE clusters (#5230)

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -193,14 +193,32 @@ jobs:
         with:
           password: ${{ secrets.PULP_PASSWORD }}
 
+      - name: check availability of KIC image
+        id: check_kic_image
+        if: ${{ inputs.kic-image != '' }}
+        # We have to check whether the image passed in inputs is available in the docker hub. 
+        # If it's not, we'll fall back to a nightly image later.
+        run: (docker manifest inspect ${{ inputs.kic-image }} && echo "kic_image=${{ inputs.kic-image }}" >> $GITHUB_OUTPUT) || true
+
+      - name: choose KIC image
+        id: choose_kic_image
+        run: |
+          if [ "${{ steps.check_kic_image.outputs.kic_image }}" != "" ]; then
+            echo "kic-image=${{ steps.check_kic_image.outputs.kic_image }}" >> $GITHUB_OUTPUT  
+          else
+            # See the https://github.com/Kong/kubernetes-testing-framework/issues/587 TODO below.
+            # If we add local image GKE support, we can get rid of this fallback.
+            echo "kic-image=kong/nightly-ingress-controller" >> $GITHUB_OUTPUT
+          fi
+
       - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
           # NOTE: The limitation of the GKE setup is that we cannot run tests against a local image,
-          # therefore we need to use the nightly one.
+          # therefore we need to use the nightly one if the input image is not availabe externally.
           # TODO: Once we have a way to load images into GKE, we can use the local image.
           # KTF issue that should enable it: https://github.com/Kong/kubernetes-testing-framework/issues/587
-          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: "kong/nightly-ingress-controller:nightly"
+          TEST_KONG_CONTROLLER_IMAGE_OVERRIDE: ${{ steps.choose_kic_image.outputs.kic-image }}
           TEST_KONG_IMAGE_OVERRIDE: ${{ inputs.kong-image }}
           TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

backport #5230  to 2.12.x to enable changing images in e2e tests on GKE.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
part of #5211.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
