### PR TITLE
feat: translate only one if multiple KongVaults with the same spec.prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,9 +133,14 @@ Adding a new version? You'll need three changes:
 - New CRD `KongVault` to reperesent a custom Kong vault for storing senstive
   data used in plugin configurations. Now users can create a `KongVault` to
   create a custom Kong vault and reference the values in configurations of
-  plugins. Reference of using Kong vaults: [Kong vault]
+  plugins. Reference of using Kong vaults: [Kong vault]. Since the prefix of
+  Kong vault is restrained unique, the `spec.prefix` field is set to immutable,
+  and only one of multiple `KongVault`s with the same `spec.prefix` will get
+  translated. Translation failiure events will be recorded for others with
+  duplicating `spec.prefix`.  
   [#5354](https://github.com/Kong/kubernetes-ingress-controller/pull/5354)
   [#5384](https://github.com/Kong/kubernetes-ingress-controller/pull/5384)
+  [#5435](https://github.com/Kong/kubernetes-ingress-controller/pull/5435)
 
 
 ### Fixed

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -82,8 +82,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -83,7 +83,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -187,6 +187,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -397,7 +397,7 @@ KongVaultSpec defines specification of a custom Kong vault.
 | Field | Description |
 | --- | --- |
 | `backend` _string_ | Backend is the type of the backend storing the secrets in the vault. The supported backends of Kong is listed here: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/ |
-| `prefix` _string_ | Prefix is the prefix of vault URI for referencing values in the vault. |
+| `prefix` _string_ | Prefix is the prefix of vault URI for referencing values in the vault. It is immutable after created. |
 | `description` _string_ | Description is the additional information about the vault. |
 | `config` _[JSON](#json)_ | Config is the configuration of the vault. Varies for different backends. |
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -307,6 +307,7 @@ func (ks *KongState) FillVaults(
 	for _, vault := range prefixToKongVault {
 		config, err := RawConfigToConfiguration(vault.Spec.Config.Raw)
 		if err != nil {
+			logger.Error(err, "failed to parse configuration of vault to JSON", "name", vault.Name)
 			failuresCollector.PushResourceFailure(
 				fmt.Sprintf("failed to parse configuration of vault %q to JSON: %v", vault.Name, err),
 				vault,

--- a/pkg/apis/configuration/v1alpha1/kong_vault_types.go
+++ b/pkg/apis/configuration/v1alpha1/kong_vault_types.go
@@ -37,6 +37,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`,description="Description",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
+// +kubebuilder:validation:XValidation:rule="self.spec.prefix == oldSelf.spec.prefix", message="The spec.prefix field is immutable"
 
 // KongVault is the schema for kongvaults API which defines a custom Kong vault.
 // A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
@@ -56,6 +57,7 @@ type KongVaultSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Backend string `json:"backend"`
 	// Prefix is the prefix of vault URI for referencing values in the vault.
+	// It is immutable after created.
 	// +kubebuilder:validation:MinLength=1
 	Prefix string `json:"prefix"`
 	// Description is the additional information about the vault.

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2238,8 +2238,9 @@ spec:
                 description: Description is the additional information about the vault.
                 type: string
               prefix:
-                description: Prefix is the prefix of vault URI for referencing values
-                  in the vault. It is immutable after created.
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
                 minLength: 1
                 type: string
             required:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2239,7 +2239,7 @@ spec:
                 type: string
               prefix:
                 description: Prefix is the prefix of vault URI for referencing values
-                  in the vault.
+                  in the vault. It is immutable after created.
                 minLength: 1
                 type: string
             required:
@@ -2343,6 +2343,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Translate only one of `KongVault`s and record translation failure events for the others if they have the same `spec.prefix` to avoid generating vaults with the same prefix in Kong configuration. The "winner" is chosen by the following rules:
- The one created earlier (earliest `metadata.creationTimestamp`)
- The one having name in smaller lexical order if the creation timestamp is the same.

And the PR also sets `spec.prefix` to be immutable. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5423 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
