### PR TITLE
fix(gwapi): only clear status of Gateway API *Routes reconciled by KIC's gateway(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@ Adding a new version? You'll need three changes:
   [5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
 - The `--dump-sensitive-config` flag is no longer backwards.
   [6073](https://github.com/Kong/kubernetes-ingress-controller/pull/6073)
+- Fixed KIC clearing HTTPRoute status of routes that it shouldn't reconcilce, e.g.
+  those attached to Gateways that do not belong to GatewayClass that KIC reconciles.
+  [6079](https://github.com/Kong/kubernetes-ingress-controller/pull/6079)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,7 @@ Adding a new version? You'll need three changes:
   [5964](https://github.com/Kong/kubernetes-ingress-controller/pull/5964)
 - The `--dump-sensitive-config` flag is no longer backwards.
   [6073](https://github.com/Kong/kubernetes-ingress-controller/pull/6073)
-- Fixed KIC clearing HTTPRoute status of routes that it shouldn't reconcilce, e.g.
+- Fixed KIC clearing Gateway API *Route status of routes that it shouldn't reconcilce, e.g.
   those attached to Gateways that do not belong to GatewayClass that KIC reconciles.
   [6079](https://github.com/Kong/kubernetes-ingress-controller/pull/6079)
 

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -326,8 +326,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, grpcroute)
-			if err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, grpcroute); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -99,12 +100,28 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 	}
 
-	// because of the additional burden of having to manage reference data-plane
-	// configurations for GRPCRoute objects in the underlying Kong Gateway, we
-	// simply reconcile ALL GRPCRoute objects. This allows us to drop the backend
-	// data-plane config for an GRPCRoute if it somehow becomes disconnected from
-	// a supported Gateway and GatewayClass.
-	return blder.For(&gatewayapi.GRPCRoute{}).
+	// We enqueue only routes that are:
+	// - attached during creation or deletion
+	// - have been attached or detached to a reconciled Gateway.
+	// This allows us to drop the backend data-plane config for a route if
+	// it somehow becomes disconnected from a supported Gateway and GatewayClass.
+	return blder.
+		For(&gatewayapi.GRPCRoute{},
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(_ event.GenericEvent) bool {
+					return false // we don't need to enqueue from generic
+				},
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -305,21 +322,14 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	debug(log, grpcroute, "Retrieving GatewayClass and Gateway for route")
 	gateways, err := getSupportedGatewayForRoute(ctx, log, r.Client, grpcroute, r.GatewayNN)
 	if err != nil {
-		if err.Error() == unsupportedGW {
-			debug(log, grpcroute, "Unsupported route found, processing to verify whether it was ever supported")
+		if errors.Is(err, ErrNoSupportedGateway) {
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			statusUpdated, err := r.ensureGatewayReferenceStatusRemoved(ctx, grpcroute)
+			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, grpcroute)
 			if err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
-			}
-			if statusUpdated {
-				// the status did in fact needed to be updated, so no need to requeue
-				// as the status update will trigger a requeue.
-				debug(log, grpcroute, "Unsupported route was previously supported, status was updated")
-				return ctrl.Result{}, nil
 			}
 
 			// if the route doesn't have a supported Gateway+GatewayClass associated with
@@ -516,34 +526,6 @@ func (r *GRPCRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 	}
 
 	// update the object status in the API
-	if err := r.Status().Update(ctx, grpcroute); err != nil {
-		return false, err
-	}
-
-	// the status needed an update and it was updated successfully
-	return true, nil
-}
-
-// ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
-// implementation to prune status references to Gateways supported by this controller
-// in the provided GRPCRoute object.
-func (r *GRPCRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Context, grpcroute *gatewayapi.GRPCRoute) (bool, error) {
-	// drop all status references to supported Gateway objects
-	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
-	for _, status := range grpcroute.Status.Parents {
-		if status.ControllerName != GetControllerName() {
-			newStatuses = append(newStatuses, status)
-		}
-	}
-
-	// if the new list of statuses is the same length as the old
-	// nothing has changed and we're all done.
-	if len(newStatuses) == len(grpcroute.Status.Parents) {
-		return false, nil
-	}
-
-	// update the object status in the API
-	grpcroute.Status.Parents = newStatuses
 	if err := r.Status().Update(ctx, grpcroute); err != nil {
 		return false, err
 	}

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -400,8 +400,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, httproute)
-			if err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, httproute); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/internal/controllers/gateway/route_parent_status.go
+++ b/internal/controllers/gateway/route_parent_status.go
@@ -89,3 +89,35 @@ func getParentRef(parentStatus gatewayapi.RouteParentStatus) parentRef {
 		SectionName: sectionName,
 	}
 }
+
+func getRouteStatusParents[T gatewayapi.RouteT](route T) []gatewayapi.RouteParentStatus {
+	switch r := any(route).(type) {
+	case *gatewayapi.HTTPRoute:
+		return r.Status.Parents
+	case *gatewayapi.TCPRoute:
+		return r.Status.Parents
+	case *gatewayapi.UDPRoute:
+		return r.Status.Parents
+	case *gatewayapi.TLSRoute:
+		return r.Status.Parents
+	case *gatewayapi.GRPCRoute:
+		return r.Status.Parents
+	default:
+		return nil
+	}
+}
+
+func setRouteStatusParents[T gatewayapi.RouteT](route T, parents []gatewayapi.RouteParentStatus) {
+	switch r := any(route).(type) {
+	case *gatewayapi.HTTPRoute:
+		r.Status.Parents = parents
+	case *gatewayapi.TCPRoute:
+		r.Status.Parents = parents
+	case *gatewayapi.UDPRoute:
+		r.Status.Parents = parents
+	case *gatewayapi.TLSRoute:
+		r.Status.Parents = parents
+	case *gatewayapi.GRPCRoute:
+		r.Status.Parents = parents
+	}
+}

--- a/internal/controllers/gateway/route_predicates.go
+++ b/internal/controllers/gateway/route_predicates.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+)
+
+func isRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
+	cl client.Client, log logr.Logger, gatewayNN controllers.OptionalNamespacedName, obj client.Object,
+) bool {
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	route, ok := obj.(routeT)
+	if !ok {
+		log.Error(
+			fmt.Errorf("unexpected object type"),
+			"Route watch predicate received unexpected object type",
+			"expected", kind, "found", reflect.TypeOf(obj),
+		)
+		return false
+	}
+
+	parentRefs := getRouteParentRefs(route)
+
+	// If the reconciler has a GatewayNN set, only HTTPRoutes attached to that Gateway are reconciled.
+	if gNN, ok := gatewayNN.Get(); ok {
+		for _, parentRef := range parentRefs {
+			if parentRef.Namespace != nil && string(*parentRef.Namespace) != gNN.Namespace {
+				continue
+			}
+			if string(parentRef.Name) != gNN.Name {
+				continue
+			}
+			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+				continue
+			}
+			if parentRef.Group != nil && *parentRef.Group != gatewayapi.Group(gatewayapi.GroupVersion.Group) {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+
+	// If the GatewayNN is not set, all HTTPRoutes are reconciled.
+	// Hence we need to check if the HTTPRoute is attached to a Gateway that is managed by this controller.
+	for _, parentRef := range parentRefs {
+		namespace := route.GetNamespace()
+		if parentRef.Namespace != nil {
+			namespace = string(*parentRef.Namespace)
+		}
+
+		kind := gatewayapi.Kind("Gateway")
+		if parentRef.Kind != nil {
+			kind = *parentRef.Kind
+		}
+
+		group := gatewayapi.GroupVersion.Group
+		if parentRef.Group != nil {
+			group = string(*parentRef.Group)
+		}
+
+		switch {
+		case kind == "Gateway" && group == gatewayapi.GroupVersion.Group:
+			var gateway gatewayapi.Gateway
+			err := cl.Get(context.Background(), k8stypes.NamespacedName{Namespace: namespace, Name: string(parentRef.Name)}, &gateway)
+			if err != nil {
+				log.Error(err, "Failed to get Gateway in HTTPRoute watch")
+				return false
+			}
+
+			var gatewayClass gatewayapi.GatewayClass
+			err = cl.Get(context.Background(), k8stypes.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, &gatewayClass)
+			if err != nil {
+				log.Error(err, "Failed to get GatewayClass in HTTPRoute watch")
+				return false
+			}
+
+			if isGatewayClassControlled(&gatewayClass) {
+				return true
+			}
+		default:
+			log.Error(
+				fmt.Errorf("unsupported parentRef kind %s and group %s", kind, group),
+				"Got an unexpected kind and group when checking route's parentRefs",
+			)
+			return false
+		}
+	}
+
+	return false
+}
+
+func isOrWasRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
+	cl client.Client, log logr.Logger, gatewayNN controllers.OptionalNamespacedName, e event.UpdateEvent,
+) bool {
+	oldObj, newObj := e.ObjectOld, e.ObjectNew
+	return isRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, oldObj) ||
+		isRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, newObj)
+}

