### PR TITLE
chore: use latest kong in envtests

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -57,8 +57,5 @@ kongintegration:
   kong-oss: '3.7.0'
 
 envtests:
-  # Because of a bug that was introduced in Kong EE 3.5 (https://konghq.atlassian.net/browse/KAG-3699),
-  # we need to stick to 3.4 in order to make our KongVault validation tests stable.
-  # This version should be bumped to the current one once the bug is fixed.
-  # PLEASE DO NOT BUMP THIS VERSION BEFORE KAG-3699 IS FIXED. renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.4.3.4'
+  # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
+  kong-ee: '3.7.0.0'


### PR DESCRIPTION
**What this PR does / why we need it**:

Drops pinning Kong EE version in envtests to `3.4.3.4` as https://konghq.atlassian.net/browse/KAG-3699 has already been implemented and shipped.
