### PR TITLE
chore(tests): reuse assertion functions for TCP and UDP in isolated tests

### DIFF
--- a/test/integration/isolated/assertion_helpers.go
+++ b/test/integration/isolated/assertion_helpers.go
@@ -1,0 +1,45 @@
+package isolated
+
+import (
+	"errors"
+	"io"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+)
+
+func assertEventuallyNoResponseUDP(t *testing.T, udpGatewayURL string) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// For UDP lack of response (a timeout) means that we can't reach a service.
+		err := test.EchoResponds(test.ProtocolUDP, udpGatewayURL, "irrelevant")
+		assert.True(c, os.IsTimeout(err), "unexpected error: %v", err)
+	}, consts.IngressWait, consts.WaitTick)
+}
+
+func assertEventuallyResponseUDP(t *testing.T, udpGatewayURL, expectedMsg string) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, test.EchoResponds(test.ProtocolUDP, udpGatewayURL, expectedMsg))
+	}, consts.IngressWait, consts.WaitTick)
+}
+
+func assertEventuallyNoResponseTCP(t *testing.T, tcpGatewayURL string) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, "irrelevant")
+		assert.True(c, errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET), "unexpected error: %v", err)
+	}, consts.IngressWait, consts.WaitTick)
+}
+
+func assertEventuallyResponseTCP(t *testing.T, tcpGatewayURL, expectedMsg string) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, expectedMsg))
+	}, consts.IngressWait, consts.WaitTick)
+}

--- a/test/integration/isolated/tcproute_test.go
+++ b/test/integration/isolated/tcproute_test.go
@@ -45,21 +45,6 @@ func TestTCPRouteEssentials(t *testing.T) {
 	gatewayClassName := uuid.NewString()
 	gatewayName := uuid.NewString()
 
-	// Helpers used in this test.
-	requireNoResponse := func(t *testing.T, tcpGatewayURL string) {
-		t.Helper()
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			err := test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, "irrelevant")
-			assert.True(c, errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET), "unexpected error: %v", err)
-		}, consts.IngressWait, consts.WaitTick)
-	}
-	requireResponse := func(t *testing.T, tcpGatewayURL, expectedMsg string) {
-		t.Helper()
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.NoError(c, test.EchoResponds(test.ProtocolTCP, tcpGatewayURL, expectedMsg))
-		}, consts.IngressWait, consts.WaitTick)
-	}
-
 	f := features.
 		New("essentials").
 		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
@@ -194,7 +179,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 
 			t.Log("verifying that the tcpecho is responding properly")
 			tcpGatewayURL := GetTCPURLFromCtx(ctx)
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -226,7 +211,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 						errors.Is(err, io.EOF), errors.Is(err, syscall.ECONNRESET), err)
 				}
 			}()
-			requireNoResponse(t, tcpGatewayURL)
+			assertEventuallyNoResponseTCP(t, tcpGatewayURL)
 
 			t.Log("putting the parentRefs back")
 			assert.Eventually(t, func() bool {
@@ -242,7 +227,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -260,7 +245,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the GatewayClass now removed")
-			requireNoResponse(t, tcpGatewayURL)
+			assertEventuallyNoResponseTCP(t, tcpGatewayURL)
 
 			t.Log("putting the GatewayClass back")
 			gwc, err := helpers.DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -271,7 +256,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the GatewayClass again triggers reconciliation of TCPRoutes and the route becomes available again")
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			t.Log("deleting the Gateway")
 			assert.NoError(t, gatewayClient.GatewayV1().Gateways(namespace).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
@@ -281,7 +266,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the TCPRoute gets dropped with the Gateway now removed")
-			requireNoResponse(t, tcpGatewayURL)
+			assertEventuallyNoResponseTCP(t, tcpGatewayURL)
 
 			t.Log("putting the Gateway back")
 			_, err = helpers.DeployGateway(ctx, gatewayClient, namespace, gatewayClassName, func(gw *gatewayapi.Gateway) {
@@ -299,7 +284,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			t.Log("deleting both GatewayClass and Gateway rapidly")
 			assert.NoError(t, gatewayClient.GatewayV1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -310,7 +295,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the TCPRoute does not get orphaned with the GatewayClass and Gateway gone")
-			requireNoResponse(t, tcpGatewayURL)
+			assertEventuallyNoResponseTCP(t, tcpGatewayURL)
 
 			t.Log("putting the GatewayClass back")
 			_, err = helpers.DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -332,7 +317,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the Gateway again triggers reconciliation of TCPRoutes and the route becomes available again")
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -366,8 +351,8 @@ func TestTCPRouteEssentials(t *testing.T) {
 			}, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the TCPRoute is now load-balanced between two services")
-			requireResponse(t, tcpGatewayURL, test1UUID)
-			requireResponse(t, tcpGatewayURL, test2UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test2UUID)
 
 			t.Log("testing port matching")
 			t.Log("putting the Gateway back")
@@ -385,7 +370,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			assert.NoError(t, err)
 
 			t.Log("verifying that the TCPRoute responds before specifying a port not existent in Gateway")
-			requireResponse(t, tcpGatewayURL, test1UUID)
+			assertEventuallyResponseTCP(t, tcpGatewayURL, test1UUID)
 
 			t.Log("setting the port in ParentRef which does not have a matching listener in Gateway")
 			assert.Eventually(t, func() bool {
@@ -401,7 +386,7 @@ func TestTCPRouteEssentials(t *testing.T) {
 			}, time.Minute, time.Second)
 
 			t.Log("verifying that the TCPRoute does not respond after specifying a port not existent in Gateway")
-			requireNoResponse(t, tcpGatewayURL)
+			assertEventuallyNoResponseTCP(t, tcpGatewayURL)
 			return ctx
 		}).
 		Teardown(featureTeardown())

--- a/test/integration/isolated/udproute_test.go
+++ b/test/integration/isolated/udproute_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -45,22 +44,6 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 	gatewayClassName := uuid.NewString()
 	gatewayName := uuid.NewString()
-
-	// Helpers used in this test.
-	requireNoResponse := func(t *testing.T, udpGatewayURL string) {
-		t.Helper()
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			// For UDP lack of response (a timeout) means that we can't reach a service.
-			err := test.EchoResponds(test.ProtocolUDP, udpGatewayURL, "irrelevant")
-			assert.True(c, os.IsTimeout(err), "unexpected error: %v", err)
-		}, consts.IngressWait, consts.WaitTick)
-	}
-	requireResponse := func(t *testing.T, udpGatewayURL, expectedMsg string) {
-		t.Helper()
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.NoError(c, test.EchoResponds(test.ProtocolUDP, udpGatewayURL, expectedMsg))
-		}, consts.IngressWait, consts.WaitTick)
-	}
 
 	f := features.
 		New("essentials").
@@ -196,7 +179,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 
 			t.Log("verifying that the udpecho is responding properly")
 			udpGatewayURL := GetUDPURLFromCtx(ctx)
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -228,7 +211,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 						errors.Is(err, io.EOF), errors.Is(err, syscall.ECONNRESET), err)
 				}
 			}()
