### PR TITLE
perf: optimize protocol validation in `ValidateProtocol`

### DIFF
--- a/internal/util/protocol.go
+++ b/internal/util/protocol.go
@@ -1,14 +1,11 @@
 package util
 
-import "regexp"
-
-// ValidateProtocol returns a bool of whether string is a valid protocol.
+// ValidateProtocol returns true if the provided protocol is valid.
 func ValidateProtocol(protocol string) bool {
-	if protocol == "" {
+	switch protocol {
+	case "", "http", "https", "grpc", "grpcs", "ws", "wss", "tls", "tcp", "tls_passthrough":
 		return true
+	default:
+		return false
 	}
-	match := validProtocols.MatchString(protocol)
-	return match
 }
-
-var validProtocols = regexp.MustCompile(`\Ahttps$|\Ahttp$|\Agrpc$|\Agrpcs|\Aws$|\Awss|\Atcp|\Atls|\Atls_passthrough$`)

--- a/internal/util/protocol_test.go
+++ b/internal/util/protocol_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestValidateProtocol(t *testing.T) {
-	assert := assert.New(t)
 	testTable := []struct {
-		input  string
-		result bool
+		input    string
+		expected bool
 	}{
 		{"", true},
 		{"http", true},
@@ -24,8 +23,19 @@ func TestValidateProtocol(t *testing.T) {
 		{"tls_passthrough", true},
 		{"grcpsfdsafdsfafdshttp", false},
 	}
-	for _, testcase := range testTable {
-		isMatch := ValidateProtocol(testcase.input)
-		assert.Equal(isMatch, testcase.result)
+	for _, tc := range testTable {
+		t.Run(tc.input, func(t *testing.T) {
+			isMatch := ValidateProtocol(tc.input)
+			assert.Equal(t, tc.expected, isMatch)
+		})
+	}
+}
+
+func BenchmarkValidateProtocol(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = ValidateProtocol("https")
+		_ = ValidateProtocol("tcp")
+		_ = ValidateProtocol("tls")
+		_ = ValidateProtocol("xxxxxxxxx")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Improve protocol validation by not using regex but a simple `switch` lookup: `-99.98%` time improvement.

```
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/util
                    │       old       │                 new                 │
                    │     sec/op      │    sec/op     vs base               │
ValidateProtocol-10   1465.0000n ± 7%   0.3166n ± 1%  -99.98% (p=0.002 n=6)

                    │    old     │              new              │
                    │    B/op    │    B/op     vs base           │
ValidateProtocol-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                    │    old     │              new              │
                    │ allocs/op  │ allocs/op   vs base           │
ValidateProtocol-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
