### PR TITLE
chore(gha): preemptively add 1p creds

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -133,6 +133,7 @@ jobs:
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: split image and tag
         id: split
@@ -220,6 +221,7 @@ jobs:
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: check availability of KIC image
         id: check_kic_image
@@ -324,6 +326,7 @@ jobs:
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: split image and tag
         id: split

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -132,6 +132,7 @@ jobs:
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Set image of Kong
         id: set_kong_image

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -51,6 +51,7 @@ jobs:
       id: license
       with:
         password: ${{ secrets.PULP_PASSWORD }}
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: checkout repository
       uses: actions/checkout@v4
@@ -97,6 +98,7 @@ jobs:
       id: license
       with:
         password: ${{ secrets.PULP_PASSWORD }}
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This change is required to accommodate the forthcoming work in https://github.com/Kong/kong-license/pull/25

That work will change kong-license such that the license is sourced directly from 1Password, rather than it being sourced from Pulp using credentials from 1Password (as is the case today). Meaning that workflows needing to run Kong/kong-license's will require 1P credentials instead of the Pulp password.

This work is a necessary step in the deprecation of Pulp aka [KAG-2247](https://konghq.atlassian.net/browse/KAG-2247) / [KAG-3254](https://konghq.atlassian.net/browse/KAG-3254).

Leaving the Pulp password for now so that https://github.com/Kong/kong-license/pull/25 can be merged *after* this PR.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
N/A

**Special notes for your reviewer**:
N/A

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:
N/A

Complete these before marking the PR as `ready to review`:

- [N/A] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR


[KAG-2247]: https://konghq.atlassian.net/browse/KAG-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