### PR TITLE
Release checklist update - support policy markdown has new location

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -59,7 +59,7 @@ body:
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.
       - label: Make sure that `app/_data/docs_nav_kic_NEWVERSION.yml` links to the latest generated `custom-resources-X.X.X.md`.
       - label: Add a section to `app/_data/kong_versions.yml` for your version and move the `latest` field to version that's being released.
-      - label: "Add entries in support policy documents: `app/_includes/md/support-policy.md` and `app/_src/kubernetes-ingress-controller/support-policy.md`."
+      - label: "Add entries in support policy documents: `app/_src/kubernetes-ingress-controller/support-policy.md` and ` app/_includes/md/kic/support.md`."
       - label: Mark the PR ready for review.
       - label: Inform and ping the @Kong/team-k8s via slack of impending release with a link to the release PR.
       - label: Ensure that [KGO](https://github.com/Kong/gateway-operator) works with the released version of KIC. Update and release it if needed.

--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -59,7 +59,7 @@ body:
       - label: Copy `app/_data/docs_nav_kic_OLDVERSION.yml` to `app/_data/docs_nav_kic_NEWVERSION.yml` and update the `release` field to `NEWVERSION`. Add entries for any new articles.
       - label: Make sure that `app/_data/docs_nav_kic_NEWVERSION.yml` links to the latest generated `custom-resources-X.X.X.md`.
       - label: Add a section to `app/_data/kong_versions.yml` for your version and move the `latest` field to version that's being released.
-      - label: "Add entries in support policy documents: `app/_src/kubernetes-ingress-controller/support-policy.md` and ` app/_includes/md/kic/support.md`."
+      - label: "Add entries in support policy documents: `app/_src/kubernetes-ingress-controller/support-policy.md` and `app/_includes/md/kic/support.md`."
       - label: Mark the PR ready for review.
       - label: Inform and ping the @Kong/team-k8s via slack of impending release with a link to the release PR.
       - label: Ensure that [KGO](https://github.com/Kong/gateway-operator) works with the released version of KIC. Update and release it if needed.


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/Kong/docs.konghq.com/pull/6695 has changed the markdown location of KIC's and Gateway's support policy, therefore requiring the person releasing KIC to follow markdown includes in order to update the right place.

This PR fixes the above - by making the locations to update exactly accurate.

**Which issue this PR fixes**:

n/a

**Special notes for your reviewer**:

Please sanity-check this change for correctness.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- ~[ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
