### PR TITLE
backport: upgrade golang to latest patch of go 1.21 in release/3.1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Standard binary
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.21.9 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Standard binary
 # Build the manager binary
-FROM golang:1.21.6 as builder
+FROM golang:1.21 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Build a manager binary with debug symbols and download Delve
-FROM golang:1.21 as builder
+FROM golang:1.21.9 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.d
 
 ### Debug
 # Create an image that runs a debug build with Delve installed
-FROM golang:1.21 AS debug
+FROM golang:1.21.9 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # We want all source so Delve file location operations work
 COPY --from=builder /workspace/bin/manager-debug /

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Build a manager binary with debug symbols and download Delve
-FROM golang:1.21.6 as builder
+FROM golang:1.21 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.d
 
 ### Debug
 # Create an image that runs a debug build with Delve installed
-FROM golang:1.21.6 AS debug
+FROM golang:1.21 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # We want all source so Delve file location operations work
 COPY --from=builder /workspace/bin/manager-debug /

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.21.6
+go 1.21.9
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -2,8 +2,6 @@ module github.com/kong/kubernetes-ingress-controller/tools
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/elastic/crd-ref-docs v0.0.10
 	github.com/go-delve/delve v1.22.0

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/tools
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/elastic/crd-ref-docs v0.0.10

--- a/third_party/skaffold/go.mod
+++ b/third_party/skaffold/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-ingress-controller/third_party/skaffold
 
-go 1.21
+go 1.21.9
 
 require github.com/GoogleContainerTools/skaffold/v2 v2.10.0
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Upgrade golang version to 1.21.9 in `release/3.1.x` branch. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

The intention of this PR is to update ALL appearances of golang version to `1.21` to use the latest patch of golang 1.21. But when I run `go mod tidy` locally, it added `toolchain go1.22.2` which is my local golang version. (Is it affected by local config of golang?)
So I updated it to 1.21.9.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
