### PR TITLE
chore: fix outdated TODO links

### DIFF
--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -146,20 +146,10 @@ func validateHTTPRouteFeatures(httproute *gatewayapi.HTTPRoute, translatorFeatur
 	for ruleIndex, rule := range httproute.Spec.Rules {
 		// Filter RequestMirror is not supported.
 
-		// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3686
-		// For URLRewrite, only FullPathHTTPPathModifier is supported.
 		for filterIndex, filter := range rule.Filters {
 			if _, unsupported := unsupportedFilterMap[filter.Type]; unsupported {
 				return fmt.Errorf("rules[%d].filters[%d]: filter type %s is unsupported",
 					ruleIndex, filterIndex, filter.Type)
-			}
-
-			if filter.Type == gatewayapi.HTTPRouteFilterURLRewrite && filter.URLRewrite != nil {
-				// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3685
-				if filter.URLRewrite.Hostname != nil {
-					return fmt.Errorf("rules[%d].filters[%d]: filter type %s (with hostname replace) is unsupported",
-						ruleIndex, filterIndex, filter.Type)
-				}
 			}
 		}
 

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -895,8 +895,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			valid:         false,
-			validationMsg: "HTTPRoute spec did not pass validation: rules[0].filters[0]: filter type URLRewrite (with hostname replace) is unsupported",
+			valid: true,
 		},
 		{
 			msg: "HTTPRoute URLRewrite ReplacePrefixMatch",

--- a/internal/dataplane/fallback/graph_dependencies_kong.go
+++ b/internal/dataplane/fallback/graph_dependencies_kong.go
@@ -9,27 +9,27 @@ import (
 	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6026
+// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveKongPluginDependencies(_ store.CacheStores, _ *kongv1.KongPlugin) []client.Object {
 	return nil
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6026
+// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveKongClusterPluginDependencies(_ store.CacheStores, _ *kongv1.KongClusterPlugin) []client.Object {
 	return nil
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6026
+// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveUDPIngressDependencies(_ store.CacheStores, _ *kongv1beta1.UDPIngress) []client.Object {
 	return nil
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6026
+// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveTCPIngressDependencies(_ store.CacheStores, _ *kongv1beta1.TCPIngress) []client.Object {
 	return nil
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6026
+// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveKongServiceFacadeDependencies(_ store.CacheStores, _ *incubatorv1alpha1.KongServiceFacade) []client.Object {
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes outdated TODO comments linking to already resolved issues:

- https://github.com/Kong/kubernetes-ingress-controller/issues/3686
- https://github.com/Kong/kubernetes-ingress-controller/issues/3685
- https://github.com/Kong/kubernetes-ingress-controller/issues/6026

Adds a unit test ensuring `filter.URLRewrite.Hostname` in HTTPRoute rule is allowed.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Makes https://github.com/Kong/kubernetes-ingress-controller/actions/runs/9122991555/job/25084686979 green.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->



