### PR TITLE
chore(docs): add checkbox for docs update in enhancement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -9,6 +9,17 @@ body:
     options:
     - label: I have searched the existing issues
       required: true
+- type: checkboxes
+  attributes:
+    label: Does this enhancement require public documentation?
+    description: |
+      Please make sure that Acceptance Criteria section includes for updating our public documentation
+      ([docs.konghq.com](https://github.com/kong/docs.konghq.com), README.md, etc.) with the new feature or enhancement.
+      If the scope of the change is too large to be documented in the Acceptance Criteria, please create a separate
+      issue and link it in the AC.
+    options:
+      - label: I have added an Acceptance Criteria item for adding and/or adjusting public documentation (if applicable)
+        required: true
 - type: textarea
   attributes:
     label: Problem Statement


### PR DESCRIPTION
**What this PR does / why we need it**:

Let's add a checkbox to the enhancement issue template that will ensure that we add docs updates in the acceptance criteria. This is to ensure we properly track docs updates and do not postpone writing them just before a release happens.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

This resolves an action item from a retro discussion about missed docs updated for KIC 3.1 release.
