### PR TITLE
Revert "chore(deps): update istio/istioctl docker tag to v1.22.0"

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -20,7 +20,7 @@ e2e:
     - # renovate: datasource=docker depName=kindest/node versioning=docker
       kind: 'v1.30.0'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
-      istio: '1.22.0'
+      istio: '1.21.2'
     - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.28.9'
       # renovate: datasource=docker depName=istio/istioctl@only-patch packageName=istio/istioctl versioning=docker


### PR DESCRIPTION
Reverts Kong/kubernetes-ingress-controller#6058

E2Es are failing with Istio v1.22.0: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/9185397422/job/25259294329