--- a/internal/controllers/gateway/route_predicates.go
+++ b/internal/controllers/gateway/route_predicates.go
@@ -17,9 +17,9 @@ import (
 func isRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 	cl client.Client, log logr.Logger, gatewayNN controllers.OptionalNamespacedName, obj client.Object,
 ) bool {
-	kind := obj.GetObjectKind().GroupVersionKind().Kind
 	route, ok := obj.(routeT)
 	if !ok {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
 		log.Error(
 			fmt.Errorf("unexpected object type"),
 			"Route watch predicate received unexpected object type",

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -995,7 +995,7 @@ func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
 	kind := route.GetObjectKind().GroupVersionKind().Kind
 	parents := getRouteStatusParents(route)
 
-	// drop all status references to supported Gateway objects
+	// Drop all status references to supported Gateway objects.
 	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
 	for _, status := range parents {
 		if status.ControllerName != GetControllerName() {
@@ -1009,13 +1009,13 @@ func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
 		}
 	}
 
-	// if the new list of statuses is the same length as the old
+	// If the new list of statuses is the same length as the old
 	// nothing has changed and we're all done.
 	if len(newStatuses) == len(parents) {
 		return false, nil
 	}
 
-	// if the route doesn't have a supported Gateway+GatewayClass associated with
+	// If the route doesn't have a supported Gateway+GatewayClass associated with
 	// it it's possible it became orphaned after becoming queued. In either case
 	// ensure that it's removed from the proxy cache to avoid orphaned data-plane
 	// configurations.
@@ -1026,7 +1026,7 @@ func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
 	}
 
 	debug(log, route, "Unsupported route was previously supported, status was updated")
-	// the status needed to be updated and it was updated successfully
+	// The status needed to be updated and it was updated successfully.
 	return true, nil
 }
 

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -27,17 +27,16 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	unsupportedGW = "no supported Gateway found for route"
-)
-
-const (
 	ConditionTypeProgrammed                                            = "Programmed"
 	ConditionReasonProgrammedUnknown   gatewayapi.RouteConditionReason = "Unknown"
 	ConditionReasonConfiguredInGateway gatewayapi.RouteConditionReason = "ConfiguredInGateway"
 	ConditionReasonTranslationError    gatewayapi.RouteConditionReason = "TranslationError"
 )
 
