### PR TITLE
chore(docs): split CRDs and other types into sections in reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,9 +14,7 @@ Package v1 contains API Schema definitions for the konghq.com v1 API group.
 - [KongConsumer](#kongconsumer)
 - [KongIngress](#kongingress)
 - [KongPlugin](#kongplugin)
-
 ### KongClusterPlugin
-
 
 
 KongClusterPlugin is the Schema for the kongclusterplugins API.
@@ -41,9 +39,7 @@ KongClusterPlugin is the Schema for the kongclusterplugins API.
 
 
 
-
 ### KongConsumer
-
 
 
 KongConsumer is the Schema for the kongconsumers API.
@@ -62,9 +58,7 @@ KongConsumer is the Schema for the kongconsumers API.
 
 
 
-
 ### KongIngress
-
 
 
 KongIngress is the Schema for the kongingresses API.
@@ -82,9 +76,7 @@ KongIngress is the Schema for the kongingresses API.
 
 
 
-
 ### KongPlugin
-
 
 
 KongPlugin is the Schema for the kongplugins API.
@@ -109,13 +101,14 @@ KongPlugin is the Schema for the kongplugins API.
 
 
 
+### Types
+
+In this section you will find types that the CRDs rely on.
 
 
 
 
-
-### ConfigPatch
-
+#### ConfigPatch
 
 
 ConfigPatch is a JSON patch (RFC6902) to add values from Secret to the generated configuration.
@@ -133,8 +126,7 @@ It is an equivalent of the following patch:
 _Appears in:_
 - [KongPlugin](#kongplugin)
 
-### ConfigSource
-
+#### ConfigSource
 
 
 ConfigSource is a wrapper around SecretValueFromSource.
@@ -154,8 +146,7 @@ _Appears in:_
 
 
 
-### KongIngressRoute
-
+#### KongIngressRoute
 
 
 KongIngressRoute contains KongIngress route configuration.
@@ -182,8 +173,7 @@ Deprecated: use Ingress' annotations instead.
 _Appears in:_
 - [KongIngress](#kongingress)
 
-### KongIngressService
-
+#### KongIngressService
 
 
 KongIngressService contains KongIngress service configuration.
@@ -205,8 +195,7 @@ Deprecated: use Service's annotations instead.
 _Appears in:_
 - [KongIngress](#kongingress)
 
-### KongIngressUpstream
-
+#### KongIngressUpstream
 
 
 KongIngressUpstream contains KongIngress upstream configuration.
@@ -237,8 +226,7 @@ _Appears in:_
 
 
 
-### KongProtocol
-
+#### KongProtocol
 _Underlying type:_ `string`
 
 KongProtocol is a valid Kong protocol.
@@ -253,8 +241,7 @@ _Appears in:_
 - [KongIngressRoute](#kongingressroute)
 - [KongPlugin](#kongplugin)
 
-### NamespacedConfigPatch
-
+#### NamespacedConfigPatch
 
 
 NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
@@ -271,8 +258,7 @@ to the generated configuration of plugin in Kong.
 _Appears in:_
 - [KongClusterPlugin](#kongclusterplugin)
 
-### NamespacedConfigSource
-
+#### NamespacedConfigSource
 
 
 NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource.
@@ -288,8 +274,7 @@ _Appears in:_
 - [KongClusterPlugin](#kongclusterplugin)
 - [NamespacedConfigPatch](#namespacedconfigpatch)
 
-### NamespacedSecretValueFromSource
-
+#### NamespacedSecretValueFromSource
 
 
 NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace.
@@ -306,8 +291,7 @@ NamespacedSecretValueFromSource represents the source of a secret value specifyi
 _Appears in:_
 - [NamespacedConfigSource](#namespacedconfigsource)
 
-### SecretValueFromSource
-
+#### SecretValueFromSource
 
 
 SecretValueFromSource represents the source of a secret value.
@@ -331,9 +315,7 @@ Package v1alpha1 contains API Schema definitions for the configuration.konghq.co
 - [IngressClassParameters](#ingressclassparameters)
 - [KongLicense](#konglicense)
 - [KongVault](#kongvault)
-
 ### IngressClassParameters
-
 
 
 IngressClassParameters is the Schema for the IngressClassParameters API.
@@ -349,9 +331,7 @@ IngressClassParameters is the Schema for the IngressClassParameters API.
 
 
 
-
 ### KongLicense
-
 
 
 KongLicense stores a Kong enterprise license to apply to managed Kong gateway instances.
@@ -368,9 +348,7 @@ KongLicense stores a Kong enterprise license to apply to managed Kong gateway in
 
 
 
-
 ### KongVault
-
 
 
 KongVault is the schema for kongvaults API which defines a custom Kong vault.
@@ -388,9 +366,10 @@ See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
 
 
 
+### Types
 
-### ControllerReference
-
+In this section you will find types that the CRDs rely on.
+#### ControllerReference
 
 
 
@@ -408,8 +387,7 @@ See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
 _Appears in:_
 - [KongLicenseControllerStatus](#konglicensecontrollerstatus)
 
-### Group
-
+#### Group
 _Underlying type:_ `string`
 
 Group refers to a Kubernetes Group. It must either be an empty string or a
@@ -422,8 +400,7 @@ RFC 1123 subdomain.
 _Appears in:_
 - [ControllerReference](#controllerreference)
 
-### IngressClassParametersSpec
-
+#### IngressClassParametersSpec
 
 
 
@@ -439,8 +416,7 @@ _Appears in:_
 _Appears in:_
 - [IngressClassParameters](#ingressclassparameters)
 
-### Kind
-
+#### Kind
 _Underlying type:_ `string`
 
 Kind refers to a Kubernetes kind.
@@ -452,8 +428,7 @@ Kind refers to a Kubernetes kind.
 _Appears in:_
 - [ControllerReference](#controllerreference)
 
-### KongLicenseControllerStatus
-
+#### KongLicenseControllerStatus
 
 
 KongLicenseControllerStatus is the status of owning KongLicense being processed
@@ -475,8 +450,7 @@ _Appears in:_
 
 
 
-### KongVaultSpec
-
+#### KongVaultSpec
 
 
 KongVaultSpec defines specification of a custom Kong vault.
@@ -496,8 +470,7 @@ _Appears in:_
 
 
 
-### Namespace
-
+#### Namespace
 _Underlying type:_ `string`
 
 Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
@@ -509,8 +482,7 @@ Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 _Appears in:_
 - [ControllerReference](#controllerreference)
 
-### ObjectName
-
+#### ObjectName
 _Underlying type:_ `string`
 
 ObjectName refers to the name of a Kubernetes object.
@@ -533,9 +505,7 @@ Package v1beta1 contains API Schema definitions for the configuration.konghq.com
 - [KongUpstreamPolicy](#kongupstreampolicy)
 - [TCPIngress](#tcpingress)
 - [UDPIngress](#udpingress)
-
 ### KongConsumerGroup
-
 
 
 KongConsumerGroup is the Schema for the kongconsumergroups API.
@@ -550,9 +520,7 @@ KongConsumerGroup is the Schema for the kongconsumergroups API.
 
 
 
-
 ### KongUpstreamPolicy
-
 
 
 KongUpstreamPolicy allows configuring algorithm that should be used for load balancing traffic between Kong
@@ -580,9 +548,7 @@ used instead. This is to allow reusing the same KongUpstreamPolicy for multiple 
 
 
 
-
 ### TCPIngress
-
 
 
 TCPIngress is the Schema for the tcpingresses API.
@@ -598,9 +564,7 @@ TCPIngress is the Schema for the tcpingresses API.
 
 
 
-
 ### UDPIngress
-
 
 
 UDPIngress is the Schema for the udpingresses API.
@@ -616,9 +580,10 @@ UDPIngress is the Schema for the udpingresses API.
 
 
 
+### Types
 
-### HTTPStatus
-
+In this section you will find types that the CRDs rely on.
+#### HTTPStatus
 _Underlying type:_ `integer`
 
 HTTPStatus is an HTTP status code.
@@ -631,8 +596,7 @@ _Appears in:_
 - [KongUpstreamHealthcheckHealthy](#kongupstreamhealthcheckhealthy)
 - [KongUpstreamHealthcheckUnhealthy](#kongupstreamhealthcheckunhealthy)
 
-### HashInput
-
+#### HashInput
 _Underlying type:_ `string`
 
 HashInput is the input for consistent-hashing load balancing algorithm.
@@ -645,8 +609,7 @@ Can be one of: "ip", "consumer", "path".
 _Appears in:_
 - [KongUpstreamHash](#kongupstreamhash)
 
-### IngressBackend
-
+#### IngressBackend
 
 
 IngressBackend describes all endpoints for a given service and port.
@@ -663,8 +626,7 @@ _Appears in:_
 - [IngressRule](#ingressrule)
 - [UDPIngressRule](#udpingressrule)
 
-### IngressRule
-
+#### IngressRule
 
 
 IngressRule represents a rule to apply against incoming requests.
@@ -682,8 +644,7 @@ Matching is performed based on an (optional) SNI and port.
 _Appears in:_
 - [TCPIngressSpec](#tcpingressspec)
 
-### IngressTLS
-
+#### IngressTLS
 
 
 IngressTLS describes the transport layer security.
@@ -701,8 +662,7 @@ _Appears in:_
 
 
 
-### KongUpstreamActiveHealthcheck
-
+#### KongUpstreamActiveHealthcheck
 
 
 KongUpstreamActiveHealthcheck configures active health check probing.
@@ -725,8 +685,7 @@ KongUpstreamActiveHealthcheck configures active health check probing.
 _Appears in:_
 - [KongUpstreamHealthcheck](#kongupstreamhealthcheck)
 
-### KongUpstreamHash
-
+#### KongUpstreamHash
 
 
 KongUpstreamHash defines how to calculate hash for consistent-hashing load balancing algorithm.
@@ -747,8 +706,7 @@ Only one of the fields must be set.
 _Appears in:_
 - [KongUpstreamPolicySpec](#kongupstreampolicyspec)
 
-### KongUpstreamHealthcheck
-
+#### KongUpstreamHealthcheck
 
 
 KongUpstreamHealthcheck represents a health-check config of an Upstream in Kong.
@@ -765,8 +723,7 @@ KongUpstreamHealthcheck represents a health-check config of an Upstream in Kong.
 _Appears in:_
 - [KongUpstreamPolicySpec](#kongupstreampolicyspec)
 
-### KongUpstreamHealthcheckHealthy
-
+#### KongUpstreamHealthcheckHealthy
 
 
 KongUpstreamHealthcheckHealthy configures thresholds and HTTP status codes to mark targets healthy for an upstream.
@@ -784,8 +741,7 @@ _Appears in:_
 - [KongUpstreamActiveHealthcheck](#kongupstreamactivehealthcheck)
 - [KongUpstreamPassiveHealthcheck](#kongupstreampassivehealthcheck)
 
-### KongUpstreamHealthcheckUnhealthy
-
+#### KongUpstreamHealthcheckUnhealthy
 
 
 KongUpstreamHealthcheckUnhealthy configures thresholds and HTTP status codes to mark targets unhealthy.
@@ -805,8 +761,7 @@ _Appears in:_
 - [KongUpstreamActiveHealthcheck](#kongupstreamactivehealthcheck)
 - [KongUpstreamPassiveHealthcheck](#kongupstreampassivehealthcheck)
 
-### KongUpstreamPassiveHealthcheck
-
+#### KongUpstreamPassiveHealthcheck
 
 
 KongUpstreamPassiveHealthcheck configures passive checks around
@@ -824,8 +779,7 @@ passive health checks.
 _Appears in:_
 - [KongUpstreamHealthcheck](#kongupstreamhealthcheck)
 
-### KongUpstreamPolicySpec
-
+#### KongUpstreamPolicySpec
 
 
 KongUpstreamPolicySpec contains the specification for KongUpstreamPolicy.
@@ -844,8 +798,7 @@ KongUpstreamPolicySpec contains the specification for KongUpstreamPolicy.
 _Appears in:_
 - [KongUpstreamPolicy](#kongupstreampolicy)
 
-### TCPIngressSpec
-
+#### TCPIngressSpec
 
 
 TCPIngressSpec defines the desired state of TCPIngress.
@@ -863,8 +816,7 @@ _Appears in:_
 
 
 
-### UDPIngressRule
-
+#### UDPIngressRule
 
 
 UDPIngressRule represents a rule to apply against incoming requests
@@ -882,8 +834,7 @@ is used to match requests.
 _Appears in:_
 - [UDPIngressSpec](#udpingressspec)
 
-### UDPIngressSpec
-
+#### UDPIngressSpec
 
 
 UDPIngressSpec defines the desired state of UDPIngress.

--- a/docs/incubator-api-reference.md
+++ b/docs/incubator-api-reference.md
@@ -9,9 +9,7 @@
 Package v1alpha1 contains API Schema definitions for the incubator.ingress-controller.konghq.com v1alpha1 API group.
 
 - [KongServiceFacade](#kongservicefacade)
-
 ### KongServiceFacade
-
 
 
 KongServiceFacade allows creating separate Kong Services for a single Kubernetes
@@ -33,9 +31,10 @@ matching the ingressClass of the Kong Ingress Controller (`kong` by default) to 
 
 
 
+### Types
 
-### KongServiceFacadeBackend
-
+In this section you will find types that the CRDs rely on.
+#### KongServiceFacadeBackend
 
 
 KongServiceFacadeBackend is a reference to a Kubernetes Service
@@ -52,8 +51,7 @@ that is used as a backend for a Kong Service Facade.
 _Appears in:_
 - [KongServiceFacadeSpec](#kongservicefacadespec)
 
-### KongServiceFacadeSpec
-
+#### KongServiceFacadeSpec
 
 
 KongServiceFacadeSpec defines the desired state of KongServiceFacade.

--- a/scripts/apidocs-gen/post-process-for-konghq.sh
+++ b/scripts/apidocs-gen/post-process-for-konghq.sh
@@ -28,5 +28,5 @@ echo "<!-- vale on -->" >> "${POST_PROCESSED_DOC}"
 
 # Replace all description placeholders with proper include directives
 sed -i -r \
-  's/<!-- (.*) description placeholder -->/{% include md\/kic\/crd-ref\/\1_description.md kong_version=page.kong_version %}/' \
+  's/<!-- \(.*\) description placeholder -->/{% include md\/kic\/crd-ref\/\1_description.md kong_version=page.kong_version %}/' \
   "${POST_PROCESSED_DOC}"

--- a/scripts/apidocs-gen/template/gv_details.tpl
+++ b/scripts/apidocs-gen/template/gv_details.tpl
@@ -14,8 +14,13 @@
 {{- /* Display exported Kinds first */ -}}
 {{- range $gv.SortedKinds -}}
 {{- $typ := $gv.TypeForKind . }}
-{{ template "type" $typ }}
+{{- $isKind := true -}}
+{{ template "type" (dict "type" $typ "isKind" $isKind) }}
 {{ end -}}
+
+### Types
+
+In this section you will find types that the CRDs rely on.
 
 {{- /* Display Types that are not exported Kinds */ -}}
 {{- range $typ := $gv.SortedTypes -}}
@@ -26,7 +31,7 @@
 {{- end -}}
 {{- end -}}
 {{- if not $isKind }}
-{{ template "type" $typ }}
+{{ template "type" (dict "type" $typ "isKind" $isKind) }}
 {{ end -}}
 {{- end }}
 

--- a/scripts/apidocs-gen/template/type.tpl
+++ b/scripts/apidocs-gen/template/type.tpl
@@ -1,8 +1,13 @@
 {{- define "type" -}}
-{{- $type := . -}}
+{{- $type := $.type -}}
+{{- $isKind := $.isKind -}}
 {{- if markdownShouldRenderType $type -}}
 
+{{- if $isKind -}}
 ### {{ $type.Name }}
+{{ else -}}
+#### {{ $type.Name }}
+{{ end -}}
 
 {{ if $type.IsAlias }}_Underlying type:_ `{{ markdownRenderTypeLink $type.UnderlyingType  }}`{{ end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Splits the top-level CRDs and the types that they rely on into separate sections to make it clear which types are meant to be used to create objects in the Kubernetes API.

It mostly influences the way a page index is generated in docs.

Before (listing all types along with CRs):
<img width="242" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/8835851/5a6137ff-c4c0-488b-87b9-9f3c08f4e44d">

After (only CRs listed + "Types" section):
<img width="258" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/8835851/c4edb2e7-6703-458a-a89e-6256f2392b36">


**Which issue this PR fixes**:

Addresses @liyangau concern about the reference not signaling clearly which types are meant to be used to create objects in a cluster.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
