### PR TITLE
Backport kic log dump to release/2.12.x

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -1,7 +1,13 @@
 name: conformance tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      log-output-file:
+        # specifies the file for KIC manager's logs to output to.
+        type: string
+        default: ""
+        required: false
 
 jobs:
   conformance-tests:
@@ -31,6 +37,16 @@ jobs:
         env:
           JUNIT_REPORT: "conformance-tests.xml"
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
+          TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
+      
+      # upload logs when test failed
+      - name: upload KIC logs 
+        if: ${{ failure() && inputs.log-output-file != '' }}
+        uses: actions/upload-artifact@v3
+        with: 
+          name: ${{ matrix.name }}-kic-logs
+          path: ${{ inputs.log-output-file }}
+          if-no-files-found: ignore
 
       - name: collect test report
         if: ${{ always() }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -33,6 +33,11 @@ on:
         type: string
         default: ""
         required: false
+      log-output-file:
+        # specifies the file for KIC manager's logs to output to.
+        type: string
+        default: ""
+        required: false
 
 jobs:
   integration-tests:
@@ -122,6 +127,7 @@ jobs:
           KONG_CONTROLLER_FEATURE_GATES: "${{ matrix.feature_gates }}"
           JUNIT_REPORT: "integration-tests-${{ matrix.name }}.xml"
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
+          TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
 
       - name: run ${{ matrix.name }} - invalid config
         run: make test.integration.${{ matrix.test }}
@@ -132,6 +138,7 @@ jobs:
           JUNIT_REPORT: "integration-tests-invalid-config-${{ matrix.name }}.xml"
           GOTESTFLAGS: "-run=TestIngressRecoverFromInvalidPath"
           TEST_RUN_INVALID_CONFIG_CASES: "true"
+          TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
 
       - name: collect test coverage
         if: ${{ !cancelled() }}
@@ -146,6 +153,15 @@ jobs:
         with:
           name: diagnostics-integration-tests-${{ matrix.name }}
           path: /tmp/ktf-diag*
+          if-no-files-found: ignore
+      
+      # upload logs when test failed
+      - name: upload KIC logs 
+        if: ${{ failure() && inputs.log-output-file != '' }}
+        uses: actions/upload-artifact@v3
+        with: 
+          name: integration-tests-kic-logs-${{ matrix.name }}
+          path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore
 
       - name: collect test report

--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -50,6 +50,7 @@ jobs:
       kong-enterprise-container-repo: kong/kong-gateway-dev
       kong-enterprise-container-tag: nightly
       kong-enterprise-effective-version: "3.4"
+      log-output-file:  /tmp/integration-tests-kic-logs
 
   test-reports:
     needs:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -98,6 +98,8 @@ jobs:
     if: needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_integration_tests.yaml
     secrets: inherit
+    with:
+      log-output-file: /tmp/integration-tests-kic-logs
 
   conformance-tests:
     needs:
@@ -105,6 +107,8 @@ jobs:
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_conformance_tests.yaml
     secrets: inherit
+    with:
+      log-output-file: /tmp/conformance-tests-kic-logs
 
   build-docker-image:
     needs:

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -79,6 +79,7 @@ jobs:
       kong-enterprise-container-repo: ${{ github.event.inputs.kong-image-repo }}
       kong-enterprise-container-tag: ${{ github.event.inputs.kong-image-tag }}
       kong-enterprise-effective-version: ${{ github.event.inputs.kong-effective-version }}
+      log-output-file:  /tmp/integration-tests-kic-logs
 
   on-finish-comment-or-close-issue:
     needs:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Backport 2 PRs to dump and upload KIC's log produced during the integration tests to 2.12.x:
#5192 
#5236 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