-var ErrNoMatchingListenerHostname = fmt.Errorf("no matching hostnames in listener")
+var (
+	ErrNoMatchingListenerHostname = fmt.Errorf("no matching hostnames in listener")
+	ErrNoSupportedGateway         = fmt.Errorf("no supported gateway found for route")
+)
 
 // supportedGatewayWithCondition is a struct that wraps a gateway and some further info
 // such as the condition Status condition Accepted of the gateway and the listenerName.
@@ -351,7 +350,7 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](ctx context.Context, logge
 	}
 
 	if len(gateways) == 0 {
-		return nil, fmt.Errorf(unsupportedGW)
+		return nil, ErrNoSupportedGateway
 	}
 
 	return gateways, nil
@@ -984,4 +983,66 @@ func isRouteAcceptedByListener[T gatewayapi.RouteT](ctx context.Context,
 	}
 
 	return true, nil
+}
+
+// ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
+// implementation to prune status references to Gateways supported by this controller
+// in the provided route.
+func ensureGatewayReferenceStatusRemoved[routeT gatewayapi.RouteT](
+	ctx context.Context, cl client.Client, log logr.Logger, route routeT,
+) (bool, error) {
+	debug(log, route, "Unsupported route found, processing to verify whether it was ever supported")
+	kind := route.GetObjectKind().GroupVersionKind().Kind
+	parents := getRouteStatusParents(route)
+
+	// drop all status references to supported Gateway objects
+	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
+	for _, status := range parents {
+		if status.ControllerName != GetControllerName() {
+			newStatuses = append(newStatuses, status)
+		} else {
+			parentRefNN := string(status.ParentRef.Name)
+			if status.ParentRef.Namespace != nil {
+				parentRefNN = fmt.Sprintf("%s/%s", *status.ParentRef.Namespace, parentRefNN)
+			}
+			debug(log, route, "Removing parentRef from route status", "parentRef", parentRefNN, "kind", kind)
+		}
+	}
+
+	// if the new list of statuses is the same length as the old
+	// nothing has changed and we're all done.
+	if len(newStatuses) == len(parents) {
+		return false, nil
+	}
+
+	// if the route doesn't have a supported Gateway+GatewayClass associated with
+	// it it's possible it became orphaned after becoming queued. In either case
+	// ensure that it's removed from the proxy cache to avoid orphaned data-plane
+	// configurations.
+	debug(log, route, "Ensuring that dataplane is updated to remove unsupported route (if applicable)")
+	setRouteStatusParents(route, newStatuses)
+	if err := cl.Status().Update(ctx, route); err != nil {
+		return false, fmt.Errorf("failed to remove Gateway parentRef from %s status: %w", kind, err)
+	}
+
+	debug(log, route, "Unsupported route was previously supported, status was updated")
+	// the status needed to be updated and it was updated successfully
+	return true, nil
+}
+
+func getRouteParentRefs[T gatewayapi.RouteT](route T) []gatewayapi.ParentReference {
+	switch r := any(route).(type) {
+	case *gatewayapi.HTTPRoute:
+		return r.Spec.ParentRefs
+	case *gatewayapi.TCPRoute:
+		return r.Spec.ParentRefs
+	case *gatewayapi.UDPRoute:
+		return r.Spec.ParentRefs
+	case *gatewayapi.TLSRoute:
+		return r.Spec.ParentRefs
+	case *gatewayapi.GRPCRoute:
+		return r.Spec.ParentRefs
+	default:
+		return nil
+	}
 }

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -1432,7 +1432,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					namespace,
 				},
 				expected:    []expected{},
