### PR TITLE
chore: encapsulate ServiceBackend

### DIFF
--- a/internal/dataplane/kongstate/service_backend.go
+++ b/internal/dataplane/kongstate/service_backend.go
@@ -1,0 +1,94 @@
+package kongstate
+
+import (
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+)
+
+// ServiceBackendType is the type of the backend.
+type ServiceBackendType string
+
+const (
+	// ServiceBackendTypeKongServiceFacade means that the backend is an incubatorv1alpha1.KongServiceFacade.
+	ServiceBackendTypeKongServiceFacade ServiceBackendType = "KongServiceFacade"
+
+	// ServiceBackendTypeKubernetesService means that the backend is a Kubernetes Service.
+	ServiceBackendTypeKubernetesService ServiceBackendType = "KongService"
+)
+
+type ServiceBackends []ServiceBackend
+
+// ServiceBackend represents a backend for a Kong Service. It can be a Kubernetes Service or a KongServiceFacade.
+type ServiceBackend struct {
+	backendType ServiceBackendType
+	name        string
+	namespace   string
+	portDef     PortDef
+	weight      *int
+}
+
+func NewServiceBackend(
+	t ServiceBackendType,
+	namespace string,
+	name string,
+	portDef PortDef,
+) ServiceBackend {
+	// TODO return error
+	return ServiceBackend{
+		backendType: t,
+		namespace:   namespace,
+		name:        name,
+		portDef:     portDef,
+	}
+}
+
+func NewServiceBackendForService(namespace, name string, portDef PortDef) ServiceBackend {
+	return ServiceBackend{
+		namespace:   namespace,
+		name:        name,
+		portDef:     portDef,
+		backendType: ServiceBackendTypeKubernetesService,
+	}
+}
+
+func NewServiceBackendForServiceFacade(namespace, name string, portDef PortDef) ServiceBackend {
+	return ServiceBackend{
+		name:        name,
+		namespace:   namespace,
+		portDef:     portDef,
+		backendType: ServiceBackendTypeKongServiceFacade,
+	}
+}
+
+func (s *ServiceBackend) SetWeight(weight int32) {
+	s.weight = lo.ToPtr(int(weight))
+}
+
+// Name returns the name of the backend resource (Service or KongServiceFacade).
+func (s *ServiceBackend) Name() string {
+	return s.name
+}
+
+// Namespace returns the namespace of the backend resource (Service or KongServiceFacade).
+func (s *ServiceBackend) Namespace() string {
+	return s.namespace
+}
+
+// PortDef returns the port definition of the backend.
+func (s *ServiceBackend) PortDef() PortDef {
+	return s.portDef
+}
+
+// Weight returns the weight of the backend used for load-balancing.
+func (s *ServiceBackend) Weight() mo.Option[int] {
+	if s.weight != nil {
+		return mo.Some(*s.weight)
+	}
+	return mo.None[int]()
+}
+
+// IsServiceFacade returns true if the backend is a KongServiceFacade. Otherwise, returns false
+// what means that the backend is a Kubernetes Service.
+func (s *ServiceBackend) IsServiceFacade() bool {
+	return s.backendType == ServiceBackendTypeKongServiceFacade
+}

--- a/internal/dataplane/kongstate/service_backend.go
+++ b/internal/dataplane/kongstate/service_backend.go
@@ -15,7 +15,7 @@ const (
 	ServiceBackendTypeKongServiceFacade ServiceBackendType = "KongServiceFacade"
 
 	// ServiceBackendTypeKubernetesService means that the backend is a Kubernetes Service.
-	ServiceBackendTypeKubernetesService ServiceBackendType = "KongService"
+	ServiceBackendTypeKubernetesService ServiceBackendType = "KubernetesService"
 )
 
 type ServiceBackends []ServiceBackend

--- a/internal/dataplane/kongstate/service_backend.go
+++ b/internal/dataplane/kongstate/service_backend.go
@@ -1,6 +1,8 @@
 package kongstate
 
 import (
+	"errors"
+
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 )
@@ -27,39 +29,51 @@ type ServiceBackend struct {
 	weight      *int
 }
 
+// NewServiceBackend creates a new ServiceBackend with an arbitrary backend type.
 func NewServiceBackend(
 	t ServiceBackendType,
 	namespace string,
 	name string,
 	portDef PortDef,
-) ServiceBackend {
-	// TODO return error
+) (ServiceBackend, error) {
+	if t == "" {
+		return ServiceBackend{}, errors.New("backend type cannot be empty")
+	}
+	if namespace == "" {
+		return ServiceBackend{}, errors.New("namespace cannot be empty")
+	}
+	if name == "" {
+		return ServiceBackend{}, errors.New("name cannot be empty")
+	}
 	return ServiceBackend{
 		backendType: t,
 		namespace:   namespace,
 		name:        name,
 		portDef:     portDef,
-	}
+	}, nil
 }
 
