### PR TITLE
chore(tests): gRPC with Ingress over HTTP and HTTPS

### DIFF
--- a/test/integration/consts/consts.go
+++ b/test/integration/consts/consts.go
@@ -8,4 +8,7 @@ const (
 
 	// IngressWait is the default amount of time to wait for any particular ingress resource to be provisioned.
 	IngressWait = 3 * time.Minute
+
+	// StatusWait is the default amount of time to wait for object statuses to fulfill a provided predicate.
+	StatusWait = 3 * time.Minute
 )

--- a/test/integration/consts_test.go
+++ b/test/integration/consts_test.go
@@ -22,5 +22,5 @@ const (
 
 	// statusWait is a const duration used in test assertions like .Eventually to
 	// wait for object statuses to fulfill a provided predicate.
-	statusWait = time.Minute * 3
+	statusWait = consts.StatusWait
 )

--- a/test/integration/isolated/ctx.go
+++ b/test/integration/isolated/ctx.go
@@ -139,3 +139,14 @@ func GetAdminURLFromCtx(ctx context.Context) *url.URL {
 	}
 	return u.(*url.URL)
 }
+
+type _ingressClass struct{}
+
+// GetIngressClassFromCtx gets the Ingress Class from the context.
+func GetIngressClassFromCtx(ctx context.Context) string {
+	r := ctx.Value(_ingressClass{})
+	if r == nil {
+		return ""
+	}
+	return r.(string)
+}

--- a/test/integration/isolated/ingress_test.go
+++ b/test/integration/isolated/ingress_test.go
@@ -36,7 +36,7 @@ func TestIngressGRPC(t *testing.T) {
 				"PROXY_LISTEN": `0.0.0.0:8000 http2\, 0.0.0.0:8443 http2 ssl`,
 			}),
 		)).
