### PR TITLE
chore(tests): add fallback golden tests for kong resources

### DIFF
--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1alpha1"
 )
 
 // rawResourceError is a Kong configuration error associated with a Kubernetes resource with Kubernetes metadata stored
@@ -197,7 +198,10 @@ func parseRawResourceError(raw rawResourceError) (ResourceError, error) {
 
 func gvkIsClusterScoped(gvk schema.GroupVersionKind) bool {
 	if gvk.Group == kongv1.GroupVersion.Group && gvk.Version == kongv1.GroupVersion.Version {
-		return gvk.Kind == "KongClusterPlugin" || gvk.Kind == "KongLicense" || gvk.Kind == "KongVault"
+		return gvk.Kind == "KongClusterPlugin" || gvk.Kind == "KongLicense"
+	}
+	if gvk.Group == kongv1alpha1.GroupVersion.Group && gvk.Version == kongv1alpha1.GroupVersion.Version {
+		return gvk.Kind == "KongVault"
 	}
 	return false
 }

--- a/internal/dataplane/testdata/golden/fallback-config-kong/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong/default_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-kong/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong/in.yaml
@@ -1,0 +1,113 @@
+# In this test case we have a set of broken Kong resources with all of their possible dependants.
+# We expect empty config because of the broken resources.
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: default
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: incubator.ingress-controller.konghq.com/v1alpha1
+kind: KongServiceFacade
+metadata:
+  name: servicefacade
+  namespace: default
+  uid: "897e9a7f-799d-427e-bdef-f64a7227e2c1"
+  annotations:
+    kubernetes.io/ingress.class: kong
+    test.konghq.com/broken: "true"
+spec:
+  backendRef:
+    name: service
+    port: 80
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: consumer
+  namespace: default
+  uid: "9f17c37c-fdb5-4c6e-b89a-1398793337e8"
+  annotations:
+    kubernetes.io/ingress.class: kong
+    test.konghq.com/broken: "true"
+username: consumer
+consumerGroups:
+  - consumer-group
+---
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongConsumerGroup
+metadata:
+  name: consumer-group
+  namespace: default
+  uid: "8c80b242-75fb-44f2-b70d-ab1995da92d8"
+  annotations:
+    kubernetes.io/ingress.class: kong
+    test.konghq.com/broken: "true"
+---
+apiVersion: configuration.konghq.com/v1beta1
+kind: UDPIngress
+metadata:
+  name: udpingress
+  namespace: default
+  uid: "8c80b242-75fb-44f2-b70d-ab1995da92d8"
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+    test.konghq.com/broken: "true"
+spec:
+  rules:
+    - backend:
+        serviceName: service
+        servicePort: 80
+      port: 9999
+---
+apiVersion: configuration.konghq.com/v1beta1
+kind: TCPIngress
+metadata:
+  name: tcpingress
+  namespace: default
+  uid: "1aec1466-196d-495a-8201-d8e07b246e19"
+  annotations:
+    kubernetes.io/ingress.class: kong
+    test.konghq.com/broken: "true"
+spec:
+  rules:
+    - port: 9999
+      backend:
+        serviceName: service
+        servicePort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: default
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              resource:
+                apiGroup: incubator.ingress-controller.konghq.com
+                kind: KongServiceFacade
+                name: servicefacade
+            path: /ingress
+            pathType: Exact
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongVault
+metadata:
+  name: vault
+  uid: "c69e2d89-0207-4d7b-a467-3ed03c650dbf"
+  annotations:
+    kubernetes.io/ingress.class: kong
+    test.konghq.com/broken: "true"
+spec:
+  backend: env
+  prefix: env
+  description: env vault
+  config:
+    prefix: kong-env

--- a/internal/dataplane/testdata/golden/fallback-config-kong/service-facade-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong/service-facade-on_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-kong/service-facade-on_settings.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong/service-facade-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  KongServiceFacade: true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -791,6 +791,8 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 		return &incubatorv1alpha1.KongServiceFacade{}, nil
 	case kongv1alpha1.GroupVersion.WithKind(kongv1alpha1.KongCustomEntityKind):
 		return &kongv1alpha1.KongCustomEntity{}, nil
+	case kongv1alpha1.GroupVersion.WithKind("KongVault"):
+		return &kongv1alpha1.KongVault{}, nil
 	default:
 		return nil, fmt.Errorf("%s is not a supported runtime.Object", gvk)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongClient` golden tests verifying fallback configuration behavior for broken:

- `KongConsumer`
- `KongConsumerGroup`
- `TCPIngress`
- `UDPIngress`
- `KongServiceFacade`
- `KongVault`

Test cases include all possible dependants of those and ensure they're excluded along with the broken objects.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #6076.