### PR TITLE
feat(creds) remove kongCredType field support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,22 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+### Breaking changes
+
+- Removed support for the deprecated `kongCredType` Secret field. If you have
+  not previously [updated to the credential label](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/migrate/credential-kongcredtype-label/)
+  you must do so before upgrading to this version. This removal includes an
+  update to the webhook configuration that checks only Secrets with
+  `konghq.com/credential` or `konghq.com/validate` labels (for Secrets that
+  contain plugin configuration). This filter improves performance and
+  reliability by not checking Secrets the controller will never use. Users that
+  wish to defer adding `konghq.com/validate` to Secrets with plugin
+  configuration can set the `ingressController.admissionWebhook.filterSecrets`
+  chart values.yaml key to `false`. Doing so does not benefit from the
+  performance benefits, however, so labeling plugin configuration Secrets and
+  enabling the filter is recommended as soon as is convenient.
+  [#5856](https://github.com/Kong/kubernetes-ingress-controller/pull/5856)
+
 ### Added
 
 - Add a `/debug/config/raw-error` endpoint to the config dump diagnostic

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,7 +18,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+# NOTE we enable this to allow patching the generated webhook. We do not have the crd/kustomization.yaml config
+# enabled, as we don't use the mutating hooks in there currently.
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/config/webhook/additional_secret_hooks.yaml
+++ b/config/webhook/additional_secret_hooks.yaml
@@ -1,0 +1,58 @@
+# https://github.com/kubernetes-sigs/controller-tools/issues/553
+# controller-tools, and by extension kubebuilder, do not support specifying objectSelector,
+# which we need for the Secret rules.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.credentials.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/credential"
+      operator: "Exists"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.plugins.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/validate"
+      operator: "Exists"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- manifests.yaml
+
+patchesStrategicMerge:
+- additional_secret_hooks.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -232,7 +232,7 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: "konghq.com/plugin-config"
+    - key: "konghq.com/validate"
       operator: "Exists"
   rules:
   - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -204,7 +204,36 @@ webhooks:
       path: /
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: secrets.validation.ingress-controller.konghq.com
+  name: secrets.credentials.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/credential"
+      operator: "Exists"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: secrets.plugins.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/plugin-config"
+      operator: "Exists"
   rules:
   - apiGroups:
     - ""

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -204,56 +204,6 @@ webhooks:
       path: /
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: secrets.credentials.validation.ingress-controller.konghq.com
-  objectSelector:
-    matchExpressions:
-    - key: "konghq.com/credential"
-      operator: "Exists"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: secrets.plugins.validation.ingress-controller.konghq.com
-  objectSelector:
-    matchExpressions:
-    - key: "konghq.com/validate"
-      operator: "Exists"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /
-  failurePolicy: Fail
-  matchPolicy: Equivalent
   name: services.validation.ingress-controller.konghq.com
   rules:
   - apiGroups:

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -257,7 +257,10 @@ func (h RequestHandler) handleKongClusterPlugin(
 	return responseBuilder.Allowed(ok).WithMessage(message).Build(), nil
 }
 
-// +kubebuilder:webhook:verbs=create;update,groups=core,resources=secrets,versions=v1,name=secrets.validation.ingress-controller.konghq.com,path=/,webhookVersions=v1,matchPolicy=equivalent,mutating=false,failurePolicy=fail,sideEffects=None,admissionReviewVersions=v1
+// NOTE this handler _does not_ use a kubebuilder directive, as our Secret handling requires webhook features
+// kubebuilder does not support (objectSelector). Instead, config/webhook/additional_secret_hooks.yaml includes
+// handwritten webhook rules that we patch into the webhook manifest.
+// See https://github.com/kubernetes-sigs/controller-tools/issues/553 for further info.
 
 func (h RequestHandler) handleSecret(
 	ctx context.Context,

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -286,7 +286,7 @@ func (h RequestHandler) handleSecret(
 		// referenced secret, labeled or not.
 
 		// plugin configuration secrets
-		if _, hasPluginLabel := secret.Labels[labels.PluginConfigLabel]; hasPluginLabel {
+		if _, hasPluginLabel := secret.Labels[labels.ValidateLabel]; hasPluginLabel {
 			ok, message, err := h.checkReferrersOfSecret(ctx, &secret)
 			if err != nil {
 				return responseBuilder.Allowed(false).WithMessage(fmt.Sprintf("failed to validate other objects referencing the secret: %v", err)).Build(), err

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
@@ -220,6 +221,9 @@ func TestHandleSecret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "plugin-conf",
+					Labels: map[string]string{
+						labels.PluginConfigLabel: "true",
+					},
 				},
 			},
 			referrers: []client.Object{
@@ -235,6 +239,9 @@ func TestHandleSecret(t *testing.T) {
 					TypeMeta: kongClusterPluginTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "cluster-plugin-0",
+						Labels: map[string]string{
+							labels.PluginConfigLabel: "true",
+						},
 					},
 					PluginName: "test-plugin",
 				},
@@ -249,6 +256,9 @@ func TestHandleSecret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "plugin-conf",
+					Labels: map[string]string{
+						labels.PluginConfigLabel: "true",
+					},
 				},
 			},
 			referrers: []client.Object{
@@ -274,6 +284,9 @@ func TestHandleSecret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "plugin-conf",
+					Labels: map[string]string{
+						labels.PluginConfigLabel: "true",
+					},
 				},
 			},
 			referrers: []client.Object{

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -222,7 +222,7 @@ func TestHandleSecret(t *testing.T) {
 					Namespace: "default",
 					Name:      "plugin-conf",
 					Labels: map[string]string{
-						labels.PluginConfigLabel: "true",
+						labels.ValidateLabel: "plugin",
 					},
 				},
 			},
@@ -240,7 +240,7 @@ func TestHandleSecret(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "cluster-plugin-0",
 						Labels: map[string]string{
-							labels.PluginConfigLabel: "true",
+							labels.ValidateLabel: "plugin",
 						},
 					},
 					PluginName: "test-plugin",
@@ -257,7 +257,7 @@ func TestHandleSecret(t *testing.T) {
 					Namespace: "default",
 					Name:      "plugin-conf",
 					Labels: map[string]string{
-						labels.PluginConfigLabel: "true",
+						labels.ValidateLabel: "plugin",
 					},
 				},
 			},
