### PR TITLE
fix: fix refChecker when namespace is specified and is the same as route's namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,6 @@ Adding a new version? You'll need three changes:
   [#5354](https://github.com/Kong/kubernetes-ingress-controller/pull/5354)
   [#5384](https://github.com/Kong/kubernetes-ingress-controller/pull/5384)
 
-
 ### Fixed
 
 - Validators of `KongPlugin` and `KongClusterPlugin` will not return `500` on
@@ -161,6 +160,9 @@ Adding a new version? You'll need three changes:
   [#5401](https://github.com/Kong/kubernetes-ingress-controller/pull/5401)
 - Support properly ConsumerGroups when fallback to the last valid configuration.
   [#5438](https://github.com/Kong/kubernetes-ingress-controller/pull/5438)
+- When specifying Gateway API Routes' `backendRef`s with namespace specified, those
+  refs are checked for existence and allowed if they exist.
+  [#5392](https://github.com/Kong/kubernetes-ingress-controller/pull/5392)
 
 ### Changed
 

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -1,19 +1,30 @@
 package translator
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
+// backendRefsToKongStateBackends takes a list of BackendRefs and returns a list of ServiceBackends.
+// The backendRefs are checked for the following conditions. If any of these conditions are met, the BackendRef is
+// not included in the returned list:
+// - If a BackendRef is not permitted by the provided ReferenceGrantTo set,
+// - If a BackendRef is not found,
+// - If a BackendRef Group & Kind pair is not supported (currently only Service is supported),
+// - If a BackendRef is missing a port.
+// The provided client is used to retrieve the Backend referenced by the BackendRef
+// to check if it exists.
 func backendRefsToKongStateBackends(
 	logger logr.Logger,
+	storer store.Storer,
 	route client.Object,
 	backendRefs []gatewayapi.BackendRef,
 	allowed map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo,
@@ -23,42 +34,65 @@ func backendRefsToKongStateBackends(
 	for _, backendRef := range backendRefs {
 		logger := loggerForBackendRef(logger, route, backendRef)
 
-		if util.IsBackendRefGroupKindSupported(
-			backendRef.Group,
-			backendRef.Kind,
-		) && newRefCheckerForRoute(route, backendRef).IsRefAllowedByGrant(allowed) {
-			port := int32(-1)
-			if backendRef.Port != nil {
-				port = int32(*backendRef.Port)
+		nn := client.ObjectKey{
+			Name:      string(backendRef.Name),
+			Namespace: route.GetNamespace(),
+		}
+		if backendRef.Namespace != nil {
+			nn.Namespace = string(*backendRef.Namespace)
+		}
+
+		if backendRef.Kind == nil {
+			logger.Error(nil, "Object requested backendRef to target, but no Kind was specified, skipping...")
+			continue
+		}
+
+		var err error
+		switch *backendRef.Kind {
+		case "Service":
+			_, err = storer.GetService(nn.Namespace, nn.Name)
+		default:
+			err = fmt.Errorf("unsupported kind %q, only 'Service' is Supported", *backendRef.Kind)
+		}
+		if err != nil {
+			switch errors.As(err, &store.NotFoundError{}) {
+			case true:
+				logger.Error(nil, "Object requested backendRef to target, but it does not exist, skipping...")
+			case false:
+				logger.Error(nil, "Object requested backendRef to target, but no ReferenceGrant permits it, skipping...")
 			}
-			namespace := route.GetNamespace()
-			if backendRef.Namespace != nil {
-				namespace = string(*backendRef.Namespace)
-			}
-			backend, err := kongstate.NewServiceBackendForService(
-				k8stypes.NamespacedName{
-					Namespace: namespace,
-					Name:      string(backendRef.Name),
-				},
-				kongstate.PortDef{
-					Mode:   kongstate.PortModeByNumber,
-					Number: port,
-				},
-			)
-			if err != nil {
-				logger.Error(err, "failed to create ServiceBackend for backendRef")
-			}
-			if backendRef.Weight != nil {
-				backend.SetWeight(*backendRef.Weight)
-			}
-			backends = append(backends, backend)
-		} else {
+			continue
+		}
+
+		if !util.IsBackendRefGroupKindSupported(backendRef.Group, backendRef.Kind) ||
+			!newRefCheckerForRoute(route, backendRef).IsRefAllowedByGrant(allowed) {
 			// we log impermissible refs rather than failing the entire rule. while we cannot actually route to
 			// these, we do not want a single impermissible ref to take the entire rule offline. in the case of edits,
 			// failing the entire rule could potentially delete routes that were previously online and in use, and
 			// that remain viable (because they still have some permissible backendRefs)
 			logger.Error(nil, "Object requested backendRef to target, but no ReferenceGrant permits it, skipping...")
+			continue
 		}
+
+		port := int32(-1)
+		if backendRef.Port != nil {
+			port = int32(*backendRef.Port)
+		}
+		backend, err := kongstate.NewServiceBackendForService(
+			nn,
+			kongstate.PortDef{
+				Mode:   kongstate.PortModeByNumber,
+				Number: port,
+			},
+		)
+		if err != nil {
+			logger.Error(err, "failed to create ServiceBackend for backendRef")
+			continue
+		}
+		if backendRef.Weight != nil {
+			backend.SetWeight(*backendRef.Weight)
+		}
+		backends = append(backends, backend)
 	}
 
 	return backends

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -43,7 +43,7 @@ func backendRefsToKongStateBackends(
 		}
 
 		if backendRef.Kind == nil {
-      // This should never happen as the default value defined by Gateway API is 'Service'. Checking just in case.
+			// This should never happen as the default value defined by Gateway API is 'Service'. Checking just in case.
 			logger.Error(nil, "Object requested backendRef to target, but no Kind was specified, skipping...")
 			continue
 		}
@@ -56,10 +56,9 @@ func backendRefsToKongStateBackends(
 			err = fmt.Errorf("unsupported kind %q, only 'Service' is supported", *backendRef.Kind)
 		}
 		if err != nil {
-			switch errors.As(err, &store.NotFoundError{}) {
-			case true:
-				logger.Error(nil, "Object requested backendRef to target, but it does not exist, skipping...")
-			case false:
+			if errors.As(err, &store.NotFoundError{}) {
+				logger.Error(err, "Object requested backendRef to target, but it does not exist, skipping...")
+			} else {
 				logger.Error(err, "Object requested backendRef to target, but an error occurred, skipping...")
 			}
 			continue

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -43,6 +43,7 @@ func backendRefsToKongStateBackends(
 		}
 
 		if backendRef.Kind == nil {
+      // This should never happen as the default value defined by Gateway API is 'Service'. Checking just in case.
 			logger.Error(nil, "Object requested backendRef to target, but no Kind was specified, skipping...")
 			continue
 		}
@@ -52,14 +53,14 @@ func backendRefsToKongStateBackends(
 		case "Service":
 			_, err = storer.GetService(nn.Namespace, nn.Name)
 		default:
-			err = fmt.Errorf("unsupported kind %q, only 'Service' is Supported", *backendRef.Kind)
+			err = fmt.Errorf("unsupported kind %q, only 'Service' is supported", *backendRef.Kind)
 		}
 		if err != nil {
 			switch errors.As(err, &store.NotFoundError{}) {
 			case true:
 				logger.Error(nil, "Object requested backendRef to target, but it does not exist, skipping...")
 			case false:
-				logger.Error(nil, "Object requested backendRef to target, but no ReferenceGrant permits it, skipping...")
+				logger.Error(err, "Object requested backendRef to target, but an error occurred, skipping...")
 			}
 			continue
 		}

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -26,7 +26,7 @@ func backendRefsToKongStateBackends(
 		if util.IsBackendRefGroupKindSupported(
 			backendRef.Group,
 			backendRef.Kind,
-		) && newRefChecker(backendRef).IsRefAllowedByGrant(allowed) {
+		) && newRefCheckerForRoute(route, backendRef).IsRefAllowedByGrant(allowed) {
 			port := int32(-1)
 			if backendRef.Port != nil {
 				port = int32(*backendRef.Port)

--- a/internal/dataplane/translator/backendref_test.go
+++ b/internal/dataplane/translator/backendref_test.go
@@ -1,0 +1,167 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
+)
+
+func TestBackendRefsToKongStateBackends(t *testing.T) {
+	testcases := []struct {
+		name        string
+		route       client.Object
+		backendRefs []gatewayapi.BackendRef
+		allowed     map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo
+		objects     store.FakeObjects
+		expected    kongstate.ServiceBackends
+	}{
+		{
+			name: "correct ReferenceGrant and an existing Service as backendRef returns a KongStateBackend with a Service",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: commonRouteSpecMock("fake-gateway-1"),
+					Hostnames: []gatewayapi.Hostname{
+						"konghq.com",
+						"www.konghq.com",
+					},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						// BackendRefs are taken from the backendRefs argument.
+						// This is done this way because the backendRefs are
+						// extracted from the route's spec before.
+						// Potentially this could be refactored to be extracted
+						// in backendRefsToKongStateBackends using a type switch.
+					}},
+				},
+			},
+			backendRefs: []gatewayapi.BackendRef{
+				builder.NewBackendRef("fake-service").WithPort(80).Build(),
+			},
+			allowed: map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo{
+				gatewayapi.Namespace(corev1.NamespaceDefault): {
+					{
+						Group: "",
+						Kind:  "Service",
+						Name:  lo.ToPtr(gatewayapi.ObjectName("fake-service")),
+					},
+				},
+			},
+			objects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-service",
+							Namespace: corev1.NamespaceDefault,
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{
+								builder.NewServicePort().WithPort(80).Build(),
+							},
+						},
+					},
+				},
+			},
+			expected: func() kongstate.ServiceBackends {
+				svcBackend, err := kongstate.NewServiceBackend(
+					kongstate.ServiceBackendTypeKubernetesService,
+					k8stypes.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "fake-service"},
+					kongstate.PortDef{
+						Mode:   kongstate.PortModeByNumber,
+						Number: 80,
+					},
+				)
+				require.NoError(t, err)
+				return kongstate.ServiceBackends{svcBackend}
+			}(),
+		},
+		{
+			name: "no ReferenceGrant and an existing Service as backendRef doesn't return a KongStateBackend with the Service",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: commonRouteSpecMock("fake-gateway-1"),
+					Hostnames: []gatewayapi.Hostname{
+						"konghq.com",
+						"www.konghq.com",
+					},
+				},
+			},
+			allowed: map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo{
+				gatewayapi.Namespace(corev1.NamespaceDefault): {
+					{
+						Group: "",
+						Kind:  "ImaginaryKind",
+						Name:  lo.ToPtr(gatewayapi.ObjectName("fake-service")),
+					},
+				},
+			},
+			objects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-service",
+							Namespace: corev1.NamespaceDefault,
+						},
+					},
+				},
+			},
+			expected: kongstate.ServiceBackends{},
+		},
+		{
+			name: "ReferenceGrant and a non existing Service as backendRef doesn't return a KongStateBackend with the Service",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-httproute",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: commonRouteSpecMock("fake-gateway-1"),
+					Hostnames: []gatewayapi.Hostname{
+						"konghq.com",
+						"www.konghq.com",
+					},
+				},
+			},
+			backendRefs: []gatewayapi.BackendRef{
+				builder.NewBackendRef("fake-service").WithPort(80).Build(),
+			},
+			allowed: map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo{
+				gatewayapi.Namespace(corev1.NamespaceDefault): {
+					{
+						Group: "",
+						Kind:  "Service",
+						Name:  lo.ToPtr(gatewayapi.ObjectName("fake-service")),
+					},
+				},
+			},
+			expected: kongstate.ServiceBackends{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(tc.objects)
+			require.NoError(t, err)
+			logger := logr.Discard()
+			ret := backendRefsToKongStateBackends(logger, fakestore, tc.route, tc.backendRefs, tc.allowed)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -34,10 +34,11 @@ var httprouteGVK = schema.GroupVersionKind{
 }
 
 type testCaseIngressRulesFromHTTPRoutes struct {
-	msg      string
-	routes   []*gatewayapi.HTTPRoute
-	expected func(routes []*gatewayapi.HTTPRoute) ingressRules
-	errs     []error
+	msg          string
+	routes       []*gatewayapi.HTTPRoute
+	storeObjects store.FakeObjects
+	expected     func(routes []*gatewayapi.HTTPRoute) ingressRules
+	errs         []error
 }
 
 func TestValidateHTTPRoute(t *testing.T) {
@@ -155,9 +156,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 }
 
 func TestIngressRulesFromHTTPRoutes(t *testing.T) {
-	fakestore, err := store.NewFakeStore(store.FakeObjects{})
-	require.NoError(t, err)
-
 	testCases := []testCaseIngressRulesFromHTTPRoutes{
 		{
 			msg: "an empty list of HTTPRoutes should produce no ingress rules",
@@ -189,6 +187,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -256,6 +264,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -320,6 +338,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -389,6 +417,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -459,6 +497,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -534,6 +582,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -617,6 +675,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 									builder.NewHTTPBackendRef("fake-service").WithPort(8080).Build(),
 								},
 							},
+						},
+					},
+				},
+			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
 						},
 					},
 				},
