### PR TITLE
feat: add support of KongServiceFacade as default Ingress backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Adding a new version? You'll need three changes:
   When installed, it has to be enabled with `ServiceFacade` feature gate.
   [#5220](https://github.com/Kong/kubernetes-ingress-controller/pull/5220)
   [#5234](https://github.com/Kong/kubernetes-ingress-controller/pull/5234)
+  [#5282](https://github.com/Kong/kubernetes-ingress-controller/pull/5282)
 - Added support for GRPC over HTTP (without TLS) in Gateway API.
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)
 - Added `-init-cache-sync-duration` CLI flag. This flag configures how long the controller waits for Kubernetes resources to populate at startup before generating the initial Kong configuration. It also fixes a bug that removed the default 5 second wait period.

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -184,7 +184,7 @@ func (i *ingressTranslationIndex) getIngressPathBackend(namespace string, httpIn
 	}
 
 	if resource := httpIngressPath.Backend.Resource; resource != nil {
-		if !isKongServiceFacade(resource) {
+		if !IsKongServiceFacade(resource) {
 			gk := resource.Kind
 			if resource.APIGroup != nil {
 				gk = *resource.APIGroup + "/" + gk
@@ -210,7 +210,8 @@ func (i *ingressTranslationIndex) getIngressPathBackend(namespace string, httpIn
 	return ingressTranslationMetaBackend{}, fmt.Errorf("no Service or Resource specified for Ingress path")
 }
 
-func isKongServiceFacade(resource *corev1.TypedLocalObjectReference) bool {
+// IsKongServiceFacade returns true if the given resource reference is a KongServiceFacade.
+func IsKongServiceFacade(resource *corev1.TypedLocalObjectReference) bool {
 	return resource.Kind == incubatorv1alpha1.KongServiceFacadeKind &&
 		resource.APIGroup != nil && *resource.APIGroup == incubatorv1alpha1.GroupVersion.Group
 }

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -18,6 +18,37 @@ plugins:
   - k8s-version:v1
 services:
 - connect_timeout: 60000
+  host: default.svc-facade-default.svc.facade
+  id: 3f003a09-c285-52aa-a944-c6e156c71e36
+  name: default.svc-facade-default.svc.facade
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path ^= "/") && ((net.protocol == "http") || (net.protocol ==
+      "https"))
+    https_redirect_status_code: 426
+    id: 95255daa-88f8-504b-9098-9300d404c741
+    name: default.beta
+    preserve_host: true
+    priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:beta
+    - k8s-namespace:default
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: default.svc-facade-beta.svc.facade
   id: 0487ced6-2552-5ccb-905d-db086a449a6c
   name: default.svc-facade-beta.svc.facade
@@ -82,6 +113,15 @@ services:
   - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: default.svc-facade-default.svc.facade
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  targets:
+  - target: 10.244.0.5:80
 - algorithm: round-robin
   name: default.svc-facade-beta.svc.facade
   tags:

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -43,10 +43,11 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-default
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
   host: default.svc-facade-beta.svc.facade
@@ -116,10 +117,11 @@ upstreams:
 - algorithm: round-robin
   name: default.svc-facade-default.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-default
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
 - algorithm: round-robin

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
@@ -47,10 +47,11 @@ services:
     - k8s-group:networking.k8s.io
     - k8s-version:v1
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-default
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
   host: default.svc-facade-beta.svc.facade
@@ -130,10 +131,11 @@ upstreams:
 - algorithm: round-robin
   name: default.svc-facade-default.svc.facade
   tags:
-  - k8s-name:svc
+  - k8s-name:svc-facade-default
   - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
+  - k8s-kind:KongServiceFacade
+  - k8s-group:incubator.konghq.com
+  - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
 - algorithm: round-robin

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
@@ -18,6 +18,41 @@ plugins:
   - k8s-version:v1
 services:
 - connect_timeout: 60000
+  host: default.svc-facade-default.svc.facade
+  id: 3f003a09-c285-52aa-a944-c6e156c71e36
+  name: default.svc-facade-default.svc.facade
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 95255daa-88f8-504b-9098-9300d404c741
+    name: default.beta
+    path_handling: v0
+    paths:
+    - /
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:beta
+    - k8s-namespace:default
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: default.svc-facade-beta.svc.facade
   id: 0487ced6-2552-5ccb-905d-db086a449a6c
   name: default.svc-facade-beta.svc.facade
@@ -92,6 +127,15 @@ services:
   - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: default.svc-facade-default.svc.facade
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  targets:
+  - target: 10.244.0.5:80
 - algorithm: round-robin
   name: default.svc-facade-beta.svc.facade
   tags:

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/in.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/in.yaml
@@ -34,6 +34,11 @@ spec:
                 name: svc-facade-beta
             path: /beta
             pathType: Exact
+  defaultBackend:
+    resource:
+      apiGroup: incubator.konghq.com
+      kind: KongServiceFacade
+      name: svc-facade-default
 ---
 apiVersion: v1
 kind: Service
@@ -86,6 +91,18 @@ metadata:
     kubernetes.io/ingress.class: kong
     konghq.com/plugins: auth-beta
   name: svc-facade-beta
+  namespace: default
+spec:
+  backendRef:
+    name: svc
+    port: 80
+---
+apiVersion: incubator.konghq.com/v1alpha1
+kind: KongServiceFacade
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: svc-facade-default
   namespace: default
 spec:
   backendRef:

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -132,7 +132,7 @@ func translateIngressDefaultBackendResource(
 		if resource.APIGroup != nil {
 			gk = *resource.APIGroup + "/" + gk
 		}
-		failuresCollector.PushResourceFailure(fmt.Sprintf("default backend: unknown resource type %s", gk), &ingress)
+		failuresCollector.PushResourceFailure(fmt.Sprintf("default backend: unsupported resource type %s", gk), &ingress)
 		return kongstate.Service{}, false
 	}
 	if !features.KongServiceFacade {
@@ -162,6 +162,8 @@ func translateIngressDefaultBackendResource(
 			ReadTimeout:    kong.Int(DefaultServiceTimeout),
 			WriteTimeout:   kong.Int(DefaultServiceTimeout),
 			Retries:        kong.Int(DefaultRetries),
+			// We do not populate Service's Tags field here because it would get overridden anyway later in the
+			// Translator pipeline (see ingressRules.generateKongServiceTags).
 		},
 		Namespace: ingress.Namespace,
 		Backends: []kongstate.ServiceBackend{{
@@ -199,7 +201,8 @@ func translateIngressDefaultBackendService(ingress netv1.Ingress, route *kongsta
 			ReadTimeout:    kong.Int(DefaultServiceTimeout),
 			WriteTimeout:   kong.Int(DefaultServiceTimeout),
 			Retries:        kong.Int(DefaultRetries),
-			Tags:           util.GenerateTagsForObject(&ingress),
+			// We do not populate Service's Tags field here because it would get overridden anyway later in the
+			// Translator pipeline (see ingressRules.generateKongServiceTags).
 		},
 		Namespace: ingress.Namespace,
 		Backends: []kongstate.ServiceBackend{{

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -6,11 +6,14 @@ import (
 	"sort"
 
 	"github.com/kong/go-kong/kong"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/atc"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
@@ -66,7 +69,7 @@ func (t *Translator) ingressRulesFromIngressV1() ingressRules {
 	}
 
 	// Add a default backend if it exists.
-	defaultBackendService, ok := getDefaultBackendService(allDefaultBackends, t.featureFlags.ExpressionRoutes)
+	defaultBackendService, ok := getDefaultBackendService(t.storer, t.failuresCollector, allDefaultBackends, t.featureFlags)
 	if ok {
 		// When such service would overwrite an existing service, merge the routes.
 		if svc, ok := result.ServiceNameToServices[*defaultBackendService.Name]; ok {
@@ -81,51 +84,131 @@ func (t *Translator) ingressRulesFromIngressV1() ingressRules {
 }
 
 // getDefaultBackendService picks the oldest Ingress with a DefaultBackend defined and returns a Kong Service for it.
-func getDefaultBackendService(allDefaultBackends []netv1.Ingress, expressionRoutes bool) (kongstate.Service, bool) {
+func getDefaultBackendService(
+	storer store.Storer,
+	failuresCollector *failures.ResourceFailuresCollector,
+	allDefaultBackends []netv1.Ingress,
+	features FeatureFlags,
+) (kongstate.Service, bool) {
+	// Sort the default backends by creation timestamp, so that the oldest one is picked.
 	sort.SliceStable(allDefaultBackends, func(i, j int) bool {
 		return allDefaultBackends[i].CreationTimestamp.Before(&allDefaultBackends[j].CreationTimestamp)
 	})
 
 	if len(allDefaultBackends) > 0 {
 		ingress := allDefaultBackends[0]
-		defaultBackend := allDefaultBackends[0].Spec.DefaultBackend
-		port := subtranslator.PortDefFromServiceBackendPort(&defaultBackend.Service.Port)
-		serviceName := fmt.Sprintf(
-			"%s.%s.%s",
-			allDefaultBackends[0].Namespace,
-			defaultBackend.Service.Name,
-			port.CanonicalString(),
-		)
-		service := kongstate.Service{
-			Service: kong.Service{
-				Name: kong.String(serviceName),
-				Host: kong.String(fmt.Sprintf(
-					"%s.%s.%s.svc",
-					defaultBackend.Service.Name,
-					ingress.Namespace,
-					port.CanonicalString(),
-				)),
-				Port:           kong.Int(DefaultHTTPPort),
-				Protocol:       kong.String("http"),
-				ConnectTimeout: kong.Int(DefaultServiceTimeout),
-				ReadTimeout:    kong.Int(DefaultServiceTimeout),
-				WriteTimeout:   kong.Int(DefaultServiceTimeout),
-				Retries:        kong.Int(DefaultRetries),
-				Tags:           util.GenerateTagsForObject(&ingress),
-			},
-			Namespace: ingress.Namespace,
-			Backends: []kongstate.ServiceBackend{{
-				Name:    defaultBackend.Service.Name,
-				PortDef: port,
-			}},
-			Parent: &ingress,
+		defaultBackend := ingress.Spec.DefaultBackend
+		route := translateIngressDefaultBackendRoute(&ingress, util.GenerateTagsForObject(&ingress), features.ExpressionRoutes)
+
+		// If the default backend is defined as an arbitrary resource, then we need handle it differently.
+		if resource := defaultBackend.Resource; resource != nil {
+			return translateIngressDefaultBackendResource(
+				resource,
+				ingress,
+				route,
+				storer,
+				failuresCollector,
+				features,
+			)
 		}
-		r := translateIngressDefaultBackendRoute(&ingress, util.GenerateTagsForObject(&ingress), expressionRoutes)
-		service.Routes = append(service.Routes, *r)
-		return service, true
+
+		// Otherwise, the default backend is defined as a Kubernetes Service.
+		return translateIngressDefaultBackendService(ingress, route)
 	}
 
 	return kongstate.Service{}, false
+}
+
+func translateIngressDefaultBackendResource(
+	resource *corev1.TypedLocalObjectReference,
+	ingress netv1.Ingress,
+	route *kongstate.Route,
+	storer store.Storer,
+	failuresCollector *failures.ResourceFailuresCollector,
+	features FeatureFlags,
+) (kongstate.Service, bool) {
+	if !subtranslator.IsKongServiceFacade(resource) {
+		gk := resource.Kind
+		if resource.APIGroup != nil {
+			gk = *resource.APIGroup + "/" + gk
+		}
+		failuresCollector.PushResourceFailure(fmt.Sprintf("default backend: unknown resource type %s", gk), &ingress)
+		return kongstate.Service{}, false
+	}
+	if !features.KongServiceFacade {
+		failuresCollector.PushResourceFailure(
+			fmt.Sprintf("default backend: KongServiceFacade is not enabled, please set the %q feature gate to 'true' to enable it", featuregates.KongServiceFacade),
+			&ingress,
+		)
+		return kongstate.Service{}, false
+	}
+	facade, err := storer.GetKongServiceFacade(ingress.Namespace, resource.Name)
+	if err != nil {
+		failuresCollector.PushResourceFailure(
+			fmt.Sprintf("default backend: KongServiceFacade %q could not be fetched: %s", resource.Name, err),
+			&ingress,
+		)
+		return kongstate.Service{}, false
+	}
+
+	serviceName := fmt.Sprintf("%s.%s.svc.facade", ingress.Namespace, resource.Name)
+	return kongstate.Service{
+		Service: kong.Service{
+			Name:           kong.String(serviceName),
+			Host:           kong.String(serviceName),
+			Port:           kong.Int(DefaultHTTPPort),
+			Protocol:       kong.String("http"),
+			ConnectTimeout: kong.Int(DefaultServiceTimeout),
+			ReadTimeout:    kong.Int(DefaultServiceTimeout),
+			WriteTimeout:   kong.Int(DefaultServiceTimeout),
+			Retries:        kong.Int(DefaultRetries),
+		},
+		Namespace: ingress.Namespace,
+		Backends: []kongstate.ServiceBackend{{
+			Type:      kongstate.ServiceBackendTypeKongServiceFacade,
+			Name:      resource.Name,
+			Namespace: ingress.Namespace,
+			PortDef:   subtranslator.PortDefFromPortNumber(facade.Spec.Backend.Port),
+		}},
+		Parent: facade,
+		Routes: []kongstate.Route{*route},
+	}, true
+}
+
+func translateIngressDefaultBackendService(ingress netv1.Ingress, route *kongstate.Route) (kongstate.Service, bool) {
+	defaultBackend := ingress.Spec.DefaultBackend
+	port := subtranslator.PortDefFromServiceBackendPort(&defaultBackend.Service.Port)
+	serviceName := fmt.Sprintf(
+		"%s.%s.%s",
+		ingress.Namespace,
+		defaultBackend.Service.Name,
+		port.CanonicalString(),
+	)
+	return kongstate.Service{
+		Service: kong.Service{
+			Name: kong.String(serviceName),
+			Host: kong.String(fmt.Sprintf(
+				"%s.%s.%s.svc",
+				defaultBackend.Service.Name,
+				ingress.Namespace,
+				port.CanonicalString(),
+			)),
+			Port:           kong.Int(DefaultHTTPPort),
+			Protocol:       kong.String("http"),
+			ConnectTimeout: kong.Int(DefaultServiceTimeout),
+			ReadTimeout:    kong.Int(DefaultServiceTimeout),
+			WriteTimeout:   kong.Int(DefaultServiceTimeout),
+			Retries:        kong.Int(DefaultRetries),
+			Tags:           util.GenerateTagsForObject(&ingress),
+		},
+		Namespace: ingress.Namespace,
+		Backends: []kongstate.ServiceBackend{{
+			Name:    defaultBackend.Service.Name,
+			PortDef: port,
+		}},
+		Parent: &ingress,
+		Routes: []kongstate.Route{*route},
+	}, true
 }
 
 func translateIngressDefaultBackendRoute(ingress *netv1.Ingress, tags []*string, expressionRoutes bool) *kongstate.Route {

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -339,7 +339,7 @@ func TestGetDefaultBackendService(t *testing.T) {
 				},
 			}},
 			expectedHaveBackendService: false,
-			expectedFailures:           []string{"default backend: unknown resource type unknown.group.com/UnknownKind"},
+			expectedFailures:           []string{"default backend: unsupported resource type unknown.group.com/UnknownKind"},
 		},
 	}
 

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -14,9 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 func TestFromIngressV1(t *testing.T) {
@@ -153,13 +156,14 @@ func TestFromIngressV1(t *testing.T) {
 }
 
 func TestGetDefaultBackendService(t *testing.T) {
-	someIngress := func(creationTimestamp time.Time, serviceName string) netv1.Ingress {
+	ingressWithDefaultBackendService := func(creationTimestamp time.Time, serviceName string) netv1.Ingress {
 		return netv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "foo",
 				Namespace:         "foo-namespace",
 				CreationTimestamp: metav1.NewTime(creationTimestamp),
 			},
+			TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: "networking.k8s.io/v1"},
 			Spec: netv1.IngressSpec{
 				DefaultBackend: &netv1.IngressBackend{
 					Service: &netv1.IngressServiceBackend{
@@ -170,40 +174,60 @@ func TestGetDefaultBackendService(t *testing.T) {
 			},
 		}
 	}
+	ingressWithDefaultBackendKongServiceFacade := func(creationTimestamp time.Time, serviceFacadeName string) netv1.Ingress {
+		return netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo",
+				Namespace:         "foo-namespace",
+				CreationTimestamp: metav1.NewTime(creationTimestamp),
+			},
+			TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: "networking.k8s.io/v1"},
+			Spec: netv1.IngressSpec{
+				DefaultBackend: &netv1.IngressBackend{
+					Resource: &corev1.TypedLocalObjectReference{
+						APIGroup: lo.ToPtr(incubatorv1alpha1.GroupVersion.Group),
+						Kind:     incubatorv1alpha1.KongServiceFacadeKind,
+						Name:     serviceFacadeName,
+					},
+					Service: &netv1.IngressServiceBackend{},
+				},
+			},
+		}
+	}
 
 	now := time.Now()
 	testCases := []struct {
 		name                       string
 		ingresses                  []netv1.Ingress
-		expressionRoutes           bool
+		featureFlags               FeatureFlags
+		storerObjects              store.FakeObjects
 		expectedHaveBackendService bool
+		expectedFailures           []string
 		expectedServiceName        string
 		expectedServiceHost        string
 	}{
 		{
 			name:                       "no ingresses",
 			ingresses:                  []netv1.Ingress{},
-			expressionRoutes:           false,
 			expectedHaveBackendService: false,
 		},
 		{
 			name:                       "no ingresses with expression routes",
 			ingresses:                  []netv1.Ingress{},
-			expressionRoutes:           true,
+			featureFlags:               FeatureFlags{ExpressionRoutes: true},
 			expectedHaveBackendService: false,
 		},
 		{
 			name:                       "one ingress with default backend",
-			ingresses:                  []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:           false,
+			ingresses:                  []netv1.Ingress{ingressWithDefaultBackendService(now, "foo-svc")},
 			expectedHaveBackendService: true,
 			expectedServiceName:        "foo-namespace.foo-svc.80",
 			expectedServiceHost:        "foo-svc.foo-namespace.80.svc",
 		},
 		{
 			name:                       "one ingress with default backend and expression routes enabled",
-			ingresses:                  []netv1.Ingress{someIngress(now, "foo-svc")},
-			expressionRoutes:           true,
+			ingresses:                  []netv1.Ingress{ingressWithDefaultBackendService(now, "foo-svc")},
+			featureFlags:               FeatureFlags{ExpressionRoutes: true},
 			expectedHaveBackendService: true,
 			expectedServiceName:        "foo-namespace.foo-svc.80",
 			expectedServiceHost:        "foo-svc.foo-namespace.80.svc",
@@ -211,10 +235,9 @@ func TestGetDefaultBackendService(t *testing.T) {
 		{
 			name: "multiple ingresses with default backend",
 			ingresses: []netv1.Ingress{
-				someIngress(now.Add(time.Second), "newer"),
-				someIngress(now, "older"),
+				ingressWithDefaultBackendService(now.Add(time.Second), "newer"),
+				ingressWithDefaultBackendService(now, "older"),
 			},
-			expressionRoutes:           false,
 			expectedHaveBackendService: true,
 			expectedServiceName:        "foo-namespace.older.80",
 			expectedServiceHost:        "older.foo-namespace.80.svc",
@@ -222,27 +245,122 @@ func TestGetDefaultBackendService(t *testing.T) {
 		{
 			name: "multiple ingresses with default backend and expression routes enabled",
 			ingresses: []netv1.Ingress{
-				someIngress(now.Add(time.Second), "newer"),
-				someIngress(now, "older"),
+				ingressWithDefaultBackendService(now.Add(time.Second), "newer"),
+				ingressWithDefaultBackendService(now, "older"),
 			},
-			expressionRoutes:           true,
+			featureFlags:               FeatureFlags{ExpressionRoutes: true},
 			expectedHaveBackendService: true,
 			expectedServiceName:        "foo-namespace.older.80",
 			expectedServiceHost:        "older.foo-namespace.80.svc",
+		},
+		{
+			name: "ingress with default backend kong service facade",
+			ingresses: []netv1.Ingress{
+				ingressWithDefaultBackendKongServiceFacade(now, "foo-svc-facade"),
+			},
+			featureFlags: FeatureFlags{KongServiceFacade: true},
+			storerObjects: store.FakeObjects{
+				KongServiceFacades: []*incubatorv1alpha1.KongServiceFacade{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-svc-facade",
+						Namespace: "foo-namespace",
+					},
+					Spec: incubatorv1alpha1.KongServiceFacadeSpec{
+						Backend: incubatorv1alpha1.KongServiceFacadeBackend{
+							Name: "foo-svc",
+							Port: 8080,
+						},
+					},
+				}},
+			},
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.foo-svc-facade.svc.facade",
+			expectedServiceHost:        "foo-namespace.foo-svc-facade.svc.facade",
+		},
+		{
+			name: "ingress with default backend kong service facade and expression routes enabled",
+			ingresses: []netv1.Ingress{
+				ingressWithDefaultBackendKongServiceFacade(now, "foo-svc-facade"),
+			},
+			featureFlags: FeatureFlags{
+				KongServiceFacade: true,
+				ExpressionRoutes:  true,
+			},
+			storerObjects: store.FakeObjects{
+				KongServiceFacades: []*incubatorv1alpha1.KongServiceFacade{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-svc-facade",
+						Namespace: "foo-namespace",
+					},
+					Spec: incubatorv1alpha1.KongServiceFacadeSpec{
+						Backend: incubatorv1alpha1.KongServiceFacadeBackend{
+							Name: "foo-svc",
+							Port: 8080,
+						},
+					},
+				}},
+			},
+			expectedHaveBackendService: true,
+			expectedServiceName:        "foo-namespace.foo-svc-facade.svc.facade",
+			expectedServiceHost:        "foo-namespace.foo-svc-facade.svc.facade",
+		},
+		{
+			name: "ingress with default backend kong service facade and no feature flag enabled",
+			ingresses: []netv1.Ingress{
+				ingressWithDefaultBackendKongServiceFacade(now, "foo-svc-facade"),
+			},
+			expectedHaveBackendService: false,
+			expectedFailures:           []string{`default backend: KongServiceFacade is not enabled, please set the "KongServiceFacade" feature gate to 'true' to enable it`},
+		},
+		{
+			name: "ingress with default non existing backend kong service facade",
+			ingresses: []netv1.Ingress{
+				ingressWithDefaultBackendKongServiceFacade(now, "foo-svc-facade"),
+			},
+			featureFlags:               FeatureFlags{KongServiceFacade: true},
+			expectedHaveBackendService: false,
+			expectedFailures:           []string{`default backend: KongServiceFacade "foo-svc-facade" could not be fetched: KongServiceFacade foo-namespace/foo-svc-facade not found`},
+		},
+		{
+			name: "ingress with default backend resource unknown",
+			ingresses: []netv1.Ingress{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo-namespace",
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: "networking.k8s.io/v1"},
+				Spec: netv1.IngressSpec{
+					DefaultBackend: &netv1.IngressBackend{
+						Resource: &corev1.TypedLocalObjectReference{
+							APIGroup: lo.ToPtr("unknown.group.com"),
+							Kind:     "UnknownKind",
+						},
+					},
+				},
+			}},
+			expectedHaveBackendService: false,
+			expectedFailures:           []string{"default backend: unknown resource type unknown.group.com/UnknownKind"},
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			svc, ok := getDefaultBackendService(tc.ingresses, tc.expressionRoutes)
+			storer := lo.Must(store.NewFakeStore(tc.storerObjects))
+			failuresCollector := failures.NewResourceFailuresCollector(logr.Discard())
+			svc, ok := getDefaultBackendService(storer, failuresCollector, tc.ingresses, tc.featureFlags)
 			require.Equal(t, tc.expectedHaveBackendService, ok)
+			var gotFailures []string
+			for _, failure := range failuresCollector.PopResourceFailures() {
+				gotFailures = append(gotFailures, failure.Message())
+			}
+			require.Equal(t, tc.expectedFailures, gotFailures)
 			if tc.expectedHaveBackendService {
 				require.Equal(t, tc.expectedServiceName, *svc.Name)
 				require.Equal(t, tc.expectedServiceHost, *svc.Host)
 				require.Len(t, svc.Routes, 1)
 				route := svc.Routes[0]
-				if tc.expressionRoutes {
+				if tc.featureFlags.ExpressionRoutes {
 					require.Equal(t, `(http.path ^= "/") && ((net.protocol == "http") || (net.protocol == "https"))`, *route.Expression)
 					require.Equal(t, subtranslator.IngressDefaultBackendPriority, *route.Priority)
 				} else {

--- a/internal/util/builder/ingress.go
+++ b/internal/util/builder/ingress.go
@@ -64,3 +64,8 @@ func (b *IngressBuilder) WithAnnotations(annotations map[string]string) *Ingress
 	}
 	return b
 }
+
+func (b *IngressBuilder) WithDefaultBackend(backend *netv1.IngressBackend) *IngressBuilder {
+	b.ingress.Spec.DefaultBackend = backend
+	return b
+}

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -243,7 +243,7 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 			}
 
 			return ok
-		}, time.Minute, 100*time.Millisecond, "failed waiting for kong addon to become ready") {
+		}, time.Minute*3, 100*time.Millisecond, "failed waiting for kong addon to become ready") {
 			return ctx
 		}
 

--- a/test/internal/helpers/http.go
+++ b/test/internal/helpers/http.go
@@ -118,7 +118,11 @@ func EventuallyGETPath(
 			n, err := b.ReadFrom(resp.Body)
 			require.NoError(t, err)
 			require.True(t, n > 0)
-			return strings.Contains(b.String(), bodyContents)
+			if !strings.Contains(b.String(), bodyContents) {
+				t.Logf("WARNING: http response body does not contain expected contents: %s, actual: \n%s", bodyContents, b.String())
+				return false
+			}
+			return true
 		}
 		return false
 	}, waitDuration, waitTick)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for `KongServiceFacade` as a default Ingress backend along with tests.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5152.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
