### PR TITLE
test: Add unit tests and  envtest tests for KongLicense controller

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -152,6 +152,7 @@ jobs:
             echo "TEST_KONG_IMAGE=${{ inputs.kong-enterprise-container-repo }}" >> $GITHUB_ENV
             echo "TEST_KONG_TAG=${kong_ee_tag}" >> $GITHUB_ENV
             echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-enterprise-effective-version }}" >> $GITHUB_ENV
+            echo "TEST_KONG_ENTERPRISE=true" >> $GITHUB_ENV
           else
             echo "TEST_KONG_IMAGE=${{ inputs.kong-container-repo }}" >> $GITHUB_ENV
             echo "TEST_KONG_TAG=${kong_oss_tag}" >> $GITHUB_ENV

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -119,13 +119,16 @@ jobs:
             router-flavor: 'traditional'
             go_test_flags: -run=TestIngressRecoverFromInvalidPath
           # Experimental tests, in the future all integration tests will be migrated to them.
+          # Set enterprise to 'true' to enable isolated integration test cases requiring enterprise features.
           - name: isolated-dbless
             test: isolated.dbless
             feature_gates: "GatewayAlpha=true"
+            enterprise: true
           - name: isolated-dbless-expression-router
             router-flavor: expressions
             test: isolated.dbless
             feature_gates: "GatewayAlpha=true"
+            enterprise: true
 
     steps:
       - uses: Kong/kong-license@master

--- a/internal/controllers/configuration/konglicense_controller_test.go
+++ b/internal/controllers/configuration/konglicense_controller_test.go
@@ -116,7 +116,7 @@ func TestKongLicenseController_pickLicense(t *testing.T) {
 			if tc.expectedNil {
 				require.Nil(t, chosenLicense, "Should get no license")
 			} else {
-				require.NotNil(t, chosenLicense, "Should return an availble license")
+				require.NotNil(t, chosenLicense, "Should return an available license")
 				require.Equal(t, tc.chosenLicenseName, chosenLicense.Name,
 					"Should choose expected KongLicense")
 			}

--- a/internal/controllers/configuration/konglicense_controller_test.go
+++ b/internal/controllers/configuration/konglicense_controller_test.go
@@ -1,0 +1,125 @@
+package configuration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
+)
+
+func TestCompareLicense(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		name           string
+		license1       *kongv1alpha1.KongLicense
+		license2       *kongv1alpha1.KongLicense
+		expectedResult bool
+	}{
+		{
+			name: "The newer one should win",
+			license1: &kongv1alpha1.KongLicense{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Second)),
+					Name:              "alpha",
+				},
+			},
+			license2: &kongv1alpha1.KongLicense{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
+					Name:              "beta",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "If the creationTimestamp equals, the one with lexical smaller name should win",
+			license1: &kongv1alpha1.KongLicense{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
+					Name:              "alpha",
+				},
+			},
+			license2: &kongv1alpha1.KongLicense{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
+					Name:              "beta",
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedResult,
+				compareKongLicense(tc.license1, tc.license2),
+				"Should return expected compare results between two licenses")
+		})
+	}
+}
+
+func TestKongLicenseController_pickLicense(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		name              string
+		licenses          []*kongv1alpha1.KongLicense
+		expectedNil       bool
+		chosenLicenseName string
+	}{
+		{
+			name:        "No licenses in cache - should return nil",
+			licenses:    []*kongv1alpha1.KongLicense{},
+			expectedNil: true,
+		},
+		{
+			name: "Should choose the newest one",
+			licenses: []*kongv1alpha1.KongLicense{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Second)),
+						Name:              "older",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Second)),
+						Name:              "newer",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Second)),
+						Name:              "newest",
+					},
+				},
+			},
+			expectedNil:       false,
+			chosenLicenseName: "newest",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			r := &KongV1Alpha1KongLicenseReconciler{
+				LicenseCache: NewLicenseCache(),
+			}
+			for _, l := range tc.licenses {
+				err := r.LicenseCache.Add(l)
+				require.NoError(t, err, "Should have no error in adding KongLicense to cache")
+			}
+			chosenLicense := r.pickLicenseInCache()
+			if tc.expectedNil {
+				require.Nil(t, chosenLicense, "Should get no license")
+			} else {
+				require.NotNil(t, chosenLicense, "Should return an availble license")
+				require.Equal(t, tc.chosenLicenseName, chosenLicense.Name,
+					"Should choose expected KongLicense")
+			}
+		})
+	}
+}

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -66,6 +66,13 @@ func TestKongLicenseController(t *testing.T) {
 	}, waitTime, tickTime, "The Programmed condition in controller status should be true")
 
 	t.Log("Wait for a second and create a new KongLicense, then verify it replaces the old one")
