### PR TITLE
chore: use specific version of go in go.mods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.22
+go 1.22.2
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/tools
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/go-delve/delve v1.22.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.22 requires the exact version to be specified in `go <version>` directive in go.mod. If only a `<major>.<minor>` is specified, it gives following output:

```terminal
$ go mod tidy
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

See: https://github.com/golang/go/issues/65568

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
