### PR TITLE
feat: implement rewrite path prefix filter for HTTPRoute in expressions router mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,9 @@ Adding a new version? You'll need three changes:
   [#5894](https://github.com/Kong/kubernetes-ingress-controller/pull/5894)
 - Add support in `HTTPRoute`s for `URLRewrite`:
   - `FullPathRewrite` [#5855](https://github.com/Kong/kubernetes-ingress-controller/pull/5855)
-  - `ReplacePrefixMatch` [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
+  - `ReplacePrefixMatch` for both router modes:
+    - `traditional_compatible`: [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
+    - `expressions`: [#5940](https://github.com/Kong/kubernetes-ingress-controller/pull/5940)
 - DB mode now supports Event reporting for resources that failed to apply.
   [#5785](https://github.com/Kong/kubernetes-ingress-controller/pull/5785)
 

--- a/internal/dataplane/translator/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
+++ b/internal/dataplane/translator/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
@@ -1,0 +1,45 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: httproute.default.httproute-testing._.0
+  id: 2fad71d1-7599-5c6e-9d4f-4afd44f99587
+  name: httproute.default.httproute-testing._.0
+  port: 8080
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/prefix") || (http.path ~ "^/prefix(/.*)")
+    https_redirect_status_code: 426
+    id: 91833860-2041-5eea-abf8-a1e85b7c64cf
+    name: httproute.default.httproute-testing._.0.0
+    plugins:
+    - config:
+        replace:
+          uri: /new-prefix$(uri_captures[1])
+      name: request-transformer
+    preserve_host: true
+    priority: 35184422424575
+    strip_path: false
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-namespace:default
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: httproute.default.httproute-testing._.0
+  tags:
+  - k8s-name:httproute-testing
+  - k8s-namespace:default
+  - k8s-kind:HTTPRoute
+  - k8s-group:gateway.networking.k8s.io
+  - k8s-version:v1

--- a/internal/dataplane/translator/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_settings.yaml
+++ b/internal/dataplane/translator/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -45,6 +45,7 @@ var expressionRoutesSupportedFeatures = []suite.SupportedFeature{
 	suite.SupportHTTPRouteQueryParamMatching,
 	suite.SupportHTTPRouteMethodMatching,
 	suite.SupportHTTPRouteResponseHeaderModification,
+	suite.SupportHTTPRoutePathRewrite,
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// suite.SupportHTTPRouteBackendTimeout,

--- a/test/integration/isolated/examples_httproute_rewrite_test.go
+++ b/test/integration/isolated/examples_httproute_rewrite_test.go
@@ -13,10 +13,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
-	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
 )
 
@@ -57,12 +55,6 @@ func TestHTTPRouteRewriteExample(t *testing.T) {
 					consts.IngressWait,
 					consts.WaitTick,
 				)
-
-				if testenv.KongRouterFlavor() != dpconf.RouterFlavorTraditional {
-					// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3686
-					t.Log("skipping prefix rewrite test for expressions router - to be implemented")
-					return ctx
-				}
 
 				t.Logf("asserting /old-prefix?msg=hello path is redirected to /echo?msg=hello replacing the prefix")
 				helpers.EventuallyGETPath(


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends HTTPRoute's `URLRewrite` filter with path type `ReplacePrefixMatch` support to the `expressions` router. Adds `SupportHTTPRoutePathRewrite` feature to the Gateway API conformance tests for `expressions` router.

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3686.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
