### PR TITLE
fix(tests): do not run TestExampleUDPRoute in parallel

### DIFF
--- a/test/integration/isolated/examples_udproute_test.go
+++ b/test/integration/isolated/examples_udproute_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestExampleUDPRoute(t *testing.T) {
-	t.Parallel()
-
 	udpRouteExampleManifests := examplesManifestPath("gateway-udproute.yaml")
 
 	f := features.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

For isolation tests generation of the test namespace may lead to conflict when tests are run in parallel. Ir results in the flake, see [buildpulse](https://app.buildpulse.io/@Kong/kubernetes-ingress-controller/tests/10411550846?filter_results_type=flaky) and related [CI run](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8594319438/job/23547213149) (grep by `ns-508-26f` to see the conflict). All other isolated tests, besides  `TestExampleUDPRoute` are currently not run in parallel, hence do not run this one too. 
