### PR TITLE
fix(conformance): do not reject HTTPRoutes with invalid spec.Rule.BackendRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,10 @@ Adding a new version? You'll need three changes:
 - Fixed KIC clearing Gateway API *Route status of routes that it shouldn't reconcilce, e.g.
   those attached to Gateways that do not belong to GatewayClass that KIC reconciles.
   [6079](https://github.com/Kong/kubernetes-ingress-controller/pull/6079)
+- Fixed KIC admission webhook rejecting HTTPRoutes that have invalid `spec.rules.backendRefs`.
+  Those are now allowed on admission and will have their status conditions filled
+  as per the Gateway API spec.
+  [6104](https://github.com/Kong/kubernetes-ingress-controller/pull/6104)
 
 ### Changed
 

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -51,6 +51,7 @@ type (
 	HTTPRouteMatch            = gatewayv1.HTTPRouteMatch
 	HTTPRouteRule             = gatewayv1.HTTPRouteRule
 	HTTPRouteTimeouts         = gatewayv1.HTTPRouteTimeouts
+	HTTPRequestMirrorFilter   = gatewayv1.HTTPRequestMirrorFilter
 	LocalObjectReference      = gatewayv1.LocalObjectReference
 	HTTPRouteSpec             = gatewayv1.HTTPRouteSpec
 	HTTPRouteStatus           = gatewayv1.HTTPRouteStatus


### PR DESCRIPTION

**What this PR does / why we need it**:

Gateway API states that HTTPRoutes with invalid `spec.rule.backendRefs` should have their status conditions filled:

```
// References to objects with invalid Group and Kind are not valid, and must
// be rejected by the implementation, with appropriate Conditions set
// on the containing object.
```

https://github.com/kubernetes-sigs/gateway-api/blob/400e36da6929b98674e1d71bdd7eb65ca72e7438/apis/v1/object_reference_types.go#L91-L93

This PR removes the rejection of those routes from the admission webhook.

This will allow KGO (which deploys KIC with admission webhook enabled) to pass conformance test `HTTPRouteInvalidBackendRefUnknownKind`.

**Which issue this PR fixes**:


**Special notes for your reviewer**:

#6103 tracks the introduction of admission webhook to conformance tests.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
