### PR TITLE
fix(test): upgrade GKE version to v1.28.3

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -12,7 +12,7 @@ e2e:
     - 'v1.24.15'
   gke:
     # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
-    - '1.28.2'
+    - '1.28.3'
 
 
   # For Istio, we define combinations of Kind and Istio versions that will be


### PR DESCRIPTION
The version of 1.28.2-gke.1157000 no longer available in the Rapid channel ref: https://cloud.google.com/kubernetes-engine/docs/release-notes#December_04_2023

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/7110214081/job/19356382978#step:7:520

```
=== Failed
=== FAIL: test/e2e TestDeployAllInOnePostgresWithMultipleReplicas (0.42s)
    all_in_one_test.go:95: configuring all-in-one-postgres.yaml manifest test
    all_in_one_test.go:97: building test cluster and environment
    all_in_one_test.go:97: no existing cluster provided, creating a new one for "gke" type
    all_in_one_test.go:97: creating a GKE cluster builder
    all_in_one_test.go:97: creating GKE cluster, name: e2e-0b0abeb0-7672-44b0-8440-4303a9abd348
    all_in_one_test.go:97: creating GKE cluster, with requested version: 1.28.2
    all_in_one_test.go:97: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/helpers_test.go:105
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/all_in_one_test.go:97
        	Error:      	Received unexpected error:
        	            	rpc error: code = InvalidArgument desc = No valid versions with the prefix "1.28.2" found.
        	            	error details: name = RequestInfo id = 0x4c759f6ee3ba6bdd data =
        	Test:       	TestDeployAllInOnePostgresWithMultipleReplicas

DONE 1 tests, 1 failure in 86.705s
```

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
