### PR TITLE
fix: restore defaulting to protocol "grpcs" for gRPC Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Adding a new version? You'll need three changes:
   errors with a GRPCRoute.
   [#5267](https://github.com/Kong/kubernetes-ingress-controller/pull/5267)
   [#5275](https://github.com/Kong/kubernetes-ingress-controller/pull/5275)
+  [#5283](https://github.com/Kong/kubernetes-ingress-controller/pull/5283)
 
 ### Changed
 

--- a/examples/gateway-grpcroute-via-http.yaml
+++ b/examples/gateway-grpcroute-via-http.yaml
@@ -8,6 +8,8 @@ metadata:
   name: grpcbin-via-http
   labels:
     app: grpcbin-via-http
+  annotations:
+    konghq.com/protocol: grpc
 spec:
   ports:
   - name: grpc
@@ -64,7 +66,7 @@ spec:
   parentRefs:
   - name: kong
   hostnames:
-  - "example.com"
+  - example-grpc-via-http.com
   rules:
   - backendRefs:
     - name: grpcbin-via-http

--- a/examples/gateway-grpcroute-via-https.yaml
+++ b/examples/gateway-grpcroute-via-https.yaml
@@ -8,6 +8,8 @@ metadata:
   name: grpcbin-via-https
   labels:
     app: grpcbin-via-https
+  annotations:
+    konghq.com/protocol: grpcs
 spec:
   ports:
   - name: grpc

--- a/test/integration/isolated/ingress_test.go
+++ b/test/integration/isolated/ingress_test.go
@@ -159,7 +159,7 @@ func TestIngressGRPC(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("checking whether Ingress status is updated and gRPC traffic over HTTPS is properly routed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		Assess("checking whether Ingress status is updated and gRPC traffic is properly routed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			t.Log("waiting for updated ingress status to include IP")
 			assert.Eventually(t, func() bool {
 				cluster := GetClusterFromCtx(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Heuristic introduced in https://github.com/Kong/kubernetes-ingress-controller/pull/5128 for guessing whether for Kong Service `grpc` or `grpcs` protocol should be set breaks default behavior, that service without annotation for `GRPCRoute` is treated as `grpcs`.

Now documentation always mentions annotations for both `grpc` and `grpcs` see
- https://github.com/Kong/docs.konghq.com/pull/6567
but before when only gRPC over HTTPS was supported annotations weren't mentioned. Thus users probably haven't configured it and we have to avoid breaking their setups. This PR ensures that such a configuration will work.



<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4273

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

- e0d56ea71a3488f49b37f565297b734e7973bbba - modifies the test to show that the assumption about `grpcs` is indeed broken (the same setup as described in the docs before the update)
- 6b2764b54b900ac4fe2f53d0536aaf09438faa0e - contains actual fix (reverting heuristic introduced in #5128 - see  `getProtocolForKongService(...)` and some small clean-ups and improvements


<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
