### PR TITLE
feat: add Programmed condition to KongUpstreamPolicy ancestors status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,9 +131,10 @@ Adding a new version? You'll need three changes:
   enforce `KongUpstreamPolicy` status. 
   The controller will set an ancestor status in `KongUpstreamPolicy` status for 
   each of its ancestors (i.e. `Service` or `KongServiceFacade`) with the `Accepted`
-  condition.
+  and `Programmed` condition.
   [#5185](https://github.com/Kong/kubernetes-ingress-controller/pull/5185)
   [#5428](https://github.com/Kong/kubernetes-ingress-controller/pull/5428)
+  [#5444](https://github.com/Kong/kubernetes-ingress-controller/pull/5444)
 - New CRD `KongVault` to reperesent a custom Kong vault for storing senstive
   data used in plugin configurations. Now users can create a `KongVault` to
   create a custom Kong vault and reference the values in configurations of

--- a/internal/controllers/configuration/kongupstreampolicy_utils_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
 	gatewaycontroller "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
@@ -37,6 +38,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 		name                             string
 		kongUpstreamPolicy               kongv1beta1.KongUpstreamPolicy
 		inputObjects                     []client.Object
+		objectsConfiguredInDataPlane     bool
 		expectedKongUpstreamPolicyStatus gatewayapi.PolicyStatus
 		updated                          bool
 	}{
@@ -100,6 +102,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 					},
 				},
 			},
+			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
 					{
@@ -116,6 +119,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
 							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
+							},
 						},
 					},
 					{
@@ -131,6 +139,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Type:   string(gatewayapi.PolicyConditionAccepted),
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
 							},
 						},
 					},
@@ -161,6 +174,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 									Status: metav1.ConditionTrue,
 									Reason: string(gatewayapi.PolicyReasonAccepted),
 								},
+								{
+									Type:   string(gatewayapi.GatewayConditionProgrammed),
+									Status: metav1.ConditionTrue,
+									Reason: string(gatewayapi.GatewayReasonProgrammed),
+								},
 							},
 						},
 						{
@@ -176,6 +194,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 									Type:   string(gatewayapi.PolicyConditionAccepted),
 									Status: metav1.ConditionTrue,
 									Reason: string(gatewayapi.PolicyReasonAccepted),
+								},
+								{
+									Type:   string(gatewayapi.GatewayConditionProgrammed),
+									Status: metav1.ConditionTrue,
+									Reason: string(gatewayapi.GatewayReasonProgrammed),
 								},
 							},
 						},
@@ -234,6 +257,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 					},
 				},
 			},
+			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
 					{
@@ -250,6 +274,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
 							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
+							},
 						},
 					},
 					{
@@ -265,6 +294,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Type:   string(gatewayapi.PolicyConditionAccepted),
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
 							},
 						},
 					},
@@ -332,6 +366,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 					},
 				},
 			},
+			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
 					{
@@ -347,6 +382,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Type:   string(gatewayapi.PolicyConditionAccepted),
 								Status: metav1.ConditionFalse,
 								Reason: string(gatewayapi.PolicyReasonConflicted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionFalse,
+								Reason: string(gatewayapi.GatewayReasonPending),
 							},
 						},
 					},
@@ -418,6 +458,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 					},
 				},
 			},
+			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
 					{
@@ -433,6 +474,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Type:   string(gatewayapi.PolicyConditionAccepted),
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
 							},
 						},
 					},
@@ -487,6 +533,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 					},
 				},
 			},
