### PR TITLE
chore(tests): migrate to isolated and simplify TestUDPIngressExample

### DIFF
--- a/examples/udpingress.yaml
+++ b/examples/udpingress.yaml
@@ -1,6 +1,5 @@
 # Usage:
 #
-# This example sets up a coredns deployment which can be proxied to via Kong UDPIngress.
 # In order to use this example make sure you're running the controller manager with the
 # following flags set:
 #
@@ -17,93 +16,53 @@
 # And then create a service configured best according to your environment to expose this port
 # on the proxy container or use a shortcut like `kubectl expose <options>`.
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns
-data:
-  Corefile: |-
-    .:53 {
-        errors
-        health {
-           lameduck 5s
-        }
-        ready
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-           pods insecure
-           fallthrough in-addr.arpa ip6.arpa
-           ttl 30
-        }
-        forward . /etc/resolv.conf {
-           max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coredns
+  name: example-udpingress-udpecho
   labels:
-    app: coredns
+    app: example-udpingress-udpecho
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      app: coredns
+      app: example-udpingress-udpecho
   template:
     metadata:
       labels:
-        app: coredns
+        app: example-udpingress-udpecho
     spec:
       containers:
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.8.6
-        imagePullPolicy: IfNotPresent
-        name: coredns
+      - name: example-udpingress-udpecho
+        image: kong/go-echo:0.3.0
         ports:
-        - containerPort: 53
-          protocol: UDP
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: config-volume
-      volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: Corefile
-            path: Corefile
-          name: coredns
-        name: config-volume
+        - containerPort: 1026
+        env:
+        - name: POD_NAME
+          value: udpingress-example-manifest
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: example-udpingress-udpecho
 spec:
   ports:
-  - port: 53
+  - port: 8888
     protocol: UDP
-    targetPort: 53
+    targetPort: 1026
   selector:
-    app: coredns
+    app: example-udpingress-udpecho
   type: ClusterIP
 ---
 apiVersion: configuration.konghq.com/v1beta1
 kind: UDPIngress
 metadata:
-  name: minudp
+  name: example-udpingress
   annotations:
     kubernetes.io/ingress.class: "kong"
 spec:
   rules:
   - backend:
-      serviceName: coredns
-      servicePort: 53
+      serviceName: example-udpingress-udpecho
+      servicePort: 8888
     port: 9999
 ---

--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -101,7 +101,7 @@ func DeployControllerManagerForCluster(
 
 	// render all controller manager flag options
 	controllerManagerFlags := []string{
-		fmt.Sprintf("--kong-admin-url=%s", proxyAdminURL.String()),
+		fmt.Sprintf("--kong-admin-url=%s", proxyAdminURL),
 		fmt.Sprintf("--kubeconfig=%s", kubeconfig.Name()),
 		"--election-id=integrationtests.konghq.com",
 		"--log-format=text",

--- a/test/integration/isolated/examples_udpingress_test.go
+++ b/test/integration/isolated/examples_udpingress_test.go
@@ -1,0 +1,64 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestUDPIngressExample(t *testing.T) {
+	udpIngressExampleManifests := examplesManifestPath("udpingress.yaml")
+
+	replaceIngressClassAnnotationInManifests := func(manifests string, ingressClass string) string {
+		const ingressClassTemplate = `kubernetes.io/ingress.class: "%s"`
+		return strings.ReplaceAll(manifests, fmt.Sprintf(ingressClassTemplate, "kong"), fmt.Sprintf(ingressClassTemplate, ingressClass))
+	}
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyIngress).
+		WithLabel(testlabels.Kind, testlabels.KindKongUDPIngress).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
+		)).
+		Assess("deploying to cluster works and UDP traffic is routed to the service",
+			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+				cluster := GetClusterFromCtx(ctx)
+				proxyUDPURL := GetUDPURLFromCtx(ctx)
+
+				t.Logf("applying yaml manifest %s", udpIngressExampleManifests)
+				b, err := os.ReadFile(udpIngressExampleManifests)
+				assert.NoError(t, err)
+				manifest := replaceIngressClassAnnotationInManifests(string(b), GetIngressClassFromCtx(ctx))
+				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, manifest))
+				cleaner.AddManifest(manifest)
+
+				t.Logf("verifying that the UDPIngress routes traffic properly")
+				assert.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.NoError(
+						c, test.EchoResponds(test.ProtocolUDP, proxyUDPURL, "udpingress-example-manifest"),
+					)
+				}, consts.IngressWait, consts.WaitTick)
+
+				return ctx
+			}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}

--- a/test/internal/testlabels/labels.go
+++ b/test/internal/testlabels/labels.go
@@ -17,7 +17,7 @@ const (
 	// NetworkingFamily is the label key used to store the networking family of
 	// resources that are being tests.
 	//
-	// Possible, values: "gatewaypi", "ingress".
+	// Possible, values: "gatewayapi", "ingress".
 	NetworkingFamily           = "networkingfamily"
 	NetworkingFamilyGatewayAPI = "gatewayapi"
 	NetworkingFamilyIngress    = "ingress"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Tests for UDP in KIC are historically overall complex, they use CoreDNS for verification. This reworks `TestUDPIngressExample` to use an isolated tests framework and makes it much simpler. Instead of CoreDNS it uses `kong/go-echo:0.3.0`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Done during work on https://github.com/Kong/kubernetes-ingress-controller/issues/5715.
There is also an initiative to get rid of CoreDNS in tests entirely.

**Special notes for your reviewer:**

Please verify whether the comment about the usage of the example `examples/udpingress.yaml` is up to date. Otherwise, I can improve it in this PR. 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