@@ -285,7 +285,7 @@ func TestHandleSecret(t *testing.T) {
 					Namespace: "default",
 					Name:      "plugin-conf",
 					Labels: map[string]string{
-						labels.PluginConfigLabel: "true",
+						labels.ValidateLabel: "plugin",
 					},
 				},
 			},

--- a/internal/admission/validation/consumers/credentials/validation.go
+++ b/internal/admission/validation/consumers/credentials/validation.go
@@ -19,9 +19,8 @@ import (
 // ValidateCredentials performs basic validation on a credential secret given
 // the Kubernetes secret which contains credentials data.
 func ValidateCredentials(secret *corev1.Secret) error {
-	credentialType, credentialSource := util.ExtractKongCredentialType(secret)
-
-	if credentialSource == util.CredentialTypeAbsent {
+	credentialType, err := util.ExtractKongCredentialType(secret)
+	if err != nil {
 		// this shouldn't occur, since we check this earlier in the admission controller's handleSecret function, but
 		// checking here also in case a refactor removes that
 		return fmt.Errorf("secret has no credential type, add a %s label", labels.CredentialTypeLabel)
@@ -123,12 +122,9 @@ type Index map[string]map[string]map[string]struct{}
 // and will validate it for both normal structure validation and for
 // unique key constraint violations.
 func (cs Index) ValidateCredentialsForUniqueKeyConstraints(secret *corev1.Secret) error {
-	credentialType, credentialSource := util.ExtractKongCredentialType(secret)
-	if credentialSource == util.CredentialTypeAbsent {
-		return fmt.Errorf(
-			"secret has no credential type, add a %s label",
-			labels.CredentialTypeLabel,
-		)
+	credentialType, err := util.ExtractKongCredentialType(secret)
+	if err != nil {
+		return fmt.Errorf("secret has no credential type, add a %s label", labels.CredentialTypeLabel)
 	}
 
 	// the additional key/values are optional, but must be validated

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -177,21 +177,6 @@ func TestValidateCredentials(t *testing.T) {
 			wantErr: fmt.Errorf("some fields were invalid due to missing data: rsa_public_key, key, secret"),
 		},
 		{
-			// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 to be removed after deprecation window
-			name: "valid credential with deprectated field",
-			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					"key":          []byte("little-rabbits-be-good"),
-					"kongCredType": []byte("key-auth"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
 			name: "invalid credential type",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/admission/validation/consumers/credentials/vars.go
+++ b/internal/admission/validation/consumers/credentials/vars.go
@@ -6,11 +6,7 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // Validation - Vars
 // -----------------------------------------------------------------------------
 
-// TypeKey indicates the key in a consumer secret which identifies the type
-// of credential that is being provided for the consumer.
-const TypeKey = "kongCredType"
-
-// SupportedTypes indicates all the "kongCredType"s which are supported for KongConsumer credentials.
+// SupportedTypes indicates all the Kong credential types which are supported for KongConsumer credentials.
 var SupportedTypes = sets.NewString(
 	"basic-auth",
 	"hmac-auth",

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -272,8 +272,11 @@ func (validator KongHTTPValidator) ValidateConsumerGroup(
 // else it returns false with the error message. If an error happens during
 // validation, error is returned.
 func (validator KongHTTPValidator) ValidateCredential(ctx context.Context, secret corev1.Secret) (bool, string) {
-	// If the secret doesn't specify a credential type (either by label or the secret's key) it's not a credentials secret.
-	if _, s := util.ExtractKongCredentialType(&secret); s == util.CredentialTypeAbsent {
+	// If the secret doesn't specify a credential type it's not a credentials secret. We shouldn't actually reach this
+	// codepath in practice because such secrets will be filtered out by the webhook secrets objectSelector and ignored.
+	// However, installs could potentially use an outdated webhook definition. Prior to 3.2 we only filtered in code and
+	// used a blanket selector.
+	if _, err := util.ExtractKongCredentialType(&secret); err != nil {
 		return true, ""
 	}
 

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -754,9 +754,15 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 		{
 			name: "valid key-auth credential with no consumers gets accepted",
 			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "credential-0",
+					Labels: map[string]string{
+						"konghq.com/credential": "key-auth",
+					},
+				},
 				Data: map[string][]byte{
-					"kongCredType": []byte("key-auth"),
-					"key":          []byte("my-key"),
+					"key": []byte("my-key"),
 				},
 			},
 			wantOK: true,
@@ -787,8 +793,14 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 		{
 			name: "invalid key-auth credential with no consumers gets rejected",
 			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "credential-0",
+					Labels: map[string]string{
+						"konghq.com/credential": "key-auth",
+					},
+				},
 				Data: map[string][]byte{
-					"kongCredType": []byte("key-auth"),
 					// missing key
 				},
 			},

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -132,7 +132,7 @@ func (ks *KongState) FillConsumersAndCredentials(
 					credConfig[k] = strings.Split(string(v), ",")
 					continue
 				}
-				// TODO this is a kongCredType-agnostic mutation that should only apply to Oauth2 credentials.
+				// TODO this is a credential type-agnostic mutation that should only apply to Oauth2 credentials.
 				// However, the credential-specific code after deals only in interface{}s, and we can't fix individual
 				// keys. To handle this properly we'd need to refactor the types used in all following code.
 				if k == "hash_secret" {

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -68,7 +68,7 @@ func (ks *KongState) SanitizedCopy() *KongState {
 }
 
 func (ks *KongState) FillConsumersAndCredentials(
-	logger logr.Logger,
+	_ logr.Logger,
 	s store.Storer,
 	failuresCollector *failures.ResourceFailuresCollector,
 ) {

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -115,11 +115,9 @@ func (ks *KongState) FillConsumersAndCredentials(
 			}
 			credConfig := map[string]interface{}{}
 			// try the label first. if it's present, no need to check the field
-			credType, credTypeSource := util.ExtractKongCredentialType(secret)
-			if credTypeSource == util.CredentialTypeFromField {
-				logger.Error(nil,
-					fmt.Sprintf("Secret uses deprecated kongCredType field, needs konghq.com/credential=%s label", credType),
-					"namesapce", secret.Namespace, "name", secret.Name)
+			credType, err := util.ExtractKongCredentialType(secret)
+			if err != nil {
+				pushCredentialResourceFailures(fmt.Sprintf("could not load credential from Secret: %s", err))
 			}
 			if !credentials.SupportedTypes.Has(credType) {
 				pushCredentialResourceFailures(

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -742,40 +742,6 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "KongConsumer with key-auth from label secret with the old cred field",
-			k8sConsumers: []*kongv1.KongConsumer{
-				{
-					TypeMeta: kongConsumerTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "default",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": annotations.DefaultIngressClass,
-						},
-					},
-					Username: "foo",
-					CustomID: "foo",
-					Credentials: []string{
-						"labeledSecretWithCredField",
-					},
-				},
-			},
-			expectedKongStateConsumers: []Consumer{
-				{
-					Consumer: kong.Consumer{
-						Username: kong.String("foo"),
-						CustomID: kong.String("foo"),
-					},
-					KeyAuths: []*KeyAuth{{kong.KeyAuth{
-						Key: kong.String("little-rabbits-be-good"),
-						Tags: util.GenerateTagsForObject(&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "labeledSecretWithCredField"},
-						}),
-					}}},
-				},
-			},
-		},
 	}
 
 	for i, tc := range testCases {

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -470,20 +470,24 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "fooCredSecret",
 				Namespace: "default",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "key-auth",
+				},
 			},
 			Data: map[string][]byte{
-				"kongCredType": []byte("key-auth"),
-				"key":          []byte("whatever"),
-				"ttl":          []byte("1024"),
+				"key": []byte("whatever"),
+				"ttl": []byte("1024"),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "barCredSecret",
 				Namespace: "default",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "oauth2",
+				},
 			},
 			Data: map[string][]byte{
-				"kongCredType":  []byte("oauth2"),
 				"name":          []byte("whatever"),
 				"client_id":     []byte("whatever"),
 				"client_secret": []byte("whatever"),
@@ -495,19 +499,22 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "emptyCredSecret",
 				Namespace: "default",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "key-auth",
+				},
 			},
-			Data: map[string][]byte{
-				"kongCredType": []byte("key-auth"),
-			},
+			Data: map[string][]byte{},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "unsupportedCredSecret",
 				Namespace: "default",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "unsupported",
+				},
 			},
 			Data: map[string][]byte{
-				"kongCredType": []byte("unsupported"),
-				"foo":          []byte("bar"),
+				"foo": []byte("bar"),
 			},
 		},
 		{
@@ -520,19 +527,6 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 			},
 			Data: map[string][]byte{
 				"key": []byte("little-rabbits-be-good"),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "labeledSecretWithCredField",
-				Namespace: "default",
-				Labels: map[string]string{
-					labels.CredentialTypeLabel: "key-auth",
-				},
-			},
-			Data: map[string][]byte{
-				"kongCredType": []byte("key-auth"),
-				"key":          []byte("little-rabbits-be-good"),
 			},
 		},
 		{

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -9,6 +9,13 @@ const (
 	// CredentialKey is the key used to indicate a Secret's credential type.
 	CredentialKey = "/credential" //nolint:gosec
 
+	// PluginConfigKey is the key used to indicate a Secret contains plugin configuration.
+	PluginConfigKey = "/plugin-config"
+
 	// CredentialTypeLabel is the label used to indicate a Secret's credential type.
 	CredentialTypeLabel = LabelPrefix + CredentialKey
+
+	// PluginConfigLabel is applied to plugins used for plugin configuration to allow the admission webhook to check
+	// updates to them.
+	PluginConfigLabel = LabelPrefix + PluginConfigKey
 )

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -9,13 +9,21 @@ const (
 	// CredentialKey is the key used to indicate a Secret's credential type.
 	CredentialKey = "/credential" //nolint:gosec
 
-	// PluginConfigKey is the key used to indicate a Secret contains plugin configuration.
-	PluginConfigKey = "/plugin-config"
+	// ValidateKey is the key used to indicate a Secret contains plugin configuration.
+	ValidateKey = "/validate"
 
 	// CredentialTypeLabel is the label used to indicate a Secret's credential type.
 	CredentialTypeLabel = LabelPrefix + CredentialKey
 
-	// PluginConfigLabel is applied to plugins used for plugin configuration to allow the admission webhook to check
+	// ValidateLabel is applied to plugins used for plugin configuration to allow the admission webhook to check
 	// updates to them.
-	PluginConfigLabel = LabelPrefix + PluginConfigKey
+	ValidateLabel = LabelPrefix + ValidateKey
+)
+
+// ValidateType indicates the type of validation applied to a Secret.
+type ValidateType string
+
+const (
+	// PluginValidate indicates a labeled Secret's contents require plugin configuration validation.
+	PluginValidate ValidateType = "plugin"
 )

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -1,36 +1,19 @@
 package util
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 )
 
-// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/4853 remove field handling when no longer supported.
-
-// CredentialTypeSource indicates the source of credential type information (or lack thereof) in a Secret.
-type CredentialTypeSource int
-
-const (
-	// CredentialTypeAbsent indicates that no credential information is present in a Secret.
-	CredentialTypeAbsent CredentialTypeSource = iota
-	// CredentialTypeFromLabel indicates that a Secret's credential type was determined from a label.
-	CredentialTypeFromLabel
-	// CredentialTypeFromField indicates that a Secret's credential type was determined from a data field.
-	CredentialTypeFromField
-)
-
-// ExtractKongCredentialType returns the credential type of a Secret and a code indicating whether the credential type
-// was obtained from a label, field, or not at all. Labels take precedence over fields if both are present.
-func ExtractKongCredentialType(secret *corev1.Secret) (string, CredentialTypeSource) {
+// ExtractKongCredentialType returns the credential type of a Secret or an error if no credential type is present.
+func ExtractKongCredentialType(secret *corev1.Secret) (string, error) {
 	credType, labelOk := secret.Labels[labels.CredentialTypeLabel]
 	if !labelOk {
-		// if no label, fall back to the deprecated field
-		credBytes, fieldOk := secret.Data["kongCredType"]
-		if !fieldOk {
-			return "", CredentialTypeAbsent
-		}
-		return string(credBytes), CredentialTypeFromField
+		return "", fmt.Errorf("Secret %s/%s used as credential, but lacks %s label",
+			secret.Namespace, secret.Name, labels.CredentialTypeLabel)
 	}
-	return credType, CredentialTypeFromLabel
+	return credType, nil
 }

--- a/internal/util/types_test.go
+++ b/internal/util/types_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
 )
 
@@ -15,11 +16,13 @@ func TestPopulateTypeMeta(t *testing.T) {
 	credential := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "corn",
+			Labels: map[string]string{
+				labels.CredentialTypeLabel: "basic-auth",
+			},
 		},
 		StringData: map[string]string{
-			"kongCredType": "basic-auth",
-			"username":     "corn",
-			"password":     "corn",
+			"username": "corn",
+			"password": "corn",
 		},
 	}
 

--- a/test/envtest/admission_webhook.go
+++ b/test/envtest/admission_webhook.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/kubectl"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
@@ -29,13 +29,13 @@ func setupValidatingWebhookConfiguration(
 }
 
 func validatingWebhookConfigWithClientConfig(t *testing.T, clientConfig admregv1.WebhookClientConfig) *admregv1.ValidatingWebhookConfiguration {
-	file, err := os.ReadFile("../../config/webhook/manifests.yaml")
+	manifest, err := kubectl.RunKustomize("../../config/webhook/")
 	require.NoError(t, err)
-	file = bytes.ReplaceAll(file, []byte("---"), []byte("")) // We're only expecting one document in the file.
+	manifest = bytes.ReplaceAll(manifest, []byte("---"), []byte("")) // We're only expecting one document in the file.
 
 	// Load the webhook configuration from the generated manifest.
 	webhookConfig := &admregv1.ValidatingWebhookConfiguration{}
-	require.NoError(t, yaml.Unmarshal(file, webhookConfig))
+	require.NoError(t, yaml.Unmarshal(manifest, webhookConfig))
 
 	// Set the client config.
 	for i := range webhookConfig.Webhooks {

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -214,6 +214,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			kongPlugin: &kongv1.KongPlugin{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rate-limiting-invalid-config-from",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				PluginName: "rate-limiting",
 				ConfigFrom: &kongv1.ConfigSource{
@@ -226,6 +229,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-invalid-config",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
@@ -234,6 +240,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-invalid-config",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":"5"}`),
@@ -267,6 +276,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-invalid-field",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config-minutes": []byte("10"),
@@ -275,6 +287,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-invalid-field",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config-minutes": []byte(`"10"`),
@@ -288,6 +303,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			kongPlugin: &kongv1.KongPlugin{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rate-limiting-valid-config",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				PluginName: "rate-limiting",
 				Config: apiextensionsv1.JSON{
@@ -308,6 +326,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-valid-field",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config-minutes": []byte(`10`),
@@ -316,6 +337,9 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "conf-secret-valid-field",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config-minutes": []byte(`15`),
@@ -409,6 +433,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-valid",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
@@ -417,6 +444,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-valid",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":10}`),
@@ -445,6 +475,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-invalid",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":5}`),
@@ -453,6 +486,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-invalid",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-config": []byte(`{"limit_by":"consumer","policy":"local","minute":"5"}`),
@@ -490,6 +526,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-valid-patch",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-minute": []byte(`5`),
@@ -498,6 +537,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-valid-patch",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-minute": []byte(`10`),
@@ -534,6 +576,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretBefore: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-invalid-patch",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-minute": []byte(`5`),
@@ -542,6 +587,9 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			secretAfter: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-conf-secret-invalid-patch",
+					Labels: map[string]string{
+						labels.ValidateLabel: "plugin",
+					},
 				},
 				Data: map[string][]byte{
 					"rate-limiting-minute": []byte(`"10"`),

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -756,7 +756,6 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 					},
 				},
 				StringData: map[string]string{
-
 					"username": "electron",
 					"password": "testpass",
 				},

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
@@ -611,21 +612,25 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "tuxcreds1",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "basic-auth",
+				},
 			},
 			StringData: map[string]string{
-				"kongCredType": "basic-auth",
-				"username":     "tux1",
-				"password":     "testpass",
+				"username": "tux1",
+				"password": "testpass",
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "tuxcreds2",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "basic-auth",
+				},
 			},
 			StringData: map[string]string{
-				"kongCredType": "basic-auth",
-				"username":     "tux2",
-				"password":     "testpass",
+				"username": "tux2",
+				"password": "testpass",
 			},
 		},
 	} {
@@ -698,11 +703,14 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 			credentials: []*corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "electronscreds",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "basic-auth",
+					},
 				},
 				StringData: map[string]string{
-					"kongCredType": "basic-auth",
-					"username":     "electron",
-					"password":     "testpass",
+
+					"username": "electron",
+					"password": "testpass",
 				},
 			}},
 			wantErr: false,
@@ -727,21 +735,25 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "protonscreds1",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "proton",
-						"password":     "testpass",
+						"username": "proton",
+						"password": "testpass",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "protonscreds2",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "electron", // username is unique constrained
-						"password":     "testpass", // password is not unique constrained
+						"username": "electron", // username is unique constrained
+						"password": "testpass", // password is not unique constrained
 					},
 				},
 			},
@@ -785,21 +797,25 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "neutronscreds1",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "neutron",
-						"password":     "testpass",
+						"username": "neutron",
+						"password": "testpass",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "neutronscreds2",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "neutron", // username is unique constrained
-						"password":     "testpass",
+						"username": "neutron", // username is unique constrained
+						"password": "testpass",
 					},
 				},
 			},
@@ -825,11 +841,13 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "reasonablehammer",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "reasonablehammer",
-						"password":     "testpass", // not unique constrained, so even though someone else is using this password this should pass
+						"username": "reasonablehammer",
+						"password": "testpass", // not unique constrained, so even though someone else is using this password this should pass
 					},
 				},
 			},
@@ -854,11 +872,13 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "unreasonablehammer",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     "tux1", // unique constrained with previous created static consumer credentials
-						"password":     "testpass",
+						"username": "tux1", // unique constrained with previous created static consumer credentials
+						"password": "testpass",
 					},
 				},
 			},
@@ -939,11 +959,13 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "brokenfence",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "invalid-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "invalid-auth", // not a valid credential type
-						"username":     "brokenfence",
-						"password":     "testpass",
+						"username": "brokenfence",
+						"password": "testpass",
 					},
 				},
 			),
@@ -954,11 +976,13 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 		validCredential := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "brokenfence",
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "basic-auth",
+				},
 			},
 			StringData: map[string]string{
-				"kongCredType": "basic-auth",
-				"username":     "brokenfence",
-				"password":     "testpass",
+				"username": "brokenfence",
+				"password": "testpass",
 			},
 		}
 		require.NoError(t, ctrlClient.Create(ctx, validCredential))
@@ -996,7 +1020,7 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 		require.NoError(t, ctrlClient.Update(ctx, validCredential))
 
 		t.Log("verifying that validation fails if the now referenced and valid credential gets updated to become invalid")
-		validCredential.Data["kongCredType"] = []byte("invalid-auth")
+		validCredential.ObjectMeta.Labels[labels.CredentialTypeLabel] = "invalid-auth"
 		err := ctrlClient.Update(ctx, validCredential)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid credential type")
@@ -1012,10 +1036,12 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 			ctrlClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "invalid-jwt-",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
 				},
 				StringData: map[string]string{
-					"kongCredType": "jwt",
-					"algorithm":    "RS256",
+					"algorithm": "RS256",
 				},
 			}),
 			"missing required field(s): rsa_public_key, key, secret",
@@ -1029,12 +1055,14 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 				require.NoError(t, ctrlClient.Create(ctx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "valid-jwt-" + strings.ToLower(algo) + "-",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "jwt",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "jwt",
-						"algorithm":    algo,
-						"key":          "key-name",
-						"secret":       "secret-name",
+						"algorithm": algo,
+						"key":       "key-name",
+						"secret":    "secret-name",
 					},
 				}), "failed to create JWT credential with algorithm %s", algo)
 			})
@@ -1047,12 +1075,14 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 				require.Error(t, ctrlClient.Create(ctx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "invalid-jwt-" + strings.ToLower(algo) + "-",
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "jwt",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "jwt",
-						"algorithm":    algo,
-						"key":          "key-name",
-						"secret":       "secret-name",
+						"algorithm": algo,
+						"key":       "key-name",
+						"secret":    "secret-name",
 					},
 				}), "expected failure when creating JWT %s", algo)
 			})
@@ -1080,11 +1110,13 @@ func createKongConsumers(ctx context.Context, t *testing.T, cl client.Client, co
 				credential := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: credentialName,
+						Labels: map[string]string{
+							labels.CredentialTypeLabel: "basic-auth",
+						},
 					},
 					StringData: map[string]string{
-						"kongCredType": "basic-auth",
-						"username":     credentialName,
-						"password":     "testpass",
+						"username": credentialName,
+						"password": "testpass",
 					},
 				}
 				t.Logf("creating %s Secret that contains credentials", credentialName)

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -15,6 +15,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
 
@@ -41,21 +42,24 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "key-auth-cred",
 				Namespace: ns.Name,
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "key-auth",
+				},
 			},
 			Data: map[string][]byte{
-				"kongCredType": []byte("key-auth"),
-				"key":          []byte("whatever"),
-				"ttl":          []byte("1024"),
+				"key": []byte("whatever"),
+				"ttl": []byte("1024"),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "empty-cred",
 				Namespace: ns.Name,
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "key-auth",
+				},
 			},
-			Data: map[string][]byte{
-				"kongCredType": []byte("key-auth"),
-			},
+			Data: map[string][]byte{},
 		},
 	}
 	for _, secret := range secrets {

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
@@ -271,10 +272,12 @@ func configureConsumerWithAPIKey(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+				Labels: map[string]string{
+					labels.CredentialTypeLabel: "key-auth",
+				},
 			},
 			StringData: map[string]string{
-				"key":          name,
-				"kongCredType": "key-auth",
+				"key": name,
 			},
 		},
 		metav1.CreateOptions{},

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
@@ -113,11 +114,13 @@ func TestConsumerCredential(t *testing.T) {
 	credential := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
+			Labels: map[string]string{
+				labels.CredentialTypeLabel: "basic-auth",
+			},
 		},
 		StringData: map[string]string{
-			"kongCredType": "basic-auth",
-			"username":     "test_consumer_credential",
-			"password":     "test_consumer_credential",
+			"username": "test_consumer_credential",
+			"password": "test_consumer_credential",
 		},
 	}
 	_, err = env.Cluster().Client().CoreV1().Secrets(ns.Name).Create(ctx, credential, metav1.CreateOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove support for the kongCredType field in credential Secrets. Only honor the konghq.com/credential label.

Add a konghq.com/plugin-config label. This label indicates that a Secret contains plugin configuration and should be validated against its referrers when updated.

Add objectSelectors to the Secret blocks in the admission webhook definition. Admission will skip any Secrets without a label indicating they should be used by KIC.

**Which issue this PR fixes**:

Fix #4853 

**Special notes for your reviewer**:

Found during this that we were kinda abusing the blanket Secret ingest for updates to plugin config also. Those Secrets did not have any label to filter them in.

Per chat discussion the approach I've taken here is to leave the existing blanket _code_ in place while changing the webhook configuration to filter on either the credential or new `konghq.com/validate` label. The latter is a simple `exists` check in the webhook configuration, and code uses the value (currently only `plugin`) to select the validation path.

Users that do not wish to update plugin Secrets will need to remove the filter from their webhook manifest. We will need to add a Helm chart toggle for this.

Although the `validate` key only has the one `plugin` value at present I felt it best to leave it open-ended because it's difficult (breaking change that requires users update resources) to transition from a plugin-specific label key to something else in the future if we add additional validated Secret types that don't need further hint info (conversely, `credential` is a dedicated label because we can't determine which validation to apply without the value to indicate it's specifically `key-auth` or whatever).

Tests check only the fully filtered variant, as we only have the one copy of the webhook manifest that they use. 
My manual check for the no-filter case was that envtest still passes with [no-label.diff.txt](https://github.com/Kong/kubernetes-ingress-controller/files/14984430/no-label.diff.txt) (and fails that doesn't have the webhook manifest diff). Do we think we'd want to set up a separate envtest run for ` TestAdmissionWebhook_KongPlugins` only with a special no-filter copy of the manifest?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
