### PR TITLE
feat(gateway-api): support ReplaceFullPath for URLRewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ Adding a new version? You'll need three changes:
 - Add constraint to limit items in `Credentials` and `ConsumerGroups` in
   `KongConsumer`s to be unique in validating admission webhooks.
   [#5787](https://github.com/Kong/kubernetes-ingress-controller/pull/5787)
+- Add support in `HTTPRoute`s for `URLRewrite`:
+  - `FullPathRewrite` [#5855](https://github.com/Kong/kubernetes-ingress-controller/pull/5855)
 
 ### Fixed
 

--- a/examples/gateway-httproute-rewrite-path-full.yaml
+++ b/examples/gateway-httproute-rewrite-path-full.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          command:
+            - /agnhost
+            - netexec
+            - --http-port=8080
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong
+  annotations:
+    konghq.com/gatewayclass-unmanaged: "true"
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /echo?msg=hello
+    backendRefs:
+    - name: echo
+      kind: Service
+      port: 80

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -41,6 +41,8 @@ type (
 	HTTPRoute                 = gatewayv1.HTTPRoute
 	HTTPRouteFilter           = gatewayv1.HTTPRouteFilter
 	HTTPRouteFilterType       = gatewayv1.HTTPRouteFilterType
+	HTTPURLRewriteFilter      = gatewayv1.HTTPURLRewriteFilter
+	HTTPPathModifier          = gatewayv1.HTTPPathModifier
 	HTTPRouteList             = gatewayv1.HTTPRouteList
 	HTTPRouteMatch            = gatewayv1.HTTPRouteMatch
 	HTTPRouteRule             = gatewayv1.HTTPRouteRule
@@ -106,6 +108,7 @@ type (
 
 const (
 	FullPathHTTPPathModifier              = gatewayv1.FullPathHTTPPathModifier
+	PrefixMatchHTTPPathModifier           = gatewayv1.PrefixMatchHTTPPathModifier
 	GatewayClassConditionStatusAccepted   = gatewayv1.GatewayClassConditionStatusAccepted
 	GatewayClassReasonAccepted            = gatewayv1.GatewayClassReasonAccepted
 	GatewayConditionAccepted              = gatewayv1.GatewayConditionAccepted

--- a/test/integration/isolated/exmples_httproute_rewrite_test.go
+++ b/test/integration/isolated/exmples_httproute_rewrite_test.go
@@ -1,0 +1,64 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestHTTPRouteRewriteExample(t *testing.T) {
+	httprouteURLRewritePathFullExampleManifests := examplesManifestPath("gateway-httproute-rewrite-path-full.yaml")
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
+		WithLabel(testlabels.Kind, testlabels.KindHTTPRoute).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
+		)).
+		Assess("deploying to cluster works and HTTP requests get properly rewritten URI",
+			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+				cluster := GetClusterFromCtx(ctx)
+				proxyURL := GetHTTPURLFromCtx(ctx)
+
+				t.Logf("applying yaml manifest %s", httprouteURLRewritePathFullExampleManifests)
+				manifest, err := os.ReadFile(httprouteURLRewritePathFullExampleManifests)
+				assert.NoError(t, err)
+				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, string(manifest)))
+				cleaner.AddManifest(string(manifest))
+
+				t.Logf("verifying that the UDPIngress routes traffic properly")
+
+				t.Logf("asserting /dummy-random-string path is redirected (as any other path for this HTTPRoute) to /echo?msg=hello from the manifest")
+				helpers.EventuallyGETPath(
+					t,
+					proxyURL,
+					proxyURL.Host,
+					"/dummy-random-string",
+					http.StatusOK,
+					"hello",
+					nil,
+					consts.IngressWait,
+					consts.WaitTick,
+				)
+
+				return ctx
+			}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}

--- a/test/internal/testlabels/labels.go
+++ b/test/internal/testlabels/labels.go
@@ -5,6 +5,7 @@ const (
 	Kind                   = "kind"
 	KindUDPRoute           = "UDPRoute"
 	KindTCPRoute           = "TCPRoute"
+	KindHTTPRoute          = "HTTPRoute"
 	KindGRPCRoute          = "GRPCRoute"
 	KindIngress            = "Ingress"
 	KindKongServiceFacade  = "KongServiceFacade"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces support for `FullPathRewrite` for [`URLRewrite`](https://github.com/kubernetes-sigs/gateway-api/blob/35fe25d1384a41c9b89dd5af7ae3214c431f008c/apis/v1/httproute_types.go#L735-L740) filter for HTTPRoutes.

Separate PRs will introduce remaining features of `URLRewrite`.

**Which issue this PR fixes**:

Part of #3686.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
