### PR TITLE
chore(deps): bump go in go.mod to 1.21.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.21.1
+go 1.21.6
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //


### PR DESCRIPTION
**What this PR does / why we need it**:

With go 1.21.1 `golangci-lint` fails like so:

```console
ERRO [linters_context/goanalysis] nilness: panic during analysis: runtime error: index out of range [1] with length 1, goroutine 27331 [running]:
runtime/debug.Stack()
	/home/yitao/go1.21/go/src/runtime/debug/stack.go:24 +0x5e
...
```

Upgrading Golang version to 1.21.6 version fixes that.
