### PR TITLE
feat: resolve dependencies for Service, KongConsumer and KongConsumerGroup, improve for plugins

### DIFF
--- a/internal/dataplane/fallback/graph_dependencies.go
+++ b/internal/dataplane/fallback/graph_dependencies.go
@@ -21,8 +21,12 @@ import (
 // Every supported object type should explicitly have a case in this function.
 func ResolveDependencies(cache store.CacheStores, obj client.Object) ([]client.Object, error) {
 	switch obj := obj.(type) {
+	// Standard Kubernetes objects.
+	case *corev1.Service:
+		return resolveServiceDependencies(cache, obj), nil
 	case *netv1.Ingress:
 		return resolveIngressDependencies(cache, obj), nil
+	// Gateway API objects.
 	case *gatewayapi.HTTPRoute:
 		return resolveHTTPRouteDependencies(cache, obj), nil
 	case *gatewayapi.TLSRoute:
@@ -33,24 +37,27 @@ func ResolveDependencies(cache store.CacheStores, obj client.Object) ([]client.O
 		return resolveUDPRouteDependencies(cache, obj), nil
 	case *gatewayapi.GRPCRoute:
 		return resolveGRPCRouteDependencies(cache, obj), nil
+	// Kong specific objects.
 	case *kongv1.KongPlugin:
 		return resolveKongPluginDependencies(cache, obj), nil
 	case *kongv1.KongClusterPlugin:
 		return resolveKongClusterPluginDependencies(cache, obj), nil
+	case *kongv1.KongConsumer:
+		return resolveKongConsumerDependencies(cache, obj), nil
+	case *kongv1beta1.KongConsumerGroup:
+		return resolveKongConsumerGroupDependencies(cache, obj), nil
 	case *kongv1beta1.UDPIngress:
 		return resolveUDPIngressDependencies(cache, obj), nil
 	case *kongv1beta1.TCPIngress:
 		return resolveTCPIngressDependencies(cache, obj), nil
 	case *incubatorv1alpha1.KongServiceFacade:
 		return resolveKongServiceFacadeDependencies(cache, obj), nil
-	case *netv1.IngressClass, // Object types that have no dependencies.
-		*corev1.Service,
+	// Object types that have no dependencies.
+	case *netv1.IngressClass,
 		*corev1.Secret,
 		*discoveryv1.EndpointSlice,
 		*gatewayapi.ReferenceGrant,
 		*gatewayapi.Gateway,
-		*kongv1.KongConsumer,
-		*kongv1beta1.KongConsumerGroup,
 		*kongv1.KongIngress,
 		*kongv1beta1.KongUpstreamPolicy,
 		*kongv1alpha1.IngressClassParameters,

--- a/internal/dataplane/fallback/graph_dependencies_common.go
+++ b/internal/dataplane/fallback/graph_dependencies_common.go
@@ -14,12 +14,17 @@ import (
 func resolveObjectDependenciesPlugin(cache store.CacheStores, obj client.Object) []client.Object {
 	var dependencies []client.Object
 	for _, pluginName := range annotations.ExtractKongPluginsFromAnnotations(obj.GetAnnotations()) {
+		// KongPlugin is tied to a namespace.
 		if plugin, exists, err := cache.Plugin.GetByKey(
 			fmt.Sprintf("%s/%s", obj.GetNamespace(), pluginName),
 		); err == nil && exists {
 			dependencies = append(dependencies, plugin.(client.Object))
+			// A namespaced KongPlugin resource takes priority over a KongClusterPlugin with the same name
+			// source: https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/custom-resources/#kongclusterplugin
+			// so it's desired to skip the KongClusterPlugin lookup if a KongPlugin is found.
+			continue
 		}
-
+		// KongClusterPlugin is global.
 		if plugin, exists, err := cache.ClusterPlugin.GetByKey(pluginName); err == nil && exists {
 			dependencies = append(dependencies, plugin.(client.Object))
 		}

--- a/internal/dataplane/fallback/graph_dependencies_kong.go
+++ b/internal/dataplane/fallback/graph_dependencies_kong.go
@@ -19,6 +19,20 @@ func resolveKongClusterPluginDependencies(_ store.CacheStores, _ *kongv1.KongClu
 	return nil
 }
 
+// resolveKongConsumerDependencies resolves potential dependencies for a KongConsumer object:
+// - KongPlugin
+// - KongClusterPlugin.
+func resolveKongConsumerDependencies(cache store.CacheStores, kongConsumer *kongv1.KongConsumer) []client.Object {
+	return resolveObjectDependenciesPlugin(cache, kongConsumer)
+}
+
+// resolveKongConsumerGroupDependencies resolves potential dependencies for a KongConsumerGroup object:
+// - KongPlugin
+// - KongClusterPlugin.
+func resolveKongConsumerGroupDependencies(cache store.CacheStores, kongConsumerGroup *kongv1beta1.KongConsumerGroup) []client.Object {
+	return resolveObjectDependenciesPlugin(cache, kongConsumerGroup)
+}
+
 // TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
 func resolveUDPIngressDependencies(_ store.CacheStores, _ *kongv1beta1.UDPIngress) []client.Object {
 	return nil

--- a/internal/dataplane/fallback/graph_dependencies_kong_test.go
+++ b/internal/dataplane/fallback/graph_dependencies_kong_test.go
@@ -1,0 +1,166 @@
+package fallback_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+)
+
+func TestResolveDependencies_KongConsumer(t *testing.T) {
+	testCases := []resolveDependenciesTestCase{
+		{
+			name: "no dependencies",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-KongConsumer",
+					Namespace: "test-namespace",
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{},
+		},
+		{
+			name: "KongConsumer -> plugins - annotation (KongPlugin and KongClusterPlugin with the same name)",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kongconsumer",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 2",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongPlugin(t, "2")},
+		},
+		{
+			name: "KongConsumer -> plugins - annotation (KongPlugin and KongClusterPlugin with different names)",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kongconsumer",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongClusterPlugin(t, "3")},
+		},
+		{
+			name: "KongConsumer -> plugins - annotation (KongClusterPlugin)",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kongconsumer",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongClusterPlugin(t, "3")},
+		},
+	}
+
+	for _, tc := range testCases {
+		runResolveDependenciesTest(t, tc)
+	}
+}
+
+func TestResolveDependencies_KongConsumerGroup(t *testing.T) {
+	testCases := []resolveDependenciesTestCase{
+		{
+			name: "no dependencies",
+			object: &kongv1beta1.KongConsumerGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-KongConsumerGroup",
+					Namespace: "test-namespace",
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{},
+		},
+		{
+			name: "KongConsumerGroup -> plugins - annotation (KongPlugin and KongClusterPlugin with the same name)",
+			object: &kongv1beta1.KongConsumerGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-KongConsumerGroup",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 2",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongPlugin(t, "2")},
+		},
+		{
+			name: "KongConsumerGroup -> plugins - annotation (KongPlugin and KongClusterPlugin with different names)",
+			object: &kongv1beta1.KongConsumerGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-KongConsumerGroup",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongClusterPlugin(t, "3")},
+		},
+		{
+			name: "KongConsumerGroup -> plugins - annotation (KongClusterPlugin)",
+			object: &kongv1beta1.KongConsumerGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-KongConsumerGroup",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongClusterPlugin(t, "3")},
+		},
+	}
+
+	for _, tc := range testCases {
+		runResolveDependenciesTest(t, tc)
+	}
+}

--- a/internal/dataplane/fallback/graph_dependencies_service.go
+++ b/internal/dataplane/fallback/graph_dependencies_service.go
@@ -1,0 +1,15 @@
+package fallback
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+)
+
+// resolveServiceDependencies resolves potential dependencies for a Service object:
+// - KongPlugin
+// - KongClusterPlugin.
+func resolveServiceDependencies(cache store.CacheStores, service *corev1.Service) []client.Object {
+	return resolveObjectDependenciesPlugin(cache, service)
+}

--- a/internal/dataplane/fallback/graph_dependencies_service_test.go
+++ b/internal/dataplane/fallback/graph_dependencies_service_test.go
@@ -1,0 +1,88 @@
+package fallback_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+)
+
+func TestResolveDependencies_Service(t *testing.T) {
+	testCases := []resolveDependenciesTestCase{
+		{
+			name: "no dependencies",
+			object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-namespace",
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{},
+		},
+		{
+			name: "Service -> plugins - annotation (KongPlugin and KongClusterPlugin with the same name)",
+			object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 2",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "1"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongPlugin(t, "2")},
+		},
+		{
+			name: "Service -> plugins - annotation (KongPlugin and KongClusterPlugin with different names)",
+			object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongPlugin(t, "1"), testKongClusterPlugin(t, "3")},
+		},
+		{
+			name: "Service -> plugins - annotation (KongClusterPlugin)",
+			object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.PluginsKey: "3",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+				testKongPlugin(t, "2"),
+				testKongClusterPlugin(t, "3"),
+			),
+			expected: []client.Object{testKongClusterPlugin(t, "3")},
+		},
+	}
+
+	for _, tc := range testCases {
+		runResolveDependenciesTest(t, tc)
+	}
+}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It implements `ResolveDependencies` cases for

- `corev1.Service`
- `kongv1.KongConsumer`
- `kongv1beta1.KongConsumerGroup`

they used to be treated by mistake as objects without any dependencies.

Furthermore, it implements the correct behavior of plugin resolution in cases when `KongPlugin` and `KongClusterPlugin` with the same names exist in the cluster - only `KongPlugin` is considered. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5929.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

