### PR TITLE
fix(konnect) avoid collisions when redacting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@ Adding a new version? You'll need three changes:
   `parentRefs`'s group/kind is not `gateway.network.k8s.io/Gateway`, the item
   is seen as a parent other than the controller and ignored in parentRef check.
   [#5919](https://github.com/Kong/kubernetes-ingress-controller/pull/5919)
+- Redacted values no longer cause collisions in configuration reported to Konnect.
+  [5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
 
 ### Changed
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -553,7 +553,7 @@ func (c *KongClient) sendToClient(
 	// If the client is Konnect and the feature flag is turned on,
 	// we should sanitize the configuration before sending it out.
 	if client.IsKonnect() && config.SanitizeKonnectConfigDumps {
-		s = s.SanitizedCopy()
+		s = s.SanitizedCopy(util.DefaultUUIDGenerator{})
 	}
 	deckGenParams := deckgen.GenerateDeckContentParams{
 		SelectorTags:                    config.FilterTags,
@@ -641,7 +641,7 @@ func prepareSendDiagnosticFn(
 	if diagnosticConfig.DumpsIncludeSensitive {
 		redactedConfig := deckgen.ToDeckContent(ctx,
 			logger,
-			targetState.SanitizedCopy(),
+			targetState.SanitizedCopy(util.DefaultUUIDGenerator{}),
 			deckGenParams,
 		)
 		config = redactedConfig

--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
 
@@ -27,13 +28,13 @@ type Consumer struct {
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
-func (c *Consumer) SanitizedCopy() *Consumer {
+func (c *Consumer) SanitizedCopy(uuidGenerator util.UUIDGenerator) *Consumer {
 	return &Consumer{
 		Consumer: c.Consumer,
 		Plugins:  c.Plugins,
 		KeyAuths: func() (res []*KeyAuth) {
 			for _, v := range c.KeyAuths {
-				res = append(res, v.SanitizedCopy())
+				res = append(res, v.SanitizedCopy(uuidGenerator))
 			}
 			return
 		}(),

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -1,8 +1,10 @@
 package kongstate
 
 import (
+	"math/rand"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 
@@ -14,6 +16,8 @@ func int64Ptr(i int64) *int64 {
 }
 
 func TestConsumer_SanitizedCopy(t *testing.T) {
+	// this needs a static random seed because some auths generate random values
+	uuid.SetRand(rand.New(rand.NewSource(1)))
 	for _, tt := range []struct {
 		name string
 		in   Consumer
@@ -50,7 +54,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
 				},
 				Plugins:    []kong.Plugin{{ID: kong.String("1")}},
-				KeyAuths:   []*KeyAuth{{kong.KeyAuth{ID: kong.String("1"), Key: redactedString}}},
+				KeyAuths:   []*KeyAuth{{kong.KeyAuth{ID: kong.String("1"), Key: randRedactedString()}}},
 				HMACAuths:  []*HMACAuth{{kong.HMACAuth{ID: kong.String("1"), Secret: redactedString}}},
 				JWTAuths:   []*JWTAuth{{kong.JWTAuth{ID: kong.String("1"), Secret: redactedString}}},
 				BasicAuths: []*BasicAuth{{kong.BasicAuth{ID: kong.String("1"), Password: redactedString}}},
@@ -63,6 +67,8 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 			},
 		},
 	} {
+		// this needs a static random seed because some auths generate random values
+		uuid.SetRand(rand.New(rand.NewSource(1)))
 		t.Run(tt.name, func(t *testing.T) {
 			got := *tt.in.SanitizedCopy()
 			assert.Equal(t, tt.want, got)

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -1,14 +1,13 @@
 package kongstate
 
 import (
-	"math/rand"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
 func int64Ptr(i int64) *int64 {
@@ -16,8 +15,6 @@ func int64Ptr(i int64) *int64 {
 }
 
 func TestConsumer_SanitizedCopy(t *testing.T) {
-	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	for _, tt := range []struct {
 		name string
 		in   Consumer
@@ -54,7 +51,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
 				},
 				Plugins:    []kong.Plugin{{ID: kong.String("1")}},
-				KeyAuths:   []*KeyAuth{{kong.KeyAuth{ID: kong.String("1"), Key: randRedactedString()}}},
+				KeyAuths:   []*KeyAuth{{kong.KeyAuth{ID: kong.String("1"), Key: kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}")}}},
 				HMACAuths:  []*HMACAuth{{kong.HMACAuth{ID: kong.String("1"), Secret: redactedString}}},
 				JWTAuths:   []*JWTAuth{{kong.JWTAuth{ID: kong.String("1"), Secret: redactedString}}},
 				BasicAuths: []*BasicAuth{{kong.BasicAuth{ID: kong.String("1"), Password: redactedString}}},
@@ -67,10 +64,8 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 			},
 		},
 	} {
-		// this needs a static random seed because some auths generate random values
-		uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 		t.Run(tt.name, func(t *testing.T) {
-			got := *tt.in.SanitizedCopy()
+			got := *tt.in.SanitizedCopy(mocks.StaticUUIDGenerator{UUID: "52fdfc07-2182-454f-963f-5f0f9a621d72"})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -17,7 +17,7 @@ func int64Ptr(i int64) *int64 {
 
 func TestConsumer_SanitizedCopy(t *testing.T) {
 	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1)))
+	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	for _, tt := range []struct {
 		name string
 		in   Consumer
@@ -68,7 +68,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 		},
 	} {
 		// this needs a static random seed because some auths generate random values
-		uuid.SetRand(rand.New(rand.NewSource(1)))
+		uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 		t.Run(tt.name, func(t *testing.T) {
 			got := *tt.in.SanitizedCopy()
 			assert.Equal(t, tt.want, got)

--- a/internal/dataplane/kongstate/credentials.go
+++ b/internal/dataplane/kongstate/credentials.go
@@ -3,6 +3,7 @@ package kongstate
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/mitchellh/mapstructure"
 )
@@ -11,6 +12,13 @@ import (
 // It uses a vault URI to pass Konnect Admin API validations (e.g. when a TLS key is expected, it's only possible
 // to pass a valid key or a vault URI).
 var redactedString = kong.String("{vault://redacted-value}")
+
+// randRedactedString is used to redact sensitive values in the KongState when the value must be random to avoid
+// collisions.
+func randRedactedString() *string {
+	s := fmt.Sprintf("{vault://%s}", uuid.NewString())
+	return &s
+}
 
 // KeyAuth represents a key-auth credential.
 type KeyAuth struct {
@@ -158,7 +166,7 @@ func (c *KeyAuth) SanitizedCopy() *KeyAuth {
 			// Consumer field omitted
 			CreatedAt: c.CreatedAt,
 			ID:        c.ID,
-			Key:       redactedString,
+			Key:       randRedactedString(),
 			Tags:      c.Tags,
 		},
 	}

--- a/internal/dataplane/kongstate/credentials.go
+++ b/internal/dataplane/kongstate/credentials.go
@@ -3,9 +3,10 @@ package kongstate
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
 // redactedString is used to redact sensitive values in the KongState.
@@ -15,8 +16,8 @@ var redactedString = kong.String("{vault://redacted-value}")
 
 // randRedactedString is used to redact sensitive values in the KongState when the value must be random to avoid
 // collisions.
-func randRedactedString() *string {
-	s := fmt.Sprintf("{vault://%s}", uuid.NewString())
+func randRedactedString(uuidGenerator util.UUIDGenerator) *string {
+	s := fmt.Sprintf("{vault://%s}", uuidGenerator.NewString())
 	return &s
 }
 
@@ -160,13 +161,13 @@ func NewMTLSAuth(config interface{}) (*MTLSAuth, error) {
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
-func (c *KeyAuth) SanitizedCopy() *KeyAuth {
+func (c *KeyAuth) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KeyAuth {
 	return &KeyAuth{
 		kong.KeyAuth{
 			// Consumer field omitted
 			CreatedAt: c.CreatedAt,
 			ID:        c.ID,
-			Key:       randRedactedString(),
+			Key:       randRedactedString(uuidGenerator),
 			Tags:      c.Tags,
 		},
 	}

--- a/internal/dataplane/kongstate/credentials_test.go
+++ b/internal/dataplane/kongstate/credentials_test.go
@@ -1,13 +1,17 @@
 package kongstate
 
 import (
+	"math/rand"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestKeyAuth_SanitizedCopy(t *testing.T) {
+	// this needs a static random seed because some auths generate random values
+	uuid.SetRand(rand.New(rand.NewSource(1)))
 	for _, tt := range []struct {
 		name string
 		in   KeyAuth
@@ -25,11 +29,13 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 			want: KeyAuth{kong.KeyAuth{
 				CreatedAt: kong.Int(1),
 				ID:        kong.String("2"),
-				Key:       redactedString,
+				Key:       randRedactedString(),
 				Tags:      []*string{kong.String("4.1"), kong.String("4.2")},
 			}},
 		},
 	} {
+		// this needs a static random seed because some auths generate random values
+		uuid.SetRand(rand.New(rand.NewSource(1)))
 		t.Run(tt.name, func(t *testing.T) {
 			got := *tt.in.SanitizedCopy()
 			assert.Equal(t, tt.want, got)

--- a/internal/dataplane/kongstate/credentials_test.go
+++ b/internal/dataplane/kongstate/credentials_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestKeyAuth_SanitizedCopy(t *testing.T) {
 	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1)))
+	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	for _, tt := range []struct {
 		name string
 		in   KeyAuth
@@ -35,7 +35,7 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 		},
 	} {
 		// this needs a static random seed because some auths generate random values
-		uuid.SetRand(rand.New(rand.NewSource(1)))
+		uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 		t.Run(tt.name, func(t *testing.T) {
 			got := *tt.in.SanitizedCopy()
 			assert.Equal(t, tt.want, got)

--- a/internal/dataplane/kongstate/credentials_test.go
+++ b/internal/dataplane/kongstate/credentials_test.go
@@ -1,17 +1,15 @@
 package kongstate
 
 import (
-	"math/rand"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
 func TestKeyAuth_SanitizedCopy(t *testing.T) {
-	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	for _, tt := range []struct {
 		name string
 		in   KeyAuth
@@ -29,15 +27,13 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 			want: KeyAuth{kong.KeyAuth{
 				CreatedAt: kong.Int(1),
 				ID:        kong.String("2"),
-				Key:       randRedactedString(),
+				Key:       kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}"),
 				Tags:      []*string{kong.String("4.1"), kong.String("4.2")},
 			}},
 		},
 	} {
-		// this needs a static random seed because some auths generate random values
-		uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 		t.Run(tt.name, func(t *testing.T) {
-			got := *tt.in.SanitizedCopy()
+			got := *tt.in.SanitizedCopy(mocks.StaticUUIDGenerator{UUID: "52fdfc07-2182-454f-963f-5f0f9a621d72"})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -36,7 +36,7 @@ type KongState struct {
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
-func (ks *KongState) SanitizedCopy() *KongState {
+func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState {
 	return &KongState{
 		Services:  ks.Services,
 		Upstreams: ks.Upstreams,
@@ -52,7 +52,7 @@ func (ks *KongState) SanitizedCopy() *KongState {
 		}),
 		Consumers: func() (res []Consumer) {
 			for _, v := range ks.Consumers {
-				res = append(res, *v.SanitizedCopy())
+				res = append(res, *v.SanitizedCopy(uuidGenerator))
 			}
 			return
 		}(),

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -48,7 +48,7 @@ var serviceTypeMeta = metav1.TypeMeta{
 func TestKongState_SanitizedCopy(t *testing.T) {
 	testedFields := sets.New[string]()
 	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1)))
+	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	for _, tt := range []struct {
 		name string
 		in   KongState
@@ -107,7 +107,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 		},
 	} {
 		// this needs a static random seed because some auths generate random values
-		uuid.SetRand(rand.New(rand.NewSource(1)))
+		uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 		t.Run(tt.name, func(t *testing.T) {
 			testedFields.Insert(extractNotEmptyFieldNames(tt.in)...)
 			got := *tt.in.SanitizedCopy()

--- a/internal/dataplane/kongstate/plugin_test.go
+++ b/internal/dataplane/kongstate/plugin_test.go
@@ -1,10 +1,8 @@
 package kongstate
 
 import (
-	"math/rand"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/dataplane/kongstate/plugin_test.go
+++ b/internal/dataplane/kongstate/plugin_test.go
@@ -769,8 +769,6 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 }
 
 func TestPlugin_SanitizedCopy(t *testing.T) {
-	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	testCases := []struct {
 		name                    string
 		config                  kong.Configuration

--- a/internal/dataplane/kongstate/plugin_test.go
+++ b/internal/dataplane/kongstate/plugin_test.go
@@ -770,7 +770,7 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 
 func TestPlugin_SanitizedCopy(t *testing.T) {
 	// this needs a static random seed because some auths generate random values
-	uuid.SetRand(rand.New(rand.NewSource(1)))
+	uuid.SetRand(rand.New(rand.NewSource(1))) //nolint:gosec
 	testCases := []struct {
 		name                    string
 		config                  kong.Configuration

--- a/internal/dataplane/kongstate/plugin_test.go
+++ b/internal/dataplane/kongstate/plugin_test.go
@@ -1,8 +1,10 @@
 package kongstate
 
 import (
+	"math/rand"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -767,6 +769,8 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 }
 
 func TestPlugin_SanitizedCopy(t *testing.T) {
+	// this needs a static random seed because some auths generate random values
+	uuid.SetRand(rand.New(rand.NewSource(1)))
 	testCases := []struct {
 		name                    string
 		config                  kong.Configuration

--- a/internal/util/uuid.go
+++ b/internal/util/uuid.go
@@ -1,0 +1,15 @@
+package util
+
+import "github.com/google/uuid"
+
+// UUIDGenerator is an interface to generate UUIDs.
+type UUIDGenerator interface {
+	NewString() string
+}
+
+// DefaultUUIDGenerator is the default implementation of UUIDGenerator.
+type DefaultUUIDGenerator struct{}
+
+func (DefaultUUIDGenerator) NewString() string {
+	return uuid.NewString()
+}

--- a/test/mocks/uuid.go
+++ b/test/mocks/uuid.go
@@ -1,0 +1,13 @@
+package mocks
+
+import "github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+
+var _ = util.UUIDGenerator(&StaticUUIDGenerator{})
+
+type StaticUUIDGenerator struct {
+	UUID string
+}
+
+func (s StaticUUIDGenerator) NewString() string {
+	return s.UUID
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the static redacted pretend Vault string to a function that generates a random pretend Vault string.

This avoids collisions for certain types of values when go-database-reconciler builds configuration. It uses an in-memory database that looks up Kong entities by unique fields. If these fields aren't actually unique, go-database-reconciler will detect a conflict and abort.

**Which issue this PR fixes**:

Reported by @mheap in chat.

**Special notes for your reviewer**:

Manual smoke testing: creating a key-auth with `{vault://04a84f95-91f0-4caa-87d1-91a2caa2a6ca}` as the `key` value to validate that UUIDs are valid Vault keys.

Originally did this for all redacted strings, but turns out that the random stuff needs accounting for in tests in less than intuitive ways, so limited to the resources we know have this problem for certain. key-auth is probably alone there, as one of the few (only?) things where the primary key has to be sensitive.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
