### PR TITLE
ci: do not fetch all history on CI

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - id: set-versions
         name: Set versions
@@ -42,8 +40,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Parse semver string
         if: ${{ inputs.tag != '' }}
@@ -79,8 +77,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -39,8 +39,6 @@ jobs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - id: setup_golang
         name: setup golang
@@ -77,10 +75,7 @@ jobs:
       gke: ${{ steps.set-versions.outputs.gke }}
       istio: ${{ steps.set-versions.outputs.istio }}
     steps:
-      - name: checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - id: set-versions
         name: Set versions
@@ -121,8 +116,6 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5
@@ -207,8 +200,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5
@@ -313,8 +304,6 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -50,8 +50,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - id: set-versions
         name: Set versions
@@ -165,8 +163,6 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_linters.yaml
+++ b/.github/workflows/_linters.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup go
         uses: actions/setup-go@v5

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -47,8 +47,6 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5
@@ -137,8 +135,6 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: collect test coverage artifacts
         id: download-coverage
@@ -48,8 +46,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: download tests report
         id: download-coverage

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/check_fixed_issues_references.yaml
+++ b/.github/workflows/check_fixed_issues_references.yaml
@@ -15,8 +15,6 @@ jobs:
       steps:
         - name: checkout repository
           uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
         - name: check issues
           run: ./hack/check_fixed_issues_references.sh
             

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Check if PR is up to date, if it is skip workflows for this ref
         id: 'up-to-date'
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
@@ -62,8 +60,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v5
         with:
@@ -30,8 +28,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: setup golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: true
           ref: ${{ github.event.inputs.tag }}
 
@@ -34,7 +34,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: true
           ref: ${{ github.event.inputs.tag }}
 

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -36,8 +36,6 @@ jobs:
       RES_NUM: ${{ inputs.res-number-for-perf }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - run: |
           MSG="performance (targeted) tests with KIND-based clusters were started at ${URL} the number of test resources is ${RES_NUM}"
           gh pr comment ${PR_NUMBER} --body "${MSG}"
@@ -93,8 +91,6 @@ jobs:
     needs: run
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/performance_trigger_via_label.yaml
+++ b/.github/workflows/performance_trigger_via_label.yaml
@@ -18,8 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+
     # Do not run e2e tests on GKE-based clusters for specific PR, because currently
     # there is no way to use an image built from PR's code for those tests.
     # https://github.com/Kong/kubernetes-testing-framework/issues/587

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Checkout KIC repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Checkout docs repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -54,8 +54,6 @@ jobs:
 
     - name: checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v5
@@ -100,8 +98,6 @@ jobs:
 
     - name: checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v5
@@ -139,8 +135,6 @@ jobs:
     steps:
     - name: checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v5
@@ -176,8 +170,6 @@ jobs:
 
     - name: checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v5


### PR DESCRIPTION
**What this PR does / why we need it**:

Looking at the CI's logs it seems that we've been spending over 1 minute on each job's run

Example: 
https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8329931649/job/22793502809?pr=5717

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8329931649/job/22793502809?pr=5717#step:2:52

According to https://github.com/actions/checkout 

```
    # Number of commits to fetch. 0 indicates all history for all branches and tags.
    # Default: 1
    fetch-depth: ''
```

Setting to 0 fetches the whole history which is in most cases unnecessary.

This PR sets the depth to 1 ( by using the default ).
