### PR TITLE
fix(fallback): resolve KongConsumer dependency on credentials

### DIFF
--- a/internal/dataplane/fallback/graph_dependencies_kong_test.go
+++ b/internal/dataplane/fallback/graph_dependencies_kong_test.go
@@ -284,6 +284,35 @@ func TestResolveDependencies_KongConsumer(t *testing.T) {
 			),
 			expected: []client.Object{testKongClusterPlugin(t, "3")},
 		},
+		{
+			name: "KongConsumer -> Secret from credentials",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kongconsumer",
+					Namespace: testNamespace,
+				},
+				Credentials: []string{"1"},
+			},
+			cache: cacheStoresFromObjs(t,
+				testSecret(t, "1"),
+				testKongPlugin(t, "1"),
+			),
+			expected: []client.Object{testSecret(t, "1")},
+		},
+		{
+			name: "KongConsumer -> non existing Secret from credentials",
+			object: &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kongconsumer",
+					Namespace: testNamespace,
+				},
+				Credentials: []string{"non-existing"},
+			},
+			cache: cacheStoresFromObjs(t,
+				testKongPlugin(t, "1"),
+			),
+			expected: []client.Object{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

We missed this dependency resolver.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5929.


