### PR TITLE
feat: introduce konghq.com/headers-separator annotation and make parsing more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ Adding a new version? You'll need three changes:
 - Improve validation - reject `Ingresses`, `Services` or `KongConsumers` that have multiple instances
   of the same type plugin attached.
   [#5972](https://github.com/Kong/kubernetes-ingress-controller/pull/5972)
+- Added support for `konghq.com/headers-separator` that allows to set custom separator (instead of default `,`)
+  for headers specified with `konghq.com/headers.*` annotations. Moreover parsing a content of `konghq.com/headers.*`
+  is more robust - leading and trailing whitespace characters are discarded.
+  [#5977](https://github.com/Kong/kubernetes-ingress-controller/pull/5977)
 
 ### Fixed
 

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -846,6 +846,15 @@ func TestExtractHeaders(t *testing.T) {
 			want: map[string][]string{},
 		},
 		{
+			name: "empty with custom separator",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/headers-separator": ";",
+				},
+			},
+			want: map[string][]string{},
+		},
+		{
 			name: "non-empty",
 			args: args{
 				anns: map[string]string{
@@ -864,6 +873,15 @@ func TestExtractHeaders(t *testing.T) {
 			want: map[string][]string{},
 		},
 		{
+			name: "separator with no header results in empty header value",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/headers.foo": "foo,",
+				},
+			},
+			want: map[string][]string{"foo": {"foo", ""}},
+		},
+		{
 			name: "no header name",
 			args: args{
 				anns: map[string]string{
@@ -871,6 +889,47 @@ func TestExtractHeaders(t *testing.T) {
 				},
 			},
 			want: map[string][]string{},
+		},
+		{
+			name: "multiple header, multiple values, trailing spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/headers.x-example":    "foo, bar, baz  ",
+					"konghq.com/headers.x-additional": "foo",
+				},
+			},
+			want: map[string][]string{
+				"x-example":    {"foo", "bar", "baz"},
+				"x-additional": {"foo"},
+			},
+		},
+		{
+			name: "multiple header, multiple values, custom separator",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/headers-separator":    ";",
+					"konghq.com/headers.x-example":    "foo, bar;baz",
+					"konghq.com/headers.x-additional": "foo",
+				},
+			},
+			want: map[string][]string{
+				"x-example":    {"foo, bar", "baz"},
+				"x-additional": {"foo"},
+			},
+		},
+		{
+			name: "multiple header, multiple values, custom separator, leading & trailing spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/headers-separator":    ";",
+					"konghq.com/headers.x-example":    " foo, bar;cat,dog ;   baz ",
+					"konghq.com/headers.x-additional": "foo;",
+				},
+			},
+			want: map[string][]string{
+				"x-example":    {"foo, bar", "cat,dog", "baz"},
+				"x-additional": {"foo", ""},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR resolves real-world problems reported by the user that `konghq.com/headers.*` doesn't allow to specify headers that contain `,` which is permitted in header values, but can't be used because KIC uses it as a separator. 

HTTP specification is very permissive in terms of what is allowed as header value
https://datatracker.ietf.org/doc/html/rfc9110#name-field-values

> Field values are usually constrained to the range of US-ASCII characters [[USASCII](https://datatracker.ietf.org/doc/html/rfc9110#USASCII)].

see also [Cloudflare docs](https://developers.cloudflare.com/rules/transform/request-header-modification/reference/header-format).

Hence coming up with an escaping pattern for commas is hard and won't be easy to use/interpret by a user. So this PR introduces an additional annotation `konghq.com/headers-separator` that allows specifying a different separator than the default `,`. 

Moreover, this PR makes parsing header values from `konghq.com/headers.*` more robust - now it discards leading and trailing whitespace characters so the below annotations are equivalent

```
konghq.com/headers.foo: foo,bar,baz
konghq.com/headers.foo: foo, bar   , baz
```

this is a safe change, because according to https://datatracker.ietf.org/doc/html/rfc9110#section-5.5-3
> A field value does not include leading or trailing whitespace. When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace before evaluating the field value.

that will make users' lives easier.

Furthermore, a test case for handling a header with an empty value has been added because it's a valid use case, see https://datatracker.ietf.org/doc/html/rfc9110#section-12.5.3-12
> An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.

**Which issue this PR fixes:**

Closes #5427

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
- [x] docs has been updated too  - https://github.com/Kong/docs.konghq.com/pull/7351