-				expectedErr: fmt.Errorf("no supported Gateway found for route"),
+				expectedErr: ErrNoSupportedGateway,
 			},
 		}
 

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -322,8 +322,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tcproute)
-			if err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tcproute); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -95,12 +96,28 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 	}
 
-	// because of the additional burden of having to manage reference data-plane
-	// configurations for TCPRoute objects in the underlying Kong Gateway, we
-	// simply reconcile ALL TCPRoute objects. This allows us to drop the backend
-	// data-plane config for an TCPRoute if it somehow becomes disconnected from
-	// a supported Gateway and GatewayClass.
-	return blder.For(&gatewayapi.TCPRoute{}).
+	// We enqueue only routes that are:
+	// - attached during creation or deletion
+	// - have been attached or detached to a reconciled Gateway.
+	// This allows us to drop the backend data-plane config for a route if
+	// it somehow becomes disconnected from a supported Gateway and GatewayClass.
+	return blder.
+		For(&gatewayapi.TCPRoute{},
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(_ event.GenericEvent) bool {
+					return false // we don't need to enqueue from generic
+				},
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -301,21 +318,14 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	debug(log, tcproute, "Retrieving GatewayClass and Gateway for route")
 	gateways, err := getSupportedGatewayForRoute(ctx, log, r.Client, tcproute, r.GatewayNN)
 	if err != nil {
-		if err.Error() == unsupportedGW {
-			debug(log, tcproute, "Unsupported route found, processing to verify whether it was ever supported")
+		if errors.Is(err, ErrNoSupportedGateway) {
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			statusUpdated, err := r.ensureGatewayReferenceStatusRemoved(ctx, tcproute)
+			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tcproute)
 			if err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
-			}
-			if statusUpdated {
-				// the status did in fact needed to be updated, so no need to requeue
-				// as the status update will trigger a requeue.
-				debug(log, tcproute, "Unsupported route was previously supported, status was updated")
-				return ctrl.Result{}, nil
 			}
 
 			// if the route doesn't have a supported Gateway+GatewayClass associated with
@@ -520,34 +530,6 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 	}
 
 	// update the object status in the API
-	if err := r.Status().Update(ctx, tcproute); err != nil {
-		return false, err
-	}
-
-	// the status needed an update and it was updated successfully
-	return true, nil
-}
-
-// ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
-// implementation to prune status references to Gateways supported by this controller
-// in the provided TCPRoute object.
-func (r *TCPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Context, tcproute *gatewayapi.TCPRoute) (bool, error) {
-	// drop all status references to supported Gateway objects
-	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
-	for _, status := range tcproute.Status.Parents {
-		if status.ControllerName != GetControllerName() {
-			newStatuses = append(newStatuses, status)
-		}
-	}
-
-	// if the new list of statuses is the same length as the old
-	// nothing has changed and we're all done.
-	if len(newStatuses) == len(tcproute.Status.Parents) {
-		return false, nil
-	}
-
-	// update the object status in the API
-	tcproute.Status.Parents = newStatuses
 	if err := r.Status().Update(ctx, tcproute); err != nil {
 		return false, err
 	}

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -90,12 +91,28 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 	}
 
