### PR TITLE
fix: print concrete error from fillPlugin in logs

### DIFF
--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -53,7 +53,7 @@ func ToDeckContent(
 			}
 			err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 			if err != nil {
-				log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
+				log.WithError(err).Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
 			}
 			service.Plugins = append(service.Plugins, &plugin)
 			sort.SliceStable(service.Plugins, func(i, j int) bool {
@@ -71,7 +71,7 @@ func ToDeckContent(
 				}
 				err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 				if err != nil {
-					log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
+					log.WithError(err).Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
 				}
 				route.Plugins = append(route.Plugins, &plugin)
 				sort.SliceStable(route.Plugins, func(i, j int) bool {
@@ -95,7 +95,7 @@ func ToDeckContent(
 		}
 		err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 		if err != nil {
-			log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
+			log.WithError(err).Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
 		}
 		content.Plugins = append(content.Plugins, plugin)
 	}

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -53,7 +53,7 @@ func ToDeckContent(
 			}
 			err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 			if err != nil {
-				log.Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
+				log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
 			}
 			service.Plugins = append(service.Plugins, &plugin)
 			sort.SliceStable(service.Plugins, func(i, j int) bool {
@@ -71,7 +71,7 @@ func ToDeckContent(
 				}
 				err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 				if err != nil {
-					log.Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
+					log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
 				}
 				route.Plugins = append(route.Plugins, &plugin)
 				sort.SliceStable(route.Plugins, func(i, j int) bool {
@@ -95,7 +95,7 @@ func ToDeckContent(
 		}
 		err = fillPlugin(ctx, &plugin, params.PluginSchemas)
 		if err != nil {
-			log.Errorf("failed to fill-in defaults for plugin: %s", *plugin.Name)
+			log.Errorf("failed to fill-in defaults for plugin: %s, error %v", *plugin.Name, err)
 		}
 		content.Plugins = append(content.Plugins, plugin)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Print the concrete error returned from `fillPlugin` function in logs.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
part of #5341 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
REVIEW: how to write changelog for this?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
