### PR TITLE
chore: temporarily disable konnect roles cleanup

### DIFF
--- a/hack/cleanup/konnect_runtime_groups.go
+++ b/hack/cleanup/konnect_runtime_groups.go
@@ -115,29 +115,31 @@ func deleteControlPlanes(ctx context.Context, log logr.Logger, cpsIDs []types.UU
 }
 
 // findOrphanedRolesToDelete gets a list of roles that belong to the orphaned control planes.
-func findOrphanedRolesToDelete(ctx context.Context, log logr.Logger, orphanedCPsIDs []types.UUID, rolesClient *roles.Client) ([]string, error) {
+func findOrphanedRolesToDelete(_ context.Context, log logr.Logger, orphanedCPsIDs []types.UUID, _ *roles.Client) ([]string, error) { //nolint:unparam
 	if len(orphanedCPsIDs) < 1 {
 		log.Info("No control planes to clean up, skipping listing roles")
 		return nil, nil
 	}
 
-	existingRoles, err := rolesClient.ListControlPlanesRoles(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list control plane roles: %w", err)
-	}
-
-	var rolesIDsToDelete []string
-	for _, role := range existingRoles {
-		belongsToOrphanedControlPlane := lo.ContainsBy(orphanedCPsIDs, func(cpID types.UUID) bool {
-			return cpID.String() == role.EntityID
-		})
-		if !belongsToOrphanedControlPlane {
-			log.Info("Role is not assigned to an orphaned control plane, skipping", "id", role.ID)
-			continue
-		}
-		rolesIDsToDelete = append(rolesIDsToDelete, role.ID)
-	}
-	return rolesIDsToDelete, nil
+	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6253
+	return nil, nil
+	// existingRoles, err := rolesClient.ListControlPlanesRoles(ctx)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to list control plane roles: %w", err)
+	// }
+	//
+	// var rolesIDsToDelete []string
+	// for _, role := range existingRoles {
+	// 	belongsToOrphanedControlPlane := lo.ContainsBy(orphanedCPsIDs, func(cpID types.UUID) bool {
+	// 		return cpID.String() == role.EntityID
+	// 	})
+	// 	if !belongsToOrphanedControlPlane {
+	// 		log.Info("Role is not assigned to an orphaned control plane, skipping", "id", role.ID)
+	// 		continue
+	// 	}
+	// 	rolesIDsToDelete = append(rolesIDsToDelete, role.ID)
+	// }
+	// return rolesIDsToDelete, nil
 }
 
 // deleteRoles deletes roles by their IDs.

--- a/test/internal/helpers/konnect/control_plane.go
+++ b/test/internal/helpers/konnect/control_plane.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	cp "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/controlplanes"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/roles"
-	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
@@ -32,11 +30,6 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 		}),
 	)
 	require.NoError(t, err)
-	rolesClient := roles.NewClient(
-		helpers.RetryableHTTPClient(helpers.DefaultHTTPClient()),
-		konnectRolesBaseURL,
-		accessToken(),
-	)
 
 	var rgID uuid.UUID
 	createRgErr := retry.Do(func() error {
@@ -82,15 +75,22 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 		//
 		// We can drop this once the automated cleanup is implemented on Konnect side:
 		// https://konghq.atlassian.net/browse/TPS-1453.
-		rgRoles, err := rolesClient.ListControlPlanesRoles(ctx)
-		require.NoErrorf(t, err, "failed to list control plane roles for cleanup: %q", rgID)
-		for _, role := range rgRoles {
-			if role.EntityID == rgID.String() { // Delete only roles created for the control plane.
-				t.Logf("deleting test Konnect Control Plane role: %q", role.ID)
-				err := rolesClient.DeleteRole(ctx, role.ID)
-				assert.NoErrorf(t, err, "failed to cleanup a control plane role: %q", role.ID)
-			}
-		}
+		//
+		// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6253
+		// rolesClient := roles.NewClient(
+		// 	helpers.RetryableHTTPClient(helpers.DefaultHTTPClient()),
+		// 	konnectRolesBaseURL,
+		// 	accessToken(),
+		// )
+		// rgRoles, err := rolesClient.ListControlPlanesRoles(ctx)
+		// require.NoErrorf(t, err, "failed to list control plane roles for cleanup: %q", rgID)
+		// for _, role := range rgRoles {
+		// 	if role.EntityID == rgID.String() { // Delete only roles created for the control plane.
+		// 		t.Logf("deleting test Konnect Control Plane role: %q", role.ID)
+		// 		err := rolesClient.DeleteRole(ctx, role.ID)
+		// 		assert.NoErrorf(t, err, "failed to cleanup a control plane role: %q", role.ID)
+		// 	}
+		// }
 	})
 
 	t.Logf("created test Konnect Control Plane: %q", rgID.String())


### PR DESCRIPTION
**What this PR does / why we need it**:

Workaround to unblock CI. https://github.com/Kong/kubernetes-ingress-controller/issues/6253 tracks fixing this.
