### PR TITLE
tests: add logs to konnect license test

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -681,13 +681,15 @@ func getLicenseFromAdminAPI(ctx context.Context, env environments.Environment, a
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return license, err
+		return license, fmt.Errorf("failed to read response body: %w; body: %s", err, body)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return license, nil
+		return license, fmt.Errorf("unexpected status code: %d; body: %s", resp.StatusCode, body)
 	}
-	err = json.Unmarshal(body, &license)
-	return license, err
+	if err = json.Unmarshal(body, &license); err != nil {
+		return licenseOutput{}, fmt.Errorf("could not unmarshal license response: %w; body: %s", err, body)
+	}
+	return license, nil
 }
 
 func verifyPostgres(ctx context.Context, t *testing.T, env environments.Environment) {

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -98,6 +98,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	require.Eventually(t, func() bool {
 		license, err := getLicenseFromAdminAPI(ctx, env, "")
 		if err != nil {
+			t.Logf("failed to get license: %v", err)
 			return false
 		}
 		return license.License.Expiration == ""
@@ -117,6 +118,7 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		license, err := getLicenseFromAdminAPI(ctx, env, "")
 		if err != nil {
+			t.Logf("failed to get license: %v", err)
 			return false
 		}
 		return license.License.Expiration != ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Add logs to Konnect license e2e test for easier debugging failures like https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8641557356/job/23691285205#step:8:98

```
konnect_test.go:98: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/konnect_test.go:98
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectLicenseActivation
    control_plane.go:68: deleting test Konnect Control Plane: "5eb8f77c-6890-4b2f-ad93-960f88a600d7"
2024/04/11 04:45:25 [DEBUG] GET https://global.api.konghq.tech/v2/users/me
2024/04/11 04:45:25 [DEBUG] GET https://global.api.konghq.tech/v2/users/515d12f2-aab2-42b3-a093-6ad793c0c7ab/assigned-roles?filter%5Bentity_type_name%5D=Runtime+Groups
    control_plane.go:89: deleting test Konnect Control Plane role: "d23d9621-dab6-439f-b[97](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/8641557356/job/23691285205#step:8:98)1-8b4894836eb8"
2024/04/11 04:45:25 [DEBUG] DELETE https://global.api.konghq.tech/v2/users/515d12f2-aab2-42b3-a093-6ad793c0c7ab/assigned-roles/d23d9621-dab6-439f-b971-8b4894836eb8
    helpers_test.go:114: TestKonnectLicenseActivation failed, dumped diagnostics to /tmp/ktf-diag-1807785900
```
