### PR TITLE
chore: remove undocumented field `net.port` in ATC expressions

### DIFF
--- a/internal/dataplane/translator/atc/field.go
+++ b/internal/dataplane/translator/atc/field.go
@@ -64,7 +64,6 @@ func (f IntField) String() string {
 // https://docs.konghq.com/gateway/latest/reference/router-expressions-language/#available-fields
 
 const (
-	FieldNetPort    IntField = "net.port"
 	FieldNetDstPort IntField = "net.dst.port"
 )
 

--- a/internal/dataplane/translator/atc/predicate_test.go
+++ b/internal/dataplane/translator/atc/predicate_test.go
@@ -38,14 +38,14 @@ func TestNewPredicate(t *testing.T) {
 		},
 		{
 			name:          "unmatched types (LHS integer RHS string)",
-			lhs:           FieldNetPort,
+			lhs:           FieldNetDstPort,
 			op:            OpEqual,
 			rhs:           StringLiteral("/"),
 			expectedError: ErrTypeNotMatch,
 		},
 		{
 			name:          "invalid operator (contains for integer)",
-			lhs:           FieldNetPort,
+			lhs:           FieldNetDstPort,
 			op:            OpContains,
 			rhs:           IntLiteral(10),
 			expectedError: ErrOperatorInvalid,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Per internal discussion of gateway team, `net.port` field is undocumented and will be deprecated in Kong gateway 3.6 (and will be removed in Kong gateway 4.0). Since this field is not used in KIC either, we will also remove the definition of the field.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No need to update changelog because no user facing changes
