### PR TITLE
chore: simplify UpdateStrategy.Update signature

### DIFF
--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -250,14 +250,9 @@ type mockUpdateStrategy struct {
 	onUpdate func(content sendconfig.ContentWithHash) error
 }
 
-func (m *mockUpdateStrategy) Update(_ context.Context, content sendconfig.ContentWithHash) (
-	err error,
-	resourceErrors []sendconfig.ResourceError,
-	rawErrBody []byte,
-	resourceErrorsParseErr error,
-) {
-	err = m.onUpdate(content)
-	return err, nil, nil, nil
+func (m *mockUpdateStrategy) Update(_ context.Context, targetContent sendconfig.ContentWithHash) (err error) {
+	err = m.onUpdate(targetContent)
+	return err
 }
 
 func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -251,8 +251,7 @@ type mockUpdateStrategy struct {
 }
 
 func (m *mockUpdateStrategy) Update(_ context.Context, targetContent sendconfig.ContentWithHash) (err error) {
-	err = m.onUpdate(targetContent)
-	return err
+	return m.onUpdate(targetContent)
 }
 
 func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/sendconfig/backoff_strategy.go
+++ b/internal/dataplane/sendconfig/backoff_strategy.go
@@ -47,17 +47,12 @@ func NewUpdateStrategyWithBackoff(
 // In case it's not, it will return a predefined ErrUpdateSkippedDueToBackoffStrategy.
 // In case it is, apart from calling UpdateStrategy.Update, it will also register a success or a failure of an update
 // attempt so that the UpdateBackoffStrategy can keep track of it.
-func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent ContentWithHash) (
-	err error,
-	resourceErrors []ResourceError,
-	rawErrBody []byte,
-	resourceErrorsParseErr error,
-) {
+func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent ContentWithHash) (err error) {
 	if canUpdate, whyNot := s.backoffStrategy.CanUpdate(targetContent.Hash); !canUpdate {
-		return NewUpdateSkippedDueToBackoffStrategyError(whyNot), nil, nil, nil
+		return NewUpdateSkippedDueToBackoffStrategyError(whyNot)
 	}
 
-	err, resourceErrors, rawErrBody, resourceErrorsParseErr = s.decorated.Update(ctx, targetContent)
+	err = s.decorated.Update(ctx, targetContent)
 	if err != nil {
 		s.logger.V(util.DebugLevel).Info("Update failed, registering it for backoff strategy", "reason", err.Error())
 		s.backoffStrategy.RegisterUpdateFailure(err, targetContent.Hash)
@@ -65,7 +60,7 @@ func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent Con
 		s.backoffStrategy.RegisterUpdateSuccess()
 	}
 
-	return err, resourceErrors, rawErrBody, resourceErrorsParseErr
+	return err
 }
 
 func (s UpdateStrategyWithBackoff) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/sendconfig/backoff_strategy.go
+++ b/internal/dataplane/sendconfig/backoff_strategy.go
@@ -56,11 +56,11 @@ func (s UpdateStrategyWithBackoff) Update(ctx context.Context, targetContent Con
 	if err != nil {
 		s.logger.V(util.DebugLevel).Info("Update failed, registering it for backoff strategy", "reason", err.Error())
 		s.backoffStrategy.RegisterUpdateFailure(err, targetContent.Hash)
-	} else {
-		s.backoffStrategy.RegisterUpdateSuccess()
+		return err
 	}
 
-	return err
+	s.backoffStrategy.RegisterUpdateSuccess()
+	return nil
 }
 
 func (s UpdateStrategyWithBackoff) MetricsProtocol() metrics.Protocol {

--- a/internal/dataplane/sendconfig/backoff_strategy_test.go
+++ b/internal/dataplane/sendconfig/backoff_strategy_test.go
@@ -24,19 +24,14 @@ func newMockUpdateStrategy(shouldSucceed bool) *mockUpdateStrategy {
 	return &mockUpdateStrategy{shouldSucceed: shouldSucceed}
 }
 
-func (m *mockUpdateStrategy) Update(context.Context, sendconfig.ContentWithHash) (
-	err error,
-	resourceErrors []sendconfig.ResourceError,
-	rawErrBody []byte,
-	resourceErrorsParseErr error,
-) {
+func (m *mockUpdateStrategy) Update(context.Context, sendconfig.ContentWithHash) (err error) {
 	m.wasUpdateCalled = true
 
 	if !m.shouldSucceed {
-		return errors.New("update failure occurred"), nil, nil, nil
+		return errors.New("update failure occurred")
 	}
 
-	return nil, nil, nil, nil
+	return nil
 }
 
 func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {
@@ -120,7 +115,7 @@ func TestUpdateStrategyWithBackoff(t *testing.T) {
 			backoffStrategy := newMockBackoffStrategy(tc.updateShouldBeAllowed)
 
 			decoratedStrategy := sendconfig.NewUpdateStrategyWithBackoff(updateStrategy, backoffStrategy, logger)
-			err, _, _, _ := decoratedStrategy.Update(ctx, sendconfig.ContentWithHash{})
+			err := decoratedStrategy.Update(ctx, sendconfig.ContentWithHash{})
 			if tc.expectError != nil {
 				require.Equal(t, tc.expectError, err)
 			} else {

--- a/internal/dataplane/sendconfig/errors.go
+++ b/internal/dataplane/sendconfig/errors.go
@@ -1,0 +1,63 @@
+package sendconfig
+
+import "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
+
+// UpdateError wraps several pieces of error information relevant to a failed Kong update attempt.
+type UpdateError struct {
+	rawResponseBody  []byte
+	resourceFailures []failures.ResourceFailure
+	err              error
+}
+
+func NewUpdateError(resourceFailures []failures.ResourceFailure, err error) UpdateError {
+	return UpdateError{
+		resourceFailures: resourceFailures,
+		err:              err,
+	}
+}
+
+func NewUpdateErrorWithResponseBody(rawResponseBody []byte, resourceFailures []failures.ResourceFailure, err error) UpdateError {
+	return UpdateError{
+		rawResponseBody:  rawResponseBody,
+		resourceFailures: resourceFailures,
+		err:              err,
+	}
+}
+
+// Error implements the Error interface. It returns the string value of the err field.
+func (e UpdateError) Error() string {
+	return e.err.Error()
+}
+
+// RawResponseBody returns the raw HTTP response body from Kong for the failed update if it was captured.
+func (e UpdateError) RawResponseBody() []byte {
+	return e.rawResponseBody
+}
+
+// ResourceFailures returns per-resource failures from a Kong configuration update attempt.
+func (e UpdateError) ResourceFailures() []failures.ResourceFailure {
+	return e.resourceFailures
+}
+
+func (e UpdateError) Unwrap() error {
+	return e.err
+}
+
+// ResponseParsingError is an error type that is returned when the response from Kong is not in the expected format.
+type ResponseParsingError struct {
+	responseBody []byte
+}
+
+func NewResponseParsingError(responseBody []byte) ResponseParsingError {
+	return ResponseParsingError{responseBody: responseBody}
+}
+
+// Error implements the Error interface.
+func (e ResponseParsingError) Error() string {
+	return "failed to parse Kong error response"
+}
+
+// ResponseBody returns the raw HTTP response body from Kong that could not be parsed.
+func (e ResponseParsingError) ResponseBody() []byte {
+	return e.responseBody
+}

--- a/internal/dataplane/sendconfig/errors_test.go
+++ b/internal/dataplane/sendconfig/errors_test.go
@@ -1,0 +1,39 @@
+package sendconfig_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+)
+
+type testError struct{}
+
+func (t testError) Error() string {
+	return "test error"
+}
+
+func TestUpdateError(t *testing.T) {
+	someResourceFailure := lo.Must(failures.NewResourceFailure("some reason", &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+	}))
+
+	updateErr := sendconfig.NewUpdateError([]failures.ResourceFailure{someResourceFailure}, testError{})
+	require.Equal(t, "test error", updateErr.Error())
+	require.Len(t, updateErr.ResourceFailures(), 1)
+	unwraps := errors.As(updateErr, &testError{})
+	require.True(t, unwraps, "UpdateError should unwrap to inner error")
+}

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
@@ -100,7 +103,7 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 				logger.Error(nil, "Could not fully parse config error", "message", message)
 			}
 		}
-		return resourceErrors, fmt.Errorf("could not unmarshal config error: %w", err)
+		return resourceErrors, NewResponseParsingError(body)
 	}
 	if len(configError.Flattened) == 0 {
 		if len(configError.Message) > 0 {
@@ -197,4 +200,36 @@ func gvkIsClusterScoped(gvk schema.GroupVersionKind) bool {
 		return gvk.Kind == "KongClusterPlugin" || gvk.Kind == "KongLicense" || gvk.Kind == "KongVault"
 	}
 	return false
+}
+
+// resourceErrorsToResourceFailures translates a slice of ResourceError to a slice of failures.ResourceFailure.
+func resourceErrorsToResourceFailures(resourceErrors []ResourceError, logger logr.Logger) []failures.ResourceFailure {
+	var out []failures.ResourceFailure
+	for _, ee := range resourceErrors {
+		obj := metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       ee.Kind,
+				APIVersion: ee.APIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ee.Namespace,
+				Name:      ee.Name,
+				UID:       k8stypes.UID(ee.UID),
+			},
+		}
+		for problemSource, problem := range ee.Problems {
+			logger.V(util.DebugLevel).Info("Adding failure", "resource_name", ee.Name, "source", problemSource, "problem", problem)
+			resourceFailure, failureCreateErr := failures.NewResourceFailure(
+				fmt.Sprintf("invalid %s: %s", problemSource, problem),
+				&obj,
+			)
+			if failureCreateErr != nil {
+				logger.Error(failureCreateErr, "Could not create resource failure event")
+			} else {
+				out = append(out, resourceFailure)
+			}
+		}
+	}
+
+	return out
 }

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -9,11 +9,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckgen"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
@@ -37,26 +34,6 @@ type AdminAPIClient interface {
 	KonnectControlPlane() string
 }
 
