### PR TITLE
feat: generate fallback cache snapshot excluding affected objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,8 +137,11 @@ Adding a new version? You'll need three changes:
   [#5982](https://github.com/Kong/kubernetes-ingress-controller/pull/5982)
   [#6006](https://github.com/Kong/kubernetes-ingress-controller/pull/6006)
 - Added `FallbackConfiguration` feature gate to enable the controller to generate a fallback configuration
-  for Kong when it fails to apply the configuration. The feature gate is disabled by default.
+  for Kong when it fails to apply the original one. The feature gate is disabled by default.
   [#5993](https://github.com/Kong/kubernetes-ingress-controller/pull/5993)
+  [#6010](https://github.com/Kong/kubernetes-ingress-controller/pull/6010)
+  [#6047](https://github.com/Kong/kubernetes-ingress-controller/pull/6047)
+  
 - Add support for Kubernetes Gateway API v1.1:
   - add a flag `--enable-controller-gwapi-grpcroute` to control whether enable or disable GRPCRoute controller.
   - add support for `GRPCRoute` v1, which requires users to upgrade the Gateway API's CRD to v1.1.

--- a/internal/dataplane/fallback/cache_to_graph.go
+++ b/internal/dataplane/fallback/cache_to_graph.go
@@ -1,0 +1,62 @@
+package fallback
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dominikbraun/graph"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+)
+
+// DefaultCacheGraphProvider is a default implementation of the CacheGraphProvider interface.
+type DefaultCacheGraphProvider struct{}
+
+func NewDefaultCacheGraphProvider() *DefaultCacheGraphProvider {
+	return &DefaultCacheGraphProvider{}
+}
+
+// CacheToGraph creates a new ConfigGraph from the given cache stores. It adds all objects
+// from the cache stores to the graph as vertices as well as edges between objects and their dependencies
+// resolved by the ResolveDependencies function.
+func (p DefaultCacheGraphProvider) CacheToGraph(c store.CacheStores) (*ConfigGraph, error) {
+	g := NewConfigGraph()
+
+	for _, s := range c.ListAllStores() {
+		for _, o := range s.List() {
+			obj, ok := o.(client.Object)
+			if !ok {
+				// Should not happen since all objects in the cache are client.Objects, but better safe than sorry.
+				return nil, fmt.Errorf("expected client.Object, got %T", o)
+			}
+			// Add the object to the graph. It can happen that the object is already in the graph (i.e. was already added
+			// as a dependency of another object), in which case we ignore the error.
+			if err := g.AddVertex(obj); err != nil && !errors.Is(err, graph.ErrVertexAlreadyExists) {
+				return nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
+			}
+
+			deps, err := ResolveDependencies(c, obj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve dependencies for %s: %w", GetObjectHash(obj), err)
+			}
+			// Add the object's dependencies to the graph.
+			for _, dep := range deps {
+				// Add the dependency to the graph in case it wasn't added before. If it was added before, we ignore the
+				// error.
+				if err := g.AddVertex(dep); err != nil && !errors.Is(err, graph.ErrVertexAlreadyExists) {
+					return nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
+				}
+
+				// Add an edge from a dependency to the object. If the edge was already added before, we ignore the error.
+				// It's on purpose that we add the edge from the dependency to the object, as it makes it easier to traverse
+				// the graph from the object to its dependants once it is broken.
+				if err := g.AddEdge(GetObjectHash(dep), GetObjectHash(obj)); err != nil && !errors.Is(err, graph.ErrEdgeAlreadyExists) {
+					return nil, fmt.Errorf("failed to add edge from %s to %s: %w", GetObjectHash(obj), GetObjectHash(dep), err)
+				}
+			}
+		}
+	}
+
+	return g, nil
+}

--- a/internal/dataplane/fallback/cache_to_graph_test.go
+++ b/internal/dataplane/fallback/cache_to_graph_test.go
@@ -1,0 +1,345 @@
+package fallback_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
+)
+
+func TestDefaultCacheGraphProvider_CacheToGraph(t *testing.T) {
+	// adjacencyGraphStrings returns a map of stringified vertices and their neighbours
+	// in the given graph for easy comparison.
+	adjacencyGraphStrings := func(t *testing.T, g *fallback.ConfigGraph) map[string][]string {
+		am, err := g.AdjacencyMap()
+		require.NoError(t, err)
+		adjacencyMapStrings := make(map[string][]string, len(am))
+		for v, neighbours := range am {
+			neighboursStrings := lo.Map(neighbours, func(n fallback.ObjectHash, _ int) string {
+				return n.String()
+			})
+			sort.Strings(neighboursStrings) // Sort for deterministic output.
+			adjacencyMapStrings[v.String()] = neighboursStrings
+		}
+		return adjacencyMapStrings
+	}
+
+	testCases := []struct {
+		name                 string
+		cache                store.CacheStores
+		expectedAdjacencyMap map[string][]string
+	}{
+		{
+			name:                 "empty cache",
+			cache:                store.NewCacheStores(),
+			expectedAdjacencyMap: map[string][]string{},
+		},
+		{
+			name: "cache with Ingress and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&netv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ingress",
+						Namespace: "test-namespace",
+					},
+					Spec: netv1.IngressSpec{
+						IngressClassName: lo.ToPtr("test-ingress-class"),
+						Rules: []netv1.IngressRule{
+							{
+								IngressRuleValue: netv1.IngressRuleValue{
+									HTTP: &netv1.HTTPIngressRuleValue{
+										Paths: []netv1.HTTPIngressPath{
+											{
+												Backend: netv1.IngressBackend{
+													Service: &netv1.IngressServiceBackend{
+														Name: "test-service",
+													},
+												},
+											},
+											{
+												Backend: netv1.IngressBackend{
+													Resource: &corev1.TypedLocalObjectReference{
+														Name:     "test-kong-service-facade",
+														Kind:     "KongServiceFacade",
+														APIGroup: lo.ToPtr(incubatorv1alpha1.GroupVersion.Group),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&netv1.IngressClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ingress-class",
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service",
+						Namespace: "test-namespace",
+					},
+				},
+				&incubatorv1alpha1.KongServiceFacade{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-kong-service-facade",
+						Namespace: "test-namespace",
+					},
+				},
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"Ingress:test-namespace/test-ingress": {},
+				"IngressClass:test-ingress-class": {
+					"Ingress:test-namespace/test-ingress",
+				},
+				"Service:test-namespace/test-service": {
+					"Ingress:test-namespace/test-ingress",
+				},
+				"KongServiceFacade:test-namespace/test-kong-service-facade": {
+					"Ingress:test-namespace/test-ingress",
+				},
+			},
+		},
+		{
+			name: "cache with HTTPRoute and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&gatewayapi.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+						Annotations: map[string]string{
+							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
+						},
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									{
+										BackendRef: gatewayapi.BackendRef{
+											BackendObjectReference: gatewayapi.BackendObjectReference{
+												Name: "1",
+												Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				testService(t, "1"),
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "cluster-1"),
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"HTTPRoute:test-namespace/test-route": {},
+				"Service:test-namespace/1": {
+					"HTTPRoute:test-namespace/test-route",
+				},
+				"KongPlugin:test-namespace/1": {
+					"HTTPRoute:test-namespace/test-route",
+				},
+				"KongClusterPlugin:test-namespace/cluster-1": {
+					"HTTPRoute:test-namespace/test-route",
+				},
+			},
+		},
+		{
+			name: "cache with TLSRoute and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&gatewayapi.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+						Annotations: map[string]string{
+							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
+						},
+					},
+					Spec: gatewayapi.TLSRouteSpec{
+						Rules: []gatewayapi.TLSRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Name: "1",
+											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				testService(t, "1"),
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "cluster-1"),
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"TLSRoute:test-namespace/test-route": {},
+				"Service:test-namespace/1": {
+					"TLSRoute:test-namespace/test-route",
+				},
+				"KongPlugin:test-namespace/1": {
+					"TLSRoute:test-namespace/test-route",
+				},
+				"KongClusterPlugin:test-namespace/cluster-1": {
+					"TLSRoute:test-namespace/test-route",
+				},
+			},
+		},
+		{
+			name: "cache with TCPRoute and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&gatewayapi.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+						Annotations: map[string]string{
+							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
+						},
+					},
+					Spec: gatewayapi.TCPRouteSpec{
+						Rules: []gatewayapi.TCPRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Name: "1",
+											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				testService(t, "1"),
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "cluster-1"),
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"TCPRoute:test-namespace/test-route": {},
+				"Service:test-namespace/1": {
+					"TCPRoute:test-namespace/test-route",
+				},
+				"KongPlugin:test-namespace/1": {
+					"TCPRoute:test-namespace/test-route",
+				},
+				"KongClusterPlugin:test-namespace/cluster-1": {
+					"TCPRoute:test-namespace/test-route",
+				},
+			},
+		},
+		{
+			name: "cache with UDPRoute and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&gatewayapi.UDPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+						Annotations: map[string]string{
+							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
+						},
+					},
+					Spec: gatewayapi.UDPRouteSpec{
+						Rules: []gatewayapi.UDPRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Name: "1",
+											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				testService(t, "1"),
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "cluster-1"),
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"UDPRoute:test-namespace/test-route": {},
+				"Service:test-namespace/1": {
+					"UDPRoute:test-namespace/test-route",
+				},
+				"KongPlugin:test-namespace/1": {
+					"UDPRoute:test-namespace/test-route",
+				},
+				"KongClusterPlugin:test-namespace/cluster-1": {
+					"UDPRoute:test-namespace/test-route",
+				},
+			},
+		},
+		{
+			name: "cache with GRPCRoute and its dependencies",
+			cache: cacheStoresFromObjs(t,
+				&gatewayapi.GRPCRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+						Annotations: map[string]string{
+							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
+						},
+					},
+					Spec: gatewayapi.GRPCRouteSpec{
+						Rules: []gatewayapi.GRPCRouteRule{
+							{
+								BackendRefs: []gatewayapi.GRPCBackendRef{
+									{
+										BackendRef: gatewayapi.BackendRef{
+											BackendObjectReference: gatewayapi.BackendObjectReference{
+												Name: "1",
+												Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				testService(t, "1"),
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "cluster-1"),
+			),
+			expectedAdjacencyMap: map[string][]string{
+				"GRPCRoute:test-namespace/test-route": {},
+				"Service:test-namespace/1": {
+					"GRPCRoute:test-namespace/test-route",
+				},
+				"KongPlugin:test-namespace/1": {
+					"GRPCRoute:test-namespace/test-route",
+				},
+				"KongClusterPlugin:test-namespace/cluster-1": {
+					"GRPCRoute:test-namespace/test-route",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := fallback.NewDefaultCacheGraphProvider()
+			g, err := p.CacheToGraph(tc.cache)
+			require.NoError(t, err)
+			require.NotNil(t, g)
+			require.Equal(t, tc.expectedAdjacencyMap, adjacencyGraphStrings(t, g))
+		})
+	}
+}

--- a/internal/dataplane/fallback/fallback.go
+++ b/internal/dataplane/fallback/fallback.go
@@ -1,0 +1,53 @@
+package fallback
+
+import (
+	"fmt"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+)
+
+type CacheGraphProvider interface {
+	// CacheToGraph returns a new ConfigGraph instance built from the given cache snapshot.
+	CacheToGraph(cache store.CacheStores) (*ConfigGraph, error)
+}
+
+// Generator is responsible for generating fallback cache snapshots.
+type Generator struct {
+	cacheGraphProvider CacheGraphProvider
+}
+
+func NewGenerator(cacheGraphProvider CacheGraphProvider) *Generator {
+	return &Generator{
+		cacheGraphProvider: cacheGraphProvider,
+	}
+}
+
+// GenerateExcludingAffected generates a new cache snapshot that excludes all objects that depend on the broken objects.
+func (g *Generator) GenerateExcludingAffected(
+	cache store.CacheStores,
+	brokenObjects []ObjectHash,
+) (store.CacheStores, error) {
+	graph, err := g.cacheGraphProvider.CacheToGraph(cache)
+	if err != nil {
+		return store.CacheStores{}, fmt.Errorf("failed to build cache graph: %w", err)
+	}
+
+	fallbackCache, err := cache.TakeSnapshot()
+	if err != nil {
+		return store.CacheStores{}, fmt.Errorf("failed to take cache snapshot: %w", err)
+	}
+
+	for _, brokenObject := range brokenObjects {
+		subgraphObjects, err := graph.SubgraphObjects(brokenObject)
+		if err != nil {
+			return store.CacheStores{}, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
+		}
+		for _, obj := range subgraphObjects {
+			if err := fallbackCache.Delete(obj); err != nil {
+				return store.CacheStores{}, fmt.Errorf("failed to delete %s from the cache: %w", GetObjectHash(obj), err)
+			}
+		}
+	}
+
+	return fallbackCache, nil
+}

--- a/internal/dataplane/fallback/fallback_test.go
+++ b/internal/dataplane/fallback/fallback_test.go
@@ -1,0 +1,112 @@
+package fallback_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+)
+
+// mockGraphProvider is a mock implementation of the CacheGraphProvider interface.
+type mockGraphProvider struct {
+	graph               *fallback.ConfigGraph
+	lastCalledWithStore store.CacheStores
+}
+
+// CacheToGraph returns the graph that was set on the mockGraphProvider. It also records the last store that was passed to it.
+func (m *mockGraphProvider) CacheToGraph(s store.CacheStores) (*fallback.ConfigGraph, error) {
+	m.lastCalledWithStore = s
+	return m.graph, nil
+}
+
+func TestGenerator_GenerateExcludingAffected(t *testing.T) {
+	// We have to use real-world object types here as we're testing integration with store.CacheStores.
+	ingressClass := testIngressClass(t, "ingressClass")
+	service := testService(t, "service")
+	serviceFacade := testKongServiceFacade(t, "serviceFacade")
+	plugin := testKongPlugin(t, "kongPlugin")
+	inputCacheStores := cacheStoresFromObjs(t, ingressClass, service, serviceFacade, plugin)
+
+	// This graph doesn't reflect real dependencies between the objects - it's only used for testing purposes.
+	// It will be injected into the Generator via the mockGraphProvider.
+	// Dependency resolving between the objects is tested in TestResolveDependencies_* tests.
+	//
+	// Graph structure (edges define dependency -> dependant relationship):
+	//  ┌────────────┐  ┌──────┐
+	//  │ingressClass│  │plugin│
+	//  └──────┬─────┘  └──────┘
+	//         │
+	//     ┌───▼───┐
+	//     │service│
+	//     └───┬───┘
+	//         │
+	//  ┌──────▼──────┐
+	//  │serviceFacade│
+	//  └─────────────┘
+	graph, err := NewGraphBuilder().
+		WithVertices(ingressClass, service, serviceFacade, plugin).
+		WithEdge(ingressClass, service).
+		WithEdge(service, serviceFacade).
+		Build()
+	require.NoError(t, err)
+
+	graphProvider := &mockGraphProvider{graph: graph}
+	g := fallback.NewGenerator(graphProvider)
+
+	t.Run("ingressClass is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})
+		require.NoError(t, err)
+		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+		require.Empty(t, fallbackCache.IngressClassV1.List(), "ingressClass should be excluded as it's broken")
+		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it depends on ingressClass")
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it depends on service")
+		require.ElementsMatch(t, fallbackCache.Plugin.List(), []any{plugin}, "plugin shouldn't be excluded as it doesn't depend on ingressClass")
+	})
+
+	t.Run("service is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(service)})
+		require.NoError(t, err)
+		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it's broken")
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it depends on service")
+		require.ElementsMatch(t, fallbackCache.IngressClassV1.List(), []any{ingressClass}, "ingressClass shouldn't be excluded as it doesn't depend on service")
+		require.ElementsMatch(t, fallbackCache.Plugin.List(), []any{plugin}, "plugin shouldn't be excluded as it doesn't depend on service")
+	})
+
+	t.Run("serviceFacade is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(serviceFacade)})
+		require.NoError(t, err)
+		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it's broken")
+		require.ElementsMatch(t, fallbackCache.IngressClassV1.List(), []any{ingressClass}, "ingressClass shouldn't be excluded as it doesn't depend on service")
+		require.ElementsMatch(t, fallbackCache.Service.List(), []any{service}, "service shouldn't be excluded as it doesn't depend on serviceFacade")
+		require.ElementsMatch(t, fallbackCache.Plugin.List(), []any{plugin}, "plugin shouldn't be excluded as it doesn't depend on serviceFacade")
+	})
+
+	t.Run("plugin is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(plugin)})
+		require.NoError(t, err)
+		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+		require.Empty(t, fallbackCache.Plugin.List(), "plugin should be excluded as it's broken")
+		require.ElementsMatch(t, fallbackCache.IngressClassV1.List(), []any{ingressClass}, "ingressClass shouldn't be excluded as it doesn't depend on plugin")
+		require.ElementsMatch(t, fallbackCache.Service.List(), []any{service}, "service shouldn't be excluded as it doesn't depend on plugin")
+		require.ElementsMatch(t, fallbackCache.KongServiceFacade.List(), []any{serviceFacade}, "serviceFacade shouldn't be excluded as it doesn't depend on plugin")
+	})
+
+	t.Run("multiple objects are broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass), fallback.GetObjectHash(service)})
+		require.NoError(t, err)
+		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+		require.Empty(t, fallbackCache.IngressClassV1.List(), "ingressClass should be excluded as it's broken")
+		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it's broken")
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it depends on service")
+		require.ElementsMatch(t, fallbackCache.Plugin.List(), []any{plugin}, "plugin shouldn't be excluded as it doesn't depend on either ingressClass or service")
+	})
+}

