### PR TITLE
feat: backfill broken objects from last valid cache state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,9 @@ Adding a new version? You'll need three changes:
   [#6010](https://github.com/Kong/kubernetes-ingress-controller/pull/6010)
   [#6047](https://github.com/Kong/kubernetes-ingress-controller/pull/6047)
   [#6071](https://github.com/Kong/kubernetes-ingress-controller/pull/6071)
-  
+- Added `--use-last-valid-config-for-fallback` CLI flag to enable using the last valid configuration cache
+  to backfill excluded broken objects when the `FallbackConfiguration` feature gate is enabled.
+  [#6098](https://github.com/Kong/kubernetes-ingress-controller/pull/6098)
 - Add support for Kubernetes Gateway API v1.1:
   - add a flag `--enable-controller-gwapi-grpcroute` to control whether enable or disable GRPCRoute controller.
   - add support for `GRPCRoute` v1, which requires users to upgrade the Gateway API's CRD to v1.1.

--- a/FEATURE_GATES.md
+++ b/FEATURE_GATES.md
@@ -70,6 +70,7 @@ Features that reach GA and over time become stable will be removed from this tab
 | RewriteURIs                | `false` | Alpha | 2.12.0 | TBD   |
 | KongServiceFacade          | `false` | Alpha | 3.1.0  | TBD   |
 | SanitizeKonnectConfigDumps | `true`  | Beta  | 3.1.0  | TBD   |
+| FallbackConfiguration      | `false` | Alpha | 3.2.0  | TBD   |
 
 **NOTE**: The `Gateway` feature gate refers to [Gateway
  API](https://github.com/kubernetes-sigs/gateway-api) APIs which are in

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -4,6 +4,7 @@
 
 | Flag | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
+| `----use-last-valid-config-for-fallback` | `bool` | When recovering from config push failures, use the last valid configuration cache to backfill broken objects. | `false` |
 | `--admission-webhook-cert` | `string` | Admission server PEM certificate value. Mutually exclusive with --admission-webhook-cert-file. |  |
 | `--admission-webhook-cert-file` | `string` | Admission server PEM certificate file path. If both this and the cert value is unset, defaults to /admission-webhook/tls.crt. Mutually exclusive with --admission-webhook-cert. |  |
 | `--admission-webhook-key` | `string` | Admission server PEM private key value. Mutually exclusive with --admission-webhook-key-file. |  |

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -4,7 +4,6 @@
 
 | Flag | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `----use-last-valid-config-for-fallback` | `bool` | When recovering from config push failures, use the last valid configuration cache to backfill broken objects. | `false` |
 | `--admission-webhook-cert` | `string` | Admission server PEM certificate value. Mutually exclusive with --admission-webhook-cert-file. |  |
 | `--admission-webhook-cert-file` | `string` | Admission server PEM certificate file path. If both this and the cert value is unset, defaults to /admission-webhook/tls.crt. Mutually exclusive with --admission-webhook-cert. |  |
 | `--admission-webhook-key` | `string` | Admission server PEM private key value. Mutually exclusive with --admission-webhook-key-file. |  |
@@ -92,4 +91,5 @@
 | `--term-delay` | `duration` | The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller. | `0s` |
 | `--update-status` | `bool` | Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.). | `true` |
 | `--update-status-queue-buffer-size` | `int` | Buffer size of the underlying channels used to update the status of resources. | `8192` |
+| `--use-last-valid-config-for-fallback` | `bool` | When recovering from config push failures, use the last valid configuration cache to backfill broken objects. | `false` |
 | `--watch-namespace` | `strings` | Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces. | `[]` |

--- a/internal/dataplane/fallback/fallback.go
+++ b/internal/dataplane/fallback/fallback.go
@@ -37,7 +37,7 @@ func (g *Generator) GenerateExcludingBrokenObjects(
 		return store.CacheStores{}, fmt.Errorf("failed to build cache graph: %w", err)
 	}
 
-	fallbackCache, _, err := cache.TakeSnapshotIfChanged(store.SnapshotHashEmpty)
+	fallbackCache, err := cache.TakeSnapshot()
 	if err != nil {
 		return store.CacheStores{}, fmt.Errorf("failed to take cache snapshot: %w", err)
 	}
@@ -59,5 +59,43 @@ func (g *Generator) GenerateExcludingBrokenObjects(
 		}
 	}
 
+	return fallbackCache, nil
+}
+
+func (g *Generator) GenerateBackfillingBrokenObjects(
+	currentCache store.CacheStores,
+	lastValidCacheSnapshot store.CacheStores,
+	brokenObjects []ObjectHash,
+) (store.CacheStores, error) {
+	// Generate a fallback cache snapshot excluding the broken objects.
+	fallbackCache, err := g.GenerateExcludingBrokenObjects(currentCache, brokenObjects)
+	if err != nil {
+		return store.CacheStores{}, fmt.Errorf("failed to generate fallback cache: %w", err)
+	}
+
+	// Build a graph from the last valid cache snapshot.
+	lastValidGraph, err := g.cacheGraphProvider.CacheToGraph(lastValidCacheSnapshot)
+	if err != nil {
+		return store.CacheStores{}, fmt.Errorf("failed to build cache graph: %w", err)
+	}
+
+	// Backfill the broken objects from the last valid cache snapshot.
+	for _, brokenObject := range brokenObjects {
+		objectsToBackfill, err := lastValidGraph.SubgraphObjects(brokenObject)
+		if err != nil {
+			return store.CacheStores{}, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
+		}
+
+		for _, obj := range objectsToBackfill {
+			if err := fallbackCache.Add(obj); err != nil {
+				return store.CacheStores{}, fmt.Errorf("failed to add %s to the cache: %w", GetObjectHash(obj), err)
+			}
+			g.logger.V(util.DebugLevel).Info("Backfilled object to fallback cache",
+				"object_kind", obj.GetObjectKind(),
+				"object_name", obj.GetName(),
+				"object_namespace", obj.GetNamespace(),
+			)
+		}
+	}
 	return fallbackCache, nil
 }

--- a/internal/dataplane/fallback/fallback_test.go
+++ b/internal/dataplane/fallback/fallback_test.go
@@ -1,25 +1,58 @@
 package fallback_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
 )
 
 // mockGraphProvider is a mock implementation of the CacheGraphProvider interface.
 type mockGraphProvider struct {
-	graph               *fallback.ConfigGraph
-	lastCalledWithStore store.CacheStores
+	graphToReturnOn   map[store.CacheStores]*fallback.ConfigGraph
+	cacheToGraphCalls []store.CacheStores
 }
 
 // CacheToGraph returns the graph that was set on the mockGraphProvider. It also records the last store that was passed to it.
 func (m *mockGraphProvider) CacheToGraph(s store.CacheStores) (*fallback.ConfigGraph, error) {
-	m.lastCalledWithStore = s
-	return m.graph, nil
+	m.cacheToGraphCalls = append(m.cacheToGraphCalls, s)
+	if g, ok := m.graphToReturnOn[s]; ok {
+		return g, nil
+	}
+	return nil, errors.New("unexpected call")
+}
+
+// ReturnGraphOn sets the graph that should be returned when CacheToGraph is called with the given cache stores.
+func (m *mockGraphProvider) ReturnGraphOn(cache store.CacheStores, graph *fallback.ConfigGraph) {
+	if m.graphToReturnOn == nil {
+		m.graphToReturnOn = make(map[store.CacheStores]*fallback.ConfigGraph)
+	}
+	m.graphToReturnOn[cache] = graph
+}
+
+// CacheToGraphLastCalledWith returns the last cache stores that were passed to CacheToGraph.
+func (m *mockGraphProvider) CacheToGraphLastCalledWith() store.CacheStores {
+	if len(m.cacheToGraphCalls) == 0 {
+		return store.CacheStores{}
+	}
+	return m.cacheToGraphCalls[len(m.cacheToGraphCalls)-1]
+}
+
+// CacheToGraphLastNCalledWith returns the last N cache stores that were passed to CacheToGraph.
+func (m *mockGraphProvider) CacheToGraphLastNCalledWith(n int) []store.CacheStores {
+	if n > len(m.cacheToGraphCalls) {
+		n = len(m.cacheToGraphCalls)
+	}
+	return m.cacheToGraphCalls[len(m.cacheToGraphCalls)-n:]
 }
 
 func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
@@ -53,13 +86,14 @@ func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	graphProvider := &mockGraphProvider{graph: graph}
+	graphProvider := &mockGraphProvider{}
+	graphProvider.ReturnGraphOn(inputCacheStores, graph)
 	g := fallback.NewGenerator(graphProvider, logr.Discard())
 
 	t.Run("ingressClass is broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})
 		require.NoError(t, err)
-		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.Equal(t, inputCacheStores, graphProvider.CacheToGraphLastCalledWith(), "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
 		require.Empty(t, fallbackCache.IngressClassV1.List(), "ingressClass should be excluded as it's broken")
 		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it depends on ingressClass")
@@ -70,7 +104,7 @@ func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 	t.Run("service is broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(service)})
 		require.NoError(t, err)
-		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.Equal(t, inputCacheStores, graphProvider.CacheToGraphLastCalledWith(), "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
 		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it's broken")
 		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it depends on service")
@@ -81,7 +115,7 @@ func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 	t.Run("serviceFacade is broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(serviceFacade)})
 		require.NoError(t, err)
-		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.Equal(t, inputCacheStores, graphProvider.CacheToGraphLastCalledWith(), "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
 		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it's broken")
 		require.ElementsMatch(t, fallbackCache.IngressClassV1.List(), []any{ingressClass}, "ingressClass shouldn't be excluded as it doesn't depend on service")
@@ -92,7 +126,7 @@ func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 	t.Run("plugin is broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(plugin)})
 		require.NoError(t, err)
-		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.Equal(t, inputCacheStores, graphProvider.CacheToGraphLastCalledWith(), "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
 		require.Empty(t, fallbackCache.Plugin.List(), "plugin should be excluded as it's broken")
 		require.ElementsMatch(t, fallbackCache.IngressClassV1.List(), []any{ingressClass}, "ingressClass shouldn't be excluded as it doesn't depend on plugin")
@@ -103,11 +137,189 @@ func TestGenerator_GenerateExcludingBrokenObjects(t *testing.T) {
 	t.Run("multiple objects are broken", func(t *testing.T) {
 		fallbackCache, err := g.GenerateExcludingBrokenObjects(inputCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass), fallback.GetObjectHash(service)})
 		require.NoError(t, err)
-		require.Equal(t, inputCacheStores, graphProvider.lastCalledWithStore, "expected the generator to call CacheToGraph with the input cache stores")
+		require.Equal(t, inputCacheStores, graphProvider.CacheToGraphLastCalledWith(), "expected the generator to call CacheToGraph with the input cache stores")
 		require.NotSame(t, inputCacheStores, fallbackCache)
 		require.Empty(t, fallbackCache.IngressClassV1.List(), "ingressClass should be excluded as it's broken")
 		require.Empty(t, fallbackCache.Service.List(), "service should be excluded as it's broken")
 		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it depends on service")
 		require.ElementsMatch(t, fallbackCache.Plugin.List(), []any{plugin}, "plugin shouldn't be excluded as it doesn't depend on either ingressClass or service")
+	})
+}
+
+func TestGenerator_GenerateBackfillingBrokenObjects(t *testing.T) {
+	// We have to use real-world object types here as we're testing integration with store.CacheStores.
+	ingressClass := testIngressClass(t, "ingressClass")
+	service := testService(t, "service")
+	serviceFacade := testKongServiceFacade(t, "serviceFacade")
+	plugin := testKongPlugin(t, "kongPlugin")
+	inputCacheStores := cacheStoresFromObjs(t, ingressClass, service, serviceFacade, plugin)
+
+	// We'll annotate the last valid objects, so we can verify that they were recovered from the last valid cache snapshot.
+	const lastValidAnnotationKey = "from-last-valid"
+	annotatedLastValid := func(o client.Object) client.Object {
+		o.SetAnnotations(map[string]string{lastValidAnnotationKey: "true"})
+		return o
+	}
+	requireAnnotatedLastValid := func(t *testing.T, o client.Object) {
+		require.Equal(t, "true", o.GetAnnotations()[lastValidAnnotationKey], "expected the object to be recovered from the last valid cache snapshot")
+	}
+	requireNotAnnotatedLastValid := func(t *testing.T, o client.Object) {
+		require.NotContains(t, o.GetAnnotations(), lastValidAnnotationKey, "expected the object to not be recovered from the last valid cache snapshot")
+	}
+
+	lastValidIngressClass := annotatedLastValid(testIngressClass(t, "ingressClass"))
+	lastValidService := annotatedLastValid(testService(t, "service"))
+	lastValidPlugin := annotatedLastValid(testKongPlugin(t, "kongPlugin"))
+	lastValidCacheStores := cacheStoresFromObjs(t, lastValidIngressClass, lastValidService, lastValidPlugin)
+
+	// This graph doesn't reflect real dependencies between the objects - it's only used for testing purposes.
+	// It will be injected into the Generator via the mockGraphProvider.
+	// Dependency resolving between the objects is tested in TestResolveDependencies_* tests.
+	//
+	// Graph structure (edges define dependency -> dependant relationship):
+	//  ┌────────────┐  ┌──────┐
+	//  │ingressClass│  │plugin│
+	//  └──────┬─────┘  └──────┘
+	//         │
+	//     ┌───▼───┐
+	//     │service│
+	//     └───┬───┘
+	//         │
+	//  ┌──────▼──────┐
+	//  │serviceFacade│
+	//  └─────────────┘
+	graph, err := NewGraphBuilder().
+		WithVertices(ingressClass, service, serviceFacade, plugin).
+		WithEdge(ingressClass, service).
+		WithEdge(service, serviceFacade).
+		Build()
+	require.NoError(t, err)
+
+	// Fallback graph differs from the input graph by lack of the serviceFacade.
+	//  ┌────────────┐  ┌──────┐
+	//  │ingressClass│  │plugin│
+	//  └──────┬─────┘  └──────┘
+	//         │
+	//     ┌───▼───┐
+	//     │service│
+	//     └───────┘
+	lastValidGraph, err := NewGraphBuilder().
+		WithVertices(lastValidIngressClass, lastValidService, lastValidPlugin).
+		WithEdge(lastValidIngressClass, lastValidService).
+		Build()
+	require.NoError(t, err)
+
+	graphProvider := &mockGraphProvider{}
+	graphProvider.ReturnGraphOn(inputCacheStores, graph)
+	graphProvider.ReturnGraphOn(lastValidCacheStores, lastValidGraph)
+	g := fallback.NewGenerator(graphProvider, logr.Discard())
+
+	t.Run("ingressClass is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateBackfillingBrokenObjects(inputCacheStores, lastValidCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass)})
+		require.NoError(t, err)
+		require.Equal(t, []store.CacheStores{inputCacheStores, lastValidCacheStores}, graphProvider.CacheToGraphLastNCalledWith(2),
+			"expected the generator to call CacheToGraph with the input cache stores and the last valid cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+
+		fallbackIngressClass, err := getFromStore[*netv1.IngressClass](fallbackCache.IngressClassV1, ingressClass)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackIngressClass)
+
+		fallbackService, err := getFromStore[*corev1.Service](fallbackCache.Service, service)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackService)
+
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade shouldn't be recovered as it wasn't in the last valid cache snapshot")
+
+		fallbackPlugin, err := getFromStore[*kongv1.KongPlugin](fallbackCache.Plugin, plugin)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackPlugin)
+	})
+
+	t.Run("service is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateBackfillingBrokenObjects(inputCacheStores, lastValidCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(service)})
+		require.NoError(t, err)
+		require.Equal(t, []store.CacheStores{inputCacheStores, lastValidCacheStores}, graphProvider.CacheToGraphLastNCalledWith(2),
+			"expected the generator to call CacheToGraph with the input cache stores and fallback cache")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+
+		fallbackService, err := getFromStore[*corev1.Service](fallbackCache.Service, service)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackService)
+
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade shouldn't be recovered as it wasn't in the last valid cache snapshot")
+
+		fallbackPlugin, err := getFromStore[*kongv1.KongPlugin](fallbackCache.Plugin, plugin)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackPlugin)
+
+		fallbackIngressClass, err := getFromStore[*netv1.IngressClass](fallbackCache.IngressClassV1, ingressClass)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackIngressClass)
+	})
+
+	t.Run("serviceFacade is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateBackfillingBrokenObjects(inputCacheStores, lastValidCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(serviceFacade)})
+		require.NoError(t, err)
+		require.Equal(t, []store.CacheStores{inputCacheStores, lastValidCacheStores}, graphProvider.CacheToGraphLastNCalledWith(2), "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade should be excluded as it's broken and it's not present in the last valid cache snapshot")
+
+		fallbackIngressClass, err := getFromStore[*netv1.IngressClass](fallbackCache.IngressClassV1, ingressClass)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackIngressClass)
+
+		fallbackService, err := getFromStore[*corev1.Service](fallbackCache.Service, service)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackService)
+
+		fallbackPlugin, err := getFromStore[*kongv1.KongPlugin](fallbackCache.Plugin, plugin)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackPlugin)
+	})
+
+	t.Run("plugin is broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateBackfillingBrokenObjects(inputCacheStores, lastValidCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(plugin)})
+		require.NoError(t, err)
+		require.Equal(t, []store.CacheStores{inputCacheStores, lastValidCacheStores}, graphProvider.CacheToGraphLastNCalledWith(2), "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+
+		fallbackPlugin, err := getFromStore[*kongv1.KongPlugin](fallbackCache.Plugin, plugin)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackPlugin)
+
+		fallbackIngressClass, err := getFromStore[*netv1.IngressClass](fallbackCache.IngressClassV1, ingressClass)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackIngressClass)
+
+		fallbackService, err := getFromStore[*corev1.Service](fallbackCache.Service, service)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackService)
+
+		fallbackServiceFacade, err := getFromStore[*incubatorv1alpha1.KongServiceFacade](fallbackCache.KongServiceFacade, serviceFacade)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackServiceFacade)
+	})
+
+	t.Run("multiple objects are broken", func(t *testing.T) {
+		fallbackCache, err := g.GenerateBackfillingBrokenObjects(inputCacheStores, lastValidCacheStores, []fallback.ObjectHash{fallback.GetObjectHash(ingressClass), fallback.GetObjectHash(service)})
+		require.NoError(t, err)
+		require.Equal(t, []store.CacheStores{inputCacheStores, lastValidCacheStores}, graphProvider.CacheToGraphLastNCalledWith(2), "expected the generator to call CacheToGraph with the input cache stores")
+		require.NotSame(t, inputCacheStores, fallbackCache)
+
+		fallbackIngressClass, err := getFromStore[*netv1.IngressClass](fallbackCache.IngressClassV1, ingressClass)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackIngressClass)
+
+		fallbackService, err := getFromStore[*corev1.Service](fallbackCache.Service, service)
+		require.NoError(t, err)
+		requireAnnotatedLastValid(t, fallbackService)
+
+		require.Empty(t, fallbackCache.KongServiceFacade.List(), "serviceFacade shouldn't be recovered as it wasn't in the last valid cache snapshot")
+
+		fallbackPlugin, err := getFromStore[*kongv1.KongPlugin](fallbackCache.Plugin, plugin)
+		require.NoError(t, err)
+		requireNotAnnotatedLastValid(t, fallbackPlugin)
 	})
 }

