### PR TITLE
fix: do reconcile secrets with `konghq.com/credential` label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ Adding a new version? You'll need three changes:
 - `KongUpstreamPolicy` controller no longer requires existence of `HTTPRoute` CRD
   to start.
   [#5780](https://github.com/Kong/kubernetes-ingress-controller/pull/5780)
+- Reconcile Secrets with `konghq.com/credential` label instead of waiting for other
+  object to contain a reference to that Secrets
+  [#5816](https://github.com/Kong/kubernetes-ingress-controller/pull/5816)
 
 ## [3.1.2]
 

--- a/internal/admission/validation/consumers/credentials/validation.go
+++ b/internal/admission/validation/consumers/credentials/validation.go
@@ -24,7 +24,7 @@ func ValidateCredentials(secret *corev1.Secret) error {
 	if credentialSource == util.CredentialTypeAbsent {
 		// this shouldn't occur, since we check this earlier in the admission controller's handleSecret function, but
 		// checking here also in case a refactor removes that
-		return fmt.Errorf("secret has no credential type, add a %s label", labels.LabelPrefix+labels.CredentialKey)
+		return fmt.Errorf("secret has no credential type, add a %s label", labels.CredentialTypeLabel)
 	}
 
 	// verify that the credential type provided is valid
@@ -127,7 +127,7 @@ func (cs Index) ValidateCredentialsForUniqueKeyConstraints(secret *corev1.Secret
 	if credentialSource == util.CredentialTypeAbsent {
 		return fmt.Errorf(
 			"secret has no credential type, add a %s label",
-			labels.LabelPrefix+labels.CredentialKey,
+			labels.CredentialTypeLabel,
 		)
 	}
 

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -78,7 +78,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+						labels.CredentialTypeLabel: "key-auth",
 					},
 				},
 				Data: map[string][]byte{
@@ -94,7 +94,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "jwt",
+						labels.CredentialTypeLabel: "jwt",
 					},
 				},
 				Data: map[string][]byte{
@@ -112,7 +112,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "jwt",
+						labels.CredentialTypeLabel: "jwt",
 					},
 				},
 				Data: map[string][]byte{
@@ -130,7 +130,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "jwt",
+						labels.CredentialTypeLabel: "jwt",
 					},
 				},
 				Data: map[string][]byte{
@@ -163,7 +163,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "bee-auth",
+						labels.CredentialTypeLabel: "bee-auth",
 					},
 				},
 				Data: map[string][]byte{
@@ -183,7 +183,7 @@ func TestValidateCredentials(t *testing.T) {
 					"key": []byte("little-rabbits-be-good"),
 				},
 			},
-			wantErr: fmt.Errorf("secret has no credential type, add a %s label", labels.LabelPrefix+labels.CredentialKey),
+			wantErr: fmt.Errorf("secret has no credential type, add a %s label", labels.CredentialTypeLabel),
 		},
 		{
 			name: "missing required field",
@@ -192,7 +192,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+						labels.CredentialTypeLabel: "key-auth",
 					},
 				},
 				Data: map[string][]byte{
@@ -208,7 +208,7 @@ func TestValidateCredentials(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+						labels.CredentialTypeLabel: "key-auth",
 					},
 				},
 				Data: map[string][]byte{

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
@@ -82,9 +83,15 @@ func (r *CoreV1SecretReconciler) shouldReconcileSecret(obj client.Object) bool {
 		return false
 	}
 
-	labels := secret.Labels
-	if labels != nil && labels[CACertLabelKey] == "true" {
-		return true
+	l := secret.Labels
+	if l != nil {
+		if l[CACertLabelKey] == "true" {
+			return true
+		}
+
+		if _, ok := l[labels.CredentialTypeLabel]; ok {
+			return true
+		}
 	}
 
 	referred, err := r.ReferenceIndexers.ObjectReferred(secret)

--- a/internal/controllers/configuration/secret_controller_test.go
+++ b/internal/controllers/configuration/secret_controller_test.go
@@ -1,0 +1,84 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
+)
+
+func TestCoreV1SecretReconciler_shouldReconcileSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   bool
+	}{
+		{
+			name: "Secret with no labels",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			want: false,
+		},
+		{
+			name: "Secret with konghq.com/ca-cert:true label",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"konghq.com/ca-cert": "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Secret with konghq.com/ca-cert:false label",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"konghq.com/ca-cert": "false",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Secret without konghq.com/ca-cert label",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"some-other-label": "true",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Secret with labels.CredentialTypeLabel label",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	r := &CoreV1SecretReconciler{
+		ReferenceIndexers: ctrlref.NewCacheIndexers(logr.Discard()),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.shouldReconcileSecret(tt.secret)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -515,7 +515,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				Name:      "labeledSecret",
 				Namespace: "default",
 				Labels: map[string]string{
-					labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					labels.CredentialTypeLabel: "key-auth",
 				},
 			},
 			Data: map[string][]byte{
@@ -527,7 +527,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				Name:      "labeledSecretWithCredField",
 				Namespace: "default",
 				Labels: map[string]string{
-					labels.LabelPrefix + labels.CredentialKey: "key-auth",
+					labels.CredentialTypeLabel: "key-auth",
 				},
 			},
 			Data: map[string][]byte{
@@ -540,7 +540,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				Name:      "badTypeLabeledSecret",
 				Namespace: "default",
 				Labels: map[string]string{
-					labels.LabelPrefix + labels.CredentialKey: "bee-auth",
+					labels.CredentialTypeLabel: "bee-auth",
 				},
 			},
 			Data: map[string][]byte{

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -8,4 +8,7 @@ const (
 
 	// CredentialKey is the key used to indicate a Secret's credential type.
 	CredentialKey = "/credential" //nolint:gosec
+
+	// CredentialTypeLabel is the label used to indicate a Secret's credential type.
+	CredentialTypeLabel = LabelPrefix + CredentialKey
 )

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -23,7 +23,7 @@ const (
 // ExtractKongCredentialType returns the credential type of a Secret and a code indicating whether the credential type
 // was obtained from a label, field, or not at all. Labels take precedence over fields if both are present.
 func ExtractKongCredentialType(secret *corev1.Secret) (string, CredentialTypeSource) {
-	credType, labelOk := secret.Labels[labels.LabelPrefix+labels.CredentialKey]
+	credType, labelOk := secret.Labels[labels.CredentialTypeLabel]
 	if !labelOk {
 		// if no label, fall back to the deprecated field
 		credBytes, fieldOk := secret.Data["kongCredType"]

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -24,7 +24,7 @@ func TestExtractKongCredentialType(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+						labels.CredentialTypeLabel: "key-auth",
 					},
 				},
 				Data: map[string][]byte{
@@ -58,7 +58,7 @@ func TestExtractKongCredentialType(t *testing.T) {
 					Name:      "secret",
 					Namespace: "default",
 					Labels: map[string]string{
-						labels.LabelPrefix + labels.CredentialKey: "key-auth",
+						labels.CredentialTypeLabel: "key-auth",
 					},
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION
**What this PR does / why we need it**:

Do reconcile secrets with `konghq.com/credential` label.

**Which issue this PR fixes**:

Closes: #5398

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
