### PR TITLE
test: verify golden configs against Konnect

### DIFF
--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -26,6 +26,7 @@ jobs:
         run: make test.kongintegration
         env:
           GOTESTSUM_JUNITFILE: kongintegration-tests.xml
+          TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
 
       - name: collect test coverage
         uses: actions/upload-artifact@v3

--- a/test/internal/helpers/konnect/access.go
+++ b/test/internal/helpers/konnect/access.go
@@ -1,0 +1,25 @@
+package konnect
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	konnectControlPlaneAdminAPIBaseURL   = "https://us.kic.api.konghq.tech"
+	konnectControlPlanesBaseURL          = "https://us.kic.api.konghq.tech/v2"
+	konnectControlPlanesConfigBaseURLFmt = "https://us.api.konghq.tech/v2/control-planes/%s/"
+	konnectRolesBaseURL                  = "https://global.api.konghq.tech/v2"
+)
+
+// SkipIfMissingRequiredKonnectEnvVariables skips the test if the required Konnect environment variables are missing.
+func SkipIfMissingRequiredKonnectEnvVariables(t *testing.T) {
+	if accessToken() == "" {
+		t.Skip("missing TEST_KONG_KONNECT_ACCESS_TOKEN")
+	}
+}
+
+// accessToken returns the access token to be used for Konnect API requests.
+func accessToken() string {
+	return os.Getenv("TEST_KONG_KONNECT_ACCESS_TOKEN")
+}

--- a/test/internal/helpers/konnect/certificates.go
+++ b/test/internal/helpers/konnect/certificates.go
@@ -1,0 +1,40 @@
+package konnect
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cpc "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/controlplanesconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+)
+
+// CreateClientCertificate creates a TLS client certificate and POSTs it to Konnect Control Plane configuration API
+// so that KIC can use the certificates to authenticate against Konnect Admin API.
+func CreateClientCertificate(ctx context.Context, t *testing.T, cpID string) (certPEM string, keyPEM string) {
+	t.Helper()
+
+	rgConfigClient, err := cpc.NewClientWithResponses(fmt.Sprintf(konnectControlPlanesConfigBaseURLFmt, cpID), cpc.WithRequestEditorFn(
+		func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+accessToken())
+			return nil
+		}),
+		cpc.WithHTTPClient(helpers.RetryableHTTPClient(helpers.DefaultHTTPClient())),
+	)
+	require.NoError(t, err)
+
+	cert, key := certificate.MustGenerateSelfSignedCertPEMFormat()
+
+	t.Log("creating client certificate in Konnect")
+	resp, err := rgConfigClient.PostDpClientCertificatesWithResponse(ctx, cpc.PostDpClientCertificatesJSONRequestBody{
+		Cert: string(cert),
+	})
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusCreated, resp.StatusCode(), "failed creating client certificate: %s", string(resp.Body))
+
+	return string(cert), string(key)
+}

--- a/test/internal/helpers/konnect/control_plane.go
+++ b/test/internal/helpers/konnect/control_plane.go
@@ -1,0 +1,127 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	cp "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/controlplanes"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/roles"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
+)
+
+// CreateTestControlPlane creates a control plane to be used in tests. It returns the created control plane's ID.
+// It also sets up a cleanup function for it to be deleted.
+func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	rgClient, err := cp.NewClientWithResponses(konnectControlPlanesBaseURL, cp.WithRequestEditorFn(
+		func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+accessToken())
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	rolesClient := roles.NewClient(
+		helpers.RetryableHTTPClient(helpers.DefaultHTTPClient()),
+		konnectRolesBaseURL,
+		accessToken(),
+	)
+
+	var rgID uuid.UUID
+	createRgErr := retry.Do(func() error {
+		rgName := uuid.NewString()
+		createRgResp, err := rgClient.CreateControlPlaneWithResponse(ctx, cp.CreateControlPlaneRequest{
+			Description: lo.ToPtr(generateTestKonnectControlPlaneDescription(t)),
+			Labels: &cp.Labels{
+				"created_in_tests": "true",
+			},
+			Name:        rgName,
+			ClusterType: cp.ClusterTypeKubernetesIngressController,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create control plane: %w", err)
+		}
+		if createRgResp.StatusCode() != http.StatusCreated {
+			return fmt.Errorf("failed to create RG: code %d, message %s", createRgResp.StatusCode(), string(createRgResp.Body))
+		}
+		if createRgResp.JSON201 == nil || createRgResp.JSON201.Id == nil {
+			return errors.New("No control plane ID in response")
+		}
+
+		rgID = *createRgResp.JSON201.Id
+		return nil
+	}, retry.Attempts(5), retry.Delay(time.Second))
+	require.NoError(t, createRgErr)
+
+	t.Cleanup(func() {
+		t.Logf("deleting test Konnect Control Plane: %q", rgID)
+		err := retry.Do(
+			func() error {
+				_, err := rgClient.DeleteControlPlaneWithResponse(ctx, rgID)
+				return err
+			},
+			retry.Attempts(5), retry.Delay(time.Second),
+		)
+		assert.NoErrorf(t, err, "failed to cleanup a control plane: %q", rgID)
+
+		// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
+		// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
+		// because of a performance issue when there's too many roles for the account
+		// (see https://konghq.atlassian.net/browse/TPS-1319).
+		//
+		// We can drop this once the automated cleanup is implemented on Konnect side:
+		// https://konghq.atlassian.net/browse/TPS-1453.
+		rgRoles, err := rolesClient.ListControlPlanesRoles(ctx)
+		require.NoErrorf(t, err, "failed to list control plane roles for cleanup: %q", rgID)
+		for _, role := range rgRoles {
+			if role.EntityID == rgID.String() { // Delete only roles created for the control plane.
+				t.Logf("deleting test Konnect Control Plane role: %q", role.ID)
+				err := rolesClient.DeleteRole(ctx, role.ID)
+				assert.NoErrorf(t, err, "failed to cleanup a control plane role: %q", role.ID)
+			}
+		}
+	})
+
+	t.Logf("created test Konnect Control Plane: %q", rgID.String())
+	return rgID.String()
+}
+
+func generateTestKonnectControlPlaneDescription(t *testing.T) string {
+	t.Helper()
+
+	desc := fmt.Sprintf("control plane for test %s", t.Name())
+	if testenv.GithubServerURL() != "" && testenv.GithubRepo() != "" && testenv.GithubRunID() != "" {
+		githubRunURL := fmt.Sprintf("%s/%s/actions/runs/%s",
+			testenv.GithubServerURL(), testenv.GithubRepo(), testenv.GithubRunID())
+		desc += ", github workflow run " + githubRunURL
+	}
+
+	return desc
+}
+
+// CreateKonnectAdminAPIClient creates an *kong.Client that will communicate with Konnect Control Plane's Admin API.
+func CreateKonnectAdminAPIClient(t *testing.T, cpID, cert, key string) *adminapi.KonnectClient {
+	t.Helper()
+
+	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
+		ControlPlaneID: cpID,
+		Address:        konnectControlPlaneAdminAPIBaseURL,
+		TLSClient: adminapi.TLSClientConfig{
+			Cert: cert,
+			Key:  key,
+		},
+	})
+	require.NoError(t, err)
+	return c
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `TestTranslatorsGoldenTestsOutputs_Konnect` that verifies all `*_default` Translator's golden test outputs are accepted by Konnect Control Plane's Admin API. 

Moves Konnect-related helper functions (for creating test control planes, client certs, etc.) that were used before only in E2E tests to the test helpers package.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes #5162.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
