### PR TITLE
fix(fallback): backfill all affected objects, not only broken

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -115,15 +115,16 @@ func Run(
 	kongSemVersion := semver.Version{Major: v.Major(), Minor: v.Minor(), Patch: v.Patch()}
 
 	kongConfig := sendconfig.Config{
-		Version:                    kongSemVersion,
-		InMemory:                   dbMode.IsDBLessMode(),
-		Concurrency:                c.Concurrency,
-		FilterTags:                 c.FilterTags,
-		SkipCACertificates:         c.SkipCACertificates,
-		EnableReverseSync:          c.EnableReverseSync,
-		ExpressionRoutes:           dpconf.ShouldEnableExpressionRoutes(routerFlavor),
-		SanitizeKonnectConfigDumps: featureGates.Enabled(featuregates.SanitizeKonnectConfigDumps),
-		FallbackConfiguration:      featureGates.Enabled(featuregates.FallbackConfiguration),
+		Version:                       kongSemVersion,
+		InMemory:                      dbMode.IsDBLessMode(),
+		Concurrency:                   c.Concurrency,
+		FilterTags:                    c.FilterTags,
+		SkipCACertificates:            c.SkipCACertificates,
+		EnableReverseSync:             c.EnableReverseSync,
+		ExpressionRoutes:              dpconf.ShouldEnableExpressionRoutes(routerFlavor),
+		SanitizeKonnectConfigDumps:    featureGates.Enabled(featuregates.SanitizeKonnectConfigDumps),
+		FallbackConfiguration:         featureGates.Enabled(featuregates.FallbackConfiguration),
+		UseLastValidConfigForFallback: c.UseLastValidConfigForFallback,
 	}
 
 	setupLog.Info("Configuring and building the controller manager")


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the backfilling algorithm to attempt to backfill all affected (broken + directly and indirectly affected) objects from the last valid state instead of only the broken ones (the ones reported by Gateway).

Also 
- Passes the `UseLastValidConfigForFallback` flag value to `sendconfig.Config` (I could swear I tested that locally E2E and it was working 🤔) 
- Fixes the integration test that incorrectly assumed that headers that we pass to `EventuallyGETPath` are the expected response headers (no, they're not - these are request headers 🤦). It was passing, but wasn't really tested what it should test.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5854.