-		Assess("deploying gRPC service exposed via Ingress", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		WithSetup("deploying gRPC service exposed via Ingress", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
 			cluster := GetClusterFromCtx(ctx)
 			namespace := GetNamespaceForT(ctx, t)
@@ -62,7 +62,7 @@ func TestIngressGRPC(t *testing.T) {
 			ctx = deployGRPCServiceWithIngress(ctx, t, true)
 
 			t.Log("deploying a minimal GRPC service exposed with Ingress via HTTP")
-			return deployGRPCServiceWithIngress(ctx, t, false) // To test GRPC over HTTP.
+			return deployGRPCServiceWithIngress(ctx, t, false)
 		}).
 		Assess("checking whether Ingress status is updated and gRPC traffic over HTTPS is properly routed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			t.Log("verifying service connectivity via HTTPS and Ingress status update")

--- a/test/integration/isolated/ingress_test.go
+++ b/test/integration/isolated/ingress_test.go
@@ -1,0 +1,157 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestIngressGRPC(t *testing.T) {
+	const testHostname = "grpcs-over-ingress.example"
+
+	f := features.
+		New("essentials").
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyIngress).
+		WithLabel(testlabels.Kind, testlabels.KindIngress).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withKongProxyEnvVars(map[string]string{
+				"PROXY_LISTEN": `0.0.0.0:8000 http2\, 0.0.0.0:8443 http2 ssl`,
+			}),
+		)).
+		Assess("deploying gRPC service exposed via Ingress", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+			cluster := GetClusterFromCtx(ctx)
+			namespace := GetNamespaceForT(ctx, t)
+
+			t.Log("configuring secret")
+			tlsRouteExampleTLSCert, tlsRouteExampleTLSKey := certificate.MustGenerateSelfSignedCertPEMFormat(certificate.WithCommonName(testHostname))
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-test",
+				},
+				Data: map[string][]byte{
+					"tls.crt": tlsRouteExampleTLSCert,
+					"tls.key": tlsRouteExampleTLSKey,
+				},
+			}
+
+			t.Log("deploying secret")
+			secret, err := cluster.Client().CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+			assert.NoError(t, err)
+			cleaner.Add(secret)
+
+			t.Log("deploying a minimal GRPC service exposed with Ingress via HTTPS")
+			ctx = deployGRPCServiceWithIngress(ctx, t, true)
+
+			t.Log("deploying a minimal GRPC service exposed with Ingress via HTTP")
+			return deployGRPCServiceWithIngress(ctx, t, false) // To test GRPC over HTTP.
+		}).
+		Assess("checking whether Ingress status is updated and gRPC traffic over HTTPS is properly routed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			t.Log("verifying service connectivity via HTTPS and Ingress status update")
+			ctx = verifyGRPCServiceAndIngress(ctx, t, testHostname)
+
+			t.Log("verifying service connectivity via HTTP and Ingress status update")
+			return verifyGRPCServiceAndIngress(ctx, t, "")
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}
+
+func deployGRPCServiceWithIngress(ctx context.Context, t *testing.T, gRPCS bool) context.Context {
+	cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+	cluster := GetClusterFromCtx(ctx)
+	namespace := GetNamespaceForT(ctx, t)
+	ingressClass := GetIngressClassFromCtx(ctx)
+	t.Log("deploying a minimal GRPC container deployment to test Ingress routes")
+
+	// Kong distinguishes gRPC over HTTP - 'grpcs' and gRPC over HTTPS - 'grpc'.
+	// Furthermore example service uses different ports for each protocol.
+	kongProtocol := "grpc"
+	grpcBinPort := int32(9000)
+	if gRPCS {
+		kongProtocol = "grpcs"
+		grpcBinPort = test.GRPCBinPort
+	}
+
+	container := generators.NewContainer("grpcbin", test.GRPCBinImage, grpcBinPort)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment.Name += kongProtocol
+	deployment, err := cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	cleaner.Add(deployment)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Name += kongProtocol
+	service.Annotations = map[string]string{
+		annotations.AnnotationPrefix + annotations.ProtocolKey: kongProtocol,
+	}
+	_, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	cleaner.Add(deployment)
+
+	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
+	ingress := generators.NewIngressForService("/", map[string]string{
+		annotations.AnnotationPrefix + annotations.ProtocolsKey: kongProtocol,
+	}, service)
+	ingress.Spec.IngressClassName = &ingressClass
+	assert.NoError(t, clusters.DeployIngress(ctx, cluster, namespace, ingress))
+	cleaner.Add(ingress)
+	ctx = SetInCtxForT(ctx, t, ingress)
+
+	return ctx
+}
+
+func verifyGRPCServiceAndIngress(ctx context.Context, t *testing.T, hostname string) context.Context {
+	t.Log("waiting for updated ingress status to include IP")
+	assert.Eventually(t, func() bool {
+		cluster := GetClusterFromCtx(ctx)
+		namespace := GetNamespaceForT(ctx, t)
+		ingress := GetFromCtxForT[*netv1.Ingress](ctx, t)
+
+		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, cluster, namespace, ingress)
+		if err != nil {
+			return false
+		}
+		return len(lbstatus.Ingress) > 0
+	}, consts.StatusWait, consts.WaitTick)
+
+	proxyURL := GetProxyURLFromCtx(ctx)
+	t.Log("verifying that gRPC service can be accessed via Ingress")
+	var tlsEnabled bool
+	proxyPort := ktfkong.DefaultProxyHTTPPort
+	if hostname != "" {
+		tlsEnabled = true
+		proxyPort = ktfkong.DefaultProxyTLSServicePort
+	}
+	assert.Eventually(t, func() bool {
+		if err := grpcEchoResponds(
+			ctx, fmt.Sprintf("%s:%d", proxyURL.Hostname(), proxyPort), hostname, fmt.Sprintf("echo %q kong", hostname), tlsEnabled,
+		); err != nil {
+			t.Log(err)
+			return false
+		}
+		return true
+	}, consts.IngressWait, consts.WaitTick)
+
+	return ctx
+}

