### PR TITLE
feat(httproute): handle URLRewrite filter's hostname rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,9 @@ Adding a new version? You'll need three changes:
 - Add support in `HTTPRoute`s for `URLRewrite`:
   - `FullPathRewrite` [#5855](https://github.com/Kong/kubernetes-ingress-controller/pull/5855)
   - `ReplacePrefixMatch` for both router modes:
-    - `traditional_compatible`: [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
-    - `expressions`: [#5940](https://github.com/Kong/kubernetes-ingress-controller/pull/5940)
+    - `traditional_compatible` [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
+    - `expressions` [#5940](https://github.com/Kong/kubernetes-ingress-controller/pull/5940)
+  - `Hostname` [#5952](https://github.com/Kong/kubernetes-ingress-controller/pull/5952)
 - DB mode now supports Event reporting for resources that failed to apply.
   [#5785](https://github.com/Kong/kubernetes-ingress-controller/pull/5785)
 - Improve validation - reject `Ingresses`, `Services` or `KongConsumers` that have multiple instances

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -483,7 +483,11 @@ func mergePluginsOfTheSameType(plugins []kong.Plugin) ([]kong.Plugin, error) {
 		plugins := plugins
 		// If we produced multiple plugins of the same type, we need to merge their configurations now.
 		if len(plugins) > 1 {
+			// Use the first plugin as the base for the merged plugin.
 			mergedPlugin := *plugins[0].DeepCopy()
+			// Merge the configurations of the other plugins into the base plugin (thus skipping the first one).
+			// If we merged the first one into itself, it could result in duplicate entries in slices because of
+			// the `mergo.WithAppendSlice` option.
 			for _, plugin := range plugins[1:] {
 				if err := mergo.Merge(&mergedPlugin.Config, plugin.Config, mergo.WithAppendSlice); err != nil {
 					// Should never happen as we're passing the same type of objects.

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"dario.cat/mergo"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 
@@ -407,14 +408,13 @@ func generatePluginsFromHTTPRouteFilters(
 	filters []gatewayapi.HTTPRouteFilter,
 	path string,
 	tags []*string,
-	// As of now, expressions router is not supported for URLRewrite with PrefixMatchHTTPPathModifier.
-	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3686
 	expressionsRouterEnabled bool,
 ) (httpRouteFiltersOriginatedPlugins, error) {
 	if len(filters) == 0 {
 		return httpRouteFiltersOriginatedPlugins{}, nil
 	}
 	var (
+		transformerPlugins          []transformerPlugin
 		kongPlugins                 []kong.Plugin
 		pluginNamesFromExtensionRef []string
 		kongRouteModifiers          []kongRouteModifier
@@ -423,13 +423,15 @@ func generatePluginsFromHTTPRouteFilters(
 	for _, filter := range filters {
 		switch filter.Type {
 		case gatewayapi.HTTPRouteFilterRequestHeaderModifier:
-			kongPlugins = append(kongPlugins, generateRequestHeaderModifierKongPlugin(filter.RequestHeaderModifier))
+			transformerPlugins = append(transformerPlugins, generateRequestHeaderModifierKongPlugin(filter.RequestHeaderModifier))
 
 		case gatewayapi.HTTPRouteFilterRequestRedirect:
-			kongPlugins = append(kongPlugins, generateRequestRedirectKongPlugin(filter.RequestRedirect, path)...)
+			kongPlugin, transformerPlugin := generateRequestRedirectKongPlugin(filter.RequestRedirect, path)
+			kongPlugins = append(kongPlugins, kongPlugin)
+			transformerPlugins = append(transformerPlugins, transformerPlugin)
 
 		case gatewayapi.HTTPRouteFilterResponseHeaderModifier:
-			kongPlugins = append(kongPlugins, generateResponseHeaderModifierKongPlugin(filter.ResponseHeaderModifier))
+			transformerPlugins = append(transformerPlugins, generateResponseHeaderModifierKongPlugin(filter.ResponseHeaderModifier))
 
 		case gatewayapi.HTTPRouteFilterExtensionRef:
 			plugin, err := generateExtensionRefKongPlugin(filter.ExtensionRef)
@@ -443,7 +445,7 @@ func generatePluginsFromHTTPRouteFilters(
 			if err != nil {
 				return httpRouteFiltersOriginatedPlugins{}, err
 			}
-			kongPlugins = append(kongPlugins, plugins...)
+			transformerPlugins = append(transformerPlugins, plugins...)
 			kongRouteModifiers = append(kongRouteModifiers, routeModifiers...)
 
 		case gatewayapi.HTTPRouteFilterRequestMirror:
@@ -451,17 +453,19 @@ func generatePluginsFromHTTPRouteFilters(
 			return httpRouteFiltersOriginatedPlugins{}, fmt.Errorf("httpFilter %s unsupported", filter.Type)
 		}
 	}
+
+	// It's possible the above loop generates multiple transformerPlugins of the same type, so we need to merge them.
+	// It can happen for example when both RequestHeaderModifier and HTTPRouteFilterURLRewrite filters are present.
+	transformerPlugins, err := mergePluginsOfTheSameType(transformerPlugins)
+	if err != nil {
+		return httpRouteFiltersOriginatedPlugins{}, fmt.Errorf("failed to merge transformerPlugins of the same type: %w", err)
+	}
+	kongPlugins = append(kongPlugins, transformerPluginsToKongPlugins(transformerPlugins)...)
+
 	for _, p := range kongPlugins {
 		// This plugin is derived from an HTTPRoute filter, not a KongPlugin, so we apply tags indicating that
-		// HTTPRoute as the parent Kubernetes resource for these generated plugins.
+		// HTTPRoute as the parent Kubernetes resource for these generated transformerPlugins.
 		p.Tags = tags
-	}
-
-	// It's possible the above loop generates multiple plugins of the same type, so we need to merge them.
-	// It can happen for example when both RequestHeaderModifier and HTTPRouteFilterURLRewrite filters are present.
-	kongPlugins, err := mergePluginsOfTheSameType(kongPlugins)
-	if err != nil {
-		return httpRouteFiltersOriginatedPlugins{}, fmt.Errorf("failed to merge plugins of the same type: %w", err)
 	}
 
 	if len(pluginNamesFromExtensionRef) > 0 {
@@ -475,35 +479,59 @@ func generatePluginsFromHTTPRouteFilters(
 }
 
 // mergePluginsOfTheSameType merges plugins of the same type into a single plugin with merged configurations.
-func mergePluginsOfTheSameType(plugins []kong.Plugin) ([]kong.Plugin, error) {
-	pluginsByName := lo.GroupBy(plugins, func(p kong.Plugin) string {
-		return *p.Name // Name is effectively a plugin type.
+func mergePluginsOfTheSameType(plugins []transformerPlugin) ([]transformerPlugin, error) {
+	pluginsByName := lo.GroupBy(plugins, func(p transformerPlugin) transformerPluginType {
+		return p.Type // Name is effectively a plugin type.
 	})
 	for pluginName, plugins := range pluginsByName {
 		plugins := plugins
 		// If we produced multiple plugins of the same type, we need to merge their configurations now.
 		if len(plugins) > 1 {
-			// Use the first plugin as the base for the merged plugin.
-			mergedPlugin := *plugins[0].DeepCopy()
-			// Merge the configurations of the other plugins into the base plugin (thus skipping the first one).
-			// If we merged the first one into itself, it could result in duplicate entries in slices because of
-			// the `mergo.WithAppendSlice` option.
-			for _, plugin := range plugins[1:] {
-				if err := mergo.Merge(&mergedPlugin.Config, plugin.Config, mergo.WithAppendSlice); err != nil {
+			mergedPlugin := transformerPlugin{}
+			for _, plugin := range plugins {
+				if err := mergo.Merge(&mergedPlugin, plugin, mergo.WithAppendSlice); err != nil {
 					// Should never happen as we're passing the same type of objects.
 					return nil, fmt.Errorf("failed to merge %q plugin configurations: %w", pluginName, err)
 				}
 			}
-			pluginsByName[pluginName] = []kong.Plugin{mergedPlugin}
+			pluginsByName[pluginName] = []transformerPlugin{mergedPlugin}
 		}
 	}
 
 	// Sort the plugins by name to ensure that the order is deterministic.
 	mergedPlugins := lo.Flatten(lo.Values(pluginsByName))
 	sort.Slice(mergedPlugins, func(i, j int) bool {
-		return *mergedPlugins[i].Name < *mergedPlugins[j].Name
+		return mergedPlugins[i].Type < mergedPlugins[j].Type
 	})
 	return mergedPlugins, nil
+}
+
+func transformerPluginsToKongPlugins(plugins []transformerPlugin) []kong.Plugin {
+	kongPlugins := make([]kong.Plugin, 0, len(plugins))
+	for _, plugin := range plugins {
+		kongPlugins = append(kongPlugins, transformerPluginToKongPlugin(plugin))
+	}
+	return kongPlugins
+}
+
+func transformerPluginToKongPlugin(plugin transformerPlugin) kong.Plugin {
+	res := kong.Plugin{
+		Name:   kong.String(string(plugin.Type)),
+		Config: kong.Configuration{},
+	}
+	if !cmp.Equal(plugin.Replace, TransformerPluginReplaceConfig{}) {
+		res.Config["replace"] = plugin.Replace
+	}
+	if !cmp.Equal(plugin.Add, TransformerPluginConfig{}) {
+		res.Config["add"] = plugin.Add
+	}
+	if !cmp.Equal(plugin.Append, TransformerPluginConfig{}) {
+		res.Config["append"] = plugin.Append
+	}
+	if !cmp.Equal(plugin.Remove, TransformerPluginConfig{}) {
+		res.Config["remove"] = plugin.Remove
+	}
+	return res
 }
 
 func generateKongRouteModifierFromExtensionRef(pluginNamesFromExtensionRef []string) kongRouteModifier {
@@ -525,9 +553,8 @@ func generateKongRouteModifierFromExtensionRef(pluginNamesFromExtensionRef []str
 
 // generateRequestRedirectKongPlugin generates configurations of plugins to satisfy the specification
 // of request redirect filter.
-func generateRequestRedirectKongPlugin(modifier *gatewayapi.HTTPRequestRedirectFilter, path string) []kong.Plugin {
-	plugins := make([]kong.Plugin, 2)
-	plugins[0] = kong.Plugin{
+func generateRequestRedirectKongPlugin(modifier *gatewayapi.HTTPRequestRedirectFilter, path string) (kong.Plugin, transformerPlugin) {
+	requestTerminationPlugin := kong.Plugin{
 		Name: kong.String("request-termination"),
 		Config: kong.Configuration{
 			"status_code": modifier.StatusCode,
@@ -556,16 +583,14 @@ func generateRequestRedirectKongPlugin(modifier *gatewayapi.HTTPRequestRedirectF
 		locationHeader = fmt.Sprintf("Location: %s", path)
 	}
 
-	plugins[1] = kong.Plugin{
-		Name: kong.String("response-transformer"),
-		Config: kong.Configuration{
-			"add": map[string][]string{
-				"headers": {locationHeader},
-			},
+	transformerPlugin := transformerPlugin{
+		Type: transformerPluginTypeResponse,
+		Add: TransformerPluginConfig{
+			Headers: []string{locationHeader},
 		},
 	}
 
-	return plugins
+	return requestTerminationPlugin, transformerPlugin
 }
 
 func generateExtensionRefKongPlugin(modifier *gatewayapi.LocalObjectReference) (string, error) {
@@ -577,50 +602,80 @@ func generateExtensionRefKongPlugin(modifier *gatewayapi.LocalObjectReference) (
 
 // generateRequestHeaderModifierKongPlugin converts a gatewayapi.HTTPRequestHeaderFilter into a
 // kong.Plugin of type request-transformer.
-func generateRequestHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter) kong.Plugin {
-	return generateHeaderModifierKongPlugin(modifier, "request-transformer")
+func generateRequestHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter) transformerPlugin {
+	return generateHeaderModifierKongPlugin(modifier, transformerPluginTypeRequest)
 }
 
 // generateResponseHeaderModifierKongPlugin converts a gatewayapi.HTTPResponseHeaderFilter into a
 // kong.Plugin of type response-transformer.
-func generateResponseHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter) kong.Plugin {
-	return generateHeaderModifierKongPlugin(modifier, "response-transformer")
+func generateResponseHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter) transformerPlugin {
+	return generateHeaderModifierKongPlugin(modifier, transformerPluginTypeResponse)
 }
 
-func generateHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter, pluginName string) kong.Plugin {
-	plugin := kong.Plugin{
-		Name:   kong.String(pluginName),
-		Config: make(kong.Configuration),
+type transformerPluginType string
+
+const (
+	transformerPluginTypeRequest  transformerPluginType = "request-transformer"
+	transformerPluginTypeResponse transformerPluginType = "response-transformer"
+)
+
+// transformerPlugin is a configuration for request-transformer and response-transformer plugins.
+type transformerPlugin struct {
+	// Type is the type of the transformer plugin (request-transformer or response-transformer).
+	Type transformerPluginType `json:"-"`
+
+	Replace TransformerPluginReplaceConfig `json:"replace,omitempty"`
+	Add     TransformerPluginConfig        `json:"add,omitempty"`
+	Append  TransformerPluginConfig        `json:"append,omitempty"`
+	Remove  TransformerPluginConfig        `json:"remove,omitempty"`
+}
+
+// TransformerPluginConfig is a configuration for request-transformer and response-transformer plugins'
+// "add", "append", and "remove" fields.
+type TransformerPluginConfig struct {
+	Headers []string `json:"headers,omitempty"`
+}
+
+// TransformerPluginReplaceConfig is a configuration for request-transformer and response-transformer plugins'
+// "replace" field.
+type TransformerPluginReplaceConfig struct {
+	Headers []string `json:"headers,omitempty"`
+	URI     string   `json:"uri,omitempty"`
+}
+
+func generateHeaderModifierKongPlugin(modifier *gatewayapi.HTTPHeaderFilter, pluginType transformerPluginType) transformerPlugin {
+	plugin := transformerPlugin{
+		Type: pluginType,
 	}
 
 	// modifier.Set is converted to a pair composed of "replace" and "add"
 	if modifier.Set != nil {
-		setModifiers := make([]interface{}, 0, len(modifier.Set))
+		setModifiers := make([]string, 0, len(modifier.Set))
 		for _, s := range modifier.Set {
 			setModifiers = append(setModifiers, kongHeaderFormatter(s))
 		}
-		plugin.Config["replace"] = map[string]interface{}{
-			"headers": setModifiers,
+		plugin.Replace = TransformerPluginReplaceConfig{
+			Headers: setModifiers,
 		}
-		plugin.Config["add"] = map[string]interface{}{
-			"headers": setModifiers,
+		plugin.Add = TransformerPluginConfig{
+			Headers: setModifiers,
 		}
 	}
 
 	// modifier.Add is converted to "append"
 	if modifier.Add != nil {
-		appendModifiers := make([]interface{}, 0, len(modifier.Add))
+		appendModifiers := make([]string, 0, len(modifier.Add))
 		for _, a := range modifier.Add {
 			appendModifiers = append(appendModifiers, kongHeaderFormatter(a))
 		}
-		plugin.Config["append"] = map[string]interface{}{
-			"headers": appendModifiers,
+		plugin.Append = TransformerPluginConfig{
+			Headers: appendModifiers,
 		}
 	}
 
 	if modifier.Remove != nil {
-		plugin.Config["remove"] = map[string]interface{}{
-			"headers": modifier.Remove,
+		plugin.Remove = TransformerPluginConfig{
+			Headers: modifier.Remove,
 		}
 	}
 
@@ -635,7 +690,7 @@ func generateRequestTransformerForURLRewrite(
 	filter *gatewayapi.HTTPURLRewriteFilter,
 	path string,
 	expressionsRouterEnabled bool,
-) ([]kong.Plugin, []kongRouteModifier, error) {
+) ([]transformerPlugin, []kongRouteModifier, error) {
 	if filter == nil {
 		return nil, nil, fmt.Errorf("%s is not provided", gatewayapi.HTTPRouteFilterURLRewrite)
 	}
@@ -644,7 +699,7 @@ func generateRequestTransformerForURLRewrite(
 	}
 
 	var (
-		plugins        []kong.Plugin
+		plugins        []transformerPlugin
 		routeModifiers []kongRouteModifier
 	)
 	if filter.Path != nil {
@@ -668,12 +723,12 @@ func generateRequestTransformerForURLRewritePath(
 	filter *gatewayapi.HTTPURLRewriteFilter,
 	path string,
 	expressionsRouterEnabled bool,
-) (kong.Plugin, kongRouteModifier, error) {
+) (transformerPlugin, kongRouteModifier, error) {
 	switch filter.Path.Type {
 	case gatewayapi.FullPathHTTPPathModifier:
 		plugin, err := generateRequestTransformerForURLRewriteFullPath(filter)
 		if err != nil {
-			return kong.Plugin{}, nil, fmt.Errorf("failed to generate request-transformer plugin for %s: %w", gatewayapi.HTTPRouteFilterURLRewrite, err)
+			return transformerPlugin{}, nil, fmt.Errorf("failed to generate request-transformer plugin for %s: %w", gatewayapi.HTTPRouteFilterURLRewrite, err)
 		}
 		return plugin, nil, nil
 
@@ -681,25 +736,23 @@ func generateRequestTransformerForURLRewritePath(
 		plugin, routeModifier := generateRequestTransformerForURLRewritePrefixMatch(filter, path, expressionsRouterEnabled)
 		return plugin, routeModifier, nil
 	default:
-		return kong.Plugin{}, nil, fmt.Errorf("unsupported path type %s for %s", filter.Path.Type, gatewayapi.HTTPRouteFilterURLRewrite)
+		return transformerPlugin{}, nil, fmt.Errorf("unsupported path type %s for %s", filter.Path.Type, gatewayapi.HTTPRouteFilterURLRewrite)
 	}
 }
 
 func generateRequestTransformerForURLRewriteHostname(
 	filter *gatewayapi.HTTPURLRewriteFilter,
-) kong.Plugin {
-	return kong.Plugin{
-		Name: kong.String("request-transformer"),
-		Config: kong.Configuration{
-			"replace": map[string][]string{
-				"headers": {
-					fmt.Sprintf("host:%s", string(*filter.Hostname)),
-				},
+) transformerPlugin {
+	return transformerPlugin{
+		Type: transformerPluginTypeRequest,
+		Replace: TransformerPluginReplaceConfig{
+			Headers: []string{
+				fmt.Sprintf("host:%s", string(*filter.Hostname)),
 			},
-			"add": map[string][]string{
-				"headers": {
-					fmt.Sprintf("host:%s", string(*filter.Hostname)),
-				},
+		},
+		Add: TransformerPluginConfig{
+			Headers: []string{
+				fmt.Sprintf("host:%s", string(*filter.Hostname)),
 			},
 		},
 	}
@@ -707,17 +760,15 @@ func generateRequestTransformerForURLRewriteHostname(
 
 // generateRequestTransformerForURLRewriteFullPath generates a request-transformer plugin for the URLRewrite filter
 // with a FullPathHTTPPathModifier.
-func generateRequestTransformerForURLRewriteFullPath(filter *gatewayapi.HTTPURLRewriteFilter) (kong.Plugin, error) {
+func generateRequestTransformerForURLRewriteFullPath(filter *gatewayapi.HTTPURLRewriteFilter) (transformerPlugin, error) {
 	if filter.Path.ReplaceFullPath == nil {
-		return kong.Plugin{}, fmt.Errorf("%s missing ReplaceFullPath", gatewayapi.HTTPRouteFilterURLRewrite)
+		return transformerPlugin{}, fmt.Errorf("%s missing ReplaceFullPath", gatewayapi.HTTPRouteFilterURLRewrite)
 	}
 
-	return kong.Plugin{
-		Name: kong.String("request-transformer"),
-		Config: kong.Configuration{
-			"replace": map[string]string{
-				"uri": *filter.Path.ReplaceFullPath,
-			},
+	return transformerPlugin{
+		Type: transformerPluginTypeRequest,
+		Replace: TransformerPluginReplaceConfig{
+			URI: *filter.Path.ReplaceFullPath,
 		},
 	}, nil
 }
@@ -728,19 +779,17 @@ func generateRequestTransformerForURLRewritePrefixMatch(
 	filter *gatewayapi.HTTPURLRewriteFilter,
 	path string,
 	expressionsRouterEnabled bool,
-) (kong.Plugin, kongRouteModifier) {
+) (transformerPlugin, kongRouteModifier) {
 	// Normalize the path before passing it down.
 	path = normalizePath(path)
 
-	return kong.Plugin{
-		Name: kong.String("request-transformer"),
-		Config: kong.Configuration{
-			"replace": map[string]string{
-				"uri": generateRequestTransformerReplaceURIForURLRewritePrefixMatch(
-					filter.Path.ReplacePrefixMatch,
-					path,
-				),
-			},
+	return transformerPlugin{
+		Type: transformerPluginTypeRequest,
+		Replace: TransformerPluginReplaceConfig{
+			URI: generateRequestTransformerReplaceURIForURLRewritePrefixMatch(
+				filter.Path.ReplacePrefixMatch,
+				path,
+			),
 		},
 	}, generateKongRouteModifierForURLRewritePrefixMatch(path, expressionsRouterEnabled)
 }

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -138,8 +138,8 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 						{
 							Name: kong.String("response-transformer"),
 							Config: kong.Configuration{
-								"add": map[string][]string{
-									"headers": {`Location: http://a.foo.com:80/exact/0`},
+								"add": TransformerPluginConfig{
+									Headers: []string{`Location: http://a.foo.com:80/exact/0`},
 								},
 							},
 						},
@@ -164,8 +164,8 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 						{
 							Name: kong.String("response-transformer"),
 							Config: kong.Configuration{
-								"add": map[string][]string{
-									"headers": {`Location: http://a.foo.com:80/exact/1`},
+								"add": TransformerPluginConfig{
+									Headers: []string{`Location: http://a.foo.com:80/exact/1`},
 								},
 							},
 						},
@@ -200,8 +200,8 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 						{
 							Name: kong.String("request-transformer"),
 							Config: kong.Configuration{
-								"append": map[string]interface{}{
-									"headers": []interface{}{"foo:bar"},
+								"append": TransformerPluginConfig{
+									Headers: []string{"foo:bar"},
 								},
 							},
 						},

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -200,8 +200,8 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 						{
 							Name: kong.String("request-transformer"),
 							Config: kong.Configuration{
-								"append": map[string][]string{
-									"headers": {"foo:bar"},
+								"append": map[string]interface{}{
+									"headers": []interface{}{"foo:bar"},
 								},
 							},
 						},

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -2,7 +2,6 @@ package subtranslator
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -54,23 +53,23 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 				{
 					Name: kong.String("request-transformer"),
 					Config: kong.Configuration{
-						"add": map[string][]string{
-							"headers": {
+						"add": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-set:bar",
 							},
 						},
-						"append": map[string][]string{
-							"headers": {
+						"append": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-add:foo",
 							},
 						},
-						"remove": map[string][]string{
-							"headers": {
+						"remove": map[string]interface{}{
+							"headers": []string{
 								"header-to-remove",
 							},
 						},
-						"replace": map[string][]string{
-							"headers": {
+						"replace": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-set:bar",
 							},
 						},
@@ -135,23 +134,23 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 				{
 					Name: kong.String("response-transformer"),
 					Config: kong.Configuration{
-						"add": map[string][]string{
-							"headers": {
+						"add": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-set:bar",
 							},
 						},
-						"append": map[string][]string{
-							"headers": {
+						"append": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-add:foo",
 							},
 						},
-						"remove": map[string][]string{
-							"headers": {
+						"remove": map[string]interface{}{
+							"headers": []string{
 								"header-to-remove",
 							},
 						},
-						"replace": map[string][]string{
-							"headers": {
+						"replace": map[string]interface{}{
+							"headers": []interface{}{
 								"header-to-set:bar",
 							},
 						},
@@ -292,7 +291,7 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 		modifier                      *gatewayapi.HTTPURLRewriteFilter
 		firstMatchPath                string
 		expectedKongRouteModification kongstate.Route
-		expected                      kong.Plugin
+		expected                      []kong.Plugin
 		expectedErr                   error
 	}{
 		{
@@ -303,14 +302,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 					ReplaceFullPath: lo.ToPtr("/new-path"),
 				},
 			},
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": "/new-path",
 					},
 				},
-			},
+			}},
 			expectedErr: nil,
 		},
 		{
@@ -322,14 +321,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/prefix",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": "/new$(uri_captures[1])",
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -348,14 +347,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/prefix",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `$(uri_captures[1] == nil and "/" or uri_captures[1])`,
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -374,14 +373,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `/prefix$(uri_captures[1] == nil and "" or "/" .. uri_captures[1])`,
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -400,14 +399,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/prefix",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `$(uri_captures[1] == nil and "/" or uri_captures[1])`,
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -426,14 +425,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `$(uri_captures[1] == nil and "/" or "/" .. uri_captures[1])`,
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -452,14 +451,14 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `/new-prefix$(uri_captures[1] == nil and "" or "/" .. uri_captures[1])`,
 					},
 				},
-			},
+			}},
 			expectedKongRouteModification: kongstate.Route{
 				Route: kong.Route{
 					Paths: []*string{
@@ -478,11 +477,76 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 			firstMatchPath: "/prefix/",
-			expected: kong.Plugin{
+			expected: []kong.Plugin{{
 				Name: lo.ToPtr("request-transformer"),
 				Config: kong.Configuration{
 					"replace": map[string]string{
 						"uri": `/new-prefix$(uri_captures[1])`,
+					},
+				},
+			}},
+			expectedKongRouteModification: kongstate.Route{
+				Route: kong.Route{
+					Paths: []*string{
+						lo.ToPtr("~/prefix$"),
+						lo.ToPtr("~/prefix(/.*)"),
+					},
+				},
+			},
+		},
+		{
+			name: "URLRewriteFilter with hostname",
+			modifier: &gatewayapi.HTTPURLRewriteFilter{
+				Hostname: lo.ToPtr(gatewayapi.PreciseHostname("replaced.host")),
+			},
+			expected: []kong.Plugin{{
+				Name: lo.ToPtr("request-transformer"),
+				Config: kong.Configuration{
+					"replace": map[string][]string{
+						"headers": {
+							"host:replaced.host",
+						},
+					},
+					"add": map[string][]string{
+						"headers": {
+							"host:replaced.host",
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "URLRewriteFilter with hostname and path",
+			modifier: &gatewayapi.HTTPURLRewriteFilter{
+				Path: &gatewayapi.HTTPPathModifier{
+					Type:               gatewayapi.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: lo.ToPtr("/new-prefix"),
+				},
+				Hostname: lo.ToPtr(gatewayapi.PreciseHostname("replaced.host")),
+			},
+			firstMatchPath: "/prefix",
+			expected: []kong.Plugin{
+				{
+					Name: lo.ToPtr("request-transformer"),
+					Config: kong.Configuration{
+						"replace": map[string]string{
+							"uri": `/new-prefix$(uri_captures[1])`,
+						},
+					},
+				},
+				{
+					Name: lo.ToPtr("request-transformer"),
+					Config: kong.Configuration{
+						"replace": map[string][]string{
+							"headers": {
+								"host:replaced.host",
+							},
+						},
+						"add": map[string][]string{
+							"headers": {
+								"host:replaced.host",
+							},
+						},
 					},
 				},
 			},
@@ -495,31 +559,22 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				},
 			},
 		},
-		// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3685
-		{
-			name: "valid URLRewriteFilter with unsupported",
-			modifier: &gatewayapi.HTTPURLRewriteFilter{
-				Hostname: lo.ToPtr(gatewayapi.PreciseHostname("hostname")),
-			},
-			expected:    kong.Plugin{},
-			expectedErr: fmt.Errorf("unsupported hostname replace for %s", gatewayapi.HTTPRouteFilterURLRewrite),
-		},
 		{
 			name:        "nil URLRewriteFilter",
 			modifier:    nil,
-			expected:    kong.Plugin{},
+			expected:    nil,
 			expectedErr: errors.New("URLRewrite is not provided"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plugin, routeModifier, err := generateRequestTransformerForURLRewrite(tc.modifier, tc.firstMatchPath, false)
+			plugins, routeModifiers, err := generateRequestTransformerForURLRewrite(tc.modifier, tc.firstMatchPath, false)
 			require.Equal(t, tc.expectedErr, err)
-			require.Equal(t, tc.expected, plugin)
+			require.Equal(t, tc.expected, plugins)
 
 			route := kongstate.Route{}
-			if routeModifier != nil {
+			for _, routeModifier := range routeModifiers {
 				routeModifier(&route)
 			}
 			require.Equal(t, tc.expectedKongRouteModification, route)
@@ -684,6 +739,31 @@ func TestMergePluginsOfTheSameType(t *testing.T) {
 					Name: lo.ToPtr("plugin1"),
 					Config: kong.Configuration{
 						"key1": "value1",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple plugins of the same types with same configuration keys - slices are appended",
+			plugins: []kong.Plugin{
+				{
+					Name: lo.ToPtr("plugin1"),
+					Config: kong.Configuration{
+						"key1": []interface{}{"value1"},
+					},
+				},
+				{
+					Name: lo.ToPtr("plugin1"),
+					Config: kong.Configuration{
+						"key1": []interface{}{"value2"},
+					},
+				},
+			},
+			expected: []kong.Plugin{
+				{
+					Name: lo.ToPtr("plugin1"),
+					Config: kong.Configuration{
+						"key1": []interface{}{"value1", "value2"},
 					},
 				},
 			},

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -1055,8 +1055,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string]interface{}{
-													"headers": []interface{}{"X-Test-Header-1:test-value-1"},
+												"append": subtranslator.TransformerPluginConfig{
+													Headers: []string{"X-Test-Header-1:test-value-1"},
 												},
 											},
 										},
@@ -1088,8 +1088,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string]interface{}{
-													"headers": []interface{}{"X-Test-Header-2:test-value-2"},
+												"append": subtranslator.TransformerPluginConfig{
+													Headers: []string{"X-Test-Header-2:test-value-2"},
 												},
 											},
 										},
@@ -1465,8 +1465,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string]interface{}{
-													"headers": []interface{}{"X-Test-Header-1:test-value-1"},
+												"append": subtranslator.TransformerPluginConfig{
+													Headers: []string{"X-Test-Header-1:test-value-1"},
 												},
 											},
 										},
@@ -2313,8 +2313,8 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 					{
 						Name: kong.String("response-transformer"),
 						Config: kong.Configuration{
-							"add": map[string][]string{
-								"headers": {"Location: http://bar.com:80/v1/foo"},
+							"add": subtranslator.TransformerPluginConfig{
+								Headers: []string{"Location: http://bar.com:80/v1/foo"},
 							},
 						},
 					},

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -1055,8 +1055,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string][]string{
-													"headers": {"X-Test-Header-1:test-value-1"},
+												"append": map[string]interface{}{
+													"headers": []interface{}{"X-Test-Header-1:test-value-1"},
 												},
 											},
 										},
@@ -1088,8 +1088,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string][]string{
-													"headers": {"X-Test-Header-2:test-value-2"},
+												"append": map[string]interface{}{
+													"headers": []interface{}{"X-Test-Header-2:test-value-2"},
 												},
 											},
 										},
@@ -1465,8 +1465,8 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 										{
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
-												"append": map[string][]string{
-													"headers": {"X-Test-Header-1:test-value-1"},
+												"append": map[string]interface{}{
+													"headers": []interface{}{"X-Test-Header-1:test-value-1"},
 												},
 											},
 										},

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -32,6 +32,7 @@ var traditionalRoutesSupportedFeatures = []suite.SupportedFeature{
 	// extended features
 	suite.SupportHTTPRouteResponseHeaderModification,
 	suite.SupportHTTPRoutePathRewrite,
+	suite.SupportHTTPRouteHostRewrite,
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// suite.SupportHTTPRouteBackendTimeout,
@@ -46,6 +47,7 @@ var expressionRoutesSupportedFeatures = []suite.SupportedFeature{
 	suite.SupportHTTPRouteMethodMatching,
 	suite.SupportHTTPRouteResponseHeaderModification,
 	suite.SupportHTTPRoutePathRewrite,
+	suite.SupportHTTPRouteHostRewrite,
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// suite.SupportHTTPRouteBackendTimeout,


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends support for `URLRewrite` filter with the `Hostname` field. Enables Gateway API conformance tests covering this feature.

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/3685.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
