### PR TITLE
chore(tests): introduce isolated TestHTTPRouteUseLastValidConfigWithBrokenPluginFallback

### DIFF
--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -28,7 +28,7 @@ const (
 	// SanitizeKonnectConfigDumps is the name of the feature-gate that enables sanitization of Konnect config dumps.
 	SanitizeKonnectConfigDumps = "SanitizeKonnectConfigDumps"
 
-	// FallbackConfiguration is the name of the featuer-gate that enables generating fallback configuration in the case
+	// FallbackConfiguration is the name of the feature-gate that enables generating fallback configuration in the case
 	// of entity errors returned by the Kong Admin API.
 	FallbackConfiguration = "FallbackConfiguration"
 

--- a/test/integration/isolated/examples_httproute_test.go
+++ b/test/integration/isolated/examples_httproute_test.go
@@ -9,10 +9,20 @@ import (
 	"testing"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
+	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
@@ -49,7 +59,7 @@ func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
 			withControllerManagerOpts(
 				helpers.ControllerManagerOptAdditionalWatchNamespace("default"),
 			),
-			withControllerManagerFeatureGates(map[string]string{"FallbackConfiguration": "true"}),
+			withControllerManagerFeatureGates(map[string]string{featuregates.FallbackConfiguration: "true"}),
 		)).
 		Assess("deploying to cluster works and HTTP requests are routed properly",
 			runHTTPRouteExampleTestScenario(httprouteWithBrokenPluginFallback),
@@ -57,6 +67,7 @@ func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
 		Assess("verify that route with misconfigured plugin is not operational", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 			proxyURL := GetHTTPURLFromCtx(ctx)
 			t.Logf("verifying that Kong gateway response in returned instead of desired site")
+
 			helpers.EventuallyGETPath(
 				t,
 				proxyURL,
@@ -68,6 +79,201 @@ func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
 				consts.IngressWait,
 				consts.WaitTick,
 			)
+			return ctx
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}
+
+func TestHTTPRouteUseLastValidConfigWithBrokenPluginFallback(t *testing.T) {
+	httprouteExampleManifest := examplesManifestPath("gateway-httproute.yaml")
+	const (
+		namespace                   = "default"
+		additionalRouteName         = "httproute-testing-additional"
+		additionalRoutePath         = "/additional-route"
+		additionalRoutServiceTarget = "echo-1"
+	)
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
+		WithLabel(testlabels.Kind, testlabels.KindHTTPRoute).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(
+				helpers.ControllerManagerOptAdditionalWatchNamespace(namespace),
+				helpers.ControllerManagerOptFlagUseLastValidConfigForFallback(),
+			),
+			withControllerManagerFeatureGates(map[string]string{featuregates.FallbackConfiguration: "true"}),
+		)).
+		Assess("deploying to cluster works and HTTP requests are routed properly", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			runHTTPRouteExampleTestScenario(httprouteExampleManifest)(ctx, t, c)
+
+			t.Log("getting a gateway client")
+			gatewayClient, err := gatewayclient.NewForConfig(GetClusterFromCtx(ctx).Config())
+			assert.NoError(t, err)
+			ctx = SetInCtxForT(ctx, t, gatewayClient)
+
+			t.Log("adding additional properly configured route")
+			_, err = gatewayClient.GatewayV1().HTTPRoutes(namespace).Create(ctx, &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      additionalRouteName,
+					Annotations: map[string]string{
+						annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+					},
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Name: "kong",
+							},
+						},
+					},
+					Rules: []gatewayapi.HTTPRouteRule{
+						{
+							Matches: []gatewayapi.HTTPRouteMatch{
+								{
+									Path: &gatewayapi.HTTPPathMatch{
+										Type:  lo.ToPtr(gatewayapi.PathMatchPathPrefix),
+										Value: lo.ToPtr(additionalRoutePath),
+									},
+								},
+							},
+							BackendRefs: []gatewayapi.HTTPBackendRef{
+								{
+									BackendRef: gatewayapi.BackendRef{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+											Name: additionalRoutServiceTarget,
+											Port: lo.ToPtr(gatewayapi.PortNumber(80)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			t.Logf("verifying that routing to %s works", additionalRoutePath)
+			proxyURL := GetHTTPURLFromCtx(ctx)
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				additionalRoutePath,
+				http.StatusOK,
+				additionalRoutServiceTarget,
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+
+			return ctx
+		}).
+		Assess("assign broken broken plugin to a working route", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			cluster := GetClusterFromCtx(ctx)
+
+			client, err := clientset.NewForConfig(cluster.Config())
+			require.NoError(t, err)
+			brokenPlugin := &kongv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "response-transformer",
+				},
+				PluginName: "response-transformer",
+				// Misconfigured on purpose.
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"test": "test"}`),
+				},
+			}
+			_, err = client.ConfigurationV1().KongPlugins(namespace).Create(ctx, brokenPlugin, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			t.Log("getting a gateway client")
+			gatewayClient, err := gatewayclient.NewForConfig(cluster.Config())
+			assert.NoError(t, err)
+			ctx = SetInCtxForT(ctx, t, gatewayClient)
+
+			route, err := gatewayClient.GatewayV1().HTTPRoutes(namespace).Get(ctx, additionalRouteName, metav1.GetOptions{})
+			assert.NoError(t, err)
+			route.Annotations[annotations.AnnotationPrefix+annotations.PluginsKey] = brokenPlugin.Name
+			_, err = gatewayClient.GatewayV1().HTTPRoutes(namespace).Update(ctx, route, metav1.UpdateOptions{})
+			assert.NoError(t, err)
+
+			return ctx
+		}).
+		Assess("verify that route with misconfigured plugin is not operational", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			proxyURL := GetHTTPURLFromCtx(ctx)
+			t.Logf("verifying that Kong gateway response in returned instead of desired site")
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				additionalRoutePath,
+				http.StatusNotFound,
+				"no Route matched with those values",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+			return ctx
+		}).
+		Assess("modify working route /httproute-testing to /new-route", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			gatewayclient := GetFromCtxForT[*gatewayclient.Clientset](ctx, t)
+			route, err := gatewayclient.GatewayV1().HTTPRoutes(namespace).Get(ctx, "httproute-testing", metav1.GetOptions{})
+			require.NoError(t, err)
+			route.Spec.Rules[0].Matches[0].Path.Value = lo.ToPtr("/new-route")
+			_, err = gatewayclient.GatewayV1().HTTPRoutes(namespace).Update(ctx, route, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			return ctx
+		}).
+		Assess("verify that route with misconfigured plugin is not operational", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			proxyURL := GetHTTPURLFromCtx(ctx)
+			const newRoute = "/new-route"
+
+			t.Logf("verifying that /httproute-testing is no longer operational")
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				"/httproute-testing",
+				http.StatusNotFound,
+				"no Route matched with those values",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+
+			t.Logf("verifying that /new-route is operational and loadbalanced")
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				newRoute,
+				http.StatusOK,
+				"echo-1",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				newRoute,
+				http.StatusOK,
+				"echo-2",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+
 			return ctx
 		}).
 		Teardown(featureTeardown())

--- a/test/integration/isolated/examples_httproute_test.go
+++ b/test/integration/isolated/examples_httproute_test.go
@@ -175,7 +175,7 @@ func TestHTTPRouteUseLastValidConfigWithBrokenPluginFallback(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("assign broken broken plugin to a working route", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+		Assess("assign broken plugin to a working route", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 			cluster := GetClusterFromCtx(ctx)
 
 			client, err := clientset.NewForConfig(cluster.Config())

--- a/test/internal/helpers/controller_manager_flag_opts.go
+++ b/test/internal/helpers/controller_manager_flag_opts.go
@@ -34,3 +34,11 @@ func ControllerManagerOptAdditionalWatchNamespace(ns string) ControllerManagerOp
 		return args
 	}
 }
+
+// ControllerManagerOptFlagUseLastValidConfigForFallback sets --use-last-valid-config-for-fallback
+// controller manager flag.
+func ControllerManagerOptFlagUseLastValidConfigForFallback() ControllerManagerOpt {
+	return func(args []string) []string {
+		return append(args, "--use-last-valid-config-for-fallback")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It introduces new isolated integration test `TestHTTPRouteUseLastValidConfigWithBrokenPluginFallback` that covers KIC which is run with feature gate `FallbackConfiguration=true` and flag `--use-last-valid-config-for-fallback` (there is already test that tests behavior only for feature flag). 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Additional to https://github.com/Kong/kubernetes-ingress-controller/issues/6077

