### PR TITLE
feat: allow multiple subscribers on single GVK status updates

### DIFF
--- a/internal/util/kubernetes/object/status/queue.go
+++ b/internal/util/kubernetes/object/status/queue.go
@@ -24,7 +24,7 @@ type Queue struct {
 	subscriptionBufferSize int
 
 	// subscriptions indexed by the string representation of the object GVK.
-	subscriptions map[string]chan event.GenericEvent
+	subscriptions map[string][]chan event.GenericEvent
 
 	// lock protects the subscriptions map.
 	lock sync.RWMutex
@@ -46,11 +46,12 @@ func WithBufferSize(size int) QueueOption {
 func NewQueue(opts ...QueueOption) *Queue {
 	q := &Queue{
 		subscriptionBufferSize: DefaultBufferSize,
-		subscriptions:          make(map[string]chan event.GenericEvent),
+		subscriptions:          make(map[string][]chan event.GenericEvent),
 	}
 	for _, opt := range opts {
 		opt(q)
 	}
+
 	return q
 }
 
@@ -58,45 +59,34 @@ func NewQueue(opts ...QueueOption) *Queue {
 // subscribers that the status of that object needs to be updated.
 // It's a no-op if there are no subscriptions for the object kind.
 func (q *Queue) Publish(obj client.Object) {
-	ch, ok := q.getSubscriptionForKind(obj.GetObjectKind().GroupVersionKind())
-	if !ok {
-		// There's no subscriber for this object kind - nothing to do.
-		return
+	// Publish the event to all subscribers.
+	for _, ch := range q.getSubscriptionsForKind(obj.GetObjectKind().GroupVersionKind()) {
+		ch <- event.GenericEvent{Object: obj}
 	}
-	ch <- event.GenericEvent{Object: obj}
 }
 
 // Subscribe provides a consumer channel where generic events for the provided
 // object kind will be published when the status for the object needs to be
 // updated.
 //
-// Note that more than one consumer can subscribe to a channel for a particular
-// object kind, but that this only represents a single channel: events will not
-// be duplicated and each subscriber will receive events on a first come first
-// serve basis.
+// Please note every call to Subscribe will create a new subscription channel.
 func (q *Queue) Subscribe(gvk schema.GroupVersionKind) chan event.GenericEvent {
-	return q.getOrCreateSubscriptionForKind(gvk)
+	return q.createSubscriptionForKind(gvk)
 }
 
-// getOrCreateSubscriptionForKind returns the subscription channel for the provided object GVK.
-// If the channel does not exist, it will be created.
-func (q *Queue) getOrCreateSubscriptionForKind(gvk schema.GroupVersionKind) chan event.GenericEvent {
+// createSubscriptionForKind creates a new subscription channel for the provided object GVK and returns it.
+func (q *Queue) createSubscriptionForKind(gvk schema.GroupVersionKind) chan event.GenericEvent {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	ch, ok := q.subscriptions[gvk.String()]
-	if !ok {
-		// If there's no channel built for this kind yet, make it.
-		ch = make(chan event.GenericEvent, q.subscriptionBufferSize)
-		q.subscriptions[gvk.String()] = ch
-	}
-	return ch
+	newSubscriptionCh := make(chan event.GenericEvent, q.subscriptionBufferSize)
+	q.subscriptions[gvk.String()] = append(q.subscriptions[gvk.String()], newSubscriptionCh)
+	return newSubscriptionCh
 }
 
-// getSubscriptionForKind returns the subscription channel for the provided object GVK.
-// The second return value indicates whether the channel exists.
-func (q *Queue) getSubscriptionForKind(gvk schema.GroupVersionKind) (chan event.GenericEvent, bool) {
+// getSubscriptionsForKind returns all the subscription channels for the provided object GVK.
+// It may return nil if there are no subscriptions for the object kind.
+func (q *Queue) getSubscriptionsForKind(gvk schema.GroupVersionKind) []chan event.GenericEvent {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
-	ch, ok := q.subscriptions[gvk.String()]
-	return ch, ok
+	return q.subscriptions[gvk.String()]
 }

--- a/internal/util/kubernetes/object/status/queue.go
+++ b/internal/util/kubernetes/object/status/queue.go
@@ -76,9 +76,9 @@ func (q *Queue) Subscribe(gvk schema.GroupVersionKind) chan event.GenericEvent {
 
 // createSubscriptionForKind creates a new subscription channel for the provided object GVK and returns it.
 func (q *Queue) createSubscriptionForKind(gvk schema.GroupVersionKind) chan event.GenericEvent {
+	newSubscriptionCh := make(chan event.GenericEvent, q.subscriptionBufferSize)
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	newSubscriptionCh := make(chan event.GenericEvent, q.subscriptionBufferSize)
 	q.subscriptions[gvk.String()] = append(q.subscriptions[gvk.String()], newSubscriptionCh)
 	return newSubscriptionCh
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

So far, we haven't had a case where we'd need two separate subscribers to receive channel status update notifications for a single GVK. https://github.com/Kong/kubernetes-ingress-controller/pull/5444 introduces a `Watch` in `KongUpstreamPolicy` controller that needs to receive status updates of `KongServiceFacade` which already has one subscriber in its controller. This PR mitigates issues that might occur because of multiple subscribers consuming notifications from a single channel by creating a separate channel for every `Subscribe` call. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up of https://github.com/Kong/kubernetes-ingress-controller/pull/5444.
