### PR TITLE
fix(annotations) allow WebSocket protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ Adding a new version? You'll need three changes:
 - Allow configuring a GRPCRoute without hostnames and matches that catch all
   requests.
   [#5303](https://github.com/Kong/kubernetes-ingress-controller/pull/5303)
+- Allow the `ws` and `wss` Enterprise protocol values for protocol annotations.
+  [#5399](https://github.com/Kong/kubernetes-ingress-controller/pull/5399)
 
 ### Changed
 

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
@@ -35,6 +36,10 @@ func ValidateHTTPRoute(
 	// validate that no unsupported features are in use
 	if err := validateHTTPRouteFeatures(httproute, translatorFeatures); err != nil {
 		return false, fmt.Sprintf("HTTPRoute spec did not pass validation: %s", err), nil
+	}
+
+	if err := validation.ValidateRouteSourceAnnotations(httproute); err != nil {
+		return false, fmt.Sprintf("HTTPRoute has invalid Kong annotations: %s", err), nil
 	}
 
 	// perform Gateway validations for the HTTPRoute (e.g. listener validation, namespace validation, e.t.c.)

--- a/internal/admission/validation/ingress/ingress.go
+++ b/internal/admission/validation/ingress/ingress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	netv1 "k8s.io/api/networking/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
@@ -32,6 +33,11 @@ func ValidateIngress(
 		errMsgs           []string
 		failuresCollector = failures.NewResourceFailuresCollector(logger)
 	)
+
+	if err := validation.ValidateRouteSourceAnnotations(ingress); err != nil {
+		return false, fmt.Sprintf("Ingress has invalid Kong annotations: %s", err), nil
+	}
+
 	for _, kg := range ingressToKongRoutesForValidation(translatorFeatures, ingress, failuresCollector, storer) {
 		kg := kg
 		// Validate by using feature of Kong Gateway.

--- a/internal/admission/validation/ingress/ingress_test.go
+++ b/internal/admission/validation/ingress/ingress_test.go
@@ -1,0 +1,71 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+)
+
+func TestValidateIngress(t *testing.T) {
+	for _, tt := range []struct {
+		msg           string
+		ingress       *netv1.Ingress
+		valid         bool
+		validationMsg string
+		err           error
+	}{
+		{
+			msg: "invalid protocols",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.ProtocolsKey: "ohno",
+					},
+				},
+			},
+			valid:         false,
+			validationMsg: "Ingress has invalid Kong annotations: invalid konghq.com/protocols value: ohno",
+		},
+	} {
+		t.Run(tt.msg, func(t *testing.T) {
+			logger := zapr.NewLogger(zap.NewNop())
+			fakestore, err := store.NewFakeStore(store.FakeObjects{
+				IngressesV1: []*netv1.Ingress{
+					tt.ingress,
+				},
+			})
+			require.NoError(t, err)
+			valid, validMsg, err := ValidateIngress(
+				context.Background(),
+				mockRoutesValidator{},
+				translator.FeatureFlags{},
+				tt.ingress,
+				logger,
+				fakestore,
+			)
+			assert.Equal(t, tt.valid, valid, tt.msg)
+			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)
+			assert.Equal(t, tt.err, err, tt.msg)
+		})
+	}
+}
+
+type mockRoutesValidator struct{}
+
+func (mockRoutesValidator) Validate(_ context.Context, _ *kong.Route) (bool, string, error) {
+	return true, "", nil
+}

--- a/internal/admission/validation/routelike.go
+++ b/internal/admission/validation/routelike.go
@@ -1,0 +1,20 @@
+package validation
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+)
+
+func ValidateRouteSourceAnnotations(obj client.Object) error {
+	protocols := annotations.ExtractProtocolNames(obj.GetAnnotations())
+	for _, protocol := range protocols {
+		if !util.ValidateProtocol(protocol) {
+			return fmt.Errorf("invalid %s value: %s", annotations.AnnotationPrefix+annotations.ProtocolsKey, protocol)
+		}
+	}
+	return nil
+}

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -214,12 +214,13 @@ func (ks *KongState) FillOverrides(
 
 		// Routes
 		for j := 0; j < len(ks.Services[i].Routes); j++ {
-			// routes nested under Services here do not include their original parent object info in kongstate. translators
-			// convert this into a util.K8sObjectInfo, which includes name/namespace/GVK as strings. unfortunately we can't
+			// Routes, opposed to Services, are not validated in their override method therefore we have no error check here.
+			// Routes nested under Services here do not include their original parent object info in kongstate. Translators
+			// convert this into a util.K8sObjectInfo, which includes name/namespace/GVK as strings. Unfortunately we can't
 			// really convert this into a client.Object for use with the failures collector, and plumbing the original object
-			// down into the kongstate route copy looked a bit annoying. protocol validation for routes instead lives in the
+			// down into the kongstate.Route copy looked a bit annoying. Protocol validation for routes instead lives in the
 			// HTTPRoute and Ingress translators (these may override to ws/wss, whereas the others are expected to derive
-			// their protcol from the resource type alone.
+			// their protcol from the resource type alone).
 			ks.Services[i].Routes[j].override(logger)
 		}
 	}

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -1313,7 +1313,7 @@ func TestFillVaults(t *testing.T) {
 	}
 }
 
