### PR TITLE
chore(tests): add fallback golden tests for gateway api

### DIFF
--- a/internal/dataplane/testdata/golden/fallback-config-gateway-api/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-gateway-api/default_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-gateway-api/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-gateway-api/in.yaml
@@ -1,0 +1,103 @@
+# In this test case we have a set of all supported Gateway API resources attached to all of their possible dependants.
+# We expect empty config because of the broken resources.
+# `test.konghq.com/broken` annotations can be removed from the plugins to generate the actual config.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute
+  namespace: default
+  annotations:
+    konghq.com/strip-path: "true"
+    test.konghq.com/broken: "true"
+spec:
+  parentRefs:
+    - name: kong
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httproute
+      backendRefs:
+        - name: service
+          kind: Service
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcproute
+  namespace: default
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  parentRefs:
+    - name: kong
+  rules:
+    - backendRefs:
+        - name: service
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: udproute
+  namespace: default
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  parentRefs:
+    - name: kong
+  rules:
+    - backendRefs:
+        - name: service
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute
+  namespace: default
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  parentRefs:
+    - name: kong
+  hostnames:
+    - tlsroute.kong.example
+  rules:
+    - backendRefs:
+        - name: service
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute
+  namespace: default
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  parentRefs:
+    - name: kong
+  hostnames:
+    - "example.com"
+  rules:
+    - backendRefs:
+        - name: service
+          port: 80
+      matches:
+        - method:
+            service: "grpcbin.GRPCBin"
+            method: "DummyUnary"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: default
+  annotations:
+    konghq.com/plugins: plugin
+spec:
+  ports:
+    - port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongClient` golden tests verifying fallback configuration behavior for broken:

- `HTTPRoute`
- `TCPRoute`
- `UDPRoute`
- `TLSRoute`
- `GRPCRoute`

Test cases include all possible dependants of those and ensure they're excluded along with the broken objects.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #6076.