+			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
 					{
@@ -503,6 +550,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
 							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
+							},
 						},
 					},
 					{
@@ -518,6 +570,107 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 								Type:   string(gatewayapi.PolicyConditionAccepted),
 								Status: metav1.ConditionTrue,
 								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
+							},
+						},
+					},
+				},
+			},
+			updated: true,
+		},
+		{
+			name: "service and kong service facade not configured in data plane, programmed=false",
+			kongUpstreamPolicy: kongv1beta1.KongUpstreamPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      policyName,
+					Namespace: testNamespace,
+				},
+			},
+			inputObjects: []client.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
+						},
+						CreationTimestamp: metav1.Now(),
+					},
+				},
+				&incubatorv1alpha1.KongServiceFacade{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-facade-1",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
+						},
+						CreationTimestamp: metav1.Time{
+							Time: metav1.Now().Add(10 * time.Second),
+						},
+					},
+				},
+				&gatewayapi.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httpRoute",
+						Namespace: testNamespace,
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("svc-1").Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			objectsConfiguredInDataPlane: false,
+			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
+				Ancestors: []gatewayapi.PolicyAncestorStatus{
+					{
+						AncestorRef: gatewayapi.ParentReference{
+							Group:     lo.ToPtr(gatewayapi.Group("core")),
+							Kind:      lo.ToPtr(gatewayapi.Kind("Service")),
+							Namespace: lo.ToPtr(gatewayapi.Namespace(testNamespace)),
+							Name:      gatewayapi.ObjectName("svc-1"),
+						},
+						ControllerName: gatewaycontroller.GetControllerName(),
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayapi.PolicyConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionFalse,
+								Reason: string(gatewayapi.GatewayReasonPending),
+							},
+						},
+					},
+					{
+						AncestorRef: gatewayapi.ParentReference{
+							Group:     lo.ToPtr(gatewayapi.Group(incubatorv1alpha1.GroupVersion.Group)),
+							Kind:      lo.ToPtr(gatewayapi.Kind(incubatorv1alpha1.KongServiceFacadeKind)),
+							Namespace: lo.ToPtr(gatewayapi.Namespace(testNamespace)),
+							Name:      gatewayapi.ObjectName("svc-facade-1"),
+						},
+						ControllerName: gatewaycontroller.GetControllerName(),
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayapi.PolicyConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionFalse,
+								Reason: string(gatewayapi.GatewayReasonPending),
 							},
 						},
 					},
@@ -543,6 +696,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 
 			reconciler := KongUpstreamPolicyReconciler{
 				Client:                   fakeClient,
+				DataplaneClient:          DataPlaneStatusClientMock{ObjectsConfigured: tc.objectsConfiguredInDataPlane},
 				KongServiceFacadeEnabled: true,
 			}
 
@@ -558,6 +712,15 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 			assert.Empty(t, cmp.Diff(tc.expectedKongUpstreamPolicyStatus, newPolicy.Status, ignoreLastTransitionTime))
 		})
 	}
+}
+
+type DataPlaneStatusClientMock struct {
+	controllers.DataPlane
+	ObjectsConfigured bool
+}
+
+func (d DataPlaneStatusClientMock) KubernetesObjectIsConfigured(client.Object) bool {
+	return d.ObjectsConfigured
 }
 
 func TestHttpRouteHasUpstreamPolicyConflictedBackendRefsWithService(t *testing.T) {
@@ -709,21 +872,28 @@ func TestBuildPolicyStatus(t *testing.T) {
 		Status: metav1.ConditionTrue,
 		Reason: string(gatewayapi.PolicyReasonAccepted),
 	}
+	programmedCondition := metav1.Condition{
+		Type:   string(gatewayapi.GatewayConditionProgrammed),
+		Status: metav1.ConditionTrue,
+		Reason: string(gatewayapi.GatewayReasonProgrammed),
+	}
 
 	serviceStatus := func(name string, creationTimestamp time.Time) ancestorStatus {
 		return ancestorStatus{
-			namespacedName:    k8stypes.NamespacedName{Namespace: "default", Name: name},
-			ancestorKind:      upstreamPolicyAncestorKindService,
-			acceptedCondition: acceptedCondition,
-			creationTimestamp: metav1.NewTime(creationTimestamp),
+			namespacedName:      k8stypes.NamespacedName{Namespace: "default", Name: name},
+			ancestorKind:        upstreamPolicyAncestorKindService,
+			acceptedCondition:   acceptedCondition,
+			programmedCondition: programmedCondition,
+			creationTimestamp:   metav1.NewTime(creationTimestamp),
 		}
 	}
 	serviceFacadeStatus := func(name string, creationTimestamp time.Time) ancestorStatus {
 		return ancestorStatus{
-			namespacedName:    k8stypes.NamespacedName{Namespace: "default", Name: name},
-			ancestorKind:      upstreamPolicyAncestorKindKongServiceFacade,
-			acceptedCondition: acceptedCondition,
-			creationTimestamp: metav1.NewTime(creationTimestamp),
+			namespacedName:      k8stypes.NamespacedName{Namespace: "default", Name: name},
+			ancestorKind:        upstreamPolicyAncestorKindKongServiceFacade,
+			acceptedCondition:   acceptedCondition,
+			programmedCondition: programmedCondition,
+			creationTimestamp:   metav1.NewTime(creationTimestamp),
 		}
 	}
 
@@ -738,6 +908,7 @@ func TestBuildPolicyStatus(t *testing.T) {
 			ControllerName: gatewaycontroller.GetControllerName(),
 			Conditions: []metav1.Condition{
 				acceptedCondition,
+				programmedCondition,
 			},
 		}
 	}
