### PR TITLE
chore: do not return requeue true when err is not nil

### DIFF
--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -368,7 +368,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			debug(log, gateway, "Reconciliation triggered but gateway does not exist, deleting it in dataplane")
 			return ctrl.Result{}, r.DataplaneClient.DeleteObject(gateway)
 		}
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	debug(log, gateway, "Processing gateway")
@@ -495,7 +495,7 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 				"name", gateway.Name,
 				"service", ref,
 			)
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		if svc != nil {
 			gatewayServices = append(gatewayServices, svc)


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered in one of the CI runs in during a failed test run:

```
2024-04-03T21:14:36.3000089Z     run.go:227: 2024-04-03T21:14:34Z	info	controllers.Gateway	Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler	{"reconcileID": "e58094f2-da9a-400c-abe5-f043b2f7ebb5"}
```