-func NewServiceBackendForService(namespace, name string, portDef PortDef) ServiceBackend {
-	return ServiceBackend{
-		namespace:   namespace,
-		name:        name,
-		portDef:     portDef,
-		backendType: ServiceBackendTypeKubernetesService,
-	}
+// NewServiceBackendForService creates a new ServiceBackend for a Kubernetes Service.
+func NewServiceBackendForService(namespace, name string, portDef PortDef) (ServiceBackend, error) {
+	return NewServiceBackend(
+		ServiceBackendTypeKubernetesService,
+		namespace,
+		name,
+		portDef,
+	)
 }
 
-func NewServiceBackendForServiceFacade(namespace, name string, portDef PortDef) ServiceBackend {
-	return ServiceBackend{
-		name:        name,
-		namespace:   namespace,
-		portDef:     portDef,
-		backendType: ServiceBackendTypeKongServiceFacade,
-	}
+// NewServiceBackendForServiceFacade creates a new ServiceBackend for a KongServiceFacade.
+func NewServiceBackendForServiceFacade(namespace, name string, portDef PortDef) (ServiceBackend, error) {
+	return NewServiceBackend(
+		ServiceBackendTypeKongServiceFacade,
+		namespace,
+		name,
+		portDef,
+	)
 }
 
+// SetWeight sets the weight of the backend used for load-balancing.
 func (s *ServiceBackend) SetWeight(weight int32) {
 	s.weight = lo.ToPtr(int(weight))
 }

--- a/internal/dataplane/kongstate/types.go
+++ b/internal/dataplane/kongstate/types.go
@@ -43,33 +43,6 @@ func (p *PortDef) CanonicalString() string {
 	return ImplicitPort
 }
 
-// ServiceBackendType is the type of the backend.
-type ServiceBackendType string
-
-const (
-	// ServiceBackendTypeKongServiceFacade means that the backend is an incubatorv1alpha1.KongServiceFacade.
-	ServiceBackendTypeKongServiceFacade ServiceBackendType = "KongServiceFacade"
-)
-
-type ServiceBackend struct {
-	// Type is the type of the backend. If left empty, it is assumed to be a Kubernetes Service.
-	Type ServiceBackendType
-
-	// Name is the name of the backend resource (Service or KongServiceFacade).
-	Name string
-
-	// Namespace is the namespace of the backend resource (Service or KongServiceFacade).
-	Namespace string
-
-	// PortDef is the port definition of the backend.
-	PortDef PortDef
-
-	// Weight is the weight of the backend used for load-balancing.
-	Weight *int32
-}
-
-type ServiceBackends []ServiceBackend
-
 // Target is a wrapper around Target object in Kong.
 type Target struct {
 	kong.Target

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -64,7 +64,7 @@ func backendRefsToKongStateBackends(
 func loggerForBackendRef(logger logr.Logger, route client.Object, backendRef gatewayapi.BackendRef) logr.Logger {
 	var (
 		namespace = route.GetNamespace()
-		kind      string
+		kind      string = "unknown"
 	)
 	if backendRef.Namespace != nil {
 		namespace = string(*backendRef.Namespace)

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -28,16 +28,20 @@ func backendRefsToKongStateBackends(
 			if backendRef.Port != nil {
 				port = int32(*backendRef.Port)
 			}
-			backend := kongstate.ServiceBackend{
-				Name: string(backendRef.Name),
-				PortDef: kongstate.PortDef{
+			namespace := route.GetNamespace()
+			if backendRef.Namespace != nil {
+				namespace = string(*backendRef.Namespace)
+			}
+			backend := kongstate.NewServiceBackendForService(
+				namespace,
+				string(backendRef.Name),
+				kongstate.PortDef{
 					Mode:   kongstate.PortModeByNumber,
 					Number: port,
 				},
-				Weight: backendRef.Weight,
-			}
-			if backendRef.Namespace != nil {
-				backend.Namespace = string(*backendRef.Namespace)
+			)
+			if backendRef.Weight != nil {
+				backend.SetWeight(*backendRef.Weight)
 			}
 			backends = append(backends, backend)
 		} else {

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
@@ -35,8 +36,10 @@ func backendRefsToKongStateBackends(
 				namespace = string(*backendRef.Namespace)
 			}
 			backend, err := kongstate.NewServiceBackendForService(
-				namespace,
-				string(backendRef.Name),
+				k8stypes.NamespacedName{
+					Namespace: namespace,
+					Name:      string(backendRef.Name),
+				},
 				kongstate.PortDef{
 					Mode:   kongstate.PortModeByNumber,
 					Number: port,

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -64,7 +64,7 @@ func backendRefsToKongStateBackends(
 func loggerForBackendRef(logger logr.Logger, route client.Object, backendRef gatewayapi.BackendRef) logr.Logger {
 	var (
 		namespace = route.GetNamespace()
-		kind      string = "unknown"
+		kind      = "unknown"
 	)
 	if backendRef.Namespace != nil {
 		namespace = string(*backendRef.Namespace)

--- a/internal/dataplane/translator/golden_test.go
+++ b/internal/dataplane/translator/golden_test.go
@@ -226,7 +226,7 @@ func runTranslatorGoldenTest(t *testing.T, tc translatorGoldenTestCase) {
 	p, err := translator.NewTranslator(logger, s, tc.featureFlags)
 	require.NoError(t, err, "failed creating translator")
 
-	// Build the Kong configuration.
+	// MustBuild the Kong configuration.
 	result := p.BuildKongConfig()
 	targetConfig := deckgen.ToDeckContent(context.Background(),
 		logger,

--- a/internal/dataplane/translator/ingressrules_test.go
+++ b/internal/dataplane/translator/ingressrules_test.go
@@ -261,10 +261,10 @@ func TestGetK8sServicesForBackends(t *testing.T) {
 			backends: kongstate.ServiceBackends{
 				builder.NewKongstateServiceBackend("test-service1").
 					WithNamespace(corev1.NamespaceDefault).
-					Build(),
+					MustBuild(),
 				builder.NewKongstateServiceBackend("test-service2").
 					WithNamespace(corev1.NamespaceDefault).
-					Build(),
+					MustBuild(),
 			},
 			services: []*corev1.Service{
 				{
@@ -316,10 +316,10 @@ func TestGetK8sServicesForBackends(t *testing.T) {
 			backends: kongstate.ServiceBackends{
 				builder.NewKongstateServiceBackend("test-service1").
 					WithNamespace(corev1.NamespaceDefault).
-					Build(),
+					MustBuild(),
 				builder.NewKongstateServiceBackend("test-service2").
 					WithNamespace(corev1.NamespaceDefault).
-					Build(),
+					MustBuild(),
 			},
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -614,9 +614,9 @@ func TestPopulateServices(t *testing.T) {
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("k8s-service-to-skip1").
-							WithNamespace("test-namespace").Build(),
+							WithNamespace("test-namespace").MustBuild(),
 						builder.NewKongstateServiceBackend("k8s-service-to-skip2").
-							WithNamespace("test-namespace").Build(),
+							WithNamespace("test-namespace").MustBuild(),
 					},
 				},
 				"service-to-keep": {
@@ -626,9 +626,9 @@ func TestPopulateServices(t *testing.T) {
 					Namespace: "test-namespace",
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("k8s-service-to-keep1").
-							WithNamespace("test-namespace").Build(),
+							WithNamespace("test-namespace").MustBuild(),
 						builder.NewKongstateServiceBackend("k8s-service-to-keep2").
-							WithNamespace("test-namespace").Build(),
+							WithNamespace("test-namespace").MustBuild(),
 					},
 				},
 			},
@@ -685,7 +685,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 			backend: builder.NewKongstateServiceBackend("test-service").
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectedService: testService(nil),
 		},
 		{
@@ -694,7 +694,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 			backend: builder.NewKongstateServiceBackend("test-service").
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectErrorContains: "Service test-namespace/test-service not found",
 		},
 		{
@@ -727,7 +727,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 				WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectedService: testService(map[string]string{
 				"common":  "common-from-facade",
 				"facade":  "facade-from-facade",
@@ -769,7 +769,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 				WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectedService: testService(map[string]string{
 				"common": "common-from-facade",
 				"facade": "facade-from-facade",
@@ -809,7 +809,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 				WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectErrorContains: "Service test-namespace/not-existing-service not found",
 		},
 		{
@@ -819,7 +819,7 @@ func TestResolveKubernetesServiceForBackend(t *testing.T) {
 				WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 				WithNamespace("test-namespace").
 				WithPortNumber(80).
-				Build(),
+				MustBuild(),
 			expectErrorContains: "KongServiceFacade test-namespace/not-existing-service-facade not found",
 		},
 	}
@@ -882,7 +882,7 @@ func TestResolveKubernetesServiceForBackend_DoesNotModifyCache(t *testing.T) {
 		WithNamespace("test-namespace").
 		WithPortNumber(80).
 		WithType(kongstate.ServiceBackendTypeKongServiceFacade).
-		Build()
+		MustBuild()
 
 	translatedObjectsCollector := NewObjectsCollector()
 	resolvedService, err := resolveKubernetesServiceForBackend(fakeStore, backend, translatedObjectsCollector)

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -331,8 +331,10 @@ func (m *ingressTranslationMeta) translateIntoKongStateService(
 ) (kongstate.Service, error) {
 	if m.backend.isServiceFacade() {
 		serviceBackend, err := kongstate.NewServiceBackendForServiceFacade(
-			m.parentIngress.GetNamespace(),
-			m.backend.name,
+			k8stypes.NamespacedName{
+				Namespace: m.parentIngress.GetNamespace(),
+				Name:      m.backend.name,
+			},
 			portDef,
 		)
 		if err != nil {
@@ -358,8 +360,10 @@ func (m *ingressTranslationMeta) translateIntoKongStateService(
 	}
 
 	serviceBackend, err := kongstate.NewServiceBackendForService(
-		m.parentIngress.GetNamespace(),
-		m.backend.name,
+		k8stypes.NamespacedName{
+			Namespace: m.parentIngress.GetNamespace(),
+			Name:      m.backend.name,
+		},
 		portDef,
 	)
 	if err != nil {

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -97,7 +97,7 @@ func TestTranslateIngressATC(t *testing.T) {
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
-							WithPortNumber(80).Build(),
+							WithPortNumber(80).MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -171,7 +171,7 @@ func TestTranslateIngressATC(t *testing.T) {
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
-							WithPortNumber(80).Build(),
+							WithPortNumber(80).MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -256,7 +256,7 @@ func TestTranslateIngressATC(t *testing.T) {
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
-							WithPortNumber(80).Build(),
+							WithPortNumber(80).MustBuild(),
 					},
 					Parent: &netv1.Ingress{
 						TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: netv1.SchemeGroupVersion.String()},
@@ -359,7 +359,7 @@ func TestTranslateIngressATC(t *testing.T) {
 							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(8080).
-							Build(),
+							MustBuild(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -355,11 +355,11 @@ func TestTranslateIngressATC(t *testing.T) {
 						ExpressionRoutes: true,
 					}},
 					Backends: []kongstate.ServiceBackend{
-						kongstate.NewServiceBackendForServiceFacade(
-							corev1.NamespaceDefault,
-							"svc-facade",
-							PortDefFromPortNumber(8080),
-						),
+						builder.NewKongstateServiceBackend("svc-facade").
+							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(8080).
+							Build(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
@@ -93,14 +94,11 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -170,14 +168,11 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -258,14 +253,11 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).Build(),
+					},
 					Parent: &netv1.Ingress{
 						TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: netv1.SchemeGroupVersion.String()},
 						ObjectMeta: metav1.ObjectMeta{
@@ -362,12 +354,13 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Type:      kongstate.ServiceBackendTypeKongServiceFacade,
-						Name:      "svc-facade",
-						Namespace: corev1.NamespaceDefault,
-						PortDef:   PortDefFromPortNumber(8080),
-					}},
+					Backends: []kongstate.ServiceBackend{
+						kongstate.NewServiceBackendForServiceFacade(
+							corev1.NamespaceDefault,
+							"svc-facade",
+							PortDefFromPortNumber(8080),
+						),
+					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "svc-facade",
@@ -444,7 +437,8 @@ func TestTranslateIngressATC(t *testing.T) {
 					ObjectMeta: i.ObjectMeta,
 				}
 			})
-			diff := cmp.Diff(tc.expectedServices, services, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta)
+			compareServiceBackend := cmp.AllowUnexported(kongstate.ServiceBackend{})
+			diff := cmp.Diff(tc.expectedServices, services, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta, compareServiceBackend)
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -112,14 +112,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -185,14 +183,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -259,14 +255,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -333,14 +327,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -407,14 +399,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -480,14 +470,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -553,14 +541,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -698,14 +684,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -841,14 +825,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -930,14 +912,12 @@ func TestTranslateIngress(t *testing.T) {
 							},
 						},
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service1",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service1").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 				"default.test-service2.80": {
@@ -973,14 +953,12 @@ func TestTranslateIngress(t *testing.T) {
 							},
 						},
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service2",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service2").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -1073,14 +1051,12 @@ func TestTranslateIngress(t *testing.T) {
 							},
 						},
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "ad-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("ad-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 				"default.mad-service.80": {
@@ -1116,14 +1092,12 @@ func TestTranslateIngress(t *testing.T) {
 							},
 						},
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "mad-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("mad-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -1189,14 +1163,12 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: 80,
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(80).
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -1271,14 +1243,12 @@ func TestTranslateIngress(t *testing.T) {
 							),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Name:      "test-service",
-						Namespace: corev1.NamespaceDefault,
-						PortDef: kongstate.PortDef{
-							Mode: kongstate.PortModeByName,
-							Name: "http",
-						},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("test-service").
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortName("http").
+							Build(),
+					},
 					Parent: expectedParentIngress(),
 				},
 			},
@@ -1356,12 +1326,13 @@ func TestTranslateIngress(t *testing.T) {
 							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
 						},
 					}},
-					Backends: []kongstate.ServiceBackend{{
-						Type:      kongstate.ServiceBackendTypeKongServiceFacade,
-						Name:      "svc-facade",
-						Namespace: corev1.NamespaceDefault,
-						PortDef:   PortDefFromPortNumber(8080),
-					}},
+					Backends: []kongstate.ServiceBackend{
+						kongstate.NewServiceBackendForServiceFacade(
+							corev1.NamespaceDefault,
+							"svc-facade",
+							PortDefFromPortNumber(8080),
+						),
+					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "svc-facade",
@@ -1524,12 +1495,13 @@ func TestTranslateIngress(t *testing.T) {
 							},
 						},
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Type:      kongstate.ServiceBackendTypeKongServiceFacade,
-						Name:      "svc-facade",
-						Namespace: corev1.NamespaceDefault,
-						PortDef:   PortDefFromPortNumber(8080),
-					}},
+					Backends: []kongstate.ServiceBackend{
+						kongstate.NewServiceBackendForServiceFacade(
+							corev1.NamespaceDefault,
+							"svc-facade",
+							PortDefFromPortNumber(8080),
+						),
+					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "svc-facade",
@@ -1587,7 +1559,8 @@ func TestTranslateIngress(t *testing.T) {
 				})
 			}
 
-			diff := cmp.Diff(tt.expected, translatedServices, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta)
+			compareServiceBackend := cmp.AllowUnexported(kongstate.ServiceBackend{})
+			diff := cmp.Diff(tt.expected, translatedServices, checkOnlyIngressMeta, checkOnlyKongServiceFacadeMeta, compareServiceBackend)
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -1327,11 +1327,11 @@ func TestTranslateIngress(t *testing.T) {
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
-						kongstate.NewServiceBackendForServiceFacade(
-							corev1.NamespaceDefault,
-							"svc-facade",
-							PortDefFromPortNumber(8080),
-						),
+						builder.NewKongstateServiceBackend("svc-facade").
+							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(8080).
+							Build(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1496,11 +1496,11 @@ func TestTranslateIngress(t *testing.T) {
 						},
 					},
 					Backends: []kongstate.ServiceBackend{
-						kongstate.NewServiceBackendForServiceFacade(
-							corev1.NamespaceDefault,
-							"svc-facade",
-							PortDefFromPortNumber(8080),
-						),
+						builder.NewKongstateServiceBackend("svc-facade").
+							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
+							WithNamespace(corev1.NamespaceDefault).
+							WithPortNumber(8080).
+							Build(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -116,7 +116,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -187,7 +187,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -259,7 +259,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -331,7 +331,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -403,7 +403,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -474,7 +474,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -545,7 +545,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -688,7 +688,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -829,7 +829,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -916,7 +916,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service1").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -957,7 +957,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service2").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -1055,7 +1055,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("ad-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -1096,7 +1096,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("mad-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -1167,7 +1167,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -1247,7 +1247,7 @@ func TestTranslateIngress(t *testing.T) {
 						builder.NewKongstateServiceBackend("test-service").
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortName("http").
-							Build(),
+							MustBuild(),
 					},
 					Parent: expectedParentIngress(),
 				},
@@ -1331,7 +1331,7 @@ func TestTranslateIngress(t *testing.T) {
 							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(8080).
-							Build(),
+							MustBuild(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1500,7 +1500,7 @@ func TestTranslateIngress(t *testing.T) {
 							WithType(kongstate.ServiceBackendTypeKongServiceFacade).
 							WithNamespace(corev1.NamespaceDefault).
 							WithPortNumber(8080).
-							Build(),
+							MustBuild(),
 					},
 					Parent: &incubatorv1alpha1.KongServiceFacade{
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/translate_grpcroute_test.go
+++ b/internal/dataplane/translator/translate_grpcroute_test.go
@@ -94,7 +94,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -105,7 +105,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -116,7 +116,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -127,7 +127,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -243,7 +243,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -254,7 +254,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -349,7 +349,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -357,7 +357,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-no-hostnames-no-matches._.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service0").WithPortNumber(80).Build(),
+						builder.NewKongstateServiceBackend("service0").WithPortNumber(80).MustBuild(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_grpcroute_test.go
+++ b/internal/dataplane/translator/translate_grpcroute_test.go
@@ -91,10 +91,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1.foo.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -102,10 +102,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1.foo.com.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -113,10 +113,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1._.bar.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -124,10 +124,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1._.bar.com.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -240,10 +240,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1.foo.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -251,10 +251,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-2._.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -346,10 +346,10 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-1._.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -357,10 +357,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("grpcroute.default.grpcroute-no-hostnames-no-matches._.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service0",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service0").WithPortNumber(80).Build(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -207,7 +207,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -274,7 +274,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -338,7 +338,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -407,7 +407,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -477,7 +477,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -552,7 +552,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -640,7 +640,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created for this service
@@ -680,7 +680,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(8080).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(8080).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{
@@ -774,8 +774,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).Build(),
-								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).Build(),
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).MustBuild(),
+								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -819,8 +819,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(8080).WithWeight(90).Build(),
-								builder.NewKongstateServiceBackend("foo-v3").WithPortNumber(8080).WithWeight(10).Build(),
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(8080).WithWeight(90).MustBuild(),
+								builder.NewKongstateServiceBackend("foo-v3").WithPortNumber(8080).WithWeight(10).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -924,7 +924,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -1061,8 +1061,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 							},
 
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).Build(),
-								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).Build(),
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).MustBuild(),
+								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -1243,8 +1243,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).Build(),
-								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).Build(),
+								builder.NewKongstateServiceBackend("foo-v1").WithPortNumber(80).WithWeight(90).MustBuild(),
+								builder.NewKongstateServiceBackend("foo-v2").WithPortNumber(8080).WithWeight(10).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{
@@ -1479,7 +1479,7 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 								WriteTimeout:   kong.Int(60000),
 							},
 							Backends: kongstate.ServiceBackends{
-								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).Build(),
+								builder.NewKongstateServiceBackend("fake-service").WithPortNumber(80).MustBuild(),
 							},
 							Namespace: "default",
 							Routes: []kongstate.Route{{ // only 1 route should be created
@@ -1587,7 +1587,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -1656,7 +1656,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -1667,7 +1667,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -1678,7 +1678,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -1689,7 +1689,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service2").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -1775,7 +1775,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -1875,7 +1875,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -1934,7 +1934,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2003,8 +2003,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).WithWeight(10).Build(),
-					builder.NewKongstateServiceBackend("service2").WithPortNumber(80).WithWeight(20).Build(),
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).WithWeight(10).MustBuild(),
+					builder.NewKongstateServiceBackend("service2").WithPortNumber(80).WithWeight(20).MustBuild(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2053,7 +2053,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1.a.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2099,7 +2099,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -1584,10 +1584,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1._.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -1653,10 +1653,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1.foo.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -1664,10 +1664,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1._.bar.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -1675,10 +1675,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1.foo.com.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -1686,10 +1686,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1._.bar.com.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -1772,10 +1772,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("httproute.default.httproute-1.foo.com.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -1875,10 +1875,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:    "service1",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-					},
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -1937,10 +1934,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:    "service1",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-					},
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2009,16 +2003,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:    "service1",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						Weight:  lo.ToPtr(int32(10)),
-					},
-					{
-						Name:    "service2",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						Weight:  lo.ToPtr(int32(20)),
-					},
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).WithWeight(10).Build(),
+					builder.NewKongstateServiceBackend("service2").WithPortNumber(80).WithWeight(20).Build(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2067,10 +2053,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1.a.foo.com.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:    "service1",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-					},
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{
@@ -2116,10 +2099,7 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					Name: kong.String("httproute.default.httproute-1._.0"),
 				},
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:    "service1",
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-					},
+					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).Build(),
 				},
 			},
 			expectedKongRoute: kongstate.Route{

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -166,12 +166,13 @@ func translateIngressDefaultBackendResource(
 			// Translator pipeline (see ingressRules.generateKongServiceTags).
 		},
 		Namespace: ingress.Namespace,
-		Backends: []kongstate.ServiceBackend{{
-			Type:      kongstate.ServiceBackendTypeKongServiceFacade,
-			Name:      resource.Name,
-			Namespace: ingress.Namespace,
-			PortDef:   subtranslator.PortDefFromPortNumber(facade.Spec.Backend.Port),
-		}},
+		Backends: []kongstate.ServiceBackend{
+			kongstate.NewServiceBackendForServiceFacade(
+				ingress.Namespace,
+				resource.Name,
+				subtranslator.PortDefFromPortNumber(facade.Spec.Backend.Port),
+			),
+		},
 		Parent: facade,
 		Routes: []kongstate.Route{*route},
 	}, true
@@ -205,10 +206,9 @@ func translateIngressDefaultBackendService(ingress netv1.Ingress, route *kongsta
 			// Translator pipeline (see ingressRules.generateKongServiceTags).
 		},
 		Namespace: ingress.Namespace,
-		Backends: []kongstate.ServiceBackend{{
-			Name:    defaultBackend.Service.Name,
-			PortDef: port,
-		}},
+		Backends: []kongstate.ServiceBackend{
+			kongstate.NewServiceBackendForService(ingress.Namespace, defaultBackend.Service.Name, port),
+		},
 		Parent: &ingress,
 		Routes: []kongstate.Route{*route},
 	}, true

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -148,7 +148,7 @@ func TestFromIngressV1(t *testing.T) {
 		}
 
 		require.Len(t, snts.Backends, 1)
-		assert.Equal(t, snts.Backends[0].Name, "svc")
+		assert.Equal(t, snts.Backends[0].Name(), "svc")
 
 		require.Contains(t, result.ServiceNameToParent, "my-ns.svc.80")
 		assert.Equal(t, result.ServiceNameToParent["my-ns.svc.80"].GetName(), "baz")

--- a/internal/dataplane/translator/translate_kong_l4.go
+++ b/internal/dataplane/translator/translate_kong_l4.go
@@ -63,10 +63,13 @@ func (t *Translator) ingressRulesFromTCPIngressV1beta1() ingressRules {
 						Retries:        kong.Int(DefaultRetries),
 					},
 					Namespace: ingress.Namespace,
-					Backends: []kongstate.ServiceBackend{{
-						Name:    rule.Backend.ServiceName,
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						kongstate.NewServiceBackendForService(
+							ingress.Namespace,
+							rule.Backend.ServiceName,
+							kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
+						),
+					},
 					Parent: ingress,
 				}
 			}
@@ -128,10 +131,13 @@ func (t *Translator) ingressRulesFromUDPIngressV1beta1() ingressRules {
 						Host:     kong.String(host),
 						Port:     kong.Int(rule.Backend.ServicePort),
 					},
-					Backends: []kongstate.ServiceBackend{{
-						Name:    rule.Backend.ServiceName,
-						PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
-					}},
+					Backends: []kongstate.ServiceBackend{
+						kongstate.NewServiceBackendForService(
+							ingress.Namespace,
+							rule.Backend.ServiceName,
+							kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
+						),
+					},
 					Parent: ingress,
 				}
 			}

--- a/internal/dataplane/translator/translate_kong_l4.go
+++ b/internal/dataplane/translator/translate_kong_l4.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/kong/go-kong/kong"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
@@ -48,8 +49,10 @@ func (t *Translator) ingressRulesFromTCPIngressV1beta1() ingressRules {
 			}
 
 			serviceBackend, err := kongstate.NewServiceBackendForService(
-				ingress.Namespace,
-				rule.Backend.ServiceName,
+				k8stypes.NamespacedName{
+					Namespace: ingress.Namespace,
+					Name:      rule.Backend.ServiceName,
+				},
 				kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
 			)
 			if err != nil {
@@ -127,8 +130,10 @@ func (t *Translator) ingressRulesFromUDPIngressV1beta1() ingressRules {
 			}
 
 			serviceBackend, err := kongstate.NewServiceBackendForService(
-				ingress.Namespace,
-				rule.Backend.ServiceName,
+				k8stypes.NamespacedName{
+					Namespace: ingress.Namespace,
+					Name:      rule.Backend.ServiceName,
+				},
 				kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(rule.Backend.ServicePort)},
 			)
 			if err != nil {

--- a/internal/dataplane/translator/translate_tcproute_test.go
+++ b/internal/dataplane/translator/translate_tcproute_test.go
@@ -83,10 +83,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
+						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).Build(),
 					},
 				},
 			},
@@ -159,14 +156,10 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(443)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
 					},
 				},
 			},
