### PR TITLE
chore(tests): add fallback config golden tests for Ingress and Service

### DIFF
--- a/internal/dataplane/testdata/golden/fallback-config-ingress/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-ingress/default_golden.yaml
@@ -1,0 +1,48 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: svc.foo-namespace.80.svc
+  id: b39d28b5-b340-5fdf-951c-7533171d95bb
+  name: foo-namespace.svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    id: 6ac99766-f0f3-51ec-ae0f-df376a67738e
+    name: foo-namespace.valid-ingress.svc.example.com.80
+    path_handling: v0
+    paths:
+    - ~/valid$
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:valid-ingress
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/testdata/golden/fallback-config-ingress/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-ingress/in.yaml
@@ -1,0 +1,56 @@
+# In this test case we have two Ingresses and one Service. One of the Ingresses is broken and the other is valid.
+# We expect the broken Ingress to be excluded.
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: broken-ingress
+  namespace: foo-namespace
+  uid: "6faea5d6-ce95-439e-b223-421a0a142e3f"
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: svc
+                port:
+                  number: 80
+            path: /broken
+            pathType: Exact
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: valid-ingress
+  namespace: foo-namespace
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: svc
+                port:
+                  number: 80
+            path: /valid
+            pathType: Exact
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: svc
+  namespace: foo-namespace
+spec:
+  ports:
+    - port: 80

--- a/internal/dataplane/testdata/golden/fallback-config-service/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-service/default_golden.yaml
@@ -1,0 +1,48 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  host: valid-svc.foo-namespace.80.svc
+  id: 7ef49b77-070d-522e-bb48-b13885406ee7
+  name: foo-namespace.valid-svc.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    id: 5e522fc0-aa10-5a7c-a220-1521a77295cd
+    name: foo-namespace.valid-ingress.valid-svc.example.com.80
+    path_handling: v0
+    paths:
+    - ~/valid$
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: false
+    tags:
+    - k8s-name:valid-ingress
+    - k8s-namespace:foo-namespace
+    - k8s-kind:Ingress
+    - k8s-group:networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:valid-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  name: valid-svc.foo-namespace.80.svc
+  tags:
+  - k8s-name:valid-svc
+  - k8s-namespace:foo-namespace
+  - k8s-kind:Service
+  - k8s-version:v1

--- a/internal/dataplane/testdata/golden/fallback-config-service/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-service/in.yaml
@@ -1,0 +1,64 @@
+# In this test case, we have two Services and two Ingresses. One of the Services is broken and the other is valid.
+# Because the broken Service is referenced in an Ingress, we expect the Ingress to be excluded.
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-broken-service
+  namespace: foo-namespace
+  uid: "6faea5d6-ce95-439e-b223-421a0a142e3f"
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: broken-svc
+                port:
+                  number: 80
+            path: /broken
+            pathType: Exact
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: valid-ingress
+  namespace: foo-namespace
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: valid-svc
+                port:
+                  number: 80
+            path: /valid
+            pathType: Exact
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    test.konghq.com/broken: "true"
+  name: broken-svc
+  namespace: foo-namespace
+  uid: "6faea5d6-ce95-439e-b223-421a0a142e3f"
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valid-svc
+  namespace: foo-namespace
+spec:
+  ports:
+    - port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusts golden tests to enable returning broken objects in `POST /config` Admin API responses and adds first two test cases for `Ingress` and `Service`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6076.
