### PR TITLE
chore: remove flaky HTTPRoute list benchmark

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -228,7 +228,7 @@ func benchmarkListHTTPRoutes(b *testing.B, count int) {
 }
 
 func BenchmarkListHTTPRoutes(b *testing.B) {
-	counts := []int{100, 1000, 10000, 100000, 1000000}
+	counts := []int{1000, 10000, 100000, 1000000}
 	for _, count := range counts {
 		b.Run(strconv.Itoa(count), func(b *testing.B) {
 			b.ResetTimer()


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove flaky benchmark case for listing 100 HTTPRoutes: 

<img width="1657" alt="image" src="https://github.com/Kong/kubernetes-ingress-controller/assets/739996/a03498f4-320a-4873-9b0e-bafc213c6f1d">

https://github.com/Kong/kubernetes-ingress-controller/commit/09abf4a87f27a2ed733bebf8c0b7840476b6ee31#commitcomment-141065828

https://kong.github.io/kubernetes-ingress-controller/dev/bench/