### PR TITLE
chore(tests): simplify TestExampleUDPRoute

### DIFF
--- a/examples/gateway-udproute.yaml
+++ b/examples/gateway-udproute.yaml
@@ -2,81 +2,41 @@
 # Follow these instructions to install them before using this example:
 # https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns
-data:
-  Corefile: |-
-    .:53 {
-        errors
-        health {
-           lameduck 5s
-        }
-        ready
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-           pods insecure
-           fallthrough in-addr.arpa ip6.arpa
-           ttl 30
-        }
-        forward . /etc/resolv.conf {
-           max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coredns
+  name: udpecho
   labels:
-    app: coredns
+    app: udpecho
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      app: coredns
+      app: udpecho
   template:
     metadata:
       labels:
-        app: coredns
+        app: udpecho
     spec:
       containers:
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.8.6
-        imagePullPolicy: IfNotPresent
-        name: coredns
+      - name: udpecho
+        image: kong/go-echo:0.3.0
         ports:
-        - containerPort: 53
-          protocol: UDP
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: config-volume
-      volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: Corefile
-            path: Corefile
-          name: coredns
-        name: config-volume
+        - containerPort: 1026
+        env:
+        - name: POD_NAME
+          value: udproute-example-manifest
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: udpecho
 spec:
   ports:
-  - port: 53
+  - port: 9999
     protocol: UDP
-    targetPort: 53
+    targetPort: 1026
   selector:
-    app: coredns
+    app: udpecho
   type: ClusterIP
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -98,18 +58,18 @@ spec:
   - name: http
     protocol: HTTP
     port: 80
-  - name: dns
+  - name: udp
     protocol: UDP
-    port: 53
+    port: 9999
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: UDPRoute
 metadata:
-  name: coredns
+  name: udpecho
 spec:
   parentRefs:
   - name: kong
   rules:
   - backendRefs:
-    - name: coredns
-      port: 53
+    - name: udpecho
+      port: 9999

--- a/examples/gateway-udproute.yaml
+++ b/examples/gateway-udproute.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: kong
+  name: example-udproute
   annotations:
     konghq.com/gatewayclass-unmanaged: "true"
 spec:
@@ -51,9 +51,9 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: kong
+  name: example-udproute
 spec:
-  gatewayClassName: kong
+  gatewayClassName: example-udproute
   listeners:
   - name: http
     protocol: HTTP
@@ -68,7 +68,7 @@ metadata:
   name: udpecho
 spec:
   parentRefs:
-  - name: kong
+  - name: example-udproute
   rules:
   - backendRefs:
     - name: udpecho

--- a/test/e2e/helpers_gateway_test.go
+++ b/test/e2e/helpers_gateway_test.go
@@ -300,7 +300,7 @@ func verifyTCPRoute(ctx context.Context, t *testing.T, env environments.Environm
 
 	t.Logf("waiting for route from TCPRoute to be operational at %s:%d", proxyIP, tcpListenerPort)
 	require.Eventually(t, func() bool {
-		if err := test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyIP, tcpListenerPort), "tcpecho-tcproute"); err != nil {
+		if err := test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyIP, tcpListenerPort), "tcpecho-tcproute"); err != nil {
 			t.Logf("failed to connect to %s:%d, error %v", proxyIP, tcpListenerPort, err)
 			return false
 		}

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -99,7 +99,7 @@ func TestTCPRouteExample(t *testing.T) {
 
 	t.Log("verifying that TCPRoute becomes routable")
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest") == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), "tcproute-example-manifest") == nil
 	}, ingressWait, waitTick)
 }
 

--- a/test/integration/isolated/examples_udproute_test.go
+++ b/test/integration/isolated/examples_udproute_test.go
@@ -5,14 +5,15 @@ package isolated
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
@@ -32,25 +33,28 @@ func TestExampleUDPRoute(t *testing.T) {
 		WithSetup("deploy kong addon into cluster", featureSetup(
 			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
 		)).
-		Assess("deploying to cluster works and deployed coredns responds to UDP queries",
+		Assess("deploying to cluster works and udp traffic is routed to the service",
 			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
 				cluster := GetClusterFromCtx(ctx)
-				proxyUDPURL := GetUDPURLFromCtx(ctx)
+				// GetUDPURLFromCtx returns the URL of the UDP service, but with http prefix
+				// http://<IP>:<PORT> (bug in KTF), taking the Host part trims scheme part.
+				proxyUDPURL := GetUDPURLFromCtx(ctx).Host
 
 				t.Logf("applying yaml manifest %s", udpRouteExampleManifests)
 				b, err := os.ReadFile(udpRouteExampleManifests)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
-				// TODO as of 2022-04-01, UDPRoute does not support using a different inbound port than the outbound
-				// destination service port. Once parentRef port functionality is stable, we should remove this
 				s := string(b)
-				s = strings.ReplaceAll(s, "port: 53", "port: 9999")
-				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, s))
+				require.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, s))
 				cleaner.AddManifest(s)
 
 				t.Logf("verifying that the UDPRoute becomes routable")
-				assert.Eventually(t, urlResolvesSuccessfullyFn(ctx, proxyUDPURL), consts.IngressWait, consts.WaitTick)
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.NoError(
+						c, test.EchoResponds(test.ProtocolUDP, proxyUDPURL, "udproute-example-manifest"),
+					)
+				}, consts.IngressWait, consts.WaitTick)
 
 				return ctx
 			}).

