### PR TITLE
fix: tag Services backed by KongServiceFacade correctly

### DIFF
--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -307,7 +308,16 @@ func (m *ingressTranslationMeta) translateIntoKongStateService(kongServiceName s
 				Namespace: m.parentIngress.GetNamespace(),
 				PortDef:   portDef,
 			}},
-			Parent: m.parentIngress,
+			Parent: &incubatorv1alpha1.KongServiceFacade{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: m.parentIngress.GetNamespace(),
+					Name:      m.backend.name,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       incubatorv1alpha1.KongServiceFacadeKind,
+					APIVersion: incubatorv1alpha1.GroupVersion.String(),
+				},
+			},
 		}
 	}
 

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -364,7 +364,16 @@ func TestTranslateIngressATC(t *testing.T) {
 						Namespace: corev1.NamespaceDefault,
 						PortDef:   PortDefFromPortNumber(8080),
 					}},
-					Parent: expectedParentIngress(),
+					Parent: &incubatorv1alpha1.KongServiceFacade{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-facade",
+							Namespace: corev1.NamespaceDefault,
+						},
+						TypeMeta: metav1.TypeMeta{
+							Kind:       incubatorv1alpha1.KongServiceFacadeKind,
+							APIVersion: incubatorv1alpha1.GroupVersion.String(),
+						},
+					},
 				},
 			},
 		},

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -43,10 +43,11 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-beta
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
   host: default.svc-facade-alpha.svc.facade
@@ -74,27 +75,30 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-alpha
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
   name: default.svc-facade-beta.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-beta
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
 - algorithm: round-robin
   name: default.svc-facade-alpha.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-alpha
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
@@ -48,10 +48,11 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-beta
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
   host: default.svc-facade-alpha.svc.facade
@@ -84,27 +85,30 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-alpha
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
   name: default.svc-facade-beta.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-beta
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
 - algorithm: round-robin
   name: default.svc-facade-alpha.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-alpha
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes flaky `TestTranslateIngress_KongServiceFacade_used_in_multiple_Ingresses` by deterministically populating Kong Service `Parent` with `KongServiceFacade`'s originated ones (instead of Ingress) and sorting Service's routes in the test.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5248.
