### PR TITLE
chore: link to guides in KIC 3.1 highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,13 +88,20 @@ Adding a new version? You'll need three changes:
 
 ### Highlights
 
-- 🔒 Kong Gateway's [secret vaults](kong-vault) now become a first-class citizen for Kubernetes users
-  thanks to the new `KongVault` CRD.
-- 🔒 Providing an Enterprise license to KIC-managed Kong Gateways becomes much easier thanks to the new `KongLicense` CRD
-  which is used to dynamically provision all the replicas with the latest license found in the cluster.
-- ✨ Populating a single field of `KongPlugin`'s configuration with use of a Kubernetes Secret becomes possible thanks 
-  to the new `KongPlugin`'s `configPatches` field.
+- 🔒 Kong Gateway's [secret vaults](kong-vault) now become a first-class citizen for Kubernetes users thanks to the new
+  `KongVault` CRD. _See [Kong Vault guide](vault-guide) and [CRDs reference](crds-ref) for more details._
+- 🔒 Providing an Enterprise license to KIC-managed Kong Gateways becomes much easier thanks to the new `KongLicense`
+  CRD which is used to dynamically provision all the replicas with the latest license found in the cluster. _See
+  [Enterprise License](license-guide) and [CRDs reference](crds-ref) for more details._
+- ✨ Populating a single field of `KongPlugin`'s configuration with use of a Kubernetes Secret becomes possible thanks
+  to the new `KongPlugin`'s `configPatches` field. _See [Using Kubernetes Secrets in Plugins](secrets-in-plugins-guide)
+  and [CRDs reference](crds-ref) for more details._
 - 🔒 All sensitive information stored in the cluster is now sanitized while sending configuration to Konnect.
+
+[crds-ref]: https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/custom-resources/
+[vault-guide]: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/security/kong-vault/
+[license-guide]: https://docs.konghq.com/kubernetes-ingress-controller/latest/license/
+[secrets-in-plugins-guide]: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/security/plugin-secrets/
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,14 +88,14 @@ Adding a new version? You'll need three changes:
 
 ### Highlights
 
-- 🔒 Kong Gateway's [secret vaults](kong-vault) now become a first-class citizen for Kubernetes users thanks to the new
-  `KongVault` CRD. _See [Kong Vault guide](vault-guide) and [CRDs reference](crds-ref) for more details._
+- 🔒 Kong Gateway's [secret vaults][kong-vault] now become a first-class citizen for Kubernetes users thanks to the new
+  `KongVault` CRD. _See [Kong Vault guide][vault-guide] and [CRDs reference][crds-ref] for more details._
 - 🔒 Providing an Enterprise license to KIC-managed Kong Gateways becomes much easier thanks to the new `KongLicense`
   CRD which is used to dynamically provision all the replicas with the latest license found in the cluster. _See
-  [Enterprise License](license-guide) and [CRDs reference](crds-ref) for more details._
+  [Enterprise License][license-guide] and [CRDs reference][crds-ref] for more details._
 - ✨ Populating a single field of `KongPlugin`'s configuration with use of a Kubernetes Secret becomes possible thanks
-  to the new `KongPlugin`'s `configPatches` field. _See [Using Kubernetes Secrets in Plugins](secrets-in-plugins-guide)
-  and [CRDs reference](crds-ref) for more details._
+  to the new `KongPlugin`'s `configPatches` field. _See [Using Kubernetes Secrets in Plugins][secrets-in-plugins-guide]
+  and [CRDs reference][crds-ref] for more details._
 - 🔒 All sensitive information stored in the cluster is now sanitized while sending configuration to Konnect.
 
 [crds-ref]: https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/custom-resources/


### PR DESCRIPTION
**What this PR does / why we need it**:

For better UX, as @pmalek suggested, we can link to guides in the release highlights to make it easier for our users to hop into using the new features right away.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #5443.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
