### PR TITLE
fix: notBefore and notAfter changed in CA test

### DIFF
--- a/test/helpers/certificate/certificate.go
+++ b/test/helpers/certificate/certificate.go
@@ -73,8 +73,8 @@ func MustGenerateSelfSignedCert(decorators ...SelfSignedCertificateOption) tls.C
 	notBefore := time.Now()
 	notAfter := notBefore.AddDate(1, 0, 0)
 	if options.Expired {
-		notBefore = notBefore.AddDate(-1, 0, 0)
-		notAfter = notAfter.AddDate(-1, 0, 0)
+		notBefore = notBefore.AddDate(-2, 0, 0)
+		notAfter = notAfter.AddDate(-2, 0, 0)
 	}
 
 	// Create a self-signed X.509 certificate.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This is needed to fix unit test failures like https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8094320723/job/22118824077?pr=5668

The test requires to have an expired test. With this PR, the after date is way before `now`, instead of being `now`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
