### PR TITLE
Fix renovate config for kustomize images

### DIFF
--- a/config/image/enterprise/kustomization.yaml
+++ b/config/image/enterprise/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Component
 images:
 - name: kong
   newName: kong/kong-gateway
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate packageName=kong/kong-gateway
 - name: kong-placeholder
   newName: kong/kong-gateway
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong/kong-gateway@regenerate packageName=kong/kong-gateway

--- a/config/image/oss/kustomization.yaml
+++ b/config/image/oss/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: kong-placeholder
   newName: kong
-  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong@regenerate
+  newTag: '3.7' # renovate: datasource=docker versioning=docker depName=kong@regenerate packageName=kong
 - name: kic-placeholder
   newName: kong/kubernetes-ingress-controller
-  newTag: '3.1' # renovate: datasource=docker versioning=docker depName=kong/kubernetes-ingress-controller@regenerate
+  newTag: '3.1' # renovate: datasource=docker versioning=docker depName=kong/kubernetes-ingress-controller@regenerate packageName=kong/kubernetes-ingress-controller

--- a/renovate.json
+++ b/renovate.json
@@ -36,14 +36,14 @@
       ]
     },
     {
-      "description": "Match versions in config/image/oss and config/image/enterprise kustomize files that are properly annotated with `# renovate: datasource={} versioning={} depName={}`.",
+      "description": "Match versions in config/image/oss and config/image/enterprise kustomize files that are properly annotated with `# renovate: datasource={} versioning={} depName={} packageName={}`.",
       "customType": "regex",
       "fileMatch": [
         "^config/image/enterprise/.*\\.yaml$",
         "^config/image/oss/.*\\.yaml$"
       ],
       "matchStrings": [
-        "'(?<currentValue>.+)' # renovate: datasource=(?<datasource>.*) versioning=(?<versioning>.*) depName=(?<depName>.+)"
+        "'(?<currentValue>.+)' # renovate: datasource=(?<datasource>.*) versioning=(?<versioning>.*) depName=(?<depName>.+) (packageName=(?<packageName>.+))"
       ]
     }
   ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix renovate config which was causing the following errors:

```
Dependency Lookup Warnings
Renovate failed to look up the following dependencies:

Failed to look up docker package https://charts.konghq.com/kong-gateway, Failed to look up docker package https://charts.konghq.com/kubernetes-ingress-controller, Failed to look up docker package kong/kong-gateway@regenerate, Failed to look up docker package kong@regenerate, Failed to look up docker package kong/kubernetes-ingress-controller@regenerate

Files affected:

config/image/enterprise/kustomization.yaml, config/image/oss/kustomization.yaml
```

This PR adds `packageName` annotation so that renovate properly looks up the dependencies by correct names.