### PR TITLE
fix(diag) correct redaction toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,8 @@ Adding a new version? You'll need three changes:
   [#5919](https://github.com/Kong/kubernetes-ingress-controller/pull/5919)
 - Redacted values no longer cause collisions in configuration reported to Konnect.
   [5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
+- The `--dump-sensitive-config` flag is no longer backwards.
+  [6073](https://github.com/Kong/kubernetes-ingress-controller/pull/6073)
 
 ### Changed
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -655,14 +655,14 @@ func prepareSendDiagnosticFn(
 
 	var config *file.Content
 	if diagnosticConfig.DumpsIncludeSensitive {
+		config = targetContent
+	} else {
 		redactedConfig := deckgen.ToDeckContent(ctx,
 			logger,
 			targetState.SanitizedCopy(util.DefaultUUIDGenerator{}),
 			deckGenParams,
 		)
 		config = redactedConfig
-	} else {
-		config = targetContent
 	}
 
 	return func(failed bool, rawResponseBody []byte) {

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -962,3 +962,69 @@ func TestKongClient_FallbackConfiguration(t *testing.T) {
 	require.NoError(t, kongClient.Update(ctx))
 	require.True(t, configBuilder.updateCacheCalled, "expected store to be updated with a snapshot")
 }
+
+func TestKongClient_ConfigDumpSanitization(t *testing.T) {
+	clientsProvider := mockGatewayClientsProvider{
+		gatewayClients: []*adminapi.Client{
+			mustSampleGatewayClient(t),
+		},
+		konnectClient: mustSampleKonnectClient(t),
+	}
+	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
+	configBuilder := newMockKongConfigBuilder()
+	kongRawStateGetter := &mockKongLastValidConfigFetcher{}
+
+	const testPrivateKey = "private-key-string"
+	configBuilder.kongState = &kongstate.KongState{
+		Certificates: []kongstate.Certificate{
+			{
+				Certificate: kong.Certificate{
+					ID:  kong.String("new_cert"),
+					Key: kong.String(testPrivateKey), // This should be redacted.
+				},
+			},
+		},
+	}
+	kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
+
+	testCases := []struct {
+		name                  string
+		dumpsIncludeSensitive bool
+		expectSanitizedDump   bool
+	}{
+		{
+			name:                  "when DumpsIncludeSensitive is true, expect no sanitization",
+			dumpsIncludeSensitive: true,
+			expectSanitizedDump:   false,
+		},
+		{
+			name:                  "when DumpsIncludeSensitive is false, expect sanitization",
+			dumpsIncludeSensitive: false,
+			expectSanitizedDump:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			diagnosticsCh := make(chan util.ConfigDump, 1) // make it buffered to avoid blocking
+			kongClient.diagnostic = util.ConfigDumpDiagnostic{
+				Configs:               diagnosticsCh,
+				DumpsIncludeSensitive: tc.dumpsIncludeSensitive,
+			}
+			ctx := context.Background()
+			err := kongClient.Update(ctx)
+			require.NoError(t, err)
+
+			dump := <-diagnosticsCh
+			require.NotNil(t, dump.Config)
+			require.Len(t, dump.Config.Certificates, 1)
+			dumpedCert := dump.Config.Certificates[0]
+			if tc.expectSanitizedDump {
+				require.Equal(t, "{vault://redacted-value}", *dumpedCert.Key)
+			} else {
+				require.Equal(t, testPrivateKey, *dumpedCert.Key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverses the dataplane logic for the sensitive config check. If diagnostic dumps are set to include sensitive data, it will use the original target content. If they are set to not include sensitive data, they will use a redacted content.

**Which issue this PR fixes**:

Some refactor made `--dump-sensitive-config` backwards. I didn't bother digging into PR history to explain how. I noticed this while trying to use it.

**Special notes for your reviewer**:

There's a more complicated issue where you'll still get redacted config (by default) if you're using Konnect, whereas you probably don't want that for the diagnostic--you care what was sent to the gateway instances, not the read-only GUI copy. Lazily we can solve this by just always generating both, but the struct is big enough that I'd like to avoid that when possible.

Submitting the smaller fix while I try to think of a better fix for the rest.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
