### PR TITLE
tests: use expressions router by default in test manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ test.golden.update:
 use-setup-envtest:
 	$(SETUP_ENVTEST) use
 
-ENVTEST_TIMEOUT ?= 5m
+ENVTEST_TIMEOUT ?= 8m
 
 .PHONY: _test.envtest
 .ONESHELL: _test.envtest

--- a/config/components/konnect/manager.yaml
+++ b/config/components/konnect/manager.yaml
@@ -27,18 +27,3 @@ spec:
               secretKeyRef:
                 name: konnect-client-tls
                 key: tls.key
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: proxy-kong
-  namespace: kong
-spec:
-  template:
-    spec:
-      containers:
-        - name: proxy
-          env:
-            - name: KONG_ROUTER_FLAVOR
-              value: traditional_compatible
-

--- a/config/variants/konnect/base/manager.yaml
+++ b/config/variants/konnect/base/manager.yaml
@@ -27,18 +27,3 @@ spec:
               secretKeyRef:
                 name: konnect-client-tls
                 key: tls.key
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: proxy-kong
-  namespace: kong
-spec:
-  template:
-    spec:
-      containers:
-        - name: proxy
-          env:
-            - name: KONG_ROUTER_FLAVOR
-              value: traditional_compatible
-

--- a/config/variants/konnect/debug/manager_debug.yaml
+++ b/config/variants/konnect/debug/manager_debug.yaml
@@ -30,17 +30,3 @@ spec:
             - name: CONTROLLER_KONNECT_ADDRESS
               value: https://us.kic.api.konghq.tech
           image: kic-placeholder:placeholder
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: proxy-kong
-  namespace: kong
-spec:
-  template:
-    spec:
-      containers:
-        - name: proxy
-          env:
-            - name: KONG_ROUTER_FLAVOR
-              value: traditional_compatible

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -3648,8 +3648,6 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
-        - name: KONG_ROUTER_FLAVOR
-          value: traditional_compatible
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
             backlog=16384
@@ -3671,6 +3669,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: expressions
         image: kong/kong-gateway:3.5
         lifecycle:
           preStop:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -3650,8 +3650,6 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
-        - name: KONG_ROUTER_FLAVOR
-          value: traditional_compatible
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport
             backlog=16384
@@ -3673,6 +3671,8 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
+        - name: KONG_ROUTER_FLAVOR
+          value: expressions
         image: kong:3.6
         lifecycle:
           preStop:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Reverts https://github.com/Kong/kubernetes-ingress-controller/pull/4994.

The support for expressions router in Konnect is already GA: https://docs.konghq.com/konnect/updates/#may-2024

**Which issue this PR fixes**:

Closes #4995