### PR TITLE
chore(ci): don't fix linting issues in CI

### DIFF
--- a/.github/workflows/_linters.yaml
+++ b/.github/workflows/_linters.yaml
@@ -18,6 +18,9 @@ jobs:
           go-version-file: third_party/go.mod
 
       - name: Run lint
+        env:
+          # Our .golangci.yaml has fix: true, but we don't want that in CI therefore the below override.
+          GOLANGCI_LINT_FLAGS: "--fix=false"
         run: make lint
 
       - name: Verify manifest consistency

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ lint: verify.tidy golangci-lint staticcheck looppointer
 
 .PHONY: golangci-lint
 golangci-lint: golangci-lint.download
-	$(GOLANGCI_LINT) run --verbose --config $(PROJECT_DIR)/.golangci.yaml
+	$(GOLANGCI_LINT) run --verbose --config $(PROJECT_DIR)/.golangci.yaml $(GOLANGCI_LINT_FLAGS)
 
 .PHONY: staticcheck
 staticcheck: staticcheck.download


### PR DESCRIPTION
**What this PR does / why we need it**:

When `--fix` flag is on, `golangci-lint` returns a 0 exit code even if there are issues found and fixed. It's not desired in CI environment where we'd like to get a non-zero exit code always in the case there are any issues found.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up to https://github.com/Kong/gateway-operator/pull/1230.
