### PR TITLE
feat: emit fallback configuration events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ Adding a new version? You'll need three changes:
 - Added `--use-last-valid-config-for-fallback` CLI flag to enable using the last valid configuration cache
   to backfill excluded broken objects when the `FallbackConfiguration` feature gate is enabled.
   [#6098](https://github.com/Kong/kubernetes-ingress-controller/pull/6098)
+- Added `FallbackKongConfigurationSucceeded`, `FallbackKongConfigurationTranslationFailed` and
+  `FallbackKongConfigurationApplyFailed` Kubernetes Events to report the status of the fallback configuration.
+  [#6099](https://github.com/Kong/kubernetes-ingress-controller/pull/6099)
 - Add support for Kubernetes Gateway API v1.1:
   - add a flag `--enable-controller-gwapi-grpcroute` to control whether enable or disable GRPCRoute controller.
   - add support for `GRPCRoute` v1, which requires users to upgrade the Gateway API's CRD to v1.1.


### PR DESCRIPTION
**What this PR does / why we need it**:

Starts emitting new Kubernetes events related to the `FallbackConfiguration` feature:

- `FallbackKongConfigurationSucceeded` - emitted on successful fallback configuration push (attached to Pod)
- `FallbackKongConfigurationTranslationFailed` - emitted when a fallback cache causes translation failures in the translator (attached to causing objects)
- `FallbackKongConfigurationApplyFailed` - emitted when a fallback configuration is rejected by Kong (attached to Pod and broken objects if any)

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6081.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
