### PR TITLE
test: allow installation using a specified GatewayAPI commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,10 +725,15 @@ _run:
 # unsupported ref and downloads the manifests from the main branch.
 #
 # [1]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md#remote-directories
+#
+# If you want to install from a specific commit,
+# you can set GATEWAY_API_VERSION to the full commit hash
+# and GATEWAY_API_PACKAGE_VERSION will be automatically obtained through go mod.
 GATEWAY_API_PACKAGE ?= sigs.k8s.io/gateway-api
 GATEWAY_API_RELEASE_CHANNEL ?= experimental
 GATEWAY_API_VERSION ?= $(shell go list -m -f '{{ .Version }}' $(GATEWAY_API_PACKAGE))
-GATEWAY_API_CRDS_LOCAL_PATH = $(shell go env GOPATH)/pkg/mod/$(GATEWAY_API_PACKAGE)@$(GATEWAY_API_VERSION)/config/crd
+GATEWAY_API_PACKAGE_VERSION ?= $(shell go list -m -f '{{ .Version }}' $(GATEWAY_API_PACKAGE))
+GATEWAY_API_CRDS_LOCAL_PATH = $(shell go env GOPATH)/pkg/mod/$(GATEWAY_API_PACKAGE)@$(GATEWAY_API_PACKAGE_VERSION)/config/crd
 GATEWAY_API_REPO ?= github.com/kubernetes-sigs/gateway-api
 GATEWAY_API_RAW_REPO ?= https://raw.githubusercontent.com/kubernetes-sigs/gateway-api
 GATEWAY_API_CRDS_URL = $(GATEWAY_API_REPO)/config/crd/$(GATEWAY_API_RELEASE_CHANNEL)?ref=$(GATEWAY_API_VERSION)
@@ -745,6 +750,7 @@ print-gateway-api-raw-repo-url:
 .PHONY: generate.gateway-api-consts
 generate.gateway-api-consts:
 	GATEWAY_API_VERSION=$(GATEWAY_API_VERSION) \
