### PR TITLE
test: Set different feature gates for versions before 3.1.x

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -250,7 +250,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	for i, container := range controllerDeployment.Spec.Template.Spec.Containers {
 		if container.Name == controllerContainerName {
 			controllerDeployment.Spec.Template.Spec.Containers[i].Env = append(controllerDeployment.Spec.Template.Spec.Containers[i].Env,
-				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: consts.DefaultFeatureGates})
+				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: testenv.GetFeatureGates()})
 		}
 	}
 

--- a/test/internal/testenv/feature_gates.go
+++ b/test/internal/testenv/feature_gates.go
@@ -1,7 +1,32 @@
 package testenv
 
-import "github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+import (
+	"github.com/blang/semver/v4"
 
-func getFeatureGates() string {
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+)
+
+func GetFeatureGates() string {
+	// Due to the possibility of running tests between different versions,
+	// it is necessary to adjust feature gates according to different KIC versions.
+	//
+	// Versions below 3.1.x cannot recognize the KongServiceFacade feature gate.
+	// We only need to set `GatewayAlpha=true`.
+	//
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/5373
+	tag := ControllerTag()
+	if tag != "" {
+		// Currently, the latest version is 3.0.x, once 3.1.x is released,
+		// we can remove this logic.
+		if tag == "latest" {
+			return "GatewayAlpha=true"
+		}
+		if v, err := semver.Make(tag); err == nil {
+			minVersion, _ := semver.ParseRange("<3.1.x")
+			if minVersion(v) {
+				return "GatewayAlpha=true"
+			}
+		}
+	}
 	return consts.DefaultFeatureGates
 }

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -105,7 +105,6 @@ func ControllerImageTag() string {
 }
 
 // KongEffectiveVersion is the effective semver of kong gateway.
-// KongEffectiveVersion is the effective semver of kong gateway.
 // When testing against "nightly" image of kong gateway, we need to set the effective version for parsing semver in chart templates.
 func KongEffectiveVersion() string {
 	return os.Getenv("TEST_KONG_EFFECTIVE_VERSION")
@@ -205,7 +204,7 @@ func GithubRunID() string {
 func ControllerFeatureGates() string {
 	featureGates := os.Getenv("KONG_CONTROLLER_FEATURE_GATES")
 	if featureGates == "" {
-		featureGates = getFeatureGates()
+		featureGates = GetFeatureGates()
 	}
 	return featureGates
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

 Due to the possibility of running tests between different versions,
 it is necessary to adjust feature gates according to different KIC versions.

Versions below 3.1.x cannot recognize the KongServiceFacade feature gate.
We only need to set `GatewayAlpha=true`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes: https://github.com/Kong/kubernetes-ingress-controller/issues/5373

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
