### PR TITLE
feat(validation): reject HTTPRoute and KongConsumerGroup with many plugins of the same type attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,9 +123,10 @@ Adding a new version? You'll need three changes:
     - `expressions`: [#5940](https://github.com/Kong/kubernetes-ingress-controller/pull/5940)
 - DB mode now supports Event reporting for resources that failed to apply.
   [#5785](https://github.com/Kong/kubernetes-ingress-controller/pull/5785)
-- Improve validation - reject `Ingresses`, `Services` or `KongConsumers` that have multiple instances
-  of the same type plugin attached.
+- Improve validation - reject `Ingresses`, `Services`, `HTTPRoutes`, `KongConsumers` or `KongConsumerGroups`
+  that have multiple instances of the same type plugin attached.
   [#5972](https://github.com/Kong/kubernetes-ingress-controller/pull/5972)
+  [#5979](https://github.com/Kong/kubernetes-ingress-controller/pull/5979)
 - Added support for `konghq.com/headers-separator` that allows to set custom separator (instead of default `,`)
   for headers specified with `konghq.com/headers.*` annotations. Moreover parsing a content of `konghq.com/headers.*`
   is more robust - leading and trailing whitespace characters are discarded.

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission/validation/kongplugin"
 	gatewaycontroller "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
@@ -44,6 +45,10 @@ func ValidateHTTPRoute(
 	}
 	if !routeIsManaged {
 		return true, "", nil
+	}
+
+	if err := kongplugin.ValidatePluginUniquenessPerObject(ctx, managerClient, httproute); err != nil {
+		return false, fmt.Sprintf("HTTPRoute has invalid KongPlugin annotation: %s", err), nil
 	}
 
 	if err := validateHTTPRouteTimeoutBackendRequest(httproute); err != nil {

--- a/internal/admission/validation/ingress/ingress_test.go
+++ b/internal/admission/validation/ingress/ingress_test.go
@@ -57,7 +57,7 @@ func TestValidateIngress(t *testing.T) {
 				tt.ingress,
 				logger,
 				fakestore,
-				fake.NewClientBuilder().Build(),
+				fake.NewFakeClient(),
 			)
 			assert.Equal(t, tt.valid, valid, tt.msg)
 			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -234,6 +234,10 @@ func (validator KongHTTPValidator) ValidateConsumerGroup(
 		return true, "", nil
 	}
 
+	if err := kongplugin.ValidatePluginUniquenessPerObject(ctx, validator.ManagerClient, &consumerGroup); err != nil {
+		return false, fmt.Sprintf("KongConsumerGroup has invalid KongPlugin annotation: %s", err), nil
+	}
+
 	infoSvc, ok := validator.AdminAPIServicesProvider.GetInfoService()
 	if !ok {
 		return true, "", nil

--- a/internal/manager/setup_test.go
+++ b/internal/manager/setup_test.go
@@ -22,7 +22,7 @@ import (
 func TestAdminAPIClientFromServiceDiscovery(t *testing.T) {
 	log := logr.Discard()
 	adminAPISvcNN := k8stypes.NamespacedName{Name: "admin-api", Namespace: "kong"}
-	kubeClient := fake.NewClientBuilder().Build()
+	kubeClient := fake.NewFakeClient()
 	genericErr := errors.New("some generic error")
 	someDiscoveredAPI := func(address string) adminapi.DiscoveredAdminAPI {
 		return adminapi.DiscoveredAdminAPI{


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->



Uses mechanism introduced in 
- https://github.com/Kong/kubernetes-ingress-controller/pull/5972

to prevent attaching many plugins of the same type to a `HTTPRoute` or `KongConsumerGroup`, because it leads to invalid configuration for Kong Gateway. Now for all entities that support `konghq.com/plugins` annotation uniqueness of plugins is validated. 

 **Which issue this PR fixes**:
 
Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5749

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
