### PR TITLE
[Backport release/3.1.x] deduplicate nil-weight targets (#5946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,9 @@ Adding a new version? You'll need three changes:
 - Support to apply licenses to DB backed Kong gateway from `KongLicense`.
   [#5648](https://github.com/Kong/kubernetes-ingress-controller/pull/5648)
 - Redacted values no longer cause collisions in configuration reported to Konnect.
-  [5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
+  [#5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
+- Assign a default value for `weight` in Kong target if the `weight` is nil.
+  [#5946](https://github.com/Kong/kubernetes-ingress-controller/pull/5946)
 
 ## [3.1.4]
 

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -449,6 +449,16 @@ func (t *Translator) getUpstreams(serviceMap map[string]kongstate.Service) ([]ko
 	return upstreams, serviceMap
 }
 
+// targetWeightOrDefault returns the effective value of a target weight pointer. If the pointer is non-nil, it returns
+// the pointee. If the pointer is nil, it returns 100, the default Kong target weight. This allows us to sum
+// deduplicated targets' weights if one happens to be unset in the controller.
+func targetWeightOrDefault(in *int) int {
+	if in != nil {
+		return *in
+	}
+	return 100
+}
+
 func updateTargetMap(targetMap map[string]kongstate.Target, t kongstate.Target) map[string]kongstate.Target {
 	// See https://github.com/Kong/kubernetes-ingress-controller/issues/5761:
 	// Duplicate targets will appear in configurations that use Services with the same selector, which are used
@@ -459,7 +469,7 @@ func updateTargetMap(targetMap map[string]kongstate.Target, t kongstate.Target) 
 	// instead requires t.Target.Target. For consistency, everything below explicitly includes the nested object
 	// name, so t.Target.Weight instead of t.Weight.
 	if existing, ok := targetMap[*t.Target.Target]; ok {
-		sum := *existing.Target.Weight + *t.Target.Weight
+		sum := targetWeightOrDefault(existing.Target.Weight) + targetWeightOrDefault(t.Target.Weight)
 		existing.Target.Weight = &sum
 		targetMap[*t.Target.Target] = existing
 	} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Backport #5946 to `release/3.1.x`. This fixes a potential segfault.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

Since the `targetWeightOrDefault` is moved to `traslator_upstreams.go` in `main`, the backporting requires to move the changes to the original file `translator.go`.
 
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
