### PR TITLE
fix(webhook): do not require rsa_public_key field in credentials secrets when working with jwt HMAC algorigthms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,10 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
-- Remove unnecessary tag support check that could incorrectly delete configuration if the check did not execute properly. [#5658](https://github.com/Kong/kubernetes-ingress-controller/issues/5658)
+- Remove unnecessary tag support check that could incorrectly delete configuration if the check did not execute properly.
+  [#5658](https://github.com/Kong/kubernetes-ingress-controller/issues/5658)
+- Do not require `rsa_public_key` field in credential `Secret`s when working with jwt HMAC credentials.
+  [#5737](https://github.com/Kong/kubernetes-ingress-controller/issues/5737)
 
 ## [3.1.2]
 

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -88,6 +88,60 @@ func TestValidateCredentials(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "valid jwt credential with HS512",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS512"),
+					"key":       []byte("key-name"),
+					"secret":    []byte("secret-name"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid jwt credential with HS384",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS384"),
+					"key":       []byte("key-name"),
+					"secret":    []byte("secret-name"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid jwt credential with HS256",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.LabelPrefix + labels.CredentialKey: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS256"),
+					"key":       []byte("key-name"),
+					"secret":    []byte("secret-name"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
 			// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 to be removed after deprecation window
 			name: "valid credential with deprectated field",
 			secret: &corev1.Secret{
@@ -167,7 +221,12 @@ func TestValidateCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateCredentials(tt.secret)
-			require.Equal(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not requiere the `rsa_public_key` field in credential secrets when working with jwt HMAC credentials.

The `algorithm` values are compares against https://docs.konghq.com/hub/kong-inc/jwt-signer/configuration/#config-enable_hs_signatures

**Which issue this PR fixes**:

Fixes #5736

Related: https://github.com/Kong/kubernetes-ingress-controller/issues/5159

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
