### PR TITLE
chore: update timeout for GitHub workflows

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dependencies-versions:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
@@ -25,7 +25,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   conformance-tests:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: dependencies-versions

--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   dependencies-versions:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
@@ -24,6 +25,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   conformance-tests:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: dependencies-versions
@@ -52,12 +54,12 @@ jobs:
           JUNIT_REPORT: "conformance-tests.xml"
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
           TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
-      
+
       # upload logs when test failed
-      - name: upload KIC logs 
+      - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
         uses: actions/upload-artifact@v3
-        with: 
+        with:
           name: ${{ matrix.name }}-kic-logs
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   prepare-tags:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.merge-tags.outputs.tags }}
@@ -70,6 +71,7 @@ jobs:
           echo "tags: ${{ steps.merge-tags.outputs.tags }}"
 
   build:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     runs-on: ubuntu-latest
     needs: prepare-tags
     outputs:

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   prepare-tags:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.merge-tags.outputs.tags }}
@@ -71,7 +71,7 @@ jobs:
           echo "tags: ${{ steps.merge-tags.outputs.tags }}"
 
   build:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     runs-on: ubuntu-latest
     needs: prepare-tags
     outputs:

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   setup-e2e-tests:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -70,7 +70,7 @@ jobs:
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 
   dependencies-versions:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       kind: ${{ steps.set-versions.outputs.kind }}
@@ -92,7 +92,7 @@ jobs:
           echo "istio=$(yq -r -ojson '.e2e.istio' < .github/test_dependencies.yaml | jq -c)" >> $GITHUB_OUTPUT
 
   kind:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs:
@@ -189,7 +189,7 @@ jobs:
           path: "*-tests.xml"
 
   gke:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.run-gke }}
     environment: "gcloud"
     runs-on: ubuntu-latest
@@ -285,7 +285,7 @@ jobs:
           path: "*-tests.xml"
 
   istio:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.run-istio }}
     runs-on: ubuntu-latest
     needs: dependencies-versions

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -34,6 +34,7 @@ on:
 
 jobs:
   setup-e2e-tests:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -69,6 +70,7 @@ jobs:
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 
   dependencies-versions:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       kind: ${{ steps.set-versions.outputs.kind }}
@@ -90,6 +92,7 @@ jobs:
           echo "istio=$(yq -r -ojson '.e2e.istio' < .github/test_dependencies.yaml | jq -c)" >> $GITHUB_OUTPUT
 
   kind:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs:
@@ -186,6 +189,7 @@ jobs:
           path: "*-tests.xml"
 
   gke:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.run-gke }}
     environment: "gcloud"
     runs-on: ubuntu-latest
@@ -215,7 +219,7 @@ jobs:
       - name: check availability of KIC image
         id: check_kic_image
         if: ${{ inputs.kic-image != '' }}
-        # We have to check whether the image passed in inputs is available in the docker hub. 
+        # We have to check whether the image passed in inputs is available in the docker hub.
         # If it's not, we'll fall back to a nightly image later.
         run: (docker manifest inspect ${{ inputs.kic-image }} && echo "kic_image=${{ inputs.kic-image }}" >> $GITHUB_OUTPUT) || true
 
@@ -235,7 +239,7 @@ jobs:
             export kic_image_repo=$(echo ${{ steps.check_kic_image.outputs.kic_image }} | awk '{split($0,a,":"); print a[1]}')
             export kic_image_tag=$(echo ${{ steps.check_kic_image.outputs.kic_image }} | awk '{split($0,a,":"); print a[2]}')
             echo "kic-image=$kic_image_repo" >> $GITHUB_OUTPUT
-            echo "kic-tag=$kic_image_tag" >> $GITHUB_OUTPUT  
+            echo "kic-tag=$kic_image_tag" >> $GITHUB_OUTPUT
           else
             # See the https://github.com/Kong/kubernetes-testing-framework/issues/587 TODO below.
             # If we add local image GKE support, we can get rid of this fallback.
@@ -281,6 +285,7 @@ jobs:
           path: "*-tests.xml"
 
   istio:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.run-istio }}
     runs-on: ubuntu-latest
     needs: dependencies-versions

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   envtest-tests:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   envtest-tests:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   dependencies-versions:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       kind: ${{ steps.set-versions.outputs.kind }}
@@ -60,6 +61,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   integration-tests:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: dependencies-versions
@@ -198,12 +200,12 @@ jobs:
           name: diagnostics-integration-tests-${{ matrix.name }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
-      
+
       # upload logs when test failed
-      - name: upload KIC logs 
+      - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
         uses: actions/upload-artifact@v3
-        with: 
+        with:
           name: integration-tests-kic-logs-${{ matrix.name }}
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   dependencies-versions:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       kind: ${{ steps.set-versions.outputs.kind }}
@@ -61,7 +61,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   integration-tests:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: dependencies-versions

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   kongintegration-tests:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   kongintegration-tests:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_linters.yaml
+++ b/.github/workflows/_linters.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lint:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/_linters.yaml
+++ b/.github/workflows/_linters.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   lint:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   performance-matrix:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.res-number-for-perf == '' }}
     runs-on: ubuntu-latest
     strategy:
