### PR TITLE
feat: use TakeSnapshotIfChanged to avoid taking redundant snapshot

### DIFF
--- a/internal/dataplane/fallback/fallback.go
+++ b/internal/dataplane/fallback/fallback.go
@@ -27,8 +27,8 @@ func NewGenerator(cacheGraphProvider CacheGraphProvider, logger logr.Logger) *Ge
 	}
 }
 
-// GenerateExcludingAffected generates a new cache snapshot that excludes all objects that depend on the broken objects.
-func (g *Generator) GenerateExcludingAffected(
+// GenerateExcludingBrokenObjects generates a new cache snapshot that excludes all objects that depend on the broken objects.
+func (g *Generator) GenerateExcludingBrokenObjects(
 	cache store.CacheStores,
 	brokenObjects []ObjectHash,
 ) (store.CacheStores, error) {
@@ -37,7 +37,7 @@ func (g *Generator) GenerateExcludingAffected(
 		return store.CacheStores{}, fmt.Errorf("failed to build cache graph: %w", err)
 	}
 
-	fallbackCache, err := cache.TakeSnapshot()
+	fallbackCache, _, err := cache.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
 	if err != nil {
 		return store.CacheStores{}, fmt.Errorf("failed to take cache snapshot: %w", err)
 	}

--- a/internal/dataplane/fallback/fallback_test.go
+++ b/internal/dataplane/fallback/fallback_test.go
@@ -22,7 +22,7 @@ func (m *mockGraphProvider) CacheToGraph(s store.CacheStores) (*fallback.ConfigG
 	return m.graph, nil
 }
 
-func TestGenerator_GenerateExcludingAffected(t *testing.T) {
+func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 	// We have to use real-world object types here as we're testing integration with store.CacheStores.
 	ingressClass := testIngressClass(t, "ingressClass")
 	service := testService(t, "service")
@@ -57,7 +57,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	g := fallback.NewGenerator(graphProvider, logr.Discard())
 
 	t.Run("ingressClass is broken", func(t *testing.T) {
-		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})
+		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})
 		require.NoError(t, err)
 		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
@@ -68,7 +68,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	})
 
 	t.Run("service is broken", func(t *testing.T) {
-		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(service)})
+		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(service)})
 		require.NoError(t, err)
 		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
@@ -79,7 +79,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	})
 
 	t.Run("serviceFacade is broken", func(t *testing.T) {
-		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(serviceFacade)})
+		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(serviceFacade)})
 		require.NoError(t, err)
 		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
@@ -90,7 +90,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	})
 
 	t.Run("plugin is broken", func(t *testing.T) {
-		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(plugin)})
+		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(plugin)})
 		require.NoError(t, err)
 		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
@@ -101,7 +101,7 @@ func TestGenerator_GenerateExcludingAffected(t *testing.T) {
 	})
 
 	t.Run("multiple objects are broken", func(t *testing.T) {
-		fallbackCache, err := g.GenerateExcludingAffected(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass), fallback.GetObjectHash(service)})
+		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass), fallback.GetObjectHash(service)})
 		require.NoError(t, err)
 		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)

--- a/internal/store/cache_stores_snapshot.go
+++ b/internal/store/cache_stores_snapshot.go
@@ -14,6 +14,8 @@ import (
 )
 
 // TakeSnapshot takes a snapshot of the CacheStores.
+//
+// Deprecated: use TakeSnapshotIfChanged instead.
 func (c CacheStores) TakeSnapshot() (CacheStores, error) {
 	// Create a fresh CacheStores instance to store the snapshot
 	// in the c.takeSnapshot method. It happens here because it's
@@ -97,7 +99,7 @@ func (c CacheStores) TakeSnapshotIfChanged(previousSnapshotHash SnapshotHash) (
 			return string(uid) + resourceVer
 		})
 		if capturedErr != nil {
-			return CacheStores{}, "", capturedErr
+			return CacheStores{}, SnapshotHashEmpty, capturedErr
 		}
 		// Strings have to be used instead of byte slices, because Cmp.Ordered has to be satisfied.
 		slices.Sort(valuesForHashComputation)
@@ -110,12 +112,12 @@ func (c CacheStores) TakeSnapshotIfChanged(previousSnapshotHash SnapshotHash) (
 
 	// If the hash of the current state is the same as the hash of the previous snapshot, return an empty snapshot.
 	if newHash == previousSnapshotHash {
-		return CacheStores{}, "", nil
+		return CacheStores{}, SnapshotHashEmpty, nil
 	}
 
 	// Take a snapshot of the current state as the hash of the current state differs from the previous one.
 	if err := takeSnapshot(&snapshot, listOfStores); err != nil {
-		return CacheStores{}, "", fmt.Errorf("failed to take snapshot: %w", err)
+		return CacheStores{}, SnapshotHashEmpty, fmt.Errorf("failed to take snapshot: %w", err)
 	}
 	return snapshot, newHash, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Replaces usage of `TakeSnapshot` with `TakeSnapshotIfChanged` that was introduced in 

- https://github.com/Kong/kubernetes-ingress-controller/pull/6017

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6080

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

