### PR TITLE
build: do not use qemu for emulation when building docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,14 @@
 !**/*.sum
 .git
 kong-ingress-controller
+bin/
+config/
+docs/
+examples/
+scripts/
+generators/
+Dockerfile*
+test/
+keps/
+third_party/
+*.md

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -88,9 +88,6 @@ jobs:
       - run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -127,6 +127,8 @@ jobs:
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_docker_build.yaml
     secrets: inherit
+    with:
+      platforms: linux/amd64, linux/arm64
 
   # We need this step to fail the workflow if any of the previous steps failed or were cancelled.
   # It allows to use this particular job as a required check for PRs.

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,8 +29,6 @@ jobs:
           echo "type=raw,value={{date 'YYYY-MM-DD'}}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,8 +81,6 @@ jobs:
           echo "" >> $GITHUB_ENV
           echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Standard binary
 # Build the manager binary
-FROM golang:1.22.1 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.1 as builder
 
 ARG GOPATH
 ARG GOCACHE

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Build a manager binary with debug symbols and download Delve
-FROM golang:1.22.1 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.1 as builder
 
 ARG GOPATH
 ARG GOCACHE


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR introduces usage of docker's `BUILDPLATFORM` build variable which allows to utilize Go's cross compilation instead of QEMU arm64 emulation.

Related: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

This cuts down the build time from around 10 minutes (on a nightly build - https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8503447872/job/23288959082#step:12:677 - because up until now we have not been running arm64 builds on PRs so there's nothing to compare against until this gets merged) to around a 1m30s https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8521142792/job/23338780301?pr=5788#step:9:1905

---

This PR also adds several entries to .dockerignore to minimize what we're sending as part of the docker context.