@@ -116,7 +116,7 @@ jobs:
           if-no-files-found: ignore
 
   performance-target:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.res-number-for-perf != '' }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   performance-matrix:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.res-number-for-perf == '' }}
     runs-on: ubuntu-latest
     strategy:
@@ -115,6 +116,7 @@ jobs:
           if-no-files-found: ignore
 
   performance-target:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.res-number-for-perf != '' }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   coverage:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.coverage && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +42,7 @@ jobs:
           verbose: true
 
   buildpulse-report:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ inputs.buildpulse && !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   coverage:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.coverage && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +42,7 @@ jobs:
           verbose: true
 
   buildpulse-report:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ inputs.buildpulse && !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   unit-tests:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   unit-tests:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     name: Backport
     runs-on: ubuntu-latest
     # Only react to merged PRs for security reasons.

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Backport
     runs-on: ubuntu-latest
     # Only react to merged PRs for security reasons.

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   benchmark:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Run Go benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   benchmark:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     name: Run Go benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check_fixed_issues_references.yaml
+++ b/.github/workflows/check_fixed_issues_references.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_issues_state:
-      timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+      timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
       runs-on: ubuntu-latest
       permissions:
         issues: read
@@ -20,7 +20,7 @@ jobs:
           run: ./hack/check_fixed_issues_references.sh
 
     notify-on-slack:
-      timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+      timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
       runs-on: ubuntu-latest
       needs:
         - check_issues_state

--- a/.github/workflows/check_fixed_issues_references.yaml
+++ b/.github/workflows/check_fixed_issues_references.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     check_issues_state:
+      timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
       runs-on: ubuntu-latest
       permissions:
         issues: read
@@ -17,8 +18,9 @@ jobs:
           uses: actions/checkout@v4
         - name: check issues
           run: ./hack/check_fixed_issues_references.sh
-            
+
     notify-on-slack:
+      timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
       runs-on: ubuntu-latest
       needs:
         - check_issues_state

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   label:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - uses: pmalek/verify-pr-label-action@v1.4.5

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - uses: pmalek/verify-pr-label-action@v1.4.5

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   up-to-date:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.up-to-date.outputs.status }}
@@ -38,6 +39,7 @@ jobs:
 
   # This job is used to check if the secrets are available. If they are not, we'll skip jobs that require them.
   should-run-with-secrets:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs:
     - up-to-date
@@ -55,6 +57,7 @@ jobs:
           fi
 
   tools:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs:
     - up-to-date
@@ -126,6 +129,7 @@ jobs:
   # It allows to use this particular job as a required check for PRs.
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
   passed:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs:
       - up-to-date

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   up-to-date:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.up-to-date.outputs.status }}
@@ -39,7 +39,7 @@ jobs:
 
   # This job is used to check if the secrets are available. If they are not, we'll skip jobs that require them.
   should-run-with-secrets:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
     - up-to-date
@@ -57,7 +57,7 @@ jobs:
           fi
 
   tools:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
     - up-to-date
@@ -129,7 +129,7 @@ jobs:
   # It allows to use this particular job as a required check for PRs.
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
   passed:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
       - up-to-date

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   gcloud:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +25,7 @@ jobs:
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
   konnect:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   gcloud:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +25,7 @@ jobs:
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
   konnect:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   analyze:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     name: analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dependencies-versions:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
@@ -29,7 +29,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   generate-report:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: dependencies-versions
     steps:

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   dependencies-versions:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
@@ -28,6 +29,7 @@ jobs:
           echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
 
   generate-report:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs: dependencies-versions
     steps:

--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ensure-nightly-image-was-built:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if image built this night exists
@@ -65,7 +65,7 @@ jobs:
 
   notify-on-slack:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs:
       - ensure-nightly-image-was-built
       - e2e-tests

