### PR TITLE
Revert "chore(deps): bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp
@@ -299,7 +299,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: kic-image
           path: /tmp

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: collect test coverage artifacts
         id: download-coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: coverage
           path: coverage
@@ -53,7 +53,7 @@ jobs:
 
       - name: download tests report
         id: download-coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: tests-report
           path: report


### PR DESCRIPTION
This reverts commit c4221073d47bc7405c27a07c494eec3980f7d67f.

Revert the download update, again! Handling the new name requirements [is difficult at present](https://github.com/Kong/kubernetes-ingress-controller/issues/5357#issuecomment-1861273344), so we probably want to wait until there are new features or suggested migration paths for workflows that generate several types of artifact that previously shared the same name.