--- a/internal/dataplane/fallback/fallback_test.go
+++ b/internal/dataplane/fallback/fallback_test.go
@@ -49,8 +49,8 @@ func (m *mockGraphProvider) CacheToGraphLastCalledWith() store.CacheStores {
 
 // CacheToGraphLastNCalledWith returns the last N cache stores that were passed to CacheToGraph.
 func (m *mockGraphProvider) CacheToGraphLastNCalledWith(n int) []store.CacheStores {
-	if n > len(m.cacheToGraphCalls) {
-		n = len(m.cacheToGraphCalls)
+	if maxLen := len(m.cacheToGraphCalls); n > maxLen {
+		n = maxLen
 	}
 	return m.cacheToGraphCalls[len(m.cacheToGraphCalls)-n:]
 }

--- a/internal/dataplane/fallback/graph_test.go
+++ b/internal/dataplane/fallback/graph_test.go
@@ -19,6 +19,7 @@ func TestConfigGraph_SubgraphObjects(t *testing.T) {
 		F = NewMockObject("F")
 		G = NewMockObject("G")
 		H = NewMockObject("H")
+		I = NewMockObject("I") // Not included in the graph.
 	)
 
 	// Graph structure (edges define dependency -> dependant relationship):
@@ -80,4 +81,8 @@ func TestConfigGraph_SubgraphObjects(t *testing.T) {
 	objects, err = g.SubgraphObjects(fallback.GetObjectHash(H))
 	require.NoError(t, err)
 	require.ElementsMatch(t, []client.Object{H}, objects)
+
+	objects, err = g.SubgraphObjects(fallback.GetObjectHash(I))
+	require.NoError(t, err)
+	require.Empty(t, objects, "expected no objects for a source object not in the graph")
 }

--- a/internal/dataplane/fallback/graph_test.go
+++ b/internal/dataplane/fallback/graph_test.go
@@ -84,5 +84,5 @@ func TestConfigGraph_SubgraphObjects(t *testing.T) {
 
 	objects, err = g.SubgraphObjects(fallback.GetObjectHash(I))
 	require.NoError(t, err)
-	require.Empty(t, objects, "expected no objects for a source object not in the graph")
+	require.Empty(t, objects, "expected no objects returned for a source object not in the graph")
 }

--- a/internal/dataplane/fallback/helpers_test.go
+++ b/internal/dataplane/fallback/helpers_test.go
@@ -169,11 +169,11 @@ func (m *MockObject) DeepCopyObject() runtime.Object {
 // getFromStore retrieves an object of type T from the given cache store.
 func getFromStore[T client.Object](c cache.Store, obj client.Object) (client.Object, error) {
 	o, exists, err := c.Get(obj)
-	if !exists {
-		return nil, errors.New("object not found")
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get object: %w", err)
+	}
+	if !exists {
+		return nil, errors.New("object not found")
 	}
 	typedObject, ok := o.(T)
 	if !ok {

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -164,6 +164,9 @@ type KongClient struct {
 	// lastValidCacheSnapshot stores the state of the cache that was last successfully synced with the gateways.
 	// Please note it is only populated when the `FallbackConfiguration` feature gate is turned on and the
 	// `--use-last-valid-config-for-fallback` flag is set.
+	// lastValidCacheSnapshot and lastProcessedSnapshotHash do not always keep values related to the same cache snapshot.
+	// While lastProcessedSnapshotHash keeps track of the last processed cache snapshot (the one kept in KongClient.cache),
+	// lastValidCacheSnapshot can also represent the fallback cache snapshot that was successfully synced with gateways.
 	lastValidCacheSnapshot store.CacheStores
 }
 

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -1109,7 +1109,8 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 			)
 
 			t.Log("Verifying that the last valid config is updated with the config excluding the broken consumer")
-			lastValidConfig, _ := lastValidConfigFetcher.LastValidConfig()
+			lastValidConfig, ok := lastValidConfigFetcher.LastValidConfig()
+			require.True(t, ok)
 			require.Len(t, lastValidConfig.Consumers, 1)
 			require.Equal(t, validConsumer.Username, *lastValidConfig.Consumers[0].Username)
 		})
@@ -1333,11 +1334,11 @@ func TestKongClient_LastValidCacheSnapshot(t *testing.T) {
 			err = kongClient.Update(ctx)
 			require.NoError(t, err)
 
+			lastValid := kongClient.lastValidCacheSnapshot
 			if tc.expectLastValidCacheSnapshotToBeSet {
-				lastValid := kongClient.lastValidCacheSnapshot
 				require.NotEmpty(t, lastValid, "expected last valid cache snapshot to be set after successful update")
 			} else {
-				require.Empty(t, kongClient.lastValidCacheSnapshot, "expected last valid cache snapshot to remain empty")
+				require.Empty(t, lastValid, "expected last valid cache snapshot to remain empty")
 			}
 		})
 	}

