### PR TITLE
chore(tests): migrate to isolated and simplify TestUDPIngressEssentials

### DIFF
--- a/test/integration/isolated/udpingress_test.go
+++ b/test/integration/isolated/udpingress_test.go
@@ -1,0 +1,156 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestUDPIngressEssentials(t *testing.T) {
+	// Constants shared in many steps of this test that doesn't change.
+	const udpIngressName = "upd-ingress-essentials"
+	const servicePort = ktfkong.DefaultUDPServicePort
+	const serviceName = "udpecho"
+	testUUID := uuid.NewString()
+
+	// Helpers used in this test.
+	requireNoResponse := func(udpGatewayURL string) {
+		t.Helper()
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// For UDP lack of response (a timeout) means that we can't reach a service.
+			err := test.EchoResponds(test.ProtocolUDP, udpGatewayURL, "irrelevant")
+			assert.True(c, os.IsTimeout(err), "unexpected error: %v", err)
+		}, consts.IngressWait, consts.WaitTick)
+	}
+	requireResponse := func(udpGatewayURL, expectedMsg string) {
+		t.Helper()
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.NoError(c, test.EchoResponds(test.ProtocolUDP, udpGatewayURL, expectedMsg))
+		}, consts.IngressWait, consts.WaitTick)
+	}
+
+	f := features.
+		New("essentials").
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
+		WithLabel(testlabels.Kind, testlabels.KindKongUDPIngress).
+		Setup(SkipIfRouterNotExpressions).
+		WithSetup("deploy kong addon into cluster", featureSetup()).
+		WithSetup("configure a udpecho Deployment and Service", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// kongClient, err := gatewayclient.NewForConfig(cfg.Client().RESTConfig())
+			kongClient, err := clientset.NewForConfig(cfg.Client().RESTConfig())
+			assert.NoError(t, err)
+			ctx = SetInCtxForT(ctx, t, kongClient)
+
+			cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+			namespace := GetNamespaceForT(ctx, t)
+			cluster := GetClusterFromCtx(ctx)
+
+			t.Log("creating a udpecho pod to test UDPRoute traffic routing")
+			container := generators.NewContainer(serviceName, test.EchoImage, test.EchoUDPPort)
+			// App go-echo sends a "Running on Pod <UUID>." immediately on connecting.
+			container.Env = []corev1.EnvVar{
+				{
+					Name:  "POD_NAME",
+					Value: testUUID,
+				},
+			}
+			deployment := generators.NewDeploymentForContainer(container)
+			deployment, err = cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+			assert.NoError(t, err)
+			cleaner.Add(deployment)
+
+			t.Logf("exposing deployment %s/%s via service", deployment.Namespace, deployment.Name)
+			service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+			service.Name = serviceName
+			// Use the same port as the default UDP port from the Kong Gateway deployment
+			// to the udpecho port, as this is what will be used to route the traffic at the Gateway.
+			service.Spec.Ports = []corev1.ServicePort{{
+				Name:       "udp",
+				Protocol:   corev1.ProtocolUDP,
+				Port:       servicePort,
+				TargetPort: intstr.FromInt(test.EchoUDPPort),
+			}}
+			service, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+			assert.NoError(t, err)
+			cleaner.Add(service)
+
+			t.Logf("creating a UDPIngress to access deployment %s via kong", deployment.Name)
+			udpIngress := &kongv1beta1.UDPIngress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: udpIngressName,
+					Annotations: map[string]string{
+						annotations.IngressClassKey: GetIngressClassFromCtx(ctx),
+					},
+				},
+				Spec: kongv1beta1.UDPIngressSpec{Rules: []kongv1beta1.UDPIngressRule{
+					{
+						Port: ktfkong.DefaultUDPServicePort,
+						Backend: kongv1beta1.IngressBackend{
+							ServiceName: service.Name,
+							ServicePort: servicePort,
+						},
+					},
+				}},
+			}
+			_, err = kongClient.ConfigurationV1beta1().UDPIngresses(namespace).Create(ctx, udpIngress, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			return ctx
+		}).
+		Assess("basic test - UDPIngress status and connectivity", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			udpGatewayURL := GetUDPURLFromCtx(ctx)
+			ingressClient := GetFromCtxForT[*clientset.Clientset](ctx, t).ConfigurationV1beta1().UDPIngresses(GetNamespaceForT(ctx, t))
+
+			t.Log("verifying UDPIngress status readiness")
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				configuredIngress, err := ingressClient.Get(ctx, udpIngressName, metav1.GetOptions{})
+				assert.NoError(c, err)
+				assert.NotNil(c, configuredIngress)
+				for _, ingress := range configuredIngress.Status.LoadBalancer.Ingress {
+					ipReportedByIngress := ingress.IP
+					assert.NotEmpty(c, ipReportedByIngress)
+					ipOfKong, _, err := net.SplitHostPort(udpGatewayURL)
+					assert.NoError(c, err)
+					assert.Equal(c, ipOfKong, ipReportedByIngress, "UDPIngress is not ready to redirect traffic")
+				}
+			}, consts.StatusWait, consts.WaitTick)
+
+			t.Log("verifying that the udpecho is responding properly")
+			requireResponse(udpGatewayURL, testUUID)
+
+			return ctx
+		}).
+		Assess("test teardown - UDPIngress deletion", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			ingressClient := GetFromCtxForT[*clientset.Clientset](ctx, t).ConfigurationV1beta1().UDPIngresses(GetNamespaceForT(ctx, t))
+
+			t.Log("deleting UDPIngress")
+			assert.NoError(t, ingressClient.Delete(ctx, udpIngressName, metav1.DeleteOptions{}))
+			t.Log("verifying that traffic is no longer routed")
+			requireNoResponse(GetUDPURLFromCtx(ctx))
+			return ctx
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}

--- a/test/internal/testlabels/labels.go
+++ b/test/internal/testlabels/labels.go
@@ -8,6 +8,7 @@ const (
 	KindGRPCRoute          = "GRPCRoute"
 	KindIngress            = "Ingress"
 	KindKongServiceFacade  = "KongServiceFacade"
+	KindKongUDPIngress     = "UDPIngress"
 	KindKongUpstreamPolicy = "KongUpstreamPolicy"
 	KindKongLicense        = "KongLicense"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Tests for UDP in KIC are historically overall complex, they use CoreDNS for verification. This reworks `TestUDPIngressEssentials` to use an isolated tests framework and makes it much simpler. Instead of CoreDNS it uses kong/go-echo:0.3.0.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Done during work on https://github.com/Kong/kubernetes-ingress-controller/issues/5715.
There is also an initiative to get rid of CoreDNS in tests entirely.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

What it tests is quite similar to https://github.com/Kong/kubernetes-ingress-controller/pull/5724 (previously with Core DNS also such similarity existed) for now I haven't decided to merge them into one test, but I think it's something to consider

<!-- Here you can add any open questions or notes that you might have for reviewers -->
