### PR TITLE
feat(validation): reject Ingress, Service and KongConsumer with many plugins of the same type attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Adding a new version? You'll need three changes:
   - `ReplacePrefixMatch` [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
 - DB mode now supports Event reporting for resources that failed to apply.
   [#5785](https://github.com/Kong/kubernetes-ingress-controller/pull/5785)
+- Improve validation - reject `Ingresses`, `Service` or `KongConsumers` that have multiple instances
+  of the same type plugin attached.
+  [#5972](https://github.com/Kong/kubernetes-ingress-controller/pull/5972)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ Adding a new version? You'll need three changes:
   - `ReplacePrefixMatch` [#5895](https://github.com/Kong/kubernetes-ingress-controller/pull/5895)
 - DB mode now supports Event reporting for resources that failed to apply.
   [#5785](https://github.com/Kong/kubernetes-ingress-controller/pull/5785)
-- Improve validation - reject `Ingresses`, `Service` or `KongConsumers` that have multiple instances
+- Improve validation - reject `Ingresses`, `Services` or `KongConsumers` that have multiple instances
   of the same type plugin attached.
   [#5972](https://github.com/Kong/kubernetes-ingress-controller/pull/5972)
 

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -82,6 +82,10 @@ func (v KongFakeValidator) ValidateVault(_ context.Context, _ kongv1alpha1.KongV
 	return v.Result, v.Message, v.Error
 }
 
+func (v KongFakeValidator) ValidateService(_ context.Context, _ corev1.Service) (bool, string, error) {
+	return v.Result, v.Message, v.Error
+}
+
 func TestServeHTTPBasic(t *testing.T) {
 	assert := assert.New(t)
 	res := httptest.NewRecorder()

--- a/internal/admission/validation/ingress/ingress.go
+++ b/internal/admission/validation/ingress/ingress.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	netv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation/kongplugin"
@@ -29,6 +30,7 @@ func ValidateIngress(
 	ingress *netv1.Ingress,
 	logger logr.Logger,
 	storer store.Storer,
+	managerClient client.Client,
 ) (bool, string, error) {
 	var (
 		errMsgs           []string
@@ -39,7 +41,7 @@ func ValidateIngress(
 		return false, fmt.Sprintf("Ingress has invalid Kong annotations: %s", err), nil
 	}
 
-	if err := kongplugin.ValidatePluginUniquenessPerObject(storer, ingress); err != nil {
+	if err := kongplugin.ValidatePluginUniquenessPerObject(ctx, managerClient, ingress); err != nil {
 		return false, fmt.Sprintf("Ingress has invalid KongPlugin annotation: %s", err), nil
 	}
 

--- a/internal/admission/validation/ingress/ingress.go
+++ b/internal/admission/validation/ingress/ingress.go
@@ -10,6 +10,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation/kongplugin"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
@@ -36,6 +37,10 @@ func ValidateIngress(
 
 	if err := validation.ValidateRouteSourceAnnotations(ingress); err != nil {
 		return false, fmt.Sprintf("Ingress has invalid Kong annotations: %s", err), nil
+	}
+
+	if err := kongplugin.ValidatePluginUniquenessPerObject(storer, ingress); err != nil {
+		return false, fmt.Sprintf("Ingress has invalid KongPlugin annotation: %s", err), nil
 	}
 
 	for _, kg := range ingressToKongRoutesForValidation(translatorFeatures, ingress, failuresCollector, storer) {

--- a/internal/admission/validation/ingress/ingress_test.go
+++ b/internal/admission/validation/ingress/ingress_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
@@ -56,6 +57,7 @@ func TestValidateIngress(t *testing.T) {
 				tt.ingress,
 				logger,
 				fakestore,
+				fake.NewClientBuilder().Build(),
 			)
 			assert.Equal(t, tt.valid, valid, tt.msg)
 			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)

--- a/internal/admission/validation/kongplugin/kongplugin.go
+++ b/internal/admission/validation/kongplugin/kongplugin.go
@@ -1,0 +1,48 @@
+package kongplugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+)
+
+type kongPluginGetter interface {
+	GetKongPlugin(namespace, name string) (*kongv1.KongPlugin, error)
+}
+
+type k8sObjectWithAnnotations interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+}
+
+// ValidatePluginUniquenessPerObject validates that only one plugin of a particular type is attached to an object.
+// It can only check when instance of particular plugin has been already created (KongPlugin has been applied before).
+// Otherwise it will not be able to check and will return nil.
+func ValidatePluginUniquenessPerObject(pluginStore kongPluginGetter, obj k8sObjectWithAnnotations) error {
+	pluginNames := annotations.ExtractKongPluginsFromAnnotations(obj.GetAnnotations())
+	if len(pluginNames) == 0 {
+		return nil
+	}
+
+	pluginsForType := make(map[string][]string)
+	for _, pn := range pluginNames {
+		plugin, err := pluginStore.GetKongPlugin(obj.GetNamespace(), pn)
+		if err != nil {
+			continue
+		}
+		// How many plugins of particular type e.g. "rate-limiting" are attached and what are those names.
+		pluginsForType[plugin.PluginName] = append(pluginsForType[plugin.PluginName], plugin.Name)
+	}
+	// Check if the plugin is unique.
+	for pluginType, pluginNames := range pluginsForType {
+		if len(pluginNames) > 1 {
+			return fmt.Errorf(
+				"cannot attach multiple plugins: %s of the same type %s",
+				strings.Join(pluginNames, ", "), pluginType,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/admission/validation/kongplugin/kongplugin.go
+++ b/internal/admission/validation/kongplugin/kongplugin.go
@@ -1,15 +1,20 @@
 package kongplugin
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
 
-type kongPluginGetter interface {
-	GetKongPlugin(namespace, name string) (*kongv1.KongPlugin, error)
+// clusterObjectsLister is an interface controller-runtime client.Client.
+type clusterObjectsLister interface {
+	List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
 }
 
 type k8sObjectWithAnnotations interface {
@@ -18,23 +23,29 @@ type k8sObjectWithAnnotations interface {
 }
 
 // ValidatePluginUniquenessPerObject validates that only one plugin of a particular type is attached to an object.
-// It can only check when instance of particular plugin has been already created (KongPlugin has been applied before).
+// It can only check when instance of particular plugin has been already created (KongPlugin has been applied before and saved by Kubernetes).
 // Otherwise it will not be able to check and will return nil.
-func ValidatePluginUniquenessPerObject(pluginStore kongPluginGetter, obj k8sObjectWithAnnotations) error {
-	pluginNames := annotations.ExtractKongPluginsFromAnnotations(obj.GetAnnotations())
-	if len(pluginNames) == 0 {
+func ValidatePluginUniquenessPerObject(ctx context.Context, objectsLister clusterObjectsLister, obj k8sObjectWithAnnotations) error {
+	attachedPlugins := annotations.ExtractKongPluginsFromAnnotations(obj.GetAnnotations())
+	if len(attachedPlugins) == 0 {
 		return nil
 	}
 
-	pluginsForType := make(map[string][]string)
-	for _, pn := range pluginNames {
-		plugin, err := pluginStore.GetKongPlugin(obj.GetNamespace(), pn)
-		if err != nil {
-			continue
-		}
-		// How many plugins of particular type e.g. "rate-limiting" are attached and what are those names.
-		pluginsForType[plugin.PluginName] = append(pluginsForType[plugin.PluginName], plugin.Name)
+	// Getting plugins directly from the cluster instead of operator's cache to make it more real-time.
+	pluginList := &kongv1.KongPluginList{}
+	if err := objectsLister.List(ctx, pluginList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
+		// If we cannot list plugins, we cannot check for uniqueness, hence assume it is valid.
+		return nil //nolint:nilerr
 	}
+
+	pluginsForType := make(map[string][]string)
+	for _, plugin := range pluginList.Items {
+		if lo.Contains(attachedPlugins, plugin.Name) {
+			// How many plugins of particular type e.g. "rate-limiting" are attached and what are those names.
+			pluginsForType[plugin.PluginName] = append(pluginsForType[plugin.PluginName], plugin.Name)
+		}
+	}
+
 	// Check if the plugin is unique.
 	for pluginType, pluginNames := range pluginsForType {
 		if len(pluginNames) > 1 {

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -152,7 +152,7 @@ func (validator KongHTTPValidator) ValidateConsumer(
 	if !validator.ingressClassMatcher(&consumer.ObjectMeta, annotations.IngressClassKey, annotations.ExactClassMatch) {
 		return true, "", nil
 	}
-	if err := kongplugin.ValidatePluginUniquenessPerObject(validator.Storer, &consumer); err != nil {
+	if err := kongplugin.ValidatePluginUniquenessPerObject(ctx, validator.ManagerClient, &consumer); err != nil {
 		return false, fmt.Sprintf("KongConsumer has invalid KongPlugin annotation: %s", err), nil
 	}
 
@@ -467,13 +467,13 @@ func (validator KongHTTPValidator) ValidateIngress(
 	if routesSvc, ok := validator.AdminAPIServicesProvider.GetRoutesService(); ok {
 		routeValidator = routesSvc
 	}
-	return ingressvalidation.ValidateIngress(ctx, routeValidator, validator.TranslatorFeatures, &ingress, validator.Logger, validator.Storer)
+	return ingressvalidation.ValidateIngress(ctx, routeValidator, validator.TranslatorFeatures, &ingress, validator.Logger, validator.Storer, validator.ManagerClient)
 }
 
 func (validator KongHTTPValidator) ValidateService(
-	_ context.Context, service corev1.Service,
+	ctx context.Context, service corev1.Service,
 ) (bool, string, error) {
-	if err := kongplugin.ValidatePluginUniquenessPerObject(validator.Storer, &service); err != nil {
+	if err := kongplugin.ValidatePluginUniquenessPerObject(ctx, validator.ManagerClient, &service); err != nil {
 		return false, fmt.Sprintf("Service has invalid KongPlugin annotation: %s", err), nil
 	}
 	return true, "", nil

--- a/internal/util/builder/ingress.go
+++ b/internal/util/builder/ingress.go
@@ -1,6 +1,8 @@
 package builder
 
 import (
+	"strings"
+
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -63,6 +65,12 @@ func (b *IngressBuilder) WithAnnotations(annotations map[string]string) *Ingress
 		b.ingress.Annotations[k] = v
 	}
 	return b
+}
+
+func (b *IngressBuilder) WithKongPlugins(names ...string) *IngressBuilder {
+	return b.WithAnnotations(map[string]string{
+		annotations.AnnotationPrefix + annotations.PluginsKey: strings.Join(names, ","),
+	})
 }
 
 func (b *IngressBuilder) WithDefaultBackend(backend *netv1.IngressBackend) *IngressBuilder {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

[KongPlugins can be attached to](https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/custom-resources/#kongplugin)
- `KongConsumer`
- `Ingress`
- `Service`

Introduce validation that prevents attaching many plugins of the same to an `Ingress`, `Service`, or `KongConsumer`, because it leads to invalid configuration for Kong Gateway. 

The validation is only possible when plugins have been already configured (accepted by K8s), for plugins mentioned in annotations but not yet configured it assumes that they're valid.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5602

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
