### PR TITLE
fix: support ConsumerGroups in KongRawStateToKongState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,9 +156,11 @@ Adding a new version? You'll need three changes:
   [#5303](https://github.com/Kong/kubernetes-ingress-controller/pull/5303)
 - Allow the `ws` and `wss` Enterprise protocol values for protocol annotations.
   [#5399](https://github.com/Kong/kubernetes-ingress-controller/pull/5399)
-- Add a `workspace` paramater in filling IDs of Kong entities to avoid
+- Add a `workspace` parameter in filling IDs of Kong entities to avoid
   duplicate IDs cross different workspaces.
-  [#5401](https://github.com/Kong/kubernetes-ingress-controller/pull/5401) 
+  [#5401](https://github.com/Kong/kubernetes-ingress-controller/pull/5401)
+- Support properly ConsumerGroups when fallback to the last valid configuration.
+  [#5438](https://github.com/Kong/kubernetes-ingress-controller/pull/5438)
 
 ### Changed
 

--- a/internal/dataplane/configfetcher/kongrawstate.go
+++ b/internal/dataplane/configfetcher/kongrawstate.go
@@ -36,6 +36,10 @@ func KongRawStateToKongState(rawstate *utils.KongRawState) *kongstate.KongState 
 		}
 	}
 
+	for _, cg := range rawstate.ConsumerGroups {
+		kongState.ConsumerGroups = append(kongState.ConsumerGroups, kongstate.ConsumerGroup{ConsumerGroup: sanitizeConsumerGroup(*cg.ConsumerGroup)})
+	}
+
 	targets := make(map[string][]*kong.Target)
 	for _, u := range rawstate.Targets {
 		if u.Upstream != nil && u.Upstream.ID != nil {
@@ -271,6 +275,12 @@ func sanitizeConsumer(consumer kong.Consumer) kong.Consumer {
 	consumer.ID = nil
 	consumer.CreatedAt = nil
 	return consumer
+}
+
+func sanitizeConsumerGroup(consumerGroup kong.ConsumerGroup) kong.ConsumerGroup {
+	consumerGroup.ID = nil
+	consumerGroup.CreatedAt = nil
+	return consumerGroup
 }
 
 type authT interface {

--- a/internal/dataplane/configfetcher/kongrawstate_test.go
+++ b/internal/dataplane/configfetcher/kongrawstate_test.go
@@ -94,6 +94,14 @@ func TestKongRawStateToKongState(t *testing.T) {
 						CustomID: kong.String("customID"),
 					},
 				},
+				ConsumerGroups: []*kong.ConsumerGroupObject{
+					{
+						ConsumerGroup: &kong.ConsumerGroup{
+							ID:   kong.String("consumerGroup"),
+							Name: kong.String("consumerGroup"),
+						},
+					},
+				},
 				KeyAuths: []*kong.KeyAuth{
 					{
 						ID:  kong.String("keyAuth"),
@@ -209,6 +217,13 @@ func TestKongRawStateToKongState(t *testing.T) {
 						Cert: kong.String("cert"),
 					},
 				},
+				ConsumerGroups: []kongstate.ConsumerGroup{
+					{
+						ConsumerGroup: kong.ConsumerGroup{
+							Name: kong.String("consumerGroup"),
+						},
+					},
+				},
 				Consumers: []kongstate.Consumer{
 					{
 						Consumer: kong.Consumer{
@@ -315,7 +330,6 @@ func ensureAllKongRawStateFieldsAreTested(t *testing.T, testedFields []string) {
 	kongRawStateFieldsKICDoesntSupport := []string{
 		// These are fields that KIC explicitly doesn't support.
 		"SNIs",
-		"ConsumerGroups",
 		"CustomEntities",
 		"Vaults",
 		"RBACRoles",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Support properly ConsumerGroups when fallback to the last valid configuration. Function `configfetcher.KongRawStateToKongState` now supports `ConsumerGroup` entities. It means that if KIC fetches the last valid configuration from Gateways, it will include all `ConsumerGroups` that a Gateway may return.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5377

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Having explicitly omitted checking this in `internal/dataplane/configfetcher/kongrawstate_test.go:318` caused that the test hasn't caught it during the work on `ConsumerGroup`. **I thing the same may happen for `Vault`** 🤔 

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
