### PR TITLE
test(istio): Update `getKialiWorkloadHealth` to adapt to different istio versions

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -20,6 +20,10 @@ e2e:
     - # renovate: datasource=docker depName=kindest/node versioning=docker
       kind: 'v1.30.0'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
+      istio: '1.22.1'
+    - # renovate: datasource=docker depName=kindest/node versioning=docker
+      kind: 'v1.30.0'
+      # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: '1.21.2'
     - # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
       kind: 'v1.28.9'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Istio 1.22 removed Kiali API `/namespaces/<ns>/health` and uses `/namespace/<ns>/workloads/<workload>` instead. While Istio 1.17 does not support the newer API. So the PR uses different APIs for different istio versions.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #6039 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
