### PR TITLE
chore(ci): migrate actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: conformance-tests-traditional-compatible-router
+        - name: traditional-compatible-router
           expression_routes: "false"
-        - name: "conformance-tests-expressions-router"
+        - name: expressions-router
           expression_routes: "true"
     steps:
       - name: checkout repository
@@ -55,22 +55,22 @@ jobs:
       - name: run conformance tests
         run: make test.conformance
         env:
-          JUNIT_REPORT: "conformance-tests.xml"
+          JUNIT_REPORT: conformance-tests.xml
           KONG_TEST_EXPRESSION_ROUTES: ${{ matrix.expression_routes }}
           TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
 
       # upload logs when test failed
       - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
-        uses: actions/upload-artifact@v3
-        with:
+        uses: actions/upload-artifact@v4
+        with: 
           name: ${{ matrix.name }}-kic-logs
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore
 
       - name: collect test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
+          name: tests-report-conformance-${{ matrix.name }}
           path: conformance-tests.xml

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -26,14 +26,14 @@ jobs:
           GOTESTSUM_JUNITFILE: envtest-tests.xml
 
       - name: collect test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-envtest
           path: coverage.envtest.out
 
       - name: collect test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
+          name: tests-report-envtest
           path: envtest-tests.xml

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -192,14 +192,14 @@ jobs:
 
       - name: collect test coverage
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.name }}
           path: coverage.*.out
 
       - name: upload diagnostics
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diagnostics-integration-tests-${{ matrix.name }}
           path: /tmp/ktf-diag*
@@ -208,15 +208,15 @@ jobs:
       # upload logs when test failed
       - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
-        uses: actions/upload-artifact@v3
-        with:
+        uses: actions/upload-artifact@v4
+        with: 
           name: integration-tests-kic-logs-${{ matrix.name }}
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore
 
       - name: collect test report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
+          name: tests-report-integration-${{ matrix.name }}
           path: integration-tests-${{ matrix.name }}.xml

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -209,7 +209,7 @@ jobs:
       - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: integration-tests-kic-logs-${{ matrix.name }}
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -32,14 +32,14 @@ jobs:
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
 
       - name: collect test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-kongintegration
           path: "coverage.*.out"
 
       - name: collect test report
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tests-report
-          path: "*-tests.xml"
+          name: tests-report-kongintegration
+          path: kongintegration-tests.xml

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -27,10 +27,11 @@ jobs:
 
       - name: collect test coverage artifacts
         id: download-coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
           path: coverage
+          merge-multiple: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -51,10 +52,11 @@ jobs:
 
       - name: download tests report
         id: download-coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: tests-report
+          pattern: tests-report-*
           path: report
+          merge-multiple: true
 
       - name: Upload test results to BuildPulse for flaky test detection
         if: ${{ !cancelled() }}

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -26,14 +26,14 @@ jobs:
           GOTESTSUM_JUNITFILE: unit-tests.xml
 
       - name: collect test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-unit
           path: coverage.unit.out
 
       - name: collect test report
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: tests-report
+          name: tests-report-unit
           path: unit-tests.xml


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of #5357

Relevant guide: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
