### PR TITLE
feat: resolve dependencies for KongServiceFacade and improve for Service

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -421,6 +421,7 @@ func ExtractRewriteURI(anns map[string]string) (string, bool) {
 	return s, ok
 }
 
+// ExtractUpstreamPolicy extracts the upstream policy annotation value.
 func ExtractUpstreamPolicy(anns map[string]string) (string, bool) {
 	s, ok := anns[kongv1beta1.KongUpstreamPolicyAnnotationKey]
 	return s, ok

--- a/internal/dataplane/fallback/graph_dependencies_common.go
+++ b/internal/dataplane/fallback/graph_dependencies_common.go
@@ -33,6 +33,21 @@ func resolveObjectDependenciesPlugin(cache store.CacheStores, obj client.Object)
 	return dependencies
 }
 
+// resolveDependenciesForServiceLikeObj resolves potential dependencies for a Service-like objects use for Service or KongServiceFacade.
+// Potential dependencies are:
+// - KongPlugin
+// - KongClusterPlugin
+// - KongUpstreamPolicy.
+func resolveDependenciesForServiceLikeObj(cache store.CacheStores, obj client.Object) []client.Object {
+	dependencies := resolveObjectDependenciesPlugin(cache, obj)
+	if kupName, ok := annotations.ExtractUpstreamPolicy(obj.GetAnnotations()); ok {
+		if kup, exists, err := cache.KongUpstreamPolicy.GetByKey(fmt.Sprintf("%s/%s", obj.GetNamespace(), kupName)); err == nil && exists {
+			dependencies = append(dependencies, kup.(client.Object))
+		}
+	}
+	return dependencies
+}
+
 // fetchSecret retrieves a Secret object as client.Object from the cache.
 func fetchSecret(cache store.CacheStores, nn k8stypes.NamespacedName) (client.Object, bool) {
 	secret, exists, err := cache.Secret.GetByKey(nn.String())

--- a/internal/dataplane/fallback/graph_dependencies_kong.go
+++ b/internal/dataplane/fallback/graph_dependencies_kong.go
@@ -92,7 +92,10 @@ func resolveTCPIngressDependencies(_ store.CacheStores, _ *kongv1beta1.TCPIngres
 	return nil
 }
 
-// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5929
-func resolveKongServiceFacadeDependencies(_ store.CacheStores, _ *incubatorv1alpha1.KongServiceFacade) []client.Object {
-	return nil
+// resolveKongServiceFacadeDependencies resolves potential dependencies for a KongServiceFacade object:
+// - KongPlugin
+// - KongClusterPlugin
+// - KongUpstreamPolicy.
+func resolveKongServiceFacadeDependencies(cache store.CacheStores, kongServiceFacade *incubatorv1alpha1.KongServiceFacade) []client.Object {
+	return resolveDependenciesForServiceLikeObj(cache, kongServiceFacade)
 }

--- a/internal/dataplane/fallback/graph_dependencies_service.go
+++ b/internal/dataplane/fallback/graph_dependencies_service.go
@@ -9,7 +9,8 @@ import (
 
 // resolveServiceDependencies resolves potential dependencies for a Service object:
 // - KongPlugin
-// - KongClusterPlugin.
+// - KongClusterPlugin
+// - KongUpstreamPolicy.
 func resolveServiceDependencies(cache store.CacheStores, service *corev1.Service) []client.Object {
-	return resolveObjectDependenciesPlugin(cache, service)
+	return resolveDependenciesForServiceLikeObj(cache, service)
 }

--- a/internal/dataplane/fallback/graph_dependencies_service_test.go
+++ b/internal/dataplane/fallback/graph_dependencies_service_test.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 )
 
 func TestResolveDependencies_Service(t *testing.T) {
@@ -27,22 +28,24 @@ func TestResolveDependencies_Service(t *testing.T) {
 			expected: []client.Object{},
 		},
 		{
-			name: "Service -> plugins - annotation (KongPlugin and KongClusterPlugin with the same name)",
+			name: "Service -> plugins - annotation (KongPlugin and KongClusterPlugin with the same name) and KongUpstreamPolicy",
 			object: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-service",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
 						annotations.AnnotationPrefix + annotations.PluginsKey: "1, 2",
+						kongv1beta1.KongUpstreamPolicyAnnotationKey:           "1",
 					},
 				},
 			},
 			cache: cacheStoresFromObjs(t,
 				testKongPlugin(t, "1"),
 				testKongPlugin(t, "2"),
+				testKongUpstreamPolicy(t, "1"),
 				testKongClusterPlugin(t, "1"),
 			),
-			expected: []client.Object{testKongPlugin(t, "1"), testKongPlugin(t, "2")},
+			expected: []client.Object{testKongPlugin(t, "1"), testKongPlugin(t, "2"), testKongUpstreamPolicy(t, "1")},
 		},
 		{
 			name: "Service -> plugins - annotation (KongPlugin and KongClusterPlugin with different names)",
@@ -59,17 +62,19 @@ func TestResolveDependencies_Service(t *testing.T) {
 				testKongPlugin(t, "1"),
 				testKongPlugin(t, "2"),
 				testKongClusterPlugin(t, "3"),
+				testKongUpstreamPolicy(t, "1"),
 			),
 			expected: []client.Object{testKongPlugin(t, "1"), testKongClusterPlugin(t, "3")},
 		},
 		{
-			name: "Service -> plugins - annotation (KongClusterPlugin)",
+			name: "Service -> plugins - annotation (KongClusterPlugin) and KongUpstreamPolicy",
 			object: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-service",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
 						annotations.AnnotationPrefix + annotations.PluginsKey: "3",
+						kongv1beta1.KongUpstreamPolicyAnnotationKey:           "3",
 					},
 				},
 			},
