### PR TITLE
Revert "chore(deps): bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp
@@ -299,7 +299,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: collect test coverage artifacts
         id: download-coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: coverage
           path: coverage
@@ -53,7 +53,7 @@ jobs:
 
       - name: download tests report
         id: download-coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: tests-report
           path: report


### PR DESCRIPTION
Reverts Kong/kubernetes-ingress-controller#5350

Both 
- actions/upload-artifact - doesn't allow upload multiple times with the same name - [breaking change](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes)
- actions/download-artifact -  [breaking changes](https://github.com/actions/download-artifact/tree/v4/?tab=readme-ov-file#breaking-changes)


It requires changes in our workflows, because of the not allowing uploading multiple artifacts with the same name (what we do).

