### PR TITLE
fix(diag): get rid of wrongly logged errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ Adding a new version? You'll need three changes:
   server. This endpoint outputs the original Kong `/config` endpoint error for
   failed configuration pushes in case error parsing fails. Attempt to log the
   `message` field of errors that KIC cannot fully parse.
-  [#5773](https://github.com/Kong/kubernetes-ingress-controller/issues/5773)
+  [#5773](https://github.com/Kong/kubernetes-ingress-controller/issues/5773), [#5846](https://github.com/Kong/kubernetes-ingress-controller/pull/5846)
 - Add constraint to limit items in `Credentials` and `ConsumerGroups` in
   `KongConsumer`s to be unique in validating admission webhooks.
   [#5787](https://github.com/Kong/kubernetes-ingress-controller/pull/5787)

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -593,11 +593,11 @@ func (c *KongClient) sendToClient(
 				if err := ctx.Err(); err != nil {
 					logger.Error(err, "Exceeded Kong API timeout, consider increasing --proxy-timeout-seconds")
 				}
-				return "", fmt.Errorf("performing update for %s failed: %w", client.AdminAPIClient().BaseRootURL(), updateErr)
+				return "", fmt.Errorf("performing update for %s failed: %w", client.BaseRootURL(), updateErr)
 			}
 		} else {
 			// It should never happen.
-			return "", fmt.Errorf("performing update for %s failed with unexpected type of error: %w", client.AdminAPIClient().BaseRootURL(), err)
+			return "", fmt.Errorf("performing update for %s failed with unexpected type of error: %w", client.BaseRootURL(), err)
 		}
 	}
 	sendDiagnostic(false, nil) // No error occurred.

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -67,7 +67,7 @@ func PerformUpdate(
 	promMetrics *metrics.CtrlFuncMetrics,
 	updateStrategyResolver UpdateStrategyResolver,
 	configChangeDetector ConfigurationChangeDetector,
-) ([]byte, UpdateError) {
+) ([]byte, error) {
 	oldSHA := client.LastConfigSHA()
 	newSHA, err := deckgen.GenerateSHA(targetContent)
 	if err != nil {
@@ -86,7 +86,7 @@ func PerformUpdate(
 			} else {
 				logger.V(util.DebugLevel).Info("No configuration change, skipping sync to Kong")
 			}
-			return oldSHA, UpdateError{}
+			return oldSHA, nil
 		}
 	}
 
@@ -119,7 +119,7 @@ func PerformUpdate(
 		logger.V(util.InfoLevel).Info("Successfully synced configuration to Kong")
 	}
 
-	return newSHA, UpdateError{}
+	return newSHA, nil
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Let's run KIC with DEBUG level logs for instance with `make debug.skaffold` and see

```log
...
[ingress-controller] 2024-04-09T15:45:39Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.24:8444", "v": 1}
[ingress-controller] 2024-04-09T15:45:39Z        debug   No change in config status, not notifying       {"v": 1}
[ingress-controller] 2024-04-09T15:45:39Z        debug   No configuration change; resource status update not necessary, skipping {"v": 1}
[ingress-controller] 2024-04-09T15:45:39Z        debug   events  failed to apply Kong configuration to https://10.244.0.24:8444: %!s(<nil>)      {"v": 1, "type": "Warning", "object": {"kind":"Pod","namespace":"kong","name":"ingress-kong-6949f45784-cfnhp","apiVersion":"v1"}, "reason": "KongConfigurationApplyFailed"}
[ingress-controller] 2024-04-09T15:45:42Z        debug   Parsing kubernetes objects into data-plane configuration        {"v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   Successfully built data-plane configuration     {"v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   Sending configuration to gateway clients        {"v": 1, "urls": ["https://10.244.0.25:8444", "https://10.244.0.24:8444"]}
[ingress-controller] 2024-04-09T15:45:42Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.25:8444", "v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   events  failed to apply Kong configuration to https://10.244.0.25:8444: %!s(<nil>)      {"v": 1, "type": "Warning", "object": {"kind":"Pod","namespace":"kong","name":"ingress-kong-6949f45784-cfnhp","apiVersion":"v1"}, "reason": "KongConfigurationApplyFailed"}
[ingress-controller] 2024-04-09T15:45:42Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.24:8444", "v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   No change in config status, not notifying       {"v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   No configuration change; resource status update not necessary, skipping {"v": 1}
[ingress-controller] 2024-04-09T15:45:42Z        debug   events  failed to apply Kong configuration to https://10.244.0.24:8444: %!s(<nil>)      {"v": 1, "type": "Warning", "object": {"kind":"Pod","namespace":"kong","name":"ingress-kong-6949f45784-cfnhp","apiVersion":"v1"}, "reason": "KongConfigurationApplyFailed"}
...
```
message 
```
[ingress-controller] 2024-04-09T15:45:42Z        debug   events  failed to apply Kong configuration to https://10.244.0.25:8444: %!s(<nil>)      {"v": 1, "type": "Warning", "object": {"kind":"Pod","namespace":"kong","name":"ingress-kong-6949f45784-cfnhp","apiVersion":"v1"}, "reason": "KongConfigurationApplyFailed"}
```
is wrong. This PR fixes it, after the change

```log
...
[ingress-controller] 2024-04-09T15:40:57Z        debug   Sending configuration to gateway clients        {"v": 1, "urls": ["https://10.244.0.21:8444", "https://10.244.0.22:8444"]}
[ingress-controller] 2024-04-09T15:40:57Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.21:8444", "v": 1}
[ingress-controller] 2024-04-09T15:40:57Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.22:8444", "v": 1}
[ingress-controller] 2024-04-09T15:40:57Z        debug   No change in config status, not notifying       {"v": 1}
[ingress-controller] 2024-04-09T15:40:57Z        debug   No configuration change; resource status update not necessary, skipping {"v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   Parsing kubernetes objects into data-plane configuration        {"v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   Successfully built data-plane configuration     {"v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   Sending configuration to gateway clients        {"v": 1, "urls": ["https://10.244.0.22:8444", "https://10.244.0.21:8444"]}
[ingress-controller] 2024-04-09T15:41:00Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.22:8444", "v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   No configuration change, skipping sync to Kong  {"url": "https://10.244.0.21:8444", "v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   No change in config status, not notifying       {"v": 1}
[ingress-controller] 2024-04-09T15:41:00Z        debug   No configuration change; resource status update not necessary, skipping {"v": 1}
...
```

Changes introduced in 
- https://github.com/Kong/kubernetes-ingress-controller/pull/5773

returned empty error value of concrete instead of `nil` for successful execution of `PerformUpdate(...)` led to that problem. Such value is interpreted by Go as an error in `err != nil` check in . I could rand about Go for not having proper option/result types and exhaustive pattern matching, but it's not a time and place.

This PR makes it in the more typical way - `error` interface is used in the function signature and for successful execution `nil` is returned. Returning a concrete pointer type error would be problematic too, because the interface with such `nil` pointer of the concrete type is non-nil. Thus let's live with those quirks and make it work as expected. 

Furthermore, it simplifies 

```go
expired, ok := timedCtx.Deadline(); ok && time.Now().After(expired)
```
to 
```go
err := ctx.Err(); err != nil
```
which I suppose should give the same results.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
