### PR TITLE
chore(refactor): make KongLicense controller importable

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,6 +88,8 @@ linters-settings:
       alias: incubator${1}
     - pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config
       alias: dpconf
+    - pkg: github.com/kong/kubernetes-ingress-controller/v3/controllers/license
+      alias: ctrllicense
   forbidigo:
     exclude-godoc-examples: false
     forbid:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     --mount=type=bind,source=go.mod,target=go.mod \
     go mod download -x
 
+COPY controllers/ controllers/
 COPY pkg/ pkg/
 COPY internal/ internal/
 COPY Makefile .

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -19,6 +19,7 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+COPY controllers/ controllers/
 COPY pkg/ pkg/
 COPY internal/ internal/
 COPY Makefile .

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ manifests.crds: controller-gen ## Generate WebhookConfiguration and CustomResour
 
 .PHONY: manifests.rbac ## Generate ClusterRole objects.
 manifests.rbac: controller-gen
-	$(CONTROLLER_GEN) rbac:roleName=kong-ingress paths="./internal/controllers/configuration/"
+	$(CONTROLLER_GEN) rbac:roleName=kong-ingress paths="./internal/controllers/configuration/" paths="./controllers/license/"
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-gateway paths="./internal/controllers/gateway/" output:rbac:artifacts:config=config/rbac/gateway
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-crds paths="./internal/controllers/crds/" output:rbac:artifacts:config=config/rbac/crds
 

--- a/controllers/license/konglicense_controller_test.go
+++ b/controllers/license/konglicense_controller_test.go
@@ -1,4 +1,4 @@
-package configuration
+package license
 
 import (
 	"testing"

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,8 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/onsi/ginkgo/v2 v2.15.0 // indirect
+	github.com/onsi/gomega v1.31.1 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,12 +337,12 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
-github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/configuration"
+	ctrllicense "github.com/kong/kubernetes-ingress-controller/v3/controllers/license"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 )
 
@@ -23,20 +24,21 @@ func TestKongLicenseController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	reconciler := &configuration.KongV1Alpha1KongLicenseReconciler{
-		Client:         ctrlClient,
-		Log:            logr.Discard(),
-		Scheme:         scheme,
-		LicenseCache:   configuration.NewLicenseCache(),
-		ControllerName: "test",
+	reconciler := &ctrllicense.KongV1Alpha1KongLicenseReconciler{
+		Client:                ctrlClient,
+		Log:                   logr.Discard(),
+		Scheme:                scheme,
+		LicenseCache:          ctrllicense.NewLicenseCache(),
+		LicenseControllerType: ctrllicense.LicenseControllerTypeKIC,
+		ElectionID:            mo.Some("test"),
 	}
 	StartReconcilers(ctx, t, ctrlClient.Scheme(), cfg, reconciler)
 
 	const (
 		waitTime            = 3 * time.Second
 		tickTime            = 100 * time.Millisecond
-		fullControllerName  = configuration.LicenseControllerType + "/test"
-		conditionProgrammed = "Programmed"
+		fullControllerName  = ctrllicense.LicenseControllerTypeKIC + "/test"
+		conditionProgrammed = ctrllicense.ConditionTypeProgrammed
 	)
 
 	t.Log("Create a KongLicense and verify that it is reconciled")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

> Start from https://github.com/Kong/gateway-operator-enterprise/pull/15 to have a big picture.

CRD `KongLicense` is not only used in KIC, the controller can be reused. Make it importable. Other projects can add it to their managers and use it. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of:
- https://github.com/Kong/gateway-operator/issues/1312

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->



<!-- Here you can add any open questions or notes that you might have for reviewers -->

