### PR TITLE
feat: enforce KongConsumer's credentials and consumerGroups uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,8 @@ Adding a new version? You'll need three changes:
   `message` field of errors that KIC cannot fully parse.
   [#5773](https://github.com/Kong/kubernetes-ingress-controller/issues/5773), [#5846](https://github.com/Kong/kubernetes-ingress-controller/pull/5846)
 - Add constraint to limit items in `Credentials` and `ConsumerGroups` in
-  `KongConsumer`s to be unique in validating admission webhooks.
-  [#5787](https://github.com/Kong/kubernetes-ingress-controller/pull/5787)
+  `KongConsumer`s to be unique by defining their `x-kubernetes-list-type` as `set`.
+  [#5894](https://github.com/Kong/kubernetes-ingress-controller/pull/5894)
 - Add support in `HTTPRoute`s for `URLRewrite`:
   - `FullPathRewrite` [#5855](https://github.com/Kong/kubernetes-ingress-controller/pull/5855)
 - DB mode now supports Event reporting for resources that failed to apply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ Adding a new version? You'll need three changes:
   [#5773](https://github.com/Kong/kubernetes-ingress-controller/issues/5773), [#5846](https://github.com/Kong/kubernetes-ingress-controller/pull/5846)
 - Add constraint to limit items in `Credentials` and `ConsumerGroups` in
   `KongConsumer`s to be unique by defining their `x-kubernetes-list-type` as `set`.
+  Please note that if you're using `helm` as the installation method, upgrading alone
+  won't make this change take effect until you manually update the CRD manifests in your
+  cluster to the current version. See [Updates to CRDs] for more details.
   [#5894](https://github.com/Kong/kubernetes-ingress-controller/pull/5894)
 - Add support in `HTTPRoute`s for `URLRewrite`:
   - `FullPathRewrite` [#5855](https://github.com/Kong/kubernetes-ingress-controller/pull/5855)
@@ -121,6 +124,8 @@ Adding a new version? You'll need three changes:
   This yields a significant performance improvements in time spent, bytes allocated
   and allocations per list operation.
   [#5824](https://github.com/Kong/kubernetes-ingress-controller/pull/5824)
+
+[Updates to CRDs]: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#updates-to-crds
 
 ## [3.1.3]
 

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -49,6 +49,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -56,6 +57,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -169,16 +169,6 @@ func (validator KongHTTPValidator) ValidateConsumer(
 		return false, fmt.Sprintf("failed to fetch managed KongConsumers from cache: %s", err), nil
 	}
 
-	// validate that no duplicate credentials and consumer groups are in the consumer.
-	dupeCredentials := lo.FindDuplicates(consumer.Credentials)
-	if len(dupeCredentials) > 0 {
-		return false, fmt.Sprintf("Credentials %s duplicated in KongConsumer", strings.Join(dupeCredentials, ",")), nil
-	}
-	dupeConsumerGroups := lo.FindDuplicates(consumer.ConsumerGroups)
-	if len(dupeConsumerGroups) > 0 {
-		return false, fmt.Sprintf("ConsumerGroups %s duplicated in KongConsumer", strings.Join(dupeConsumerGroups, ",")), nil
-	}
-
 	// retrieve the consumer's credentials secrets to validate them with the index
 	credentials := make([]*corev1.Secret, 0, len(consumer.Credentials))
 	ignoredSecrets := make(map[string]map[string]struct{})

--- a/pkg/apis/configuration/v1/kongconsumer_types.go
+++ b/pkg/apis/configuration/v1/kongconsumer_types.go
@@ -45,10 +45,12 @@ type KongConsumer struct {
 
 	// Credentials are references to secrets containing a credential to be
 	// provisioned in Kong.
+	// +listType=set
 	Credentials []string `json:"credentials,omitempty"`
 
 	// ConsumerGroups are references to consumer groups (that consumer wants to be part of)
 	// provisioned in Kong.
+	// +listType=set
 	ConsumerGroups []string `json:"consumerGroups,omitempty"`
 
 	// Status represents the current status of the KongConsumer resource.

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -580,6 +580,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -587,6 +588,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -780,6 +780,46 @@ func TestCRDValidations(t *testing.T) {
 					"The spec.prefix field is immutable")
 			},
 		},
+		{
+			name: "KongConsumer - duplicate credentials are not allowed",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				consumer := &kongv1.KongConsumer{
+					Username:    "u1",
+					Credentials: []string{"c1", "c1", "c2"},
+				}
+				assert.ErrorContains(t, createKongConsumer(ctx, ctrlClient, ns, consumer), `Duplicate value: "c1"`)
+			},
+		},
+		{
+			name: "KongConsumer - unique credentials are allowed",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				consumer := &kongv1.KongConsumer{
+					Username:    "u1",
+					Credentials: []string{"c1", "c2"},
+				}
+				assert.NoError(t, createKongConsumer(ctx, ctrlClient, ns, consumer))
+			},
+		},
+		{
+			name: "KongConsumer - duplicate consumer groups are not allowed",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				consumer := &kongv1.KongConsumer{
+					Username:       "u1",
+					ConsumerGroups: []string{"cg1", "cg1", "cg2"},
+				}
+				assert.ErrorContains(t, createKongConsumer(ctx, ctrlClient, ns, consumer), `Duplicate value: "cg1"`)
+			},
+		},
+		{
+			name: "KongConsumer - unique consumer groups are allowed",
+			scenario: func(ctx context.Context, t *testing.T, ns string) {
+				consumer := &kongv1.KongConsumer{
+					Username:       "u1",
+					ConsumerGroups: []string{"cg1", "cg2"},
+				}
+				assert.NoError(t, createKongConsumer(ctx, ctrlClient, ns, consumer))
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -960,4 +1000,10 @@ func createKongVault(ctx context.Context, c client.Client, vault *kongv1alpha1.K
 func updateKongVault(ctx context.Context, c client.Client, vault *kongv1alpha1.KongVault) error {
 	vault.GenerateName = "test-"
 	return c.Update(ctx, vault)
+}
+
+func createKongConsumer(ctx context.Context, c client.Client, ns string, consumer *kongv1.KongConsumer) error {
+	consumer.GenerateName = "test-"
+	consumer.Namespace = ns
+	return c.Create(ctx, consumer)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I propose an alternative to the admission [webhook-based approach](https://github.com/Kong/kubernetes-ingress-controller/pull/5787) that annotates `credentials` and `consumerGroup` with `+listType=set` which enforces the uniqueness of the elements in the list.

I verified the following scenario to ensure that migrating from the old CRD manifests to the new ones (with `x-kubernetes-list-type: set`) is allowed:

1. Create a fresh cluster, and apply old CRD manifests.
2. Create a couple of KongConsumers (both with duplicate and non-duplicate credentials/consumerGroups).
3. Apply the new CRD manifests (with `x-kubernetes-list-type: set`).
4. Ensure it works as expected:
     - Fetching the old KongConsumers works.
     - New KongConsumers violating the constraints are rejected. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5402. 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
