### PR TITLE
chore: use depth 0 when checking out repo in performance tests

### DIFF
--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -36,6 +36,8 @@ jobs:
       RES_NUM: ${{ inputs.res-number-for-perf }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: |
           MSG="performance (targeted) tests with KIND-based clusters were started at ${URL} the number of test resources is ${RES_NUM}"
           gh pr comment ${PR_NUMBER} --body "${MSG}"
@@ -90,8 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run
     steps:
-      - name: checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup ruby

--- a/.github/workflows/performance_trigger_via_label.yaml
+++ b/.github/workflows/performance_trigger_via_label.yaml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     # Do not run e2e tests on GKE-based clusters for specific PR, because currently
     # there is no way to use an image built from PR's code for those tests.
     # https://github.com/Kong/kubernetes-testing-framework/issues/587


### PR DESCRIPTION
**What this PR does / why we need it**:

I've noticed that repo checkout took nearly a minute in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/7815845008/job/21321138776#step:2:52 so proposing to add `depth: 0` as in other places in the repository.