### PR TITLE
chore: add defaultServiceTimeoutInKongFormat helper

### DIFF
--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -58,13 +58,19 @@ var defaultHTTPIngressPathType = netv1.PathTypeImplementationSpecific
 const (
 	defaultHTTPPort = 80
 	defaultRetries  = 5
-
-	// defaultServiceTimeout indicates the amount of time by default that we wait
-	// for connections to an underlying Kubernetes service to complete in the
-	// data-plane. The current value is based on a historical default that started
-	// in version 0 of the ingress controller.
-	defaultServiceTimeout = time.Second * 60
 )
+
+// defaultServiceTimeoutKongFormat returns the defaultServiceTimeout in format
+// expected by Kong (pointer to an integer representing milliseconds).
+//
+// defaultServiceTimeout indicates the amount of time by default that we wait
+// for connections to an underlying Kubernetes service to complete in the
+// data-plane. The current value is based on a historical default that started
+// in version 0 of the ingress controller.
+func defaultServiceTimeoutInKongFormat() *int {
+	const defaultServiceTimeout = time.Second * 60
+	return kong.Int(int(defaultServiceTimeout.Milliseconds()))
+}
 
 // -----------------------------------------------------------------------------
 // Ingress Translation - Private - Index
@@ -194,9 +200,9 @@ func (m *ingressTranslationMeta) translateIntoKongStateService(kongServiceName s
 			Port:           kong.Int(defaultHTTPPort),
 			Protocol:       kong.String("http"),
 			Path:           kong.String("/"),
-			ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
-			ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-			WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+			ConnectTimeout: defaultServiceTimeoutInKongFormat(),
+			ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+			WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 			Retries:        kong.Int(defaultRetries),
 		},
 		Backends: []kongstate.ServiceBackend{{

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -58,13 +58,13 @@ func TestTranslateIngressATC(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -135,13 +135,13 @@ func TestTranslateIngressATC(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -217,13 +217,13 @@ func TestTranslateIngressATC(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -78,13 +78,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -151,13 +151,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -225,13 +225,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -299,13 +299,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -373,13 +373,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -446,13 +446,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -519,13 +519,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -657,13 +657,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -801,13 +801,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -894,13 +894,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service1.80"),
 						Host:           kong.String("test-service1.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{
 						{
@@ -937,13 +937,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service2.80"),
 						Host:           kong.String("test-service2.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{
 						{
@@ -1037,13 +1037,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.ad-service.80"),
 						Host:           kong.String("ad-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{
 						{
@@ -1080,13 +1080,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.mad-service.80"),
 						Host:           kong.String("mad-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{
 						{
@@ -1155,13 +1155,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.80"),
 						Host:           kong.String("test-service.default.80.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
@@ -1231,13 +1231,13 @@ func TestTranslateIngress(t *testing.T) {
 					Service: kong.Service{
 						Name:           kong.String("default.test-service.http"),
 						Host:           kong.String("test-service.default.http.svc"),
-						ConnectTimeout: kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ConnectTimeout: defaultServiceTimeoutInKongFormat(),
 						Path:           kong.String("/"),
 						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						Retries:        kong.Int(defaultRetries),
-						ReadTimeout:    kong.Int(int(defaultServiceTimeout.Milliseconds())),
-						WriteTimeout:   kong.Int(int(defaultServiceTimeout.Milliseconds())),
+						ReadTimeout:    defaultServiceTimeoutInKongFormat(),
+						WriteTimeout:   defaultServiceTimeoutInKongFormat(),
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of repeating `kong.Int(int(defaultServiceTimeout.Milliseconds()))` everywhere, let's use a common helper that returns the timeout in the format expected by Kong.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up to https://github.com/Kong/kubernetes-ingress-controller/pull/5234.
