### PR TITLE
chore: rearange changelog, add 3.2 highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Adding a new version? You'll need three changes:
 ### Highlights
 
 - 🚀 **Fallback Configuration**: New `FallbackConfiguration` feature enables isolating configuration failure domains so
-  that one broken object does no longer prevent the entire configuration from being applied. See [Fallback Configuration guide]
+  that one broken object no longer prevents the entire configuration from being applied. See [Fallback Configuration guide]
   to learn more.
 - 🏗️ **Custom Kong Entities**: New `KongCustomEntity` CRD allows defining Kong custom entities programmatically in KIC.
   See [Using Custom Entities guide] to learn more.


### PR DESCRIPTION
**What this PR does / why we need it**:

Rearrange the 3.2 changelog so that the highlight items are at the top. Adds the highlights section.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6135.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
