### PR TITLE
fix: allow GRPCRoute without hostnames and matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Adding a new version? You'll need three changes:
   [#5302](https://github.com/Kong/kubernetes-ingress-controller/pull/5302)
 - Added support for GRPC over HTTP (without TLS) in Gateway API.
   [#5128](https://github.com/Kong/kubernetes-ingress-controller/pull/5128)
+  [#5283](https://github.com/Kong/kubernetes-ingress-controller/pull/5283)
 - Added `-init-cache-sync-duration` CLI flag. This flag configures how long the controller waits for Kubernetes resources to populate at startup before generating the initial Kong configuration. It also fixes a bug that removed the default 5 second wait period.
   [#5238](https://github.com/Kong/kubernetes-ingress-controller/pull/5238)
 - Added `--emit-kubernetes-events` CLI flag to disable the creation of events
@@ -121,9 +122,11 @@ Adding a new version? You'll need three changes:
   errors with a GRPCRoute.
   [#5267](https://github.com/Kong/kubernetes-ingress-controller/pull/5267)
   [#5275](https://github.com/Kong/kubernetes-ingress-controller/pull/5275)
-  [#5283](https://github.com/Kong/kubernetes-ingress-controller/pull/5283)
 - Restore the diagnostics server functionality, which was accidentally disabled.
   [#5270](https://github.com/Kong/kubernetes-ingress-controller/pull/5270)
+- Allow configuring a GRPCRoute without hostnames and matches that catch all
+  requests.
+  [#5303](https://github.com/Kong/kubernetes-ingress-controller/pull/5303)
 
 ### Changed
 

--- a/internal/dataplane/translator/translate_grpcroute_test.go
+++ b/internal/dataplane/translator/translate_grpcroute_test.go
@@ -2,7 +2,6 @@ package translator
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/zapr"
@@ -34,7 +33,6 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 		expectedKongServices []kongstate.Service
 		// service name -> routes
 		expectedKongRoutes map[string][]kongstate.Route
-		expectedFailures   []failures.ResourceFailure
 	}{
 		{
 			name: "single GRPCRoute with multiple hostnames and multiple rules",
@@ -384,16 +382,6 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 				},
 			},
-			expectedFailures: []failures.ResourceFailure{
-				newResourceFailure(t, subtranslator.ErrRouteValidationNoRules.Error(),
-					&gatewayapi.GRPCRoute{
-						TypeMeta: grpcRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "grpcroute-no-rules",
-						},
-					}),
-			},
 		},
 	}
 
@@ -427,15 +415,9 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 					require.Equal(t, *expectedRoute.Expression, *r.Expression)
 				}
 			}
-			// check translation failures
+			// Check translation failures.
 			translationFailures := failureCollector.PopResourceFailures()
-			require.Equal(t, len(tc.expectedFailures), len(translationFailures))
-			for _, expectedTranslationFailure := range tc.expectedFailures {
-				expectedFailureMessage := expectedTranslationFailure.Message()
-				require.True(t, lo.ContainsBy(translationFailures, func(failure failures.ResourceFailure) bool {
-					return strings.Contains(failure.Message(), expectedFailureMessage)
-				}))
-			}
+			require.Empty(t, translationFailures)
 		})
 
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

For `GRPCRoute` in GWAPI specs you can read 
- > If no matches are specified, the default is to match every gRPC request.
      [src](https://gateway-api.sigs.k8s.io/api-types/grpcroute/#matches)
- > If no hostname is specified, traffic is routed based on GRPCRoute rules and filters (optional).
     [src](https://gateway-api.sigs.k8s.io/api-types/grpcroute/#matches)

The above and the fact that both fields are optional in CRD leads to the conclusion that configuration without those fields shouldn't be rejected.

In Kong documentation, you can read that for Kong Route, the required fields are
> For `grpc`, at least one of `hosts`, `headers` or `paths`;
   [src](https://docs.konghq.com/gateway/latest/admin-api/#route-object)

and to catch-all set paths to `/` ([src](https://docs.konghq.com/gateway/latest/production/configuring-a-grpc-service/#single-grpc-service-and-route)).

Order of evaluation [described in the docs](https://docs.konghq.com/gateway/latest/key-concepts/routes/#how-requests-are-routed) says that routes that have a regular expression path that matches are used to route traffic first, later prefix paths (read more in the issue https://github.com/Kong/kong/issues/4121).

Thus for the traditional one Kong Route's field path is set to prefix match `/` and protocol to `grpc, grpcs` ([see docs](https://docs.konghq.com/gateway/latest/production/configuring-a-grpc-service/#single-grpc-service-and-route)). For expressions `(net.protocol == "http") || (net.protocol == "https")` is configured to catch every service name and method name combination (according to gRPC spec they are encoded as URL, [see](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests)). AFAIK for a catch-all for standard HTTP explicit prefix path `/` is always configured. It shouldn't collide due to the mechanism of assigning priorities by KIC, should it?




<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

I found related old issues/PRs that touched this code (mentioning them for reference)
 - https://github.com/Kong/kubernetes-ingress-controller/issues/4154

This comment mentioned not supporting the behavior introduced in this PR on purpose to be consistent with `HTTPRoute` -  https://github.com/Kong/kubernetes-ingress-controller/pull/4512#discussion_r1295608690.
It's not true, from a user perspective. `HTTPRoute` without `Hostnames` and `Rules` specified in YAML works as expected (it configures Kong properly) because of defaults in GWAPI spec
 
```go
	// Rules are a list of HTTP matchers, filters and actions.
	//
	// +optional
	// +kubebuilder:validation:MaxItems=16
	// +kubebuilder:default={{matches: {{path: {type: "PathPrefix", value: "/"}}}}}
	Rules []HTTPRouteRule `json:"rules,omitempty"`
```
[src](https://github.com/kubernetes-sigs/gateway-api/blob/9da7e8a9bbc2f0eb897f4046f9b95670adae4342/apis/v1/httproute_types.go#L116-L121
)

so KIC never gets an empty rule and configures everything properly.


<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

A separate integration test hasn't been introduced, since it would be more testing behavior of Kong Gateway and its routing priorities than KIC behavior - a unit test should be enough. 

Fixed misplaced an item in CHANGELOG.md too.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
