### PR TITLE
chore: document latest tag update in docs on release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -58,7 +58,7 @@ body:
       - label: Update `reference/version-compatibility.md` to include the new versions (make sure you capture any new Kubernetes/Istio versions that have been tested)
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.
       - label: Make sure that `app/_data/docs_nav_kic_NEWVERSION.yml` links to the latest generated `custom-resources-X.X.X.md`.
-      - label: Add a section to `app/_data/kong_versions.yml` for your version.
+      - label: Add a section to `app/_data/kong_versions.yml` for your version and move the `latest` field to version that's being released.
       - label: "Add entries in support policy documents: `app/_includes/md/support-policy.md` and `app/_src/kubernetes-ingress-controller/support-policy.md`."
       - label: Mark the PR ready for review.
       - label: Inform and ping the @Kong/team-k8s via slack of impending release with a link to the release PR.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a mention of updating the `latest` tag in docs repository in `app/_data/kong_versions.yml` like so: https://github.com/Kong/docs.konghq.com/blob/8e867c08455238a32e63e9bb723e9d9919eec6da/app/_data/kong_versions.yml#L263 during release.

This allows devs to work on documentation for yet unreleased versions and merge this work to main branch without publishing it.
