### PR TITLE
fix: correct version check of converting plugins and do not use /~ prefix for tests agianst Kong 2.x

### DIFF
--- a/internal/dataplane/kongstate/util.go
+++ b/internal/dataplane/kongstate/util.go
@@ -313,7 +313,7 @@ func (p plugin) toKongPlugin(kongVersion semver.Version) kong.Plugin {
 	if len(p.Protocols) > 0 {
 		result.Protocols = kong.StringSlice(p.Protocols...)
 	}
-	if p.InstanceName != "" && kongVersion.GT(versions.PluginInstanceNameCutoff) {
+	if p.InstanceName != "" && kongVersion.GTE(versions.PluginInstanceNameCutoff) {
 		result.InstanceName = kong.String(p.InstanceName)
 	}
 	return result

--- a/internal/dataplane/kongstate/util_test.go
+++ b/internal/dataplane/kongstate/util_test.go
@@ -57,7 +57,7 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
 				},
-				kongVersion: semver.MustParse("3.4.0"),
+				kongVersion: semver.MustParse("3.2.0"),
 			},
 			want: kong.Plugin{
 				Name: kong.String("correlation-id"),
@@ -96,8 +96,9 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 			name: "secret configuration",
 			args: args{
 				plugin: kongv1.KongClusterPlugin{
-					Protocols:  []kongv1.KongProtocol{"http"},
-					PluginName: "correlation-id",
+					Protocols:    []kongv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
 					ConfigFrom: &kongv1.NamespacedConfigSource{
 						SecretValue: kongv1.NamespacedSecretValueFromSource{
 							Key:       "correlation-id-config",
@@ -109,7 +110,8 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 				kongVersion: semver.MustParse("3.4.0"),
 			},
 			want: kong.Plugin{
-				Name: kong.String("correlation-id"),
+				Name:         kong.String("correlation-id"),
+				InstanceName: kong.String("example"),
 				Config: kong.Configuration{
 					"header_name": "foo",
 				},
@@ -223,7 +225,7 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 						Raw: []byte(`{"header_name": "foo"}`),
 					},
 				},
-				kongVersion: semver.MustParse("3.4.0"),
+				kongVersion: semver.MustParse("3.2.0"),
 			},
 			want: kong.Plugin{
 				Name: kong.String("correlation-id"),
@@ -266,8 +268,9 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 						Name:      "foo",
 						Namespace: "default",
 					},
-					Protocols:  []kongv1.KongProtocol{"http"},
-					PluginName: "correlation-id",
+					Protocols:    []kongv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
 					ConfigFrom: &kongv1.ConfigSource{
 						SecretValue: kongv1.SecretValueFromSource{
 							Key:    "correlation-id-config",
@@ -278,7 +281,8 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 				kongVersion: semver.MustParse("3.4.0"),
 			},
 			want: kong.Plugin{
-				Name: kong.String("correlation-id"),
+				Name:         kong.String("correlation-id"),
+				InstanceName: kong.String("example"),
 				Config: kong.Configuration{
 					"header_name": "foo",
 				},

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -1209,9 +1209,15 @@ func TestIngressRewriteURI(t *testing.T) {
 	const (
 		jpegMagicNumber = "\xff\xd8\xff\xe0\x00\x10JFIF"
 		pngMagicNumber  = "\x89PNG\r\n\x1a\n"
+
+		// Since Kong adds `~` prefix for regex paths from 3.0,
+		// we append `/~` to ingress paths if Kong major version >= 3.
+		addRegexPrefixMinimalMajorVersion = 3
+		pathRegexPrefix                   = "/~"
 	)
 
 	ctx := context.Background()
+	kongVersion := eventuallyGetKongVersion(t, proxyAdminURL)
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
@@ -1302,7 +1308,11 @@ func TestIngressRewriteURI(t *testing.T) {
 
 	t.Logf("creating an Ingress for service %s with rewrite annotation", service.Name)
 	const serviceDomainRewrite = "rewrite.example"
-	ingressRewrite := generators.NewIngressForService("/~/foo/(.*)", map[string]string{
+	ingressPath := "/foo/(.*)"
+	if kongVersion.Major() >= addRegexPrefixMinimalMajorVersion {
+		ingressPath = pathRegexPrefix + ingressPath
+	}
+	ingressRewrite := generators.NewIngressForService(ingressPath, map[string]string{
 		annotations.AnnotationPrefix + annotations.StripPathKey:  "true",
 		annotations.AnnotationPrefix + annotations.RewriteURIKey: "/image/$1",
 	}, service)
@@ -1335,8 +1345,13 @@ func TestIngressRewriteURI(t *testing.T) {
 	ingressRewrite, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, ingressRewrite.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	t.Log("update the ingress capture group")
+	ingressPath = "/foo/(\\w+)/(.*)"
+	if kongVersion.Major() >= addRegexPrefixMinimalMajorVersion {
+		ingressPath = pathRegexPrefix + ingressPath
+	}
+
 	for i := range ingressRewrite.Spec.Rules {
-		ingressRewrite.Spec.Rules[i].HTTP.Paths[0].Path = "/~/foo/(\\w+)/(.*)"
+		ingressRewrite.Spec.Rules[i].HTTP.Paths[0].Path = ingressPath
 	}
 
 	_, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Update(ctx, ingressRewrite, metav1.UpdateOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

- Fix version check of converting plugins: `GT` -> `GTE` 
- Do not use `/~` prefix for regex paths in tests against Kong 2.x

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fix of #5250 and part of #5211 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