-	// because of the additional burden of having to manage reference data-plane
-	// configurations for TLSRoute objects in the underlying Kong Gateway, we
-	// simply reconcile ALL TLSRoute objects. This allows us to drop the backend
-	// data-plane config for an TLSRoute if it somehow becomes disconnected from
-	// a supported Gateway and GatewayClass.
-	return blder.For(&gatewayapi.TLSRoute{}).
+	// We enqueue only routes that are:
+	// - attached during creation or deletion
+	// - have been attached or detached to a reconciled Gateway.
+	// This allows us to drop the backend data-plane config for a route if
+	// it somehow becomes disconnected from a supported Gateway and GatewayClass.
+	return blder.
+		For(&gatewayapi.TLSRoute{},
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(_ event.GenericEvent) bool {
+					return false // we don't need to enqueue from generic
+				},
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -296,21 +313,14 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	debug(log, tlsroute, "Retrieving GatewayClass and Gateway for route")
 	gateways, err := getSupportedGatewayForRoute(ctx, log, r.Client, tlsroute, r.GatewayNN)
 	if err != nil {
-		if err.Error() == unsupportedGW {
-			debug(log, tlsroute, "Unsupported route found, processing to verify whether it was ever supported")
+		if errors.Is(err, ErrNoSupportedGateway) {
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			statusUpdated, err := r.ensureGatewayReferenceStatusRemoved(ctx, tlsroute)
+			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tlsroute)
 			if err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
-			}
-			if statusUpdated {
-				// the status did in fact needed to be updated, so no need to requeue
-				// as the status update will trigger a requeue.
-				debug(log, tlsroute, "Unsupported route was previously supported, status was updated")
-				return ctrl.Result{}, nil
 			}
 
 			// if the route doesn't have a supported Gateway+GatewayClass associated with
@@ -506,34 +516,6 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	}
 
 	// update the object status in the API
-	if err := r.Status().Update(ctx, tlsroute); err != nil {
-		return false, err
-	}
-
-	// the status needed an update and it was updated successfully
-	return true, nil
-}
-
-// ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
-// implementation to prune status references to Gateways supported by this controller
-// in the provided TLSRoute object.
-func (r *TLSRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Context, tlsroute *gatewayapi.TLSRoute) (bool, error) {
-	// drop all status references to supported Gateway objects
-	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
-	for _, status := range tlsroute.Status.Parents {
-		if status.ControllerName != GetControllerName() {
-			newStatuses = append(newStatuses, status)
-		}
-	}
-
-	// if the new list of statuses is the same length as the old
-	// nothing has changed and we're all done.
-	if len(newStatuses) == len(tlsroute.Status.Parents) {
-		return false, nil
-	}
-
-	// update the object status in the API
-	tlsroute.Status.Parents = newStatuses
 	if err := r.Status().Update(ctx, tlsroute); err != nil {
 		return false, err
 	}

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -317,8 +317,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tlsroute)
-			if err != nil {
+			if _, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, tlsroute); err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
 			}

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -94,12 +95,28 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 	}
 
