### PR TITLE
fix(fallback): guard for nil last valid cache

### DIFF
--- a/internal/dataplane/fallback/fallback.go
+++ b/internal/dataplane/fallback/fallback.go
@@ -64,7 +64,7 @@ func (g *Generator) GenerateExcludingBrokenObjects(
 
 func (g *Generator) GenerateBackfillingBrokenObjects(
 	currentCache store.CacheStores,
-	lastValidCacheSnapshot store.CacheStores,
+	lastValidCacheSnapshot *store.CacheStores,
 	brokenObjects []ObjectHash,
 ) (store.CacheStores, error) {
 	// Build a graph from the current cache.
@@ -100,8 +100,13 @@ func (g *Generator) GenerateBackfillingBrokenObjects(
 		}
 	}
 
+	if lastValidCacheSnapshot == nil {
+		g.logger.V(util.DebugLevel).Info("No previous valid cache snapshot found, skipping backfilling")
+		return fallbackCache, nil
+	}
+
 	// Build a graph from the last valid cache snapshot.
-	lastValidGraph, err := g.cacheGraphProvider.CacheToGraph(lastValidCacheSnapshot)
+	lastValidGraph, err := g.cacheGraphProvider.CacheToGraph(*lastValidCacheSnapshot)
 	if err != nil {
 		return store.CacheStores{}, fmt.Errorf("failed to build cache graph: %w", err)
 	}

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -73,7 +73,7 @@ type FallbackConfigGenerator interface {
 	GenerateExcludingBrokenObjects(store.CacheStores, []fallback.ObjectHash) (store.CacheStores, error)
 	GenerateBackfillingBrokenObjects(
 		currentCache store.CacheStores,
-		lastValidCache store.CacheStores,
+		lastValidCache *store.CacheStores,
 		brokenObjects []fallback.ObjectHash,
 	) (store.CacheStores, error)
 }
@@ -175,7 +175,7 @@ type KongClient struct {
 	// lastValidCacheSnapshot and lastProcessedSnapshotHash do not always keep values related to the same cache snapshot.
 	// While lastProcessedSnapshotHash keeps track of the last processed cache snapshot (the one kept in KongClient.cache),
 	// lastValidCacheSnapshot can also represent the fallback cache snapshot that was successfully synced with gateways.
-	lastValidCacheSnapshot store.CacheStores
+	lastValidCacheSnapshot *store.CacheStores
 
 	// brokenObjects is a list of the Kubernetes resources that failed to sync and triggered a fallback sync.
 	brokenObjects []fallback.ObjectHash
@@ -520,7 +520,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 func (c *KongClient) maybePreserveTheLastValidConfigCache(lastValidCache store.CacheStores) {
 	if c.kongConfig.FallbackConfiguration && c.kongConfig.UseLastValidConfigForFallback {
 		c.logger.V(util.DebugLevel).Info("Preserving the last valid configuration cache")
-		c.lastValidCacheSnapshot = lastValidCache
+		c.lastValidCacheSnapshot = &lastValidCache
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We should account for the situation where no last valid cache was preserved and avoid nil pointer dereferences.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5854.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