@@ -752,6 +923,7 @@ func TestBuildPolicyStatus(t *testing.T) {
 			ControllerName: gatewaycontroller.GetControllerName(),
 			Conditions: []metav1.Condition{
 				acceptedCondition,
+				programmedCondition,
 			},
 		}
 	}
@@ -872,6 +1044,21 @@ func TestIsSupportedHTTPRouteBackendRef(t *testing.T) {
 				Kind: lo.ToPtr(gatewayapi.Kind("UnsupportedKind")),
 			},
 			expected: false,
+		},
+		{
+			name: "empty group",
+			backendRef: gatewayapi.BackendObjectReference{
+				Group: lo.ToPtr(gatewayapi.Group("")),
+				Kind:  lo.ToPtr(gatewayapi.Kind("Service")),
+			},
+			expected: true,
+		},
+		{
+			name: "empty group with nil kind",
+			backendRef: gatewayapi.BackendObjectReference{
+				Group: lo.ToPtr(gatewayapi.Group("")),
+			},
+			expected: true,
 		},
 	}
 

--- a/internal/controllers/dataplane.go
+++ b/internal/controllers/dataplane.go
@@ -13,8 +13,12 @@ import (
 // with the Kong dataplane.
 type DataPlane interface {
 	DataPlaneClient
+	DataPlaneStatusClient
 
 	Listeners(ctx context.Context) ([]kong.ProxyListener, []kong.StreamListener, error)
+}
+
+type DataPlaneStatusClient interface {
 	AreKubernetesObjectReportsEnabled() bool
 	KubernetesObjectConfigurationStatus(obj client.Object) k8sobj.ConfigurationStatus
 	KubernetesObjectIsConfigured(obj client.Object) bool

--- a/internal/dataplane/translator/ingressrules.go
+++ b/internal/dataplane/translator/ingressrules.go
@@ -358,6 +358,10 @@ func resolveKubernetesServiceForBackend(
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch Service %s/%s: %w", backend.Namespace(), backend.Name(), err)
 	}
+
+	// After Kubernetes Service is fetched successfully, we can consider it a translated object.
+	translatedObjectsCollector.Add(k8sService)
+
 	return k8sService, nil
 }
 

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -270,6 +270,7 @@ func setupControllers(
 					DataplaneClient:          dataplaneClient,
 					CacheSyncTimeout:         c.CacheSyncTimeout,
 					KongServiceFacadeEnabled: featureGates.Enabled(featuregates.KongServiceFacade) && c.KongServiceFacadeEnabled,
+					StatusQueue:              kubernetesStatusQueue,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `Programmed` condition to `KongUpstreamPolicy` ancestors status for `Service` and `KongServiceFacade` based on their configuration status in the data plane.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5249.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
