### PR TITLE
fix(translate) handle client cert issues early

### DIFF
--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -1073,8 +1073,11 @@ func TestServiceClientCertificate(t *testing.T) {
 		require.NoError(t, err)
 		p := mustNewTranslator(t, store)
 		result := p.BuildKongConfig()
-		require.NotEmpty(t, result.TranslationFailures)
-		state := result.KongState
+
+		require.Len(t, result.TranslationFailures, 1)
+		failure := result.TranslationFailures[0]
+		assert.Contains(failure.Message(), "client certificate requested for incompatible service protocol 'http'")
+		
 		require.NotNil(t, state)
 		assert.Equal(1, len(state.Services))
 		assert.Nil(state.Services[0].ClientCertificate)

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -1077,7 +1077,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		require.Len(t, result.TranslationFailures, 1)
 		failure := result.TranslationFailures[0]
 		assert.Contains(failure.Message(), "client certificate requested for incompatible service protocol 'http'")
-		
+
 		state := result.KongState
 		require.NotNil(t, state)
 		assert.Equal(1, len(state.Services))

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -1078,6 +1078,7 @@ func TestServiceClientCertificate(t *testing.T) {
 		failure := result.TranslationFailures[0]
 		assert.Contains(failure.Message(), "client certificate requested for incompatible service protocol 'http'")
 		
+		state := result.KongState
 		require.NotNil(t, state)
 		assert.Equal(1, len(state.Services))
 		assert.Nil(state.Services[0].ClientCertificate)


### PR DESCRIPTION
**What this PR does / why we need it**:

If the translator finds a Service that requests a client cert for a non-TLS protocol, do not apply the client certificate and emit a translation failure event. This prevents the misconfigured Service from locking up configuration.

**Which issue this PR fixes**:

Reported in chat. Configuration similar to the below (note that the Secret isn't shown, it needs to be a TLS cert) results in an apply failure because client certificates are not allowed if the Service has no protocol annotation (default `http`) or has some non-TLS protocol annotation.

```
---
apiVersion: v1
kind: Service
metadata:
  name: svc-test
  annotations:
    konghq.com/client-cert: cert
spec:
  type: ExternalName
  externalName: example.com
  ports:
    - protocol: TCP
      port: 443
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ing-test
spec:
  ingressClassName: kong
  rules:
    - host: example.com
      http:
        paths:
          - backend:
              service:
                name: svc-test
                port:
                  number: 443
            path: /
            pathType: ImplementationSpecific
```

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
