### PR TITLE
chore(test): test SectionName and port do not match.

### DIFF
--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -255,6 +255,7 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](ctx context.Context, logge
 				portMatched = true
 			}
 
+			// Check if listener protocol matches
 			if !routeTypeMatchesListenerType(route, listener) {
 				listenerLogger.V(util.DebugLevel).Info(
 					"Route's type does not match listener's type",

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -387,6 +387,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 		}
 		notExistingPort := gatewayapi.PortNumber(81)
 		tcpRoute.Spec.ParentRefs[0].Port = &notExistingPort
+		tcpRoute.Spec.ParentRefs[0].Name = gatewayapi.ObjectName(service1.Name)
 		tcpRoute, err = gatewayClient.GatewayV1alpha2().TCPRoutes(ns.Name).Update(ctx, tcpRoute, metav1.UpdateOptions{})
 		return err == nil
 	}, time.Minute, time.Second)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Added relevant tests to clarify the specific behavior of KIC in this scenario.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
closes https://github.com/Kong/kubernetes-ingress-controller/issues/4958
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

Replace  https://github.com/Kong/kubernetes-ingress-controller/pull/5147 with this.
In fact, we have already implemented the relevant logic. If there is a scenario where sectionName and port do not match, it will not be processed by the translator.


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
