### PR TITLE
feat: rename incubator package to incubator.ingress-controller.konghq.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Adding a new version? You'll need three changes:
   [#5234](https://github.com/Kong/kubernetes-ingress-controller/pull/5234)
   [#5290](https://github.com/Kong/kubernetes-ingress-controller/pull/5290)
   [#5282](https://github.com/Kong/kubernetes-ingress-controller/pull/5282)
+  [#5302](https://github.com/Kong/kubernetes-ingress-controller/pull/5302)
 - Added support for GRPC over HTTP (without TLS) in Gateway API.
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)
 - Added `-init-cache-sync-duration` CLI flag. This flag configures how long the controller waits for Kubernetes resources to populate at startup before generating the initial Kong configuration. It also fixes a bug that removed the default 5 second wait period.

--- a/config/crd/incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
+++ b/config/crd/incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: kongservicefacades.incubator.konghq.com
+  name: kongservicefacades.incubator.ingress-controller.konghq.com
 spec:
-  group: incubator.konghq.com
+  group: incubator.ingress-controller.konghq.com
   names:
     categories:
     - kong-ingress-controller

--- a/config/crd/incubator/kustomization.yaml
+++ b/config/crd/incubator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- incubator.konghq.com_kongservicefacades.yaml
+- incubator.ingress-controller.konghq.com_kongservicefacades.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -194,7 +194,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -202,7 +202,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -234,7 +234,7 @@ var inputControllersNeeded = &typesNeeded{
 		RBACVerbs:                         []string{"get", "list", "watch"},
 	},
 	typeNeeded{
-		Group:                             "incubator.konghq.com",
+		Group:                             "incubator.ingress-controller.konghq.com",
 		Version:                           "v1alpha1",
 		Kind:                              "KongServiceFacade",
 		PackageImportAlias:                "incubatorv1alpha1",

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -1845,7 +1845,7 @@ func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) SetupWithManager(mgr ctrl
 	if r.StatusQueue != nil {
 		if err := c.Watch(
 			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
-				Group:   "incubator.konghq.com",
+				Group:   "incubator.ingress-controller.konghq.com",
 				Version: "v1alpha1",
 				Kind:    "KongServiceFacade",
 			})},
@@ -1898,8 +1898,8 @@ func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) SetLogger(l logr.Logger) 
 	r.Log = l
 }
 
-//+kubebuilder:rbac:groups=incubator.konghq.com,resources=kongservicefacades,verbs=get;list;watch
-//+kubebuilder:rbac:groups=incubator.konghq.com,resources=kongservicefacades/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=incubator.ingress-controller.konghq.com,resources=kongservicefacades,verbs=get;list;watch
+//+kubebuilder:rbac:groups=incubator.ingress-controller.konghq.com,resources=kongservicefacades/status,verbs=get;update;patch
 
 // Reconcile processes the watched objects
 func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -46,7 +46,7 @@ services:
   - k8s-name:svc-facade-default
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
@@ -78,7 +78,7 @@ services:
   - k8s-name:svc-facade-beta
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
@@ -110,7 +110,7 @@ services:
   - k8s-name:svc-facade-alpha
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
@@ -120,7 +120,7 @@ upstreams:
   - k8s-name:svc-facade-default
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
@@ -130,7 +130,7 @@ upstreams:
   - k8s-name:svc-facade-beta
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
@@ -140,7 +140,7 @@ upstreams:
   - k8s-name:svc-facade-alpha
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/feature-flag-on_golden.yaml
@@ -50,7 +50,7 @@ services:
   - k8s-name:svc-facade-default
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
@@ -87,7 +87,7 @@ services:
   - k8s-name:svc-facade-beta
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 - connect_timeout: 60000
@@ -124,7 +124,7 @@ services:
   - k8s-name:svc-facade-alpha
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   write_timeout: 60000
 upstreams:
@@ -134,7 +134,7 @@ upstreams:
   - k8s-name:svc-facade-default
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
@@ -144,7 +144,7 @@ upstreams:
   - k8s-name:svc-facade-beta
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80
@@ -154,7 +154,7 @@ upstreams:
   - k8s-name:svc-facade-alpha
   - k8s-namespace:default
   - k8s-kind:KongServiceFacade
-  - k8s-group:incubator.konghq.com
+  - k8s-group:incubator.ingress-controller.konghq.com
   - k8s-version:v1alpha1
   targets:
   - target: 10.244.0.5:80

--- a/internal/dataplane/translator/testdata/golden/kong-service-facade/in.yaml
+++ b/internal/dataplane/translator/testdata/golden/kong-service-facade/in.yaml
@@ -11,7 +11,7 @@ spec:
         paths:
           - backend:
               resource:
-                apiGroup: incubator.konghq.com
+                apiGroup: incubator.ingress-controller.konghq.com
                 kind: KongServiceFacade
                 name: svc-facade-alpha
             path: /alpha
@@ -29,14 +29,14 @@ spec:
         paths:
           - backend:
               resource:
-                apiGroup: incubator.konghq.com
+                apiGroup: incubator.ingress-controller.konghq.com
                 kind: KongServiceFacade
                 name: svc-facade-beta
             path: /beta
             pathType: Exact
   defaultBackend:
     resource:
-      apiGroup: incubator.konghq.com
+      apiGroup: incubator.ingress-controller.konghq.com
       kind: KongServiceFacade
       name: svc-facade-default
 ---
@@ -71,7 +71,7 @@ ports:
     port: 80
     protocol: TCP
 ---
-apiVersion: incubator.konghq.com/v1alpha1
+apiVersion: incubator.ingress-controller.konghq.com/v1alpha1
 kind: KongServiceFacade
 metadata:
   annotations:
@@ -84,7 +84,7 @@ spec:
     name: svc
     port: 80
 ---
-apiVersion: incubator.konghq.com/v1alpha1
+apiVersion: incubator.ingress-controller.konghq.com/v1alpha1
 kind: KongServiceFacade
 metadata:
   annotations:
@@ -97,7 +97,7 @@ spec:
     name: svc
     port: 80
 ---
-apiVersion: incubator.konghq.com/v1alpha1
+apiVersion: incubator.ingress-controller.konghq.com/v1alpha1
 kind: KongServiceFacade
 metadata:
   annotations:

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -2554,7 +2554,7 @@ func TestDefaultBackend(t *testing.T) {
 			lo.ToPtr("k8s-name:foo-facade"),
 			lo.ToPtr("k8s-namespace:default"),
 			lo.ToPtr("k8s-kind:KongServiceFacade"),
-			lo.ToPtr("k8s-group:incubator.konghq.com"),
+			lo.ToPtr("k8s-group:incubator.ingress-controller.konghq.com"),
 			lo.ToPtr("k8s-version:v1alpha1"),
 		}, service.Tags, "tags are populated with KongServiceFacade as a parent")
 	})

