### PR TITLE
backport: bump golang to 1.21.9 in 2.12.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Standard binary
 # Build the manager binary
-FROM golang:1.21.1 as builder
+FROM golang:1.21.9 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Build a manager binary with debug symbols and download Delve
-FROM golang:1.21.1 as builder
+FROM golang:1.21.9 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GO111MODULE=on make _build.d
 
 ### Debug
 # Create an image that runs a debug build with Delve installed
-FROM golang:1.21.1 AS debug
+FROM golang:1.21.9 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # We want all source so Delve file location operations work
 COPY --from=builder /workspace/bin/manager-debug /

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v2
 
-go 1.21
+go 1.21.9
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -1,8 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/tools
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.9
 
 require (
 	github.com/GoogleContainerTools/skaffold/v2 v2.7.1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Bump golang version to 1.21.9 in release 2.12.x. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


Part of #5900

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
