### PR TITLE
chore: add skaffold config for multi gw enterprise

### DIFF
--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -134,6 +134,9 @@ spec:
         - name: cmetrics
           containerPort: 10255
           protocol: TCP
+        - name: diagnostics
+          containerPort: 10256
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/components/manager_dev_patch/kustomization.yaml
+++ b/config/components/manager_dev_patch/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- path: manager.yaml

--- a/config/components/manager_dev_patch/manager.yaml
+++ b/config/components/manager_dev_patch/manager.yaml
@@ -16,10 +16,13 @@ spec:
     spec:
       containers:
       - name: ingress-controller
-        args:
-          - --feature-gates=GatewayAlpha=true,KongServiceFacade=true
-          - --anonymous-reports=false
         env:
+        - name: CONTROLLER_DUMP_CONFIG
+          value: "true"
         - name: CONTROLLER_LOG_LEVEL
           value: debug
+        - name: CONTROLLER_FEATURE_GATES
+          value: GatewayAlpha=true,KongServiceFacade=true,FallbackConfiguration=true
+        - name: CONTROLLER_ANONYMOUS_REPORTS
+          value: "false"
         image: kic-placeholder:placeholder

--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.5'
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.5'
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.7'
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '3.1'
+  newTag: '3.1' # renovate: datasource=docker versioning=docker depName=kong/kubernetes-ingress-controller

--- a/config/variants/multi-gw/dev/kustomization.yaml
+++ b/config/variants/multi-gw/dev/kustomization.yaml
@@ -8,6 +8,4 @@ resources:
 
 components:
 - ../../../components/manager_dev_webhook
-
-patches:
-- path: manager.yaml
+- ../../../components/manager_dev_patch

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,20 @@
       "addLabels": [
         "renovate/auto-regenerate"
       ]
+    },
+    {
+      "description": "Match versions in config/image/oss and config/image/enterprise kustomize files that are properly annotated with `# renovate: datasource={} versioning={} depName={}`.",
+      "customType": "regex",
+      "fileMatch": [
+        "^config/image/enterprise/.*\\.yaml$",
+        "^config/image/oss/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "'(?<currentValue>.+)' # renovate: datasource=(?<datasource>.*) versioning=(?<versioning>.*) depName=(?<depName>.+)"
+      ],
+      "addLabels": [
+        "renovate/auto-regenerate"
+      ]
     }
   ]
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -62,6 +62,22 @@ profiles:
           COMMIT: ${{ .COMMIT }}
           REPO_INFO: ${{ .REPO_INFO }}
           GOCACHE: "{{ .GOCACHE }}"
+- name: multi_gw_enterprise
+  manifests:
+    kustomize:
+      paths:
+      - config/variants/multi-gw/enterprise
+  build:
+    artifacts:
+    - image: kic-placeholder
+      docker:
+        dockerfile: Dockerfile
+        target: distroless
+        buildArgs:
+          TAG: ${{ .TAG }}
+          COMMIT: ${{ .COMMIT }}
+          REPO_INFO: ${{ .REPO_INFO }}
+          GOCACHE: "{{ .GOCACHE }}"
 - name: multi_gw_postgres
   manifests:
     kustomize:

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -3788,6 +3788,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -3874,7 +3877,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: expressions
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         lifecycle:
           preStop:
             exec:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -3803,6 +3803,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -3884,7 +3887,7 @@ spec:
           value: /dev/stderr
         - name: KONG_ROUTER_FLAVOR
           value: expressions
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         lifecycle:
           preStop:
             exec:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -3805,6 +3805,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -3790,6 +3790,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -3823,7 +3823,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         lifecycle:
           preStop:
             exec:
@@ -3910,6 +3910,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -3942,7 +3945,7 @@ spec:
           value: postgres
         - name: KONG_PG_PASSWORD
           value: kong
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         name: wait-for-migrations
       serviceAccountName: kong-serviceaccount
       volumes:
@@ -4041,7 +4044,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         name: kong-migrations
       imagePullSecrets:
       - name: kong-enterprise-edition-docker
@@ -4056,7 +4059,7 @@ spec:
           value: postgres
         - name: KONG_PG_PORT
           value: "5432"
-        image: kong/kong-gateway:3.5
+        image: kong/kong-gateway:3.7
         name: wait-for-postgres
       restartPolicy: OnFailure
 ---

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -3804,6 +3804,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -3854,6 +3854,9 @@ spec:
         - containerPort: 10255
           name: cmetrics
           protocol: TCP
+        - containerPort: 10256
+          name: diagnostics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds multi gw enterprise skaffold config which deploys `kong/kong-gateway` instead of `kong`

```
make run.skaffold SKAFFOLD_RUN_PROFILE=multi_gw_enterprise
```

It also introduced the changes so that kustomize images are updated by renovate. Config dump port (10256) is also exposed for ease of use.