-// Note that UpdateError is used for both DB-less and DB-backed update strategies, but does not have parity between the
-// two. Pending a refactor of database reconciler (https://github.com/Kong/go-database-reconciler/issues/22), KIC does
-// not have access to per-resource errors or any original response bodies in database mode. Future DB mode work would
-// need to find some way to reconcile the single /config raw body and many per-resource responses from DB endpoints.
-
-// UpdateError wraps several pieces of error information relevant to a failed Kong update attempt.
-type UpdateError struct {
-	// RawBody is the original Kong HTTP error response body from a failed update.
-	RawBody []byte
-	// ResourceFailures are per-resource failures from a Kong configuration update attempt.
-	ResourceFailures []failures.ResourceFailure
-	// Err is an overall description of the update failure.
-	Err error
-}
-
-// Error implements the Error interface. It returns the string value of the Err field.
-func (e UpdateError) Error() string {
-	return fmt.Sprintf("%s", e.Err)
-}
-
 // PerformUpdate writes `targetContent` to Kong Admin API specified by `kongConfig`.
 func PerformUpdate(
 	ctx context.Context,
@@ -71,14 +48,14 @@ func PerformUpdate(
 	oldSHA := client.LastConfigSHA()
 	newSHA, err := deckgen.GenerateSHA(targetContent)
 	if err != nil {
-		return oldSHA, UpdateError{ResourceFailures: []failures.ResourceFailure{}, Err: err}
+		return oldSHA, fmt.Errorf("failed to generate SHA for target content: %w", err)
 	}
 
 	// disable optimization if reverse sync is enabled
 	if !config.EnableReverseSync {
 		configurationChanged, err := configChangeDetector.HasConfigurationChanged(ctx, oldSHA, newSHA, targetContent, client, client.AdminAPIClient())
 		if err != nil {
-			return nil, UpdateError{Err: err}
+			return nil, fmt.Errorf("failed to detect configuration change: %w", err)
 		}
 		if !configurationChanged {
 			if client.IsKonnect() {
@@ -93,7 +70,7 @@ func PerformUpdate(
 	updateStrategy := updateStrategyResolver.ResolveUpdateStrategy(client)
 	logger = logger.WithValues("update_strategy", updateStrategy.Type())
 	timeStart := time.Now()
-	err, resourceErrors, rawErrBody, resourceErrorsParseErr := updateStrategy.Update(ctx, ContentWithHash{
+	err = updateStrategy.Update(ctx, ContentWithHash{
 		Content: targetContent,
 		Hash:    newSHA,
 	})
@@ -101,14 +78,15 @@ func PerformUpdate(
 
 	metricsProtocol := updateStrategy.MetricsProtocol()
 	if err != nil {
-		// Not pushing metrics in case it's an update skip due to a backoff.
-		if errors.As(err, &UpdateSkippedDueToBackoffStrategyError{}) {
-			return nil, UpdateError{RawBody: rawErrBody, Err: err}
+		// For UpdateError, record the failure and return the error.
+		var updateError UpdateError
+		if errors.As(err, &updateError) {
+			promMetrics.RecordPushFailure(metricsProtocol, duration, client.BaseRootURL(), len(updateError.ResourceFailures()), updateError.err)
+			return nil, updateError
 		}
 
-		resourceFailures := resourceErrorsToResourceFailures(resourceErrors, resourceErrorsParseErr, logger)
-		promMetrics.RecordPushFailure(metricsProtocol, duration, client.BaseRootURL(), len(resourceFailures), err)
-		return nil, UpdateError{ResourceFailures: resourceFailures, RawBody: rawErrBody, Err: err}
+		// Any other error, simply return it and skip metrics recording - we have no details to record.
+		return nil, fmt.Errorf("config update failed: %w", err)
 	}
 
 	promMetrics.RecordPushSuccess(metricsProtocol, duration, client.BaseRootURL())
@@ -125,41 +103,3 @@ func PerformUpdate(
 // -----------------------------------------------------------------------------
 // Sendconfig - Private Functions
 // -----------------------------------------------------------------------------
-
-// resourceErrorsToResourceFailures translates a slice of ResourceError to a slice of failures.ResourceFailure.
-// In case of parseErr being not nil, it just returns a nil slice.
-func resourceErrorsToResourceFailures(resourceErrors []ResourceError, parseErr error, logger logr.Logger) []failures.ResourceFailure {
-	if parseErr != nil {
-		logger.Error(parseErr, "Failed parsing resource errors")
-		return nil
-	}
-
-	var out []failures.ResourceFailure
-	for _, ee := range resourceErrors {
-		obj := metav1.PartialObjectMetadata{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       ee.Kind,
-				APIVersion: ee.APIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ee.Namespace,
-				Name:      ee.Name,
-				UID:       k8stypes.UID(ee.UID),
-			},
-		}
-		for problemSource, problem := range ee.Problems {
-			logger.V(util.DebugLevel).Info("Adding failure", "resource_name", ee.Name, "source", problemSource, "problem", problem)
-			resourceFailure, failureCreateErr := failures.NewResourceFailure(
-				fmt.Sprintf("invalid %s: %s", problemSource, problem),
-				&obj,
-			)
-			if failureCreateErr != nil {
-				logger.Error(failureCreateErr, "Could not create resource failure event")
-			} else {
-				out = append(out, resourceFailure)
-			}
-		}
-	}
-
-	return out
-}

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -21,12 +21,7 @@ type ContentWithHash struct {
 // UpdateStrategy is the way we approach updating data-plane's configuration, depending on its type.
 type UpdateStrategy interface {
 	// Update applies targetConfig to the data-plane.
-	Update(ctx context.Context, targetContent ContentWithHash) (
-		err error,
-		resourceErrors []ResourceError,
-		rawErrorBody []byte,
-		resourceErrorsParseErr error,
-	)
+	Update(ctx context.Context, targetContent ContentWithHash) error
 
 	// MetricsProtocol returns a string describing the update strategy type to be used in metrics.
 	MetricsProtocol() metrics.Protocol

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -239,8 +239,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 
 			// Update Kong with the Upstream.
 			require.Eventually(t, func() bool {
-				err = updateStrategy.Update(ctx, content)
-				if err != nil {
+				if err := updateStrategy.Update(ctx, content); err != nil {
 					t.Logf("error updating Kong configuration: %v", err)
 					return false
 				}

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -239,7 +239,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 
 			// Update Kong with the Upstream.
 			require.Eventually(t, func() bool {
-				err, _, _, _ = updateStrategy.Update(ctx, content)
+				err = updateStrategy.Update(ctx, content)
 				if err != nil {
 					t.Logf("error updating Kong configuration: %v", err)
 					return false

--- a/test/kongintegration/translator_golden_tests_outputs_test.go
+++ b/test/kongintegration/translator_golden_tests_outputs_test.go
@@ -127,18 +127,9 @@ func ensureGoldenTestOutputIsAccepted(
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		err, resourceErrors, rawErrBody, parseErr := sut.Update(ctx, sendconfig.ContentWithHash{Content: content})
+		err := sut.Update(ctx, sendconfig.ContentWithHash{Content: content})
 		if err != nil {
 			t.Logf("error: %v", err)
-			return false
-		}
-		if len(resourceErrors) > 0 {
-			t.Logf("resource errors: %v", resourceErrors)
-			return false
-		}
-		if parseErr != nil {
-			t.Logf("parse error: %v", parseErr)
-			t.Logf("raw error: %v", rawErrBody)
 			return false
 		}
 		return true

--- a/test/kongintegration/translator_golden_tests_outputs_test.go
+++ b/test/kongintegration/translator_golden_tests_outputs_test.go
@@ -127,8 +127,7 @@ func ensureGoldenTestOutputIsAccepted(
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		err := sut.Update(ctx, sendconfig.ContentWithHash{Content: content})
-		if err != nil {
+		if err := sut.Update(ctx, sendconfig.ContentWithHash{Content: content}); err != nil {
 			t.Logf("error: %v", err)
 			return false
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of returning multiple error-related values from `UpdateStrategy.Update`, return specific errors that downstream can cast if needed (`UpdateError`, `ResponseParsingError`).

**Which issue this PR fixes**:

Refactor needed for https://github.com/Kong/kubernetes-ingress-controller/issues/5931.