@@ -286,14 +279,10 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(443)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
 					},
 				},
 				{
@@ -301,14 +290,8 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-2.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service3",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
-						{
-							Name:    "service4",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8443)},
-						},
+						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).Build(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_tcproute_test.go
+++ b/internal/dataplane/translator/translate_tcproute_test.go
@@ -83,7 +83,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).MustBuild(),
 					},
 				},
 			},
@@ -159,7 +159,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
+							MustBuild(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).MustBuild(),
 					},
 				},
 			},
@@ -282,7 +282,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
+							MustBuild(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).MustBuild(),
 					},
 				},
 				{
@@ -290,8 +290,8 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tcproute.default.tcproute-2.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).Build(),
-						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).Build(),
+						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).MustBuild(),
+						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).MustBuild(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_tlsroute_test.go
+++ b/internal/dataplane/translator/translate_tlsroute_test.go
@@ -63,7 +63,7 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
+							MustBuild(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).MustBuild(),
 					},
 				},
 			},
@@ -121,7 +121,7 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
+							MustBuild(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).MustBuild(),
 					},
 				},
 				{
@@ -129,8 +129,8 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tlsroute.default.tlsroute-1.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).Build(),
-						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).Build(),
+						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).MustBuild(),
+						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).MustBuild(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_tlsroute_test.go
+++ b/internal/dataplane/translator/translate_tlsroute_test.go
@@ -60,14 +60,10 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tlsroute.default.tlsroute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(443)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
 					},
 				},
 			},