--- a/test/integration/isolated/ingress_test.go
+++ b/test/integration/isolated/ingress_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -18,6 +20,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
@@ -58,100 +61,138 @@ func TestIngressGRPC(t *testing.T) {
 			assert.NoError(t, err)
 			cleaner.Add(secret)
 
-			t.Log("deploying a minimal GRPC service exposed with Ingress via HTTPS")
-			ctx = deployGRPCServiceWithIngress(ctx, t, true)
+			type kongProtocolAnnotation string
+			const (
+				gRPC  kongProtocolAnnotation = "grpc"
+				gRPCS kongProtocolAnnotation = "grpcs"
+			)
+			const (
+				gRPCBinPort  int32 = 9000
+				gRPCSBinPort int32 = 9001
+			)
+			t.Log("deploying a minimal gRPC container deployment to test Ingress routes")
+			container := generators.NewContainer("grpcbin", test.GRPCBinImage, 0)
+			// Overwrite ports to specify gRPC over HTTP (9000) and gRPC over HTTPS (9001).
+			container.Ports = []corev1.ContainerPort{{ContainerPort: gRPCBinPort, Name: string(gRPC)}, {ContainerPort: gRPCSBinPort, Name: string(gRPCS)}}
+			deployment := generators.NewDeploymentForContainer(container)
+			deployment, err = cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+			assert.NoError(t, err)
+			cleaner.Add(deployment)
 
-			t.Log("deploying a minimal GRPC service exposed with Ingress via HTTP")
-			return deployGRPCServiceWithIngress(ctx, t, false)
+			exposeWithService := func(p kongProtocolAnnotation) *corev1.Service {
+				grpcBinPort := gRPCBinPort
+				if p == gRPCS {
+					grpcBinPort = gRPCSBinPort
+				}
+				kongProtocol := string(p)
+				t.Logf("exposing deployment gRPC (%s) port %s via service", kongProtocol, deployment.Name)
+				svc := generators.NewServiceForDeploymentWithMappedPorts(deployment, corev1.ServiceTypeLoadBalancer, map[int32]int32{grpcBinPort: grpcBinPort})
+				svc.Name += kongProtocol
+				svc.Annotations = map[string]string{
+					annotations.AnnotationPrefix + annotations.ProtocolKey: kongProtocol,
+				}
+				_, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+				assert.NoError(t, err)
+				cleaner.Add(svc)
+				return svc
+			}
+
+			// Deploy two services, one for gRPC and one for gRPCS. Two protocols in one service annotation (konghq.com/protocol) are not supported.
+			serviceGRPC := exposeWithService(gRPC)
+			serviceGRPCS := exposeWithService(gRPCS)
+
+			ingressClass := GetIngressClassFromCtx(ctx)
+			t.Logf("creating an ingress for services: %s, %s with ingress.class %s", serviceGRPC.Name, serviceGRPCS.Name, ingressClass)
+			ingress := builder.NewIngress(uuid.NewString(), ingressClass).WithRules(
+				netv1.IngressRule{
+					Host: testHostname,
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: lo.ToPtr(netv1.PathTypePrefix),
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: serviceGRPCS.Name,
+											Port: netv1.ServiceBackendPort{
+												Number: gRPCSBinPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				netv1.IngressRule{
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: lo.ToPtr(netv1.PathTypePrefix),
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: serviceGRPC.Name,
+											Port: netv1.ServiceBackendPort{
+												Number: gRPCBinPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			).Build()
+			ingress.Annotations[annotations.AnnotationPrefix+annotations.ProtocolsKey] = fmt.Sprintf("%s,%s", gRPC, gRPCS)
+			assert.NoError(t, clusters.DeployIngress(ctx, cluster, namespace, ingress))
+			cleaner.Add(ingress)
+			ctx = SetInCtxForT(ctx, t, ingress)
+
+			return ctx
 		}).
 		Assess("checking whether Ingress status is updated and gRPC traffic over HTTPS is properly routed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			t.Log("verifying service connectivity via HTTPS and Ingress status update")
-			ctx = verifyGRPCServiceAndIngress(ctx, t, testHostname)
+			t.Log("waiting for updated ingress status to include IP")
+			assert.Eventually(t, func() bool {
+				cluster := GetClusterFromCtx(ctx)
+				namespace := GetNamespaceForT(ctx, t)
+				ingress := GetFromCtxForT[*netv1.Ingress](ctx, t)
 
-			t.Log("verifying service connectivity via HTTP and Ingress status update")
-			return verifyGRPCServiceAndIngress(ctx, t, "")
+				lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, cluster, namespace, ingress)
+				if err != nil {
+					return false
+				}
+				return len(lbstatus.Ingress) > 0
+			}, consts.StatusWait, consts.WaitTick)
+
+			verifyEchoResponds := func(hostname string) {
+				// Kong Gateway uses different ports for HTTP and HTTPS traffic.
+				proxyPort := ktfkong.DefaultProxyTLSServicePort
+				tlsEnabled := true
+				if hostname == "" {
+					proxyPort = ktfkong.DefaultProxyHTTPPort
+					tlsEnabled = false
+				}
+				assert.Eventually(t, func() bool {
+					if err := grpcEchoResponds(
+						ctx, fmt.Sprintf("%s:%d", GetProxyURLFromCtx(ctx).Hostname(), proxyPort), hostname, "echo Kong", tlsEnabled,
+					); err != nil {
+						t.Log(err)
+						return false
+					}
+					return true
+				}, consts.IngressWait, consts.WaitTick)
+			}
+			t.Log("verifying service connectivity via HTTPS (gRPCS)")
+			verifyEchoResponds(testHostname)
+			t.Log("verifying service connectivity via HTTP (gRPC)")
+			verifyEchoResponds("")
+
+			return ctx
 		}).
 		Teardown(featureTeardown())
 
 	tenv.Test(t, f.Feature())
-}
-
-func deployGRPCServiceWithIngress(ctx context.Context, t *testing.T, gRPCS bool) context.Context {
-	cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
-	cluster := GetClusterFromCtx(ctx)
-	namespace := GetNamespaceForT(ctx, t)
-	ingressClass := GetIngressClassFromCtx(ctx)
-	t.Log("deploying a minimal GRPC container deployment to test Ingress routes")
-
-	// Kong distinguishes gRPC over HTTP - 'grpcs' and gRPC over HTTPS - 'grpc'.
-	// Furthermore example service uses different ports for each protocol.
-	kongProtocol := "grpc"
-	grpcBinPort := int32(9000)
-	if gRPCS {
-		kongProtocol = "grpcs"
-		grpcBinPort = test.GRPCBinPort
-	}
-
-	container := generators.NewContainer("grpcbin", test.GRPCBinImage, grpcBinPort)
-	deployment := generators.NewDeploymentForContainer(container)
-	deployment.Name += kongProtocol
-	deployment, err := cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
-	assert.NoError(t, err)
-	cleaner.Add(deployment)
-
-	t.Logf("exposing deployment %s via service", deployment.Name)
-	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	service.Name += kongProtocol
-	service.Annotations = map[string]string{
-		annotations.AnnotationPrefix + annotations.ProtocolKey: kongProtocol,
-	}
-	_, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
-	assert.NoError(t, err)
-	cleaner.Add(deployment)
-
-	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
-	ingress := generators.NewIngressForService("/", map[string]string{
-		annotations.AnnotationPrefix + annotations.ProtocolsKey: kongProtocol,
-	}, service)
-	ingress.Spec.IngressClassName = &ingressClass
-	assert.NoError(t, clusters.DeployIngress(ctx, cluster, namespace, ingress))
-	cleaner.Add(ingress)
-	ctx = SetInCtxForT(ctx, t, ingress)
-
-	return ctx
-}
-
-func verifyGRPCServiceAndIngress(ctx context.Context, t *testing.T, hostname string) context.Context {
-	t.Log("waiting for updated ingress status to include IP")
-	assert.Eventually(t, func() bool {
-		cluster := GetClusterFromCtx(ctx)
-		namespace := GetNamespaceForT(ctx, t)
-		ingress := GetFromCtxForT[*netv1.Ingress](ctx, t)
-
-		lbstatus, err := clusters.GetIngressLoadbalancerStatus(ctx, cluster, namespace, ingress)
-		if err != nil {
-			return false
-		}
-		return len(lbstatus.Ingress) > 0
-	}, consts.StatusWait, consts.WaitTick)
-
-	proxyURL := GetProxyURLFromCtx(ctx)
-	t.Log("verifying that gRPC service can be accessed via Ingress")
-	var tlsEnabled bool
-	proxyPort := ktfkong.DefaultProxyHTTPPort
-	if hostname != "" {
-		tlsEnabled = true
-		proxyPort = ktfkong.DefaultProxyTLSServicePort
-	}
-	assert.Eventually(t, func() bool {
-		if err := grpcEchoResponds(
-			ctx, fmt.Sprintf("%s:%d", proxyURL.Hostname(), proxyPort), hostname, fmt.Sprintf("echo %q kong", hostname), tlsEnabled,
-		); err != nil {
-			t.Log(err)
-			return false
-		}
-		return true
-	}, consts.IngressWait, consts.WaitTick)
-
-	return ctx
 }

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -329,6 +329,7 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 			// the cleaner always gets a 404 on it for unknown reasons
 			_ = cluster.Client().NetworkingV1().IngressClasses().Delete(ctx, ingressClass, metav1.DeleteOptions{})
 		}()
+		ctx = setInCtx(ctx, _ingressClass{}, ingressClass)
 
 		clusterVersion, err := cluster.Version()
 		if !assert.NoError(t, err, "failed getting cluster version") {

--- a/test/internal/testlabels/labels.go
+++ b/test/internal/testlabels/labels.go
@@ -5,6 +5,7 @@ const (
 	Kind          = "kind"
 	KindUDPRoute  = "UDPRoute"
 	KindGRPCRoute = "GRPCRoute"
+	KindIngress   = "Ingress"
 )
 
 const (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Kong allows to expose gRPC services over Ingress as [described in the docs](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/services/grpc/) (they will be updated accordingly as described in https://github.com/Kong/kubernetes-ingress-controller/issues/5134). It's a limited support, specific to Kong solution, it's not a part of any standard.

This PR migrates the integration test that verifies it to an isolated one. It increases coverage, to not only verify proper status setting but also proper traffic routing. Furthermore, it tests support for gRPC over HTTP (without TLS), which requires adjustment of Kong Gateway's setting (the rationale is described in https://github.com/Kong/kubernetes-ingress-controller/pull/5128). It works without any problems (it hasn't required any code changes).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of the https://github.com/Kong/kubernetes-ingress-controller/issues/4273

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

