### PR TITLE
chore: improve naming in package certificate

### DIFF
--- a/test/helpers/certificate/certificate.go
+++ b/test/helpers/certificate/certificate.go
@@ -14,39 +14,39 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 )
 
-type SelfSignedCertificateOptions struct {
+type selfSignedCertificateOptions struct {
 	CommonName string
 	DNSNames   []string
 	CATrue     bool
 	Expired    bool
 }
 
-type SelfSignedCertificateOptionsDecorator func(SelfSignedCertificateOptions) SelfSignedCertificateOptions
+type SelfSignedCertificateOption func(selfSignedCertificateOptions) selfSignedCertificateOptions
 
-func WithCommonName(commonName string) SelfSignedCertificateOptionsDecorator {
-	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
+func WithCommonName(commonName string) SelfSignedCertificateOption {
+	return func(opts selfSignedCertificateOptions) selfSignedCertificateOptions {
 		opts.CommonName = commonName
 		return opts
 	}
 }
 
-func WithDNSNames(dnsNames ...string) SelfSignedCertificateOptionsDecorator {
-	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
+func WithDNSNames(dnsNames ...string) SelfSignedCertificateOption {
+	return func(opts selfSignedCertificateOptions) selfSignedCertificateOptions {
 		opts.DNSNames = append(opts.DNSNames, dnsNames...)
 		return opts
 	}
 }
 
 // WithCATrue allows to use returned certificate to sign other certificates (uses BasicConstraints extension).
-func WithCATrue() SelfSignedCertificateOptionsDecorator {
-	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
+func WithCATrue() SelfSignedCertificateOption {
+	return func(opts selfSignedCertificateOptions) selfSignedCertificateOptions {
 		opts.CATrue = true
 		return opts
 	}
 }
 
-func WithAlreadyExpired() SelfSignedCertificateOptionsDecorator {
-	return func(opts SelfSignedCertificateOptions) SelfSignedCertificateOptions {
+func WithAlreadyExpired() SelfSignedCertificateOption {
+	return func(opts selfSignedCertificateOptions) selfSignedCertificateOptions {
 		opts.Expired = true
 		return opts
 	}
@@ -54,14 +54,14 @@ func WithAlreadyExpired() SelfSignedCertificateOptionsDecorator {
 
 // MustGenerateSelfSignedCert generates a tls.Certificate struct to be used in TLS client/listener configurations.
 // Certificate is self-signed thus returned cert can be used as CA for it.
-func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOptionsDecorator) tls.Certificate {
+func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOption) tls.Certificate {
 	// Generate a new RSA private key.
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to generate RSA key: %s", err))
 	}
 
-	options := SelfSignedCertificateOptions{
+	options := selfSignedCertificateOptions{
 		CommonName: "",
 		DNSNames:   []string{},
 	}
@@ -112,7 +112,7 @@ func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOptionsDecora
 // MustGenerateSelfSignedCertPEMFormat generates self-signed certificate
 // and returns certificate and key in PEM format. Certificate is self-signed
 // thus returned cert can be used as CA for it.
-func MustGenerateSelfSignedCertPEMFormat(decorators ...SelfSignedCertificateOptionsDecorator) (cert []byte, key []byte) {
+func MustGenerateSelfSignedCertPEMFormat(decorators ...SelfSignedCertificateOption) (cert []byte, key []byte) {
 	tlsCert := MustGenerateSelfSignedCert(decorators...)
 
 	certBlock := &pem.Block{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Type `SelfSignedCertificateOptionsDecorator` is too verbose, typical in Go something like that is named `SelfSignedCertificateOption`. Furthermore `SelfSignedCertificateOptions` doesn't need to be exposed, so rename to `selfSignedCertificateOptions`.