@@ -122,14 +118,10 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tlsroute.default.tlsroute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(443)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(), builder.NewKongstateServiceBackend("service2").WithPortNumber(443).Build(),
 					},
 				},
 				{
@@ -137,14 +129,8 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 						Name: kong.String("tlsroute.default.tlsroute-1.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service3",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
-						{
-							Name:    "service4",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8443)},
-						},
+						builder.NewKongstateServiceBackend("service3").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service4").WithPortNumber(8443).Build(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_udproute_test.go
+++ b/internal/dataplane/translator/translate_udproute_test.go
@@ -85,10 +85,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -185,10 +185,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -197,10 +197,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
-						},
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(81).Build(),
 					},
 				},
 			},
@@ -285,14 +282,14 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(81).
+							Build(),
 					},
 				},
 			},
@@ -389,10 +386,10 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -401,10 +398,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).Build(),
 					},
 				},
 			},
@@ -559,10 +553,10 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 			},
@@ -659,10 +653,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
+						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).Build(),
 					},
 				},
 				{
@@ -671,10 +662,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8181)},
-						},
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8181).Build(),
 					},
 				},
 			},
@@ -754,14 +742,14 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(81)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(81).
+							Build(),
 					},
 				},
 			},
@@ -855,10 +843,10 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service1",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(80)},
-						},
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							Build(),
 					},
 				},
 				{
@@ -867,10 +855,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						{
-							Name:    "service2",
-							PortDef: kongstate.PortDef{Mode: kongstate.PortModeByNumber, Number: int32(8080)},
-						},
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).Build(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_udproute_test.go
+++ b/internal/dataplane/translator/translate_udproute_test.go
@@ -88,7 +88,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -188,7 +188,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -197,7 +197,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").WithPortNumber(81).Build(),
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(81).MustBuild(),
 					},
 				},
 			},