@@ -751,6 +819,28 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 									builder.NewHTTPBackendRef("foo-v3").WithPort(8080).WithWeight(10).Build(),
 								},
 							},
+						},
+					},
+				},
+			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v2",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v3",
 						},
 					},
 				},
@@ -906,6 +996,16 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					},
 				},
 			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "fake-service",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -1042,6 +1142,22 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v2",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -1225,6 +1341,22 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 					},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: corev1.NamespaceDefault,
+							Name:      "foo-v2",
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -1353,6 +1485,9 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.msg, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(tt.storeObjects)
+			require.NoError(t, err)
+
 			p := mustNewTranslator(t, fakestore)
 
 			ingressRules := newIngressRules()
@@ -1430,11 +1565,6 @@ func TestGetHTTPRouteHostnamesAsSliceOfStringPointers(t *testing.T) {
 }
 
 func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
-	fakestore, err := store.NewFakeStore(store.FakeObjects{})
-	require.NoError(t, err)
-	translator := mustNewTranslator(t, fakestore)
-	translatorWithCombinedServiceRoutes := mustNewTranslator(t, fakestore)
-
 	for _, tt := range []testCaseIngressRulesFromHTTPRoutes{
 		{
 			msg: "an HTTPRoute with regex path matches is supported",
@@ -1461,6 +1591,16 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 					}},
 				},
 			}},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-service",
