### PR TITLE
chore: enable prealloc linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,7 @@ linters:
   - nilerr
   - nolintlint
   - predeclared
+  - prealloc
   - revive
   - staticcheck
   - tenv
@@ -142,6 +143,8 @@ linters-settings:
     klog: true
     logr: true
     zap: false
+  prealloc:
+    for-loops: true
 issues:
   fix: true
   max-same-issues: 0
@@ -169,11 +172,21 @@ issues:
     linters:
       - gosec
     text: "TLS InsecureSkipVerify set true|Potential hardcoded credentials"
+  # Ignore prealloc in tests
+  - path: _test\.go
+    linters:
+      - prealloc
+    text: "Consider pre-allocating"
+  # Ignore prealloc in hack/ directory
+  - path: hack/
+    linters:
+      - prealloc
+    text: "Consider pre-allocating"
   # It's fine to use variable urls in tests.
   - linters:
       - gosec
     text: "Potential HTTP request made with variable url"
-    path: test\.go
+    path: _test\.go
   # Allow using SchemeGroupVersion, GroupVersion, GroupName, AddToScheme, and Install from gatewayv1alpha2,
   # gatewayv1beta1 and gatewayv1 as their values are different between versions, and we can't alias them in internal/gatewayapi/aliases.go.
   - linters:

