### PR TITLE
feat: set KongServiceFacade's Programmed condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Adding a new version? You'll need three changes:
   When installed, it has to be enabled with `ServiceFacade` feature gate.
   [#5220](https://github.com/Kong/kubernetes-ingress-controller/pull/5220)
   [#5234](https://github.com/Kong/kubernetes-ingress-controller/pull/5234)
+  [#5290](https://github.com/Kong/kubernetes-ingress-controller/pull/5290)
   [#5282](https://github.com/Kong/kubernetes-ingress-controller/pull/5282)
 - Added support for GRPC over HTTP (without TLS) in Gateway API.
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -314,6 +314,10 @@ func TestTranslateIngressATC(t *testing.T) {
 						Name:      "svc-facade",
 						Namespace: "default",
 					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       incubatorv1alpha1.KongServiceFacadeKind,
+						APIVersion: incubatorv1alpha1.GroupVersion.String(),
+					},
 					Spec: incubatorv1alpha1.KongServiceFacadeSpec{
 						Backend: incubatorv1alpha1.KongServiceFacadeBackend{
 							Name: "svc",
@@ -426,14 +430,21 @@ func TestTranslateIngressATC(t *testing.T) {
 				failuresCollector,
 				storer,
 			)
-			checkOnlyObjectMeta := cmp.Transformer("checkOnlyObjectMeta", func(i *netv1.Ingress) *netv1.Ingress {
+			checkOnlyIngressMeta := cmp.Transformer("checkOnlyIngressMeta", func(i *netv1.Ingress) *netv1.Ingress {
 				// In the result we only care about ingresses' metadata being equal.
 				// We ignore specification to simplify tests.
 				return &netv1.Ingress{
 					ObjectMeta: i.ObjectMeta,
 				}
 			})
-			diff := cmp.Diff(tc.expectedServices, services, checkOnlyObjectMeta)
+			checkOnlyKongServiceFacadeMeta := cmp.Transformer("checkOnlyKongServiceFacadeMeta", func(i *incubatorv1alpha1.KongServiceFacade) *incubatorv1alpha1.KongServiceFacade {
+				// In the result we only care about KongServiceFacades' metadata being equal.
+				// We ignore specification to simplify tests.
+				return &incubatorv1alpha1.KongServiceFacade{
+					ObjectMeta: i.ObjectMeta,
+				}
+			})
+			diff := cmp.Diff(tc.expectedServices, services, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta)
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -1548,10 +1548,17 @@ func TestTranslateIngress(t *testing.T) {
 	for _, tt := range tts {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			checkOnlyObjectMeta := cmp.Transformer("checkOnlyObjectMeta", func(i *netv1.Ingress) *netv1.Ingress {
+			checkOnlyIngressMeta := cmp.Transformer("checkOnlyIngressMeta", func(i *netv1.Ingress) *netv1.Ingress {
 				// In the result we only care about ingresses' metadata being equal.
 				// We ignore specification to simplify tests.
 				return &netv1.Ingress{
+					ObjectMeta: i.ObjectMeta,
+				}
+			})
+			checkOnlyKongServiceFacadeMeta := cmp.Transformer("checkOnlyKongServiceFacadeMeta", func(i *incubatorv1alpha1.KongServiceFacade) *incubatorv1alpha1.KongServiceFacade {
+				// In the result we only care about KongServiceFacades' metadata being equal.
+				// We ignore specification to simplify tests.
+				return &incubatorv1alpha1.KongServiceFacade{
 					ObjectMeta: i.ObjectMeta,
 				}
 			})
@@ -1580,7 +1587,7 @@ func TestTranslateIngress(t *testing.T) {
 				})
 			}
 
-			diff := cmp.Diff(tt.expected, translatedServices, checkOnlyObjectMeta)
+			diff := cmp.Diff(tt.expected, translatedServices, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta)
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -153,7 +153,7 @@ func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
 
 	// populate any Kubernetes Service objects relevant objects and get the
 	// services to be skipped because of annotations inconsistency
-	servicesToBeSkipped := ingressRules.populateServices(t.logger, t.storer, t.failuresCollector)
+	servicesToBeSkipped := ingressRules.populateServices(t.logger, t.storer, t.failuresCollector, t.translatedObjectsCollector)
 
 	// add the routes and services to the state
 	var result kongstate.KongState

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -141,6 +141,12 @@ func WithUpdateStatus() func(cfg *manager.Config) {
 	}
 }
 
+func WithKongServiceFacadeFeatureEnabled() func(cfg *manager.Config) {
+	return func(cfg *manager.Config) {
+		cfg.FeatureGates[featuregates.KongServiceFacade] = true
+	}
+}
+
 // AdminAPIOptFns wraps a variadic list of mocks.AdminAPIHandlerOpt and returns
 // a slice containing all of them.
 // The purpose of this is func is to make the call sites a bit less verbose.

--- a/test/envtest/scheme.go
+++ b/test/envtest/scheme.go
@@ -13,6 +13,7 @@ import (
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 type SchemeOption func(t *testing.T, s *k8sruntime.Scheme)
@@ -29,6 +30,7 @@ func WithKong(t *testing.T, s *k8sruntime.Scheme) {
 	require.NoError(t, kongv1.AddToScheme(s))
 	require.NoError(t, kongv1beta1.AddToScheme(s))
 	require.NoError(t, kongv1alpha1.AddToScheme(s))
+	require.NoError(t, incubatorv1alpha1.AddToScheme(s))
 }
 
 // Scheme returns a new scheme with the default Kubernetes types registered.

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -144,10 +144,11 @@ func installKongCRDs(t *testing.T, scheme *k8sruntime.Scheme, cfg *rest.Config) 
 	projectRoot := filepath.Join(filepath.Dir(thisFilePath), "..", "..")
 	// install Kong CRDs from config/crd/bases.
 	kongCRDPath := filepath.Join(projectRoot, "config", "crd", "bases")
+	kongIncubatorCRDPath := filepath.Join(projectRoot, "config", "crd", "incubator")
 	t.Logf("install Kong CRDs from manifests in %s", kongCRDPath)
 	_, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
 		Scheme:             scheme,
-		Paths:              []string{kongCRDPath},
+		Paths:              []string{kongCRDPath, kongIncubatorCRDPath},
 		ErrorIfPathMissing: true,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Propagates `KongServiceFacade` to the `translatedObjectsCollector` in the `Translator` so that its `Programmed` condition is properly set.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5152.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
