### PR TITLE
chore(ci) fix CLI doc generator

### DIFF
--- a/scripts/cli-arguments-docs-gen/post-process-for-konghq.sh
+++ b/scripts/cli-arguments-docs-gen/post-process-for-konghq.sh
@@ -44,5 +44,6 @@ and not CLI flags.
 # Add the generated doc content
 cat "${CRD_REF_DOC}" >> "${POST_PROCESSED_DOC}"
 
-# Turn the linter back on
+# Turn the linter back on. Add a newline first, otherwise parsing breaks.
+echo "" >> "${POST_PROCESSED_DOC}"
 echo "<!-- vale on -->" >> "${POST_PROCESSED_DOC}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a newline before the Vale directive comment. Without this, Jekyll tries to include the directive comment in the table and breaks formatting.

**Which issue this PR fixes**:

See https://github.com/Kong/docs.konghq.com/pull/6979

**Special notes for your reviewer**:

Upstream docs PR manually fixes the current files, this is for future ones.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] ~the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~