### PR TITLE
perf: optimize `GetCombinations`

### DIFF
--- a/internal/util/relations.go
+++ b/internal/util/relations.go
@@ -9,47 +9,53 @@ type Rel struct {
 }
 
 func (relations *ForeignRelations) GetCombinations() []Rel {
+	var (
+		lConsumer      = len(relations.Consumer)
+		lConsumerGroup = len(relations.ConsumerGroup)
+		lRoutes        = len(relations.Route)
+		lServices      = len(relations.Service)
+		l              = lRoutes + lServices
+	)
+
 	var cartesianProduct []Rel
 
 	// gocritic I don't care that you think switch statements are the one true god of readability, the language offers
 	// multiple options for a reason. go away, gocritic.
-	if len(relations.Consumer) > 0 { //nolint:gocritic
-		consumers := relations.Consumer
-		if len(relations.Route)+len(relations.Service) > 0 {
-			for _, service := range relations.Service {
-				for _, consumer := range consumers {
+	if lConsumer > 0 { // nolint:gocritic
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumer)
+			for _, consumer := range relations.Consumer {
+				for _, service := range relations.Service {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Service:  service,
 						Consumer: consumer,
 					})
 				}
-			}
-			for _, route := range relations.Route {
-				for _, consumer := range consumers {
+				for _, route := range relations.Route {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Route:    route,
 						Consumer: consumer,
 					})
 				}
 			}
+
 		} else {
+			cartesianProduct = make([]Rel, 0, len(relations.Consumer))
 			for _, consumer := range relations.Consumer {
 				cartesianProduct = append(cartesianProduct, Rel{Consumer: consumer})
 			}
 		}
-	} else if len(relations.ConsumerGroup) > 0 {
-		groups := relations.ConsumerGroup
-		if len(relations.Route)+len(relations.Service) > 0 {
-			for _, service := range relations.Service {
-				for _, group := range groups {
+	} else if lConsumerGroup > 0 {
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumerGroup)
+			for _, group := range relations.ConsumerGroup {
+				for _, service := range relations.Service {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Service:       service,
 						ConsumerGroup: group,
 					})
 				}
-			}
-			for _, route := range relations.Route {
-				for _, group := range groups {
+				for _, route := range relations.Route {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Route:         route,
 						ConsumerGroup: group,
@@ -57,11 +63,13 @@ func (relations *ForeignRelations) GetCombinations() []Rel {
 				}
 			}
 		} else {
+			cartesianProduct = make([]Rel, 0, lConsumerGroup)
 			for _, group := range relations.ConsumerGroup {
 				cartesianProduct = append(cartesianProduct, Rel{ConsumerGroup: group})
 			}
 		}
-	} else {
+	} else if l > 0 {
+		cartesianProduct = make([]Rel, 0, l)
 		for _, service := range relations.Service {
 			cartesianProduct = append(cartesianProduct, Rel{Service: service})
 		}

--- a/internal/util/relations.go
+++ b/internal/util/relations.go
@@ -21,7 +21,7 @@ func (relations *ForeignRelations) GetCombinations() []Rel {
 
 	// gocritic I don't care that you think switch statements are the one true god of readability, the language offers
 	// multiple options for a reason. go away, gocritic.
-	if lConsumer > 0 { // nolint:gocritic
+	if lConsumer > 0 { //nolint:gocritic
 		if l > 0 {
 			cartesianProduct = make([]Rel, 0, l*lConsumer)
 			for _, consumer := range relations.Consumer {

--- a/internal/util/relations_test.go
+++ b/internal/util/relations_test.go
@@ -123,12 +123,12 @@ func TestGetCombinations(t *testing.T) {
 					Route:    "foo",
 				},
 				{
-					Consumer: "bar",
-					Route:    "foo",
-				},
-				{
 					Consumer: "foo",
 					Route:    "bar",
+				},
+				{
+					Consumer: "bar",
+					Route:    "foo",
 				},
 				{
 					Consumer: "bar",
@@ -150,12 +150,12 @@ func TestGetCombinations(t *testing.T) {
 					Service:  "foo",
 				},
 				{
-					Consumer: "bar",
-					Service:  "foo",
-				},
-				{
 					Consumer: "foo",
 					Service:  "bar",
+				},
+				{
+					Consumer: "bar",
+					Service:  "foo",
 				},
 				{
 					Consumer: "bar",
@@ -178,28 +178,28 @@ func TestGetCombinations(t *testing.T) {
 					Service:  "s1",
 				},
 				{
-					Consumer: "c2",
-					Service:  "s1",
-				},
-				{
 					Consumer: "c1",
 					Service:  "s2",
 				},
 				{
-					Consumer: "c2",
-					Service:  "s2",
-				},
-				{
 					Consumer: "c1",
-					Route:    "r1",
-				},
-				{
-					Consumer: "c2",
 					Route:    "r1",
 				},
 				{
 					Consumer: "c1",
 					Route:    "r2",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s1",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s2",
+				},
+				{
+					Consumer: "c2",
+					Route:    "r1",
 				},
 				{
 					Consumer: "c2",
@@ -222,28 +222,28 @@ func TestGetCombinations(t *testing.T) {
 					Service:       "s1",
 				},
 				{
-					ConsumerGroup: "cg2",
-					Service:       "s1",
-				},
-				{
 					ConsumerGroup: "cg1",
 					Service:       "s2",
 				},
 				{
-					ConsumerGroup: "cg2",
-					Service:       "s2",
-				},
-				{
 					ConsumerGroup: "cg1",
-					Route:         "r1",
-				},
-				{
-					ConsumerGroup: "cg2",
 					Route:         "r1",
 				},
 				{
 					ConsumerGroup: "cg1",
 					Route:         "r2",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Service:       "s1",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Service:       "s2",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Route:         "r1",
 				},
 				{
 					ConsumerGroup: "cg2",
@@ -262,25 +262,25 @@ func TestGetCombinations(t *testing.T) {
 func BenchmarkGetCombinations(b *testing.B) {
 	b.Run("consumer groups", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			relationsCG := ForeignRelations{
+			relations := ForeignRelations{
 				Route:         []string{"r1", "r2"},
 				Service:       []string{"s1", "s2"},
 				ConsumerGroup: []string{"cg1", "cg2"},
 			}
 
-			rels := relationsCG.GetCombinations()
+			rels := relations.GetCombinations()
 			_ = rels
 		}
 	})
 	b.Run("consumers", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			relationsCG := ForeignRelations{
+			relations := ForeignRelations{
 				Route:    []string{"r1", "r2"},
 				Service:  []string{"s1", "s2"},
 				Consumer: []string{"c1", "c2", "c3"},
 			}
 
-			rels := relationsCG.GetCombinations()
+			rels := relations.GetCombinations()
 			_ = rels
 		}
 	})

--- a/internal/util/relations_test.go
+++ b/internal/util/relations_test.go
@@ -206,6 +206,50 @@ func TestGetCombinations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "plugins on combination of service,route and consumer group",
+			args: args{
+				relations: ForeignRelations{
+					Route:         []string{"r1", "r2"},
+					Service:       []string{"s1", "s2"},
+					ConsumerGroup: []string{"cg1", "cg2"},
+				},
+			},
+			want: []Rel{
+				{
+					Consumer: "cg1",
+					Service:  "s1",
+				},
+				{
+					Consumer: "cg2",
+					Service:  "s1",
+				},
+				{
+					Consumer: "cg1",
+					Service:  "s2",
+				},
+				{
+					Consumer: "cg2",
+					Service:  "s2",
+				},
+				{
+					Consumer: "cg1",
+					Route:    "r1",
+				},
+				{
+					Consumer: "cg2",
+					Route:    "r1",
+				},
+				{
+					Consumer: "cg1",
+					Route:    "r2",
+				},
+				{
+					Consumer: "cg2",
+					Route:    "r2",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -214,4 +258,31 @@ func TestGetCombinations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkGetCombinations(b *testing.B) {
+	b.Run("consumer groups", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			relationsCG := ForeignRelations{
+				Route:         []string{"r1", "r2"},
+				Service:       []string{"s1", "s2"},
+				ConsumerGroup: []string{"cg1", "cg2"},
+			}
+
+			rels := relationsCG.GetCombinations()
+			_ = rels
+		}
+	})
+	b.Run("consumers", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			relationsCG := ForeignRelations{
+				Route:    []string{"r1", "r2"},
+				Service:  []string{"s1", "s2"},
+				Consumer: []string{"c1", "c2", "c3"},
+			}
+
+			rels := relationsCG.GetCombinations()
+			_ = rels
+		}
+	})
 }

--- a/internal/util/relations_test.go
+++ b/internal/util/relations_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCombinations(t *testing.T) {
@@ -217,45 +218,43 @@ func TestGetCombinations(t *testing.T) {
 			},
 			want: []Rel{
 				{
-					Consumer: "cg1",
-					Service:  "s1",
+					ConsumerGroup: "cg1",
+					Service:       "s1",
 				},
 				{
-					Consumer: "cg2",
-					Service:  "s1",
+					ConsumerGroup: "cg2",
+					Service:       "s1",
 				},
 				{
-					Consumer: "cg1",
-					Service:  "s2",
+					ConsumerGroup: "cg1",
+					Service:       "s2",
 				},
 				{
-					Consumer: "cg2",
-					Service:  "s2",
+					ConsumerGroup: "cg2",
+					Service:       "s2",
 				},
 				{
-					Consumer: "cg1",
-					Route:    "r1",
+					ConsumerGroup: "cg1",
+					Route:         "r1",
 				},
 				{
-					Consumer: "cg2",
-					Route:    "r1",
+					ConsumerGroup: "cg2",
+					Route:         "r1",
 				},
 				{
-					Consumer: "cg1",
-					Route:    "r2",
+					ConsumerGroup: "cg1",
+					Route:         "r2",
 				},
 				{
-					Consumer: "cg2",
-					Route:    "r2",
+					ConsumerGroup: "cg2",
+					Route:         "r2",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.args.relations.GetCombinations(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetCombinations() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.relations.GetCombinations())
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Optimizes `GetCombinations` + adds a testcase for consumer groups

old e6de62fc1

```
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/util
BenchmarkGetCombinations/consumer_groups-10              3546044               346.5 ns/op           960 B/op          4 allocs/op
BenchmarkGetCombinations/consumer_groups-10              3691382               338.9 ns/op           960 B/op          4 allocs/op
BenchmarkGetCombinations/consumer_groups-10              3682710               366.5 ns/op           960 B/op          4 allocs/op
BenchmarkGetCombinations/consumer_groups-10              3747121               342.3 ns/op           960 B/op          4 allocs/op
BenchmarkGetCombinations/consumer_groups-10              3453127               331.8 ns/op           960 B/op          4 allocs/op
BenchmarkGetCombinations/consumers-10                    1819192               710.9 ns/op          2112 B/op          5 allocs/op
BenchmarkGetCombinations/consumers-10                    1795992               610.2 ns/op          2112 B/op          5 allocs/op
BenchmarkGetCombinations/consumers-10                    1989704               689.6 ns/op          2112 B/op          5 allocs/op
BenchmarkGetCombinations/consumers-10                    1794462               665.6 ns/op          2112 B/op          5 allocs/op
BenchmarkGetCombinations/consumers-10                    1986769               648.5 ns/op          2112 B/op          5 allocs/op
PASS
ok      github.com/kong/kubernetes-ingress-controller/v3/internal/util  17.853s
```

new 9b1af75aadd98aca9550d02518c6dace483a34cb

```
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/util
BenchmarkGetCombinations/consumer_groups-10              7226517               165.5 ns/op           512 B/op          1 allocs/op
BenchmarkGetCombinations/consumer_groups-10              7329960               162.8 ns/op           512 B/op          1 allocs/op
BenchmarkGetCombinations/consumer_groups-10              7136982               161.8 ns/op           512 B/op          1 allocs/op
BenchmarkGetCombinations/consumer_groups-10              7452933               160.4 ns/op           512 B/op          1 allocs/op
BenchmarkGetCombinations/consumer_groups-10              7399339               161.7 ns/op           512 B/op          1 allocs/op
BenchmarkGetCombinations/consumers-10                    4639536               253.1 ns/op           896 B/op          1 allocs/op
BenchmarkGetCombinations/consumers-10                    4779056               256.3 ns/op           896 B/op          1 allocs/op
BenchmarkGetCombinations/consumers-10                    4606189               250.9 ns/op           896 B/op          1 allocs/op
BenchmarkGetCombinations/consumers-10                    4803146               252.7 ns/op           896 B/op          1 allocs/op
BenchmarkGetCombinations/consumers-10                    4661347               253.2 ns/op           896 B/op          1 allocs/op
PASS
ok      github.com/kong/kubernetes-ingress-controller/v3/internal/util  14.439s
```

```
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/util
                                   │   old.txt   │              new.txt               │
                                   │   sec/op    │   sec/op     vs base               │
GetCombinations/consumer_groups-10   342.3n ± 1%   161.8n ± 1%  -52.73% (p=0.008 n=5)
GetCombinations/consumers-10         665.6n ± 4%   253.1n ± 0%  -61.97% (p=0.008 n=5)
geomean                              477.3n        202.4n       -57.60%

                                   │   old.txt    │              new.txt              │
                                   │     B/op     │    B/op     vs base               │
GetCombinations/consumer_groups-10     960.0 ± 0%   512.0 ± 0%  -46.67% (p=0.008 n=5)
GetCombinations/consumers-10          2112.0 ± 0%   896.0 ± 0%  -57.58% (p=0.008 n=5)
geomean                              1.391Ki        677.3       -52.43%

                                   │  old.txt   │              new.txt              │
                                   │ allocs/op  │ allocs/op   vs base               │
GetCombinations/consumer_groups-10   4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.008 n=5)
GetCombinations/consumers-10         5.000 ± 0%   1.000 ± 0%  -80.00% (p=0.008 n=5)
geomean                              4.472        1.000       -77.64%
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
