### PR TITLE
chore: fix renovate annotation for kubernetes/code-generator

### DIFF
--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -1,4 +1,4 @@
-# renovate: datasource=github-releases depName=kubernetes/code-generator
+# renovate: datasource=github-tags depName=kubernetes/code-generator
 kube-code-generator: "0.29.1"
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 controller-tools: "0.15.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/code-generator doesn't publish releases so use [`github-tags` datasource for renovate instead of `github-releases`](https://docs.renovatebot.com/modules/datasource/github-tags/).
