### PR TITLE
fix: don't populate fields disallowed for expressions router in Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,11 @@ Adding a new version? You'll need three changes:
 - Stale `HTTPRoute`'s parent statuses are now removed when the `HTTPRoute` no longer
   defines a parent `Gateway` in its `spec.parentRefs`.
   [#5477](https://github.com/Kong/kubernetes-ingress-controller/pull/5477)
+- `expressions` router flavor can now successfully be now used with Konnect synchronization
+  turned on. The controller will no longer populate disallowed `regex_priority` and `path_handling`
+  Kong Route's fields when the router flavor is `expressions` that were causing Konnect to reject
+  the configuration.
+  [#5581](https://github.com/Kong/kubernetes-ingress-controller/pull/5581)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/kong/go-database-reconciler v1.5.0
+	github.com/kong/go-database-reconciler v1.6.0
 	github.com/kong/go-kong v0.51.1-0.20240125175037-0c077f5b9ac7
 	github.com/kong/kubernetes-telemetry v0.1.3
 	github.com/kong/kubernetes-testing-framework v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
-github.com/kong/go-database-reconciler v1.5.0 h1:OHUmFFse5nUqcO7FvChITBK9PoXEhZdw95dE4arlhxs=
-github.com/kong/go-database-reconciler v1.5.0/go.mod h1:KtstdZjxNI7+jZJRT896iDsS0Yte1x1sX4B2TaaASgk=
+github.com/kong/go-database-reconciler v1.6.0 h1:LUzYK57IsPDiruLUnFgrUwlclBtkYOFXZkQ0w1Gp2E8=
+github.com/kong/go-database-reconciler v1.6.0/go.mod h1:7E566ZzzY+Pf5PcJFjJJelrbMO4Je96iMeahKSrLP7w=
 github.com/kong/go-kong v0.51.1-0.20240125175037-0c077f5b9ac7 h1:/iV93Gwv410lIeJx8VCfCA4fpuvSuTw2LqZpDXsIE9Q=
 github.com/kong/go-kong v0.51.1-0.20240125175037-0c077f5b9ac7/go.mod h1:YNkLvjxfOqS+BZ1J2YWOy/83wc26JM5QJbAukoeg1sY=
 github.com/kong/kubernetes-telemetry v0.1.3 h1:Hz2tkHGIIUqbn1x46QRDmmNjbEtJyxyOvHSPne3uPto=

--- a/test/kongintegration/translator_golden_tests_outputs_test.go
+++ b/test/kongintegration/translator_golden_tests_outputs_test.go
@@ -96,9 +96,6 @@ func TestTranslatorsGoldenTestsOutputs_Konnect(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	defaultOutputsPaths := lo.Filter(allGoldenTestsOutputsPaths(t), func(path string, _ int) bool {
-		return strings.Contains(path, "default_")
-	})
 
 	cpID := konnect.CreateTestControlPlane(ctx, t)
 	cert, key := konnect.CreateClientCertificate(ctx, t, cpID)
@@ -108,7 +105,7 @@ func TestTranslatorsGoldenTestsOutputs_Konnect(t *testing.T) {
 		KonnectControlPlane: cpID,
 	}, semver.MustParse("3.5.0"), 10)
 
-	for _, goldenTestOutputPath := range defaultOutputsPaths {
+	for _, goldenTestOutputPath := range allGoldenTestsOutputsPaths(t) {
 		t.Run(goldenTestOutputPath, func(t *testing.T) {
 			ensureGoldenTestOutputIsAccepted(ctx, t, goldenTestOutputPath, updateStrategy)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump `go-database-reconciler` to a version that fixes the issue with populating `regex_priority` and `path_handling` for expression routes. Starts running `kongintegration` tests against Konnect with all golden tests outputs (including the ones with expressions router which were disabled before).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5148.

**Special notes for your reviewer**:

It's fixed thanks to the changes in `go-database-reconciler`: https://github.com/Kong/go-database-reconciler/pull/55
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
