### PR TITLE
chore(tests): add fallback golden tests for remaining resources

### DIFF
--- a/internal/dataplane/testdata/golden/fallback-config-ingress-class/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-ingress-class/default_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-ingress-class/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-ingress-class/in.yaml
@@ -1,0 +1,39 @@
+# In this test case we have an Ingress using a broken IngressClass.
+# We expect empty config because the IngressClass affects the Ingress directly.
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+  uid: "365fde8d-1cb4-45c5-bba1-b46eebdca3eb"
+  annotations:
+    test.konghq.com/broken: "true"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: default
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: service
+                port:
+                  number: 80
+            path: /ingress
+            pathType: Exact
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: default
+  annotations:
+    konghq.com/plugins: plugin
+spec:
+  ports:
+    - port: 80

--- a/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/default_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/in.yaml
@@ -1,0 +1,96 @@
+# In this test case we have a broken KongUpstreamPolicy resource that is referenced by a Service and a KongServiceFacade
+# that are used by an Ingress.
+# We expect empty config as the KongUpstreamPolicy is broken and affects all the resources.
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongUpstreamPolicy
+metadata:
+  name: policy
+  namespace: default
+  uid: "46a5031a-6b32-49d4-be98-877265ed08f3"
+  annotations:
+    test.konghq.com/broken: "true"
+spec:
+  algorithm: consistent-hashing
+  slots: 100
+  hashOn:
+    header: session-id
+  hashOnFallback:
+    input: consumer
+  healthchecks:
+    active:
+      type: http
+      httpPath: /status
+      httpsSni: example.com
+      httpsVerifyCertificate: false
+      concurrency: 20
+      timeout: 15
+      headers:
+        X-Health-Check:
+          - kong
+          - dataplane
+      healthy:
+        httpStatuses: [200, 302]
+        interval: 5
+        successes: 5
+      unhealthy:
+        httpStatuses: [400, 500]
+        httpFailures: 5
+        timeouts: 5
+        interval: 10
+    passive:
+      type: tcp
+      healthy:
+        successes: 5
+      unhealthy:
+        tcpFailures: 5
+        timeouts: 10
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: default
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: service
+                port:
+                  number: 80
+            path: /ingress
+            pathType: Exact
+          - backend:
+              resource:
+                apiGroup: incubator.ingress-controller.konghq.com
+                kind: KongServiceFacade
+                name: servicefacade
+            path: /ingress-facade
+            pathType: Exact
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: default
+  annotations:
+    konghq.com/upstream-policy: policy
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: incubator.ingress-controller.konghq.com/v1alpha1
+kind: KongServiceFacade
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+    konghq.com/upstream-policy: policy
+  name: servicefacade
+  namespace: default
+spec:
+  backendRef:
+    name: service
+    port: 80

--- a/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/service-facade-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/service-facade-on_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/service-facade-on_settings.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-kong-upstream-policy/service-facade-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  KongServiceFacade: true

--- a/internal/dataplane/testdata/golden/fallback-config-secret/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-secret/default_golden.yaml
@@ -1,0 +1,3 @@
+_format_version: "3.0"
+upstreams:
+- name: kong

--- a/internal/dataplane/testdata/golden/fallback-config-secret/in.yaml
+++ b/internal/dataplane/testdata/golden/fallback-config-secret/in.yaml
@@ -1,0 +1,66 @@
+# In this test case we have a broken Secret that is used by KongPlugin and KongClusterPlugin.
+# We expect all resources to be excluded because secrets affect directly (plugins) and indirectly (Ingress) them.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: default
+  uid: "5adfe8cc-cafc-45c1-9c9f-85f8a0cdbafa"
+  annotations:
+    test.konghq.com/broken: "true"
+type: Opaque
+data:
+  key: YmFyCg==
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: default
+spec:
+  ingressClassName: kong
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: service
+                port:
+                  number: 80
+            path: /ingress
+            pathType: Exact
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: default
+  annotations:
+    konghq.com/plugins: plugin
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: plugin
+  namespace: default
+configFrom:
+  secretKeyRef:
+    name: secret
+    key: key
+plugin: key-auth
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+metadata:
+  name: plugin
+  namespace: default
+configFrom:
+  secretKeyRef:
+    name: secret
+    namespace: default
+    key: key
+plugin: key-auth


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `KongClient` golden tests verifying fallback configuration behavior for broken:

- `IngressClass`
- `KongUpstreamPolicy`
- `Secret`

Test cases include all possible dependants of those and ensure they're excluded along with the broken objects.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of #6076.