### PR TITLE
feat(diag) expose unparseable config errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+### Added
+
+- Add a `/debug/config/raw-error` endpoint to the config dump diagnostic
+  server. This endpoint outputs the original Kong `/config` endpoint error for
+  failed configuration pushes in case error parsing fails. Attempt to log the
+  `message` field of errors that KIC cannot fully parse.
+  [#5773](https://github.com/Kong/kubernetes-ingress-controller/issues/5773)
+
 ### Fixed
 
 - Remove unnecessary tag support check that could incorrectly delete configuration if the check did not execute properly.

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -567,7 +567,7 @@ func (c *KongClient) sendToClient(
 	// apply the configuration update in Kong
 	timedCtx, cancel := context.WithTimeout(ctx, c.requestTimeout)
 	defer cancel()
-	newConfigSHA, entityErrors, err := sendconfig.PerformUpdate(
+	newConfigSHA, entityErrors, rawErrBody, err := sendconfig.PerformUpdate(
 		timedCtx,
 		logger,
 		client,
@@ -583,7 +583,7 @@ func (c *KongClient) sendToClient(
 	if !client.IsKonnect() {
 		c.recordApplyConfigurationEvents(err, client.BaseRootURL())
 	}
-	sendDiagnostic(err != nil)
+	sendDiagnostic(err != nil, rawErrBody)
 
 	if err != nil {
 		if expired, ok := timedCtx.Deadline(); ok && time.Now().After(expired) {
@@ -611,7 +611,7 @@ func (c *KongClient) SetConfigStatusNotifier(n clients.ConfigStatusNotifier) {
 // Dataplane Client - Kong - Private
 // -----------------------------------------------------------------------------
 
-type sendDiagnosticFn func(failed bool)
+type sendDiagnosticFn func(failed bool, raw []byte)
 
 // prepareSendDiagnosticFn generates sendDiagnosticFn.
 // Diagnostics are sent only when provided diagnostic config (--dump-config) is set.
@@ -625,7 +625,7 @@ func prepareSendDiagnosticFn(
 ) sendDiagnosticFn {
 	if diagnosticConfig == (util.ConfigDumpDiagnostic{}) {
 		// noop, diagnostics won't be sent
-		return func(bool) {}
+		return func(bool, []byte) {}
 	}
 
 	var config *file.Content
@@ -640,7 +640,7 @@ func prepareSendDiagnosticFn(
 		config = targetContent
 	}
 
-	return func(failed bool) {
+	return func(failed bool, raw []byte) {
 		// Given that we can send multiple configs to this channel and
 		// the fact that the API that exposes that can only expose 1 config
 		// at a time it means that users utilizing the diagnostics API
@@ -648,7 +648,7 @@ func prepareSendDiagnosticFn(
 		// or successfully send configs might be covered by those send
 		// later on but we're OK with this limitation of said API.
 		select {
-		case diagnosticConfig.Configs <- util.ConfigDump{Failed: failed, Config: *config}:
+		case diagnosticConfig.Configs <- util.ConfigDump{Failed: failed, Config: *config, Raw: raw}:
 			logger.V(util.DebugLevel).Info("Shipping config to diagnostic server")
 		default:
 			logger.Error(nil, "Config diagnostic buffer full, dropping diagnostic config")

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -648,7 +648,7 @@ func prepareSendDiagnosticFn(
 		// or successfully send configs might be covered by those send
 		// later on but we're OK with this limitation of said API.
 		select {
-		case diagnosticConfig.Configs <- util.ConfigDump{Failed: failed, Config: *config, Raw: raw}:
+		case diagnosticConfig.Configs <- util.ConfigDump{Failed: failed, Config: *config, RawResponseBody: raw}:
 			logger.V(util.DebugLevel).Info("Shipping config to diagnostic server")
 		default:
 			logger.Error(nil, "Config diagnostic buffer full, dropping diagnostic config")

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -253,10 +253,11 @@ type mockUpdateStrategy struct {
 func (m *mockUpdateStrategy) Update(_ context.Context, content sendconfig.ContentWithHash) (
 	err error,
 	resourceErrors []sendconfig.ResourceError,
+	rawErrBody []byte,
 	resourceErrorsParseErr error,
 ) {
 	err = m.onUpdate(content)
-	return err, nil, nil
+	return err, nil, nil, nil
 }
 
 func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/sendconfig/backoff_strategy_test.go
+++ b/internal/dataplane/sendconfig/backoff_strategy_test.go
@@ -27,15 +27,16 @@ func newMockUpdateStrategy(shouldSucceed bool) *mockUpdateStrategy {
 func (m *mockUpdateStrategy) Update(context.Context, sendconfig.ContentWithHash) (
 	err error,
 	resourceErrors []sendconfig.ResourceError,
+	rawErrBody []byte,
 	resourceErrorsParseErr error,
 ) {
 	m.wasUpdateCalled = true
 
 	if !m.shouldSucceed {
-		return errors.New("update failure occurred"), nil, nil
+		return errors.New("update failure occurred"), nil, nil, nil
 	}
 
-	return nil, nil, nil
+	return nil, nil, nil, nil
 }
 
 func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {
@@ -119,7 +120,7 @@ func TestUpdateStrategyWithBackoff(t *testing.T) {
 			backoffStrategy := newMockBackoffStrategy(tc.updateShouldBeAllowed)
 
 			decoratedStrategy := sendconfig.NewUpdateStrategyWithBackoff(updateStrategy, backoffStrategy, logger)
-			err, _, _ := decoratedStrategy.Update(ctx, sendconfig.ContentWithHash{})
+			err, _, _, _ := decoratedStrategy.Update(ctx, sendconfig.ContentWithHash{})
 			if tc.expectError != nil {
 				require.Equal(t, tc.expectError, err)
 			} else {

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -51,20 +51,21 @@ func NewUpdateStrategyInMemory(
 func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentWithHash) (
 	err error,
 	resourceErrors []ResourceError,
+	rawErrBody []byte,
 	resourceErrorsParseErr error,
 ) {
 	dblessConfig := s.configConverter.Convert(targetState.Content)
 	config, err := json.Marshal(dblessConfig)
 	if err != nil {
-		return fmt.Errorf("constructing kong configuration: %w", err), nil, nil
+		return fmt.Errorf("constructing kong configuration: %w", err), nil, nil, nil
 	}
 
 	if errBody, err := s.configService.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(config), true, true); err != nil {
 		resourceErrors, parseErr := parseFlatEntityErrors(errBody, s.logger)
-		return err, resourceErrors, parseErr
+		return err, resourceErrors, errBody, parseErr
 	}
 
-	return nil, nil, nil
+	return nil, nil, nil, nil
 }
 
 func (s UpdateStrategyInMemory) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -91,6 +91,15 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 
 	err := json.Unmarshal(body, &configError)
 	if err != nil {
+		// we _should_ arguably be able to parse the "message" field into a ConfigError even if we can't parse a full set
+		// of flattened errors, but for some reason those incomplete errors still don't unmarshal. as a fallback, try and
+		// yank the field out via a more basic unmarshal target
+		fallback := map[string]interface{}{}
+		if fallbackErr := json.Unmarshal(body, &fallback); fallbackErr == nil {
+			if message, ok := fallback["message"]; ok {
+				logger.Error(nil, "Could not fully parse config error", "message", message)
+			}
+		}
 		return resourceErrors, fmt.Errorf("could not unmarshal config error: %w", err)
 	}
 	if len(configError.Flattened) == 0 {

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -93,6 +93,13 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 	if err != nil {
 		return resourceErrors, fmt.Errorf("could not unmarshal config error: %w", err)
 	}
+	if len(configError.Flattened) == 0 {
+		if len(configError.Message) > 0 {
+			logger.Error(nil, "config error missing per-resource errors", "message", configError.Message)
+		} else {
+			logger.Error(nil, "config error missing per-resource and message", "message", configError.Message)
+		}
+	}
 	for _, ee := range configError.Flattened {
 		raw := rawResourceError{
 			Name:     ee.Name,

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -95,9 +95,9 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 	}
 	if len(configError.Flattened) == 0 {
 		if len(configError.Message) > 0 {
-			logger.Error(nil, "config error missing per-resource errors", "message", configError.Message)
+			logger.Error(nil, "Config error missing per-resource errors", "message", configError.Message)
 		} else {
-			logger.Error(nil, "config error missing per-resource and message", "message", configError.Message)
+			logger.Error(nil, "Config error missing per-resource and message", "message", configError.Message)
 		}
 	}
 	for _, ee := range configError.Flattened {

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -24,6 +24,7 @@ type UpdateStrategy interface {
 	Update(ctx context.Context, targetContent ContentWithHash) (
 		err error,
 		resourceErrors []ResourceError,
+		rawErrorBody []byte,
 		resourceErrorsParseErr error,
 	)
 

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -123,7 +123,7 @@ func (s *Server) receiveConfig(ctx context.Context) {
 			s.configLock.Lock()
 			if dump.Failed {
 				s.failedConfigDump = dump.Config
-				s.rawErrBody = dump.Raw
+				s.rawErrBody = dump.RawResponseBody
 			} else {
 				s.successfulConfigDump = dump.Config
 			}

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -48,9 +48,9 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 		for i := 0; i < configDumpsToWrite; i++ {
 			failed = !failed // Toggle failed flag.
 			configsCh <- util.ConfigDump{
-				Config: file.Content{},
-				Failed: failed,
-				Raw:    []byte("fake error body"),
+				Config:          file.Content{},
+				Failed:          failed,
+				RawResponseBody: []byte("fake error body"),
 			}
 		}
 	}()

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -50,6 +50,7 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 			configsCh <- util.ConfigDump{
 				Config: file.Content{},
 				Failed: failed,
+				Raw:    []byte("fake error body"),
 			}
 		}
 	}()
@@ -71,6 +72,10 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 					_ = resp.Body.Close()
 				}
 				resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/failed", port))
+				if err == nil {
+					_ = resp.Body.Close()
+				}
+				resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/raw-error", port))
 				if err == nil {
 					_ = resp.Body.Close()
 				}

--- a/internal/util/configdiag.go
+++ b/internal/util/configdiag.go
@@ -6,6 +6,7 @@ import "github.com/kong/go-database-reconciler/pkg/file"
 type ConfigDump struct {
 	Config file.Content
 	Failed bool
+	Raw    []byte
 }
 
 // ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps.

--- a/internal/util/configdiag.go
+++ b/internal/util/configdiag.go
@@ -4,13 +4,19 @@ import "github.com/kong/go-database-reconciler/pkg/file"
 
 // ConfigDump contains a config dump and a flag indicating that the config was not successfully applid.
 type ConfigDump struct {
+	// Config is the configuration KIC applied or attempted to apply.
 	Config file.Content
+	// Failed is true if the configuration apply failed.
 	Failed bool
-	Raw    []byte
+	// RawResponseBody is the raw Kong Admin API response body from a config apply. It is only available in DB-less mode.
+	RawResponseBody []byte
 }
 
 // ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps.
 type ConfigDumpDiagnostic struct {
+	// DumpsIncludeSensitive is true if the configuration dump includes sensitive values, such as certificate private
+	// keys and credential secrets.
 	DumpsIncludeSensitive bool
-	Configs               chan ConfigDump
+	// Configs is the channel that receives configuration blobs from the configuration update strategy implementation.
+	Configs chan ConfigDump
 }

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -239,7 +239,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 
 			// Update Kong with the Upstream.
 			require.Eventually(t, func() bool {
-				err, _, _ = updateStrategy.Update(ctx, content)
+				err, _, _, _ = updateStrategy.Update(ctx, content)
 				if err != nil {
 					t.Logf("error updating Kong configuration: %v", err)
 					return false

--- a/test/kongintegration/translator_golden_tests_outputs_test.go
+++ b/test/kongintegration/translator_golden_tests_outputs_test.go
@@ -127,7 +127,7 @@ func ensureGoldenTestOutputIsAccepted(
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		err, resourceErrors, parseErr := sut.Update(ctx, sendconfig.ContentWithHash{Content: content})
+		err, resourceErrors, rawErrBody, parseErr := sut.Update(ctx, sendconfig.ContentWithHash{Content: content})
 		if err != nil {
 			t.Logf("error: %v", err)
 			return false
@@ -138,6 +138,7 @@ func ensureGoldenTestOutputIsAccepted(
 		}
 		if parseErr != nil {
 			t.Logf("parse error: %v", parseErr)
+			t.Logf("raw error: %v", rawErrBody)
 			return false
 		}
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a diagnostic endpoint for raw config errors to simplify problem identification when Kong does not return flattened errors.

Attempt to log the `message` field if we cannot unmarshal a config error into the proper type.

**Which issue this PR fixes**:

Fix #5762 

**Special notes for your reviewer**:

Logs from practical testing:

```
2024-03-28T19:45:41Z	error	could not fully parse config error	{"message": "declarative config is invalid: {targets={[2]=\"uniqueness violation: 'targets' entity with primary key set to '172fcf76-2116-5155-ae84-e534423f5354' already declared\"}}"}
2024-03-28T19:45:41Z	error	Failed parsing resource errors	{"url": "https://10.244.0.6:8444", "update_strategy": "InMemory", "error": "could not unmarshal config error: json: cannot unmarshal object into Go struct field ConfigError.flattened_errors of type []sendconfig.FlatEntityError"}
2024-03-28T19:45:41Z	error	dataplane-synchronizer	Could not update kong admin	{"error": "performing update for https://10.244.0.7:8444 failed: failed posting new config to /config: got status code 400\nperforming update for https://10.244.0.6:8444 failed: failed posting new config to /config: got status code 400"}
```
Diag output looks like [endpoints.txt](https://github.com/Kong/kubernetes-ingress-controller/files/14794709/endpoints.txt) using resources in [test.yaml.txt](https://github.com/Kong/kubernetes-ingress-controller/files/14794711/test.yaml.txt)

---

I wanted to log the basic `message` field as well, to provide a more accessible (no need to enable config dumps) record of mystery errors. The body observed in [the original report](https://github.com/Kong/kubernetes-ingress-controller/issues/5676#issuecomment-2000481013) _does_ have a `message` field:

```
{                      
  "message": "declarative config is invalid: {targets={[2]=\"uniqueness violation: targets entity with primary key set to 0500bbf6-db53-52da-ad42-d13937d1e29c already declared\"}}",
  "flattened_errors": {},
  "code": 14,
  "fields": {
    "targets": [
      null,
      "uniqueness violation: targets entity with primary key set to 0500bbf6-db53-52da-ad42-d13937d1e29c already declared"
    ]
  },
  "name": "invalid declarative configuration"
}
```

We [unmarshal](https://github.com/Kong/kubernetes-ingress-controller/blob/7fe98ba1ceec461462a324f20d758774e6ec46aa/internal/dataplane/sendconfig/inmemory_error_handling.go#L90-L92) into [a struct that has a `message` field](https://github.com/Kong/kubernetes-ingress-controller/blob/7fe98ba1ceec461462a324f20d758774e6ec46aa/internal/dataplane/sendconfig/inmemory_error_handling.go#L24-L30) and omits the rest if missing, but it's still failing for some reason. The lazier `map[string]interface{}{}` unmarshal hopefully handles this if we've at least gotten a Kong JSON config error and not a generic 500 or whatever.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
