### PR TITLE
test(e2e): set appProtocol to HTTP for kuma tests

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -411,6 +411,9 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+	for i := range service.Spec.Ports {
+		service.Spec.Ports[i].AppProtocol = lo.ToPtr("http")
+	}
 	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -412,9 +412,9 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
 	for i := range service.Spec.Ports {
-    // Set Service's appProtocol to http so that Kuma load-balances requests on HTTP-level instead of TCP. 
-    // TCP load-balancing proved to cause issues with not distributing load evenly in short time spans like in this test.
-    // Ref: https://github.com/Kong/kubernetes-ingress-controller/issues/5498
+		// Set Service's appProtocol to http so that Kuma load-balances requests on HTTP-level instead of TCP.
+		// TCP load-balancing proved to cause issues with not distributing load evenly in short time spans like in this test.
+		// Ref: https://github.com/Kong/kubernetes-ingress-controller/issues/5498
 		service.Spec.Ports[i].AppProtocol = lo.ToPtr("http")
 	}
 	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -412,6 +412,9 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
 	for i := range service.Spec.Ports {
+    // Set Service's appProtocol to http so that Kuma load-balances requests on HTTP-level instead of TCP. 
+    // TCP load-balancing proved to cause issues with not distributing load evenly in short time spans like in this test.
+    // Ref: https://github.com/Kong/kubernetes-ingress-controller/issues/5498
 		service.Spec.Ports[i].AppProtocol = lo.ToPtr("http")
 	}
 	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

As discussed internally, setting `appProtocol` to `HTTP` will make kuma to load balance at request level. While by default kuma may only load balance at the connection level. When Kong gateway changed the `upstream_keepalive_max_requests` from 1000 to 10000: https://github.com/Kong/kong/pull/12223, the upstream connection is reused during all the test which only send about 3000 requests. So the requests constantly go to the same backend pod from one Kong gateway pod. 

I changed `appProtocol` to `http`, the failure disappears in my local run.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

maybe fix #5498 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No changelog required
