### PR TITLE
tests: skip flaky `TestMetricsAreServed/with_push_error_and_FallbackConfiguration_enabled`

### DIFF
--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -36,9 +36,11 @@ func TestMetricsAreServed(t *testing.T) {
 		withPushError                bool
 		fallbackConfigurationEnabled bool
 		expectedMetrics              []string
+		skippedMessage               string
 	}{
 		{
 			name:                         "with push error and FallbackConfiguration enabled",
+			skippedMessage:               "flaky, see https://github.com/Kong/kubernetes-ingress-controller/issues/6125",
 			withPushError:                true,
 			fallbackConfigurationEnabled: true,
 			expectedMetrics: []string{
@@ -74,6 +76,9 @@ func TestMetricsAreServed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.skippedMessage != "" {
+				t.Skip(tc.skippedMessage)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), waitTime)
 			defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip until https://github.com/Kong/kubernetes-ingress-controller/issues/6125 is resolved.
