### PR TITLE
tests: disable controller manager graceful shutdown timeout

### DIFF
--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -32,6 +32,9 @@ type OptionalNamespacedName = mo.Option[k8stypes.NamespacedName]
 // Type override to be used with OptionalNamespacedName variables to override their type name printed in the help text.
 var nnTypeNameOverride = flags.WithTypeNameOverride[OptionalNamespacedName]("namespaced-name")
 
+// ConfigOpt is a function that modifies a Config.
+type ConfigOpt func(*Config)
+
 // -----------------------------------------------------------------------------
 // Controller Manager - Config
 // -----------------------------------------------------------------------------

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -138,7 +138,7 @@ func prepareEnvForGatewayConformanceTests(t *testing.T) (c client.Client, gatewa
 		featureGateFlag,
 		"--anonymous-reports=false",
 	}
-	cancel, err := testutils.DeployControllerManagerForCluster(ctx, globalLogger, env.Cluster(), nil, args...)
+	cancel, err := testutils.DeployControllerManagerForCluster(ctx, globalLogger, env.Cluster(), nil, args)
 	require.NoError(t, err)
 	t.Cleanup(func() { cancel() })
 

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -114,7 +114,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	t.Log("Preparing the environment to run the controller manager")
 	require.NoError(t, testutils.PrepareClusterForRunningControllerManager(ctx, env.Cluster()))
 	t.Log("starting the controller manager")
-	cancel, err := testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), kongAddon, "--log-level=debug")
+	cancel, err := testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), kongAddon, []string{"--log-level=debug"})
 	require.NoError(t, err)
 	t.Cleanup(func() { cancel() })
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -186,7 +186,7 @@ func TestMain(m *testing.M) {
 			fmt.Sprintf("--election-namespace=%s", kongAddon.Namespace()),
 		}
 		allControllerArgs := append(standardControllerArgs, extraControllerArgs...)
-		cancel, err := testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), kongAddon, allControllerArgs...)
+		cancel, err := testutils.DeployControllerManagerForCluster(ctx, logger, env.Cluster(), kongAddon, allControllerArgs)
 		defer cancel()
 		helpers.ExitOnErr(ctx, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This should help in recent errors on CI

```
ERROR: Problems with Controller Manager: failed waiting for all runnables to end within grace period of 30s: context deadline exceeded
```

This was already fixed similarly in envtest suite in 

https://github.com/Kong/kubernetes-ingress-controller/blob/459e10ba801bcded656cdfdfbdc1b2c4788de56f/test/envtest/run.go#L71-L74

This time around let's not disable graceful shutdown completely but instead, let's just disable the timeout. 