### PR TITLE
feat: log an error when configuration fails to get applied and `KongConfigurationApplyFailed` is emitted

### DIFF
--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -712,6 +712,17 @@ func (c *KongClient) updateKubernetesObjectReportFilter(set k8sobj.Configuration
 func (c *KongClient) recordResourceFailureEvents(resourceFailures []failures.ResourceFailure, reason string) {
 	for _, failure := range resourceFailures {
 		for _, obj := range failure.CausingObjects() {
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			c.logger.Error(
+				errors.New("object failed to apply"),
+				"recording a Warning event for object",
+				"name", obj.GetName(),
+				"namespace", obj.GetNamespace(),
+				"kind", gvk.Kind,
+				"apiVersion", gvk.Group+"/"+gvk.Version,
+				"reason", reason,
+				"message", failure.Message(),
+			)
 			c.eventRecorder.Event(obj, corev1.EventTypeWarning, reason, failure.Message())
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will make KIC emit error logs for each error that is emitted as `KongConfigurationApplyFailed` event to help users discover errors in their configuration.

Example:

```
2024-03-28T11:09:33+01:00	error	recording a Warning event for object	{"name": "alice1", "namespace": "default", "kind": "KongConsumer", "apiVersion": "configuration.konghq.com/v1", "reason": "KongConfigurationApplyFailed", "message": "invalid consumer:: uniqueness violation: 'consumers' entity with username set to 'alice' already declared", "error": "object failed to apply"}
```

**Which issue this PR fixes**:

Part of #5431

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
