### PR TITLE
fix: change events emit toggle name to --emit-kubernetes-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,10 @@ Adding a new version? You'll need three changes:
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)
 - Added `-init-cache-sync-duration` CLI flag. This flag configures how long the controller waits for Kubernetes resources to populate at startup before generating the initial Kong configuration. It also fixes a bug that removed the default 5 second wait period.
   [#5238](https://github.com/Kong/kubernetes-ingress-controller/pull/5238)
-- Added `--emit-translation-events` CLI flag to disable the creation of events
+- Added `--emit-kubernetes-events` CLI flag to disable the creation of events
   in translating and applying configurations to Kong.
   [#5296](https://github.com/Kong/kubernetes-ingress-controller/pull/5296)
+  [#5299](https://github.com/Kong/kubernetes-ingress-controller/pull/5299)
 
 ### Fixed
 

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -18,7 +18,7 @@
 | `--dump-sensitive-config` | `bool` | Include credentials and TLS secrets in configs exposed with --dump-config flag. | `false` |
 | `--election-id` | `string` | Election id to use for status update. | `5b374a9e.konghq.com` |
 | `--election-namespace` | `string` | Leader election namespace to use when running outside a cluster. |  |
-| `--emit-translation-events` | `bool` | Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects. | `true` |
+| `--emit-kubernetes-events` | `bool` | Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects. | `true` |
 | `--enable-controller-gwapi-gateway` | `bool` | Enable the Gateway API Gateway controller. | `true` |
 | `--enable-controller-gwapi-httproute` | `bool` | Enable the Gateway API HTTPRoute controller. | `true` |
 | `--enable-controller-gwapi-reference-grant` | `bool` | Enable the Gateway API ReferenceGrant controller. | `true` |

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	WatchNamespaces          []string
 	GatewayAPIControllerName string
 	Impersonate              string
-	EmitTranslationEvents    bool
+	EmitKubernetesEvents     bool
 
 	// Ingress status
 	PublishServiceUDP       OptionalNamespacedName
@@ -214,7 +214,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.IntVar(&c.Concurrency, "kong-admin-concurrency", 10, "Max number of concurrent requests sent to Kong's Admin API.")
 	flagSet.StringSliceVar(&c.WatchNamespaces, "watch-namespace", nil,
 		`Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces.`)
-	flagSet.BoolVar(&c.EmitTranslationEvents, "emit-translation-events", true, `Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.`)
+	flagSet.BoolVar(&c.EmitKubernetesEvents, "emit-kubernetes-events", true, `Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.`)
 
 	// Ingress status
 	flagSet.Var(flags.NewValidatedValue(&c.PublishService, namespacedNameFromFlagValue, nnTypeNameOverride), "publish-service",

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -142,11 +142,12 @@ func Run(
 
 	setupLog.Info("Initializing Dataplane Client")
 	var eventRecorder record.EventRecorder
-	if c.EmitTranslationEvents {
-		setupLog.Info("Emit translation event enabled, create event recorder for " + KongClientEventRecorderComponentName)
+	if c.EmitKubernetesEvents {
+		setupLog.Info("Emitting Kubernetes events enabled, creating an event recorder for " + KongClientEventRecorderComponentName)
 		eventRecorder = mgr.GetEventRecorderFor(KongClientEventRecorderComponentName)
 	} else {
-		setupLog.Info("Emit translation event disabled, discard all events")
+		setupLog.Info("Emitting Kubernetes events disabled, discarding all events")
+		// Create an empty record.FakeRecorder with no Events channel to discard all events.
 		eventRecorder = &record.FakeRecorder{}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the new `--emit-translation-events` flag name to `--emit-kubernetes-events` as it decides not only about the translation events but all the events we generate (including configuration application success and failure). 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5252.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
