### PR TITLE
feat: add metrics for FallbackConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ Adding a new version? You'll need three changes:
 - Added `FallbackKongConfigurationSucceeded`, `FallbackKongConfigurationTranslationFailed` and
   `FallbackKongConfigurationApplyFailed` Kubernetes Events to report the status of the fallback configuration.
   [#6099](https://github.com/Kong/kubernetes-ingress-controller/pull/6099)
+- Added Prometheus metrics covering `FallbackConfiguration` feature: 
+  - `ingress_controller_fallback_translation_count`
+  - `ingress_controller_fallback_translation_broken_resource_count`
+  - `ingress_controller_fallback_configuration_push_count`
+  - `ingress_controller_fallback_configuration_push_last`
+  - `ingress_controller_fallback_configuration_push_duration_milliseconds`
+  - `ingress_controller_fallback_configuration_push_broken_resource_count`
+  - `ingress_controller_fallback_cache_generating_duration_milliseconds`
+  - `ingress_controller_processed_config_snapshot_cache_hit`
+  - `ingress_controller_processed_config_snapshot_cache_miss`
+  [#6105](https://github.com/Kong/kubernetes-ingress-controller/pull/6105)
 - Add support for Kubernetes Gateway API v1.1:
   - add a flag `--enable-controller-gwapi-grpcroute` to control whether enable or disable GRPCRoute controller.
   - add support for `GRPCRoute` v1, which requires users to upgrade the Gateway API's CRD to v1.1.

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -446,9 +446,12 @@ func (c *KongClient) Update(ctx context.Context) error {
 		// Empty snapshot hash means that the cache hasn't changed since the last snapshot was taken. That optimization can be used
 		// in main code path to avoid unnecessary processing. TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6095
 		if newSnapshotHash == store.SnapshotHashEmpty {
+			c.prometheusMetrics.RecordProcessedConfigSnapshotCacheHit()
 			c.logger.V(util.DebugLevel).Info("No configuration change; pushing config to gateway is not necessary, skipping")
 			return nil
 		}
+
+		c.prometheusMetrics.RecordProcessedConfigSnapshotCacheMiss()
 		c.lastProcessedSnapshotHash = newSnapshotHash
 		c.kongConfigBuilder.UpdateCache(cacheSnapshot)
 	}
@@ -575,11 +578,13 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 
 	if failuresCount := len(fallbackParsingResult.TranslationFailures); failuresCount > 0 {
 		c.recordResourceFailureEvents(fallbackParsingResult.TranslationFailures, FallbackKongConfigurationTranslationFailedEventReason)
+		c.prometheusMetrics.RecordFallbackTranslationBrokenResources(failuresCount)
+		c.prometheusMetrics.RecordFallbackTranslationFailure()
 		c.logger.V(util.DebugLevel).Info("Translation failures occurred when building fallback data-plane configuration", "count", failuresCount)
+	} else {
+		c.prometheusMetrics.RecordFallbackTranslationBrokenResources(0)
+		c.prometheusMetrics.RecordFallbackTranslationSuccess()
 	}
-
-	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6082
-	// Expose Prometheus metrics for fallback configuration parsing result.
 
 	const isFallback = true
 	_, gatewaysSyncErr = c.sendOutToGatewayClients(ctx, fallbackParsingResult.KongState, c.kongConfig, isFallback)
@@ -603,7 +608,11 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 func (c *KongClient) generateFallbackCache(
 	currentCache store.CacheStores,
 	brokenObjects []fallback.ObjectHash,
-) (store.CacheStores, error) {
+) (s store.CacheStores, err error) {
+	start := time.Now()
+	defer func() {
+		c.prometheusMetrics.RecordFallbackCacheGeneratingDuration(time.Since(start), err)
+	}()
 	if c.kongConfig.UseLastValidConfigForFallback {
 		return c.fallbackConfigGenerator.GenerateBackfillingBrokenObjects(
 			currentCache,
@@ -773,6 +782,7 @@ func (c *KongClient) sendToClient(
 		c.prometheusMetrics,
 		c.updateStrategyResolver,
 		c.configChangeDetector,
+		isFallback,
 	)
 	// Only record events on applying configuration to Kong gateway here.
 	// Nil error is expected to be passed to indicate success.

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -611,7 +611,7 @@ func (c *KongClient) generateFallbackCache(
 ) (s store.CacheStores, err error) {
 	start := time.Now()
 	defer func() {
-		c.prometheusMetrics.RecordFallbackCacheGeneratingDuration(time.Since(start), err)
+		c.prometheusMetrics.RecordFallbackCacheGenerationDuration(time.Since(start), err)
 	}()
 	if c.kongConfig.UseLastValidConfigForFallback {
 		return c.fallbackConfigGenerator.GenerateBackfillingBrokenObjects(

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -95,7 +95,7 @@ const (
 	MetricNameFallbackConfigPushSuccessTime      = "ingress_controller_fallback_configuration_push_last"
 	MetricNameFallbackConfigPushDuration         = "ingress_controller_fallback_configuration_push_duration_milliseconds"
 	MetricNameFallbackConfigPushBrokenResources  = "ingress_controller_fallback_configuration_push_broken_resource_count"
-	MetricNameFallbackCacheGeneratingDuration    = "ingress_controller_fallback_cache_generating_duration_milliseconds"
+	MetricNameFallbackCacheGenerationDuration    = "ingress_controller_fallback_cache_generation_duration_milliseconds"
 	MetricNameProcessedConfigSnapshotCacheHit    = "ingress_controller_processed_config_snapshot_cache_hit"
 	MetricNameProcessedConfigSnapshotCacheMiss   = "ingress_controller_processed_config_snapshot_cache_miss"
 )
@@ -270,7 +270,7 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 
 	controllerMetrics.FallbackCacheGeneratingDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: MetricNameFallbackCacheGeneratingDuration,
+			Name: MetricNameFallbackCacheGenerationDuration,
 			Help: fmt.Sprintf("How long it took to generate a fallback cache, in milliseconds. "+
 				"`%s` describes whether the cache generation was successful (`%s`) or not (`%s`).",
 				SuccessKey, SuccessTrue, SuccessFalse,
@@ -370,10 +370,12 @@ func (c *CtrlFuncMetrics) RecordFallbackTranslationSuccess() {
 	}).Inc()
 }
 
+// RecordProcessedConfigSnapshotCacheHit records a hit on the processed config snapshot cache.
 func (c *CtrlFuncMetrics) RecordProcessedConfigSnapshotCacheHit() {
 	c.ProcessedConfigSnapshotCacheHit.Inc()
 }
 
+// RecordProcessedConfigSnapshotCacheMiss records a miss on the processed config snapshot cache.
 func (c *CtrlFuncMetrics) RecordProcessedConfigSnapshotCacheMiss() {
 	c.ProcessedConfigSnapshotCacheMiss.Inc()
 }
@@ -400,7 +402,8 @@ func (c *CtrlFuncMetrics) RecordFallbackPushFailure(p Protocol, duration time.Du
 	c.recordFallbackPushBrokenResources(brokenResourcesCount, dpOpt)
 }
 
-func (c *CtrlFuncMetrics) RecordFallbackCacheGeneratingDuration(d time.Duration, err error) {
+// RecordFallbackCacheGenerationDuration records the duration of a fallback cache generation.
+func (c *CtrlFuncMetrics) RecordFallbackCacheGenerationDuration(d time.Duration, err error) {
 	labels := prometheus.Labels{
 		SuccessKey: SuccessTrue,
 	}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -16,17 +16,24 @@ import (
 // descriptions of these metrics are found below, where their help text is set in NewCtrlFuncMetrics()
 
 type CtrlFuncMetrics struct {
-	ConfigPushCount *prometheus.CounterVec
-
-	ConfigPushBrokenResources *prometheus.GaugeVec
-
-	TranslationCount *prometheus.CounterVec
-
+	// Regular config push metrics.
+	ConfigPushCount            *prometheus.CounterVec
+	ConfigPushBrokenResources  *prometheus.GaugeVec
+	TranslationCount           *prometheus.CounterVec
 	TranslationBrokenResources prometheus.Gauge
+	ConfigPushDuration         *prometheus.HistogramVec
+	ConfigPushSuccessTime      *prometheus.GaugeVec
 
-	ConfigPushDuration *prometheus.HistogramVec
-
-	ConfigPushSuccessTime *prometheus.GaugeVec
+	// Fallback config push metrics.
+	FallbackTranslationCount           *prometheus.CounterVec
+	FallbackTranslationBrokenResources prometheus.Gauge
+	FallbackConfigPushCount            *prometheus.CounterVec
+	FallbackConfigPushSuccessTime      *prometheus.GaugeVec
+	FallbackConfigPushBrokenResources  *prometheus.GaugeVec
+	FallbackConfigPushDuration         *prometheus.HistogramVec
+	FallbackCacheGeneratingDuration    *prometheus.HistogramVec
+	ProcessedConfigSnapshotCacheHit    prometheus.Counter
+	ProcessedConfigSnapshotCacheMiss   prometheus.Counter
 }
 
 const (
@@ -70,6 +77,7 @@ const (
 	DataplaneKey string = "dataplane"
 )
 
+// Regular config push metrics names.
 const (
 	MetricNameConfigPushCount            = "ingress_controller_configuration_push_count"
 	MetricNameConfigPushBrokenResources  = "ingress_controller_configuration_push_broken_resource_count"
@@ -77,6 +85,19 @@ const (
 	MetricNameTranslationCount           = "ingress_controller_translation_count"
 	MetricNameTranslationBrokenResources = "ingress_controller_translation_broken_resource_count"
 	MetricNameConfigPushDuration         = "ingress_controller_configuration_push_duration_milliseconds"
+)
+
+// Fallback config push metrics names.
+const (
+	MetricNameFallbackTranslationCount           = "ingress_controller_fallback_translation_count"
+	MetricNameFallbackTranslationBrokenResources = "ingress_controller_fallback_translation_broken_resource_count"
+	MetricNameFallbackConfigPushCount            = "ingress_controller_fallback_configuration_push_count"
+	MetricNameFallbackConfigPushSuccessTime      = "ingress_controller_fallback_configuration_push_last"
+	MetricNameFallbackConfigPushDuration         = "ingress_controller_fallback_configuration_push_duration_milliseconds"
+	MetricNameFallbackConfigPushBrokenResources  = "ingress_controller_fallback_configuration_push_broken_resource_count"
+	MetricNameFallbackCacheGeneratingDuration    = "ingress_controller_fallback_cache_generating_duration_milliseconds"
+	MetricNameProcessedConfigSnapshotCacheHit    = "ingress_controller_processed_config_snapshot_cache_hit"
+	MetricNameProcessedConfigSnapshotCacheMiss   = "ingress_controller_processed_config_snapshot_cache_miss"
 )
 
 var _lock sync.Mutex
@@ -168,21 +189,133 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 		[]string{DataplaneKey},
 	)
 
-	metrics.Registry.Unregister(controllerMetrics.ConfigPushCount)
-	metrics.Registry.Unregister(controllerMetrics.ConfigPushBrokenResources)
-	metrics.Registry.Unregister(controllerMetrics.TranslationCount)
-	metrics.Registry.Unregister(controllerMetrics.TranslationBrokenResources)
-	metrics.Registry.Unregister(controllerMetrics.ConfigPushDuration)
-	metrics.Registry.Unregister(controllerMetrics.ConfigPushSuccessTime)
+	controllerMetrics.FallbackTranslationCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameFallbackTranslationCount,
+			Help: fmt.Sprintf("Count of translations from Kubernetes state to Kong state in fallback mode. "+
+				"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`). "+
+				"Unrecoverable error in this case means KIC wasn't able to translate a Kubernetes object to Kong model.",
+				SuccessKey, SuccessFalse, SuccessTrue,
+			),
+		},
+		[]string{SuccessKey},
+	)
 
-	metrics.Registry.MustRegister(
+	controllerMetrics.FallbackTranslationBrokenResources = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: MetricNameFallbackTranslationBrokenResources,
+			Help: fmt.Sprintf("The number of resources that the controller cannot successfully translate to Kong " +
+				"configuration in fallback mode.",
+			),
+		},
+	)
+
+	controllerMetrics.FallbackConfigPushCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameFallbackConfigPushCount,
+			Help: fmt.Sprintf(
+				"Count of successful/failed fallback configuration pushes to Kong. "+
+					"`%s` describes the dataplane that was the target of configuration push. "+
+					"`%s` describes the configuration protocol (`%s` or `%s`) in use. "+
+					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`). "+
+					"`%s` is populated in case of `%s=\"%s\"` and describes the reason of failure "+
+					"(one of `%s`, `%s`, `%s`).",
+				DataplaneKey,
+				ProtocolKey, ProtocolDBLess, ProtocolDeck,
+				SuccessKey, SuccessFalse, SuccessTrue,
+				FailureReasonKey, SuccessKey, SuccessFalse,
+				FailureReasonConflict, FailureReasonNetwork, FailureReasonOther,
+			),
+		},
+		[]string{SuccessKey, ProtocolKey, FailureReasonKey, DataplaneKey},
+	)
+
+	controllerMetrics.FallbackConfigPushSuccessTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameFallbackConfigPushSuccessTime,
+			Help: fmt.Sprintf("The time of the last successful fallback configuration push. "+
+				"`%s` describes the dataplane that was the target of the configuration push.",
+				DataplaneKey,
+			),
+		},
+		[]string{DataplaneKey},
+	)
+
+	controllerMetrics.FallbackConfigPushDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: MetricNameFallbackConfigPushDuration,
+			Help: fmt.Sprintf(
+				"How long it took to push the fallback configuration to Kong, in milliseconds. "+
+					"`%s` describes the dataplane that was the target of configuration push. "+
+					"`%s` describes the configuration protocol (`%s` or `%s`) in use. "+
+					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`).",
+				DataplaneKey,
+				ProtocolKey, ProtocolDBLess, ProtocolDeck,
+				SuccessKey, SuccessFalse, SuccessTrue,
+			),
+		},
+		[]string{SuccessKey, ProtocolKey, DataplaneKey},
+	)
+
+	controllerMetrics.FallbackConfigPushBrokenResources = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameFallbackConfigPushBrokenResources,
+			Help: fmt.Sprintf("The number of resources not accepted by Kong when attempting to push "+
+				"fallback configuration. `%s` describes the dataplane that was the target of the configuration push.",
+				DataplaneKey,
+			),
+		},
+		[]string{DataplaneKey},
+	)
+
+	controllerMetrics.FallbackCacheGeneratingDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: MetricNameFallbackCacheGeneratingDuration,
+			Help: fmt.Sprintf("How long it took to generate a fallback cache, in milliseconds. "+
+				"`%s` describes whether the cache generation was successful (`%s`) or not (`%s`).",
+				SuccessKey, SuccessTrue, SuccessFalse,
+			),
+		},
+		[]string{SuccessKey},
+	)
+
+	controllerMetrics.ProcessedConfigSnapshotCacheHit = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: MetricNameProcessedConfigSnapshotCacheHit,
+			Help: "The number of times the controller hit the processed config snapshot cache and skipped generating " +
+				"a new one.",
+		},
+	)
+
+	controllerMetrics.ProcessedConfigSnapshotCacheMiss = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: MetricNameProcessedConfigSnapshotCacheMiss,
+			Help: "The number of times the controller missed the processed config snapshot cache and had to generate " +
+				"a new one.",
+		},
+	)
+
+	allMetrics := []prometheus.Collector{
 		controllerMetrics.ConfigPushCount,
 		controllerMetrics.ConfigPushBrokenResources,
 		controllerMetrics.TranslationCount,
 		controllerMetrics.TranslationBrokenResources,
 		controllerMetrics.ConfigPushDuration,
 		controllerMetrics.ConfigPushSuccessTime,
-	)
+		controllerMetrics.FallbackTranslationBrokenResources,
+		controllerMetrics.FallbackTranslationCount,
+		controllerMetrics.FallbackConfigPushCount,
+		controllerMetrics.FallbackConfigPushSuccessTime,
+		controllerMetrics.FallbackConfigPushDuration,
+		controllerMetrics.FallbackConfigPushBrokenResources,
+		controllerMetrics.FallbackCacheGeneratingDuration,
+		controllerMetrics.ProcessedConfigSnapshotCacheHit,
+		controllerMetrics.ProcessedConfigSnapshotCacheMiss,
+	}
+	for _, m := range allMetrics {
+		metrics.Registry.Unregister(m)
+		metrics.Registry.MustRegister(m)
+	}
 
 	return controllerMetrics
 }
@@ -221,6 +354,60 @@ func (c *CtrlFuncMetrics) RecordTranslationFailure() {
 // RecordTranslationBrokenResources records the number of resources failing translation.
 func (c *CtrlFuncMetrics) RecordTranslationBrokenResources(count int) {
 	c.TranslationBrokenResources.Set(float64(count))
+}
+
+// RecordFallbackTranslationFailure records a failed fallback configuration translation.
+func (c *CtrlFuncMetrics) RecordFallbackTranslationFailure() {
+	c.FallbackTranslationCount.With(prometheus.Labels{
+		SuccessKey: SuccessFalse,
+	}).Inc()
+}
+
+// RecordFallbackTranslationSuccess records a failed fallback configuration translation.
+func (c *CtrlFuncMetrics) RecordFallbackTranslationSuccess() {
+	c.FallbackTranslationCount.With(prometheus.Labels{
+		SuccessKey: SuccessTrue,
+	}).Inc()
+}
+
+func (c *CtrlFuncMetrics) RecordProcessedConfigSnapshotCacheHit() {
+	c.ProcessedConfigSnapshotCacheHit.Inc()
+}
+
+func (c *CtrlFuncMetrics) RecordProcessedConfigSnapshotCacheMiss() {
+	c.ProcessedConfigSnapshotCacheMiss.Inc()
+}
+
+// RecordFallbackTranslationBrokenResources records the number of fallback resources failing translation.
+func (c *CtrlFuncMetrics) RecordFallbackTranslationBrokenResources(count int) {
+	c.FallbackTranslationBrokenResources.Set(float64(count))
+}
+
+// RecordFallbackPushSuccess records a successful fallback configuration push.
+func (c *CtrlFuncMetrics) RecordFallbackPushSuccess(p Protocol, duration time.Duration, dataplane string) {
+	dpOpt := withDataplane(dataplane)
+	c.recordFallbackPushCount(p, dpOpt)
+	c.recordFallbackPushDuration(p, duration, dpOpt)
+	c.recordFallbackPushSuccessTime(dpOpt)
+	c.recordFallbackPushBrokenResources(0, dpOpt)
+}
+
+// RecordFallbackPushFailure records a failed fallback configuration push.
+func (c *CtrlFuncMetrics) RecordFallbackPushFailure(p Protocol, duration time.Duration, dataplane string, brokenResourcesCount int, err error) {
+	dpOpt := withDataplane(dataplane)
+	c.recordFallbackPushDuration(p, duration, dpOpt, withFailure())
+	c.recordFallbackPushCount(p, dpOpt, withError(err))
+	c.recordFallbackPushBrokenResources(brokenResourcesCount, dpOpt)
+}
+
+func (c *CtrlFuncMetrics) RecordFallbackCacheGeneratingDuration(d time.Duration, err error) {
+	labels := prometheus.Labels{
+		SuccessKey: SuccessTrue,
+	}
+	if err != nil {
+		labels[SuccessKey] = SuccessFalse
+	}
+	c.FallbackCacheGeneratingDuration.With(labels).Observe(float64(d.Milliseconds()))
 }
 
 type recordOption func(prometheus.Labels) prometheus.Labels
@@ -294,6 +481,55 @@ func (c *CtrlFuncMetrics) recordPushSuccessTime(opts ...recordOption) {
 	}
 
 	c.ConfigPushSuccessTime.With(labels).SetToCurrentTime()
+}
+
+func (c *CtrlFuncMetrics) recordFallbackPushCount(p Protocol, opts ...recordOption) {
+	labels := prometheus.Labels{
+		// Although this is hardcoded to true here, the withError or withFailure opt function will flip it to false.
+		SuccessKey:       SuccessTrue,
+		ProtocolKey:      string(p),
+		FailureReasonKey: "",
+	}
+
+	for _, opt := range opts {
+		labels = opt(labels)
+	}
+
+	c.FallbackConfigPushCount.With(labels).Inc()
+}
+
+func (c *CtrlFuncMetrics) recordFallbackPushSuccessTime(opts ...recordOption) {
+	labels := prometheus.Labels{}
+
+	for _, opt := range opts {
+		labels = opt(labels)
+	}
+
+	c.FallbackConfigPushSuccessTime.With(labels).SetToCurrentTime()
+}
+
+func (c *CtrlFuncMetrics) recordFallbackPushDuration(p Protocol, d time.Duration, opts ...recordOption) {
+	labels := prometheus.Labels{
+		// Although this is hardcoded to true here, the withError or withFailure opt function will flip it to false.
+		SuccessKey:  SuccessTrue,
+		ProtocolKey: string(p),
+	}
+
+	for _, opt := range opts {
+		labels = opt(labels)
+	}
+
+	c.FallbackConfigPushDuration.With(labels).Observe(float64(d.Milliseconds()))
+}
+
+func (c *CtrlFuncMetrics) recordFallbackPushBrokenResources(brokenObjectsCount int, opts ...recordOption) {
+	labels := prometheus.Labels{}
+
+	for _, opt := range opts {
+		labels = opt(labels)
+	}
+
+	c.FallbackConfigPushBrokenResources.With(labels).Set(float64(brokenObjectsCount))
 }
 
 // pushFailureReason extracts config push failure reason from an error returned

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -33,8 +33,7 @@ func TestRecordPush(t *testing.T) {
 	})
 	t.Run("recording push failure works", func(t *testing.T) {
 		require.NotPanics(t, func() {
-			m.RecordPushFailure(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080", 5,
-				fmt.Errorf("custom error"))
+			m.RecordPushFailure(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080", 5, fmt.Errorf("custom error"))
 		})
 	})
 }

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
 func TestMetricsAreServed(t *testing.T) {
@@ -28,65 +31,113 @@ func TestMetricsAreServed(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 
-	ctx, cancel := context.WithTimeout(context.Background(), waitTime)
-	defer cancel()
+	testCases := []struct {
+		name                         string
+		withPushError                bool
+		fallbackConfigurationEnabled bool
+		expectedMetrics              []string
+	}{
+		{
+			name:                         "with push error and FallbackConfiguration enabled",
+			withPushError:                true,
+			fallbackConfigurationEnabled: true,
+			expectedMetrics: []string{
+				metrics.MetricNameConfigPushCount,
+				metrics.MetricNameConfigPushBrokenResources,
+				metrics.MetricNameTranslationCount,
+				metrics.MetricNameTranslationBrokenResources,
+				metrics.MetricNameConfigPushDuration,
 
-	cfg, _ := RunManager(ctx, t, envcfg,
-		AdminAPIOptFns(),
-	)
-
-	wantMetrics := []string{
-		metrics.MetricNameConfigPushCount,
-		metrics.MetricNameConfigPushBrokenResources,
-		metrics.MetricNameTranslationCount,
-		metrics.MetricNameTranslationBrokenResources,
-		metrics.MetricNameConfigPushDuration,
-		metrics.MetricNameConfigPushSuccessTime,
+				metrics.MetricNameFallbackTranslationBrokenResources,
+				metrics.MetricNameFallbackTranslationCount,
+				metrics.MetricNameFallbackConfigPushCount,
+				metrics.MetricNameFallbackConfigPushSuccessTime,
+				metrics.MetricNameFallbackConfigPushDuration,
+				metrics.MetricNameFallbackConfigPushBrokenResources,
+				metrics.MetricNameProcessedConfigSnapshotCacheHit,
+				metrics.MetricNameProcessedConfigSnapshotCacheMiss,
+			},
+		},
+		{
+			name:          "without push error",
+			withPushError: false,
+			expectedMetrics: []string{
+				metrics.MetricNameConfigPushCount,
+				metrics.MetricNameConfigPushBrokenResources,
+				metrics.MetricNameTranslationCount,
+				metrics.MetricNameTranslationBrokenResources,
+				metrics.MetricNameConfigPushDuration,
+				metrics.MetricNameConfigPushSuccessTime,
+			},
+		},
 	}
 
-	metricsURL := fmt.Sprintf("http://%s/metrics", cfg.MetricsAddr)
-	t.Logf("waiting for metrics to be available at %q", metricsURL)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), waitTime)
+			defer cancel()
 
-	for _, metric := range wantMetrics {
-		metric := metric
-		t.Run(metric, func(t *testing.T) {
-			require.NoError(t,
-				retry.Do(func() error {
-					resp, err := http.Get(metricsURL)
-					if err != nil {
-						return fmt.Errorf("error %w checking %q", err, metricsURL)
-					}
-
-					defer resp.Body.Close()
-					if http.StatusOK != resp.StatusCode {
-						return fmt.Errorf("status code %v not as expected (200)", resp.StatusCode)
-					}
-
-					var parser expfmt.TextParser
-					mf, err := parser.TextToMetricFamilies(resp.Body)
-					if err != nil {
-						return fmt.Errorf("error %w parsing %q", err, metricsURL)
-					}
-
-					if _, ok := mf[metric]; !ok {
-						return fmt.Errorf("metric %q not present yet", metric)
-					}
-					return nil
+			var adminAPIOpts []mocks.AdminAPIHandlerOpt
+			if tc.withPushError {
+				adminAPIOpts = append(adminAPIOpts,
+					mocks.WithConfigPostError([]byte(`{"flattened_errors": [{"errors": [{"messages": ["broken object"]}], "entity_tags": ["k8s-name:test-service","k8s-namespace:default","k8s-kind:Service","k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3","k8s-group:","k8s-version:v1"]}]}`)),
+					mocks.WithConfigPostErrorOnlyOnFirstRequest(),
+				)
+			}
+			cfg, _ := RunManager(ctx, t, envcfg,
+				AdminAPIOptFns(adminAPIOpts...),
+				func(cfg *manager.Config) {
+					cfg.FeatureGates[featuregates.FallbackConfiguration] = tc.fallbackConfigurationEnabled
 				},
-					retry.Context(ctx),
-					retry.Delay(tickTime),
-					retry.MaxDelay(maxDelay),
-					retry.MaxJitter(maxDelay),
-					retry.DelayType(retry.BackOffDelay),
-					retry.Attempts(0), // We're using a context with timeout, so we don't need to limit the number of attempts.
-					retry.LastErrorOnly(true),
-					retry.OnRetry(func(_ uint, err error) {
-						t.Logf("metric %s not present yet, err: %v", metric, err.Error())
-					}),
-				),
 			)
 
-			t.Logf("metric %q is present at /metrics", metric)
+			wantMetrics := tc.expectedMetrics
+
+			metricsURL := fmt.Sprintf("http://%s/metrics", cfg.MetricsAddr)
+			t.Logf("waiting for metrics to be available at %q", metricsURL)
+
+			for _, metric := range wantMetrics {
+				metric := metric
+				t.Run(metric, func(t *testing.T) {
+					require.NoError(t,
+						retry.Do(func() error {
+							resp, err := http.Get(metricsURL)
+							if err != nil {
+								return fmt.Errorf("error %w checking %q", err, metricsURL)
+							}
+
+							defer resp.Body.Close()
+							if http.StatusOK != resp.StatusCode {
+								return fmt.Errorf("status code %v not as expected (200)", resp.StatusCode)
+							}
+
+							var parser expfmt.TextParser
+							mf, err := parser.TextToMetricFamilies(resp.Body)
+							if err != nil {
+								return fmt.Errorf("error %w parsing %q", err, metricsURL)
+							}
+
+							if _, ok := mf[metric]; !ok {
+								return fmt.Errorf("metric %q not present yet", metric)
+							}
+							return nil
+						},
+							retry.Context(ctx),
+							retry.Delay(tickTime),
+							retry.MaxDelay(maxDelay),
+							retry.MaxJitter(maxDelay),
+							retry.DelayType(retry.BackOffDelay),
+							retry.Attempts(0), // We're using a context with timeout, so we don't need to limit the number of attempts.
+							retry.LastErrorOnly(true),
+							retry.OnRetry(func(_ uint, err error) {
+								t.Logf("metric %s not present yet, err: %v", metric, err.Error())
+							}),
+						),
+					)
+
+					t.Logf("metric %q is present at /metrics", metric)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds new Prometheus metrics covering `FallbackConfiguration` feature:

- `ingress_controller_fallback_translation_count`
- `ingress_controller_fallback_translation_broken_resource_count`
- `ingress_controller_fallback_configuration_push_count`
- `ingress_controller_fallback_configuration_push_last`
- `ingress_controller_fallback_configuration_push_duration_milliseconds`
- `ingress_controller_fallback_configuration_push_broken_resource_count`
- `ingress_controller_fallback_cache_generating_duration_milliseconds`
- `ingress_controller_processed_config_snapshot_cache_hit`
- `ingress_controller_processed_config_snapshot_cache_miss`

Metrics reported after generating fallback configuration and pushing it successfully:

```text
# HELP ingress_controller_processed_config_snapshot_cache_hit The number of times the controller hit the processed config snapshot cache and skipped generating a new one.
# TYPE ingress_controller_processed_config_snapshot_cache_hit counter
ingress_controller_processed_config_snapshot_cache_hit 1

# HELP ingress_controller_processed_config_snapshot_cache_miss The number of times the controller missed the processed config snapshot cache and had to generate a new one.
# TYPE ingress_controller_processed_config_snapshot_cache_miss counter
ingress_controller_processed_config_snapshot_cache_miss 1

# HELP ingress_controller_fallback_configuration_push_broken_resource_count The number of resources not accepted by Kong when attempting to push fallback configuration. `dataplane` describes the dataplane that was the target of the configuration push.
# TYPE ingress_controller_fallback_configuration_push_broken_resource_count gauge
ingress_controller_fallback_configuration_push_broken_resource_count{dataplane="http://127.0.0.1:52549"} 0

# HELP ingress_controller_fallback_cache_generating_duration_milliseconds How long it took to generate a fallback cache, in milliseconds. `success` describes whether the cache generation was successful (`true`) or not (`false`).
# TYPE ingress_controller_fallback_cache_generating_duration_milliseconds histogram
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.005"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.01"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.025"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.05"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.1"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.25"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="0.5"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="1"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="2.5"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="5"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="10"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_bucket{success="true",le="+Inf"} 1
ingress_controller_fallback_cache_generating_duration_milliseconds_sum{success="true"} 0
ingress_controller_fallback_cache_generating_duration_milliseconds_count{success="true"} 1

# HELP ingress_controller_fallback_configuration_push_count Count of successful/failed fallback configuration pushes to Kong. `dataplane` describes the dataplane that was the target of configuration push. `protocol` describes the configuration protocol (`db-less` or `deck`) in use. `success` describes whether there were unrecoverable errors (`false`) or not (`true`). `failure_reason` is populated in case of `success="false"` and describes the reason of failure (one of `conflict`, `network`, `other`).
# TYPE ingress_controller_fallback_configuration_push_count counter
ingress_controller_fallback_configuration_push_count{dataplane="http://127.0.0.1:52549",failure_reason="",protocol="db-less",success="true"} 1

# HELP ingress_controller_fallback_configuration_push_duration_milliseconds How long it took to push the fallback configuration to Kong, in milliseconds. `dataplane` describes the dataplane that was the target of configuration push. `protocol` describes the configuration protocol (`db-less` or `deck`) in use. `success` describes whether there were unrecoverable errors (`false`) or not (`true`).
# TYPE ingress_controller_fallback_configuration_push_duration_milliseconds histogram
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.005"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.01"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.025"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.05"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.1"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.25"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="0.5"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="1"} 0
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="2.5"} 1
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="5"} 1
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="10"} 1
ingress_controller_fallback_configuration_push_duration_milliseconds_bucket{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true",le="+Inf"} 1
ingress_controller_fallback_configuration_push_duration_milliseconds_sum{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true"} 2
ingress_controller_fallback_configuration_push_duration_milliseconds_count{dataplane="http://127.0.0.1:52549",protocol="db-less",success="true"} 1

# HELP ingress_controller_fallback_configuration_push_last The time of the last successful fallback configuration push. `dataplane` describes the dataplane that was the target of the configuration push.
# TYPE ingress_controller_fallback_configuration_push_last gauge
ingress_controller_fallback_configuration_push_last{dataplane="http://127.0.0.1:52549"} 1.7169937377764149e+09

# HELP ingress_controller_fallback_translation_broken_resource_count The number of resources that the controller cannot successfully translate to Kong configuration in fallback mode.
# TYPE ingress_controller_fallback_translation_broken_resource_count gauge
ingress_controller_fallback_translation_broken_resource_count 0

# HELP ingress_controller_fallback_translation_count Count of translations from Kubernetes state to Kong state in fallback mode. `success` describes whether there were unrecoverable errors (`false`) or not (`true`). Unrecoverable error in this case means KIC wasn't able to translate a Kubernetes object to Kong model.
# TYPE ingress_controller_fallback_translation_count counter
ingress_controller_fallback_translation_count{success="true"} 1
``` 


**Which issue this PR fixes**:

Closes #6082.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
