### PR TITLE
tests: fix e2e tests by installing incubator CRDs

### DIFF
--- a/test/consts/consts.go
+++ b/test/consts/consts.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	IncubatorCRDKustomizeDir = "../../config/crd/incubator"
+)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	conststest "github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
@@ -104,6 +105,9 @@ func setupE2ETest(t *testing.T, addons ...clusters.Addon) (context.Context, envi
 	env, err := builder.WithAddons(addons...).Build(ctx)
 	require.NoError(t, err)
 	logClusterInfo(t, env.Cluster())
+
+	t.Logf("deploying KIC Incubator CRDs from %s (since they are not packaged with base CRDs)", conststest.IncubatorCRDKustomizeDir)
+	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), conststest.IncubatorCRDKustomizeDir))
 
 	t.Cleanup(func() {
 		helpers.TeardownCluster(ctx, t, env.Cluster())

--- a/test/internal/testenv/feature_gates.go
+++ b/test/internal/testenv/feature_gates.go
@@ -15,18 +15,16 @@ func GetFeatureGates() string {
 	//
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/5373
 	tag := ControllerTag()
-	if tag != "" {
-		// Currently, the latest version is 3.0.x, once 3.1.x is released,
-		// we can remove this logic.
-		if tag == "latest" {
+	if tag == "" || tag == "latest" || tag == "nightly" {
+		return consts.DefaultFeatureGates
+	}
+
+	if v, err := semver.Make(tag); err == nil {
+		minVersion, _ := semver.ParseRange("<3.1.x")
+		if minVersion(v) {
 			return "GatewayAlpha=true"
 		}
-		if v, err := semver.Make(tag); err == nil {
-			minVersion, _ := semver.ParseRange("<3.1.x")
-			if minVersion(v) {
-				return "GatewayAlpha=true"
-			}
-		}
 	}
+
 	return consts.DefaultFeatureGates
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The following can be observed in KIC logs in e2e tests (in downloaded diagnostics):

```
Error: unable to create controller "*crds.DynamicCRDController": failed to index KongServiceFacades on annotation konghq.com/upstream-policy: no matches for kind "KongServiceFacade" in version "incubator.ingress-controller.konghq.com/v1alpha1"
```

It seems that `KongServiceFacade` is not installed by default in e2e tests because it's not packaged in default CRD kustomization (nor is it packaged with all in one manifests that we use for e2e tests) but the default feature gates env flag used in tests does enable its usage:

https://github.com/Kong/kubernetes-ingress-controller/blob/96941c3014b72e1a73996829f5f0e0b58a30ed44/test/consts/feature_gates.go#L8

This PR makes e2e tests install incubator CRDs via `confifg/rbac/incubator` kustomization dir


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

