### PR TITLE
chore: remove -s -w ldflags from debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ _build.template.debug:
 	go build -o bin/manager-debug \
 		-trimpath \
 		-gcflags=all="-N -l" \
-		-ldflags "-s -w $(LDFLAGS_METADATA)" \
+		-ldflags "$(LDFLAGS_METADATA)" \
 		${MAIN}
 
 .PHONY: fmt


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove `-s -w` ldflags from debug build which:

```
-s
	Omit the symbol table and debug information.
...
-w
	Omit the DWARF symbol table.
```

Causing the debugger to fail to attach.