+							Namespace: corev1.NamespaceDefault,
+						},
+					},
+				},
+			},
 			expected: func(routes []*gatewayapi.HTTPRoute) ingressRules {
 				return ingressRules{
 					SecretNameToSNIs: newSecretNameToSNIs(),
@@ -1536,16 +1676,17 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 			}
 		}
 
+		fakestore, err := store.NewFakeStore(tt.storeObjects)
+		require.NoError(t, err)
+		translator := mustNewTranslator(t, fakestore)
+		translatorWithCombinedServiceRoutes := mustNewTranslator(t, fakestore)
+
 		t.Run(tt.msg+" using legacy translator", withTranslator(translator))
 		t.Run(tt.msg+" using combined service routes translator", withTranslator(translatorWithCombinedServiceRoutes))
 	}
 }
 
 func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
-	fakestore, err := store.NewFakeStore(store.FakeObjects{})
-	require.NoError(t, err)
-	translator := mustNewTranslator(t, fakestore)
-	translator.featureFlags.ExpressionRoutes = true
 	httpRouteTypeMeta := metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayv1beta1.GroupVersion.String()}
 
 	testCases := []struct {
@@ -1553,6 +1694,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 		httpRoutes           []*gatewayapi.HTTPRoute
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
+		fakeObjects          store.FakeObjects
 	}{
 		{
 			name: "single HTTPRoute with no hostname and multiple matches",
@@ -1574,6 +1716,16 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
 								},
 							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
 						},
 					},
 				},
