### PR TITLE
chore: use feature flags in dev manifests

### DIFF
--- a/config/dev/manager_dev.yaml
+++ b/config/dev/manager_dev.yaml
@@ -16,10 +16,11 @@ spec:
     spec:
       containers:
       - name: ingress-controller
-        args:
-          - --feature-gates=GatewayAlpha=true,KongServiceFacade=true
-          - --anonymous-reports=false
         env:
         - name: CONTROLLER_LOG_LEVEL
           value: debug
+        - name: CONTROLLER_FEATURE_GATES
+          value: GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true
+        - name: CONTROLLER_ANONYMOUS_REPORTS
+          value: "false"
         image: kic-placeholder:placeholder

--- a/config/variants/konnect/debug/manager_debug.yaml
+++ b/config/variants/konnect/debug/manager_debug.yaml
@@ -21,12 +21,13 @@ spec:
             - exec
             - /manager-debug
             - --
-          args:
-            - --feature-gates=GatewayAlpha=true
-            - --anonymous-reports=false
           env:
             - name: CONTROLLER_LOG_LEVEL
               value: debug
+            - name: CONTROLLER_FEATURE_GATES
+              value: GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
             - name: CONTROLLER_KONNECT_ADDRESS
               value: https://us.kic.api.konghq.tech
           image: kic-placeholder:placeholder

--- a/config/variants/multi-gw-postgres/dev/kustomization.yaml
+++ b/config/variants/multi-gw-postgres/dev/kustomization.yaml
@@ -29,12 +29,13 @@ patches:
         spec:
           containers:
           - name: ingress-controller
-            args:
-              - --feature-gates=GatewayAlpha=true
-              - --anonymous-reports=false
             env:
             - name: CONTROLLER_LOG_LEVEL
               value: debug
             - name: CONTROLLER_KONG_ADMIN_SVC_PORT_NAMES
               value: admin-tls
+            - name: CONTROLLER_FEATURE_GATES
+              value: GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
             image: kic-placeholder:placeholder

--- a/config/variants/multi-gw/debug/manager_debug.yaml
+++ b/config/variants/multi-gw/debug/manager_debug.yaml
@@ -29,10 +29,11 @@ spec:
           - exec
           - /manager-debug
           - --
-        args:
-          - --feature-gates=GatewayAlpha=true,FallbackConfiguration=true
-          - --anonymous-reports=false
         env:
         - name: CONTROLLER_LOG_LEVEL
           value: debug
+        - name: CONTROLLER_FEATURE_GATES
+          value: GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true
+        - name: CONTROLLER_ANONYMOUS_REPORTS
+          value: "false"
         image: kic-placeholder:placeholder

--- a/test/consts/feature_gates.go
+++ b/test/consts/feature_gates.go
@@ -5,5 +5,5 @@ const (
 	// provided if none are provided by the user. This generally includes features
 	// that are innocuous, or otherwise don't actually get triggered unless the
 	// user takes further action.
-	DefaultFeatureGates = "GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true"
+	DefaultFeatureGates = "GatewayAlpha=true,KongServiceFacade=true,KongCustomEntity=true"
 )

--- a/test/consts/feature_gates.go
+++ b/test/consts/feature_gates.go
@@ -5,5 +5,5 @@ const (
 	// provided if none are provided by the user. This generally includes features
 	// that are innocuous, or otherwise don't actually get triggered unless the
 	// user takes further action.
-	DefaultFeatureGates = "GatewayAlpha=true,KongServiceFacade=true,KongCustomEntity=true"
+	DefaultFeatureGates = "GatewayAlpha=true,KongServiceFacade=true,RewriteURIs=true,FallbackConfiguration=true,KongCustomEntity=true"
 )


### PR DESCRIPTION

**What this PR does / why we need it**:

Use feature flags in tests and dev manifests.

Also move from args to env since that's the recommended way to configure KIC.
