### PR TITLE
feat: implement KongLicense controller and inject to translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,8 +167,14 @@ Adding a new version? You'll need three changes:
   sourced from a Secret (i.e. `configFrom` or `configPatches` is used).
   [#5495](https://github.com/Kong/kubernetes-ingress-controller/pull/5495)
 - New CRD `KongLicense` to represent a Kong enterprise license to apply to
-  managed Kong gateway enterprise instances.
+  managed Kong gateway enterprise instances. The `Enabled` field of `KongLicense`
+  (set to `True` if not present) need to be set to true to get reconciled.
+  If there are multiple `KongLicense`s in the cluster, the newest one
+  (with latest `metadata.creationTimestamp`) is chosen. The `KongLicense`
+  controller is disabled when synchoroniztion of license with Konnect is turned
+  on. When sync license with Konnect is turned on, licenses from Konnect are used.  
   [#5487](https://github.com/Kong/kubernetes-ingress-controller/pull/5487)
+  [#5514](https://github.com/Kong/kubernetes-ingress-controller/pull/5514)
 
 ### Fixed
 

--- a/config/crd/bases/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/bases/configuration.konghq.com_konglicenses.yaml
@@ -24,12 +24,9 @@ spec:
       name: Age
       type: date
     - description: Enabled to configure on Kong gateway instances
-      jsonPath: .Enabled
+      jsonPath: .enabled
       name: Enabled
       type: boolean
-    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
-      name: Programmed
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - bases/configuration.konghq.com_ingressclassparameterses.yaml
 - bases/configuration.konghq.com_kongupstreampolicies.yaml
 - bases/configuration.konghq.com_kongvaults.yaml
+- bases/configuration.konghq.com_konglicenses.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -25,6 +25,7 @@
 | `--enable-controller-ingress-class-networkingv1` | `bool` | Enable the networking.k8s.io/v1 IngressClass controller. | `true` |
 | `--enable-controller-ingress-class-parameters` | `bool` | Enable the IngressClassParameters controller. | `true` |
 | `--enable-controller-ingress-networkingv1` | `bool` | Enable the networking.k8s.io/v1 Ingress controller. | `true` |
+| `--enable-controller-kong-license` | `bool` | Enable the KongLicense controller. | `true` |
 | `--enable-controller-kong-service-facade` | `bool` | Enable the KongServiceFacade controller. | `true` |
 | `--enable-controller-kong-upstream-policy` | `bool` | Enable the KongUpstreamPolicy controller. | `true` |
 | `--enable-controller-kong-vault` | `bool` | Enable the KongVault controller. | `true` |

--- a/internal/controllers/configuration/konglicense_controller.go
+++ b/internal/controllers/configuration/konglicense_controller.go
@@ -83,7 +83,6 @@ func kongLicenseKeyFunc(obj interface{}) (string, error) {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Alpha1KongLicenseReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// TODO: it fails when KongLicense CRD is absent. How should we fix it? By wrapping with DynamicCRDController?
 	c, err := controller.New("KongV1Alpha1KongLicense", mgr, controller.Options{
 		Reconciler: r,
 		LogConstructor: func(_ *reconcile.Request) logr.Logger {

--- a/internal/controllers/configuration/konglicense_controller.go
+++ b/internal/controllers/configuration/konglicense_controller.go
@@ -213,7 +213,8 @@ func (r *KongV1Alpha1KongLicenseReconciler) GetLicense() mo.Option[kong.License]
 		return mo.None[kong.License]()
 	}
 	r.Log.V(util.DebugLevel).Info("Get license from KongLicense resource", "name", chosenLicense.Name)
-	// TODO: Validate KongLicense on Kong gateway.
+	// TODO: Validate KongLicense on Kong gateway:
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/5566
 	return mo.Some(kong.License{
 		ID:      kong.String(uuid.NewSHA1(uuid.Nil, []byte("KongLicense:"+chosenLicense.Name)).String()),
 		Payload: kong.String(chosenLicense.RawLicenseString),
@@ -360,7 +361,6 @@ func (r *KongV1Alpha1KongLicenseReconciler) ensureControllerStatusProgrammedCond
 
 // WrapKongLicenseReconcilerToDynamicCRDController wraps KongLicenseReconciler to DynamicCRDController
 // to watch precense of KongLicense CRD to avoid aborts if KongLicense is not installed when controller initialized.
-// REVIEW: Is there a better way to resolve that?
 func WrapKongLicenseReconcilerToDynamicCRDController(
 	ctx context.Context, mgr ctrl.Manager, r *KongV1Alpha1KongLicenseReconciler,
 ) *crds.DynamicCRDController {

--- a/internal/controllers/configuration/konglicense_controller.go
+++ b/internal/controllers/configuration/konglicense_controller.go
@@ -1,0 +1,185 @@
+package configuration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/kong/go-kong/kong"
+	"github.com/samber/mo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
+)
+
+// -----------------------------------------------------------------------------
+// KongV1Alpha1 KongLicense - Reconciler
+// -----------------------------------------------------------------------------
+
+// KongV1Alpha1KongLicenseReconciler reconciles KongLicense resources.
+type KongV1Alpha1KongLicenseReconciler struct {
+	client.Client
+
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	LicenseCache     cache.Store
+	CacheSyncTimeout time.Duration
+	StatusQueue      *status.Queue
+
+	controllerName string
+}
+
+var _ controllers.Reconciler = &KongV1Alpha1KongLicenseReconciler{}
+
+func NewLicenseCache() cache.Store {
+	return cache.NewStore(kongLicenseKeyFunc)
+}
+
+func kongLicenseKeyFunc(obj interface{}) (string, error) {
+	l, ok := obj.(*kongv1alpha1.KongLicense)
+	if !ok {
+		return "", fmt.Errorf("object is type %T, not KongLicense", obj)
+	}
+	return l.Name, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *KongV1Alpha1KongLicenseReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("KongV1Alpha1KongLicense", mgr, controller.Options{
+		Reconciler: r,
+		LogConstructor: func(_ *reconcile.Request) logr.Logger {
+			return r.Log
+		},
+		CacheSyncTimeout: r.CacheSyncTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	// if configured, start the status updater controller
+	if r.StatusQueue != nil {
+		if err := c.Watch(
+			&source.Channel{Source: r.StatusQueue.Subscribe(schema.GroupVersionKind{
+				Group:   "configuration.konghq.com",
+				Version: "v1alpha1",
+				Kind:    "KongLicense",
+			})},
+			&handler.EnqueueRequestForObject{},
+		); err != nil {
+			return err
+		}
+	}
+	return c.Watch(
+		source.Kind(mgr.GetCache(), &kongv1alpha1.KongLicense{}),
+		&handler.EnqueueRequestForObject{},
+		predicate.NewPredicateFuncs(isKongLicenseEnabled),
+	)
+}
+
+// SetLogger sets the logger.
+func (r *KongV1Alpha1KongLicenseReconciler) SetLogger(l logr.Logger) {
+	r.Log = l
+}
+
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=konglicenses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=configuration.konghq.com,resources=konglicenses/status,verbs=get;update;patch
+
+// Reconcile processes the watched objects.
+func (r *KongV1Alpha1KongLicenseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("KongV1Alpha1KongLicense", req.NamespacedName)
+
+	// get the relevant object
+	obj := new(kongv1alpha1.KongLicense)
+
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			obj.Namespace = req.Namespace
+			obj.Name = req.Name
+
+			return ctrl.Result{}, r.LicenseCache.Delete(obj)
+		}
+		return ctrl.Result{}, err
+	}
+	log.V(util.DebugLevel).Info("Reconciling resource", "namespace", req.Namespace, "name", req.Name)
+
+	// clean the object up if it's being deleted
+	if !obj.DeletionTimestamp.IsZero() && time.Now().After(obj.DeletionTimestamp.Time) {
+		log.V(util.DebugLevel).Info("Resource is being deleted, its configuration will be removed", "type", "KongLicense", "namespace", req.Namespace, "name", req.Name)
+
+		_, objectExistsInCache, err := r.LicenseCache.Get(obj)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if objectExistsInCache {
+			if err := r.LicenseCache.Delete(obj); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil // wait until the object is no longer present in the cache
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// update the kong Admin API with the changes
+	if err := r.LicenseCache.Add(obj); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func isKongLicenseEnabled(obj client.Object) bool {
+	kongLicense, ok := obj.(*kongv1alpha1.KongLicense)
+	if !ok {
+		return false
+	}
+	return kongLicense.Enabled
+}
+
+func compareKongLicense(license1, license2 *kongv1alpha1.KongLicense) bool {
+	if license1.CreationTimestamp.Before(&license2.CreationTimestamp) {
+		return true
+	}
+	if license2.CreationTimestamp.Before(&license1.CreationTimestamp) {
+		return false
+	}
+	return license1.Name < license2.Name
+}
+
+func (r *KongV1Alpha1KongLicenseReconciler) GetLicense() mo.Option[kong.License] {
+	licenseList := r.LicenseCache.List()
+	var chosenLicense *kongv1alpha1.KongLicense
+	for _, obj := range licenseList {
+		license, ok := obj.(*kongv1alpha1.KongLicense)
+		if !ok {
+			continue
+		}
+		if chosenLicense == nil || compareKongLicense(license, chosenLicense) {
+			chosenLicense = license
+		}
+	}
+	if chosenLicense == nil {
+		r.Log.V(util.DebugLevel).Info("No available KongLicenses found in cluster")
+		return mo.None[kong.License]()
+	}
+	// convert chosen KongLicense to kong.License
+	// TODO: validate the license against Kong gateway.
+	r.Log.V(util.DebugLevel).Info("Get license from KongLicense resource", "name", chosenLicense.Name)
+	return mo.Some(kong.License{
+		ID:      kong.String(uuid.NewSHA1(uuid.Nil, []byte("KongLicense:"+chosenLicense.Name)).String()),
+		Payload: kong.String(chosenLicense.RawLicenseString),
+	})
+}

--- a/internal/controllers/configuration/konglicense_controller.go
+++ b/internal/controllers/configuration/konglicense_controller.go
@@ -82,6 +82,7 @@ func kongLicenseKeyFunc(obj interface{}) (string, error) {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KongV1Alpha1KongLicenseReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// TODO: it fails when KongLicense CRD is absent. How should we fix it? By wrapping with DynamicCRDController?
 	c, err := controller.New("KongV1Alpha1KongLicense", mgr, controller.Options{
 		Reconciler: r,
 		LogConstructor: func(_ *reconcile.Request) logr.Logger {

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -110,6 +110,7 @@ type Config struct {
 	KongUpstreamPolicyEnabled     bool
 	KongServiceFacadeEnabled      bool
 	KongVaultEnabled              bool
+	KongLicenseEnabled            bool
 
 	// Gateway API toggling.
 	GatewayAPIGatewayController        bool
@@ -256,6 +257,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 		`Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway.`)
 	flagSet.BoolVar(&c.KongServiceFacadeEnabled, "enable-controller-kong-service-facade", true, "Enable the KongServiceFacade controller.")
 	flagSet.BoolVar(&c.KongVaultEnabled, "enable-controller-kong-vault", true, "Enable the KongVault controller.")
+	flagSet.BoolVar(&c.KongLicenseEnabled, "enable-controller-kong-license", true, "Enable the KongLicense controller.")
 
 	// Admission Webhook server config
 	flagSet.StringVar(&c.AdmissionServer.ListenAddr, "admission-webhook-listen", "off",

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -314,21 +314,21 @@ func Run(
 		}
 		configTranslator.InjectLicenseGetter(agent)
 	}
-
+	// enable KongLicense controller if license synchornizition from Konnect is disabled.
 	if c.KongLicenseEnabled && !c.Konnect.LicenseSynchronizationEnabled {
 		setupLog.Info("Starting KongLicense controller")
-		licenseController :=
-			&configuration.KongV1Alpha1KongLicenseReconciler{
-				Client:           mgr.GetClient(),
-				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
-				Scheme:           mgr.GetScheme(),
-				LicenseCache:     configuration.NewLicenseCache(),
-				CacheSyncTimeout: c.CacheSyncTimeout,
-				StatusQueue:      kubernetesStatusQueue,
-			}
+		licenseController := &configuration.KongV1Alpha1KongLicenseReconciler{
+			Client:           mgr.GetClient(),
+			Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
+			Scheme:           mgr.GetScheme(),
+			LicenseCache:     configuration.NewLicenseCache(),
+			CacheSyncTimeout: c.CacheSyncTimeout,
+			StatusQueue:      kubernetesStatusQueue,
+			ControllerName:   c.LeaderElectionID,
+		}
 		err := licenseController.SetupWithManager(mgr)
 		if err != nil {
-			return fmt.Errorf("failed to start KongLicense controller: %v", err)
+			return fmt.Errorf("failed to start KongLicense controller: %w", err)
 		}
 		configTranslator.InjectLicenseGetter(licenseController)
 	}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -326,7 +326,10 @@ func Run(
 			StatusQueue:      kubernetesStatusQueue,
 			ControllerName:   c.LeaderElectionID,
 		}
-		err := licenseController.SetupWithManager(mgr)
+		dynamicLicenseController := configuration.WrapKongLicenseReconcilerToDynamicCRDController(
+			ctx, mgr, licenseController,
+		)
+		err := dynamicLicenseController.SetupWithManager(mgr)
 		if err != nil {
 			return fmt.Errorf("failed to start KongLicense controller: %w", err)
 		}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/configuration"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
@@ -31,9 +30,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
-	konnectLicense "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/telemetry"
@@ -291,49 +288,22 @@ func Run(
 		}
 	}
 
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/3922
-	// This requires the Konnect client, which currently requires c.Konnect.ConfigSynchronizationEnabled also.
-	// We need to figure out exactly how that config surface works. Initial direction says add a separate toggle, but
-	// we probably want to avoid that long term. If we do have separate toggles, we need an AND condition that sets up
-	// the client and makes it available to all Konnect-related subsystems.
-	if c.Konnect.LicenseSynchronizationEnabled {
-		konnectLicenseAPIClient, err := konnectLicense.NewClient(c.Konnect)
-		if err != nil {
-			return fmt.Errorf("failed creating konnect client: %w", err)
-		}
-		setupLog.Info("Starting license agent")
-		agent := license.NewAgent(
-			konnectLicenseAPIClient,
-			ctrl.LoggerFrom(ctx).WithName("license-agent"),
-			license.WithInitialPollingPeriod(c.Konnect.InitialLicensePollingPeriod),
-			license.WithPollingPeriod(c.Konnect.LicensePollingPeriod),
-		)
-		err = mgr.Add(agent)
-		if err != nil {
-			return fmt.Errorf("could not add license agent to manager: %w", err)
-		}
-		configTranslator.InjectLicenseGetter(agent)
+	// Setup and inject license getter.
+	licenseGetter, err := setupLicenseGetter(
+		ctx,
+		c,
+		setupLog,
+		mgr,
+		kubernetesStatusQueue,
+	)
+	if err != nil {
+		setupLog.Error(err, "Failed to create a license getter from configuration")
+		return err
 	}
-	// enable KongLicense controller if license synchornizition from Konnect is disabled.
-	if c.KongLicenseEnabled && !c.Konnect.LicenseSynchronizationEnabled {
-		setupLog.Info("Starting KongLicense controller")
-		licenseController := &configuration.KongV1Alpha1KongLicenseReconciler{
-			Client:           mgr.GetClient(),
-			Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
-			Scheme:           mgr.GetScheme(),
-			LicenseCache:     configuration.NewLicenseCache(),
-			CacheSyncTimeout: c.CacheSyncTimeout,
-			StatusQueue:      kubernetesStatusQueue,
-			ControllerName:   c.LeaderElectionID,
-		}
-		dynamicLicenseController := configuration.WrapKongLicenseReconcilerToDynamicCRDController(
-			ctx, mgr, licenseController,
-		)
-		err := dynamicLicenseController.SetupWithManager(mgr)
-		if err != nil {
-			return fmt.Errorf("failed to start KongLicense controller: %w", err)
-		}
-		configTranslator.InjectLicenseGetter(licenseController)
+	if licenseGetter != nil {
+		setupLog.Info("Inject license getter to config translator",
+			"license_getter_type", fmt.Sprintf("%T", licenseGetter))
+		configTranslator.InjectLicenseGetter(licenseGetter)
 	}
 
 	if c.AnonymousReports {

--- a/pkg/apis/configuration/v1alpha1/kong_license_types.go
+++ b/pkg/apis/configuration/v1alpha1/kong_license_types.go
@@ -5,6 +5,7 @@ import (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=kl,categories=kong-ingress-controller,path=konglicenses

--- a/pkg/apis/configuration/v1alpha1/kong_license_types.go
+++ b/pkg/apis/configuration/v1alpha1/kong_license_types.go
@@ -11,8 +11,7 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
-// +kubebuilder:printcolumn:name="Enabled",type=boolean,JSONPath=`.Enabled`,description="Enabled to configure on Kong gateway instances"
-// +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
+// +kubebuilder:printcolumn:name="Enabled",type=boolean,JSONPath=`.enabled`,description="Enabled to configure on Kong gateway instances"
 
 // KongLicense stores a Kong enterprise license to apply to managed Kong gateway instances.
 type KongLicense struct {

--- a/pkg/clientset/typed/configuration/v1alpha1/configuration_client.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/configuration_client.go
@@ -42,8 +42,8 @@ func (c *ConfigurationV1alpha1Client) IngressClassParameterses(namespace string)
 	return newIngressClassParameterses(c, namespace)
 }
 
-func (c *ConfigurationV1alpha1Client) KongLicenses(namespace string) KongLicenseInterface {
-	return newKongLicenses(c, namespace)
+func (c *ConfigurationV1alpha1Client) KongLicenses() KongLicenseInterface {
+	return newKongLicenses(c)
 }
 
 func (c *ConfigurationV1alpha1Client) KongVaults() KongVaultInterface {

--- a/pkg/clientset/typed/configuration/v1alpha1/fake/fake_configuration_client.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/fake/fake_configuration_client.go
@@ -32,8 +32,8 @@ func (c *FakeConfigurationV1alpha1) IngressClassParameterses(namespace string) v
 	return &FakeIngressClassParameterses{c, namespace}
 }
 
-func (c *FakeConfigurationV1alpha1) KongLicenses(namespace string) v1alpha1.KongLicenseInterface {
-	return &FakeKongLicenses{c, namespace}
+func (c *FakeConfigurationV1alpha1) KongLicenses() v1alpha1.KongLicenseInterface {
+	return &FakeKongLicenses{c}
 }
 
 func (c *FakeConfigurationV1alpha1) KongVaults() v1alpha1.KongVaultInterface {

--- a/pkg/clientset/typed/configuration/v1alpha1/fake/fake_konglicense.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/fake/fake_konglicense.go
@@ -32,7 +32,6 @@ import (
 // FakeKongLicenses implements KongLicenseInterface
 type FakeKongLicenses struct {
 	Fake *FakeConfigurationV1alpha1
-	ns   string
 }
 
 var konglicensesResource = v1alpha1.SchemeGroupVersion.WithResource("konglicenses")
@@ -42,8 +41,7 @@ var konglicensesKind = v1alpha1.SchemeGroupVersion.WithKind("KongLicense")
 // Get takes name of the kongLicense, and returns the corresponding kongLicense object, and an error if there is any.
 func (c *FakeKongLicenses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.KongLicense, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(konglicensesResource, c.ns, name), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootGetAction(konglicensesResource, name), &v1alpha1.KongLicense{})
 	if obj == nil {
 		return nil, err
 	}
@@ -53,8 +51,7 @@ func (c *FakeKongLicenses) Get(ctx context.Context, name string, options v1.GetO
 // List takes label and field selectors, and returns the list of KongLicenses that match those selectors.
 func (c *FakeKongLicenses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.KongLicenseList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(konglicensesResource, konglicensesKind, c.ns, opts), &v1alpha1.KongLicenseList{})
-
+		Invokes(testing.NewRootListAction(konglicensesResource, konglicensesKind, opts), &v1alpha1.KongLicenseList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -75,15 +72,13 @@ func (c *FakeKongLicenses) List(ctx context.Context, opts v1.ListOptions) (resul
 // Watch returns a watch.Interface that watches the requested kongLicenses.
 func (c *FakeKongLicenses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(konglicensesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(konglicensesResource, opts))
 }
 
 // Create takes the representation of a kongLicense and creates it.  Returns the server's representation of the kongLicense, and an error, if there is any.
 func (c *FakeKongLicenses) Create(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.CreateOptions) (result *v1alpha1.KongLicense, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(konglicensesResource, c.ns, kongLicense), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootCreateAction(konglicensesResource, kongLicense), &v1alpha1.KongLicense{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +88,7 @@ func (c *FakeKongLicenses) Create(ctx context.Context, kongLicense *v1alpha1.Kon
 // Update takes the representation of a kongLicense and updates it. Returns the server's representation of the kongLicense, and an error, if there is any.
 func (c *FakeKongLicenses) Update(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.UpdateOptions) (result *v1alpha1.KongLicense, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(konglicensesResource, c.ns, kongLicense), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootUpdateAction(konglicensesResource, kongLicense), &v1alpha1.KongLicense{})
 	if obj == nil {
 		return nil, err
 	}
@@ -105,8 +99,7 @@ func (c *FakeKongLicenses) Update(ctx context.Context, kongLicense *v1alpha1.Kon
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeKongLicenses) UpdateStatus(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.UpdateOptions) (*v1alpha1.KongLicense, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(konglicensesResource, "status", c.ns, kongLicense), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(konglicensesResource, "status", kongLicense), &v1alpha1.KongLicense{})
 	if obj == nil {
 		return nil, err
 	}
@@ -116,14 +109,13 @@ func (c *FakeKongLicenses) UpdateStatus(ctx context.Context, kongLicense *v1alph
 // Delete takes name of the kongLicense and deletes it. Returns an error if one occurs.
 func (c *FakeKongLicenses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(konglicensesResource, c.ns, name, opts), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(konglicensesResource, name, opts), &v1alpha1.KongLicense{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeKongLicenses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(konglicensesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(konglicensesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.KongLicenseList{})
 	return err
@@ -132,8 +124,7 @@ func (c *FakeKongLicenses) DeleteCollection(ctx context.Context, opts v1.DeleteO
 // Patch applies the patch and returns the patched kongLicense.
 func (c *FakeKongLicenses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.KongLicense, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(konglicensesResource, c.ns, name, pt, data, subresources...), &v1alpha1.KongLicense{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(konglicensesResource, name, pt, data, subresources...), &v1alpha1.KongLicense{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/clientset/typed/configuration/v1alpha1/konglicense.go
+++ b/pkg/clientset/typed/configuration/v1alpha1/konglicense.go
@@ -33,7 +33,7 @@ import (
 // KongLicensesGetter has a method to return a KongLicenseInterface.
 // A group's client should implement this interface.
 type KongLicensesGetter interface {
-	KongLicenses(namespace string) KongLicenseInterface
+	KongLicenses() KongLicenseInterface
 }
 
 // KongLicenseInterface has methods to work with KongLicense resources.
@@ -53,14 +53,12 @@ type KongLicenseInterface interface {
 // kongLicenses implements KongLicenseInterface
 type kongLicenses struct {
 	client rest.Interface
-	ns     string
 }
 
 // newKongLicenses returns a KongLicenses
-func newKongLicenses(c *ConfigurationV1alpha1Client, namespace string) *kongLicenses {
+func newKongLicenses(c *ConfigurationV1alpha1Client) *kongLicenses {
 	return &kongLicenses{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -68,7 +66,6 @@ func newKongLicenses(c *ConfigurationV1alpha1Client, namespace string) *kongLice
 func (c *kongLicenses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.KongLicense, err error) {
 	result = &v1alpha1.KongLicense{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,7 +82,6 @@ func (c *kongLicenses) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1alpha1.KongLicenseList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,7 +98,6 @@ func (c *kongLicenses) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,7 +108,6 @@ func (c *kongLicenses) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 func (c *kongLicenses) Create(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.CreateOptions) (result *v1alpha1.KongLicense, err error) {
 	result = &v1alpha1.KongLicense{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(kongLicense).
@@ -126,7 +120,6 @@ func (c *kongLicenses) Create(ctx context.Context, kongLicense *v1alpha1.KongLic
 func (c *kongLicenses) Update(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.UpdateOptions) (result *v1alpha1.KongLicense, err error) {
 	result = &v1alpha1.KongLicense{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		Name(kongLicense.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *kongLicenses) Update(ctx context.Context, kongLicense *v1alpha1.KongLic
 func (c *kongLicenses) UpdateStatus(ctx context.Context, kongLicense *v1alpha1.KongLicense, opts v1.UpdateOptions) (result *v1alpha1.KongLicense, err error) {
 	result = &v1alpha1.KongLicense{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		Name(kongLicense.Name).
 		SubResource("status").
@@ -155,7 +147,6 @@ func (c *kongLicenses) UpdateStatus(ctx context.Context, kongLicense *v1alpha1.K
 // Delete takes name of the kongLicense and deletes it. Returns an error if one occurs.
 func (c *kongLicenses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		Name(name).
 		Body(&opts).
@@ -170,7 +161,6 @@ func (c *kongLicenses) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("konglicenses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -183,7 +173,6 @@ func (c *kongLicenses) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 func (c *kongLicenses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.KongLicense, err error) {
 	result = &v1alpha1.KongLicense{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("konglicenses").
 		Name(name).
 		SubResource(subresources...).

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -1102,6 +1102,219 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2901,6 +2901,22 @@ rules:
 - apiGroups:
   - configuration.konghq.com
   resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
   - kongplugins
   verbs:
   - get

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -1,0 +1,35 @@
+package isolated
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKongLicense(t *testing.T) {
+	f := features.
+		New("essentials").
+		WithLabel(testlabels.Kind, testlabels.KindKongLicense).
+		WithSetup("deploy kong addon into cluster", featureSetup()).
+		WithSetup("prepare clients", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			cluster := GetClusterFromCtx(ctx)
+
+			kongClients, err := clientset.NewForConfig(cluster.Config())
+			require.NoError(t, err)
+			ctx = SetInCtxForT(ctx, t, kongClients)
+
+			gatewayClient, err := gatewayclient.NewForConfig(cluster.Config())
+			require.NoError(t, err)
+			ctx = SetInCtxForT(ctx, t, gatewayClient)
+
+			return ctx
+		})
+	tenv.Test(t, f.Feature())
+}

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -1,3 +1,5 @@
+//go:build integration_tests
+
 package isolated
 
 import (
@@ -28,7 +30,6 @@ func TestKongLicense(t *testing.T) {
 		Assess(
 			"Expect No Licenses found before creating KongLicense resource",
 			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 				adminURL := GetAdminURLFromCtx(ctx)
 				require.NotNil(t, adminURL, "Should get URL to access Kong gateway admin APIs from context")
 				licenses, err := helpers.GetKongLicenses(ctx, adminURL, consts.KongTestPassword)

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -25,7 +25,7 @@ func TestKongLicense(t *testing.T) {
 	f := features.
 		New("essentials").
 		WithLabel(testlabels.Kind, testlabels.KindKongLicense).
-		// TODO: Add a "Skip" condition to enable the run when non-enterprise image used.
+		Setup(SkipIfEnterpriseNotEnabled).
 		WithSetup("deploy kong addon into cluster", featureSetup()).
 		Assess(
 			"Expect No Licenses found before creating KongLicense resource",

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -3,33 +3,83 @@ package isolated
 import (
 	"context"
 	"testing"
+	"time"
 
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKongLicense(t *testing.T) {
 	f := features.
 		New("essentials").
 		WithLabel(testlabels.Kind, testlabels.KindKongLicense).
+		// TODO: Add a "Skip" condition to enable the run when non-enterprise image used.
 		WithSetup("deploy kong addon into cluster", featureSetup()).
-		WithSetup("prepare clients", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		Assess(
+			"Expect No Licenses found before creating KongLicense resource",
+			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+
+				adminURL := GetAdminURLFromCtx(ctx)
+				require.NotNil(t, adminURL, "Should get URL to access Kong gateway admin APIs from context")
+				licenses, err := helpers.GetKongLicenses(ctx, adminURL, consts.KongTestPassword)
+				require.NoError(t, err, "Expect No errors in listing all licenses in Kong gateway")
+				require.Len(t, licenses, 0, "Expect No licenses in Kong gateway now")
+
+				return ctx
+			},
+		).Assess(
+		"Expect Licenses available when KongLicense created",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			licenseString, err := ktfkong.GetLicenseJSONFromEnv()
+			require.NoError(t, err)
+
+			kongLicenseResource := &kongv1alpha1.KongLicense{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-license",
+				},
+				RawLicenseString: licenseString,
+				Enabled:          true,
+			}
 			cluster := GetClusterFromCtx(ctx)
-
 			kongClients, err := clientset.NewForConfig(cluster.Config())
-			require.NoError(t, err)
-			ctx = SetInCtxForT(ctx, t, kongClients)
+			require.NoError(t, err, "Should get clientset to operate KongLicense with no errors")
+			_, err = kongClients.ConfigurationV1alpha1().KongLicenses().Create(ctx, kongLicenseResource, metav1.CreateOptions{})
+			require.NoError(t, err, "Should return no errors on creating KongLicense")
 
-			gatewayClient, err := gatewayclient.NewForConfig(cluster.Config())
-			require.NoError(t, err)
-			ctx = SetInCtxForT(ctx, t, gatewayClient)
+			require.Eventually(t, func() bool {
+				kongLicenseResource, err = kongClients.ConfigurationV1alpha1().KongLicenses().Get(ctx, kongLicenseResource.Name, metav1.GetOptions{})
+				require.NoError(t, err, "Should not return error on getting the latest status of KongLicense")
+				if len(kongLicenseResource.Status.KongLicenseControllerStatuses) != 1 {
+					return false
+				}
+				controllerStatus := kongLicenseResource.Status.KongLicenseControllerStatuses[0]
+				return lo.ContainsBy(controllerStatus.Conditions, func(c metav1.Condition) bool {
+					return c.Type == "Programmed" && c.Status == metav1.ConditionTrue
+				})
+			}, time.Minute, time.Second,
+				"Expect Programmed condition in controller status to become 'True' in one minute")
+
+			adminURL := GetAdminURLFromCtx(ctx)
+			require.Eventually(t, func() bool {
+				licenses, err := helpers.GetKongLicenses(ctx, adminURL, consts.KongTestPassword)
+				require.NoError(t, err, "Expect No errors in listing all licenses in Kong gateway")
+				return len(licenses) == 1
+			},
+				time.Minute, time.Second,
+				"Expect 1 license found in Kong gateway")
 
 			return ctx
-		})
+		},
+	).Teardown(featureTeardown())
 	tenv.Test(t, f.Feature())
 }

--- a/test/integration/isolated/skip.go
+++ b/test/integration/isolated/skip.go
@@ -19,3 +19,10 @@ func SkipIfRouterNotExpressions(ctx context.Context, t *testing.T, _ *envconf.Co
 	}
 	return ctx
 }
+
+func SkipIfEnterpriseNotEnabled(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	if !testenv.KongEnterpriseEnabled() {
+		t.Skip("skipping, Kong enterprise is required")
+	}
+	return ctx
+}

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -98,3 +98,13 @@ func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPa
 	}
 	return routerFlavor, nil
 }
+
+// GetKongLicenses fetches all licenses applied to Kong gateway.
+func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) ([]*kong.License, error) {
+	httpClient, err := adminapi.MakeHTTPClient(&adminapi.HTTPClientOpts{}, kongTestPassword)
+	kc, err := kong.NewClient(lo.ToPtr(proxyAdminURL.String()), httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return kc.Licenses.ListAll(ctx)
+}

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -102,6 +102,9 @@ func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPa
 // GetKongLicenses fetches all licenses applied to Kong gateway.
 func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) ([]*kong.License, error) {
 	httpClient, err := adminapi.MakeHTTPClient(&adminapi.HTTPClientOpts{}, kongTestPassword)
+	if err != nil {
+		return nil, err
+	}
 	kc, err := kong.NewClient(lo.ToPtr(proxyAdminURL.String()), httpClient)
 	if err != nil {
 		return nil, err

--- a/test/internal/testlabels/labels.go
+++ b/test/internal/testlabels/labels.go
@@ -9,6 +9,7 @@ const (
 	KindIngress            = "Ingress"
 	KindKongServiceFacade  = "KongServiceFacade"
 	KindKongUpstreamPolicy = "KongUpstreamPolicy"
+	KindKongLicense        = "KongLicense"
 )
 
 const (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

The PR implements a `KongLicense` controller which picks the newest `KongLicense` in the cluster and provides a `GetLicense` method for translator to inject Kong license into Kong configurations. 
The controller is enabled when `--enable-controller-kong-license` is set to `true` (by default) and sync license with Konnect disabled. When sync license with Konnect is enabled, the licenses from Konnect takes the precedence.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Major part of #5437.
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

Not fully finished yet, but can reconcile `KongLicense` resources and ready to receive some reviews. Major remaining part:
- When no `KongLicense` CRD in cluster, the controller will exit abnormally
- Maybe add validation of `KongLicense`?
- Disable applying to Kong gateway when it is OSS (in another issue/PR?)


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