@@ -1643,6 +1795,22 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPBackendRef("service2").WithPort(80).Build(),
 								},
 							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service2",
 						},
 					},
 				},
@@ -1766,6 +1934,16 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 				},
 			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -1797,8 +1975,11 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			failureCollector := failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
-			translator.failuresCollector = failureCollector
+			fakestore, err := store.NewFakeStore(tc.fakeObjects)
+			require.NoError(t, err)
+			translator := mustNewTranslator(t, fakestore)
+			translator.featureFlags.ExpressionRoutes = true
+			translator.failuresCollector = failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
 
 			result := newIngressRules()
 			translator.ingressRulesFromHTTPRoutesUsingExpressionRoutes(tc.httpRoutes, &result)
@@ -1828,15 +2009,12 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 }
 
 func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
-	fakestore, err := store.NewFakeStore(store.FakeObjects{})
-	require.NoError(t, err)
-	translator := mustNewTranslator(t, fakestore)
-	translator.featureFlags.ExpressionRoutes = true
 	httpRouteTypeMeta := metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayv1beta1.GroupVersion.String()}
 
 	testCases := []struct {
 		name                string
 		matchWithPriority   subtranslator.SplitHTTPRouteMatchToKongRoutePriority
+		storeObjects        store.FakeObjects
 		expectedKongService kongstate.Service
 		expectedKongRoute   kongstate.Route
 		expectedError       error
@@ -1869,6 +2047,16 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					MatchIndex: 0,
 				},
 				Priority: 1024,
