### PR TITLE
fix: reconcile admin API endpoints on all replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,9 @@ Adding a new version? You'll need three changes:
 - Fixed KIC clearing Gateway API *Route status of routes that it shouldn't reconcilce, e.g.
   those attached to Gateways that do not belong to GatewayClass that KIC reconciles.
   [6079](https://github.com/Kong/kubernetes-ingress-controller/pull/6079)
+- Fixed KIC non leaders correctly getting up to date Admin API addresses by not
+  requiring leader election for the related controller.
+  [6126](https://github.com/Kong/kubernetes-ingress-controller/pull/6126)
 
 ### Changed
 

--- a/internal/controllers/configuration/kongadminapi_controller.go
+++ b/internal/controllers/configuration/kongadminapi_controller.go
@@ -71,6 +71,10 @@ func (r *KongAdminAPIServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 				return r.Log
 			},
 			CacheSyncTimeout: r.CacheSyncTimeout,
+			// In order to get up to date Admin API endpoints in all KIC replicas, we need to
+			// not require leader election so that AdminAPI controller runs in all replicas
+			// and notifies about the changes regardless of the leader election status.
+			NeedLeaderElection: lo.ToPtr(false),
 		}).
 		Watches(&discoveryv1.EndpointSlice{},
 			&handler.EnqueueRequestForObject{},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to fix an issue where non leader replicas would not get an up to date state of admin API endpoints and hence by an extension the admission webhook - which is started on each replica - would query the non existing admin API endpoints and thus cause failures.

**Which issue this PR fixes**:

Fixes #6008

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
