### PR TITLE
feat: enable Konnect config dumps sanitization by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,8 +161,10 @@ Adding a new version? You'll need three changes:
   to Konnect.
   [#5453](https://github.com/Kong/kubernetes-ingress-controller/pull/5453)
 - Added `SanitizeKonnectConfigDumps` feature gate allowing to enable sanitizing
-  sensitive data in Konnect configuration dumps.
+  sensitive data (like TLS private keys, Secret-sourced Plugins configuration, etc.) 
+  in Konnect configuration dumps. It's turned on by default.
   [#5489](https://github.com/Kong/kubernetes-ingress-controller/pull/5489)
+  [#5573](https://github.com/Kong/kubernetes-ingress-controller/pull/5573)
 - Kong Plugin's `config` field now is sanitized when it contains sensitive data
   sourced from a Secret (i.e. `configFrom` or `configPatches` is used).
   [#5495](https://github.com/Kong/kubernetes-ingress-controller/pull/5495)

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -69,7 +69,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | FillIDs                    | `true`  | Beta  | 3.0.0  | TBD   |
 | RewriteURIs                | `false` | Alpha | 2.12.0 | TBD   |
 | KongServiceFacade          | `false` | Alpha | 3.1.0  | TBD   |
-| SanitizeKonnectConfigDumps | `false` | Alpha | 3.1.0  | TBD   |
+| SanitizeKonnectConfigDumps | `true`  | Beta  | 3.1.0  | TBD   |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -67,6 +67,6 @@ func GetFeatureGatesDefaults() FeatureGates {
 		FillIDsFeature:             true,
 		RewriteURIsFeature:         false,
 		KongServiceFacade:          false,
-		SanitizeKonnectConfigDumps: false,
+		SanitizeKonnectConfigDumps: true,
 	}
 }

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -362,7 +362,7 @@ func verifyTelemetryReport(t *testing.T, k8sVersion *version.Info, report string
 			"feature-kongservicefacade=false;"+
 			"feature-konnect-sync=false;"+
 			"feature-rewriteuris=false;"+
-			"feature-sanitizekonnectconfigdumps=false;"+
+			"feature-sanitizekonnectconfigdumps=true;"+
 			"hn=%s;"+
 			"kv=3.4.1;"+
 			"rf=traditional;"+


### PR DESCRIPTION
**What this PR does / why we need it**:

@mheap suggested we might want to make this feature gate enabled by default.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5467.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