--- a/test/integration/isolated/examples_udproute_test.go
+++ b/test/integration/isolated/examples_udproute_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -43,14 +42,14 @@ func TestExampleUDPRoute(t *testing.T) {
 
 				t.Logf("applying yaml manifest %s", udpRouteExampleManifests)
 				b, err := os.ReadFile(udpRouteExampleManifests)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				s := string(b)
-				require.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, s))
+				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, s))
 				cleaner.AddManifest(s)
 
 				t.Logf("verifying that the UDPRoute becomes routable")
-				require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.EventuallyWithT(t, func(c *assert.CollectT) {
 					assert.NoError(
 						c, test.EchoResponds(test.ProtocolUDP, proxyUDPURL, "udproute-example-manifest"),
 					)

--- a/test/integration/isolated/tcproute_test.go
+++ b/test/integration/isolated/tcproute_test.go
@@ -49,13 +49,13 @@ func TestTCPRouteEssentials(t *testing.T) {
 	// Helpers used in this test.
 	requireNoResponse := func(tcpGatewayURL string) {
 		assert.Eventually(t, func() bool {
-			err := test.TCPEchoResponds(tcpGatewayURL, "irrelevant")
+			err := test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, "irrelevant")
 			return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
 		}, consts.IngressWait, consts.WaitTick)
 	}
 	requireResponse := func(tcpGatewayURL, expectedMsg string) {
 		assert.Eventually(t, func() bool {
-			return test.TCPEchoResponds(tcpGatewayURL, expectedMsg) == nil
+			return test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, expectedMsg) == nil
 		}, consts.IngressWait, consts.WaitTick)
 	}
 
@@ -221,7 +221,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			t.Log("verifying that the tcpecho is no longer responding")
 			defer func() {
 				if t.Failed() {
-					err := test.TCPEchoResponds(tcpGatewayURL, test1UUID)
+					err := test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, test1UUID)
 					t.Logf("no longer responding check failure state: eof=%v, reset=%v, err=%v",
 						errors.Is(err, io.EOF), errors.Is(err, syscall.ECONNRESET), err)
 				}

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -160,10 +160,10 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that only the local tcpecho is responding without a ReferenceGrant")
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait*2, waitTick)
 	require.Never(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, time.Second*10, time.Second)
 
 	t.Logf("creating a ReferenceGrant that permits tcproute access from %s to services in %s", ns.Name, otherNs.Name)
@@ -204,10 +204,10 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 
 	t.Log("verifying that requests reach both the local and remote namespace echo instances")
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID1) == nil
 	}, ingressWait, waitTick)
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait, waitTick)
 
 	t.Logf("testing specific name references")
@@ -222,7 +222,7 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) == nil
 	}, ingressWait*2, waitTick)
 
 	t.Logf("testing incorrect name does not match")
@@ -232,6 +232,6 @@ func TestTCPRouteReferenceGrant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return test.TCPEchoResponds(fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) != nil
+		return test.EchoResponds(test.ProtocolTCP, fmt.Sprintf("%s:%d", proxyURL.Hostname(), ktfkong.DefaultTCPServicePort), testUUID2) != nil
 	}, ingressWait, waitTick)
 }

--- a/test/tcp_utils.go
+++ b/test/tcp_utils.go
@@ -7,20 +7,27 @@ import (
 	"time"
 )
 
-// TCPEchoResponds takes a TCP address URL and a Pod name and checks if
+type Protocol string
+
+const (
+	ProtocolTCP Protocol = "tcp"
+	ProtocolUDP Protocol = "udp"
+)
+
+// EchoResponds takes a TCP or UDP address URL and a Pod name and checks if
 // a go-echo instance is running on that Pod at that address. It sends
 // a message and checks if returned one matches. It returns an error with
 // an explanation if it is not (typical network related errors like
 // io.EOF or syscall.ECONNRESET are returned directly).
-func TCPEchoResponds(url string, podName string) error {
+func EchoResponds(protocol Protocol, url string, podName string) error {
 	dialer := net.Dialer{Timeout: RequestTimeout}
-	conn, err := dialer.Dial("tcp", url)
+	conn, err := dialer.Dial(string(protocol), url)
 	if err != nil {
 		return err
 	}
 
 	header := []byte(fmt.Sprintf("Running on Pod %s.", podName))
-	message := []byte("testing tcproute")
+	message := []byte(fmt.Sprintf("testing %sroute", protocol))
 
 	wrote, err := conn.Write(message)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Tests for UDP in KIC are historically overall complex, they use CoreDNS for verification. This PR makes `TestExampleUDPRoute` much simpler, and uses the same approach as `TestTCPRouteExample`. Instead of CoreDNS it uses `kong/go-echo:0.3.0` furthermore it refactors `TCPEchoResponds` to `EchoResponds` which works with both TCP and UDP protocol.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5715, contains the proposed resolution from https://github.com/Kong/kubernetes-ingress-controller/pull/5717 - making naming unique.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Making `test/integration/isolated/udproute_test.go` similar to `test/integration/isolated/tcproute_test.go` will be handled in a separate PR.

