### PR TITLE
fix: do not translate licenses if Kong gateway is not enterprise edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- When managed Kong gateways are OSS edition, KIC will not apply licenses to
+  the Kong gateway instances to avoid invalid configurations.
+  [#5640](https://github.com/Kong/kubernetes-ingress-controller/pull/5640)
+
 ## [3.1.0]
 
 > Release date: 2024-02-07

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -51,7 +51,7 @@ type FeatureFlags struct {
 	// ExpressionRoutes indicates whether to translate Kubernetes objects to expression based Kong Routes.
 	ExpressionRoutes bool
 
-	// EnterpriseEdition indicates whether to translate objects that are only available in Kong enterpreise edition.
+	// EnterpriseEdition indicates whether to translate objects that are only available in the Kong enterprise edition.
 	EnterpriseEdition bool
 
 	// FillIDs enables the translator to fill in the IDs fields of Kong entities - Services, Routes, and Consumers - based

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -51,6 +51,9 @@ type FeatureFlags struct {
 	// ExpressionRoutes indicates whether to translate Kubernetes objects to expression based Kong Routes.
 	ExpressionRoutes bool
 
+	// EnterpriseEdition indicates whether to translate objects that are only available in Kong enterpreise edition.
+	EnterpriseEdition bool
+
 	// FillIDs enables the translator to fill in the IDs fields of Kong entities - Services, Routes, and Consumers - based
 	// on their names. It ensures that IDs remain stable across restarts of the controller.
 	FillIDs bool
@@ -66,10 +69,12 @@ func NewFeatureFlags(
 	featureGates featuregates.FeatureGates,
 	routerFlavor dpconf.RouterFlavor,
 	updateStatusFlag bool,
+	enterpriseEdition bool,
 ) FeatureFlags {
 	return FeatureFlags{
 		ReportConfiguredKubernetesObjects: updateStatusFlag,
 		ExpressionRoutes:                  dpconf.ShouldEnableExpressionRoutes(routerFlavor),
+		EnterpriseEdition:                 enterpriseEdition,
 		FillIDs:                           featureGates.Enabled(featuregates.FillIDsFeature),
 		RewriteURIs:                       featureGates.Enabled(featuregates.RewriteURIsFeature),
 		KongServiceFacade:                 featureGates.Enabled(featuregates.KongServiceFacade),
@@ -210,7 +215,7 @@ func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
 	// populate CA certificates in Kong
 	result.CACertificates = t.getCACerts()
 
-	if t.licenseGetter != nil {
+	if t.licenseGetter != nil && t.featureFlags.EnterpriseEdition {
 		optionalLicense := t.licenseGetter.GetLicense()
 		if l, ok := optionalLicense.Get(); ok {
 			result.Licenses = append(result.Licenses, kongstate.License{License: l})

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -172,6 +172,7 @@ func Run(
 		featureGates,
 		routerFlavor,
 		c.UpdateStatus,
+		kongStartUpConfig.Version.IsKongGatewayEnterprise(),
 	)
 
 	referenceIndexers := ctrlref.NewCacheIndexers(setupLog.WithName("reference-indexers"))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Add an `EnterpriseEdition` feature flag in translator and disable the translation of licenses if `EnterpriseEdition` is not enabled. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5638 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

- Since we added the `EnterpriseEdition` flag, we can actually do more things on translation of "enterprise only" Kong configurations (like consumergroups). Should we do this in later PRs?
- Since Kong 3.6, an `edition` field is added in the response of root endpoint. Should we implement a dedicated function to fetch this field (and fall back to judge by version if the field does not present)?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
