### PR TITLE
chore: improve docstring for ExtractClientCertificates and other tweaks

### DIFF
--- a/internal/util/tls/tls_cert.go
+++ b/internal/util/tls/tls_cert.go
@@ -8,13 +8,13 @@ import (
 
 // ExtractClientCertificates extracts tls.Certificates from TLSClientConfig.
 // It returns nil in case there was no client cert and/or client key provided.
-// REVIEW: in case of no certs specified, return nil, nil, OR return non-nil error, OR add a boolean return value?
+// In case of no certs specified, it returns nil, nil.
 func ExtractClientCertificates(cert []byte, certFile string, key []byte, keyFile string) (*tls.Certificate, error) {
-	clientCert, err := ValueFromVariableOrFile(cert, certFile)
+	clientCert, err := valueFromVariableOrFile(cert, certFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract TLS client cert")
 	}
-	clientKey, err := ValueFromVariableOrFile(key, keyFile)
+	clientKey, err := valueFromVariableOrFile(key, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract TLS client key")
 	}
@@ -30,20 +30,14 @@ func ExtractClientCertificates(cert []byte, certFile string, key []byte, keyFile
 	return nil, nil
 }
 
-// ValueFromVariableOrFile uses v value if it's not empty, and falls back to reading a file content when value is missing.
+// valueFromVariableOrFile uses v value if it's not empty, and falls back to reading a file content when value is missing.
 // When both are empty, nil is returned.
-func ValueFromVariableOrFile(v []byte, file string) ([]byte, error) {
+func valueFromVariableOrFile(v []byte, file string) ([]byte, error) {
 	if len(v) > 0 {
 		return v, nil
 	}
 	if file != "" {
-		b, err := os.ReadFile(file)
-		if err != nil {
-			return nil, err
-		}
-
-		return b, nil
+		return os.ReadFile(file)
 	}
-
 	return nil, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Replace docstring that is leftover from review, make helper `ValueFromVariableOrFile` private because it's not used outside this package, and simplify its code. 
