### PR TITLE
tests: fix TestMetricsAreServed's flakiness

### DIFF
--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -36,11 +36,9 @@ func TestMetricsAreServed(t *testing.T) {
 		withPushError                bool
 		fallbackConfigurationEnabled bool
 		expectedMetrics              []string
-		skippedMessage               string
 	}{
 		{
 			name:                         "with push error and FallbackConfiguration enabled",
-			skippedMessage:               "flaky, see https://github.com/Kong/kubernetes-ingress-controller/issues/6125",
 			withPushError:                true,
 			fallbackConfigurationEnabled: true,
 			expectedMetrics: []string{
@@ -76,9 +74,6 @@ func TestMetricsAreServed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.skippedMessage != "" {
-				t.Skip(tc.skippedMessage)
-			}
 			ctx, cancel := context.WithTimeout(context.Background(), waitTime)
 			defer cancel()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