+			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+				},
 			},
 			expectedKongService: kongstate.Service{
 				Service: kong.Service{
@@ -1928,6 +2116,16 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					MatchIndex: 1,
 				},
 				Priority: 1024,
+			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+				},
 			},
 			expectedKongService: kongstate.Service{
 				Service: kong.Service{
@@ -1998,6 +2196,22 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 				},
 				Priority: 1024,
 			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service2",
+						},
+					},
+				},
+			},
 			expectedKongService: kongstate.Service{
 				Service: kong.Service{
 					Name: kong.String("httproute.default.httproute-1._.foo.com.0"),
@@ -2048,6 +2262,16 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 				},
 				Priority: 1024,
 			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+				},
+			},
 			expectedKongService: kongstate.Service{
 				Service: kong.Service{
 					Name: kong.String("httproute.default.httproute-1.a.foo.com.0"),
@@ -2094,6 +2318,16 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 				},
 				Priority: 1024,
 			},
+			storeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service1",
+						},
+					},
+				},
+			},
 			expectedKongService: kongstate.Service{
 				Service: kong.Service{
 					Name: kong.String("httproute.default.httproute-1._.0"),
@@ -2118,12 +2352,17 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(tc.storeObjects)
+			require.NoError(t, err)
+			translator := mustNewTranslator(t, fakestore)
+			translator.featureFlags.ExpressionRoutes = true
+
 			match := tc.matchWithPriority.Match
 			tc.expectedKongRoute.Tags = util.GenerateTagsForObject(match.Source)
 			tc.expectedKongRoute.Ingress = util.FromK8sObject(match.Source)
 
 			res := newIngressRules()
-			err := translator.ingressRulesFromSplitHTTPRouteMatchWithPriority(&res, tc.matchWithPriority)
+			err = translator.ingressRulesFromSplitHTTPRouteMatchWithPriority(&res, tc.matchWithPriority)
 			if tc.expectedError != nil {
 				require.ErrorAs(t, err, tc.expectedError)
 				return

--- a/internal/dataplane/translator/translate_tcproute_test.go
+++ b/internal/dataplane/translator/translate_tcproute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -26,6 +27,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 		name                 string
 		gateways             []*gatewayapi.Gateway
 		tcpRoutes            []*gatewayapi.TCPRoute
+		services             []*corev1.Service
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
@@ -74,6 +76,14 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
 					},
 				},
 			},
@@ -147,6 +157,20 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
 					},
 				},
 			},
@@ -273,6 +297,32 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 				},
 			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service3",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service4",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -328,6 +378,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 			fakeStore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,
 				TCPRoutes: tc.tcpRoutes,
+				Services:  tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakeStore)

