### PR TITLE
feat: implement translator to translate path segment matching

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -56,6 +56,7 @@ const (
 	ResponseBuffering    = "/response-buffering"
 	HostAliasesKey       = "/host-aliases"
 	RegexPrefixKey       = "/regex-prefix"
+	SegmentPrefixKey     = "/segment-prefix"
 	ConnectTimeoutKey    = "/connect-timeout"
 	WriteTimeoutKey      = "/write-timeout"
 	ReadTimeoutKey       = "/read-timeout"
@@ -210,6 +211,10 @@ func ExtractPreserveHost(anns map[string]string) string {
 
 func ExtractRegexPrefix(anns map[string]string) string {
 	return anns[AnnotationPrefix+RegexPrefixKey]
+}
+
+func ExtractSegmentPrefix(anns map[string]string) string {
+	return anns[AnnotationPrefix+SegmentPrefixKey]
 }
 
 // HasServiceUpstreamAnnotation returns true if the annotation

--- a/internal/dataplane/translator/atc/predicate.go
+++ b/internal/dataplane/translator/atc/predicate.go
@@ -105,6 +105,8 @@ type Predicate struct {
 	value Literal
 }
 
+var _ Matcher = Predicate{}
+
 // Expression returns a string representation of a Predicate.
 func (p Predicate) Expression() string {
 	lhs := p.field.String()

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -328,7 +328,9 @@ func TestGenerateMatcherFromHTTPRouteMatch(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expression, generateMatcherFromHTTPRouteMatch(tc.match).Expression())
+			matcher, err := generateMatcherFromHTTPRouteMatch(tc.match, map[string]string{})
+			require.NoError(t, err)
+			require.Equal(t, tc.expression, matcher.Expression())
 		})
 	}
 }

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -230,7 +230,11 @@ func (i *ingressTranslationIndex) Translate() map[string]kongstate.Service {
 		}
 
 		if i.featureFlags.ExpressionRoutes {
-			route := meta.translateIntoKongExpressionRoute()
+			route, err := meta.translateIntoKongExpressionRoute()
+			if err != nil {
+				i.failuresCollector.PushResourceFailure(fmt.Sprintf("failed to translate to expression based route: %s", err), meta.parentIngress)
+				continue
+			}
 			kongStateService.Routes = append(kongStateService.Routes, *route)
 		} else {
 			route := meta.translateIntoKongRoute()

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -9,3 +9,9 @@ var KICv3VersionCutoff = semver.Version{Major: 3, Minor: 4, Patch: 1}
 
 // DeckFileFormatVersion is the version of the decK file format used by KIC everywhere.
 const DeckFileFormatVersion = "3.0"
+
+var (
+	HTTPPathSegmentMatchVersionCutoff      = semver.Version{Major: 3, Minor: 6, Patch: 0}
+	HTTPPathSegmentMatchMinPatchVersion3_5 = semver.Version{Major: 3, Minor: 5, Patch: 1}
+	HTTPPathSegmentMatchMinPatchVersion3_4 = semver.Version{Major: 3, Minor: 4, Patch: 3}
+)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Implement the translator for path segment matching in `Ingress`es.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
First part of #5485

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
TODO: implement validating webhooks in path segment matching

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
