### PR TITLE
fix: handing GRPCRoute hostname from Gateway

### DIFF
--- a/internal/dataplane/translator/subtranslator/grpcroute.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute.go
@@ -144,6 +144,10 @@ func getGRPCRouteHostnamesAsSliceOfStringPointers(grpcroute *gatewayapi.GRPCRout
 	if len(grpcroute.Spec.Hostnames) == 0 {
 		namespace := grpcroute.GetNamespace()
 
+		if grpcroute.Spec.ParentRefs == nil {
+			return nil
+		}
+
 		for _, parentRef := range grpcroute.Spec.ParentRefs {
 			// we only care about Gateways
 			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -220,7 +220,7 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule})
+			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule}, nil)
 			routes := GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute, 0)
 			require.Equal(t, tc.expectedRoutes, routes)
 		})

--- a/internal/dataplane/translator/subtranslator/grpcroute_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_test.go
@@ -30,6 +30,7 @@ func makeTestGRPCRoute(
 	name string, namespace string, annotations map[string]string,
 	hostnames []string,
 	rules []gatewayapi.GRPCRouteRule,
+	parentRef []gatewayapi.ParentReference,
 ) *gatewayapi.GRPCRoute {
 	return &gatewayapi.GRPCRoute{
 		TypeMeta: metav1.TypeMeta{
@@ -46,6 +47,9 @@ func makeTestGRPCRoute(
 				return gatewayapi.Hostname(h)
 			}),
 			Rules: rules,
+			CommonRouteSpec: gatewayapi.CommonRouteSpec{
+				ParentRefs: parentRef,
+			},
 		},
 	}
 }
@@ -58,6 +62,8 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 		hostnames      []string
 		rule           gatewayapi.GRPCRouteRule
 		expectedRoutes []kongstate.Route
+		parentRef      []gatewayapi.ParentReference
+		storer         store.Storer
 	}{
 		{
 			name:        "single match without hostname",
@@ -278,14 +284,70 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "no match with hostname from gateway",
+			objectName:  "hostname-from-gateway",
+			annotations: map[string]string{},
+			rule:        gatewayapi.GRPCRouteRule{},
+			expectedRoutes: []kongstate.Route{
+				{
+					Ingress: util.K8sObjectInfo{
+						Name:             "hostname-from-gateway",
+						Namespace:        "default",
+						Annotations:      map[string]string{},
+						GroupVersionKind: grpcRouteGVK,
+					},
+					Route: kong.Route{
+						Name:      kong.String("grpcroute.default.hostname-from-gateway.0.0"),
+						Hosts:     kong.StringSlice("bar.com"),
+						Protocols: kong.StringSlice("grpc", "grpcs"),
+						Tags: kong.StringSlice(
+							"k8s-name:hostname-from-gateway",
+							"k8s-namespace:default",
+							"k8s-kind:GRPCRoute",
+							"k8s-group:gateway.networking.k8s.io",
+							"k8s-version:v1",
+						),
+					},
+				},
+			},
+			parentRef: []gatewayapi.ParentReference{
+				{
+					Name:        "gateway",
+					Namespace:   lo.ToPtr(gatewayapi.Namespace("default")),
+					SectionName: lo.ToPtr(gatewayapi.SectionName("listener-1")),
+				},
+			},
+			storer: lo.Must(store.NewFakeStore(store.FakeObjects{
+				Gateways: []*gatewayapi.Gateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gateway",
+							Namespace: "default",
+						},
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Gateway",
+							APIVersion: "gateway.networking.k8s.io/v1",
+						},
+						Spec: gatewayapi.GatewaySpec{
+							Listeners: []gatewayapi.Listener{
+								{
+									Name:     "listener-1",
+									Hostname: lo.ToPtr(gatewayapi.Hostname("bar.com")),
+								},
+							},
+						},
+					},
+				},
+			})),
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			storer := lo.Must(store.NewFakeStore(store.FakeObjects{}))
-			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule})
-			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, storer)
+			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule}, tc.parentRef)
+			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, tc.storer)
 			require.Equal(t, tc.expectedRoutes, routes)
 		})
 	}

--- a/internal/dataplane/translator/subtranslator/grpcroute_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
@@ -282,8 +283,9 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			storer := lo.Must(store.NewFakeStore(store.FakeObjects{}))
 			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule})
-			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0)
+			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, storer)
 			require.Equal(t, tc.expectedRoutes, routes)
 		})
 	}
@@ -325,7 +327,8 @@ func TestGetGRPCRouteHostnamesAsSliceOfStringPointers(t *testing.T) {
 		},
 	} {
 		t.Run(tC.name, func(t *testing.T) {
-			result := getGRPCRouteHostnamesAsSliceOfStringPointers(tC.grpcroute)
+			storer := lo.Must(store.NewFakeStore(store.FakeObjects{}))
+			result := getGRPCRouteHostnamesAsSliceOfStringPointers(tC.grpcroute, storer)
 			require.Equal(t, tC.expected, result)
 		})
 	}

--- a/internal/dataplane/translator/translate_grpcroute.go
+++ b/internal/dataplane/translator/translate_grpcroute.go
@@ -60,7 +60,7 @@ func (t *Translator) ingressRulesFromGRPCRoute(result *ingressRules, grpcroute *
 		if err != nil {
 			return err
 		}
-		service.Routes = append(service.Routes, subtranslator.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber)...)
+		service.Routes = append(service.Routes, subtranslator.GenerateKongRoutesFromGRPCRouteRule(grpcroute, ruleNumber, t.storer)...)
 
 		// cache the service to avoid duplicates in further loop iterations
 		result.ServiceNameToServices[*service.Service.Name] = service

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -24,9 +24,6 @@ import (
 var skippedTestsForTraditionalRoutes = []string{
 	// core conformance
 	tests.HTTPRouteHeaderMatching.ShortName,
-	// There is an issue with KIC when processing this scenario.
-	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6136
-	tests.GRPCRouteListenerHostnameMatching.ShortName,
 	// tests.GRPCRouteHeaderMatching.ShortName and tests.GRPCExactMethodMatching.ShortName may
 	// have some conflicts, skipping either one will still pass normally.
 	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6144


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

There is[ a test case ](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/grpcroute-listener-hostname-matching.yaml)in the conformance test of GWAPI where hostname is not specified in GRPCRoute, but it is specified in Gateway. Therefore, when routing requests, the configuration for hostname needs to be obtained from Gateway and routes need to be generated accordingly so that request proxying can proceed normally.
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes:  https://github.com/Kong/kubernetes-ingress-controller/issues/6136

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

This can be seen as a fix to the existing logic, or it can be seen as a feature enhancement. However, there won't be too much of a noticeable difference for users, so I didn't add it to the CHANGELOG.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
