### PR TITLE
feat: validate --use-last-valid-config-for-fallback flag

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -92,5 +92,5 @@
 | `--term-delay` | `duration` | The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller. | `0s` |
 | `--update-status` | `bool` | Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.). | `true` |
 | `--update-status-queue-buffer-size` | `int` | Buffer size of the underlying channels used to update the status of resources. | `8192` |
-| `--use-last-valid-config-for-fallback` | `bool` | When recovering from config push failures, use the last valid configuration cache to backfill broken objects. | `false` |
+| `--use-last-valid-config-for-fallback` | `bool` | When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the FallbackConfiguration feature gate enabled. | `false` |
 | `--watch-namespace` | `strings` | Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces. | `[]` |

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -181,6 +181,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong.`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
+	// TODO: When FallbackConfiguration graduates we should remove the feature gate mention from the help text.
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/6170
 	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, fmt.Sprintf(`When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the %s feature gate enabled.`, featuregates.FallbackConfiguration))
 	// Default has to be explicitly passed to generate the proper docs. See https://github.com/kubernetes-sigs/controller-runtime/blob/f1c5dd3851ce3df8b4b7830d9b6eae6271f6932d/pkg/cache/cache.go#L146-L151.
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", 10*time.Hour, `Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.`)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -181,7 +181,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong.`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
-	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, `When recovering from config push failures, use the last valid configuration cache to backfill broken objects.`)
+	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, fmt.Sprintf(`When recovering from config push failures, use the last valid configuration cache to backfill broken objects. Can only be used with the %s feature gate enabled.`, featuregates.FallbackConfiguration))
 	// Default has to be explicitly passed to generate the proper docs. See https://github.com/kubernetes-sigs/controller-runtime/blob/f1c5dd3851ce3df8b4b7830d9b6eae6271f6932d/pkg/cache/cache.go#L146-L151.
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", 10*time.Hour, `Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.`)
 	flagSet.BoolVar(&c.SkipCACertificates, "skip-ca-certificates", false, `Disable syncing CA certificate syncing (for use with multi-workspace environments).`)

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -181,7 +181,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.KongWorkspace, "kong-workspace", "", "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.")
 	flagSet.BoolVar(&c.AnonymousReports, "anonymous-reports", true, `Send anonymized usage data to help improve Kong.`)
 	flagSet.BoolVar(&c.EnableReverseSync, "enable-reverse-sync", false, `Send configuration to Kong even if the configuration checksum has not changed since previous update.`)