--- a/pkg/apis/incubator/doc.go
+++ b/pkg/apis/incubator/doc.go
@@ -1,4 +1,4 @@
-// Package incubator contains API Schema definitions for the incubator.konghq.com API group.
+// Package incubator contains API Schema definitions for the incubator.ingress-controller.konghq.com API group.
 // This group is for APIs that are highly experimental and may not be supported in the future.
 // It's not distributed by default and has to be installed separately.
 //

--- a/pkg/apis/incubator/v1alpha1/doc.go
+++ b/pkg/apis/incubator/v1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Package v1alpha1 contains API Schema definitions for the incubator.konghq.com v1alpha1 API group.
+// Package v1alpha1 contains API Schema definitions for the incubator.ingress-controller.konghq.com v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=incubator.konghq.com
+// +groupName=incubator.ingress-controller.konghq.com
 package v1alpha1

--- a/pkg/apis/incubator/v1alpha1/groupversion_info.go
+++ b/pkg/apis/incubator/v1alpha1/groupversion_info.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "incubator.konghq.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "incubator.ingress-controller.konghq.com", Version: "v1alpha1"}
 
 	// SchemeGroupVersion is a convenience var for generated clientsets.
 	SchemeGroupVersion = GroupVersion

--- a/pkg/clientset/typed/incubator/v1alpha1/incubator_client.go
+++ b/pkg/clientset/typed/incubator/v1alpha1/incubator_client.go
@@ -31,7 +31,7 @@ type IncubatorV1alpha1Interface interface {
 	KongServiceFacadesGetter
 }
 
-// IncubatorV1alpha1Client is used to interact with features provided by the incubator.konghq.com group.
+// IncubatorV1alpha1Client is used to interact with features provided by the incubator.ingress-controller.konghq.com group.
 type IncubatorV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2279,7 +2279,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -2287,7 +2287,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:

After a discussion regarding package naming, we've decided to use a better-namespaced pattern for new packages. In `configuration.konghq.com` we lacked a part that would namespace our packages specifically to KIC which is not perfect as that would be better to keep our APIs in Kong to be consistently namespaced. In KGO we've used `*.gateway-operator.konghq.com` pattern so using `incubator.ingress-controller.konghq.com` in KIC is consistent with that and the pattern we'd like to follow in the future is `<component-local-package-name>.<component-name>.konghq.com`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5152.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
