### PR TITLE
feat(dataplane) include licenses with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ Adding a new version? You'll need three changes:
   for consumers managed by other users without requiring those users to create
   consumers in the Service's namespace.
   [#5965](https://github.com/Kong/kubernetes-ingress-controller/pull/5965)
+- Fallback configuration no longer omits licenses and vaults.
+  [#6048](https://github.com/Kong/kubernetes-ingress-controller/pull/6048)
 
 ### Fixed
 

--- a/internal/dataplane/configfetcher/kongrawstate.go
+++ b/internal/dataplane/configfetcher/kongrawstate.go
@@ -75,6 +75,8 @@ func KongRawStateToKongState(rawstate *utils.KongRawState) *kongstate.KongState 
 		kongState.Upstreams = append(kongState.Upstreams, sanitizeUpstream(newUpstream))
 	}
 
+	kongState.Vaults = rawVaultsToVaults(rawstate.Vaults)
+
 	kongState.CACertificates = rawCACertificatesToCACertificates(rawstate.CACertificates)
 	kongState.Certificates = rawCertificatesToCertificates(rawstate.Certificates)
 
@@ -221,6 +223,20 @@ func rawCACertificatesToCACertificates(caCertificates []*kong.CACertificate) []k
 	return certs
 }
 
+func rawVaultsToVaults(rawVaults []*kong.Vault) []kongstate.Vault {
+	if len(rawVaults) == 0 {
+		return nil
+	}
+	vaults := []kongstate.Vault{}
+
+	for _, v := range rawVaults {
+		vaults = append(vaults, kongstate.Vault{
+			Vault: sanitizeVault(*v),
+		})
+	}
+	return vaults
+}
+
 // -----------------------------------------------------------------------------
 // Sanitization functions
 // -----------------------------------------------------------------------------
@@ -269,6 +285,12 @@ func sanitizeCACertificate(caCertificate kong.CACertificate) kong.CACertificate 
 	caCertificate.ID = nil
 	caCertificate.CreatedAt = nil
 	return caCertificate
+}
+
+func sanitizeVault(v kong.Vault) kong.Vault {
+	v.ID = nil
+	v.CreatedAt = nil
+	return v
 }
 
 func sanitizeConsumer(consumer kong.Consumer) kong.Consumer {

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -2,14 +2,13 @@ package translator
 
 import (
 	"github.com/go-logr/logr"
-	"github.com/kong/go-kong/kong"
-	"github.com/samber/mo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
@@ -64,12 +63,6 @@ func NewFeatureFlags(
 	}
 }
 
-// LicenseGetter is an interface for getting the Kong Enterprise license.
-type LicenseGetter interface {
-	// GetLicense returns an optional license.
-	GetLicense() mo.Option[kong.License]
-}
-
 // Translator translates Kubernetes objects and configurations into their
 // equivalent Kong objects and configurations, producing a complete
 // state configuration for the Kong Admin API.
@@ -77,7 +70,7 @@ type Translator struct {
 	logger        logr.Logger
 	storer        store.Storer
 	workspace     string
-	licenseGetter LicenseGetter
+	licenseGetter license.Getter
 	featureFlags  FeatureFlags
 
 	failuresCollector          *failures.ResourceFailuresCollector
@@ -228,7 +221,7 @@ func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
 // -----------------------------------------------------------------------------
 
 // InjectLicenseGetter sets a license getter to be used by the translator.
-func (t *Translator) InjectLicenseGetter(licenseGetter LicenseGetter) {
+func (t *Translator) InjectLicenseGetter(licenseGetter license.Getter) {
 	t.licenseGetter = licenseGetter
 }
 

--- a/internal/license/agent.go
+++ b/internal/license/agent.go
@@ -26,6 +26,12 @@ const (
 	PollingTimeout = time.Minute * 5
 )
 
+// Getter is an interface for getting a Kong Enterprise license.
+type Getter interface {
+	// GetLicense returns an optional license.
+	GetLicense() mo.Option[kong.License]
+}
+
 // KonnectLicense is a license retrieved from Konnect.
 type KonnectLicense struct {
 	ID        string

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -300,6 +300,7 @@ func Run(
 		setupLog.Info("Inject license getter to config translator",
 			"license_getter_type", fmt.Sprintf("%T", licenseGetter))
 		configTranslator.InjectLicenseGetter(licenseGetter)
+		kongConfigFetcher.InjectLicenseGetter(licenseGetter)
 	}
 
 	if c.AnonymousReports {

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -424,7 +424,7 @@ func setupLicenseGetter(
 	setupLog logr.Logger,
 	mgr manager.Manager,
 	statusQueue *status.Queue,
-) (translator.LicenseGetter, error) {
+) (license.Getter, error) {
 	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/3922
 	// This requires the Konnect client, which currently requires c.Konnect.ConfigSynchronizationEnabled also.
 	// We need to figure out exactly how that config surface works. Initial direction says add a separate toggle, but


### PR DESCRIPTION
**What this PR does / why we need it**:

Include licenses (and Vaults) when sending fallback configuration.

**Which issue this PR fixes**:

Fix #5447 

**Special notes for your reviewer**:

License handling was left as an open question in the original criteria. I chose to always populate the current license from the license getter, which will (sort of) modify the last good config. I've left TODO comments explaining the rationale for doing that over attempting to pull the license from the original config struct.

Will need to either strip (or at least shorten) those if reviewer agrees with the rationale or change stuff if we actually want to use another approach.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
