### PR TITLE
tests: fix free ports assignment

### DIFF
--- a/test/helpers/ports.go
+++ b/test/helpers/ports.go
@@ -7,7 +7,7 @@ import (
 	"github.com/phayes/freeport"
 )
 
-var l = sync.Mutex{}
+var freePortLock = sync.Mutex{}
 
 // GetFreePort asks the kernel for a free open port that is ready to use.
 // On top of that, it also makes sure that the port hasn't been used in the current test run yet to reduce
@@ -20,16 +20,16 @@ func GetFreePort(t *testing.T) int {
 	for {
 		// Get a random free port, but do not use it yet...
 		var err error
-		l.Lock()
+		freePortLock.Lock()
 		freePort, err = freeport.GetFreePort()
 		if err != nil {
-			l.Unlock()
+			freePortLock.Unlock()
 			continue
 		}
 
 		// ... First, check if the port has been used in this test run already to reduce chances of a race condition.
 		_, wasUsed := usedPorts.LoadOrStore(freePort, true)
-		l.Unlock()
+		freePortLock.Unlock()
 
 		// The port hasn't been used in this test run - we can use it. It was stored in usedPorts, so it will not be
 		// used again during this test run.

--- a/test/helpers/ports.go
+++ b/test/helpers/ports.go
@@ -7,6 +7,8 @@ import (
 	"github.com/phayes/freeport"
 )
 
+var l = sync.Mutex{}
+
 // GetFreePort asks the kernel for a free open port that is ready to use.
 // On top of that, it also makes sure that the port hasn't been used in the current test run yet to reduce
 // chances of a race condition in parallel tests.
@@ -18,13 +20,16 @@ func GetFreePort(t *testing.T) int {
 	for {
 		// Get a random free port, but do not use it yet...
 		var err error
+		l.Lock()
 		freePort, err = freeport.GetFreePort()
 		if err != nil {
+			l.Unlock()
 			continue
 		}
 
 		// ... First, check if the port has been used in this test run already to reduce chances of a race condition.
 		_, wasUsed := usedPorts.LoadOrStore(freePort, true)
+		l.Unlock()
 
 		// The port hasn't been used in this test run - we can use it. It was stored in usedPorts, so it will not be
 		// used again during this test run.

--- a/test/helpers/ports_test.go
+++ b/test/helpers/ports_test.go
@@ -1,0 +1,69 @@
+package helpers
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFreePort(t *testing.T) {
+	tests := []struct {
+		count int
+	}{
+		{
+			count: 10,
+		},
+		{
+			count: 100,
+		},
+		{
+			count: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.count), func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			wg.Add(tt.count)
+			ch := make(chan struct{})
+			// p := GetFreePort(t)
+			for i := 0; i < tt.count; i++ {
+				go func() {
+					defer wg.Done()
+					<-ch
+					p := GetFreePort(t)
+
+					// NOTE: simply net.Listen() and net.Close() was not yielding expected test results.
+					l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", p))
+					if !assert.NoError(t, err) {
+						return
+					}
+					s := httptest.Server{
+						Listener: l,
+						Config: &http.Server{ //nolint:gosec
+							Addr: fmt.Sprintf("localhost:%d", p),
+							Handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+							}),
+						},
+					}
+					s.Start()
+					defer s.Close()
+
+					resp, err := http.Get(s.URL)
+					if !assert.NoError(t, err) {
+						return
+					}
+					assert.NoError(t, resp.Body.Close())
+				}()
+			}
+			close(ch)
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix free ports assignment by using a lock between obtaining the free port and placing it in the local lookup cache to prevent a race where 2 tests running in parallel would possible get the  same port and not see it yet being used in the cache.

**Which issue this PR fixes**:

Attempt at fixing #5869 