### PR TITLE
feat: resolve dependencies for UDPIngress and TCPIngress

### DIFF
--- a/internal/dataplane/fallback/helpers_test.go
+++ b/internal/dataplane/fallback/helpers_test.go
@@ -29,13 +29,17 @@ func testIngressClass(t *testing.T, name string) *netv1.IngressClass {
 	})
 }
 
-func testService(t *testing.T, name string) *corev1.Service {
-	return helpers.WithTypeMeta(t, &corev1.Service{
+func testService(t *testing.T, name string, modifiers ...func(s *corev1.Service)) *corev1.Service {
+	svc := helpers.WithTypeMeta(t, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 		},
 	})
+	for _, mod := range modifiers {
+		mod(svc)
+	}
+	return svc
 }
 
 func testSecret(t *testing.T, name string, modifiers ...func(s *corev1.Secret)) *corev1.Secret {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It implements `ResolveDependencies` cases for
- `kongv1.UDPIngress`
- `kongv1.TCPIngress`

**Which issue this PR fixes:**

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5929.
There will be one more PR with small refactor to close this issue.

