### PR TITLE
feat: make a new snapshot of the store only when it's needed

### DIFF
--- a/internal/store/cache_stores_snapshot.go
+++ b/internal/store/cache_stores_snapshot.go
@@ -1,12 +1,18 @@
 package store
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
+	"slices"
 
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 )
 
+// TakeSnapshot takes a snapshot of the CacheStores.
 func (c CacheStores) TakeSnapshot() (CacheStores, error) {
 	// Create a fresh CacheStores instance to store the snapshot
 	// in the c.takeSnapshot method. It happens here because it's
@@ -19,6 +25,68 @@ func (c CacheStores) TakeSnapshot() (CacheStores, error) {
 
 	err := takeSnapshot(&snapshot, listOfStores)
 	return snapshot, err
+}
+
+// TakeSnapshotIfChanged takes a snapshot of the CacheStores if the hash of the current state
+// differs from the hash of the previous snapshot supplied as an argument (to make and initial
+// just pass empty string). When error is not nil discard all other return values.
+// When newHash is empty it means that the snapshot hasn't been taken - returned snapshot is
+// meaningless. This is a situation when hash of the current state is the same as the hash of
+// the previous snapshot supplied as an argument.
+func (c CacheStores) TakeSnapshotIfChanged(previousSnapshotHash string) (
+	snapshot CacheStores,
+	newHash string,
+	err error,
+) {
+	// Initialize all variables that don't need to be guarded by a lock.
+	snapshot = NewCacheStores()
+	listOfStores := c.listAllStores()
+	accessor := meta.NewAccessor()
+	hashCalculator := sha256.New()
+	var capturedErr error
+
+	c.l.RLock()
+	defer c.l.RUnlock()
+
+	// Compute the hash of the current store.
+	for _, store := range listOfStores {
+		// Underlying store is implemented a thread-safe map so for method List() it doesn't maintain order of items.
+		// To successfully calculate hash we need to sort the items.
+		valuesForHashComputation := lo.Map(store.List(), func(item interface{}, _ int) string {
+			obj, ok := item.(runtime.Object)
+			if !ok {
+				capturedErr = fmt.Errorf("expected runtime.Object, got %T", item)
+				return ""
+			}
+			uid, err := accessor.UID(obj)
+			if err != nil {
+				capturedErr = fmt.Errorf("failed to get UID: %w", err)
+				return ""
+			}
+			resourceVer, err := accessor.ResourceVersion(obj)
+			if err != nil {
+				capturedErr = fmt.Errorf("failed to get ResourceVersion: %w", err)
+				return ""
+			}
+			// UID is unique for each object in Kubernetes and ResourceVersion reflects the version of the object.
+			return string(uid) + resourceVer
+		})
+		if capturedErr != nil {
+			return CacheStores{}, "", capturedErr
+		}
+		// Strings have to be used instead of byte slices, because Cmp.Ordered has to be satisfied.
+		slices.Sort(valuesForHashComputation)
+		for _, v := range valuesForHashComputation {
+			hashCalculator.Write([]byte(v))
+		}
+	}
+	// Encode the hash to base32 string to make it human-readable.
+	if newHash = base32.StdEncoding.EncodeToString(hashCalculator.Sum(nil)); newHash != previousSnapshotHash {
+		err := takeSnapshot(&snapshot, listOfStores)
+		return snapshot, newHash, err
+	}
+
+	return CacheStores{}, "", nil
 }
 
 // takeSnapshot iterates over all stores and add a deep copy of each object to the snapshot.

--- a/internal/store/cache_stores_snapshot.go
+++ b/internal/store/cache_stores_snapshot.go
@@ -93,11 +93,6 @@ func (c CacheStores) TakeSnapshotIfChanged(previousSnapshotHash string) (
 		return CacheStores{}, "", fmt.Errorf("failed to take snapshot: %w", err)
 	}
 	return snapshot, newHash, nil
-		err := takeSnapshot(&snapshot, listOfStores)
-		return snapshot, newHash, err
-	}
-
-	return CacheStores{}, "", nil
 }
 
 // takeSnapshot iterates over all stores and add a deep copy of each object to the snapshot.

