### PR TITLE
fix(plugins) handle CG plugins like consumers (#6132)

### DIFF
--- a/internal/util/relations.go
+++ b/internal/util/relations.go
@@ -9,36 +9,67 @@ type Rel struct {
 }
 
 func (relations *ForeignRelations) GetCombinations() []Rel {
+	var (
+		lConsumer      = len(relations.Consumer)
+		lConsumerGroup = len(relations.ConsumerGroup)
+		lRoutes        = len(relations.Route)
+		lServices      = len(relations.Service)
+		l              = lRoutes + lServices
+	)
+
 	var cartesianProduct []Rel
 
-	if len(relations.Consumer) > 0 {
-		consumers := relations.Consumer
-		if len(relations.Route)+len(relations.Service) > 0 {
-			for _, service := range relations.Service {
-				for _, consumer := range consumers {
+	// gocritic I don't care that you think switch statements are the one true god of readability, the language offers
+	// multiple options for a reason. go away, gocritic.
+	if lConsumer > 0 { //nolint:gocritic
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumer)
+			for _, consumer := range relations.Consumer {
+				for _, service := range relations.Service {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Service:  service,
 						Consumer: consumer,
 					})
 				}
-			}
-			for _, route := range relations.Route {
-				for _, consumer := range consumers {
+				for _, route := range relations.Route {
 					cartesianProduct = append(cartesianProduct, Rel{
 						Route:    route,
 						Consumer: consumer,
 					})
 				}
 			}
+
 		} else {
+			cartesianProduct = make([]Rel, 0, len(relations.Consumer))
 			for _, consumer := range relations.Consumer {
 				cartesianProduct = append(cartesianProduct, Rel{Consumer: consumer})
 			}
 		}
-	} else {
-		for _, consumerGroup := range relations.ConsumerGroup {
-			cartesianProduct = append(cartesianProduct, Rel{ConsumerGroup: consumerGroup})
+	} else if lConsumerGroup > 0 {
+		if l > 0 {
+			cartesianProduct = make([]Rel, 0, l*lConsumerGroup)
+			for _, group := range relations.ConsumerGroup {
+				for _, service := range relations.Service {
+					cartesianProduct = append(cartesianProduct, Rel{
+						Service:       service,
+						ConsumerGroup: group,
+					})
+				}
+				for _, route := range relations.Route {
+					cartesianProduct = append(cartesianProduct, Rel{
+						Route:         route,
+						ConsumerGroup: group,
+					})
+				}
+			}
+		} else {
+			cartesianProduct = make([]Rel, 0, lConsumerGroup)
+			for _, group := range relations.ConsumerGroup {
+				cartesianProduct = append(cartesianProduct, Rel{ConsumerGroup: group})
+			}
 		}
+	} else if l > 0 {
+		cartesianProduct = make([]Rel, 0, l)
 		for _, service := range relations.Service {
 			cartesianProduct = append(cartesianProduct, Rel{Service: service})
 		}

--- a/internal/util/relations_test.go
+++ b/internal/util/relations_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCombinations(t *testing.T) {
@@ -122,12 +123,12 @@ func TestGetCombinations(t *testing.T) {
 					Route:    "foo",
 				},
 				{
-					Consumer: "bar",
-					Route:    "foo",
-				},
-				{
 					Consumer: "foo",
 					Route:    "bar",
+				},
+				{
+					Consumer: "bar",
+					Route:    "foo",
 				},
 				{
 					Consumer: "bar",
@@ -149,12 +150,12 @@ func TestGetCombinations(t *testing.T) {
 					Service:  "foo",
 				},
 				{
-					Consumer: "bar",
-					Service:  "foo",
-				},
-				{
 					Consumer: "foo",
 					Service:  "bar",
+				},
+				{
+					Consumer: "bar",
+					Service:  "foo",
 				},
 				{
 					Consumer: "bar",
@@ -177,28 +178,28 @@ func TestGetCombinations(t *testing.T) {
 					Service:  "s1",
 				},
 				{
-					Consumer: "c2",
-					Service:  "s1",
-				},
-				{
 					Consumer: "c1",
 					Service:  "s2",
 				},
 				{
-					Consumer: "c2",
-					Service:  "s2",
-				},
-				{
 					Consumer: "c1",
-					Route:    "r1",
-				},
-				{
-					Consumer: "c2",
 					Route:    "r1",
 				},
 				{
 					Consumer: "c1",
 					Route:    "r2",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s1",
+				},
+				{
+					Consumer: "c2",
+					Service:  "s2",
+				},
+				{
+					Consumer: "c2",
+					Route:    "r1",
 				},
 				{
 					Consumer: "c2",
@@ -206,12 +207,81 @@ func TestGetCombinations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "plugins on combination of service,route and consumer group",
+			args: args{
+				relations: ForeignRelations{
+					Route:         []string{"r1", "r2"},
+					Service:       []string{"s1", "s2"},
+					ConsumerGroup: []string{"cg1", "cg2"},
+				},
+			},
+			want: []Rel{
+				{
+					ConsumerGroup: "cg1",
+					Service:       "s1",
+				},
+				{
+					ConsumerGroup: "cg1",
+					Service:       "s2",
+				},
+				{
+					ConsumerGroup: "cg1",
+					Route:         "r1",
+				},
+				{
+					ConsumerGroup: "cg1",
+					Route:         "r2",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Service:       "s1",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Service:       "s2",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Route:         "r1",
+				},
+				{
+					ConsumerGroup: "cg2",
+					Route:         "r2",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.args.relations.GetCombinations(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetCombinations() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.args.relations.GetCombinations())
 		})
 	}
+}
+
+func BenchmarkGetCombinations(b *testing.B) {
+	b.Run("consumer groups", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			relations := ForeignRelations{
+				Route:         []string{"r1", "r2"},
+				Service:       []string{"s1", "s2"},
+				ConsumerGroup: []string{"cg1", "cg2"},
+			}
+
+			rels := relations.GetCombinations()
+			_ = rels
+		}
+	})
+	b.Run("consumers", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			relations := ForeignRelations{
+				Route:    []string{"r1", "r2"},
+				Service:  []string{"s1", "s2"},
+				Consumer: []string{"c1", "c2", "c3"},
+			}
+
+			rels := relations.GetCombinations()
+			_ = rels
+		}
+	})
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

Backporting https://github.com/Kong/kubernetes-ingress-controller/pull/6132 to 3.1

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