--- a/internal/dataplane/sendconfig/kong.go
+++ b/internal/dataplane/sendconfig/kong.go
@@ -37,4 +37,8 @@ type Config struct {
 	// FallbackConfiguration indicates whether to generate fallback configuration in the case of entity
 	// errors returned by the Kong Admin API.
 	FallbackConfiguration bool
+
+	// UseLastValidConfigForFallback indicates whether to use the last valid config cache to backfill broken objects
+	// when recovering from a config push failure.
+	UseLastValidConfigForFallback bool
 }

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -180,7 +180,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong.`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
-	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "--use-last-valid-config-for-fallback", false, `When recovering from config push failures, use the last valid configuration cache to backfill broken objects.`)
+	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, `When recovering from config push failures, use the last valid configuration cache to backfill broken objects.`)
 	// Default has to be explicitly passed to generate the proper docs. See https://github.com/kubernetes-sigs/controller-runtime/blob/f1c5dd3851ce3df8b4b7830d9b6eae6271f6932d/pkg/cache/cache.go#L146-L151.
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", 10*time.Hour, `Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.`)
 	flagSet.BoolVar(&c.SkipCACertificates, "skip-ca-certificates", false, `Disable syncing CA certificate syncing (for use with multi-workspace environments).`)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	KongWorkspace                     string
 	AnonymousReports                  bool
 	EnableReverseSync                 bool
+	UseLastValidConfigForFallback     bool
 	SyncPeriod                        time.Duration
 	SkipCACertificates                bool
 	CacheSyncTimeout                  time.Duration
@@ -179,6 +180,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong.`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
+	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "--use-last-valid-config-for-fallback", false, `When recovering from config push failures, use the last valid configuration cache to backfill broken objects.`)
 	// Default has to be explicitly passed to generate the proper docs. See https://github.com/kubernetes-sigs/controller-runtime/blob/f1c5dd3851ce3df8b4b7830d9b6eae6271f6932d/pkg/cache/cache.go#L146-L151.
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", 10*time.Hour, `Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.`)
 	flagSet.BoolVar(&c.SkipCACertificates, "skip-ca-certificates", false, `Disable syncing CA certificate syncing (for use with multi-workspace environments).`)

--- a/internal/store/cache_stores_snapshot.go
+++ b/internal/store/cache_stores_snapshot.go
@@ -14,8 +14,6 @@ import (
 )
 
 // TakeSnapshot takes a snapshot of the CacheStores.
-//
-// Deprecated: use TakeSnapshotIfChanged instead.
 func (c CacheStores) TakeSnapshot() (CacheStores, error) {
 	// Create a fresh CacheStores instance to store the snapshot
 	// in the c.takeSnapshot method. It happens here because it's


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `--use-last-valid-config-for-fallback` flag that changes the default behavior of `FallbackConfiguration` feature by backfilling broken objects using the last valid config cache instead of only excluding those.

**Which issue this PR fixes**:

Solves https://github.com/Kong/kubernetes-ingress-controller/issues/6096.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
