### PR TITLE
chore: pin fossa action to the newest 1.3.3 tag

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: fossas/fossa-action@v1
+      - uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{secrets.fossaApiKey}}
           branch: main


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin fossa action to the newest tag available: [v1.3.3](https://github.com/fossas/fossa-action/releases/tag/v1.3.3).

This is to avoid the following warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: fossas/fossa-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8503018185

The reason for this is the fact that v1 of that action still points to a commit in 2021: https://github.com/fossas/fossa-action/releases/tag/v1