### PR TITLE
ci: fix main's up-to-date job by setting fetch-depth to 0

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Check if PR is up to date, if it is skip workflows for this ref
         id: 'up-to-date'
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/Kong/kubernetes-ingress-controller/pull/5720 didn't fix the issue: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8333401781

So this PR revert the fetch depth to 0. This can probably be optimized but I failed to reproduce the failure in my fork so leaving this at 0 (which causes the somewhat unnecessary checkout of ~~ 1minute currently)
