### PR TITLE
fix: set proper User-Agent for request made to Kong and Konnect

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,6 +96,8 @@ linters-settings:
       - 'gatewayv1alpha2|gatewayv1beta1|gatewayv1(# use internal/gatewayapi aliases instead)?'
       - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
       - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'
+      - '(gokong|kong)\.NewClient(# use adminapi.NewKongAPIClient instead )?'
+        
   gomodguard:
     blocked:
       modules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ Adding a new version? You'll need three changes:
   [#5658](https://github.com/Kong/kubernetes-ingress-controller/issues/5658)
 - Do not require `rsa_public_key` field in credential `Secret`s when working with jwt HMAC credentials.
   [#5737](https://github.com/Kong/kubernetes-ingress-controller/issues/5737)
+- Set proper User-Agent for request made to Kong and Konnect.
+  [#5753](https://github.com/Kong/kubernetes-ingress-controller/pull/5753)
 
 ## [3.1.2]
 

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -11,7 +11,6 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
-	"github.com/samber/lo"
 
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
 )
@@ -42,7 +41,7 @@ func NewKongClientForKonnectControlPlane(c KonnectConfig) (*KonnectClient, error
 		return nil, fmt.Errorf("failed to extract client certificates: %w", err)
 	}
 	if clientCertificate == nil {
-		return nil, fmt.Errorf("client ceritficate is missing")
+		return nil, fmt.Errorf("client certificate is missing")
 	}
 
 	tlsConfig := tls.Config{
@@ -51,8 +50,8 @@ func NewKongClientForKonnectControlPlane(c KonnectConfig) (*KonnectClient, error
 	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tlsConfig
-	client, err := kong.NewClient(
-		lo.ToPtr(fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control-planes", c.ControlPlaneID)),
+	client, err := NewKongAPIClient(
+		fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control-planes", c.ControlPlaneID),
 		&http.Client{
 			Transport: transport,
 		},

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -716,7 +716,7 @@ func mustSampleGatewayClient(t *testing.T) *adminapi.Client {
 func mustSampleKonnectClient(t *testing.T) *adminapi.KonnectClient {
 	t.Helper()
 
-	c, err := kong.NewClient(lo.ToPtr(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString())), &http.Client{})
+	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), &http.Client{})
 	require.NoError(t, err)
 
 	rgID := uuid.NewString()

--- a/internal/konnect/controlplanes/client.go
+++ b/internal/konnect/controlplanes/client.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -379,6 +380,11 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 	if client.Client == nil {
 		client.Client = &http.Client{}
 	}
+	client.RequestEditors = append([]RequestEditorFn{func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("User-Agent", metadata.UserAgent())
+		return nil
+	}}, client.RequestEditors...)
+
 	return &client, nil
 }
 

--- a/internal/konnect/controlplanes/client_test.go
+++ b/internal/konnect/controlplanes/client_test.go
@@ -1,0 +1,44 @@
+package controlplanes_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/controlplanes"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+)
+
+type mockControlPlanesServer struct {
+	t *testing.T
+}
+
+func newMockControlPlanesServer(t *testing.T) *mockControlPlanesServer {
+	return &mockControlPlanesServer{
+		t: t,
+	}
+}
+
+func (m *mockControlPlanesServer) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	require.Equal(m.t, metadata.UserAgent(), r.Header.Get("User-Agent"))
+}
+
+func TestControlPlanesClientUserAgent(t *testing.T) {
+	ts := httptest.NewServer(newMockControlPlanesServer(t))
+	t.Cleanup(ts.Close)
+
+	c, err := controlplanes.NewClient(ts.URL)
+	require.NoError(t, err)
+
+	r, err := c.GetControlPlane(context.Background(), uuid.New())
+	require.NoError(t, err)
+	r.Body.Close()
+
+	r, err = c.DeleteControlPlane(context.Background(), uuid.New())
+	require.NoError(t, err)
+	r.Body.Close()
+}

--- a/internal/konnect/controlplanesconfig/client.go
+++ b/internal/konnect/controlplanesconfig/client.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	"github.com/oapi-codegen/runtime"
 )
 
@@ -195,6 +196,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 	if client.Client == nil {
 		client.Client = &http.Client{}
 	}
+	client.RequestEditors = append([]RequestEditorFn{func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("User-Agent", metadata.UserAgent())
+		return nil
+	}}, client.RequestEditors...)
 	return &client, nil
 }
 