--- a/internal/store/cache_stores_snapshot_test.go
+++ b/internal/store/cache_stores_snapshot_test.go
@@ -30,9 +30,9 @@ func TestCacheStores_TakeSnapshot(t *testing.T) {
 func TestCacheStores_TakeSnapshotIfChanged(t *testing.T) {
 	originalStores := getStoresForTests(t)
 	t.Log("Taking a snapshot of the originalStores")
-	originalStoresSnapshot, originalStoresHash, err := originalStores.TakeSnapshotIfChanged("")
+	originalStoresSnapshot, originalStoresHash, err := originalStores.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
 	require.NoError(t, err)
-	require.Equal(t, "4FU3CVGPMPGXTSC2I3L4UCKE6M46LWOJBSQMJ2N7HAYR46IVHNGQ====", originalStoresHash)
+	require.Equal(t, store.SnapshotHash("4FU3CVGPMPGXTSC2I3L4UCKE6M46LWOJBSQMJ2N7HAYR46IVHNGQ===="), originalStoresHash)
 	require.NotEqual(t, store.CacheStores{}, originalStoresSnapshot)
 
 	t.Log("Taking again a snapshot of the originalStores")
@@ -281,26 +281,26 @@ func BenchmarkCacheStores_TakeSnapshot(b *testing.B) {
 		}
 	})
 	b.Run("Small_With_Cache", func(b *testing.B) {
-		s, hash, err := smallStores.TakeSnapshotIfChanged("")
+		s, hash, err := smallStores.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
 		require.NoError(b, err)
 		require.NotEmpty(b, hash)
 		require.NotEqual(b, store.CacheStores{}, s)
 		for i := 0; i < b.N; i++ {
 			s, hashNew, err := smallStores.TakeSnapshotIfChanged(hash)
-			if err != nil || hashNew != "" || s != (store.CacheStores{}) {
+			if err != nil || hashNew != store.SnapshotHashEmpty || s != (store.CacheStores{}) {
 				b.Fatalf("unexpected error or non-empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
 			}
 		}
 	})
 
 	b.Run("Big_With_Cache", func(b *testing.B) {
-		s, hash, err := bigStores.TakeSnapshotIfChanged("")
+		s, hash, err := bigStores.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
 		require.NoError(b, err)
 		require.NotEmpty(b, hash)
 		require.NotEqual(b, store.CacheStores{}, s)
 		for i := 0; i < b.N; i++ {
 			s, hashNew, err := bigStores.TakeSnapshotIfChanged(hash)
-			if err != nil || hashNew != "" || s != (store.CacheStores{}) {
+			if err != nil || hashNew != store.SnapshotHashEmpty || s != (store.CacheStores{}) {
 				b.Fatalf("unexpected error or non-empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
 			}
 		}
@@ -308,8 +308,8 @@ func BenchmarkCacheStores_TakeSnapshot(b *testing.B) {
 
 	b.Run("Small_With_Missed_Cache", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			s, hashNew, err := smallStores.TakeSnapshotIfChanged("")
-			if err != nil || hashNew == "" || s == (store.CacheStores{}) {
+			s, hashNew, err := smallStores.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
+			if err != nil || hashNew == store.SnapshotHashEmpty || s == (store.CacheStores{}) {
 				b.Fatalf("unexpected error or empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
 			}
 		}
@@ -317,8 +317,8 @@ func BenchmarkCacheStores_TakeSnapshot(b *testing.B) {
 
 	b.Run("Big_With_Missed_Cache", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			s, hashNew, err := bigStores.TakeSnapshotIfChanged("")
-			if err != nil || hashNew == "" || s == (store.CacheStores{}) {
+			s, hashNew, err := bigStores.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
+			if err != nil || hashNew == store.SnapshotHashEmpty || s == (store.CacheStores{}) {
 				b.Fatalf("unexpected error or empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
 			}
 		}

--- a/internal/store/cache_stores_snapshot_test.go
+++ b/internal/store/cache_stores_snapshot_test.go
@@ -1,17 +1,61 @@
 package store_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
 
 func TestCacheStores_TakeSnapshot(t *testing.T) {
+	originalStores := getStoresForTests(t)
+	t.Log("Taking a snapshot of the originalStores")
+	snapshot, err := originalStores.TakeSnapshot()
+	require.NoError(t, err)
+	require.NotEqual(t, store.CacheStores{}, snapshot)
+
+	testIfSnapshotIsIndependentFromSource(t, &originalStores, &snapshot)
+}
+
+func TestCacheStores_TakeSnapshotIfChanged(t *testing.T) {
+	originalStores := getStoresForTests(t)
+	t.Log("Taking a snapshot of the originalStores")
+	originalStoresSnapshot, originalStoresHash, err := originalStores.TakeSnapshotIfChanged("")
+	require.NoError(t, err)
+	require.Equal(t, "4FU3CVGPMPGXTSC2I3L4UCKE6M46LWOJBSQMJ2N7HAYR46IVHNGQ====", originalStoresHash)
+	require.NotEqual(t, store.CacheStores{}, originalStoresSnapshot)
+
+	t.Log("Taking again a snapshot of the originalStores")
+	originalStoresSnapshot2, originalStoresHash2, err := originalStores.TakeSnapshotIfChanged(originalStoresHash)
+	require.NoError(t, err)
+	require.Empty(t, originalStoresHash2)
+	require.Equal(t, store.CacheStores{}, originalStoresSnapshot2)
+
+	testIfSnapshotIsIndependentFromSource(t, &originalStores, &originalStoresSnapshot) // This modifies the originalStores.
+
+	t.Log("Taking a snapshot of the originalStores after modifying it")
+	modStoresSnapshot, modStoresHash, err := originalStores.TakeSnapshotIfChanged(originalStoresHash)
+	require.NoError(t, err)
+	require.NotEmpty(t, modStoresHash)
+	require.NotEqual(t, originalStoresHash, modStoresSnapshot)
+	require.NotEqual(t, store.CacheStores{}, modStoresSnapshot)
+
+	originalStores = getStoresForTests(t)
+	t.Log("Taking a snapshot of the originalStores after resetting it")
+}
+
+func getStoresForTests(t *testing.T) store.CacheStores {
+	t.Helper()
 	originalStores, err := store.NewCacheStoresFromObjs([]runtime.Object{
 		&netv1.Ingress{
 			TypeMeta: metav1.TypeMeta{
@@ -24,30 +68,47 @@ func TestCacheStores_TakeSnapshot(t *testing.T) {
 				Annotations: map[string]string{
 					"foo": "bar",
 				},
+				ResourceVersion: "123",
+				UID:             "19c1f570-b301-4b09-adcb-a1d29eb0b27e",
+			},
+		},
+		&netv1.Ingress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "Ingress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"foo": "bar",
+				},
+				ResourceVersion: "456",
+				UID:             "3a463a14-59ba-422d-9d7b-02f57ddb2800",
+			},
+		},
+		&netv1.Ingress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "Ingress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"foo": "bar",
+				},
+				ResourceVersion: "789",
+				UID:             "2f37d2d3-0e95-40e7-810a-31953df5ee69",
 			},
 		},
 	}...)
 	require.NoError(t, err)
+	return originalStores
+}
 
-	t.Log("Taking a snapshot of the originalStores")
-	snapshot, err := originalStores.TakeSnapshot()
-	require.NoError(t, err)
-
-	t.Log("Adding a new object to the original store")
-	err = originalStores.Add(&netv1.Ingress{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "networking.k8s.io/v1",
-			Kind:       "Ingress",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bar",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"foo": "baz",
-			},
-		},
-	})
-	require.NoError(t, err)
+func testIfSnapshotIsIndependentFromSource(t *testing.T, originalStores, snapshot *store.CacheStores) {
+	t.Helper()
 
 	// We'll use ingressMeta in .Get() calls.
 	ingressMeta := &netv1.Ingress{
@@ -69,6 +130,7 @@ func TestCacheStores_TakeSnapshot(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "bar", ingressFromOriginalStore.Annotations["foo"])
 	ingressFromOriginalStore.Annotations["foo"] = "qux"
+	ingressFromOriginalStore.ResourceVersion = "567"
 
 	t.Log("Checking that the original store returns the modified object")
 	obj, ok, err = originalStores.IngressV1.Get(ingressMeta)
@@ -85,4 +147,180 @@ func TestCacheStores_TakeSnapshot(t *testing.T) {
 	ingressFromSnapshot, ok := obj.(*netv1.Ingress)
 	require.True(t, ok)
 	require.Equal(t, "bar", ingressFromSnapshot.Annotations["foo"], "Snapshot should not be affected by the change in the original store")
+}
+
+func BenchmarkCacheStores_TakeSnapshot(b *testing.B) {
+	smallStores, err := store.NewCacheStoresFromObjs([]runtime.Object{
+		&netv1.Ingress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "Ingress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"foo": "bar",
+				},
+				ResourceVersion: "123",
+				UID:             k8stypes.UID(uuid.New().String()),
+			},
+		},
+	}...)
+	require.NoError(b, err)
+
+	var k8sObjects []runtime.Object
+	for i := 0; i < 1_000; i++ {
+		route := &gatewayapi.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("route-%d", i),
+				Namespace:       "default",
+				ResourceVersion: fmt.Sprintf("12%d", i),
+				UID:             k8stypes.UID(uuid.New().String()),
+			},
+			Spec: gatewayapi.HTTPRouteSpec{
+				Rules: []gatewayapi.HTTPRouteRule{
+					{
+						Matches: []gatewayapi.HTTPRouteMatch{
+							{
+								Path: &gatewayapi.HTTPPathMatch{
+									Type:  lo.ToPtr(gatewayapi.PathMatchExact),
+									Value: lo.ToPtr("/test1"),
+								},
+								Method: lo.ToPtr(gatewayapi.HTTPMethodGet),
+							},
+							{
+								Path: &gatewayapi.HTTPPathMatch{
+									Type:  lo.ToPtr(gatewayapi.PathMatchExact),
+									Value: lo.ToPtr("/test2"),
+								},
+								Method: lo.ToPtr(gatewayapi.HTTPMethodGet),
+							},
+						},
+					},
+				},
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{},
+			},
+		}
+		k8sObjects = append(k8sObjects, route)
+
+		service := &corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Service",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("service-%d", i),
+				Namespace:       "default",
+				ResourceVersion: fmt.Sprintf("12%d", i),
+				UID:             k8stypes.UID(uuid.New().String()),
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "http",
+						Port: int32(i),
+					},
+				},
+			},
+		}
+		k8sObjects = append(k8sObjects, service)
+
+		ingress := &netv1.Ingress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "Ingress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("ingress-%d", i),
+				Namespace:       "default",
+				ResourceVersion: fmt.Sprintf("12%d", i),
+				UID:             k8stypes.UID(uuid.New().String()),
+			},
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: fmt.Sprintf("host-%d", i),
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path:     fmt.Sprintf("/path-%d", i),
+										PathType: lo.ToPtr(netv1.PathTypeExact),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		k8sObjects = append(k8sObjects, ingress)
+	}
+	bigStores, err := store.NewCacheStoresFromObjs(k8sObjects...)
+	require.NoError(b, err)
+
+	b.Run("Small_Without_Cache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			s, err := smallStores.TakeSnapshot()
+			if err != nil || (s == store.CacheStores{}) {
+				b.Fatalf("unexpected error or empty snapshot err: %v, snapshot: %v", err, s)
+			}
+		}
+	})
+	b.Run("Big_Without_Cache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			s, err := bigStores.TakeSnapshot()
+			if err != nil || (s == store.CacheStores{}) {
+				b.Fatalf("unexpected error or empty snapshot err: %v, snapshot: %v", err, s)
+			}
+		}
+	})
+	b.Run("Small_With_Cache", func(b *testing.B) {
+		s, hash, err := smallStores.TakeSnapshotIfChanged("")
+		require.NoError(b, err)
+		require.NotEmpty(b, hash)
+		require.NotEqual(b, store.CacheStores{}, s)
+		for i := 0; i < b.N; i++ {
+			s, hashNew, err := smallStores.TakeSnapshotIfChanged(hash)
+			if err != nil || hashNew != "" || s != (store.CacheStores{}) {
+				b.Fatalf("unexpected error or non-empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
+			}
+		}
+	})
+
+	b.Run("Big_With_Cache", func(b *testing.B) {
+		s, hash, err := bigStores.TakeSnapshotIfChanged("")
+		require.NoError(b, err)
+		require.NotEmpty(b, hash)
+		require.NotEqual(b, store.CacheStores{}, s)
+		for i := 0; i < b.N; i++ {
+			s, hashNew, err := bigStores.TakeSnapshotIfChanged(hash)
+			if err != nil || hashNew != "" || s != (store.CacheStores{}) {
+				b.Fatalf("unexpected error or non-empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
+			}
+		}
+	})
+
+	b.Run("Small_With_Missed_Cache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			s, hashNew, err := smallStores.TakeSnapshotIfChanged("")
+			if err != nil || hashNew == "" || s == (store.CacheStores{}) {
+				b.Fatalf("unexpected error or empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
+			}
+		}
+	})
+
+	b.Run("Big_With_Missed_Cache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			s, hashNew, err := bigStores.TakeSnapshotIfChanged("")
+			if err != nil || hashNew == "" || s == (store.CacheStores{}) {
+				b.Fatalf("unexpected error or empty snapshot err: %v, hash: %s, snapshot: %v", err, hashNew, s)
+			}
+		}
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

PR introduces a new method `TakeSnapshotIfChanged` with a benchmark that allows making snapshots only when underlying `cacheStores` is changed. It yields significant performance improvements for big stores in terms of time and number of allocations. Since it's part of a broader initiative of generating partial/fallback configuration it may change to a certain degree in the foreseeable future. This PR is a starting point

Results

```log
BenchmarkCacheStores_TakeSnapshot
BenchmarkCacheStores_TakeSnapshot/Small_Without_Cache
BenchmarkCacheStores_TakeSnapshot/Small_Without_Cache-10         	   40017	     26269 ns/op	    7104 B/op	     163 allocs/op
BenchmarkCacheStores_TakeSnapshot/Big_Without_Cache
BenchmarkCacheStores_TakeSnapshot/Big_Without_Cache-10           	      51	  25153930 ns/op	 4769862 B/op	   75235 allocs/op
BenchmarkCacheStores_TakeSnapshot/Small_With_Cache
BenchmarkCacheStores_TakeSnapshot/Small_With_Cache-10            	   44198	     31291 ns/op	    5648 B/op	     146 allocs/op
BenchmarkCacheStores_TakeSnapshot/Big_With_Cache
BenchmarkCacheStores_TakeSnapshot/Big_With_Cache-10              	     424	   2871726 ns/op	  404007 B/op	    6339 allocs/op
BenchmarkCacheStores_TakeSnapshot/Small_With_Missed_Cache
BenchmarkCacheStores_TakeSnapshot/Small_With_Missed_Cache-10     	   28734	     42037 ns/op	    7392 B/op	     170 allocs/op
BenchmarkCacheStores_TakeSnapshot/Big_With_Missed_Cache
BenchmarkCacheStores_TakeSnapshot/Big_With_Missed_Cache-10       	      39	  28571720 ns/op	 5155891 B/op	   81242 allocs/op
```

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5996

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


