### PR TITLE
chore(tests): introduce isolated TestHTTPRouteWithBrokenPluginFallback

### DIFF
--- a/examples/gateway-httproute-broken-plugin-fallback.yaml
+++ b/examples/gateway-httproute-broken-plugin-fallback.yaml
@@ -1,7 +1,6 @@
-# NOTE The Gateway APIs are not yet available by default in Kubernetes.
-# Follow these instructions to install them before using this example:
-# https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel
----
+# This configuration file presents fallback configuration (feature gate FallbackConfiguration=true),
+# it contains a plugin that is misconfigured and will not work. The whole route /for-auth-users won't
+# be configured. Only the route /httproute-testing will be configured.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,7 +74,7 @@ spec:
         resources:
           limits:
             memory: "64Mi"
-            cpu: "250m"
+            cpu: "250m"          
 ---
 apiVersion: v1
 kind: Service
@@ -135,3 +134,38 @@ spec:
       kind: Service
       port: 8080
       weight: 25
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-testing2
+  annotations:
+    konghq.com/strip-path: "true"
+    konghq.com/plugins: key-auth
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /for-auth-users
+    backendRefs:
+    - name: echo-1
+      kind: Service
+      port: 80
+      weight: 75
+    - name: echo-2
+      kind: Service
+      port: 8080
+      weight: 25
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: key-auth
+  namespace: default
+plugin: key-auth
+config:
+  # Should be key_names, not keys.
+  keys: ["key"]

--- a/test/integration/isolated/examples_httproute_test.go
+++ b/test/integration/isolated/examples_httproute_test.go
@@ -1,0 +1,120 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestHTTPRouteExample(t *testing.T) {
+	httprouteExampleManifest := examplesManifestPath("gateway-httproute.yaml")
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
+		WithLabel(testlabels.Kind, testlabels.KindHTTPRoute).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
+		)).
+		Assess("deploying to cluster works and HTTP requests are routed properly",
+			runHTTPRouteExampleTestScenario(httprouteExampleManifest),
+		).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}
+
+func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
+	httprouteWithBrokenPluginFallback := examplesManifestPath("gateway-httproute-broken-plugin-fallback.yaml")
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
+		WithLabel(testlabels.Kind, testlabels.KindHTTPRoute).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(
+				helpers.ControllerManagerOptAdditionalWatchNamespace("default"),
+			),
+			withControllerManagerFeatureGates(map[string]string{"FallbackConfiguration": "true"}),
+		)).
+		Assess("deploying to cluster works and HTTP requests are routed properly",
+			runHTTPRouteExampleTestScenario(httprouteWithBrokenPluginFallback),
+		).
+		Assess("verify that route with misconfigured plugin is not operational", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			proxyURL := GetHTTPURLFromCtx(ctx)
+			t.Logf("verifying that Kong gateway response in returned instead of desired site")
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				"/for-auth-users",
+				http.StatusNotFound,
+				"no Route matched with those values",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+			return ctx
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}
+
+func runHTTPRouteExampleTestScenario(manifestToUse string) func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+		cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+		cluster := GetClusterFromCtx(ctx)
+		proxyURL := GetHTTPURLFromCtx(ctx)
+
+		t.Logf("applying yaml manifest %s", manifestToUse)
+		manifest, err := os.ReadFile(manifestToUse)
+		assert.NoError(t, err)
+		assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, string(manifest)))
+		cleaner.AddManifest(string(manifest))
+
+		t.Logf("verifying that traffic is routed properly")
+
+		t.Logf("verifying that the HTTPRoute becomes routable")
+		helpers.EventuallyGETPath(
+			t,
+			proxyURL,
+			proxyURL.Host,
+			"/httproute-testing",
+			http.StatusOK,
+			"echo-1",
+			nil,
+			consts.IngressWait,
+			consts.WaitTick,
+		)
+
+		t.Logf("verifying that the backendRefs are being loadbalanced")
+		helpers.EventuallyGETPath(
+			t,
+			proxyURL,
+			proxyURL.Host,
+			"/httproute-testing",
+			http.StatusOK,
+			"echo-2",
+			nil,
+			consts.IngressWait,
+			consts.WaitTick,
+		)
+
+		return ctx
+	}
+}

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -149,8 +149,9 @@ func TestMain(m *testing.M) {
 }
 
 type featureSetupCfg struct {
-	controllerManagerOpts []helpers.ControllerManagerOpt
-	kongProxyEnvVars      map[string]string
+	controllerManagerOpts         []helpers.ControllerManagerOpt
+	controllerManagerFeatureGates map[string]string
+	kongProxyEnvVars              map[string]string
 }
 
 type featureSetupOpt func(*featureSetupCfg)
@@ -164,6 +165,12 @@ func withControllerManagerOpts(opts ...helpers.ControllerManagerOpt) featureSetu
 func withKongProxyEnvVars(envVars map[string]string) featureSetupOpt {
 	return func(o *featureSetupCfg) {
 		o.kongProxyEnvVars = envVars
+	}
+}
+
+func withControllerManagerFeatureGates(gates map[string]string) featureSetupOpt {
+	return func(o *featureSetupCfg) {
+		o.controllerManagerFeatureGates = gates
 	}
 }
 
@@ -313,6 +320,9 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 		t.Logf("configuring feature gates")
 		// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/4849
 		featureGates := consts.DefaultFeatureGates
+		for gate, value := range setupCfg.controllerManagerFeatureGates {
+			featureGates += "," + fmt.Sprintf("%s=%s", gate, value)
+		}
 		t.Logf("feature gates enabled: %s", featureGates)
 
 		t.Logf("starting the controller manager")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

That PR simplifies and converts `TestHTTPRouteExample` to an isolated one and introduces a new test `TestHTTPRouteWithBrokenPluginFallback` that tests fallback configuration 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6077

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->




