### PR TITLE
fix: remove check of namespace in generating translation failures

### DIFF
--- a/internal/dataplane/failures/failures.go
+++ b/internal/dataplane/failures/failures.go
@@ -41,11 +41,6 @@ func NewResourceFailure(reason string, causingObjects ...client.Object) (Resourc
 		if obj.GetName() == "" {
 			return ResourceFailure{}, fmt.Errorf("one of causing objects (%s) has no name", gvk.String())
 		}
-
-		if obj.GetNamespace() == "" {
-			return ResourceFailure{}, fmt.Errorf("one of causing objects (%s) has no namespace", gvk.String())
-		}
-
 	}
 
 	return ResourceFailure{

--- a/internal/dataplane/failures/failures_test.go
+++ b/internal/dataplane/failures/failures_test.go
@@ -54,11 +54,6 @@ func TestResourceFailure(t *testing.T) {
 		noName.Name = ""
 		_, err = NewResourceFailure(someValidResourceFailureReason, noName)
 		assert.Error(t, err, "expected an empty name object to be rejected")
-
-		noNamespace := validCausingObject()
-		noNamespace.Namespace = ""
-		_, err = NewResourceFailure(someValidResourceFailureReason, noNamespace)
-		assert.Error(t, err, "expected an empty namespace object to be rejected")
 	})
 }
 

--- a/internal/dataplane/failures/failures_test.go
+++ b/internal/dataplane/failures/failures_test.go
@@ -54,6 +54,11 @@ func TestResourceFailure(t *testing.T) {
 		noName.Name = ""
 		_, err = NewResourceFailure(someValidResourceFailureReason, noName)
 		assert.Error(t, err, "expected an empty name object to be rejected")
+
+		noNamespace := validCausingObject()
+		noNamespace.Namespace = ""
+		_, err = NewResourceFailure(someValidResourceFailureReason, noNamespace)
+		assert.NoError(t, err, "expected an empty namespace object to also be accepted")
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Accept objects without namespaces in constructing a translation failure record in `NewResourceFailure`. This allows attaching translation failures to cluster scoped resources like `KongClusterPlugin` or `KongVault`. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Fixes #5387

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