@@ -285,11 +285,11 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(81).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -389,7 +389,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -398,7 +398,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).MustBuild(),
 					},
 				},
 			},
@@ -556,7 +556,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -653,7 +653,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service1").WithPortNumber(8080).MustBuild(),
 					},
 				},
 				{
@@ -662,7 +662,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").WithPortNumber(8181).Build(),
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8181).MustBuild(),
 					},
 				},
 			},
@@ -745,11 +745,11 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(81).
-							Build(),
+							MustBuild(),
 					},
 				},
 			},
@@ -846,7 +846,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						builder.NewKongstateServiceBackend("service1").
 							WithNamespace("default").
 							WithPortNumber(80).
-							Build(),
+							MustBuild(),
 					},
 				},
 				{
@@ -855,7 +855,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 						Protocol: kong.String("udp"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).Build(),
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).MustBuild(),
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_utils_test.go
+++ b/internal/dataplane/translator/translate_utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
 )
 
 func TestConvertGatewayMatchHeadersToKongRouteMatchHeaders(t *testing.T) {
@@ -377,20 +378,14 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 				},
 				Namespace: "cholpon",
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name: string(blueObjName),
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: int32(port),
-						},
-					},
-					{
-						Name: string(redObjName),
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: int32(port),
-						},
-					},
+					builder.NewKongstateServiceBackend(string(blueObjName)).
+						WithNamespace(string(cholponNamespace)).
+						WithPortNumber(int(port)).
+						Build(),
+					builder.NewKongstateServiceBackend(string(redObjName)).
+						WithNamespace(string(cholponNamespace)).
+						WithPortNumber(int(port)).
+						Build(),
 				},
 				Parent: &gatewayapi.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