+		GATEWAY_API_PACKAGE_VERSION=$(GATEWAY_API_PACKAGE_VERSION) \
 		CRDS_STANDARD_URL=$(shell GATEWAY_API_RELEASE_CHANNEL="" $(MAKE) print-gateway-api-crds-url) \
 		CRDS_EXPERIMENTAL_URL=$(shell GATEWAY_API_RELEASE_CHANNEL="experimental" $(MAKE) print-gateway-api-crds-url) \
 		RAW_REPO_URL=$(shell $(MAKE) print-gateway-api-raw-repo-url) \

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -5,6 +5,7 @@ package consts
 
 const (
 	GatewayAPIVersion                   = "v1.0.0"
+	GatewayAPIPackageVersion            = "v1.0.0"
 	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.0.0"
 	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0"
 	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0"

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -127,7 +127,7 @@ func Setup(t *testing.T, scheme *k8sruntime.Scheme, optModifiers ...OptionModifi
 func installGatewayCRDs(t *testing.T, scheme *k8sruntime.Scheme, cfg *rest.Config) {
 	t.Helper()
 
-	gatewayCRDPath := filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "gateway-api@"+consts.GatewayAPIVersion, "config", "crd", "experimental")
+	gatewayCRDPath := filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "gateway-api@"+consts.GatewayAPIPackageVersion, "config", "crd", "experimental")
 	_, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
 		Scheme:             scheme,
 		Paths:              []string{gatewayCRDPath},

--- a/test/internal/cmd/generate-gateway-api-consts/gateway_consts.tmpl
+++ b/test/internal/cmd/generate-gateway-api-consts/gateway_consts.tmpl
@@ -5,6 +5,7 @@ package consts
 
 const (
 	GatewayAPIVersion = "{{.GatewayAPIVersion}}"
+	GatewayAPIPackageVersion = "{{.GatewayAPIPackageVersion}}"
 	GatewayStandardCRDsKustomizeURL = "{{.CRDsStandardKustomizeURL}}"
 	GatewayExperimentalCRDsKustomizeURL = "{{.CRDsExperimentalKustomizeURL}}"
 	GatewayRawRepoURL = "{{.RawRepoURL}}"

--- a/test/internal/cmd/generate-gateway-api-consts/main.go
+++ b/test/internal/cmd/generate-gateway-api-consts/main.go
@@ -14,19 +14,21 @@ import (
 	"text/template"
 )
 
-//go:generate go run --tags generate_gateway_api_consts . -gateway-api-version $GATEWAY_API_VERSION -crds-standard-url $CRDS_STANDARD_URL -crds-experimental-url $CRDS_EXPERIMENTAL_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
+//go:generate go run --tags generate_gateway_api_consts . -gateway-api-version $GATEWAY_API_VERSION -gateway-api-package-version $GATEWAY_API_PACKAGE_VERSION -crds-standard-url $CRDS_STANDARD_URL -crds-experimental-url $CRDS_EXPERIMENTAL_URL -raw-repo-url $RAW_REPO_URL -in $INPUT -out $OUTPUT
 
 var (
-	gatewayAPIVersionFlag   = flag.String("gateway-api-version", "", "The semver version of Gateway API that should be used")
-	crdsStandardURLFlag     = flag.String("crds-standard-url", "", "The URL of standard Gateway API CRDs to be consumed by kustomize")
-	crdsExperimentalURLFlag = flag.String("crds-experimental-url", "", "The URL of experimental Gateway API CRDs to be consumed by kustomize")
-	rawRepoURLFlag          = flag.String("raw-repo-url", "", "The raw URL of Gateway API repository")
-	inFlag                  = flag.String("in", "", "Template file path")
-	outFlag                 = flag.String("out", "", "Output file path where the generated file will be placed")
+	gatewayAPIVersionFlag        = flag.String("gateway-api-version", "", "The semver version of Gateway API that should be used")
+	gatewayAPIPackageVersionFlag = flag.String("gateway-api-package-version", "", "The version of Gateway API package that should be used")
+	crdsStandardURLFlag          = flag.String("crds-standard-url", "", "The URL of standard Gateway API CRDs to be consumed by kustomize")
+	crdsExperimentalURLFlag      = flag.String("crds-experimental-url", "", "The URL of experimental Gateway API CRDs to be consumed by kustomize")
+	rawRepoURLFlag               = flag.String("raw-repo-url", "", "The raw URL of Gateway API repository")
+	inFlag                       = flag.String("in", "", "Template file path")
+	outFlag                      = flag.String("out", "", "Output file path where the generated file will be placed")
 )
 
 type Data struct {
 	GatewayAPIVersion            string
+	GatewayAPIPackageVersion     string
 	CRDsStandardKustomizeURL     string
 	CRDsExperimentalKustomizeURL string
 	RawRepoURL                   string
@@ -37,6 +39,7 @@ func main() {
 
 	data := Data{
 		GatewayAPIVersion:            *gatewayAPIVersionFlag,
+		GatewayAPIPackageVersion:     *gatewayAPIPackageVersionFlag,
 		CRDsStandardKustomizeURL:     *crdsStandardURLFlag,
 		CRDsExperimentalKustomizeURL: *crdsExperimentalURLFlag,
 		RawRepoURL:                   *rawRepoURLFlag,
@@ -55,6 +58,9 @@ func flagParse() {
 	if *gatewayAPIVersionFlag == "" {
 		log.Print("Please provide the 'gateway-api-version' flag")
 		os.Exit(0)
+	}
+	if *gatewayAPIPackageVersionFlag == "" {
+		*gatewayAPIPackageVersionFlag = *gatewayAPIVersionFlag
 	}
 	if *crdsStandardURLFlag == "" {
 		log.Print("Please provide the 'crds-standard-url' flag")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

There are two ways to install GWAPI CRDs in our testing:

* install from go mod https://github.com/Kong/kubernetes-ingress-controller/blob/28889089a48a6f0b99505967791b4618f2ab9a4b/test/envtest/setup.go#L130
* install from GitHub via kustomize https://github.com/Kong/kubernetes-ingress-controller/blob/28889089a48a6f0b99505967791b4618f2ab9a4b/test/e2e/features_test.go#L280

However, kustomize does not support the use of short commits generated by go mod, 
and go mod also does not support the use of full commit hashes.

This PR introduces a new variable, GATEWAY_API_PACKAGE_VERSION. It will automatically resolve the package version in dependencies through go mod and allow us to use the full commit hash to use the GATEWAY API package.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

This PR is from 
https://github.com/Kong/kubernetes-ingress-controller/pull/5776/commits/91d2c60aada7ea7bc1f43f6d35b425e50b31282e

I used a specific commit hash of GWAPI in https://github.com/Kong/kubernetes-ingress-controller/pull/5776  and it has passed the test.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