--- a/internal/konnect/controlplanesconfig/client_test.go
+++ b/internal/konnect/controlplanesconfig/client_test.go
@@ -1,0 +1,43 @@
+package controlplanesconfig_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/controlplanesconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+)
+
+type mockControlPlanesConfigServer struct {
+	t *testing.T
+}
+
+func newMockControlPlanesConfigServer(t *testing.T) *mockControlPlanesConfigServer {
+	return &mockControlPlanesConfigServer{
+		t: t,
+	}
+}
+
+func (m *mockControlPlanesConfigServer) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	require.Equal(m.t, metadata.UserAgent(), r.Header.Get("User-Agent"))
+}
+
+func TestControlPlanesConfigClientUserAgent(t *testing.T) {
+	ts := httptest.NewServer(newMockControlPlanesConfigServer(t))
+	t.Cleanup(ts.Close)
+
+	c, err := controlplanesconfig.NewClient(ts.URL)
+	require.NoError(t, err)
+
+	r, err := c.GetNodes(context.Background(), &controlplanesconfig.GetNodesParams{})
+	require.NoError(t, err)
+	r.Body.Close()
+
+	r, err = c.DeleteCoreEntities(context.Background(), "test")
+	require.NoError(t, err)
+	r.Body.Close()
+}

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/useragent"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
 )
@@ -44,7 +45,7 @@ func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
 	c := &http.Client{}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tlsConfig
-	c.Transport = transport
+	c.Transport = useragent.NewTransport(transport)
 
 	return &Client{
 		address:        cfg.Address,

--- a/internal/konnect/nodes/client.go
+++ b/internal/konnect/nodes/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/useragent"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
 )
 
@@ -43,7 +44,7 @@ func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
 	c := &http.Client{}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tlsConfig
-	c.Transport = transport
+	c.Transport = useragent.NewTransport(transport)
 
 	return &Client{
 		address:        cfg.Address,

--- a/internal/konnect/nodes/client_test.go
+++ b/internal/konnect/nodes/client_test.go
@@ -1,0 +1,42 @@
+package nodes_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+)
+
+type mockNodesServer struct {
+	t *testing.T
+}
+
+func newMockNodesServer(t *testing.T) *mockNodesServer {
+	return &mockNodesServer{
+		t: t,
+	}
+}
+
+func (m *mockNodesServer) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	require.Equal(m.t, metadata.UserAgent(), r.Header.Get("User-Agent"))
+}
+
+func TestNodesClientUserAgent(t *testing.T) {
+	ts := httptest.NewServer(newMockNodesServer(t))
+	t.Cleanup(ts.Close)
+
+	c, err := nodes.NewClient(adminapi.KonnectConfig{Address: ts.URL})
+	require.NoError(t, err)
+
+	_, err = c.GetNode(context.Background(), "test-node-id")
+	require.Error(t, err)
+
+	err = c.DeleteNode(context.Background(), "test-node-id")
+	require.NoError(t, err)
+}