--- a/internal/admission/validation/ingress/ingress.go
+++ b/internal/admission/validation/ingress/ingress.go
@@ -32,7 +32,7 @@ func ValidateIngress(
 	storer store.Storer,
 	managerClient client.Client,
 ) (bool, string, error) {
-	var (
+	var ( //nolint:prealloc
 		errMsgs           []string
 		failuresCollector = failures.NewResourceFailuresCollector(logger)
 	)

--- a/internal/dataplane/address_finder.go
+++ b/internal/dataplane/address_finder.go
@@ -89,7 +89,7 @@ func (a *AddressFinder) GetLoadBalancerAddresses(ctx context.Context) ([]netv1.I
 // (https://pkg.go.dev/k8s.io/api/networking/v1#IngressLoadBalancerIngress), or an error if one of the given strings
 // is neither a valid IP nor a valid hostname.
 func getAddressHelper(addrs []string) ([]netv1.IngressLoadBalancerIngress, error) {
-	var loadBalancerAddresses []netv1.IngressLoadBalancerIngress
+	var loadBalancerAddresses []netv1.IngressLoadBalancerIngress //nolint:prealloc
 	for _, addr := range addrs {
 		ing := netv1.IngressLoadBalancerIngress{}
 		if net.ParseIP(addr) != nil {

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -48,7 +48,7 @@ func GetFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 }
 
 func getSNIs(names []*string) []kong.SNI {
-	var snis []kong.SNI
+	snis := make([]kong.SNI, 0, len(names))
 	for _, name := range names {
 		snis = append(snis, kong.SNI{
 			Name: kong.String(*name),

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -588,11 +588,7 @@ func globalKongClusterPlugins(logger logr.Logger, s store.Storer) ([]Plugin, err
 	for _, plugin := range duplicates {
 		delete(res, plugin)
 	}
-	var plugins []Plugin
-	for _, p := range res {
-		plugins = append(plugins, p)
-	}
-	return plugins, nil
+	return lo.Values(res), nil
 }
 
 func (ks *KongState) FillPlugins(

--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -117,7 +117,7 @@ func (r *Route) overrideProtocols(anns map[string]string) {
 	if len(protocols) == 0 {
 		return
 	}
-	var prots []*string
+	var prots []*string //nolint:prealloc
 	for _, prot := range protocols {
 		if !util.ValidateProtocol(prot) {
 			return

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -90,7 +90,7 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 		return nil, nil
 	}
 
-	var resourceErrors []ResourceError
+	var resourceErrors []ResourceError //nolint:prealloc
 	var configError ConfigError
 
 	err := json.Unmarshal(body, &configError)

--- a/internal/dataplane/translator/atc/matcher.go
+++ b/internal/dataplane/translator/atc/matcher.go
@@ -42,8 +42,7 @@ func (m *OrMatcher) Expression() string {
 		return m.subMatchers[0].Expression()
 	}
 
-	var grouped []string
-
+	grouped := make([]string, 0, len(m.subMatchers))
 	for _, m := range m.subMatchers {
 		grouped = append(grouped, fmt.Sprintf("(%s)", m.Expression()))
 	}
@@ -92,8 +91,7 @@ func (m *AndMatcher) Expression() string {
 		return m.subMatchers[0].Expression()
 	}
 
-	var grouped []string
-
+	grouped := make([]string, 0, len(m.subMatchers))
 	for _, m := range m.subMatchers {
 		grouped = append(grouped, fmt.Sprintf("(%s)", m.Expression()))
 	}

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -497,7 +497,7 @@ func PathsFromIngressPaths(httpIngressPath netv1.HTTPIngressPath) []*string {
 }
 
 func flattenMultipleSlashes(path string) string {
-	var out []rune
+	out := make([]rune, 0, len(path))
 	in := []rune(path)
 	for i := 0; i < len(in); i++ {
 		c := in[i]

--- a/internal/dataplane/translator/translate_certs.go
+++ b/internal/dataplane/translator/translate_certs.go
@@ -216,12 +216,14 @@ func mergeCerts(logger logr.Logger, certLists ...[]certWrapper) []kongstate.Cert
 			certsSeen[current.identifier] = current
 		}
 	}
-	var res []kongstate.Certificate
+	res := make([]kongstate.Certificate, 0, len(certsSeen))
 	for _, cw := range certsSeen {
 		sort.SliceStable(cw.cert.SNIs, func(i, j int) bool {
 			return strings.Compare(*cw.cert.SNIs[i], *cw.cert.SNIs[j]) < 0
 		})
-		res = append(res, kongstate.Certificate{Certificate: cw.cert})
+		res = append(res, kongstate.Certificate{
+			Certificate: cw.cert,
+		})
 	}
 	return res
 }

--- a/internal/dataplane/translator/translate_kong_l4.go
+++ b/internal/dataplane/translator/translate_kong_l4.go
@@ -183,7 +183,7 @@ func (t *Translator) ingressRulesFromUDPIngressV1beta1() ingressRules {
 }
 
 func tcpIngressToNetworkingTLS(tls []kongv1beta1.IngressTLS) []netv1.IngressTLS {
-	var result []netv1.IngressTLS
+	result := make([]netv1.IngressTLS, 0, len(tls))
 
 	for _, t := range tls {
 		result = append(result, netv1.IngressTLS{

--- a/internal/dataplane/translator/translate_secrets.go
+++ b/internal/dataplane/translator/translate_secrets.go
@@ -26,7 +26,7 @@ func (t *Translator) getCACerts() []kong.CACertificate {
 		return nil
 	}
 
-	var caCerts []kong.CACertificate
+	caCerts := make([]kong.CACertificate, 0, len(caCertSecrets))
 	for _, certSecret := range caCertSecrets {
 		idBytes, ok := certSecret.Data["id"]
 		if !ok {

--- a/internal/konnect/roles/client.go
+++ b/internal/konnect/roles/client.go
@@ -86,7 +86,7 @@ func (c *Client) ListControlPlanesRoles(ctx context.Context) ([]Role, error) {
 		return nil, fmt.Errorf("failed to decode roles response: %w", err)
 	}
 
-	var roles []Role
+	roles := make([]Role, 0, len(rolesResponse.Data))
 	for _, role := range rolesResponse.Data {
 		r, err := NewRole(role.ID, role.EntityID)
 		if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -161,8 +161,11 @@ func (s Store) GetService(namespace, name string) (*corev1.Service, error) {
 // ListIngressesV1 returns the list of Ingresses in the Ingress v1 store.
 func (s Store) ListIngressesV1() []*netv1.Ingress {
 	// filter ingress rules
-	var ingresses []*netv1.Ingress
-	for _, item := range s.stores.IngressV1.List() {
+	var (
+		list      = s.stores.IngressV1.List()
+		ingresses = make([]*netv1.Ingress, 0, len(list))
+	)
+	for _, item := range list {
 		ing, ok := item.(*netv1.Ingress)
 		if !ok {
 			s.logger.Error(nil, "ListIngressesV1: dropping object of unexpected type", "type", fmt.Sprintf("%T", item))
@@ -201,8 +204,11 @@ func (s Store) ListIngressesV1() []*netv1.Ingress {
 // ListIngressClassesV1 returns the list of Ingresses in the Ingress v1 store.
 func (s Store) ListIngressClassesV1() []*netv1.IngressClass {
 	// filter ingress rules
-	var classes []*netv1.IngressClass
-	for _, item := range s.stores.IngressClassV1.List() {
+	var (
+		list    = s.stores.IngressClassV1.List()
+		classes = make([]*netv1.IngressClass, 0, len(list))
+	)
+	for _, item := range list {
 		class, ok := item.(*netv1.IngressClass)
 		if !ok {
 			s.logger.Error(nil, "ListIngressClassesV1: dropping object of unexpected type", "type", fmt.Sprintf("%T", item))
@@ -223,7 +229,7 @@ func (s Store) ListIngressClassesV1() []*netv1.IngressClass {
 
 // ListIngressClassParametersV1Alpha1 returns the list of IngressClassParameters in the Ingress v1alpha1 store.
 func (s Store) ListIngressClassParametersV1Alpha1() []*kongv1alpha1.IngressClassParameters {
-	var classParams []*kongv1alpha1.IngressClassParameters
+	var classParams []*kongv1alpha1.IngressClassParameters //nolint:prealloc
 	for _, item := range s.stores.IngressClassParametersV1alpha1.List() {
 		classParam, ok := item.(*kongv1alpha1.IngressClassParameters)
 		if !ok {

--- a/pkg/apis/configuration/v1/kongprotocol_types.go
+++ b/pkg/apis/configuration/v1/kongprotocol_types.go
@@ -7,24 +7,26 @@ package v1
 type KongProtocol string
 
 // KongProtocolsToStrings converts a slice of KongProtocol to plain strings.
-func KongProtocolsToStrings(protocols []KongProtocol) (res []string) {
+func KongProtocolsToStrings(protocols []KongProtocol) []string {
+	res := make([]string, 0, len(protocols))
 	for _, protocol := range protocols {
 		res = append(res, string(protocol))
 	}
-	return
+	return res
 }
 
 // StringsToKongProtocols converts a slice of strings to KongProtocols.
-func StringsToKongProtocols(strings []string) (res []KongProtocol) {
+func StringsToKongProtocols(strings []string) []KongProtocol {
+	res := make([]KongProtocol, 0, len(strings))
 	for _, protocol := range strings {
 		res = append(res, KongProtocol(protocol))
 	}
-	return
+	return res
 }
 
 // ProtocolSlice converts a slice of string to a slice of *KongProtocol.
 func ProtocolSlice(elements ...string) []*KongProtocol {
-	var res []*KongProtocol
+	res := make([]*KongProtocol, 0, len(elements))
 	for _, element := range elements {
 		e := KongProtocol(element)
 		res = append(res, &e)


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable prealloc linter to easily spot places where we can preallocate.
