### PR TITLE
suggestion: fallback config diagnostics server

### DIFF
--- a/internal/dataplane/fallback/cache_to_graph.go
+++ b/internal/dataplane/fallback/cache_to_graph.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dominikbraun/graph"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 )
 
@@ -21,7 +20,7 @@ func NewDefaultCacheGraphProvider() *DefaultCacheGraphProvider {
 // CacheToGraph creates a new ConfigGraph from the given cache stores. It adds all objects
 // from the cache stores to the graph as vertices as well as edges between objects and their dependencies
 // resolved by the ResolveDependencies function.
-func (p DefaultCacheGraphProvider) CacheToGraph(c store.CacheStores) (*ConfigGraph, []diagnostics.FallbackDiagnostic, error) {
+func (p DefaultCacheGraphProvider) CacheToGraph(c store.CacheStores) (*ConfigGraph, error) {
 	g := NewConfigGraph()
 
 	for _, s := range c.ListAllStores() {
@@ -29,35 +28,35 @@ func (p DefaultCacheGraphProvider) CacheToGraph(c store.CacheStores) (*ConfigGra
 			obj, ok := o.(client.Object)
 			if !ok {
 				// Should not happen since all objects in the cache are client.Objects, but better safe than sorry.
-				return nil, nil, fmt.Errorf("expected client.Object, got %T", o)
+				return nil, fmt.Errorf("expected client.Object, got %T", o)
 			}
 			// Add the object to the graph. It can happen that the object is already in the graph (i.e. was already added
 			// as a dependency of another object), in which case we ignore the error.
 			if err := g.AddVertex(obj); err != nil && !errors.Is(err, graph.ErrVertexAlreadyExists) {
-				return nil, nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
+				return nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
 			}
 
 			deps, err := ResolveDependencies(c, obj)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to resolve dependencies for %s: %w", GetObjectHash(obj), err)
+				return nil, fmt.Errorf("failed to resolve dependencies for %s: %w", GetObjectHash(obj), err)
 			}
 			// Add the object's dependencies to the graph.
 			for _, dep := range deps {
 				// Add the dependency to the graph in case it wasn't added before. If it was added before, we ignore the
 				// error.
 				if err := g.AddVertex(dep); err != nil && !errors.Is(err, graph.ErrVertexAlreadyExists) {
-					return nil, nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
+					return nil, fmt.Errorf("failed to add %s to the graph: %w", GetObjectHash(obj), err)
 				}
 
 				// Add an edge from a dependency to the object. If the edge was already added before, we ignore the error.
 				// It's on purpose that we add the edge from the dependency to the object, as it makes it easier to traverse
 				// the graph from the object to its dependants once it is broken.
 				if err := g.AddEdge(GetObjectHash(dep), GetObjectHash(obj)); err != nil && !errors.Is(err, graph.ErrEdgeAlreadyExists) {
-					return nil, nil, fmt.Errorf("failed to add edge from %s to %s: %w", GetObjectHash(obj), GetObjectHash(dep), err)
+					return nil, fmt.Errorf("failed to add edge from %s to %s: %w", GetObjectHash(obj), GetObjectHash(dep), err)
 				}
 			}
 		}
 	}
 
-	return g, nil, nil
+	return g, nil
 }

--- a/internal/dataplane/fallback/cache_to_graph_test.go
+++ b/internal/dataplane/fallback/cache_to_graph_test.go
@@ -336,7 +336,7 @@ func TestDefaultCacheGraphProvider_CacheToGraph(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := fallback.NewDefaultCacheGraphProvider()
-			g, _, err := p.CacheToGraph(tc.cache)
+			g, err := p.CacheToGraph(tc.cache)
 			require.NoError(t, err)
 			require.NotNil(t, g)
 			require.Equal(t, tc.expectedAdjacencyMap, adjacencyGraphStrings(t, g))

--- a/internal/dataplane/fallback/fallback.go
+++ b/internal/dataplane/fallback/fallback.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
 type CacheGraphProvider interface {
 	// CacheToGraph returns a new ConfigGraph instance built from the given cache snapshot.
-	CacheToGraph(cache store.CacheStores) (*ConfigGraph, []diagnostics.FallbackDiagnostic, error)
+	CacheToGraph(cache store.CacheStores) (*ConfigGraph, error)
 }
 
 // Generator is responsible for generating fallback cache snapshots.
@@ -32,125 +31,95 @@ func NewGenerator(cacheGraphProvider CacheGraphProvider, logger logr.Logger) *Ge
 func (g *Generator) GenerateExcludingBrokenObjects(
 	cache store.CacheStores,
 	brokenObjects []ObjectHash,
-) (store.CacheStores, []diagnostics.FallbackDiagnostic, error) {
-	graph, diag, err := g.cacheGraphProvider.CacheToGraph(cache)
+) (store.CacheStores, GeneratedCacheMetadata, error) {
+	metadataCollector := NewGenerateCacheMetadataCollector(brokenObjects...)
+
+	graph, err := g.cacheGraphProvider.CacheToGraph(cache)
 	if err != nil {
-		return store.CacheStores{}, nil, fmt.Errorf("failed to build cache graph: %w", err)
+		return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to build cache graph: %w", err)
 	}
 
 	fallbackCache, err := cache.TakeSnapshot()
 	if err != nil {
-		return store.CacheStores{}, nil, fmt.Errorf("failed to take cache snapshot: %w", err)
+		return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to take cache snapshot: %w", err)
 	}
 
 	for _, brokenObject := range brokenObjects {
 		subgraphObjects, err := graph.SubgraphObjects(brokenObject)
-		diag = make([]diagnostics.FallbackDiagnostic, len(subgraphObjects))
 		if err != nil {
-			return store.CacheStores{}, nil, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
+			return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
 		}
-		for i, obj := range subgraphObjects {
+		for _, obj := range subgraphObjects {
 			if err := fallbackCache.Delete(obj); err != nil {
-				return store.CacheStores{}, nil, fmt.Errorf("failed to delete %s from the cache: %w", GetObjectHash(obj), err)
+				return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to delete %s from the cache: %w", GetObjectHash(obj), err)
 			}
-			g.logger.V(util.DebugLevel).Info("Excluded object from fallback cache",
-				"object_kind", obj.GetObjectKind(),
-				"object_name", obj.GetName(),
-				"object_namespace", obj.GetNamespace(),
-			)
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			diag[i] = diagnostics.FallbackDiagnostic{
-				GroupKind:     fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind),
-				Namespace:     obj.GetNamespace(),
-				Name:          obj.GetName(),
-				ID:            string(obj.GetUID()),
-				Status:        "excluded",
-				CausingObject: brokenObject.String(),
-			}
+			metadataCollector.CollectExcluded(obj, brokenObject)
 		}
 	}
 
-	return fallbackCache, diag, nil
+	return fallbackCache, metadataCollector.Metadata(), nil
 }
 
 func (g *Generator) GenerateBackfillingBrokenObjects(
 	currentCache store.CacheStores,
 	lastValidCacheSnapshot *store.CacheStores,
 	brokenObjects []ObjectHash,
-) (store.CacheStores, []diagnostics.FallbackDiagnostic, error) {
+) (store.CacheStores, GeneratedCacheMetadata, error) {
+	metadataCollector := NewGenerateCacheMetadataCollector(brokenObjects...)
+
 	// Build a graph from the current cache.
-	currentGraph, diag, err := g.cacheGraphProvider.CacheToGraph(currentCache)
+	currentGraph, err := g.cacheGraphProvider.CacheToGraph(currentCache)
 	if err != nil {
-		return store.CacheStores{}, diag, fmt.Errorf("failed to build current cache graph: %w", err)
+		return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to build current cache graph: %w", err)
 	}
 
 	// Take a snapshot of the current cache to use as a fallback.
 	fallbackCache, err := currentCache.TakeSnapshot()
 	if err != nil {
-		return store.CacheStores{}, diag, fmt.Errorf("failed to take current cache snapshot: %w", err)
+		return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to take current cache snapshot: %w", err)
 	}
 
 	// Exclude the affected objects from the fallback cache. Also, collect all the affected objects as they will be
 	// subjects of backfilling.
 	var affectedObjects []ObjectHash
-	// Backfill the broken objects from the last valid cache snapshot.
-	var backdiag []diagnostics.FallbackDiagnostic
 	for _, brokenObject := range brokenObjects {
 		subgraphObjects, err := currentGraph.SubgraphObjects(brokenObject)
 		if err != nil {
-			return store.CacheStores{}, diag, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
+			return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to find dependants for %s: %w", brokenObject, err)
 		}
 		for _, obj := range subgraphObjects {
 			if err := fallbackCache.Delete(obj); err != nil {
-				return store.CacheStores{}, nil, fmt.Errorf("failed to delete %s from the fallback cache: %w", GetObjectHash(obj), err)
+				return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to delete %s from the fallback cache: %w", GetObjectHash(obj), err)
 			}
-			g.logger.V(util.DebugLevel).Info("Excluded object from fallback cache",
-				"object_kind", obj.GetObjectKind(),
-				"object_name", obj.GetName(),
-				"object_namespace", obj.GetNamespace(),
-			)
 			affectedObjects = append(affectedObjects, GetObjectHash(obj))
+			metadataCollector.CollectExcluded(obj, brokenObject)
 		}
 	}
 
 	if lastValidCacheSnapshot == nil {
 		g.logger.V(util.DebugLevel).Info("No previous valid cache snapshot found, skipping backfilling")
-		return fallbackCache, nil, nil
+		return fallbackCache, metadataCollector.Metadata(), nil
 	}
 
 	// Build a graph from the last valid cache snapshot.
-	lastValidGraph, diag, err := g.cacheGraphProvider.CacheToGraph(*lastValidCacheSnapshot)
+	lastValidGraph, err := g.cacheGraphProvider.CacheToGraph(*lastValidCacheSnapshot)
 	if err != nil {
-		return store.CacheStores{}, nil, fmt.Errorf("failed to build cache graph: %w", err)
+		return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to build cache graph: %w", err)
 	}
 
 	// Backfill the affected objects from the last valid cache snapshot.
 	for _, affectedObject := range affectedObjects {
 		objectsToBackfill, err := lastValidGraph.SubgraphObjects(affectedObject)
 		if err != nil {
-			return store.CacheStores{}, nil, fmt.Errorf("failed to find dependants for %s: %w", affectedObject, err)
+			return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to find dependants for %s: %w", affectedObject, err)
 		}
 
-		backdiag = make([]diagnostics.FallbackDiagnostic, len(objectsToBackfill))
-		for i, obj := range objectsToBackfill {
+		for _, obj := range objectsToBackfill {
 			if err := fallbackCache.Add(obj); err != nil {
-				return store.CacheStores{}, diag, fmt.Errorf("failed to add %s to the cache: %w", GetObjectHash(obj), err)
+				return store.CacheStores{}, GeneratedCacheMetadata{}, fmt.Errorf("failed to add %s to the cache: %w", GetObjectHash(obj), err)
 			}
-			g.logger.V(util.DebugLevel).Info("Backfilled object to fallback cache from previous valid cache snapshot",
-				"object_kind", obj.GetObjectKind(),
-				"object_name", obj.GetName(),
-				"object_namespace", obj.GetNamespace(),
-			)
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			backdiag[i] = diagnostics.FallbackDiagnostic{
-				GroupKind:     fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind),
-				Namespace:     obj.GetNamespace(),
-				Name:          obj.GetName(),
-				ID:            string(obj.GetUID()),
-				Status:        "backfilled",
-				CausingObject: affectedObject.String(),
-			}
+			metadataCollector.CollectBackfilled(obj, affectedObject)
 		}
 	}
-	return fallbackCache, backdiag, nil
+	return fallbackCache, metadataCollector.Metadata(), nil
 }

--- a/internal/dataplane/fallback/fallback_meta.go
+++ b/internal/dataplane/fallback/fallback_meta.go
@@ -1,0 +1,75 @@
+package fallback
+
+import (
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GeneratedCacheMetadata contains metadata generated during the fallback process.
+type GeneratedCacheMetadata struct {
+	// BrokenObjects are objects that were reported as broken by the Kong Admin API.
+	BrokenObjects []ObjectHash
+	// ExcludedObjects are objects that were excluded from the fallback configuration as they were broken or either of their
+	// dependencies was broken.
+	ExcludedObjects []AffectedCacheObjectMetadata
+	// BackfilledObjects are objects that were backfilled from the last valid cache state as they were broken or either of
+	// their dependencies was broken.
+	BackfilledObjects []AffectedCacheObjectMetadata
+}
+
+// GeneratedCacheMetadataCollector is a collector for cache metadata generated during the fallback process.
+// It's primarily used to deduplicate the metadata and make it easier to work with.
+type GeneratedCacheMetadataCollector struct {
+	brokenObjects     []ObjectHash
+	excludedObjects   map[ObjectHash]AffectedCacheObjectMetadata
+	backfilledObjects map[ObjectHash]AffectedCacheObjectMetadata
+}
+
+// AffectedCacheObjectMetadata contains an object and a list of objects that caused it to be excluded or backfilled
+// during the fallback process.
+type AffectedCacheObjectMetadata struct {
+	Object         client.Object
+	CausingObjects []ObjectHash
+}
+
+// NewGenerateCacheMetadataCollector creates a new GeneratedCacheMetadataCollector instance.
+func NewGenerateCacheMetadataCollector(brokenObjects ...ObjectHash) *GeneratedCacheMetadataCollector {
+	return &GeneratedCacheMetadataCollector{
+		brokenObjects:     brokenObjects,
+		excludedObjects:   make(map[ObjectHash]AffectedCacheObjectMetadata),
+		backfilledObjects: make(map[ObjectHash]AffectedCacheObjectMetadata),
+	}
+}
+
+// CollectExcluded collects an excluded object (an object that was excluded from the fallback configuration as it was
+// broken or one of its dependencies was broken).
+func (m *GeneratedCacheMetadataCollector) CollectExcluded(excluded client.Object, causing ObjectHash) {
+	objHash := GetObjectHash(excluded)
+	if existingEntry, ok := m.excludedObjects[objHash]; ok {
+		existingEntry.CausingObjects = append(existingEntry.CausingObjects, causing)
+		m.excludedObjects[objHash] = existingEntry
+	} else {
+		m.excludedObjects[objHash] = AffectedCacheObjectMetadata{Object: excluded, CausingObjects: []ObjectHash{causing}}
+	}
+}
+
+// CollectBackfilled collects a backfilled object (an object that was backfilled from the last valid cache state as that or
+// one of its dependencies was broken).
+func (m *GeneratedCacheMetadataCollector) CollectBackfilled(backfilled client.Object, causing ObjectHash) {
+	objHash := GetObjectHash(backfilled)
+	if existingEntry, ok := m.backfilledObjects[objHash]; ok {
+		existingEntry.CausingObjects = append(existingEntry.CausingObjects, causing)
+		m.backfilledObjects[objHash] = existingEntry
+	} else {
+		m.backfilledObjects[objHash] = AffectedCacheObjectMetadata{Object: backfilled, CausingObjects: []ObjectHash{causing}}
+	}
+}
+
+// Metadata generates the final cache metadata from the collected data.
+func (m *GeneratedCacheMetadataCollector) Metadata() GeneratedCacheMetadata {
+	return GeneratedCacheMetadata{
+		BrokenObjects:     m.brokenObjects,
+		ExcludedObjects:   lo.Values(m.excludedObjects),
+		BackfilledObjects: lo.Values(m.backfilledObjects),
+	}
+}

--- a/internal/dataplane/fallback/fallback_meta_test.go
+++ b/internal/dataplane/fallback/fallback_meta_test.go
@@ -1,0 +1,94 @@
+package fallback_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+)
+
+func TestGeneratedCacheMetadataCollector(t *testing.T) {
+	excluded1 := testService(t, "excluded-1")
+	excluded2 := testService(t, "excluded-2")
+	backfilled1 := testService(t, "backfilled-1")
+	backfilled2 := testService(t, "backfilled-2")
+	causing1 := testService(t, "causing-1")
+	causing2 := testService(t, "causing-2")
+
+	t.Run("only excluded", func(t *testing.T) {
+		c := fallback.NewGenerateCacheMetadataCollector(
+			fallback.GetObjectHash(causing1),
+			fallback.GetObjectHash(causing2),
+		)
+		c.CollectExcluded(excluded1, fallback.GetObjectHash(causing1))
+		c.CollectExcluded(excluded2, fallback.GetObjectHash(causing1))
+		c.CollectExcluded(excluded2, fallback.GetObjectHash(causing2)) // Duplicate with another causing object.
+
+		meta := c.Metadata()
+		require.ElementsMatch(t, []fallback.ObjectHash{
+			fallback.GetObjectHash(causing1),
+			fallback.GetObjectHash(causing2),
+		},
+			meta.BrokenObjects,
+		)
+		require.ElementsMatch(t, []fallback.AffectedCacheObjectMetadata{
+			{
+				Object:         excluded1,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1)},
+			},
+			{
+				Object:         excluded2,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1), fallback.GetObjectHash(causing2)},
+			},
+		},
+			meta.ExcludedObjects,
+		)
+	})
+
+	t.Run("excluded and backfilled", func(t *testing.T) {
+		c := fallback.NewGenerateCacheMetadataCollector(
+			fallback.GetObjectHash(causing1),
+			fallback.GetObjectHash(causing2),
+		)
+		c.CollectExcluded(excluded1, fallback.GetObjectHash(causing1))
+		c.CollectExcluded(excluded2, fallback.GetObjectHash(causing1))
+		c.CollectExcluded(excluded2, fallback.GetObjectHash(causing2)) // Duplicate with another causing object.
+
+		c.CollectBackfilled(backfilled1, fallback.GetObjectHash(causing1))
+		c.CollectBackfilled(backfilled2, fallback.GetObjectHash(causing1))
+		c.CollectBackfilled(backfilled2, fallback.GetObjectHash(causing2)) // Duplicate with another causing object.
+
+		meta := c.Metadata()
+		require.ElementsMatch(t, []fallback.ObjectHash{
+			fallback.GetObjectHash(causing1),
+			fallback.GetObjectHash(causing2),
+		},
+			meta.BrokenObjects,
+		)
+		require.ElementsMatch(t, []fallback.AffectedCacheObjectMetadata{
+			{
+				Object:         excluded1,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1)},
+			},
+			{
+				Object:         excluded2,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1), fallback.GetObjectHash(causing2)},
+			},
+		},
+			meta.ExcludedObjects,
+		)
+		require.ElementsMatch(t, []fallback.AffectedCacheObjectMetadata{
+			{
+				Object:         backfilled1,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1)},
+			},
+			{
+				Object:         backfilled2,
+				CausingObjects: []fallback.ObjectHash{fallback.GetObjectHash(causing1), fallback.GetObjectHash(causing2)},
+			},
+		},
+			meta.BackfilledObjects,
+		)
+	})
+}

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -293,7 +293,7 @@ func (m mockConfigurationChangeDetector) HasConfigurationChanged(
 type mockFallbackConfigGenerator struct {
 	GenerateResult store.CacheStores
 
-	GenerateExcludingBrokenObjectsCalledWith   lo.Tuple3[store.CacheStores, []diagnostics.FallbackDiagnostic, []fallback.ObjectHash]
+	GenerateExcludingBrokenObjectsCalledWith   lo.Tuple2[store.CacheStores, []fallback.ObjectHash]
 	GenerateBackfillingBrokenObjectsCalledWith lo.Tuple3[store.CacheStores, *store.CacheStores, []fallback.ObjectHash]
 }
 
@@ -304,18 +304,18 @@ func newMockFallbackConfigGenerator() *mockFallbackConfigGenerator {
 func (m *mockFallbackConfigGenerator) GenerateExcludingBrokenObjects(
 	stores store.CacheStores,
 	hashes []fallback.ObjectHash,
-) (store.CacheStores, []diagnostics.FallbackDiagnostic, error) {
-	m.GenerateExcludingBrokenObjectsCalledWith = lo.T3(stores, []diagnostics.FallbackDiagnostic{}, hashes)
-	return m.GenerateResult, []diagnostics.FallbackDiagnostic{}, nil
+) (store.CacheStores, fallback.GeneratedCacheMetadata, error) {
+	m.GenerateExcludingBrokenObjectsCalledWith = lo.T2(stores, hashes)
+	return m.GenerateResult, fallback.GeneratedCacheMetadata{}, nil
 }
 
 func (m *mockFallbackConfigGenerator) GenerateBackfillingBrokenObjects(
 	currentStores store.CacheStores,
 	lastValidStores *store.CacheStores,
 	brokenObjects []fallback.ObjectHash,
-) (store.CacheStores, []diagnostics.FallbackDiagnostic, error) {
+) (store.CacheStores, fallback.GeneratedCacheMetadata, error) {
 	m.GenerateBackfillingBrokenObjectsCalledWith = lo.T3(currentStores, lastValidStores, brokenObjects)
-	return m.GenerateResult, []diagnostics.FallbackDiagnostic{}, nil
+	return m.GenerateResult, fallback.GeneratedCacheMetadata{}, nil
 }
 
 func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *testing.T) {
@@ -1320,21 +1320,17 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 	require.Equal(t, validConsumer.Username, *lastValidConfig.Consumers[0].Username)
 
 	t.Log("Verifying that the diagnostic server received a dump indicating that the broken consumer caused a problem")
-	// the test will have pushed several successful configs that we don't care about into the diag buffer. this is a
-	// silly hack to churn through those until we get to the successful fallback
+	// The test will have pushed several successful configs that we don't care about into the diag buffer. This is a
+	// silly hack to churn through those until we get to the successful fallback.
 	var dump diagnostics.ConfigDump
 	require.Eventually(t, func() bool {
 		dump = <-diagnosticsCh
-		return len(dump.Meta.AffectedObjects) > 0
+		return dump.Meta.Fallback
 	}, time.Second, time.Nanosecond)
 
-	// once we have the fallback diagnostic dump, check to confirm that it was a successful fallback push triggered by
-	// the expected broken consumer
+	// Once we have the fallback diagnostic dump, check to confirm that it was a successful fallback push.
 	require.False(t, dump.Meta.Failed)
 	require.True(t, dump.Meta.Fallback)
-
-	require.Equal(t, dump.Meta.AffectedObjects[0].Namespace, brokenConsumer.ObjectMeta.Namespace)
-	require.Equal(t, dump.Meta.AffectedObjects[0].Name, brokenConsumer.ObjectMeta.Name)
 }
 
 func TestKongClient_FallbackConfiguration_SkipMakingRedundantSnapshot(t *testing.T) {
@@ -1483,21 +1479,16 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 	require.False(t, hasLastValidConfig, "expected no last valid config to be stored as no successful recovery happened")
 
 	t.Log("Verifying that the diagnostic server received a dump indicating that the broken consumer caused a problem")
-	// the test will have pushed several successful configs that we don't care about into the diag buffer. this is a
-	// silly hack to churn through those until we get to the failed fallback
+	// The test will have pushed several successful configs that we don't care about into the diag buffer. This is a
+	// silly hack to churn through those until we get to the failed fallback.
 	var dump diagnostics.ConfigDump
 	require.Eventually(t, func() bool {
 		dump = <-diagnosticsCh
-		return len(dump.Meta.AffectedObjects) > 0
+		return dump.Meta.Fallback
 	}, time.Second, time.Nanosecond)
 
-	// once we have the fallback diagnostic dump, check to confirm that it was a successful fallback push triggered by
-	// the expected broken consumer
+	// Once we have the fallback diagnostic dump, check to confirm that it was a failed fallback push.
 	require.True(t, dump.Meta.Failed)
-	require.True(t, dump.Meta.Fallback)
-
-	require.Equal(t, dump.Meta.AffectedObjects[0].Namespace, brokenConsumer.ObjectMeta.Namespace)
-	require.Equal(t, dump.Meta.AffectedObjects[0].Name, brokenConsumer.ObjectMeta.Name)
 }
 
 func TestKongClient_LastValidCacheSnapshot(t *testing.T) {

--- a/internal/diagnostics/api_types.go
+++ b/internal/diagnostics/api_types.go
@@ -1,0 +1,51 @@
+package diagnostics
+
+import "github.com/kong/go-database-reconciler/pkg/file"
+
+// ConfigDumpResponse is the GET /debug/config/[successful|failed] response schema.
+type ConfigDumpResponse struct {
+	ConfigHash string       `json:"hash"`
+	Config     file.Content `json:"config"`
+}
+
+// FallbackResponse is the GET /debug/config/fallback response schema.
+type FallbackResponse struct {
+	// Status is the fallback configuration generation status.
+	Status FallbackStatus `json:"status"`
+	// BrokenObjects is the list of objects that are broken.
+	BrokenObjects []FallbackAffectedObjectMeta `json:"brokenObjects,omitempty"`
+	// ExcludedObjects is the list of objects that were excluded from the fallback configuration.
+	ExcludedObjects []FallbackAffectedObjectMeta `json:"excludedObjects,omitempty"`
+	// BackfilledObjects is the list of objects that were backfilled from the last valid cache state.
+	BackfilledObjects []FallbackAffectedObjectMeta `json:"backfilledObjects,omitempty"`
+}
+
+// FallbackStatus describes whether the fallback configuration generation was triggered or not.
+// Making this a string type not a bool to allow for potential future expansion of the status.
+type FallbackStatus string
+
+const (
+	// FallbackStatusTriggered indicates that the fallback configuration generation was triggered.
+	FallbackStatusTriggered FallbackStatus = "triggered"
+
+	// FallbackStatusNotTriggered indicates that the fallback configuration generation was not triggered.
+	FallbackStatusNotTriggered FallbackStatus = "not-triggered"
+)
+
+// FallbackAffectedObjectMeta is a fallback affected object metadata.
+type FallbackAffectedObjectMeta struct {
+	// Group is the resource group.
+	Group string `json:"group"`
+	// Kind is the resource kind.
+	Kind string `json:"kind"`
+	// Version is the resource version.
+	Version string `json:"version,omitempty"`
+	// Namespace is the object namespace.
+	Namespace string `json:"namespace"`
+	// Namespace is the object name.
+	Name string `json:"name"`
+	// ID is the object UID.
+	ID string `json:"id"`
+	// CausingObjects is the object that triggered this
+	CausingObjects []string `json:"causingObjects,omitempty"`
+}

--- a/internal/diagnostics/mapping.go
+++ b/internal/diagnostics/mapping.go
@@ -1,0 +1,48 @@
+package diagnostics
+
+import (
+	"github.com/samber/lo"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+)
+
+// mapFallbackCacheMetadataIntoFallbackResponse maps the generated cache metadata into a FallbackResponse.
+func mapFallbackCacheMetadataIntoFallbackResponse(meta *fallback.GeneratedCacheMetadata) FallbackResponse {
+	if meta == nil {
+		return FallbackResponse{
+			Status: FallbackStatusNotTriggered,
+		}
+	}
+
+	brokenObjects := lo.Map(meta.BrokenObjects, func(objHash fallback.ObjectHash, _ int) FallbackAffectedObjectMeta {
+		return FallbackAffectedObjectMeta{
+			Group:     objHash.Group,
+			Kind:      objHash.Kind,
+			Namespace: objHash.Namespace,
+			Name:      objHash.Name,
+			ID:        string(objHash.UID),
+		}
+	})
+	mapAffectedObjectsMeta := func(affectedObjects []fallback.AffectedCacheObjectMetadata) []FallbackAffectedObjectMeta {
+		return lo.Map(affectedObjects, func(affectedObject fallback.AffectedCacheObjectMetadata, _ int) FallbackAffectedObjectMeta {
+			gvk := affectedObject.Object.GetObjectKind().GroupVersionKind()
+			return FallbackAffectedObjectMeta{
+				Group:     gvk.Group,
+				Kind:      gvk.Kind,
+				Version:   gvk.Version,
+				Namespace: affectedObject.Object.GetNamespace(),
+				Name:      affectedObject.Object.GetName(),
+				ID:        string(affectedObject.Object.GetUID()),
+				CausingObjects: lo.Map(affectedObject.CausingObjects, func(objHash fallback.ObjectHash, _ int) string {
+					return objHash.String()
+				}),
+			}
+		})
+	}
+	return FallbackResponse{
+		Status:            FallbackStatusTriggered,
+		BrokenObjects:     brokenObjects,
+		ExcludedObjects:   mapAffectedObjectsMeta(meta.ExcludedObjects),
+		BackfilledObjects: mapAffectedObjectsMeta(meta.BackfilledObjects),
+	}
+}

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-database-reconciler/pkg/file"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
@@ -33,13 +34,15 @@ type Server struct {
 	profilingEnabled bool
 	configDumps      ConfigDumpDiagnostic
 
-	successfulConfigDump file.Content
-	failedConfigDump     file.Content
+	lastSuccessfulConfigDump file.Content
+	lastSuccessHash          string
 
-	fallback     FallbackDiagnosticCollection
-	failedHash   string
-	successHash  string
-	rawErrBody   []byte
+	lastFailedConfigDump file.Content
+	lastFailedHash       string
+	lastRawErrBody       []byte
+
+	currentFallbackCacheMetadata *fallback.GeneratedCacheMetadata
+
 	configLock   *sync.RWMutex
 	fallbackLock *sync.RWMutex
 }
@@ -69,7 +72,7 @@ func NewServer(logger logr.Logger, cfg ServerConfig) Server {
 		s.configDumps = ConfigDumpDiagnostic{
 			DumpsIncludeSensitive: cfg.DumpSensitiveConfig,
 			Configs:               make(chan ConfigDump, diagnosticConfigBufferDepth),
-			Fallbacks:             make(chan FallbackDiagnosticCollection, diagnosticConfigBufferDepth),
+			FallbackCacheMetadata: make(chan fallback.GeneratedCacheMetadata, diagnosticConfigBufferDepth),
 		}
 	}
 
@@ -86,7 +89,7 @@ func (s *Server) ConfigDumps() ConfigDumpDiagnostic {
 func (s *Server) Listen(ctx context.Context, port int) error {
 	mux := http.NewServeMux()
 	if s.configDumps != (ConfigDumpDiagnostic{}) {
-		s.installDumpHandlers(mux)
+		s.installConfigDebugHandlers(mux)
 	}
 	if s.profilingEnabled {
 		installProfilingHandlers(mux)
@@ -127,20 +130,9 @@ func (s *Server) receiveConfig(ctx context.Context) {
 	for {
 		select {
 		case dump := <-s.configDumps.Configs:
-			s.configLock.Lock()
-			if dump.Meta.Failed {
-				s.failedConfigDump = dump.Config
-				s.rawErrBody = dump.RawResponseBody
-				s.failedHash = dump.Meta.Hash
-			} else {
-				s.successfulConfigDump = dump.Config
-				s.successHash = dump.Meta.Hash
-			}
-			s.configLock.Unlock()
-		case fallback := <-s.configDumps.Fallbacks:
-			s.fallbackLock.Lock()
-			s.fallback = fallback
-			s.fallbackLock.Unlock()
+			s.onConfigDump(dump)
+		case meta := <-s.configDumps.FallbackCacheMetadata:
+			s.onFallbackCacheMetadata(meta)
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
 				s.logger.Error(err, "Shutting down diagnostic config collection: context completed with error")
@@ -150,6 +142,34 @@ func (s *Server) receiveConfig(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func (s *Server) onConfigDump(dump ConfigDump) {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
+
+	if dump.Meta.Failed {
+		// If the config push failed, we need to keep the failed config dump and the raw error body.
+		s.lastFailedConfigDump = dump.Config
+		s.lastFailedHash = dump.Meta.Hash
+		s.lastRawErrBody = dump.RawResponseBody
+	} else {
+		// If the config push was successful, we need to keep successful config dump and the hash.
+		s.lastSuccessfulConfigDump = dump.Config
+		s.lastSuccessHash = dump.Meta.Hash
+
+		// If the regular config push was successful, we can drop the fallback cache metadata as it is
+		// no longer relevant.
+		if !dump.Meta.Fallback {
+			s.currentFallbackCacheMetadata = nil
+		}
+	}
+}
+
+func (s *Server) onFallbackCacheMetadata(meta fallback.GeneratedCacheMetadata) {
+	s.fallbackLock.Lock()
+	defer s.fallbackLock.Unlock()
+	s.currentFallbackCacheMetadata = &meta
 }
 
 // installProfilingHandlers adds the Profiling webservice to the given mux.
@@ -167,11 +187,11 @@ func installProfilingHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
-// installDumpHandlers adds the config dump webservice to the given mux.
-func (s *Server) installDumpHandlers(mux *http.ServeMux) {
+// installConfigDebugHandlers adds the config dump webservice to the given mux.
+func (s *Server) installConfigDebugHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/config/successful", s.handleLastValidConfig)
 	mux.HandleFunc("/debug/config/failed", s.handleLastFailedConfig)
-	mux.HandleFunc("/debug/config/fallback", s.handleLastFallback)
+	mux.HandleFunc("/debug/config/fallback", s.handleCurrentFallback)
 	mux.HandleFunc("/debug/config/raw-error", s.handleLastErrBody)
 }
 
@@ -187,9 +207,9 @@ func (s *Server) handleLastValidConfig(rw http.ResponseWriter, _ *http.Request) 
 	s.configLock.RLock()
 	defer s.configLock.RUnlock()
 	if err := json.NewEncoder(rw).Encode(
-		configDumpResponse{
-			Config:     s.successfulConfigDump,
-			ConfigHash: s.successHash,
+		ConfigDumpResponse{
+			Config:     s.lastSuccessfulConfigDump,
+			ConfigHash: s.lastSuccessHash,
 		}); err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
 	}
@@ -200,22 +220,20 @@ func (s *Server) handleLastFailedConfig(rw http.ResponseWriter, _ *http.Request)
 	s.configLock.RLock()
 	defer s.configLock.RUnlock()
 	if err := json.NewEncoder(rw).Encode(
-		configDumpResponse{
-			Config:     s.failedConfigDump,
-			ConfigHash: s.failedHash,
+		ConfigDumpResponse{
+			Config:     s.lastFailedConfigDump,
+			ConfigHash: s.lastFailedHash,
 		}); err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
-func (s *Server) handleLastFallback(rw http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleCurrentFallback(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	s.configLock.RLock()
 	defer s.configLock.RUnlock()
-	if err := json.NewEncoder(rw).Encode(
-		fallbackResponse{
-			FallbackObjects: s.fallback.Objects,
-		}); err != nil {
+	resp := mapFallbackCacheMetadataIntoFallbackResponse(s.currentFallbackCacheMetadata)
+	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		rw.WriteHeader(http.StatusOK)
 	}
 }
@@ -224,7 +242,7 @@ func (s *Server) handleLastErrBody(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-Type", "text/plain")
 	s.configLock.RLock()
 	defer s.configLock.RUnlock()
-	raw := s.rawErrBody
+	raw := s.lastRawErrBody
 	if len(raw) == 0 {
 		raw = []byte("No raw error body available.\n")
 	}

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	testhelpers "github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 )
 
@@ -84,4 +85,61 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 	t.Log("Started reading config dumps")
 
 	<-ctx.Done()
+}
+
+func TestServer_EventsHandling(t *testing.T) {
+	successfulDump := ConfigDump{
+		Meta: DumpMeta{
+			Failed:   false,
+			Fallback: false,
+			Hash:     "success-hash",
+		},
+		Config: file.Content{
+			FormatVersion: "success", // Just for the sake of distinguishing between success and failure.
+		},
+	}
+	failedDump := ConfigDump{
+		Config: file.Content{
+			FormatVersion: "failed", // Just for the sake of distinguishing between success and failure.
+		},
+		Meta: DumpMeta{
+			Failed:   true,
+			Fallback: false,
+		},
+		RawResponseBody: []byte("error body"),
+	}
+	fallbackMeta := fallback.GeneratedCacheMetadata{
+		BrokenObjects: []fallback.ObjectHash{
+			{
+				Name: "object",
+			},
+		},
+	}
+
+	s := NewServer(logr.Discard(), ServerConfig{
+		ConfigDumpsEnabled: true,
+	})
+
+	t.Run("on successful config dump", func(t *testing.T) {
+		s.onConfigDump(successfulDump)
+		require.Equal(t, successfulDump.Config, s.lastSuccessfulConfigDump)
+		require.Equal(t, successfulDump.Meta.Hash, s.lastSuccessHash)
+	})
+	t.Run("on failed config dump", func(t *testing.T) {
+		s.onConfigDump(failedDump)
+		require.Equal(t, failedDump.Config, s.lastFailedConfigDump)
+		require.Equal(t, failedDump.Meta.Hash, s.lastFailedHash)
+		require.Equal(t, failedDump.RawResponseBody, s.lastRawErrBody)
+	})
+	t.Run("on fallback cache metadata", func(t *testing.T) {
+		s.onFallbackCacheMetadata(fallbackMeta)
+		require.NotNilf(t, s.currentFallbackCacheMetadata, "expected fallback cache metadata to be set")
+		require.Equal(t, fallbackMeta, *s.currentFallbackCacheMetadata)
+	})
+	t.Run("on successful config dump after fallback", func(t *testing.T) {
+		s.onConfigDump(successfulDump)
+		require.Equal(t, successfulDump.Config, s.lastSuccessfulConfigDump)
+		require.Equal(t, successfulDump.Meta.Hash, s.lastSuccessHash)
+		require.Nil(t, s.currentFallbackCacheMetadata, "expected fallback cache metadata to be dropped as it's no more relevant")
+	})
 }

--- a/internal/diagnostics/types.go
+++ b/internal/diagnostics/types.go
@@ -2,7 +2,8 @@ package diagnostics
 
 import (
 	"github.com/kong/go-database-reconciler/pkg/file"
-	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 )
 
 // DumpMeta annotates a config dump.
@@ -11,8 +12,6 @@ type DumpMeta struct {
 	Failed bool
 	// Fallback indicates that the dump is a fallback configuration attempted after a failed config update.
 	Fallback bool
-	// AffectedObjects are objects excluded from the fallback configuration.
-	AffectedObjects []AffectedObject
 	// Hash is the configuration hash.
 	Hash string
 }
@@ -27,57 +26,13 @@ type ConfigDump struct {
 	RawResponseBody []byte
 }
 
-type configDumpResponse struct {
-	ConfigHash string       `json:"hash"`
-	Config     file.Content `json:"config"`
-}
-
-type fallbackResponse struct {
-	FallbackObjects []FallbackDiagnostic `json:"objects"`
-}
-
-// FallbackDiagnosticCollection is a set of fallback object diagnostics associated with a config hash.
-type FallbackDiagnosticCollection struct {
-	Objects []FallbackDiagnostic
-}
-
-// FallbackDiagnostic are fallback objects.
-type FallbackDiagnostic struct {
-	// GroupKind is the object group and kind.
-	GroupKind string `json:"resource"`
-	// Namespace is the object namespace.
-	Namespace string `json:"namespace"`
-	// Namespace is the object name.
-	Name string `json:"name"`
-	// ID is the object UID.
-	ID string `json:"id"`
-	// Status is the object's fallback status.
-	Status string `json:"status"`
-	// CausingObject is the object that triggered this
-	CausingObject string `json:"cause"`
-}
-
 // ConfigDumpDiagnostic contains settings and channels for receiving diagnostic configuration dumps.
 type ConfigDumpDiagnostic struct {
 	// DumpsIncludeSensitive is true if the configuration dump includes sensitive values, such as certificate private
 	// keys and credential secrets.
 	DumpsIncludeSensitive bool
 	// Configs is the channel that receives configuration blobs from the configuration update strategy implementation.
-	Configs   chan ConfigDump
-	Fallbacks chan FallbackDiagnosticCollection
-}
-
-// AffectedObject is a Kubernetes object associated with diagnostic information.
-type AffectedObject struct {
-	// UID is the unique identifier of the object.
-	UID k8stypes.UID
-
-	// Group is the object's group.
-	Group string
-	// Kind is the object's Kind.
-	Kind string
-	// Namespace is the object's Namespace.
-	Namespace string
-	// Name is the object's Name.
-	Name string
+	Configs chan ConfigDump
+	// FallbackCacheMetadata is the channel that receives fallback metadata from the fallback cache generator.
+	FallbackCacheMetadata chan fallback.GeneratedCacheMetadata
 }


### PR DESCRIPTION
- Extracts `GeneratedCacheMetadataCollector` for easier metadata collection (deduplication of excluded/backfilled objects was needed) and isolation
- Adds unit tests for the diagnostics server and fallback config generator
- Changes the response schema to include both excluded and backfilled objects at the same time (as that is a valid scenario: an object can be first excluded, then backfilled or not depending on the last valid cache state)
- Ensures we push diagnostics only if they're enabled (c.diagnostic.FallbackCacheMetadata is not nil)
- Extracts diagnostics server response schema types to a separate file for readability
- Extracts config dump and fallback diagnostics retrieval handling methods in the server
- Added `status` field to the response to clearly indicate whether the fallback config generation was triggered or not
- Fixes cosmetic issues

## Sample responses from manual testing:

### excluded + backfilled
```json
{
  "status": "triggered",
  "brokenObjects": [
    {
      "group": "configuration.konghq.com",
      "kind": "KongPlugin",
      "namespace": "default",
      "name": "rate-limit-consumer",
      "id": "0a823310-7b01-4e8e-b85e-1ebb160ddc3e"
    }
  ],
  "excludedObjects": [
    {
      "group": "configuration.konghq.com",
      "kind": "KongPlugin",
      "version": "v1",
      "namespace": "default",
      "name": "rate-limit-consumer",
      "id": "0a823310-7b01-4e8e-b85e-1ebb160ddc3e",
      "causingObjects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    },
    {
      "group": "gateway.networking.k8s.io",
      "kind": "HTTPRoute",
      "version": "v1",
      "namespace": "default",
      "name": "route-b",
      "id": "21c65967-909a-4a18-b875-c8d5652ee538",
      "causingObjects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    }
  ],
  "backfilledObjects": [
    {
      "group": "gateway.networking.k8s.io",
      "kind": "HTTPRoute",
      "version": "v1",
      "namespace": "default",
      "name": "route-b",
      "id": "21c65967-909a-4a18-b875-c8d5652ee538",
      "causingObjects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    },
    {
      "group": "configuration.konghq.com",
      "kind": "KongPlugin",
      "version": "v1",
      "namespace": "default",
      "name": "rate-limit-consumer",
      "id": "0a823310-7b01-4e8e-b85e-1ebb160ddc3e",
      "causingObjects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    },
    {
      "group": "configuration.konghq.com",
      "kind": "KongConsumer",
      "version": "v1",
      "namespace": "default",
      "name": "bob",
      "id": "bd24d998-2b37-46b4-896e-634c910226d6",
      "causingObjects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    }
  ]
}
```

### only excluded
```json
{
  "status": "triggered",
  "brokenObjects": [
    "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
  ],
  "excludedObjects": [
    {
      "resource": "configuration.konghq.com/v1, Kind=KongPlugin",
      "namespace": "default",
      "name": "rate-limit-consumer",
      "id": "0a823310-7b01-4e8e-b85e-1ebb160ddc3e",
      "causing_objects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    },
    {
      "resource": "gateway.networking.k8s.io/v1, Kind=HTTPRoute",
      "namespace": "default",
      "name": "route-b",
      "id": "21c65967-909a-4a18-b875-c8d5652ee538",
      "causing_objects": [
        "configuration.konghq.com/KongPlugin:default/rate-limit-consumer"
      ]
    }
  ]
}
```

### no fallback triggered
```json
{
  "status": "not_triggered"
}
```
