### PR TITLE
feat(manager) block synchronizer on cache readiness

### DIFF
--- a/internal/dataplane/synchronizer.go
+++ b/internal/dataplane/synchronizer.go
@@ -110,15 +110,6 @@ func NewSynchronizer(logger logr.Logger, client Client, opts ...SynchronizerOpti
 //
 // To stop the server, the provided context must be Done().
 func (p *Synchronizer) Start(ctx context.Context) error {
-	select {
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/2315
-	// This is a temporary mitigation to allow some time for controllers to
-	// populate their dataplaneClient cache.
-	case <-time.After(p.initWaitPeriod):
-	case <-ctx.Done():
-		return fmt.Errorf("Synchronizer Start() interrupted: %w", ctx.Err())
-	}
-
 	// unsure if it makes sense to do this _after_ the lock for any particular reason
 	if sync := p.cache.WaitForCacheSync(ctx); sync == false {
 		return fmt.Errorf("cache did not sync, aborting")

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -154,6 +154,7 @@ func setupDataplaneSynchronizer(
 		dataplaneClient,
 		dataplane.WithStagger(time.Duration(proxySyncSeconds*float32(time.Second))),
 		dataplane.WithInitCacheSyncDuration(initCacheSyncWait),
+		dataplane.WithCache(mgr.GetCache()),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the time-based startup delay in favor of obtaining the manager cache and calling its wait function during synchronizer start. In situations where the cache has not fully synced, the dataplane synchronizer will block until it has. If the cache never syncs within its grace period, a cache sync timeout will terminate the controller, preventing it from ever syncing config.

This better addresses situations where the controller may incorrectly delete configuration upon gaining leadership because it cannot yet see all resources on the cluster. Configuration previously added by another controller replica should remain intact.

The previous naive time-based delay addressed this for some cases, but relied on an arbitrary "good enough" wait time. AFAIK this time did work in practice during normal startup. However, it did not work if the cache sync got stuck, such as when the controller role was broken or when API resources were not defined.

**Which issue this PR fixes**:

Fix https://github.com/Kong/kubernetes-ingress-controller/issues/2315

**Special notes for your reviewer**:

I could have sworn that [we had no means of getting the manager cache](https://github.com/Kong/kubernetes-ingress-controller/issues/2249), that it was reserved for the manager's internal use. I then saw a `GetCache()` call in one of the controllers and re-checked that, and apparently it's (maybe always?) been accessible despite being in an `internal.go`.

Manual testing supports the notion that this works in problem scenarios. I deployed a test image to a normal install and confirmed successful start and config population. While watching the admin API for configuration changes, I deleted the Ingress permissions from the controller role, scaled to 0, and scaled back to 1. The new replica started and blocked without syncing configuration before eventually hitting a cache sync timeout and dying.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