-			requireNoResponse(t, udpGatewayURL)
+			assertEventuallyNoResponseUDP(t, udpGatewayURL)
 
 			t.Log("putting the parentRefs back")
 			assert.Eventually(t, func() bool {
@@ -244,7 +227,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that putting the parentRefs back results in the routes becoming available again")
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -262,7 +245,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the GatewayClass now removed")
-			requireNoResponse(t, udpGatewayURL)
+			assertEventuallyNoResponseUDP(t, udpGatewayURL)
 
 			t.Log("putting the GatewayClass back")
 			gwc, err := helpers.DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -273,7 +256,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the GatewayClass again triggers reconciliation of UDPRoutes and the route becomes available again")
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			t.Log("deleting the Gateway")
 			assert.NoError(t, gatewayClient.GatewayV1().Gateways(namespace).Delete(ctx, gatewayName, metav1.DeleteOptions{}))
@@ -283,7 +266,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the UDPRoute gets dropped with the Gateway now removed")
-			requireNoResponse(t, udpGatewayURL)
+			assertEventuallyNoResponseUDP(t, udpGatewayURL)
 
 			t.Log("putting the Gateway back")
 			_, err = helpers.DeployGateway(ctx, gatewayClient, namespace, gatewayClassName, func(gw *gatewayapi.Gateway) {
@@ -301,7 +284,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the Gateway again triggers reconciliation of UDPRoutes and the route becomes available again")
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			t.Log("deleting both GatewayClass and Gateway rapidly")
 			assert.NoError(t, gatewayClient.GatewayV1().GatewayClasses().Delete(ctx, gwc.Name, metav1.DeleteOptions{}))
@@ -312,7 +295,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the data-plane configuration from the UDPRoute does not get orphaned with the GatewayClass and Gateway gone")
-			requireNoResponse(t, udpGatewayURL)
+			assertEventuallyNoResponseUDP(t, udpGatewayURL)
 
 			t.Log("putting the GatewayClass back")
 			_, err = helpers.DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
@@ -334,7 +317,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.Eventually(t, callback, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that creating the Gateway again triggers reconciliation of UDPRoutes and the route becomes available again")
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			return ctx
 		}).
@@ -368,8 +351,8 @@ func TestUDPRouteEssentials(t *testing.T) {
 			}, consts.IngressWait, consts.WaitTick)
 
 			t.Log("verifying that the UDPRoute is now load-balanced between two services")
-			requireResponse(t, udpGatewayURL, test1UUID)
-			requireResponse(t, udpGatewayURL, test2UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test2UUID)
 
 			t.Log("testing port matching")
 			t.Log("putting the Gateway back")
@@ -387,7 +370,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			assert.NoError(t, err)
 
 			t.Log("verifying that the UDPRoute responds before specifying a port not existent in Gateway")
-			requireResponse(t, udpGatewayURL, test1UUID)
+			assertEventuallyResponseUDP(t, udpGatewayURL, test1UUID)
 
 			t.Log("setting the port in ParentRef which does not have a matching listener in Gateway")
 			assert.Eventually(t, func() bool {
@@ -403,7 +386,7 @@ func TestUDPRouteEssentials(t *testing.T) {
 			}, time.Minute, time.Second)
 
 			t.Log("verifying that the UDPRoute does not respond after specifying a port not existent in Gateway")
-			requireNoResponse(t, udpGatewayURL)
+			assertEventuallyNoResponseUDP(t, udpGatewayURL)
 			return ctx
 		}).
 		Teardown(featureTeardown())


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Keep test code DRY. We are currently migrating to isolated tests, but even now helpers for common assertions can be reused in isolated tests. Probably it will evolve in the future.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
