### PR TITLE
chore: remove stale todo

### DIFF
--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -365,8 +365,6 @@ func SetRoutePlugins(
 	filters []gatewayapi.HTTPRouteFilter,
 	path string,
 	tags []*string,
-	// As of now, expressions router is not supported for URLRewrite with PrefixMatchHTTPPathModifier.
-	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3686
 	expressionsRouterEnabled bool,
 ) error {
 	generatedPlugins, err := generatePluginsFromHTTPRouteFilters(filters, path, tags, expressionsRouterEnabled)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes stale TODO comment. It's been implemented in https://github.com/Kong/kubernetes-ingress-controller/pull/5940. 
