### PR TITLE
test(integration): add postgres in isolated integration tests

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -124,6 +124,10 @@ jobs:
             test: isolated.dbless
             feature_gates: "GatewayAlpha=true"
             enterprise: true
+          - name: isolated-postgres
+            test: isolated.postgres
+            feature_gates: "GatewayAlpha=true"
+            enterprise: true
           - name: isolated-dbless-expression-router
             router-flavor: expressions
             test: isolated.dbless

--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,14 @@ test.integration.isolated.dbless:
 		DBMODE=off \
 		COVERAGE_OUT=coverage.dbless.out
 
+.PHONY: test.integration.isolated.postgres
+test.integration.isolated.postgres:
+	@$(MAKE) _test.integration.isolated \
+		GOTAGS="integration_tests" \
+		DBMODE=postgres \
+		COVERAGE_OUT=coverage.dbless.out
+
+
 .PHONY: test.integration.dbless
 test.integration.dbless:
 	@$(MAKE) _test.integration \

--- a/Makefile
+++ b/Makefile
@@ -460,8 +460,7 @@ test.integration.isolated.postgres:
 	@$(MAKE) _test.integration.isolated \
 		GOTAGS="integration_tests" \
 		DBMODE=postgres \
-		COVERAGE_OUT=coverage.dbless.out
-
+		COVERAGE_OUT=coverage.postgres.out
 
 .PHONY: test.integration.dbless
 test.integration.dbless:

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -26,6 +26,9 @@ func TestKongLicense(t *testing.T) {
 		New("essentials").
 		WithLabel(testlabels.Kind, testlabels.KindKongLicense).
 		Setup(SkipIfEnterpriseNotEnabled).
+		// TODO: enable the test with DB backed mode after fixed syncing license with DB backed Kong gateways
+		// https://github.com/Kong/kubernetes-ingress-controller/issues/5644
+		Setup(SkipIfDBBacked).
 		WithSetup("deploy kong addon into cluster", featureSetup()).
 		Assess(
 			"Expect No Licenses found before creating KongLicense resource",

--- a/test/integration/isolated/skip.go
+++ b/test/integration/isolated/skip.go
@@ -26,3 +26,10 @@ func SkipIfEnterpriseNotEnabled(ctx context.Context, t *testing.T, _ *envconf.Co
 	}
 	return ctx
 }
+
+func SkipIfDBBacked(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	if testenv.DBMode() != testenv.DBModeOff {
+		t.Skip("skipping, DBLess mode is required")
+	}
+	return ctx
+}

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -306,7 +306,8 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 			fmt.Sprintf("--admission-webhook-listen=0.0.0.0:%d", testutils.AdmissionWebhookListenPort),
 			"--anonymous-reports=false",
 			fmt.Sprintf("--feature-gates=%s", featureGates),
-			fmt.Sprintf("--election-namespace=%s", kongAddon.Namespace()),
+			// Use fixed election namespace because RBAC roles for leader election are in the namespace
+			fmt.Sprintf("--election-namespace=%s", consts.ControllerNamespace),
 			fmt.Sprintf("--watch-namespace=%s", kongAddon.Namespace()),
 		}
 		allControllerArgs := append(standardControllerArgs, extraControllerArgs...)

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -306,7 +306,8 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 			fmt.Sprintf("--admission-webhook-listen=0.0.0.0:%d", testutils.AdmissionWebhookListenPort),
 			"--anonymous-reports=false",
 			fmt.Sprintf("--feature-gates=%s", featureGates),
-			// Use fixed election namespace because RBAC roles for leader election are in the namespace
+			// Use fixed election namespace `kong` because RBAC roles for leader election are in the namespace,
+			// so we create resources for leader election in the namespace to make sure that KIC can operate these resources.
 			fmt.Sprintf("--election-namespace=%s", consts.ControllerNamespace),
 			fmt.Sprintf("--watch-namespace=%s", kongAddon.Namespace()),
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
- Fix election namespace used for isolated integration tests to make isolated tests able to run with DB backed Kong gateway
- Add a Makefile item to run isolated integration tests

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Since there is still problems with `KongLicense` in DB mode, we would enable the postgres isolated integration tests after #5644.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
