### PR TITLE
conformance: enable HTTPRouteHostRewrite

### DIFF
--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -33,7 +33,6 @@ var traditionalRoutesSupportedFeatures = []features.SupportedFeature{
 	// extended features
 	features.SupportHTTPRouteResponseHeaderModification,
 	features.SupportHTTPRoutePathRewrite,
-	features.SupportHTTPRouteHostRewrite,
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// suite.SupportHTTPRouteBackendTimeout,
@@ -48,7 +47,6 @@ var expressionRoutesSupportedFeatures = []features.SupportedFeature{
 	features.SupportHTTPRouteMethodMatching,
 	features.SupportHTTPRouteResponseHeaderModification,
 	features.SupportHTTPRoutePathRewrite,
-	features.SupportHTTPRouteHostRewrite,
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/5868
 	// Temporarily disabled and tracking through the following issue.
 	// features.SupportHTTPRouteBackendTimeout,


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `SupportHTTPRouteHostRewrite` in Gateway API conformance suite.

**Which issue this PR fixes**:

Closes #3685