### PR TITLE
[backport release/3.1.x] fix: remove check of parentRef group and kind in validating HTTPRoutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ Adding a new version? You'll need three changes:
 - Bump `golang.org/x/net` to `0.23.0` and `google.golang.org/protobuf` to `1.33.0`
   To fix [GO-2024-2687](https://pkg.go.dev/vuln/GO-2024-2687) and [GO-2024-2611](https://pkg.go.dev/vuln/GO-2024-2611).
   [#5938](https://github.com/Kong/kubernetes-ingress-controller/pull/5938)
+- Remove the constraint of items of `parentRefs` can only be empty or
+  `gateway.network.k8s.io/Gateway` in validating `HTTPRoute`s. If an item in
+  `parentRefs`'s group/kind is not `gateway.network.k8s.io/Gateway`, the item
+  is seen as a parent other than the controller and ignored in parentRef check.
+  [#5919](https://github.com/Kong/kubernetes-ingress-controller/pull/5919)
+
 
 ## [3.1.2]
 

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -78,6 +78,50 @@ func TestValidateHTTPRoute(t *testing.T) {
 			valid: true,
 		},
 		{
+			msg: "route with parentRef to non-gateway object is accepted with no vlaidation",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "testing-httproute",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Kind:      lo.ToPtr(gatewayapi.Kind("Service")),
+								Namespace: lo.ToPtr(gatewayapi.Namespace(corev1.NamespaceDefault)),
+								Name:      gatewayapi.ObjectName("kuma-cp"),
+							},
+						},
+					},
+				},
+			}, // parentRef to a Service
+			cachedObjects: []client.Object{
+				gatewayClass,
+				&gatewayapi.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: corev1.NamespaceDefault,
+						Name:      "testing-gateway",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						GatewayClassName: gatewayClassName,
+						Listeners: []gatewayapi.Listener{{
+							Name:     "http",
+							Port:     80,
+							Protocol: (gatewayapi.HTTPProtocolType),
+							AllowedRoutes: &gatewayapi.AllowedRoutes{
+								Kinds: []gatewayapi.RouteGroupKind{{
+									Group: &group,
+									Kind:  "HTTPRoute",
+								}},
+							},
+						}},
+					},
+				},
+			},
+			valid: true,
+		},
+		{
 			msg: "parentRefs which omit the namespace pass validation in the same namespace",
 			route: &gatewayapi.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
(cherry picked from commit 14e51abf9038e085a5dfec2f06845b4fcf80965d)
