### PR TITLE
chore(tests): enable ee kongintegration tests

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -55,6 +55,8 @@ integration:
 kongintegration:
   # renovate: datasource=docker depName=kong versioning=docker
   kong-oss: '3.7.1'
+  # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
+  kong-ee: '3.7.1.1'
 
 envtests:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -7,6 +7,14 @@ jobs:
   kongintegration-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    strategy:
+      matrix:
+        include:
+          - name: enterprise
+            enterprise: true
+          - name: oss
+            enterprise: false
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
@@ -16,10 +24,22 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: set kong version
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: set kong oss version
+        if: ${{ !matrix.enterprise }}
         run: |
           echo "TEST_KONG_IMAGE=kong" >> $GITHUB_ENV
           echo "TEST_KONG_TAG=$(yq -ojson -r '.kongintegration.kong-oss' < .github/test_dependencies.yaml )" >> $GITHUB_ENV
+
+      - name: set kong ee version
+        if: ${{ matrix.enterprise }}
+        run: |
+          echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
+          echo "TEST_KONG_TAG=$(yq -ojson -r '.kongintegration.kong-ee' < .github/test_dependencies.yaml )" >> $GITHUB_ENV
 
       - uses: jdx/mise-action@v2
         with:
@@ -30,13 +50,15 @@ jobs:
         env:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
-          GOTESTSUM_JUNITFILE: kongintegration-tests.xml
+          GOTESTSUM_JUNITFILE: kongintegration-${{ matrix.name }}-tests.xml
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+          TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
 
       - name: collect test coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-kongintegration
+          name: coverage-kongintegration-${{ matrix.name }}
           path: "coverage.*.out"
 
       - name: collect test report

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -251,3 +251,8 @@ func IsCI() bool {
 	// set the CI environment variable.
 	return os.Getenv("CI") == "true"
 }
+
+// KongLicenseData returns the Kong license data to use in tests.
+func KongLicenseData() string {
+	return os.Getenv("KONG_LICENSE_DATA")
+}

--- a/test/kongintegration/containers/kong.go
+++ b/test/kongintegration/containers/kong.go
@@ -140,11 +140,14 @@ func (c Kong) Terminate(ctx context.Context) error {
 
 // kongImageUnderTest returns the Kong image to be used for integration tests. If both TEST_KONG_IMAGE and
 // TEST_KONG_TAG are set, it will return the image and tag specified by them. Otherwise, it will return
-// the default image (kong:latest).
+// the default image (kong:latest or kong/kong-gateway if EE tests enabled).
 func kongImageUnderTest() string {
 	if testenv.KongImage() != "" && testenv.KongTag() != "" {
 		return fmt.Sprintf("%s:%s", testenv.KongImage(), testenv.KongTag())
 	}
 
+	if testenv.KongEnterpriseEnabled() {
+		return "kong/kong-gateway:latest"
+	}
 	return "kong:latest"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables EE `kongintegration` tests so that golden tests EE variants are properly verified with the EE Gateway.

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4815.
