### PR TITLE
fix(upstreams) deduplicate like targets

### DIFF
--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -5073,3 +5073,94 @@ func TestTargetsForEndpoints(t *testing.T) {
 
 	require.Equal(t, wantTargets, targets)
 }
+
+func TestUpdateTargetMap(t *testing.T) {
+	testCases := []struct {
+		name        string
+		newTarget   kongstate.Target
+		currentMap  map[string]kongstate.Target
+		expectedMap map[string]kongstate.Target
+	}{
+		{
+			name: "empty map",
+			newTarget: kongstate.Target{
+				Target: kong.Target{
+					Target: lo.ToPtr("1.1.1.1"),
+					Weight: lo.ToPtr(10),
+				},
+			},
+			currentMap: map[string]kongstate.Target{},
+			expectedMap: map[string]kongstate.Target{
+				"1.1.1.1": {
+					Target: kong.Target{
+						Target: lo.ToPtr("1.1.1.1"),
+						Weight: lo.ToPtr(10),
+					},
+				},
+			},
+		},
+		{
+			name: "other target in map",
+			newTarget: kongstate.Target{
+				Target: kong.Target{
+					Target: lo.ToPtr("1.1.1.1"),
+					Weight: lo.ToPtr(10),
+				},
+			},
+			currentMap: map[string]kongstate.Target{
+				"2.2.2.2": {
+					Target: kong.Target{
+						Target: lo.ToPtr("2.2.2.2"),
+						Weight: lo.ToPtr(10),
+					},
+				},
+			},
+			expectedMap: map[string]kongstate.Target{
+				"2.2.2.2": {
+					Target: kong.Target{
+						Target: lo.ToPtr("2.2.2.2"),
+						Weight: lo.ToPtr(10),
+					},
+				},
+				"1.1.1.1": {
+					Target: kong.Target{
+						Target: lo.ToPtr("1.1.1.1"),
+						Weight: lo.ToPtr(10),
+					},
+				},
+			},
+		},
+		{
+			name: "like target in map",
+			newTarget: kongstate.Target{
+				Target: kong.Target{
+					Target: lo.ToPtr("1.1.1.1"),
+					Weight: lo.ToPtr(10),
+				},
+			},
+			currentMap: map[string]kongstate.Target{
+				"1.1.1.1": {
+					Target: kong.Target{
+						Target: lo.ToPtr("1.1.1.1"),
+						Weight: lo.ToPtr(10),
+					},
+				},
+			},
+			expectedMap: map[string]kongstate.Target{
+				"1.1.1.1": {
+					Target: kong.Target{
+						Target: lo.ToPtr("1.1.1.1"),
+						Weight: lo.ToPtr(20),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := updateTargetMap(tc.currentMap, tc.newTarget)
+			require.Equal(t, tc.expectedMap, result)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Combine targets with the same address or hostname by summing their weights into a single target. Previously, same address targets would result in duplicates and would be rejected by Kong.

**Which issue this PR fixes**:

Fix https://github.com/Kong/kubernetes-ingress-controller/issues/5761. Summing weights wasn't actually that hard!

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
