### PR TITLE
fix(tests): skip upgrade tests if not upgrading between two consecutive Kong versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.7+incompatible // indirect
+	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -3,12 +3,17 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -16,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
 const (
@@ -77,12 +83,14 @@ func testManifestsUpgrade(
 	oldManifestResp, err := httpClient.Get(testParams.fromManifestURL)
 	require.NoError(t, err)
 	defer oldManifestResp.Body.Close()
+	oldManifestPath := dumpToTempFile(t, oldManifestResp.Body)
+
+	skipIfNotTwoConsecutiveKongMinorVersions(t, oldManifestPath, testParams.toManifestPath)
 
 	t.Log("configuring upgrade manifests test")
 	ctx, env := setupE2ETest(t)
 
 	t.Logf("deploying previous kong manifests: %s", testParams.fromManifestURL)
-	oldManifestPath := dumpToTempFile(t, oldManifestResp.Body)
 	ManifestDeploy{
 		Path:            oldManifestPath,
 		SkipTestPatches: true,
@@ -97,23 +105,9 @@ func testManifestsUpgrade(
 		hook(ctx, t, env)
 	}
 
-	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/4973
-	// This router flavor substitution is a workaround for the fact that KIC doesn't
-	// support configuring Gateways of different router flavors at the same time.
-	// Since pre 3.0 the default router flavor was "traditional", use it here during
-	// the upgrade.
-	// When 4973 is fixed, this will go away as those new tests will use a different
-	// testing strategy.
-	// Using expressions router in earlier version (e.g. 2.12) was causing
-	// configuration translation errors.
-	newManifestB, err := os.ReadFile(testParams.toManifestPath)
-	require.NoError(t, err)
-	newManifestB = bytes.ReplaceAll(newManifestB, []byte("value: expressions"), []byte("value: traditional"))
-	newManifestPath := dumpToTempFile(t, bytes.NewReader(newManifestB))
-
 	t.Logf("deploying target version of kong manifests: %s", testParams.toManifestPath)
 	deployments := ManifestDeploy{
-		Path: newManifestPath,
+		Path: testParams.toManifestPath,
 		// Do not skip test patches - we want to verify that upgrade works with an image override in target manifest.
 		SkipTestPatches: false,
 	}.Run(ctx, t, env)
@@ -141,4 +135,81 @@ func testManifestsUpgrade(
 	require.NoError(t, err)
 
 	verifyIngressWithEchoBackendsPath(ctx, t, env, numberOfEchoBackends, newPath)
+}
+
+// skipIfNotTwoConsecutiveKongMinorVersions skips the test if the old and new Kong versions are not two consecutive
+// minor versions. This is necessary because Kong in DB-mode doesn't support skipping minor versions when upgrading.
+// See the Gateway upgrade guide for details: https://docs.konghq.com/gateway/latest/upgrade/.
+func skipIfNotTwoConsecutiveKongMinorVersions(
+	t *testing.T,
+	oldManifestPath string,
+	newManifestPath string,
+) {
+	oldKongVersion := extractKongVersionFromManifest(t, oldManifestPath)
+
+	var newKongVersion kong.Version
+	if targetKongImage := testenv.KongImageTag(); targetKongImage != "" {
+		// If the target Kong image is specified via environment variable, use it...
+		newKongVersion = extractKongVersionFromDockerImage(t, targetKongImage)
+	} else {
+		// ...otherwise, use the version used in the new manifest.
+		newKongVersion = extractKongVersionFromManifest(t, newManifestPath)
+	}
+
+	if oldKongVersion.Major() != newKongVersion.Major() ||
+		oldKongVersion.Minor()+1 != newKongVersion.Minor() {
+		t.Skipf("skipping upgrade test because the old and new Kong versions are not two consecutive minor versions: %s and %s",
+			oldKongVersion, newKongVersion)
+	}
+}
+
+var kongVersionRegex = regexp.MustCompile(`image: (kong:.*)`)
+
+// extractKongVersionFromManifest extracts the Kong version from the manifest.
+func extractKongVersionFromManifest(t *testing.T, manifestPath string) kong.Version {
+	manifest, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	res := kongVersionRegex.FindStringSubmatch(string(manifest))
+	require.NotEmpty(t, res)
+
+	version := res[1]
+	return extractKongVersionFromDockerImage(t, version)
+}
+
+// extractKongVersionFromDockerImage extracts the Kong version from the docker image by inspecting the image's env vars
+// for the KONG_VERSION env var.
+func extractKongVersionFromDockerImage(t *testing.T, image string) kong.Version {
+	dockerc, err := client.NewClientWithOpts(client.FromEnv)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Logf("pulling docker image %s to inspect it", image)
+	_, err = dockerc.ImagePull(ctx, image, types.ImagePullOptions{})
+	require.NoError(t, err)
+
+	t.Logf("inspecting docker image %s", image)
+	var imageDetails types.ImageInspect
+	// Retry because the image may not be available immediately after pulling it.
+	require.Eventually(t, func() bool {
+		var err error
+		imageDetails, _, err = dockerc.ImageInspectWithRaw(ctx, image)
+		if err != nil {
+			t.Logf("failed to inspect docker image %s: %s", image, err)
+			return false
+		}
+		return true
+	}, time.Minute, time.Second)
+
+	kongVersionEnv, ok := lo.Find(imageDetails.Config.Env, func(s string) bool {
+		return strings.HasPrefix(s, "KONG_VERSION=")
+	})
+	require.True(t, ok, "KONG_VERSION env var not found in image %s", image)
+
+	version, err := kong.ParseSemanticVersion(strings.TrimPrefix(kongVersionEnv, "KONG_VERSION="))
+	require.NoError(t, err)
+	t.Logf("parsed Kong version %s from docker image %s", version, image)
+
+	return version
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

~Adds `migrations finish` command before the `migrations up` to finish potential leftovers. Fixes failing `TestDeployAndUpgradeAllInOnePostgres` E2E test: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/7190768562/job/19584462222~

Skips the upgrade E2E tests if the versions we're trying to migrate between are not two consecutive Kong minor versions.

**Which issue this PR fixes**:

Should fix https://github.com/Kong/kubernetes-ingress-controller/issues/5313.