--- a/internal/konnect/roles/client.go
+++ b/internal/konnect/roles/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/useragent"
 )
 
 const (
@@ -43,6 +45,7 @@ func NewRole(id, entityID string) (Role, error) {
 }
 
 func NewClient(httpClient *http.Client, baseURL string, personalAccessToken string) *Client {
+	httpClient.Transport = useragent.NewTransport(httpClient.Transport)
 	return &Client{
 		baseURL:             baseURL,
 		httpClient:          httpClient,

--- a/internal/konnect/useragent/user_agent_round_tripper.go
+++ b/internal/konnect/useragent/user_agent_round_tripper.go
@@ -1,0 +1,25 @@
+package useragent
+
+import (
+	"net/http"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+)
+
+func NewTransport(underlyingTransport http.RoundTripper) http.RoundTripper {
+	return &transport{
+		underlyingTransport: underlyingTransport,
+	}
+}
+
+type transport struct {
+	underlyingTransport http.RoundTripper
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("User-Agent", metadata.UserAgent())
+	if t.underlyingTransport != nil {
+		return t.underlyingTransport.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -343,7 +343,7 @@ func (c *Config) GetKubeconfig() (*rest.Config, error) {
 		config.Impersonate.UserName = c.Impersonate
 	}
 
-	config.UserAgent = "kong-ingress-controller/" + metadata.Release
+	config.UserAgent = metadata.UserAgent()
 
 	return config, err
 }

--- a/internal/manager/metadata/metadata.go
+++ b/internal/manager/metadata/metadata.go
@@ -1,7 +1,9 @@
 // Package metadata includes metadata variables for logging and reporting.
 package metadata
 
-import "strings"
+import (
+	"strings"
+)
 
 // -----------------------------------------------------------------------------
 // Controller Manager - Versioning Information
@@ -38,4 +40,8 @@ func projectNameFromRepo(repo string) string {
 		return NotSet
 	}
 	return projectName
+}
+
+func UserAgent() string {
+	return "kong-ingress-controller/" + Release
 }

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -12,10 +12,8 @@ import (
 	"testing"
 	"time"
 
-	gokong "github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
@@ -355,7 +354,7 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 			localPort := startPortForwarder(forwardCtx, t, env, proxyDeploymentNN.Namespace, pod.Name, "8444")
 			address := fmt.Sprintf("https://localhost:%d", localPort)
 
-			kongClient, err := gokong.NewClient(lo.ToPtr(address), client)
+			kongClient, err := adminapi.NewKongAPIClient(address, client)
 			require.NoError(t, err)
 
 			verifyIngressWithEchoBackendsInAdminAPI(ctx, t, kongClient, numberOfEchoBackends)

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	gokong "github.com/kong/go-kong/kong"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -312,7 +311,7 @@ func requireAllProxyReplicasIDsConsistentWithKonnect(
 		localPort := startPortForwarder(forwardCtx, t, env, proxyDeploymentNN.Namespace, proxyPod.Name, "8444")
 		address := fmt.Sprintf("https://localhost:%d", localPort)
 
-		kongClient, err := gokong.NewClient(lo.ToPtr(address), client)
+		kongClient, err := adminapi.NewKongAPIClient(address, client)
 		require.NoError(t, err)
 
 		nodeID, err := adminapi.NewClient(kongClient).NodeID(ctx)

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
-	"github.com/samber/lo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
@@ -22,7 +21,7 @@ func GetKongRootConfig(ctx context.Context, proxyAdminURL *url.URL, kongTestPass
 	if err != nil {
 		return nil, fmt.Errorf("failed creating specific HTTP client for Kong API URL: %q: %w", proxyAdminURL, err)
 	}
-	kc, err := kong.NewClient(lo.ToPtr(proxyAdminURL.String()), httpClient)
+	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating Kong API client for URL: %q: %w", proxyAdminURL, err)
 	}
@@ -105,7 +104,8 @@ func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPasswo
 	if err != nil {
 		return nil, err
 	}
-	kc, err := kong.NewClient(lo.ToPtr(proxyAdminURL.String()), httpClient)
+
+	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/test/kongintegration/expression_router_test.go
+++ b/test/kongintegration/expression_router_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/atc"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
@@ -32,7 +32,7 @@ func TestExpressionsRouterMatchers_GenerateValidExpressions(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := kong.NewClient(lo.ToPtr(kongC.AdminURL(ctx, t)), helpers.DefaultHTTPClient())
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), helpers.DefaultHTTPClient())
 	require.NoError(t, err)
 
 	httpBinC := containers.NewHTTPBin(ctx, t)

--- a/test/kongintegration/inmemory_update_strategy_test.go
+++ b/test/kongintegration/inmemory_update_strategy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
 )
@@ -32,7 +33,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := kong.NewClient(lo.ToPtr(kongC.AdminURL(ctx, t)), &http.Client{})
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), &http.Client{})
 	require.NoError(t, err)
 
 	logbase, err := zap.NewDevelopment()

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
@@ -32,7 +33,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := kong.NewClient(lo.ToPtr(kongC.AdminURL(ctx, t)), &http.Client{})
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), &http.Client{})
 	require.NoError(t, err)
 	updateStrategy := sendconfig.NewUpdateStrategyInMemory(
 		kongClient,

--- a/test/kongintegration/translator_golden_tests_outputs_test.go
+++ b/test/kongintegration/translator_golden_tests_outputs_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-database-reconciler/pkg/dump"
 	"github.com/kong/go-database-reconciler/pkg/file"
-	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers/konnect"
@@ -52,7 +52,8 @@ func TestTranslatorsGoldenTestsOutputs(t *testing.T) {
 		t.Parallel()
 
 		kongC := containers.NewKong(ctx, t, containers.KongWithRouterFlavor("expressions"))
-		kongClient, err := kong.NewClient(kong.String(kongC.AdminURL(ctx, t)), helpers.DefaultHTTPClient())
+
+		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), helpers.DefaultHTTPClient())
 		require.NoError(t, err)
 
 		sut := sendconfig.NewUpdateStrategyInMemory(
@@ -72,7 +73,7 @@ func TestTranslatorsGoldenTestsOutputs(t *testing.T) {
 		t.Parallel()
 
 		kongC := containers.NewKong(ctx, t, containers.KongWithRouterFlavor("traditional"))
-		kongClient, err := kong.NewClient(kong.String(kongC.AdminURL(ctx, t)), helpers.DefaultHTTPClient())
+		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), helpers.DefaultHTTPClient())
 		require.NoError(t, err)
 
 		sut := sendconfig.NewUpdateStrategyInMemory(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It uses `go-kong` feature introduced in `v0.52.0`, see
- https://github.com/Kong/go-kong/pull/427

It allows setting `User-Agent` to ensure that KIC always uses the client with the proper `User-Agent` set. The linter configuration will enforce it across the whole repo.

For clients that live in the KIC repo `internal/konnect/*` `User-Agent` is also added. Those clients are considered as a temporary solution because they will be deprecated as fast as the proper SDK will be released. Thus it's not in the scope of this PR to make a bigger refactor, etc. of those clients, just add the missing `User-Agent`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5418

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
