### PR TITLE
backport(2.12.x): fix: Re-fill client certificates of services after merging certificate (#6228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- Services using `Secret`s containing the same certificate as client certificates
+  by annotation `konghq.com/client-cert` can be correctly translated.
+  [#6228](https://github.com/Kong/kubernetes-ingress-controller/pull/6228)
+
 ## [2.12.4]
 
 > Release date: 2024-04-30

--- a/internal/dataplane/parser/parser_test.go
+++ b/internal/dataplane/parser/parser_test.go
@@ -859,6 +859,17 @@ func TestServiceClientCertificate(t *testing.T) {
 												},
 											},
 										},
+										{
+											Path: "/bar",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "bar-svc",
+													Port: netv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
 									},
 								},
 							},
@@ -886,6 +897,17 @@ func TestServiceClientCertificate(t *testing.T) {
 					"tls.key": key,
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       k8stypes.UID("ffaabbcc-180b-4702-a91f-61351a33c6e4"),
+					Name:      "secret2",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"tls.crt": crt,
+					"tls.key": key,
+				},
+			},
 		}
 		services := []*corev1.Service{
 			{
@@ -894,6 +916,16 @@ func TestServiceClientCertificate(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"konghq.com/client-cert": "secret1",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar-svc",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"konghq.com/client-cert": "secret2",
+						"konghq.com/protocol":    "https",
 					},
 				},
 			},
@@ -914,9 +946,11 @@ func TestServiceClientCertificate(t *testing.T) {
 		assert.Equal("7428fb98-180b-4702-a91f-61351a33c6e4",
 			*state.Certificates[0].ID)
 
-		assert.Equal(1, len(state.Services))
+		assert.Equal(2, len(state.Services))
 		assert.Equal("7428fb98-180b-4702-a91f-61351a33c6e4",
 			*state.Services[0].ClientCertificate.ID)
+		assert.Equal("7428fb98-180b-4702-a91f-61351a33c6e4",
+			*state.Services[1].ClientCertificate.ID)
 	})
 	t.Run("client-cert secret doesn't exist", func(t *testing.T) {
 		ingresses := []*netv1.Ingress{

--- a/internal/dataplane/parser/translate_certs_test.go
+++ b/internal/dataplane/parser/translate_certs_test.go
@@ -1,0 +1,144 @@
+package parser
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v2/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v2/test/helpers/certificate"
+)
+
+func TestMergeCerts(t *testing.T) {
+	crt1, key1 := certificate.MustGenerateSelfSignedCertPEMFormat(certificate.WithCommonName("foo.com"))
+	crt2, key2 := certificate.MustGenerateSelfSignedCertPEMFormat(certificate.WithCommonName("bar.com"))
+	testCases := []struct {
+		name         string
+		certs        []certWrapper
+		mergedCerts  []kongstate.Certificate
+		idToMergedID certIDToMergedCertID
+	}{
+		{
+			name: "single certificate",
+			certs: []certWrapper{
+				{
+					identifier: string(crt1) + string(key1),
+					cert: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+					},
+					snis: []string{"foo.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					Certificate: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+						SNIs: kong.StringSlice("foo.com"),
+					},
+				},
+			},
+			idToMergedID: certIDToMergedCertID{"certificate-1": "certificate-1"},
+		},
+		{
+			name: "multiple different certifcates",
+			certs: []certWrapper{
+				{
+					identifier: string(crt1) + string(key1),
+					cert: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+					},
+					snis: []string{"foo.com"},
+				},
+				{
+					identifier: string(crt2) + string(key2),
+					cert: kong.Certificate{
+						ID:   kong.String("certificate-2"),
+						Cert: kong.String(string(crt2)),
+						Key:  kong.String(string(key2)),
+					},
+					snis: []string{"bar.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					Certificate: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+						SNIs: kong.StringSlice("foo.com"),
+					},
+				},
+				{
+					Certificate: kong.Certificate{
+						ID:   kong.String("certificate-2"),
+						Cert: kong.String(string(crt2)),
+						Key:  kong.String(string(key2)),
+						SNIs: kong.StringSlice("bar.com"),
+					},
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1": "certificate-1",
+				"certificate-2": "certificate-2",
+			},
+		},
+		{
+			name: "multiple certs with same content should be merged",
+			certs: []certWrapper{
+				{
+					identifier: string(crt1) + string(key1),
+					cert: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+					},
+					snis: []string{"foo.com"},
+				},
+				{
+					identifier: string(crt1) + string(key1),
+					cert: kong.Certificate{
+						ID:   kong.String("certificate-1-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+					},
+					snis: []string{"baz.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					Certificate: kong.Certificate{
+						ID:   kong.String("certificate-1"),
+						Cert: kong.String(string(crt1)),
+						Key:  kong.String(string(key1)),
+						// SNIs should be sorted
+						SNIs: kong.StringSlice("baz.com", "foo.com"),
+					},
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1":   "certificate-1",
+				"certificate-1-1": "certificate-1",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mergedCerts, idToMergedID := mergeCerts(logrus.StandardLogger(), tc.certs)
+			// sort certs by their IDs to make a stable order of the result merged certs.
+			sort.SliceStable(mergedCerts, func(i, j int) bool {
+				return *mergedCerts[i].Certificate.ID < *mergedCerts[j].Certificate.ID
+			})
+			require.Equal(t, tc.mergedCerts, mergedCerts)
+			require.Equal(t, tc.idToMergedID, idToMergedID)
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit d410be40f1e93dbfd6a2c9c8421bbba0009ca378)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Backport the fix of #6223 (PR #6228) to KIC 2.12.x.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