-	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, fmt.Sprintf(`When recovering from config push failures, use the last valid configuration cache to backfill broken objects. Can only be used with the %s feature gate enabled.`, featuregates.FallbackConfiguration))
+	flagSet.BoolVar(&c.UseLastValidConfigForFallback, "use-last-valid-config-for-fallback", false, fmt.Sprintf(`When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the %s feature gate enabled.`, featuregates.FallbackConfiguration))
 	// Default has to be explicitly passed to generate the proper docs. See https://github.com/kubernetes-sigs/controller-runtime/blob/f1c5dd3851ce3df8b4b7830d9b6eae6271f6932d/pkg/cache/cache.go#L146-L151.
 	flagSet.DurationVar(&c.SyncPeriod, "sync-period", 10*time.Hour, `Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.`)
 	flagSet.BoolVar(&c.SkipCACertificates, "skip-ca-certificates", false, `Disable syncing CA certificate syncing (for use with multi-workspace environments).`)

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -6,12 +6,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/samber/mo"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config/types"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 )
 
 // https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -112,7 +112,7 @@ func (c *Config) validateKongAdminAPI() error {
 func (c *Config) validateFallbackConfiguration() error {
 	if !c.FeatureGates[featuregates.FallbackConfiguration] && c.UseLastValidConfigForFallback {
 		return fmt.Errorf(
-			"--use-last-valid-config-for-fallback can only be used with %s feature gate enabled",
+			"--use-last-valid-config-for-fallback or USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with %s feature gate enabled",
 			featuregates.FallbackConfiguration,
 		)
 	}

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -112,7 +112,7 @@ func (c *Config) validateKongAdminAPI() error {
 func (c *Config) validateFallbackConfiguration() error {
 	if !c.FeatureGates[featuregates.FallbackConfiguration] && c.UseLastValidConfigForFallback {
 		return fmt.Errorf(
-			"--use-last-valid-config-for-fallback or USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with %s feature gate enabled",
+			"--use-last-valid-config-for-fallback or CONTROLLER_USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with %s feature gate enabled",
 			featuregates.FallbackConfiguration,
 		)
 	}

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/samber/mo"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -70,6 +71,9 @@ func (c *Config) Validate() error {
 	if err := c.validateKongAdminAPI(); err != nil {
 		return fmt.Errorf("invalid kong admin api configuration: %w", err)
 	}
+	if err := c.validateFallbackConfiguration(); err != nil {
+		return fmt.Errorf("invalid fallback config settings: %w", err)
+	}
 
 	return nil
 }
@@ -101,6 +105,16 @@ func (c *Config) validateKonnect() error {
 func (c *Config) validateKongAdminAPI() error {
 	if err := validateClientTLS(c.KongAdminAPIConfig.TLSClient); err != nil {
 		return fmt.Errorf("TLS client config invalid: %w", err)
+	}
+	return nil
+}
+
+func (c *Config) validateFallbackConfiguration() error {
+	if !c.FeatureGates[featuregates.FallbackConfiguration] && c.UseLastValidConfigForFallback {
+		return fmt.Errorf(
+			"--use-last-valid-config-for-fallback can only be used with %s feature gate enabled",
+			featuregates.FallbackConfiguration,
+		)
 	}
 	return nil
 }

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -299,6 +300,24 @@ func TestConfigValidate(t *testing.T) {
 			c := validWithTokenPath()
 			c.KongAdminToken = "non-empty-token"
 			require.ErrorContains(t, c.Validate(), "both admin token and admin token file specified, only one allowed")
+		})
+	})
+
+	t.Run("--use-last-valid-config-for-fallback", func(t *testing.T) {
+		t.Run("enabled without feature gate is rejected", func(t *testing.T) {
+			c := manager.Config{
+				UseLastValidConfigForFallback: true,
+			}
+			require.ErrorContains(t, c.Validate(), "--use-last-valid-config-for-fallback can only be used with FallbackConfiguration feature gate enabled")
+		})
+		t.Run("enabled with feature gate is accepted", func(t *testing.T) {
+			c := manager.Config{
+				UseLastValidConfigForFallback: true,
+				FeatureGates: map[string]bool{
+					featuregates.FallbackConfiguration: true,
+				},
+			}
+			require.NoError(t, c.Validate())
 		})
 	})
 }

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -308,7 +308,7 @@ func TestConfigValidate(t *testing.T) {
 			c := manager.Config{
 				UseLastValidConfigForFallback: true,
 			}
-			require.ErrorContains(t, c.Validate(), "--use-last-valid-config-for-fallback or USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with FallbackConfiguration feature gate enabled")
+			require.ErrorContains(t, c.Validate(), "--use-last-valid-config-for-fallback or CONTROLLER_USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with FallbackConfiguration feature gate enabled")
 		})
 		t.Run("enabled with feature gate is accepted", func(t *testing.T) {
 			c := manager.Config{

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -13,6 +12,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 )
 
 func TestConfigValidatedVars(t *testing.T) {

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -308,7 +308,7 @@ func TestConfigValidate(t *testing.T) {
 			c := manager.Config{
 				UseLastValidConfigForFallback: true,
 			}
-			require.ErrorContains(t, c.Validate(), "--use-last-valid-config-for-fallback can only be used with FallbackConfiguration feature gate enabled")
+			require.ErrorContains(t, c.Validate(), "--use-last-valid-config-for-fallback or USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with FallbackConfiguration feature gate enabled")
 		})
 		t.Run("enabled with feature gate is accepted", func(t *testing.T) {
 			c := manager.Config{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds validation for the `--use-last-valid-config-for-fallback` flag that is only relevant when the `FallbackConfiguration` feature gate is turned on.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5854.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


