### PR TITLE
test: add job to run e2e and integration tests daily for validating kong images

### DIFF
--- a/.github/workflows/validate_kong_image_nightly.yaml
+++ b/.github/workflows/validate_kong_image_nightly.yaml
@@ -1,0 +1,51 @@
+name: validate Kong image
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  run-validate-kong-image-tests:
+    runs-on: ubuntu-latest
+    name: validate-kong-image-${{ matrix.kong-version }}
+    strategy:
+      matrix:
+        kong-version:
+        - "2.8"
+        - "3.4"
+        kic-version:
+        - "2.12"
+    steps:
+      - id: checkout_release_branch
+        name: "Checkout to release branch release/${{ matrix.kic-version }}.x"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          with:
+            ref: "release/${{ matrix.kic-version }}.x"
+
+      - id: run_e2e_tests
+        name: "Run e2e tests against KIC ${{ matrix.kic-version }} and Kong gateway ${{ matrix.kong-version }}"
+        uses:  ./.github/workflows/_e2e_tests.yaml
+        secrets: inherit
+        with:
+          kic-image: kong/kubernetes-ingress-controller:${{ matrix.kic-version }}
+          kong-image: kong/kong-gateway:${{ matrix.kong-version }}
+          load-local-image: false
+          run-gke: false
+          run-istio: true
+          all-supported-k8s-versions: false
+
+      - id: run_integration_tests
+        name: "Run integration tests against KIC codebase on release/${{ matrix.kic-version }}.x and Kong gateway ${{ matrix.kong-version }}"
+        uses: ./.github/workflows/_integration_tests.yaml
+        secrets: inherit
+        with:
+          kong-container-repo: "kong"
+          kong-container-tag:  "${{ matrix.kong-version }}"
+          kong-oss-effective-version: "${{ matrix.kong-version }}"
+          kong-enterprise-container-repo: "kong/kong-gateway"
+          kong-enterprise-container-tag: "${{ matrix.kong-version }}"
+          kong-enterprise-effective-version: "${{ matrix.kong-version }}"
+          log-output-file:  /tmp/integration-tests-kic-logs


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Adds a daily workflow to run e2e tests and integration tests on KIC 2.12 LTS against Kong 2.8 LTS and Kong 3.4 LTS to verify compatibility. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5286 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
- We need to enable this after KIC 2.12.3 releases #5257 to include the fixes.
- Do we need to run against on kubernetes versions and GKE clusters?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
