### PR TITLE
deps: bump sigs.k8s.io/e2e-framework to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.3
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //
@@ -58,6 +56,7 @@ require (
 	k8s.io/client-go v0.30.1
 	k8s.io/component-base v0.30.1
 	sigs.k8s.io/controller-runtime v0.18.3
+	sigs.k8s.io/e2e-framework v0.4.0
 	sigs.k8s.io/gateway-api v1.1.0
 	sigs.k8s.io/kustomize/api v0.17.2
 	sigs.k8s.io/kustomize/kyaml v0.17.1
@@ -227,7 +226,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f // indirect
 	k8s.io/kubectl v0.30.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
-	sigs.k8s.io/e2e-framework v0.3.1-0.20231113122213-262cac32d35e
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.22.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,8 @@ k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 h1:jgGTlFYnhF1PM1Ax/lAlxUPE+KfCI
 k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.18.3 h1:B5Wmmo8WMWK7izei+2LlXLVDGzMwAHBNLX68lwtlSR4=
 sigs.k8s.io/controller-runtime v0.18.3/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
-sigs.k8s.io/e2e-framework v0.3.1-0.20231113122213-262cac32d35e h1:lJqSZb2bAyfkPpBhUbzXsoAHKJn+3/KzBpvktR1wlMQ=
-sigs.k8s.io/e2e-framework v0.3.1-0.20231113122213-262cac32d35e/go.mod h1:VIozg+of0zhkVGZcCWvKqH7vn7GTDDAa3h+w1OfH7Co=
+sigs.k8s.io/e2e-framework v0.4.0 h1:4yYmFDNNoTnazqmZJXQ6dlQF1vrnDbutmxlyvBpC5rY=
+sigs.k8s.io/e2e-framework v0.4.0/go.mod h1:JilFQPF1OL1728ABhMlf9huse7h+uBJDXl9YeTs49A8=
 sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
 sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump sigs.k8s.io/e2e-framework to [v0.4.0](https://github.com/kubernetes-sigs/e2e-framework/releases/tag/v0.4.0). Dependabot didn't want to bump it because it was set to a custom SHA.