-func TestFillOverridesFailures(t *testing.T) {
+func TestFillOverrides_ServiceFailures(t *testing.T) {
 	tests := []struct {
 		name                               string
 		state                              *KongState

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -186,7 +186,7 @@ func TestOverrideService(t *testing.T) {
 func TestNilServiceOverrideDoesntPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		var nilService *Service
-		nilService.override()
+		nilService.override() //nolint:errcheck
 	})
 }
 
@@ -527,6 +527,6 @@ func TestServiceOverride_DeterministicOrderWhenMoreThan1KubernetesService(t *tes
 
 	// We expect default/service-3 to be the last one to be processed effectively overriding the previous annotations.
 	const expectedRetries = 3
-	service.override()
+	require.NoError(t, service.override())
 	require.Equal(t, expectedRetries, *service.Service.Retries)
 }

--- a/internal/util/protocol.go
+++ b/internal/util/protocol.go
@@ -4,8 +4,11 @@ import "regexp"
 
 // ValidateProtocol returns a bool of whether string is a valid protocol.
 func ValidateProtocol(protocol string) bool {
+	if protocol == "" {
+		return true
+	}
 	match := validProtocols.MatchString(protocol)
 	return match
 }
 
-var validProtocols = regexp.MustCompile(`\Ahttps$|\Ahttp$|\Agrpc$|\Agrpcs|\Atcp|\Atls|\Atls_passthrough$`)
+var validProtocols = regexp.MustCompile(`\Ahttps$|\Ahttp$|\Agrpc$|\Agrpcs|\Aws$|\Awss|\Atcp|\Atls|\Atls_passthrough$`)

--- a/internal/util/protocol_test.go
+++ b/internal/util/protocol_test.go
@@ -12,10 +12,13 @@ func TestValidateProtocol(t *testing.T) {
 		input  string
 		result bool
 	}{
+		{"", true},
 		{"http", true},
 		{"https", true},
 		{"grpc", true},
 		{"grpcs", true},
+		{"ws", true},
+		{"wss", true},
 		{"tls", true},
 		{"tcp", true},
 		{"tls_passthrough", true},


### PR DESCRIPTION
**What this PR does / why we need it**:

Accept the `wss` and `ws` protocols in the protocol annotation value filter. Enterprise added these at some point (see FT-2127 internally) for additional plugin capabilities (`https` and `http` accept WebSocket traffic also, but can't inspect the stream after the initial Upgrade request and 101 response) but we never updated the filter.

**Which issue this PR fixes**:

Reported by field teams in chat. Attempting to use `ws` or `wss` instead gets you a route with the default `http,https` in 3.0 and older.

**Special notes for your reviewer**:

Test tools for WebSockets seem annoyingly uncommon. There's not really an httpbin equivalent that I could find, so we'd probably need to add functionality to our echo server to do integration tests. Unit tests are probably fine for the filter itself, but it'd be nice to test WebSocket functionality in general. For manual testing, I built an image and created 
[wss-example.yaml.txt](https://github.com/Kong/kubernetes-ingress-controller/files/13834849/wss-example.yaml.txt) (https://websocket.org/tools/websocket-echo-server is a hosted echo service) and used https://www.npmjs.com/package/wscat to connect to that ExternalName Service.

As noted in the override comment, the way we handle route object parents, parent info in kongstate doesn't include the original object and thus can't use the failures system. Validating protocols is easy enough earlier in the translators, but it'd be nice to do it all in one place. I only validated Ingress and HTTPRoute there, since WebSockets are the odd protocol out that doesn't have a dedicated GWAPI resource type.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