@@ -448,21 +443,14 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 				},
 				Namespace: "behbudiy",
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name:      string(blueObjName),
-						Namespace: "cholpon",
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: int32(port),
-						},
-					},
-					{
-						Name: string(redObjName),
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: int32(port),
-						},
-					},
+					builder.NewKongstateServiceBackend(string(blueObjName)).
+						WithNamespace(string(cholponNamespace)).
+						WithPortNumber(int(port)).
+						Build(),
+					builder.NewKongstateServiceBackend(string(redObjName)).
+						WithNamespace("behbudiy").
+						WithPortNumber(int(port)).
+						Build(),
 				},
 				Parent: &gatewayapi.UDPRoute{
 					ObjectMeta: metav1.ObjectMeta{
@@ -577,13 +565,10 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 				},
 				Namespace: "behbudiy",
 				Backends: []kongstate.ServiceBackend{
-					{
-						Name: string(redObjName),
-						PortDef: kongstate.PortDef{
-							Mode:   kongstate.PortModeByNumber,
-							Number: int32(port),
-						},
-					},
+					builder.NewKongstateServiceBackend(string(redObjName)).
+						WithNamespace("behbudiy").
+						WithPortNumber(int(port)).
+						Build(),
 				},
 				Parent: &gatewayapi.TCPRoute{
 					ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/translate_utils_test.go
+++ b/internal/dataplane/translator/translate_utils_test.go
@@ -381,11 +381,11 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					builder.NewKongstateServiceBackend(string(blueObjName)).
 						WithNamespace(string(cholponNamespace)).
 						WithPortNumber(int(port)).
-						Build(),
+						MustBuild(),
 					builder.NewKongstateServiceBackend(string(redObjName)).
 						WithNamespace(string(cholponNamespace)).
 						WithPortNumber(int(port)).
-						Build(),
+						MustBuild(),
 				},
 				Parent: &gatewayapi.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
@@ -446,11 +446,11 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					builder.NewKongstateServiceBackend(string(blueObjName)).
 						WithNamespace(string(cholponNamespace)).
 						WithPortNumber(int(port)).
-						Build(),
+						MustBuild(),
 					builder.NewKongstateServiceBackend(string(redObjName)).
 						WithNamespace("behbudiy").
 						WithPortNumber(int(port)).
-						Build(),
+						MustBuild(),
 				},
 				Parent: &gatewayapi.UDPRoute{
 					ObjectMeta: metav1.ObjectMeta{
@@ -568,7 +568,7 @@ func TestGenerateKongServiceFromBackendRef(t *testing.T) {
 					builder.NewKongstateServiceBackend(string(redObjName)).
 						WithNamespace("behbudiy").
 						WithPortNumber(int(port)).
-						Build(),
+						MustBuild(),
 				},
 				Parent: &gatewayapi.TCPRoute{
 					ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -330,22 +330,15 @@ func (t *Translator) getUpstreams(serviceMap map[string]kongstate.Service) ([]ko
 			var targets []kongstate.Target
 			for _, backend := range service.Backends {
 				// gather the Kubernetes service for the backend
-				backendNamespace := backend.Namespace
-				if backendNamespace == "" {
-					// if the backend namespace isn't specified, it's in the same namespace as the referee route (which is,
-					// somewhat confusingly, the _service_ namespace in serviceMap services, as historically there was no option
-					// to reference services outside the route namespace, and we could always stuff the route namespace into the
-					// placeholder service.
-					backendNamespace = service.Namespace
-				}
+				backendNamespace := backend.Namespace()
 
-				backendName := backend.Name
-				if backend.Type == kongstate.ServiceBackendTypeKongServiceFacade {
+				backendName := backend.Name()
+				if backend.IsServiceFacade() {
 					// In the case of KongServiceFacade we need to look it up to determine the backing Kubernetes Service.
-					svcFacade, err := t.storer.GetKongServiceFacade(backend.Namespace, backend.Name)
+					svcFacade, err := t.storer.GetKongServiceFacade(backend.Namespace(), backend.Name())
 					if err != nil {
 						t.registerTranslationFailure(
-							fmt.Sprintf("couldn't get KongServiceFacade %s: %v", backend.Name, err),
+							fmt.Sprintf("couldn't get KongServiceFacade %s: %v", backend.Name(), err),
 							service.Parent,
 						)
 						continue
@@ -362,7 +355,7 @@ func (t *Translator) getUpstreams(serviceMap map[string]kongstate.Service) ([]ko
 				}
 
 				// determine the port for the backend
-				port, err := findPort(k8sService, backend.PortDef)
+				port, err := findPort(k8sService, backend.PortDef())
 				if err != nil {
 					t.registerTranslationFailure(
 						fmt.Sprintf("can't find port for backend kubernetes service: %v", err),
@@ -383,19 +376,19 @@ func (t *Translator) getUpstreams(serviceMap map[string]kongstate.Service) ([]ko
 
 				// if weights were set for the backend then that weight needs to be
 				// distributed equally among all the targets.
-				if backend.Weight != nil && len(newTargets) != 0 {
+				if weight, weightPresent := backend.Weight().Get(); weightPresent && len(newTargets) != 0 {
 					// initialize the weight of the target based on the weight of the backend
 					// which governs that target (and potentially more). If the weight of the
 					// backend is 0 then this indicates an intention to drop all targets from
 					// this backend from the load-balancer and is a special situation where
 					// all derived targets will receive a weight of 0.
-					targetWeight := int(*backend.Weight)
+					targetWeight := weight
 
 					// if the backend governing this target is not set to a weight of 0,
 					// all targets derived from the backend split the weight, therefore
 					// equally splitting the traffic load.
-					if *backend.Weight != 0 {
-						targetWeight = int(*backend.Weight) / len(newTargets)
+					if weight != 0 {
+						targetWeight = weight / len(newTargets)
 						// minimum weight of 1 if weight zero was not specifically set.
 						if targetWeight == 0 {
 							targetWeight = 1

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 )
@@ -9,40 +10,68 @@ import (
 // KongstateServiceBackendBuilder is a builder for KongstateServiceBackend.
 // Primarily used for testing.
 type KongstateServiceBackendBuilder struct {
-	kongstateServiceBackend kongstate.ServiceBackend
+	name      string
+	namespace string
+	weight    *int32
+	portDef   kongstate.PortDef
+	t         kongstate.ServiceBackendType
 }
 
 func NewKongstateServiceBackend(name string) *KongstateServiceBackendBuilder {
 	return &KongstateServiceBackendBuilder{
-		kongstateServiceBackend: kongstate.ServiceBackend{
-			Name: name,
-		},
+		name: name,
 	}
 }
 
 func (b *KongstateServiceBackendBuilder) WithNamespace(namespace string) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.Namespace = namespace
+	b.namespace = namespace
 	return b
 }
 
 func (b *KongstateServiceBackendBuilder) WithWeight(weight int) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.Weight = lo.ToPtr(int32(weight))
+	b.weight = lo.ToPtr(int32(weight))
 	return b
 }
 
 func (b *KongstateServiceBackendBuilder) WithPortNumber(port int) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.PortDef = kongstate.PortDef{
+	b.portDef = kongstate.PortDef{
 		Number: int32(port),
 		Mode:   kongstate.PortModeByNumber,
 	}
 	return b
 }
 
+func (b *KongstateServiceBackendBuilder) WithPortName(port string) *KongstateServiceBackendBuilder {
+	b.portDef = kongstate.PortDef{
+		Name: port,
+		Mode: kongstate.PortModeByName,
+	}
+	return b
+}
+
 func (b *KongstateServiceBackendBuilder) WithType(t kongstate.ServiceBackendType) *KongstateServiceBackendBuilder {
-	b.kongstateServiceBackend.Type = t
+	b.t = t
 	return b
 }
 
 func (b *KongstateServiceBackendBuilder) Build() kongstate.ServiceBackend {
-	return b.kongstateServiceBackend
+	// Default to Kubernetes Service backend type if not specified.
+	if b.t == "" {
+		b.t = kongstate.ServiceBackendTypeKubernetesService
+	}
+	// Default to default namespace if not specified.
+	if b.namespace == "" {
+		b.namespace = metav1.NamespaceDefault
+	}
+
+	s := kongstate.NewServiceBackend(
+		b.t,
+		b.namespace,
+		b.name,
+		b.portDef,
+	)
+	if b.weight != nil {
+		s.SetWeight(*b.weight)
+	}
+	return s
 }

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -1,6 +1,8 @@
 package builder
 
 import (
+	"fmt"
+
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -64,12 +66,17 @@ func (b *KongstateServiceBackendBuilder) Build() kongstate.ServiceBackend {
 		b.namespace = metav1.NamespaceDefault
 	}
 
-	s := kongstate.NewServiceBackend(
+	s, err := kongstate.NewServiceBackend(
 		b.t,
 		b.namespace,
 		b.name,
 		b.portDef,
 	)
+	if err != nil {
+		// This should never happen. If it does, it's a bug that will be discovered in tests as the builder
+		// is used in tests only.
+		panic(fmt.Errorf("failed to build service backend: %w", err))
+	}
 	if b.weight != nil {
 		s.SetWeight(*b.weight)
 	}

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 )
@@ -68,8 +69,10 @@ func (b *KongstateServiceBackendBuilder) MustBuild() kongstate.ServiceBackend {
 
 	s, err := kongstate.NewServiceBackend(
 		b.t,
-		b.namespace,
-		b.name,
+		k8stypes.NamespacedName{
+			Namespace: b.namespace,
+			Name:      b.name,
+		},
 		b.portDef,
 	)
 	if err != nil {

--- a/internal/util/builder/kongstateservicebackend.go
+++ b/internal/util/builder/kongstateservicebackend.go
@@ -56,7 +56,7 @@ func (b *KongstateServiceBackendBuilder) WithType(t kongstate.ServiceBackendType
 	return b
 }
 
-func (b *KongstateServiceBackendBuilder) Build() kongstate.ServiceBackend {
+func (b *KongstateServiceBackendBuilder) MustBuild() kongstate.ServiceBackend {
 	// Default to Kubernetes Service backend type if not specified.
 	if b.t == "" {
 		b.t = kongstate.ServiceBackendTypeKubernetesService


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors `kongstate.ServiceBackend` by making its fields private (so they cannot be arbitrarily set outside of the package) and implementing constructors validating the data integrity to be used by the production code. Thanks to that, if we're interacting with the `kongstate.ServiceBackend` object anywhere outside of its package, we can be sure it's in a valid state (if it's not empty).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes #5258.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
