### PR TITLE
perf: preallocate when listing Gateway API objects in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,13 @@ Adding a new version? You'll need three changes:
 - Support to apply licenses to DB backed Kong gateway from `KongLicense`.
   [#5648](https://github.com/Kong/kubernetes-ingress-controller/pull/5648)
 
+### Changed
+
+- Preallocate slices for Gateway API objects when listing in store.
+  This yields a significant performance improvements in time spent, bytes allocated
+  and allocations per list operation.
+  [#5824](https://github.com/Kong/kubernetes-ingress-controller/pull/5824)
+
 ## [3.1.2]
 
 > Release date: 2024-03-08


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Listing in `Store` apparently uses the `ListAll()` which doesn't preallocate the objects slice https://github.com/kubernetes/client-go/blob/v0.29.3/tools/cache/listers.go#L36-L50. This is especially relevant when using an empty label selector like what's used with the Gateway API objects.

This PR makes that code preallocate the objects slice.

The difference depends on the actual number of objects in the cache but:

- time wise this yields around 30% improvement (decreased time of listing)
- bytes allocated wise this yields 30% - 60% percent improvement (less bytes allocated)
- allocations per operation this yields ~~ 65% up to 95% less allocations 

```
benchstat -confidence 0.93 old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/store
                          │   old.txt   │               new.txt               │
                          │   sec/op    │    sec/op     vs base               │
ListHTTPRoutes/1-10         257.0n ± 1%   258.5n ±  0%   +0.58% (p=0.040 n=5)
ListHTTPRoutes/10-10        549.3n ± 1%   389.7n ±  1%  -29.06% (p=0.008 n=5)
ListHTTPRoutes/100-10       2.493µ ± 1%   1.705µ ±  1%  -31.61% (p=0.008 n=5)
ListHTTPRoutes/1000-10      20.41µ ± 1%   15.23µ ±  1%  -25.38% (p=0.008 n=5)
ListHTTPRoutes/10000-10     202.2µ ± 1%   134.1µ ±  1%  -33.70% (p=0.008 n=5)
ListHTTPRoutes/100000-10    2.502m ± 2%   1.402m ±  1%  -43.96% (p=0.008 n=5)
ListHTTPRoutes/1000000-10   32.32m ± 8%   19.55m ± 12%  -39.52% (p=0.008 n=5)
geomean                     38.14µ        26.68µ        -30.06%

                          │   old.txt    │                new.txt                │
                          │     B/op     │     B/op      vs base                 │
ListHTTPRoutes/1-10           24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=5) ¹
ListHTTPRoutes/10-10          408.0 ± 0%     240.0 ± 0%  -41.18% (p=0.008 n=5)
ListHTTPRoutes/100-10       3.867Ki ± 0%   2.625Ki ± 0%  -32.12% (p=0.008 n=5)
ListHTTPRoutes/1000-10      33.12Ki ± 0%   24.00Ki ± 0%  -27.53% (p=0.008 n=5)
ListHTTPRoutes/10000-10     463.1Ki ± 0%   240.0Ki ± 0%  -48.18% (p=0.008 n=5)
ListHTTPRoutes/100000-10    5.819Mi ± 0%   2.297Mi ± 0%  -60.53% (p=0.008 n=5)
ListHTTPRoutes/1000000-10   58.13Mi ± 0%   22.90Mi ± 0%  -60.61% (p=0.008 n=5)
geomean                     41.05Ki        24.00Ki       -41.55%
¹ all samples are equal

                          │   old.txt   │               new.txt               │
                          │  allocs/op  │ allocs/op   vs base                 │
ListHTTPRoutes/1-10          2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=5) ¹
ListHTTPRoutes/10-10         6.000 ± 0%   2.000 ± 0%  -66.67% (p=0.008 n=5)
ListHTTPRoutes/100-10        9.000 ± 0%   2.000 ± 0%  -77.78% (p=0.008 n=5)
ListHTTPRoutes/1000-10      12.000 ± 0%   2.000 ± 0%  -83.33% (p=0.008 n=5)
ListHTTPRoutes/10000-10     19.000 ± 0%   2.000 ± 0%  -89.47% (p=0.008 n=5)
ListHTTPRoutes/100000-10    29.000 ± 0%   2.000 ± 0%  -93.10% (p=0.008 n=5)
ListHTTPRoutes/1000000-10   39.000 ± 0%   2.000 ± 0%  -94.87% (p=0.008 n=5)
geomean                      11.58        2.000       -82.72%
¹ all samples are equal
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
