### PR TITLE
ci: set timeout for e2e test and perf test

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -193,7 +193,7 @@ jobs:
           path: "*-tests.xml"
 
   gke:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     if: ${{ inputs.run-gke }}
     environment: "gcloud"
     runs-on: ubuntu-latest

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   performance-matrix:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     if: ${{ inputs.res-number-for-perf == '' }}
     runs-on: ubuntu-latest
     strategy:
@@ -119,7 +119,7 @@ jobs:
           if-no-files-found: ignore
 
   performance-target:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     if: ${{ inputs.res-number-for-perf != '' }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

~As we have already set a timeout for ORG, any job that does not specify its timeout will default to using the global 10 minutes.~

Company wide vars.GHA_DEFAULT_TIMEOUT = 10 minutes for our use-case repo wide vars.GHA_EXTENDED_TIMEOUT_MINUTES = 30 minutes was defined too

The e2e tests and performance tests running on GKE took more than 10 minutes, so I have set them to run for 30 minutes.

> [e2e-tests / gke (1.29.2, TestDeployAllInOnePostgresGatewayDiscovery$)](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8517470363/job/23328098244)
The job running on runner GitHub Actions 30 has exceeded the maximum execution time of 10 minutes.

ref: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8517470363


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
