### PR TITLE
fix(controllers) skip routes bound to excluded GWs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ Adding a new version? You'll need three changes:
 - When managed Kong gateways are OSS edition, KIC will not apply licenses to
   the Kong gateway instances to avoid invalid configurations.
   [#5640](https://github.com/Kong/kubernetes-ingress-controller/pull/5640)
+- Fixed an issue where single-Gateway mode did not actually filter out routes
+  associated with other Gateways in the controller class.
+  [#5642](https://github.com/Kong/kubernetes-ingress-controller/pull/5642)
 
 ## [3.1.0]
 

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -151,9 +151,13 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](ctx context.Context, logge
 		// If the flag `--gateway-to-reconcile` is set, KIC will only reconcile the specified gateway.
 		// https://github.com/Kong/kubernetes-ingress-controller/issues/5322
 		if gatewayToReconcile, ok := specifiedGW.Get(); ok {
-			namespace = gatewayToReconcile.Namespace
-			name = gatewayToReconcile.Name
-
+			parentNamespace := route.GetNamespace()
+			if parentRef.Namespace != nil {
+				parentNamespace = string(*parentRef.Namespace)
+			}
+			if !(parentNamespace == gatewayToReconcile.Namespace && string(parentRef.Name) == gatewayToReconcile.Name) {
+				continue
+			}
 		}
 
 		// pull the Gateway object from the cached client


### PR DESCRIPTION
**What this PR does / why we need it**:

In single-Gateway mode, properly skip route parent references for other Gateways when determining whether to include a route.

**Which issue this PR fixes**:

Currently, single-Gateway mode doesn't actually restrict the controller to routes attached to that Gateway. The original work in https://github.com/Kong/kubernetes-ingress-controller/commit/2e22a101c8a962a4bf17eb3ec72f8845c598d320 doesn't actually filter other routes for two reasons:

- Although we change the controller map functions (via filters in `listHTTPRoutesForGateway()` and the like), controllers [actually queue _all_ route objects](https://github.com/Kong/kubernetes-ingress-controller/blob/7b732489a5e1ec80211e7f61a806bb1818401daf/internal/controllers/gateway/httproute_controller.go#L138-L147), not just those attached to matching Gateways, so that we can process deletes for routes whose Gateway no longer matches or who no longer have a matching Gateway as a parent.
- Although the route filter had some code from the earlier commit, it's unclear how it was supposed to actually filter non-matching routes. In practice it would sorta pretend that the assigned Gateway was the parent even when it doesn't

This fix addresses the second item. We don't need to (and arguably can't--I'm pretty sure there's no other way to handle that class of deletes) address both.

**Special notes for your reviewer**:

Integration can't really test this because it doesn't normally filter Gateways. I used 
[multi-gw.diff.txt](https://github.com/Kong/kubernetes-ingress-controller/files/14352276/multi-gw.diff.txt) off 6e1dcfe534c966f88378886b3375957d0d38479e to validate it. https://github.com/Kong/gateway-operator/pull/1480 can test it in operator integration, but that's obviously elsewhere.

I don't think the existing envtest can check this. It's already checking that there's only one _reported_ attached route, which seems wrong. I didn't check the full path, but I think we maybe have an additional filter on reporting causing that?

E2E could check this. IDK if we want to set that up for regression on what I understand as mostly an operator feature. I don't recall when all/if we run operator tests against controller main.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