--- a/internal/dataplane/fallback/graph_test.go
+++ b/internal/dataplane/fallback/graph_test.go
@@ -1,344 +1,83 @@
 package fallback_test
 
 import (
-	"sort"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
-	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
-func TestNewConfigGraphFromCacheStores(t *testing.T) {
-	// adjacencyGraphStrings returns a map of stringified vertices and their neighbours
-	// in the given graph for easy comparison.
-	adjacencyGraphStrings := func(t *testing.T, g *fallback.ConfigGraph) map[string][]string {
-		am, err := g.AdjacencyMap()
-		require.NoError(t, err)
-		adjacencyMapStrings := make(map[string][]string, len(am))
-		for v, neighbours := range am {
-			neighboursStrings := lo.Map(neighbours, func(n fallback.ObjectHash, _ int) string {
-				return n.String()
-			})
-			sort.Strings(neighboursStrings) // Sort for deterministic output.
-			adjacencyMapStrings[v.String()] = neighboursStrings
-		}
-		return adjacencyMapStrings
-	}
+func TestConfigGraph_SubgraphObjects(t *testing.T) {
+	var (
+		A = NewMockObject("A")
+		B = NewMockObject("B")
+		C = NewMockObject("C")
+		D = NewMockObject("D")
+		E = NewMockObject("E")
+		F = NewMockObject("F")
+		G = NewMockObject("G")
+		H = NewMockObject("H")
+	)
 
-	testCases := []struct {
-		name                 string
-		cache                store.CacheStores
-		expectedAdjacencyMap map[string][]string
-	}{
-		{
-			name:                 "empty cache",
-			cache:                store.NewCacheStores(),
-			expectedAdjacencyMap: map[string][]string{},
-		},
-		{
-			name: "cache with Ingress and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&netv1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ingress",
-						Namespace: "test-namespace",
-					},
-					Spec: netv1.IngressSpec{
-						IngressClassName: lo.ToPtr("test-ingress-class"),
-						Rules: []netv1.IngressRule{
-							{
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{
-											{
-												Backend: netv1.IngressBackend{
-													Service: &netv1.IngressServiceBackend{
-														Name: "test-service",
-													},
-												},
-											},
-											{
-												Backend: netv1.IngressBackend{
-													Resource: &corev1.TypedLocalObjectReference{
-														Name:     "test-kong-service-facade",
-														Kind:     "KongServiceFacade",
-														APIGroup: lo.ToPtr(incubatorv1alpha1.GroupVersion.Group),
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				&netv1.IngressClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-ingress-class",
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-service",
-						Namespace: "test-namespace",
-					},
-				},
-				&incubatorv1alpha1.KongServiceFacade{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-kong-service-facade",
-						Namespace: "test-namespace",
-					},
-				},
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"Ingress:test-namespace/test-ingress": {},
-				"IngressClass:test-ingress-class": {
-					"Ingress:test-namespace/test-ingress",
-				},
-				"Service:test-namespace/test-service": {
-					"Ingress:test-namespace/test-ingress",
-				},
-				"KongServiceFacade:test-namespace/test-kong-service-facade": {
-					"Ingress:test-namespace/test-ingress",
-				},
-			},
-		},
-		{
-			name: "cache with HTTPRoute and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&gatewayapi.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-route",
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
-						},
-					},
-					Spec: gatewayapi.HTTPRouteSpec{
-						Rules: []gatewayapi.HTTPRouteRule{
-							{
-								BackendRefs: []gatewayapi.HTTPBackendRef{
-									{
-										BackendRef: gatewayapi.BackendRef{
-											BackendObjectReference: gatewayapi.BackendObjectReference{
-												Name: "1",
-												Kind: lo.ToPtr(gatewayapi.Kind("Service")),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				testService(t, "1"),
-				testKongPlugin(t, "1"),
-				testKongClusterPlugin(t, "cluster-1"),
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"HTTPRoute:test-namespace/test-route": {},
-				"Service:test-namespace/1": {
-					"HTTPRoute:test-namespace/test-route",
-				},
-				"KongPlugin:test-namespace/1": {
-					"HTTPRoute:test-namespace/test-route",
-				},
-				"KongClusterPlugin:test-namespace/cluster-1": {
-					"HTTPRoute:test-namespace/test-route",
-				},
-			},
-		},
-		{
-			name: "cache with TLSRoute and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&gatewayapi.TLSRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-route",
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
-						},
-					},
-					Spec: gatewayapi.TLSRouteSpec{
-						Rules: []gatewayapi.TLSRouteRule{
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									{
-										BackendObjectReference: gatewayapi.BackendObjectReference{
-											Name: "1",
-											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				testService(t, "1"),
-				testKongPlugin(t, "1"),
-				testKongClusterPlugin(t, "cluster-1"),
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"TLSRoute:test-namespace/test-route": {},
-				"Service:test-namespace/1": {
-					"TLSRoute:test-namespace/test-route",
-				},
-				"KongPlugin:test-namespace/1": {
-					"TLSRoute:test-namespace/test-route",
-				},
-				"KongClusterPlugin:test-namespace/cluster-1": {
-					"TLSRoute:test-namespace/test-route",
-				},
-			},
-		},
-		{
-			name: "cache with TCPRoute and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&gatewayapi.TCPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-route",
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
-						},
-					},
-					Spec: gatewayapi.TCPRouteSpec{
-						Rules: []gatewayapi.TCPRouteRule{
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									{
-										BackendObjectReference: gatewayapi.BackendObjectReference{
-											Name: "1",
-											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				testService(t, "1"),
-				testKongPlugin(t, "1"),
-				testKongClusterPlugin(t, "cluster-1"),
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"TCPRoute:test-namespace/test-route": {},
-				"Service:test-namespace/1": {
-					"TCPRoute:test-namespace/test-route",
-				},
-				"KongPlugin:test-namespace/1": {
-					"TCPRoute:test-namespace/test-route",
-				},
-				"KongClusterPlugin:test-namespace/cluster-1": {
-					"TCPRoute:test-namespace/test-route",
-				},
-			},
-		},
-		{
-			name: "cache with UDPRoute and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&gatewayapi.UDPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-route",
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
-						},
-					},
-					Spec: gatewayapi.UDPRouteSpec{
-						Rules: []gatewayapi.UDPRouteRule{
-							{
-								BackendRefs: []gatewayapi.BackendRef{
-									{
-										BackendObjectReference: gatewayapi.BackendObjectReference{
-											Name: "1",
-											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				testService(t, "1"),
-				testKongPlugin(t, "1"),
-				testKongClusterPlugin(t, "cluster-1"),
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"UDPRoute:test-namespace/test-route": {},
-				"Service:test-namespace/1": {
-					"UDPRoute:test-namespace/test-route",
-				},
-				"KongPlugin:test-namespace/1": {
-					"UDPRoute:test-namespace/test-route",
-				},
-				"KongClusterPlugin:test-namespace/cluster-1": {
-					"UDPRoute:test-namespace/test-route",
-				},
-			},
-		},
-		{
-			name: "cache with GRPCRoute and its dependencies",
-			cache: cacheStoresFromObjs(t,
-				&gatewayapi.GRPCRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-route",
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							annotations.AnnotationPrefix + annotations.PluginsKey: "1,cluster-1",
-						},
-					},
-					Spec: gatewayapi.GRPCRouteSpec{
-						Rules: []gatewayapi.GRPCRouteRule{
-							{
-								BackendRefs: []gatewayapi.GRPCBackendRef{
-									{
-										BackendRef: gatewayapi.BackendRef{
-											BackendObjectReference: gatewayapi.BackendObjectReference{
-												Name: "1",
-												Kind: lo.ToPtr(gatewayapi.Kind("Service")),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				testService(t, "1"),
-				testKongPlugin(t, "1"),
-				testKongClusterPlugin(t, "cluster-1"),
-			),
-			expectedAdjacencyMap: map[string][]string{
-				"GRPCRoute:test-namespace/test-route": {},
-				"Service:test-namespace/1": {
-					"GRPCRoute:test-namespace/test-route",
-				},
-				"KongPlugin:test-namespace/1": {
-					"GRPCRoute:test-namespace/test-route",
-				},
-				"KongClusterPlugin:test-namespace/cluster-1": {
-					"GRPCRoute:test-namespace/test-route",
-				},
-			},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g, err := fallback.NewConfigGraphFromCacheStores(tc.cache)
-			require.NoError(t, err)
-			require.NotNil(t, g)
-			require.Equal(t, tc.expectedAdjacencyMap, adjacencyGraphStrings(t, g))
-		})
-	}
+	// Graph structure (edges define dependency -> dependant relationship):
+	//     ┌───┐     ┌───┐   ┌───┐   ┌───┐
+	//     │ A │     │ E │   │ F │   │ G │
+	//     └─┬─┘     └─┬─┘   └─┬─┘   └─┬─┘
+	//       │         │       │       │
+	//   ┌───┴───┐     │       └───┬───┘
+	//   │       │     │           │
+	// ┌─▼─┐   ┌─▼─┐   │         ┌─▼─┐
+	// │ B │   │ C │   │         │ H │
+	// └───┘   └─┬─┘   │         └───┘
+	//           │     │
+	//           ├─────┘
+	//           │
+	//         ┌─▼─┐
+	//         │ D │
+	//         └───┘
+	g, err := NewGraphBuilder().
+		WithVertices(A, B, C, D, E).
+		WithEdge(A, B).
+		WithEdge(A, C).
+		WithEdge(C, D).
+		WithEdge(E, D).
+		WithVertices(F, G, H).
+		WithEdge(F, H).
+		WithEdge(G, H).
+		Build()
+	require.NoError(t, err)
+
+	objects, err := g.SubgraphObjects(fallback.GetObjectHash(A))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{A, B, C, D}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(B))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{B}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(C))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{C, D}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(D))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{D}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(E))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{E, D}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(F))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{F, H}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(G))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{G, H}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(H))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []client.Object{H}, objects)
 }

--- a/internal/dataplane/fallback/helpers_test.go
+++ b/internal/dataplane/fallback/helpers_test.go
@@ -1,12 +1,16 @@
 package fallback_test
 
 import (
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
@@ -58,4 +62,73 @@ func testKongClusterPlugin(t *testing.T, name string) *kongv1.KongClusterPlugin 
 			Namespace: testNamespace,
 		},
 	})
+}
+
+// GraphBuilder is a helper to build a graph for testing.
+type GraphBuilder struct {
+	vertices []client.Object
+	edges    map[fallback.ObjectHash][]fallback.ObjectHash
+}
+
+func NewGraphBuilder() *GraphBuilder {
+	return &GraphBuilder{
+		edges: make(map[fallback.ObjectHash][]fallback.ObjectHash),
+	}
+}
+
+// WithVertices adds vertices to the graph.
+func (b *GraphBuilder) WithVertices(objs ...client.Object) *GraphBuilder {
+	b.vertices = append(b.vertices, objs...)
+	return b
+}
+
+// WithEdge adds an edge between two vertices in the graph.
+func (b *GraphBuilder) WithEdge(from, to client.Object) *GraphBuilder {
+	fromHash := fallback.GetObjectHash(from)
+	toHash := fallback.GetObjectHash(to)
+	b.edges[fromHash] = append(b.edges[fromHash], toHash)
+	return b
+}
+
+// Build builds the graph.
+func (b *GraphBuilder) Build() (*fallback.ConfigGraph, error) {
+	g := fallback.NewConfigGraph()
+
+	for _, v := range b.vertices {
+		if err := g.AddVertex(v); err != nil {
+			return nil, fmt.Errorf("failed to add vertex %s to the graph: %w", fallback.GetObjectHash(v), err)
+		}
+	}
+
+	for from, tos := range b.edges {
+		for _, to := range tos {
+			if err := g.AddEdge(from, to); err != nil {
+				return nil, fmt.Errorf("failed to add edge from %s to %s: %w", from, to, err)
+			}
+		}
+	}
+
+	return g, nil
+}
+
+var _ client.Object = &MockObject{}
+
+// MockObject is a mock object that implements the client.Object interface.
+type MockObject struct {
+	metav1.ObjectMeta
+	metav1.TypeMeta
+}
+
+// NewMockObject creates a new mock object with the given name.
+func NewMockObject(name string) *MockObject {
+	return &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// DeepCopyObject is required for runtime.Object interface.
+func (m *MockObject) DeepCopyObject() runtime.Object {
+	return m
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Implements a fallback cache `Generator` with the `GenerateExcludingAffected` method. It depends on a `CacheGraphProvider` implemented by `DefaultCacheGraphProvider` (formerly `NewConfigGraphFromCacheStores` function). It's tested in isolation in the `TestGenerator_ GenerateExcludingAffected` test.
- Implements `ConfigGraph.SubgraphObjects` capable of finding all objects depending on a broken source object and tests that in `TestConfigGraph_SubgraphObjects`
- Moves `NewConfigGraphFromCacheStores` to `cache_to_graph.go` and refactors it into a struct implementing `CacheGraphProvider` interface (also moves its tests to `cache_to_graph_test.go` with no modifications). 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5930.

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