--- a/internal/dataplane/translator/translate_tlsroute_test.go
+++ b/internal/dataplane/translator/translate_tlsroute_test.go
@@ -25,6 +25,7 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		tcpRoutes            []*gatewayapi.TLSRoute
+		services             []*corev1.Service
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
@@ -51,6 +52,23 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			// After https://github.com/Kong/kubernetes-ingress-controller/pull/5392
+			// is merged the backendRef will be checked for existence in the store
+			// so we need to add them here.
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
 					},
 				},
 			},
@@ -112,6 +130,35 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 				},
 			},
+			// After https://github.com/Kong/kubernetes-ingress-controller/pull/5392
+			// is merged the backendRef will be checked for existence in the store
+			// so we need to add them here.
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service3",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service4",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -164,7 +211,10 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			fakestore, err := store.NewFakeStore(store.FakeObjects{TLSRoutes: tc.tcpRoutes})
+			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				TLSRoutes: tc.tcpRoutes,
+				Services:  tc.services,
+			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakestore)
 			translator.featureFlags.ExpressionRoutes = true

--- a/internal/dataplane/translator/translate_udproute_test.go
+++ b/internal/dataplane/translator/translate_udproute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -27,6 +28,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 		name                 string
 		gateways             []*gatewayapi.Gateway
 		udpRoutes            []*gatewayapi.UDPRoute
+		services             []*corev1.Service
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
@@ -75,6 +77,14 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
 					},
 				},
 			},
@@ -178,6 +188,20 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					},
 				},
 			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -272,6 +296,14 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
 					},
 				},
 			},
@@ -379,6 +411,20 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 					Spec:       gatewayapi.UDPRouteSpec{},
 				},
 			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -444,6 +490,7 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,
 				UDPRoutes: tc.udpRoutes,
+				Services:  tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakestore)
@@ -496,6 +543,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 		name                 string
 		gateways             []*gatewayapi.Gateway
 		udpRoutes            []*gatewayapi.UDPRoute
+		services             []*corev1.Service
 		expectedKongServices []kongstate.Service
 		expectedKongRoutes   map[string][]kongstate.Route
 		expectedFailures     []failures.ResourceFailure
@@ -543,6 +591,14 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
 					},
 				},
 			},
@@ -646,6 +702,20 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					},
 				},
 			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -732,6 +802,20 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
 					},
 				},
 			},
@@ -836,6 +920,20 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 					Spec:       gatewayapi.UDPRouteSpec{},
 				},
 			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+			},
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
@@ -897,6 +995,7 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,
 				UDPRoutes: tc.udpRoutes,
+				Services:  tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakestore)

--- a/internal/dataplane/translator/translate_utils.go
+++ b/internal/dataplane/translator/translate_utils.go
@@ -87,7 +87,7 @@ func generateKongServiceFromBackendRefWithName(
 		Namespace: gatewayapi.Namespace(route.GetNamespace()),
 	}, grants)
 
-	backends := backendRefsToKongStateBackends(logger, route, backendRefs, allowed)
+	backends := backendRefsToKongStateBackends(logger, storer, route, backendRefs, allowed)
 
 	// the service host needs to be a resolvable name due to legacy logic so we'll
 	// use the anchor backendRef as the basis for the name

--- a/internal/dataplane/translator/wrappers_refchecker.go
+++ b/internal/dataplane/translator/wrappers_refchecker.go
@@ -35,7 +35,7 @@ func (rc refChecker[T]) IsRefAllowedByGrant(
 		}
 
 		// If the namespace is specified but is the same as the route's namespace, then the ref is allowed.
-		if br.Namespace != nil && rc.route.GetNamespace() == string(*br.Namespace) {
+		if rc.route.GetNamespace() == string(*br.Namespace) {
 			return true
 		}
 

--- a/internal/dataplane/translator/wrappers_refchecker.go
+++ b/internal/dataplane/translator/wrappers_refchecker.go
@@ -1,17 +1,22 @@
 package translator
 
 import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 )
 
 // refChecker is a wrapper type that facilitates checking whether a backenRef is allowed
 // by a referenceGrantTo set.
 type refChecker[T gatewayapi.BackendRefT] struct {
+	route      client.Object
 	backendRef T
 }
 
