### PR TITLE
fix(ci): fix nightly build by adding missing GOCACHE and GOPATH build params

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,8 +13,15 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+
+      # Setup Golang to use go pkg cache which is utilized in Dockerfile's cache mount.
+      - name: Setup golang
+        uses: actions/setup-go@v5
         with:
-          fetch-depth: 0
+          go-version-file: go.mod
+      - run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+      - run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Add standard tags
         id: tags-standard
         run: |
@@ -59,6 +66,8 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
+            GOPATH=${{ env.GOPATH}}
+            GOCACHE=${{ env.GOCACHE}}
       - name: Build and push distroless image to DockerHub
         id: docker_build
         uses: docker/build-push-action@v5
@@ -73,3 +82,5 @@ jobs:
             TAG=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
+            GOPATH=${{ env.GOPATH}}
+            GOCACHE=${{ env.GOCACHE}}


### PR DESCRIPTION
**What this PR does / why we need it**:

#5768 missed adding those params to nightly pipeline which should in fact use `.github/workflows/_docker_build.yaml` but apparently it's still defined as a standalone job.