### PR TITLE
 fix: remove stale parent statuses from HTTPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,9 @@ Adding a new version? You'll need three changes:
   if the config was being updated while the HTTP endpoint was being hit at the same
   time.
   [#5474](https://github.com/Kong/kubernetes-ingress-controller/pull/5474)
+- Stale `HTTPRoute`'s parent statuses are now removed when the `HTTPRoute` no longer
+  defines a parent `Gateway` in its `spec.parentRefs`.
+  [#5477](https://github.com/Kong/kubernetes-ingress-controller/pull/5477)
 
 ### Changed
 

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -795,5 +796,12 @@ func parentReferenceKey(routeNamespace string, parentRef gatewayapi.ParentRefere
 	if parentRef.SectionName != nil {
 		sectionName = string(*parentRef.SectionName)
 	}
-	return fmt.Sprintf("%s/%s/%s", namespace, parentRef.Name, sectionName)
+	portNumber := ""
+	if parentRef.Port != nil {
+		portNumber = strconv.Itoa(int(*parentRef.Port))
+	}
+
+	// We intentionally do not take into account Kind and Group here as we only support Gateways
+	// and that's the only kind we should be getting here thanks to the admission webhook validation.
+	return fmt.Sprintf("%s/%s/%s/%s", namespace, parentRef.Name, sectionName, portNumber)
 }

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -417,6 +418,14 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	// Ensure we have no status for no-longer defined parentRefs.
+	if wasAnyStatusRemoved := ensureNoStaleParentStatus(httproute); wasAnyStatusRemoved {
+		if err := r.Status().Update(ctx, httproute); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// the referenced gateway object(s) for the HTTPRoute needs to be ready
 	// before we'll attempt any configurations of it. If it's not we'll
 	// requeue the object and wait until all supported gateways are ready.
@@ -751,4 +760,40 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 // SetLogger sets the logger.
 func (r *HTTPRouteReconciler) SetLogger(l logr.Logger) {
 	r.Log = l
+}
+
+// ensureNoStaleParentStatus removes any status references to Gateways that are no longer in the HTTPRoute's parentRefs
+// and returns true if any status was removed.
+func ensureNoStaleParentStatus(httproute *gatewayapi.HTTPRoute) (wasAnyStatusRemoved bool) {
+	// Create a map of currently defined parentRefs for fast lookup.
+	currentlyDefinedParentRefs := make(map[string]struct{})
+	for _, parentRef := range httproute.Spec.ParentRefs {
+		currentlyDefinedParentRefs[parentReferenceKey(httproute.Namespace, parentRef)] = struct{}{}
+	}
+
+	for parentIdx, parentStatus := range httproute.Status.Parents {
+		// Don't touch statuses from other controllers.
+		if parentStatus.ControllerName != GetControllerName() {
+			continue
+		}
+		// Remove the status if the parentRef is no longer defined.
+		if _, ok := currentlyDefinedParentRefs[parentReferenceKey(httproute.Namespace, parentStatus.ParentRef)]; !ok {
+			httproute.Status.Parents = slices.Delete(httproute.Status.Parents, parentIdx, parentIdx+1)
+			wasAnyStatusRemoved = true
+		}
+	}
+	return wasAnyStatusRemoved
+}
+
+// parentReferenceKey returns a string key for a parentRef of a route. It can be used for indexing a map.
+func parentReferenceKey(routeNamespace string, parentRef gatewayapi.ParentReference) string {
+	namespace := routeNamespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+	sectionName := ""
+	if parentRef.SectionName != nil {
+		sectionName = string(*parentRef.SectionName)
+	}
+	return fmt.Sprintf("%s/%s/%s", namespace, parentRef.Name, sectionName)
 }

--- a/internal/controllers/gateway/httproute_controller_test.go
+++ b/internal/controllers/gateway/httproute_controller_test.go
@@ -1,0 +1,160 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+)
+
+func TestEnsureNoStaleParentStatus(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		httproute                *gatewayapi.HTTPRoute
+		expectedAnyStatusRemoved bool
+		expectedStatusesForRefs  []gatewayapi.ParentReference
+	}{
+		{
+			name: "no stale status",
+			httproute: &gatewayapi.HTTPRoute{
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{Name: "defined-in-spec"},
+						},
+					},
+				},
+			},
+			expectedAnyStatusRemoved: false,
+			expectedStatusesForRefs:  nil, // There was no status for `defined-in-spec` created yet.
+		},
+		{
+			name: "no stale status with existing status for spec parent ref",
+			httproute: &gatewayapi.HTTPRoute{
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{Name: "defined-in-spec"},
+						},
+					},
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef:      gatewayapi.ParentReference{Name: "defined-in-spec"},
+							},
+						},
+					},
+				},
+			},
+			expectedStatusesForRefs: []gatewayapi.ParentReference{
+				{Name: "defined-in-spec"},
+			},
+			expectedAnyStatusRemoved: false,
+		},
+		{
+			name: "stale status",
+			httproute: &gatewayapi.HTTPRoute{
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{Name: "defined-in-spec"},
+						},
+					},
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef:      gatewayapi.ParentReference{Name: "not-defined-in-spec"},
+							},
+						},
+					},
+				},
+			},
+			expectedStatusesForRefs:  nil, // There was no status for `defined-in-spec` created yet.
+			expectedAnyStatusRemoved: true,
+		},
+		{
+			name: "stale status with existing status for spec parent ref",
+			httproute: &gatewayapi.HTTPRoute{
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{Name: "defined-in-spec"},
+						},
+					},
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: GetControllerName(),
+								ParentRef:      gatewayapi.ParentReference{Name: "not-defined-in-spec"},
+							},
+							{
+								ControllerName: GetControllerName(),
+								ParentRef:      gatewayapi.ParentReference{Name: "defined-in-spec"},
+							},
+						},
+					},
+				},
+			},
+			expectedStatusesForRefs: []gatewayapi.ParentReference{
+				{Name: "defined-in-spec"},
+			},
+			expectedAnyStatusRemoved: true,
+		},
+		{
+			name: "do not remove status for other controllers",
+			httproute: &gatewayapi.HTTPRoute{
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{Name: "defined-in-spec"},
+						},
+					},
+				},
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{
+						Parents: []gatewayapi.RouteParentStatus{
+							{
+								ControllerName: gatewayapi.GatewayController("another-controller"),
+								ParentRef:      gatewayapi.ParentReference{Name: "not-defined-in-spec"},
+							},
+							{
+								ControllerName: GetControllerName(),
+								ParentRef:      gatewayapi.ParentReference{Name: "defined-in-spec"},
+							},
+						},
+					},
+				},
+			},
+			expectedStatusesForRefs: []gatewayapi.ParentReference{
+				{Name: "not-defined-in-spec"},
+				{Name: "defined-in-spec"},
+			},
+			expectedAnyStatusRemoved: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasAnyStatusRemoved := ensureNoStaleParentStatus(tc.httproute)
+			assert.Equal(t, tc.expectedAnyStatusRemoved, wasAnyStatusRemoved)
+
+			actualStatuses := lo.Map(tc.httproute.Status.Parents, func(status gatewayapi.RouteParentStatus, _ int) string {
+				return parentReferenceKey(tc.httproute.Namespace, status.ParentRef)
+			})
+			expectedStatuses := lo.Map(tc.expectedStatusesForRefs, func(ref gatewayapi.ParentReference, _ int) string {
+				return parentReferenceKey(tc.httproute.Namespace, ref)
+			})
+			assert.ElementsMatch(t, expectedStatuses, actualStatuses)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It ensures we leave no stale parent statuses in `HTTPRoute`s (e.g. after moving a route from one Gateway to another by changing its `spec.parentRefs`).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5277.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