-	// because of the additional burden of having to manage reference data-plane
-	// configurations for UDPRoute objects in the underlying Kong Gateway, we
-	// simply reconcile ALL UDPRoute objects. This allows us to drop the backend
-	// data-plane config for an UDPRoute if it somehow becomes disconnected from
-	// a supported Gateway and GatewayClass.
-	return blder.For(&gatewayapi.UDPRoute{}).
+	// We enqueue only routes that are:
+	// - attached during creation or deletion
+	// - have been attached or detached to a reconciled Gateway.
+	// This allows us to drop the backend data-plane config for a route if
+	// it somehow becomes disconnected from a supported Gateway and GatewayClass.
+	return blder.
+		For(&gatewayapi.UDPRoute{},
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(_ event.GenericEvent) bool {
+					return false // we don't need to enqueue from generic
+				},
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return isRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -300,21 +317,14 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	debug(log, udproute, "Retrieving GatewayClass and Gateway for route")
 	gateways, err := getSupportedGatewayForRoute(ctx, log, r.Client, udproute, r.GatewayNN)
 	if err != nil {
-		if err.Error() == unsupportedGW {
-			debug(log, udproute, "Unsupported route found, processing to verify whether it was ever supported")
+		if errors.Is(err, ErrNoSupportedGateway) {
 			// if there's no supported Gateway then this route could have been previously
 			// supported by this controller. As such we ensure that no supported Gateway
 			// references exist in the object status any longer.
-			statusUpdated, err := r.ensureGatewayReferenceStatusRemoved(ctx, udproute)
+			_, err := ensureGatewayReferenceStatusRemoved(ctx, r.Client, log, udproute)
 			if err != nil {
 				// some failure happened so we need to retry to avoid orphaned statuses
 				return ctrl.Result{}, err
-			}
-			if statusUpdated {
-				// the status did in fact needed to be updated, so no need to requeue
-				// as the status update will trigger a requeue.
-				debug(log, udproute, "Unsupported route was previously supported, status was updated")
-				return ctrl.Result{}, nil
 			}
 
 			// if the route doesn't have a supported Gateway+GatewayClass associated with
@@ -510,34 +520,6 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	}
 
 	// update the object status in the API
-	if err := r.Status().Update(ctx, udproute); err != nil {
-		return false, err
-	}
-
-	// the status needed an update and it was updated successfully
-	return true, nil
-}
-
-// ensureGatewayReferenceStatusRemoved uses the ControllerName provided by the Gateway
-// implementation to prune status references to Gateways supported by this controller
-// in the provided UDPRoute object.
-func (r *UDPRouteReconciler) ensureGatewayReferenceStatusRemoved(ctx context.Context, udproute *gatewayapi.UDPRoute) (bool, error) {
-	// drop all status references to supported Gateway objects
-	newStatuses := make([]gatewayapi.RouteParentStatus, 0)
-	for _, status := range udproute.Status.Parents {
-		if status.ControllerName != GetControllerName() {
-			newStatuses = append(newStatuses, status)
-		}
-	}
-
-	// if the new list of statuses is the same length as the old
-	// nothing has changed and we're all done.
-	if len(newStatuses) == len(udproute.Status.Parents) {
-		return false, nil
-	}
-
-	// update the object status in the API
-	udproute.Status.Parents = newStatuses
 	if err := r.Status().Update(ctx, udproute); err != nil {
 		return false, err
 	}

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -104,7 +104,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayapi.UDPRoute{},
 			builder.WithPredicates(predicate.Funcs{
 				GenericFunc: func(_ event.GenericEvent) bool {
-					return false // we don't need to enqueue from generic
+					return false // We don't need to enqueue from generic.
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
 					return isRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -6,7 +6,10 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-var InstallV1 = gatewayv1.Install
+var (
+	InstallV1    = gatewayv1.Install
+	GroupVersion = gatewayv1.GroupVersion
+)
 
 // This file contains aliases for types and consts from the Gateway API.  Its purpose is to allow easy migration from
 // one version of the Gateway API to another with minimal changes to the codebase.
@@ -20,6 +23,7 @@ type (
 	Gateway                   = gatewayv1.Gateway
 	GatewayAddress            = gatewayv1.GatewayAddress
 	GatewayClass              = gatewayv1.GatewayClass
+	GatewayClassList          = gatewayv1.GatewayClassList
 	GatewayClassSpec          = gatewayv1.GatewayClassSpec
 	GatewayClassStatus        = gatewayv1.GatewayClassStatus
 	GatewayController         = gatewayv1.GatewayController

--- a/test/internal/helpers/gatewayapi.go
+++ b/test/internal/helpers/gatewayapi.go
@@ -119,7 +119,7 @@ func gatewayLinkStatusMatches(
 		groute, gerr := c.GatewayV1alpha2().GRPCRoutes(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil && gerr != nil {
 			t.Logf("error getting http route: %v", err)
-			t.Logf("error getting grpc route: %v", err)
+			t.Logf("error getting grpc route: %v", gerr)
 		} else {
 			if err == nil {
 				return newRouteParentsStatus(route.Status.Parents).


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue when there's more than 1 KIC (or there are other controllers that reconcile ~HTTPRoutes~ Gateway API *Routes) and KIC then tries to clear status of ~`HTTPRoute`~  *Routes that it should not touch (anymore).

**Which issue this PR fixes**:

Fixes #6067

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