--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ensure-nightly-image-was-built:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if image built this night exists
@@ -64,6 +65,7 @@ jobs:
 
   notify-on-slack:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     needs:
       - ensure-nightly-image-was-built
       - e2e-tests

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   post-comment-in-pr:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     if: ${{ github.event.inputs.pr-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -63,6 +64,7 @@ jobs:
   # We need to pick an image to use for the tests. If the input specified one, we use that. Otherwise, we use the one
   # built by the previous job.
   choose-image:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: build-image

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   post-comment-in-pr:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     if: ${{ github.event.inputs.pr-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -64,7 +64,7 @@ jobs:
   # We need to pick an image to use for the tests. If the input specified one, we use that. Otherwise, we use the one
   # built by the previous job.
   choose-image:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: build-image

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-e2e-tests-targeted:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   trigger-e2e-tests-targeted:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
-
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   fossa-scan:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     environment: "FOSSA"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   fossa-scan:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     environment: "FOSSA"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-push-images:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     environment: 'Docker Push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-push-images:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     environment: 'Docker Push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/performance_nightly.yaml
+++ b/.github/workflows/performance_nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ensure-nightly-image-was-built:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if image built this night exists
@@ -45,7 +45,7 @@ jobs:
       coverage: false
 
   notify-on-slack:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
       - ensure-nightly-image-was-built

--- a/.github/workflows/performance_nightly.yaml
+++ b/.github/workflows/performance_nightly.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ensure-nightly-image-was-built:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if image built this night exists
@@ -44,6 +45,7 @@ jobs:
       coverage: false
 
   notify-on-slack:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs:
       - ensure-nightly-image-was-built

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   post-comment-in-pr:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ github.event.inputs.pr-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -52,7 +52,7 @@ jobs:
   # We need to pick an image to use for the tests. If the input specified one, we use that. Otherwise, we use the one
   # built by the previous job.
   choose-image:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: build-image
@@ -89,7 +89,7 @@ jobs:
       coverage: false
 
   performance-reports:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: run
     steps:

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   post-comment-in-pr:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ github.event.inputs.pr-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -51,6 +52,7 @@ jobs:
   # We need to pick an image to use for the tests. If the input specified one, we use that. Otherwise, we use the one
   # built by the previous job.
   choose-image:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: build-image
@@ -87,6 +89,7 @@ jobs:
       coverage: false
 
   performance-reports:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs: run
     steps:

--- a/.github/workflows/performance_trigger_via_label.yaml
+++ b/.github/workflows/performance_trigger_via_label.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   trigger-performance-tests-targeted:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: contains(github.event.*.labels.*.name, 'ci/run-performance')
-
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}

--- a/.github/workflows/performance_trigger_via_label.yaml
+++ b/.github/workflows/performance_trigger_via_label.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-performance-tests-targeted:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: contains(github.event.*.labels.*.name, 'ci/run-performance')
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   regenerate:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: contains(github.event.*.labels.*.name, 'renovate/auto-regenerate')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   regenerate:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: contains(github.event.*.labels.*.name, 'renovate/auto-regenerate')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   verify-manifest-tag:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     outputs:
       fullversion_tag: ${{ steps.semver_parser.outputs.fullversion }}
@@ -53,6 +54,7 @@ jobs:
         run: make verify.versions
 
   build-push-images:
+    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
     environment: 'Docker Push'
     needs: verify-manifest-tag
     runs-on: ubuntu-latest
@@ -141,6 +143,7 @@ jobs:
       all-supported-k8s-versions: true
 
   publish-release:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     needs: [build-push-images, test-e2e]
     steps:
@@ -171,6 +174,7 @@ jobs:
         makeLatest: ${{ github.event.inputs.latest == 'true' }}
 
   update-latest-branch:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     if: github.event.inputs.latest == 'true'
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   verify-manifest-tag:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       fullversion_tag: ${{ steps.semver_parser.outputs.fullversion }}
@@ -54,7 +54,7 @@ jobs:
         run: make verify.versions
 
   build-push-images:
-    timeout-minutes: ${{ vars.GHA_EXTENDED_TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     environment: 'Docker Push'
     needs: verify-manifest-tag
     runs-on: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
       all-supported-k8s-versions: true
 
   publish-release:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: [build-push-images, test-e2e]
     steps:
@@ -174,7 +174,7 @@ jobs:
         makeLatest: ${{ github.event.inputs.latest == 'true' }}
 
   update-latest-branch:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: github.event.inputs.latest == 'true'
     needs:

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create_docs_pr:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: Parse semver string

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   create_docs_pr:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     runs-on: ubuntu-latest
     steps:
       - name: Parse semver string

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -17,7 +17,7 @@ on:
       kong-effective-version:
         description: Effective semantic version of Kong Gateway Docker image. If not given, the semantic version will be parsed from the image tag.
         type: string
-        required: false 
+        required: false
       e2e-controller-image-repo:
         description: KIC Docker image for E2E tests (repository).
         type: string
@@ -35,6 +35,7 @@ on:
 
 jobs:
   startup-issue-comment:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     if: ${{ github.event.inputs.issue-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -82,6 +83,7 @@ jobs:
       log-output-file:  /tmp/integration-tests-kic-logs
 
   on-finish-comment-or-close-issue:
+    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
     needs:
     - startup-issue-comment
     - run-e2e-tests

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   startup-issue-comment:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ github.event.inputs.issue-number != '' }}
     runs-on: ubuntu-latest
     env:
@@ -83,7 +83,7 @@ jobs:
       log-output-file:  /tmp/integration-tests-kic-logs
 
   on-finish-comment-or-close-issue:
-    timeout-minutes: ${{ vars.GHA_DEFAULT_TIMEOUT }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs:
     - startup-issue-comment
     - run-e2e-tests


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

There are [29 PRs](https://github.com/Kong/kubernetes-ingress-controller/pulls/team-eng-enablement) from @team-eng-enablement that set the default timeout for our GitHub workflows. This PR aims to do it in one shot.

Company wide `vars.GHA_DEFAULT_TIMEOUT = 10 minutes` for our use-case repo wide `vars.GHA_EXTENDED_TIMEOUT_MINUTES = 30 minutes` was defined too

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Special notes for your reviewer**:

I am wondering if I set it everywhere properly...

<!-- Here you can add any open questions or notes that you might have for reviewers -->

