### PR TITLE
feat: add path segment field and not operator in atc translator

### DIFF
--- a/internal/dataplane/translator/atc/field.go
+++ b/internal/dataplane/translator/atc/field.go
@@ -64,7 +64,8 @@ func (f IntField) String() string {
 // https://docs.konghq.com/gateway/latest/reference/router-expressions-language/#available-fields
 
 const (
-	FieldNetDstPort IntField = "net.dst.port"
+	FieldNetDstPort          IntField = "net.dst.port"
+	FieldHTTPPathSegmentsLen IntField = "http.path.segments.len"
 )
 
 // HTTPHeaderField extracts the value of an HTTP header from the request.
@@ -91,4 +92,31 @@ func (f HTTPQueryField) FieldType() FieldType {
 
 func (f HTTPQueryField) String() string {
 	return "http.queries." + f.QueryParamName
+}
+
+// HTTPPathSingleSegmentField represensts a single segment of HTTP path with 0 based index.
+type HTTPPathSingleSegmentField struct {
+	Index int
+}
+
+func (f HTTPPathSingleSegmentField) FieldType() FieldType {
+	return FieldTypeString
+}
+
+func (f HTTPPathSingleSegmentField) String() string {
+	return fmt.Sprintf("http.path.segments.%d", f.Index)
+}
+
+// HTTPPathSegmentIntervalField represents a closed interval of segments in HTTP path.
+type HTTPPathSegmentIntervalField struct {
+	Start int
+	End   int
+}
+
+func (f HTTPPathSegmentIntervalField) FieldType() FieldType {
+	return FieldTypeString
+}
+
+func (f HTTPPathSegmentIntervalField) String() string {
+	return fmt.Sprintf("http.path.segments.%d_%d", f.Start, f.End)
 }

--- a/internal/dataplane/translator/atc/matcher.go
+++ b/internal/dataplane/translator/atc/matcher.go
@@ -19,6 +19,7 @@ type Matcher interface {
 var (
 	_ Matcher = &OrMatcher{}
 	_ Matcher = &AndMatcher{}
+	_ Matcher = &NotMatcher{}
 )
 
 // OrMatcher is a group of Matchers joined by logical ORs.
@@ -120,4 +121,27 @@ func And(matchers ...Matcher) *AndMatcher {
 	return &AndMatcher{
 		subMatchers: actual,
 	}
+}
+
+// NotMatcher is a matcher which negates the internal submatcher.
+type NotMatcher struct {
+	subMatcher Matcher
+}
+
+// Not returns a matcher that negates the matcher in the parameter.
+func Not(m Matcher) Matcher {
+	return &NotMatcher{
+		subMatcher: m,
+	}
+}
+
+func (m *NotMatcher) IsEmpty() bool {
+	return m == nil || m.subMatcher.IsEmpty()
+}
+
+func (m *NotMatcher) Expression() string {
+	if m == nil || m.IsEmpty() {
+		return ""
+	}
+	return fmt.Sprintf("!(%s)", m.subMatcher.Expression())
 }

--- a/internal/dataplane/translator/atc/predicate.go
+++ b/internal/dataplane/translator/atc/predicate.go
@@ -209,3 +209,32 @@ func NewPredicateHTTPQuery(key string, op BinaryOperator, value string) Predicat
 		value: StringLiteral(value),
 	}
 }
+
+func NewPredicateHTTPPathSingleSegment(index int, op BinaryOperator, value string) Predicate {
+	return Predicate{
+		field: HTTPPathSingleSegmentField{
+			Index: index,
+		},
+		op:    op,
+		value: StringLiteral(value),
+	}
+}
+
+func NewPredicateHTTPPathSegmentInterval(start, end int, op BinaryOperator, value string) Predicate {
+	return Predicate{
+		field: HTTPPathSegmentIntervalField{
+			Start: start,
+			End:   end,
+		},
+		op:    op,
+		value: StringLiteral(value),
+	}
+}
+
+func NewPredicateHTTPPathSegmentLength(op BinaryOperator, value int) Predicate {
+	return Predicate{
+		field: FieldHTTPPathSegmentsLen,
+		op:    op,
+		value: IntLiteral(value),
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Update the ATC (expression) translator as the following features are added in Kong gateway's ATC(expression) router:
- Add `NOT` (`!`) operator for negating an expression
- Add the fields and predicates for HTTP path segments matching (`http.path.segments.len`,`http.path.segments.<index>`,`http.path.segments.<index>_<index>`)

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
First step of #5485 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
