### PR TITLE
chore(tests) increase webhook timeout

### DIFF
--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -1115,6 +1115,7 @@ func ensureAdmissionRegistration(ctx context.Context, t *testing.T, namespace, c
 					Name:                    "validations.kong.konghq.com",
 					FailurePolicy:           lo.ToPtr(admregv1.Ignore),
 					SideEffects:             lo.ToPtr(admregv1.SideEffectClassNone),
+					TimeoutSeconds:          lo.ToPtr(int32(30)),
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					Rules:                   rules,
 					ClientConfig: admregv1.WebhookClientConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

Increase the webhook timeout to decrease the likelihood of permitting a bad resource due to an ignored timeout on slow workers.

**Special notes for your reviewer**:

More limited version of https://github.com/Kong/kubernetes-ingress-controller/pull/5564 that just increases the timeout.

Unfortunately the webhook tests loop over subtests within the tests, and those tests aren't compatible with one another, so adding the usual cleaner that deletes all resources at the end is complicated.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
