### PR TITLE
Backport(v2.12.x): fix(tests): skip upgrade tests if not upgrading between two consecuti…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.6+incompatible // indirect
+	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -1,6 +1,7 @@
 package testenv
 
 import (
+	"fmt"
 	"os"
 	"time"
 )
@@ -38,6 +39,14 @@ func KongImage() string {
 // KongTag is the Kong image tag to use in tests.
 func KongTag() string {
 	return os.Getenv("TEST_KONG_TAG")
+}
+
+// KongImageTag is the combined Kong image and tag if both are set, or empty string if not.
+func KongImageTag() string {
+	if KongImage() != "" && KongTag() != "" {
+		return fmt.Sprintf("%s:%s", KongImage(), KongTag())
+	}
+	return ""
 }
 
 // KongEffectiveVersion is the effective semver of kong gateway.


### PR DESCRIPTION
…ve Kong versions (#5327)

(cherry picked from commit 614c6c0eda0d730252314ca85a213a45655f48ff)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
https://github.com/Kong/kubernetes-ingress-controller/issues/5257#issuecomment-1862436777
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
