### PR TITLE
chore: improve Gateway's publish service error logs

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -486,7 +486,14 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 		r.Log.V(util.DebugLevel).Info("Determining service for ref", "ref", ref)
 		svc, err := r.determineServiceForGateway(ctx, ref)
 		if err != nil {
-			log.Error(err, "Could not determine service for gateway", "namespace", gateway.Namespace, "name", gateway.Name)
+			annotation := annotations.AnnotationPrefix + annotations.GatewayPublishServiceKey
+			log.Error(
+				err,
+				fmt.Sprintf("One of publish services defined in Gateway's %q annotation didn't match controller manager's configuration", annotation),
+				"namespace", gateway.Namespace,
+				"name", gateway.Name,
+				"service", ref,
+			)
 			return ctrl.Result{Requeue: true}, err
 		}
 		if svc != nil {
@@ -637,8 +644,12 @@ func (r *GatewayReconciler) determineServiceForGateway(ctx context.Context, ref 
 	case r.PublishServiceUDPRef.IsPresent() && ref == r.PublishServiceUDPRef.MustGet().String():
 		name = r.PublishServiceUDPRef.MustGet()
 	default:
-		return nil, fmt.Errorf("service ref %s did not match controller manager ref %s or %s",
-			ref, r.PublishServiceRef.String(), r.PublishServiceUDPRef.OrEmpty())
+		configuredServiceRefs := []string{fmt.Sprintf("%q", r.PublishServiceRef)}
+		if udpRef, ok := r.PublishServiceUDPRef.Get(); ok {
+			configuredServiceRefs = append(configuredServiceRefs, fmt.Sprintf("%q [udp]", udpRef))
+		}
+		return nil, fmt.Errorf("publish service reference %q from Gateway's annotations did not match configured controller manager's publish services (%s)",
+			ref, strings.Join(configuredServiceRefs, ", "))
 	}
 
 	// retrieve the service for the kong gateway
@@ -647,7 +658,14 @@ func (r *GatewayReconciler) determineServiceForGateway(ctx context.Context, ref 
 		r.Log.V(util.DebugLevel).Info("Service not configured, discarding it", "ref", ref)
 		return nil, nil
 	}
-	return svc, r.Client.Get(ctx, name, svc)
+	if err := r.Client.Get(ctx, name, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("publish service %q couldn't be found: %w", name, err)
+		}
+		return nil, fmt.Errorf("publish service %q couldn't be retrieved: %w", name, err)
+
+	}
+	return svc, nil
 }
 
 // determineL4ListenersFromService generates L4 addresses and listeners for a


### PR DESCRIPTION
**What this PR does / why we need it**:

It improves error logs emitted once a Gateway's publish service (defined in `konghq.com/publish-service` annotation) doesn't match the publish service configured in KIC's `--publish-service` and `--publish-service-udp` CLI flags.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5328.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
