### PR TITLE
fix(fallback): do not skip config update when gateways out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ Adding a new version? You'll need three changes:
 - Services using `Secret`s containing the same certificate as client certificates
   by annotation `konghq.com/client-cert` can be correctly translated.
   [#6228](https://github.com/Kong/kubernetes-ingress-controller/pull/6228)
+- Fixed an issue where new gateways were not being populated with the current configuration when
+  `FallbackConfiguration` feature gate was turned on. Previously, configuration updates were skipped
+  if the Kubernetes config cache did not change, leading to inconsistencies. Now, the system ensures
+  that all gateways are populated with the latest configuration regardless of cache changes.
+  [#6271](https://github.com/Kong/kubernetes-ingress-controller/pull/6271)
 
 ## 3.2.1 
 

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
 )
@@ -25,6 +26,7 @@ type Client struct {
 	isKonnect           bool
 	konnectControlPlane string
 	lastConfigSHA       []byte
+	lastCacheStoresHash store.SnapshotHash
 
 	// podRef (optional) describes the Pod that the Client communicates with.
 	podRef *k8stypes.NamespacedName
@@ -152,6 +154,16 @@ func (c *Client) KonnectControlPlane() string {
 	}
 
 	return c.konnectControlPlane
+}
+
+// SetLastCacheStoresHash overrides last cache stores hash.
+func (c *Client) SetLastCacheStoresHash(s store.SnapshotHash) {
+	c.lastCacheStoresHash = s
+}
+
+// LastCacheStoresHash returns a checksum of the last successful cache stores push.
+func (c *Client) LastCacheStoresHash() store.SnapshotHash {
+	return c.lastCacheStoresHash
 }
 
 // SetLastConfigSHA overrides last config SHA.

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -307,7 +307,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 		sendconfig.NewDefaultConfigurationChangeDetector(logger),
 		lastValidConfigFetcher,
 		p,
-		cacheStores,
+		&cacheStores,
 		fallbackConfigGenerator,
 	)
 	require.NoError(t, err)

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckgen"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
@@ -27,6 +28,7 @@ type AdminAPIClient interface {
 	AdminAPIClient() *kong.Client
 	LastConfigSHA() []byte
 	SetLastConfigSHA([]byte)
+	SetLastCacheStoresHash(store.SnapshotHash)
 	BaseRootURL() string
 	PluginSchemaStore() *util.PluginSchemaStore
 
@@ -110,7 +112,3 @@ func PerformUpdate(
 
 	return newSHA, nil
 }
-
-// -----------------------------------------------------------------------------
-// Sendconfig - Private Functions
-// -----------------------------------------------------------------------------

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -206,7 +206,7 @@ func Run(
 		configurationChangeDetector,
 		kongConfigFetcher,
 		configTranslator,
-		cache,
+		&cache,
 		fallbackConfigGenerator,
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

We didn't take into account that when new gateways are discovered, we need to make sure they're all populated with the current configuration. We cannot skip config updates based only on the Kubernetes config cache not changing - we also need to ensure all the gateways are populated using it.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6219.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
