### PR TITLE
chore: fix renovate config

### DIFF
--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong@regenerate
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '3.1' # renovate: datasource=docker versioning=docker depName=kong/kubernetes-ingress-controller
+  newTag: '3.1' # renovate: datasource=docker versioning=docker depName=kong/kubernetes-ingress-controller@regenerate

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,17 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
       ]
+    },
+    {
+      "description": "Match versions in config/image/oss and config/image/enterprise kustomize files that are properly annotated with `# renovate: datasource={} versioning={} depName={}`.",
+      "customType": "regex",
+      "fileMatch": [
+        "^config/image/enterprise/.*\\.yaml$",
+        "^config/image/oss/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "'(?<currentValue>.+)' # renovate: datasource=(?<datasource>.*) versioning=(?<versioning>.*) depName=(?<depName>.+)"
+      ]
     }
   ],
   "customDatasources": {
@@ -63,14 +74,9 @@
       ]
     },
     {
-      "description": "Match versions in config/image/oss and config/image/enterprise kustomize files that are properly annotated with `# renovate: datasource={} versioning={} depName={}`.",
-      "customType": "regex",
-      "fileMatch": [
-        "^config/image/enterprise/.*\\.yaml$",
-        "^config/image/oss/.*\\.yaml$"
-      ],
-      "matchStrings": [
-        "'(?<currentValue>.+)' # renovate: datasource=(?<datasource>.*) versioning=(?<versioning>.*) depName=(?<depName>.+)"
+      "description": "Add 'renovate/auto-regenerate' label to a PR if it changes kustomize files containing images to trigger regenerate_on_deps_bump.yaml workflow.",
+      "matchDepPatterns": [
+        ".*@regenerate"
       ],
       "addLabels": [
         "renovate/auto-regenerate"


### PR DESCRIPTION

**What this PR does / why we need it**:

Validated using `npx --yes --package renovate -- renovate-config-validator`

**Which issue this PR fixes**:

Fixes #6148 

particularly user-facing) changes introduced by this PR
