### PR TITLE
fix: set tags on GRPCRoute routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ Adding a new version? You'll need three changes:
   configuration. Instead, it will return `400` with message to tell the
   validation failures.
   [#5208](https://github.com/Kong/kubernetes-ingress-controller/pull/5208)
+- Fixed an issue that prevented the controller from associating admin API
+  errors with a GRPCRoute.
+  [#5267](https://github.com/Kong/kubernetes-ingress-controller/pull/5267)
 
 ### Changed
 

--- a/internal/dataplane/translator/subtranslator/grpcroute.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute.go
@@ -45,6 +45,7 @@ func GenerateKongRoutesFromGRPCRouteRule(
 	routes := make([]kongstate.Route, 0, len(rule.Matches))
 	// gather the k8s object information and hostnames from the grpcroute
 	ingressObjectInfo := util.FromK8sObject(grpcroute)
+	tags := util.GenerateTagsForObject(grpcroute)
 
 	// generate a route to match hostnames only if there is no match in the rule.
 	if len(rule.Matches) == 0 {
@@ -59,6 +60,7 @@ func GenerateKongRoutesFromGRPCRouteRule(
 			Route: kong.Route{
 				Name:      kong.String(routeName),
 				Protocols: kong.StringSlice("grpc", "grpcs"),
+				Tags:      tags,
 			},
 		}
 		r.Hosts = getGRPCRouteHostnamesAsSliceOfStringPointers(grpcroute)

--- a/internal/dataplane/translator/subtranslator/grpcroute_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_test.go
@@ -210,6 +210,13 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 						Name:      kong.String("grpcroute.default.hostname-only.0.0"),
 						Protocols: kong.StringSlice("grpc", "grpcs"),
 						Hosts:     kong.StringSlice("foo.com"),
+						Tags: kong.StringSlice(
+							"k8s-name:hostname-only",
+							"k8s-namespace:default",
+							"k8s-kind:GRPCRoute",
+							"k8s-group:gateway.networking.k8s.io",
+							"k8s-version:v1alpha2",
+						),
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds source entity tags to GRPCRoute in the traditional translator.

**Which issue this PR fixes**:

We forgot to put source entity tags on GRPCRoute and were unable to attach admin API errors to them.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
