### PR TITLE
Backport "fix: do not translate licenses if Kong gateway is not enterprise edition (#5640)" to 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- When managed Kong gateways are OSS edition, KIC will not apply licenses to
+  the Kong gateway instances to avoid invalid configurations.
+  [#5640](https://github.com/Kong/kubernetes-ingress-controller/pull/5640)
+
 ## [3.1.1]
 
 ### Added
@@ -94,9 +102,6 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- When managed Kong gateways are OSS edition, KIC will not apply licenses to
-  the Kong gateway instances to avoid invalid configurations.
-  [#5640](https://github.com/Kong/kubernetes-ingress-controller/pull/5640)
 - Fixed an issue where single-`Gateway` mode did not actually filter out routes
   associated with other `Gateway`s in the controller class.
   [#5642](https://github.com/Kong/kubernetes-ingress-controller/pull/5642)

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -172,6 +172,7 @@ func Run(
 		featureGates,
 		routerFlavor,
 		c.UpdateStatus,
+		kongStartUpConfig.Version.IsKongGatewayEnterprise(),
 	)
 
 	referenceIndexers := ctrlref.NewCacheIndexers(setupLog.WithName("reference-indexers"))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Backport #5640 to `release/3.1.x` to disable translating licenses when Kong is not enterprise edition.
**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Updated changelogs because #5640 is not included in 3.1.1. 
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
