### PR TITLE
feat(license): add ability to validate KongLicense

### DIFF
--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -437,7 +437,7 @@ func setupLicenseGetter(
 	// Enable KongLicense controller if license synchornizition from Konnect is disabled.
 	if c.KongLicenseEnabled && !c.Konnect.LicenseSynchronizationEnabled {
 		setupLog.Info("Starting KongLicense controller")
-		licenseController := ctrllicense.NewKongV1Alpha1KongLicenseReconcilerWithoutLicenseValidation(
+		licenseController := ctrllicense.NewKongV1Alpha1KongLicenseReconciler(
 			mgr.GetClient(),
 			ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
 			mgr.GetScheme(),
@@ -446,6 +446,7 @@ func setupLicenseGetter(
 			statusQueue,
 			ctrllicense.LicenseControllerTypeKIC,
 			mo.Some(c.LeaderElectionID),
+			mo.None[ctrllicense.ValidatorFunc](),
 		)
 		dynamicLicenseController := ctrllicense.WrapKongLicenseReconcilerToDynamicCRDController(
 			ctx, mgr, licenseController,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -437,16 +437,16 @@ func setupLicenseGetter(
 	// Enable KongLicense controller if license synchornizition from Konnect is disabled.
 	if c.KongLicenseEnabled && !c.Konnect.LicenseSynchronizationEnabled {
 		setupLog.Info("Starting KongLicense controller")
-		licenseController := &ctrllicense.KongV1Alpha1KongLicenseReconciler{
-			Client:                mgr.GetClient(),
-			Log:                   ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
-			Scheme:                mgr.GetScheme(),
-			LicenseCache:          ctrllicense.NewLicenseCache(),
-			CacheSyncTimeout:      c.CacheSyncTimeout,
-			StatusQueue:           statusQueue,
-			ElectionID:            mo.Some(c.LeaderElectionID),
-			LicenseControllerType: ctrllicense.LicenseControllerTypeKIC,
-		}
+		licenseController := ctrllicense.NewKongV1Alpha1KongLicenseReconcilerWithoutLicenseValidation(
+			mgr.GetClient(),
+			ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongLicense"),
+			mgr.GetScheme(),
+			ctrllicense.NewLicenseCache(),
+			c.CacheSyncTimeout,
+			statusQueue,
+			ctrllicense.LicenseControllerTypeKIC,
+			mo.Some(c.LeaderElectionID),
+		)
 		dynamicLicenseController := ctrllicense.WrapKongLicenseReconcilerToDynamicCRDController(
 			ctx, mgr, licenseController,
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

> Prerequisite for https://github.com/Kong/gateway-operator-enterprise/pull/20

This PR introduces API for the `KongLicense` controller that allows injecting a custom validator for a license and sets the additional condition accordingly. Moreover, the API for retrieving a license is enhanced with information about validity.

**Which issue this PR fixes**

Part of
- https://github.com/Kong/kubernetes-ingress-controller/issues/5566

Prerequisite for (part of)
- https://github.com/Kong/gateway-operator/issues/1312

**Special notes for your reviewer**:

Know issue is that when a license expires, the condition in status will not be updated automatically - the user won't be able to spot this in real time. When a new reconciliation is triggered it will get an update. For getting a license on demand validation happens on every get thus information about validity will not be stale.

I propose updating the status's conditions in such cases in a more real-time manner to put in a separate GH issue and do it later. It can be achieved by re-queueing object for reconciliation, by using `*status.Queue` of Kong License controller.