@@ -77,8 +82,28 @@ func TestResolveDependencies_Service(t *testing.T) {
 				testKongPlugin(t, "1"),
 				testKongPlugin(t, "2"),
 				testKongClusterPlugin(t, "3"),
+				testKongUpstreamPolicy(t, "3"),
 			),
-			expected: []client.Object{testKongClusterPlugin(t, "3")},
+			expected: []client.Object{testKongClusterPlugin(t, "3"), testKongUpstreamPolicy(t, "3")},
+		},
+		{
+			name: "Service -> KongUpstreamPolicy - the same name in different namespaces",
+			object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						kongv1beta1.KongUpstreamPolicyAnnotationKey: "1",
+					},
+				},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongUpstreamPolicy(t, "1"),
+				testKongUpstreamPolicy(t, "1", func(kup *kongv1beta1.KongUpstreamPolicy) {
+					kup.Namespace = "other-namespace"
+				}),
+			),
+			expected: []client.Object{testKongUpstreamPolicy(t, "1")},
 		},
 	}
 

--- a/internal/dataplane/fallback/helpers_test.go
+++ b/internal/dataplane/fallback/helpers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 )
@@ -75,6 +76,19 @@ func testKongClusterPlugin(t *testing.T, name string) *kongv1.KongClusterPlugin 
 			Namespace: testNamespace,
 		},
 	})
+}
+
+func testKongUpstreamPolicy(t *testing.T, name string, modifiers ...func(kup *kongv1beta1.KongUpstreamPolicy)) *kongv1beta1.KongUpstreamPolicy {
+	kup := helpers.WithTypeMeta(t, &kongv1beta1.KongUpstreamPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+	})
+	for _, mod := range modifiers {
+		mod(kup)
+	}
+	return kup
 }
 
 // GraphBuilder is a helper to build a graph for testing.


### PR DESCRIPTION
**What this PR does / why we need it**:

It implements `ResolveDependencies` cases for `incubatorv1alpha1.KongServiceFacade`. Moreover, it improves resolving dependencies for `corev1.Service` - adds `kongv1beta1.KongUpstreamPolicy`, because [it can be attached to a Service](https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/custom-resources/#kongupstreampolicy). 

**Which issue this PR fixes:**

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5929.