### PR TITLE
feat: generate and push fallback config on update failure

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -118,6 +118,12 @@ jobs:
             # https://github.com/Kong/kubernetes-ingress-controller/issues/5127 is resolved.
             router-flavor: 'traditional'
             go_test_flags: -run=TestIngressRecoverFromInvalidPath
+          - name: postgres-fallback-config
+            test: postgres
+            feature_gates: "GatewayAlpha=true,FallbackConfiguration=true"
+          - name: dbless-fallback-config
+            test: dbless
+            feature_gates: "GatewayAlpha=true,FallbackConfiguration=true"
           # Experimental tests, in the future all integration tests will be migrated to them.
           # Set enterprise to 'true' to enable isolated integration test cases requiring enterprise features.
           - name: isolated-dbless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Adding a new version? You'll need three changes:
   [#5993](https://github.com/Kong/kubernetes-ingress-controller/pull/5993)
   [#6010](https://github.com/Kong/kubernetes-ingress-controller/pull/6010)
   [#6047](https://github.com/Kong/kubernetes-ingress-controller/pull/6047)
+  [#6071](https://github.com/Kong/kubernetes-ingress-controller/pull/6071)
   
 - Add support for Kubernetes Gateway API v1.1:
   - add a flag `--enable-controller-gwapi-grpcroute` to control whether enable or disable GRPCRoute controller.

--- a/config/variants/multi-gw/debug/manager_debug.yaml
+++ b/config/variants/multi-gw/debug/manager_debug.yaml
@@ -30,7 +30,7 @@ spec:
           - /manager-debug
           - --
         args:
-          - --feature-gates=GatewayAlpha=true
+          - --feature-gates=GatewayAlpha=true,FallbackConfiguration=true
           - --anonymous-reports=false
         env:
         - name: CONTROLLER_LOG_LEVEL

--- a/internal/dataplane/fallback/fallback_test.go
+++ b/internal/dataplane/fallback/fallback_test.go
@@ -3,6 +3,7 @@ package fallback_test
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
@@ -53,7 +54,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	require.NoError(t, err)
 
 	graphProvider := &mockGraphProvider{graph: graph}
-	g := fallback.NewGenerator(graphProvider)
+	g := fallback.NewGenerator(graphProvider, logr.Discard())
 
 	t.Run("ingressClass is broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/configfetcher"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
@@ -191,6 +192,7 @@ func Run(
 	updateStrategyResolver := sendconfig.NewDefaultUpdateStrategyResolver(kongConfig, logger)
 	configurationChangeDetector := sendconfig.NewDefaultConfigurationChangeDetector(logger)
 	kongConfigFetcher := configfetcher.NewDefaultKongLastGoodConfigFetcher(translatorFeatureFlags.FillIDs, c.KongWorkspace)
+	fallbackConfigGenerator := fallback.NewGenerator(fallback.NewDefaultCacheGraphProvider(), logger)
 	dataplaneClient, err := dataplane.NewKongClient(
 		logger,
 		time.Duration(c.ProxyTimeoutSeconds*float32(time.Second)),
@@ -204,6 +206,7 @@ func Run(
 		kongConfigFetcher,
 		configTranslator,
 		cache,
+		fallbackConfigGenerator,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize kong data-plane client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `KongClient` try to recover from regular config update failures by generating a fallback configuration, excluding affected objects reported back by gateways.

Enables integration tests with the `FallbackConfiguration` feature gate enabled to ensure no existing scenarios are broken.

Adds only unit tests covering `KongClient`. More integration/E2E test coverage is expected to be added under https://github.com/Kong/kubernetes-ingress-controller/issues/5933.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/5931.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