-func newRefChecker[T gatewayapi.BackendRefT](ref T) refChecker[T] {
+// newRefCheckerForRoute returns a refChecker for the provided route and backendRef.
+func newRefCheckerForRoute[T gatewayapi.BackendRefT](route client.Object, ref T) refChecker[T] {
 	return refChecker[T]{
+		route:      route,
 		backendRef: ref,
 	}
 }
@@ -26,6 +31,11 @@ func (rc refChecker[T]) IsRefAllowedByGrant(
 	switch br := (interface{})(rc.backendRef).(type) {
 	case gatewayapi.BackendRef:
 		if br.Namespace == nil {
+			return true
+		}
+
+		// If the namespace is specified but is the same as the route's namespace, then the ref is allowed.
+		if br.Namespace != nil && rc.route.GetNamespace() == string(*br.Namespace) {
 			return true
 		}
 

--- a/internal/dataplane/translator/wrappers_refchecker_test.go
+++ b/internal/dataplane/translator/wrappers_refchecker_test.go
@@ -1,0 +1,119 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+)
+
+func TestRefChecker_IsRefAllowedByGrant(t *testing.T) {
+	testcases := []struct {
+		name        string
+		route       *gatewayapi.HTTPRoute
+		backendRef  gatewayapi.BackendRef
+		allowedRefs map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo
+		expected    bool
+	}{
+		{
+			name: "allowed by grant",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example-namespace",
+					Name:      "example-name",
+				},
+			},
+			backendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Kind:  lo.ToPtr(gatewayapi.Kind("example-kind")),
+					Group: lo.ToPtr(gatewayapi.Group("example-group")),
+					Name:  "example-name",
+				},
+			},
+			allowedRefs: map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo{
+				"example-namespace": {
+					{
+						Kind:  gatewayapi.Kind("example-kind"),
+						Group: gatewayapi.Group("example-group"),
+						Name:  lo.ToPtr(gatewayapi.ObjectName("example-name")),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed by grant with namespace",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example-namespace",
+					Name:      "example-name",
+				},
+			},
+			backendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Kind:      lo.ToPtr(gatewayapi.Kind("example-kind")),
+					Group:     lo.ToPtr(gatewayapi.Group("example-group")),
+					Name:      "example-name",
+					Namespace: lo.ToPtr(gatewayapi.Namespace("example-namespace")),
+				},
+			},
+			allowedRefs: map[gatewayapi.Namespace][]gatewayapi.ReferenceGrantTo{
+				"example-namespace": {
+					{
+						Kind:  gatewayapi.Kind("example-kind"),
+						Group: gatewayapi.Group("example-group"),
+						Name:  lo.ToPtr(gatewayapi.ObjectName("example-name")),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed because backendRef and route use the same namespace",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example-namespace",
+					Name:      "example-name",
+				},
+			},
+			backendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Kind:      lo.ToPtr(gatewayapi.Kind("example-kind")),
+					Group:     lo.ToPtr(gatewayapi.Group("example-group")),
+					Name:      "example-name",
+					Namespace: lo.ToPtr(gatewayapi.Namespace("example-namespace")),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not allowed when not in grant and using different namespace",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example-namespace-2",
+					Name:      "example-name",
+				},
+			},
+			backendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Kind:      lo.ToPtr(gatewayapi.Kind("example-kind")),
+					Group:     lo.ToPtr(gatewayapi.Group("example-group")),
+					Name:      "example-name",
+					Namespace: lo.ToPtr(gatewayapi.Namespace("example-namespace")),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rc := newRefCheckerForRoute(tc.route, tc.backendRef)
+			result := rc.IsRefAllowedByGrant(tc.allowedRefs)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When route has the same namespace specified as the backendref, then it should be allowed without a `ReferenceGrant`.

Additionally this PR adds `Service` lookup in ` backendRefsToKongStateBackends()` to verify if the provided namespace exists.

The gist of this change is in `internal/dataplane/translator/backendref.go`. The rest is just adapting the tests basically.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Fixes: #5388

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