+	// We're waiting specifically for 1 second because Kubernetes object's CreationTimestamp is stored with a seconds-level
+	// precision. If we create the new KongLicense immediately after the old one, the CreationTimestamps will be the same
+	// and the controller will not pick up the new one as the latest.
+	// The controller should always pick up only a single KongLicense with the latest CreationTimestamp to be used for
+	// configuring Gateways. That one KongLicense should have Programmed condition set to true, while all others should
+	// have it set to false.
+	// CreationTimestamp precision upstream issue: https://github.com/kubernetes/kubernetes/issues/81026
 	time.Sleep(time.Second)
 	kongLicense2 := &kongv1alpha1.KongLicense{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -108,7 +108,6 @@ func TestKongLicenseController(t *testing.T) {
 		return findConditionInControllerStatus(
 			kongLicense1, fullControllerName, conditionProgrammed, metav1.ConditionTrue)
 	}, waitTime, tickTime, "The Programmed condition in controller status should be back to true after the new one deleted")
-
 }
 
 func findConditionInControllerStatus(

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -1,0 +1,127 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/configuration"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
+)
+
+func TestKongLicenseController(t *testing.T) {
+	scheme := Scheme(t, WithKong)
+	cfg := Setup(t, scheme)
+	ctrlClient := NewControllerClient(t, scheme, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reconciler := &configuration.KongV1Alpha1KongLicenseReconciler{
+		Client:         ctrlClient,
+		Log:            logr.Discard(),
+		Scheme:         scheme,
+		LicenseCache:   configuration.NewLicenseCache(),
+		ControllerName: "test",
+	}
+	StartReconcilers(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
+
+	const (
+		waitTime            = 3 * time.Second
+		tickTime            = 100 * time.Millisecond
+		fullControllerName  = configuration.LicenseControllerType + "/test"
+		conditionProgrammed = "Programmed"
+	)
+
+	t.Log("Create a KongLicense and verify that it is reconciled")
+	kongLicense1 := &kongv1alpha1.KongLicense{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "license-1",
+		},
+		RawLicenseString: "test-license-1",
+		Enabled:          true,
+	}
+	err := ctrlClient.Create(ctx, kongLicense1)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		l, ok := reconciler.GetLicense().Get()
+		if !ok {
+			return false
+		}
+		return l.Payload != nil && *l.Payload == "test-license-1"
+	}, waitTime, tickTime, "Should return the license in GetLicense method")
+
+	require.Eventually(t, func() bool {
+		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{Name: kongLicense1.Name}, kongLicense1)
+		require.NoError(t, err, "Should not have error in getting the latest status")
+		return findConditionInControllerStatus(
+			kongLicense1, fullControllerName, conditionProgrammed, metav1.ConditionTrue)
+	}, waitTime, tickTime, "The Programmed condition in controller status should be true")
+
+	t.Log("Wait for a second and create a new KongLicense, then verify it replaces the old one")
+	time.Sleep(time.Second)
+	kongLicense2 := &kongv1alpha1.KongLicense{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "license-2",
+		},
+		RawLicenseString: "test-license-2",
+		Enabled:          true,
+	}
+	err = ctrlClient.Create(ctx, kongLicense2)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		l, ok := reconciler.GetLicense().Get()
+		if !ok {
+			return false
+		}
+		return l.Payload != nil && *l.Payload == "test-license-2"
+	}, waitTime, tickTime, "Should return *NEW* license in GetLicense method")
+
+	require.Eventually(t, func() bool {
+		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{Name: kongLicense1.Name}, kongLicense1)
+		require.NoError(t, err, "Should not have error in getting the latest status")
+		return findConditionInControllerStatus(
+			kongLicense1, fullControllerName, conditionProgrammed, metav1.ConditionFalse)
+	}, waitTime, tickTime, "The Programmed condition in controller status of the *OLD* KongLicense should be false")
+
+	t.Log("Delete the new KongLicense and verify that the old one get chosen")
+	err = ctrlClient.Delete(ctx, kongLicense2)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		l, ok := reconciler.GetLicense().Get()
+		if !ok {
+			return false
+		}
+		return l.Payload != nil && *l.Payload == "test-license-1"
+	}, waitTime, tickTime, "Should return old license in GetLicense method after the new one deleted")
+	require.Eventually(t, func() bool {
+		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{Name: kongLicense1.Name}, kongLicense1)
+		require.NoError(t, err, "Should not have error in getting the latest status")
+		return findConditionInControllerStatus(
+			kongLicense1, fullControllerName, conditionProgrammed, metav1.ConditionTrue)
+	}, waitTime, tickTime, "The Programmed condition in controller status should be back to true after the new one deleted")
+
+}
+
+func findConditionInControllerStatus(
+	l *kongv1alpha1.KongLicense, controllerName string, conditionType string, conditionStatus metav1.ConditionStatus,
+) bool {
+	controllerStatus, found := lo.Find(
+		l.Status.KongLicenseControllerStatuses, func(c kongv1alpha1.KongLicenseControllerStatus) bool {
+			return c.ControllerName == controllerName
+		})
+	if !found {
+		return false
+	}
+	return lo.ContainsBy(controllerStatus.Conditions, func(c metav1.Condition) bool {
+		return c.Type == conditionType && c.Status == conditionStatus
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Add unit tests, envtest tests and isolated integration tests for KongLicense controller.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5565.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
This also sets enterprise to true in isolated integration tests to enable enterprise features because applying Kong licenses needs Kong gateway enterprise. Which is better, create an "enterprise" job or enable enterprise feature in all isolated integration test cases? I prefer the latter because the "enterprise" mode includes all cases.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ No need to update changelog.
