### PR TITLE
test: dump KIC logs in integration tests run in e2e nigthly and validate kong image actions

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -50,6 +50,7 @@ jobs:
       kong-enterprise-container-repo: kong/kong-gateway-dev
       kong-enterprise-container-tag: nightly
       kong-enterprise-effective-version: "3.4.1"
+      log-output-file:  /tmp/integration-tests-kic-logs
 
   test-reports:
     needs:

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -79,6 +79,7 @@ jobs:
       kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
       kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}
       kong-enterprise-effective-version: ${{ github.event.inputs.kong-effective-version }}
+      log-output-file:  /tmp/integration-tests-kic-logs
 
   on-finish-comment-or-close-issue:
     needs:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

dump KIC logs in integration tests run in e2e nightly and validate Kong image actions. 
Prevents large amount of logs printed by KIC in integration tests. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
Missing part in #5191. 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Also part of #5211. I want to dump the KIC logs for validate Kong image tests also in release/2.12.x branch.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
