### PR TITLE
Revert "chore(deps): update istio/istioctl docker tag to v1.22.0"

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -20,7 +20,7 @@ e2e:
     - # renovate: datasource=docker depName=kindest/node versioning=docker
       kind: 'v1.29.4'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
-      istio: '1.22.0'
+      istio: '1.21.2'
     - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.28.9'
       # renovate: datasource=docker depName=istio/istioctl@only-patch packageName=istio/istioctl versioning=docker


### PR DESCRIPTION
Reverts Kong/kubernetes-ingress-controller#6022. For temp fix of #6039 that KIC may not be compatible with istio 1.22, or some configuration required.