### PR TITLE
chore: read admin api response body from error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.12.2
-	github.com/kong/go-kong v0.56.0
+	github.com/kong/go-kong v0.57.0
 	github.com/kong/kubernetes-telemetry v0.1.4
 	github.com/kong/kubernetes-testing-framework v0.47.1
 	github.com/lithammer/dedent v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJw
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kong/go-database-reconciler v1.12.2 h1:bnlvLCgP4OjgJOK5JYqq1MlIJ2F7erXERMj8n/LNU8M=
 github.com/kong/go-database-reconciler v1.12.2/go.mod h1:bUPJkoeW//x4hzNxewQMoIkeoDzJzunI0stDMYJ3BkU=
-github.com/kong/go-kong v0.56.0 h1:/9qbnQJWAgrSAKzL2RViBhHMTYOEyG8N4ClkKnUwEW4=
-github.com/kong/go-kong v0.56.0/go.mod h1:gyNwyP1fzztT6sX/0/ygMQ30OiRMIQ51b2jSfstMrcU=
+github.com/kong/go-kong v0.57.0 h1:e+4bHTzcO0xhFPVyGIUtlO+B4E4l14k55NH8Vjw6ORY=
+github.com/kong/go-kong v0.57.0/go.mod h1:gyNwyP1fzztT6sX/0/ygMQ30OiRMIQ51b2jSfstMrcU=
 github.com/kong/kubernetes-telemetry v0.1.4 h1:Yz7OlECxWKgNRG1wJ5imA4+H0dQEpdU9d86uhwUVpu4=
 github.com/kong/kubernetes-telemetry v0.1.4/go.mod h1:z3yB5naZjUmQCFjzD3hsJ9PVYar7BgPJFKzskUuOejU=
 github.com/kong/kubernetes-testing-framework v0.47.1 h1:BE2mQLC0Zj/NC5Y8B1Nm5VZymmrdVfu7cfwVKSobWtg=

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -23,7 +23,7 @@ type ConfigService interface {
 		config io.Reader,
 		checkHash bool,
 		flattenErrors bool,
-	) ([]byte, error)
+	) error
 }
 
 type ContentToDBLessConfigConverter interface {
@@ -74,7 +74,7 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 		}
 	}
 
-	if _, reloadConfigErr := s.configService.ReloadDeclarativeRawConfig(
+	if reloadConfigErr := s.configService.ReloadDeclarativeRawConfig(
 		ctx,
 		bytes.NewReader(config),
 		true,

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -74,7 +74,7 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 		}
 	}
 
-	if errBody, reloadConfigErr := s.configService.ReloadDeclarativeRawConfig(
+	if _, reloadConfigErr := s.configService.ReloadDeclarativeRawConfig(
 		ctx,
 		bytes.NewReader(config),
 		true,
@@ -84,12 +84,12 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 		// resource errors and produce an UpdateError with them.
 		var apiError *kong.APIError
 		if errors.As(reloadConfigErr, &apiError) && apiError.Code() == http.StatusBadRequest {
-			resourceErrors, parseErr := parseFlatEntityErrors(errBody, s.logger)
+			resourceErrors, parseErr := parseFlatEntityErrors(apiError.Raw(), s.logger)
 			if parseErr != nil {
 				return fmt.Errorf("failed to parse flat entity errors from error response: %w", parseErr)
 			}
 			return NewUpdateErrorWithResponseBody(
-				errBody,
+				apiError.Raw(),
 				resourceErrorsToResourceFailures(resourceErrors, s.logger),
 				reloadConfigErr,
 			)

--- a/internal/dataplane/sendconfig/inmemory_test.go
+++ b/internal/dataplane/sendconfig/inmemory_test.go
@@ -76,8 +76,8 @@ type mockConfigService struct {
 	err error
 }
 
-func (m *mockConfigService) ReloadDeclarativeRawConfig(context.Context, io.Reader, bool, bool) ([]byte, error) {
-	return nil, m.err
+func (m *mockConfigService) ReloadDeclarativeRawConfig(context.Context, io.Reader, bool, bool) error {
+	return m.err
 }
 
 type mockConfigConverter struct {

--- a/internal/dataplane/sendconfig/inmemory_test.go
+++ b/internal/dataplane/sendconfig/inmemory_test.go
@@ -73,12 +73,11 @@ const validFlattenedErrorsResponse = `{
 }`
 
 type mockConfigService struct {
-	responseBody []byte
-	err          error
+	err error
 }
 
 func (m *mockConfigService) ReloadDeclarativeRawConfig(context.Context, io.Reader, bool, bool) ([]byte, error) {
-	return m.responseBody, m.err
+	return nil, m.err
 }
 
 type mockConfigConverter struct {
@@ -118,9 +117,8 @@ func TestUpdateStrategyInMemory(t *testing.T) {
 			expectedError:      sendconfig.NewUpdateError(nil, kong.NewAPIError(400, "bad request")),
 		},
 		{
-			name:                      "APIError 400 with resource failures returned from config service",
-			configServiceError:        kong.NewAPIError(400, "bad request"),
-			configServiceResponseBody: []byte(validFlattenedErrorsResponse),
+			name:               "APIError 400 with resource failures returned from config service",
+			configServiceError: kong.NewAPIErrorWithRaw(400, "bad request", []byte(validFlattenedErrorsResponse)),
 			expectedError: sendconfig.NewUpdateErrorWithResponseBody(
 				[]byte(validFlattenedErrorsResponse),
 				[]failures.ResourceFailure{
@@ -136,14 +134,14 @@ func TestUpdateStrategyInMemory(t *testing.T) {
 						},
 					})),
 				},
-				kong.NewAPIError(400, "bad request"),
+				kong.NewAPIErrorWithRaw(400, "bad request", []byte(validFlattenedErrorsResponse)),
 			),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configService := &mockConfigService{responseBody: tc.configServiceResponseBody, err: tc.configServiceError}
+			configService := &mockConfigService{err: tc.configServiceError}
 			configConverter := &mockConfigConverter{}
 			s := sendconfig.NewUpdateStrategyInMemory(configService, configConverter, logr.Discard())
 			err := s.Update(context.Background(), sendconfig.ContentWithHash{})

--- a/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -128,7 +128,7 @@ func ensureGoldenTestOutputIsAccepted(ctx context.Context, t *testing.T, goldenT
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, err := kongClient.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(cfgAsJSON), true, true)
+		err := kongClient.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(cfgAsJSON), true, true)
 		if !assert.NoErrorf(t, err, "failed to reload declarative config") {
 			apiErr := &kong.APIError{}
 			if errors.As(err, &apiErr) {

--- a/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,8 +128,13 @@ func ensureGoldenTestOutputIsAccepted(ctx context.Context, t *testing.T, goldenT
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := kongClient.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(cfgAsJSON), true, true)
-		assert.NoErrorf(t, err, "failed to reload declarative config, resp: %s", string(resp))
+		_, err := kongClient.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(cfgAsJSON), true, true)
+		if !assert.NoErrorf(t, err, "failed to reload declarative config") {
+			apiErr := &kong.APIError{}
+			if errors.As(err, &apiErr) {
+				t.Errorf("Kong Admin API response: %s", apiErr.Raw())
+			}
+		}
 	}, timeout, tick)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't rely on `ReloadDeclarativeRawConfig` to return the error body when `err != nil` as it might be considered a Go anti-pattern to use variables when an error is returned. Instead, rely on the `APIError` being returned in cases where the error body is available.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up to https://github.com/Kong/kubernetes-ingress-controller/pull/6237#discussion_r1652781910.
