### PR TITLE
fix: remove check of parentRef group and kind in validating HTTPRoutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ Adding a new version? You'll need three changes:
 - Do not generate invalid duplicate upstream targets when routes use multiple
   Services with the same endpoints.
   [#5817](https://github.com/Kong/kubernetes-ingress-controller/pull/5817)
+- Remove the constraint of items of `parentRefs` can only be empty or 
+  `gateway.network.k8s.io/Gateway` in validating `HTTPRoute`s. If an item in
+  `parentRefs`'s group/kind is not `gateway.network.k8s.io/Gateway`, the item
+  is seen as a parent other than the controller and ignored in parentRef check.
+  [#5919](https://github.com/Kong/kubernetes-ingress-controller/pull/5919)
 
 ### Changed
 

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -78,6 +78,50 @@ func TestValidateHTTPRoute(t *testing.T) {
 			valid: true,
 		},
 		{
+			msg: "route with parentRef to non-gateway object is accepted with no vlaidation",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-httproute",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Kind:      lo.ToPtr(gatewayapi.Kind("Service")),
+								Namespace: lo.ToPtr(gatewayapi.Namespace(corev1.NamespaceDefault)),
+								Name:      gatewayapi.ObjectName("kuma-cp"),
+							},
+						},
+					},
+				},
+			}, // parentRef to a Service
+			cachedObjects: []client.Object{
+				gatewayClass,
+				&gatewayapi.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: corev1.NamespaceDefault,
+						Name:      "testing-gateway",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						GatewayClassName: gatewayClassName,
+						Listeners: []gatewayapi.Listener{{
+							Name:     "http",
+							Port:     80,
+							Protocol: (gatewayapi.HTTPProtocolType),
+							AllowedRoutes: &gatewayapi.AllowedRoutes{
+								Kinds: []gatewayapi.RouteGroupKind{{
+									Group: &group,
+									Kind:  "HTTPRoute",
+								}},
+							},
+						}},
+					},
+				},
+			},
+			valid: true,
+		},
+		{
 			msg: "parentRefs which omit the namespace pass validation in the same namespace",
 			route: &gatewayapi.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Do not constrain group/kind of `parentRef`s of `HTTPRoute` to be empty or `gateway.network.k8s.io/Gateway` to allow HTTPRoutes to use other resources (like using a service in kuma) as their parents. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #5912 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
