### PR TITLE
fix(translator): Pass typemeta in ingress sub-translator

### DIFF
--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -415,11 +415,7 @@ func (m *ingressTranslationMeta) translateIntoKongRoute() *kongstate.Route {
 	routeName := m.backend.intoKongRouteName(k8stypes.NamespacedName{Namespace: m.ingressNamespace, Name: m.ingressName}, ingressHost)
 
 	route := &kongstate.Route{
-		Ingress: util.K8sObjectInfo{
-			Namespace:   m.parentIngress.GetNamespace(),
-			Name:        m.parentIngress.GetName(),
-			Annotations: m.parentIngress.GetAnnotations(),
-		},
+		Ingress: util.FromK8sObject(m.parentIngress),
 		Route: kong.Route{
 			Name:              kong.String(routeName),
 			StripPath:         kong.Bool(false),

--- a/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -39,11 +39,7 @@ func (m *ingressTranslationMeta) translateIntoKongExpressionRoute() *kongstate.R
 	)
 
 	route := &kongstate.Route{
-		Ingress: util.K8sObjectInfo{
-			Namespace:   m.parentIngress.GetNamespace(),
-			Name:        m.parentIngress.GetName(),
-			Annotations: m.parentIngress.GetAnnotations(),
-		},
+		Ingress: util.FromK8sObject(m.parentIngress),
 		Route: kong.Route{
 			Name:              kong.String(routeName),
 			StripPath:         kong.Bool(false),

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -31,6 +31,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		{
 			name: "a basic ingress resource with a single rule and prefix path type",
 			ingress: &netv1.Ingress{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -74,8 +75,9 @@ func TestTranslateIngressATC(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -90,7 +92,7 @@ func TestTranslateIngressATC(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 						ExpressionRoutes: true,
 					}},
@@ -106,6 +108,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		{
 			name: "a basic ingress resource with a single rule, and only one path results in a single kong service and route",
 			ingress: &netv1.Ingress{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -148,8 +151,9 @@ func TestTranslateIngressATC(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -164,7 +168,7 @@ func TestTranslateIngressATC(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 						ExpressionRoutes: true,
 					}},
@@ -180,6 +184,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		{
 			name: "an ingress with method, protocol, and header annotations",
 			ingress: &netv1.Ingress{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress-annotations",
 					Namespace: corev1.NamespaceDefault,
@@ -234,6 +239,7 @@ func TestTranslateIngressATC(t *testing.T) {
 								"konghq.com/protocols":   "http",
 								"konghq.com/headers.foo": "bar",
 							},
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress-annotations.test-service.konghq.com.80"),
@@ -249,7 +255,7 @@ func TestTranslateIngressATC(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress-annotations", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress-annotations", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 						ExpressionRoutes: true,
 					}},
@@ -276,6 +282,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		{
 			name: "KongServiceFacade used as a backend",
 			ingress: &netv1.Ingress{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: "default",
@@ -334,8 +341,9 @@ func TestTranslateIngressATC(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.konghq.com.svc-facade.svc.facade"),
@@ -350,7 +358,7 @@ func TestTranslateIngressATC(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 						ExpressionRoutes: true,
 					}},
@@ -377,6 +385,7 @@ func TestTranslateIngressATC(t *testing.T) {
 		{
 			name: "not existing KongServiceFacade used as a backend",
 			ingress: &netv1.Ingress{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: "default",

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
@@ -30,6 +31,15 @@ var (
 	pathTypeExact                  = netv1.PathTypeExact
 	pathTypeImplementationSpecific = netv1.PathTypeImplementationSpecific
 	pathTypePrefix                 = netv1.PathTypePrefix
+	ingressTypeMeta                = metav1.TypeMeta{
+		APIVersion: netv1.SchemeGroupVersion.Group + "/" + netv1.SchemeGroupVersion.Version,
+		Kind:       "Ingress",
+	}
+	ingressGVK = schema.GroupVersionKind{
+		Group:   netv1.SchemeGroupVersion.Group,
+		Version: netv1.SchemeGroupVersion.Version,
+		Kind:    "Ingress",
+	}
 )
 
 func expectedParentIngress() *netv1.Ingress {
@@ -53,6 +63,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "a basic ingress resource with a single rule and prefix path type",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -96,8 +107,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -109,7 +121,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -125,6 +137,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "a basic ingress resource with a single rule, and only one path results in a single kong service and route",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -167,8 +180,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -180,7 +194,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -196,6 +210,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "a basic ingress resource with a single rule and prefix path type",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -239,8 +254,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -252,7 +268,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -268,6 +284,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "an ingress with path type exact gets a kong route with an exact path match",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -311,8 +328,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -324,7 +342,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -340,6 +358,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "an Ingress resource with implementation specific path type doesn't modify the path",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -383,8 +402,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -396,7 +416,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -412,6 +432,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "an Ingress resource with paths with double /'s gets flattened",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -454,8 +475,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -467,7 +489,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -483,6 +505,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "empty paths get treated as '/'",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -525,8 +548,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -538,7 +562,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -554,6 +578,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "multiple and various paths get compiled together properly",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -661,8 +686,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:  kong.String("default.test-ingress.test-service.konghq.com.80"),
@@ -681,7 +707,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -697,6 +723,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "when no host is provided, all hosts are matched",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -803,8 +830,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name: kong.String("default.test-ingress.test-service..80"),
@@ -822,7 +850,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -838,6 +866,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "when there are multiple backends services, paths wont be combined and separate kong services will be provided",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -895,8 +924,9 @@ func TestTranslateIngress(t *testing.T) {
 					Routes: []kongstate.Route{
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress.test-service1.konghq.com.80"),
@@ -908,7 +938,7 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 					},
@@ -936,8 +966,9 @@ func TestTranslateIngress(t *testing.T) {
 					Routes: []kongstate.Route{
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress.test-service2.konghq.com.80"),
@@ -949,7 +980,7 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 					},
@@ -966,6 +997,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "when there are multiple ingress rules with overlapping host and service, separate kong services will be provided",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -1034,8 +1066,9 @@ func TestTranslateIngress(t *testing.T) {
 					Routes: []kongstate.Route{
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress.ad-service.konghq.com.80"),
@@ -1047,7 +1080,7 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 					},
@@ -1075,8 +1108,9 @@ func TestTranslateIngress(t *testing.T) {
 					Routes: []kongstate.Route{
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress.mad-service.konghq.co.80"),
@@ -1088,7 +1122,7 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 					},
@@ -1105,6 +1139,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "* in host is replaced to _",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
@@ -1147,8 +1182,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service._.konghq.com.80"),
@@ -1160,7 +1196,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -1176,13 +1212,10 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "use port name when service port number is not provided",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: corev1.NamespaceDefault,
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Ingress",
-					APIVersion: "networking.k8s.io/v1",
 				},
 				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{{
@@ -1221,8 +1254,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.test-service.konghq.com.http"),
@@ -1256,6 +1290,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "KongServiceFacade used as a backend",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: "default",
@@ -1310,8 +1345,9 @@ func TestTranslateIngress(t *testing.T) {
 					},
 					Routes: []kongstate.Route{{
 						Ingress: util.K8sObjectInfo{
-							Name:      "test-ingress",
-							Namespace: corev1.NamespaceDefault,
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
 							Name:              kong.String("default.test-ingress.konghq.com.svc-facade.svc.facade"),
@@ -1323,7 +1359,7 @@ func TestTranslateIngress(t *testing.T) {
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
-							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 						},
 					}},
 					Backends: []kongstate.ServiceBackend{
@@ -1349,6 +1385,7 @@ func TestTranslateIngress(t *testing.T) {
 		{
 			name: "not existing KongServiceFacade used as a backend",
 			ingresses: []*netv1.Ingress{{
+				TypeMeta: ingressTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
 					Namespace: "default",
@@ -1379,6 +1416,7 @@ func TestTranslateIngress(t *testing.T) {
 			name: "KongServiceFacade used in multiple Ingresses",
 			ingresses: []*netv1.Ingress{
 				{
+					TypeMeta: ingressTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-ingress",
 						Namespace: "default",
@@ -1404,6 +1442,7 @@ func TestTranslateIngress(t *testing.T) {
 					},
 				},
 				{
+					TypeMeta: ingressTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-ingress-2",
 						Namespace: "default",
@@ -1460,8 +1499,9 @@ func TestTranslateIngress(t *testing.T) {
 					Routes: []kongstate.Route{
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress.konghq.com.svc-facade.svc.facade"),
@@ -1473,13 +1513,14 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 						{
 							Ingress: util.K8sObjectInfo{
-								Name:      "test-ingress-2",
-								Namespace: corev1.NamespaceDefault,
+								Name:             "test-ingress-2",
+								Namespace:        corev1.NamespaceDefault,
+								GroupVersionKind: ingressGVK,
 							},
 							Route: kong.Route{
 								Name:              kong.String("default.test-ingress-2.konghq.com.svc-facade.svc.facade"),
@@ -1491,7 +1532,7 @@ func TestTranslateIngress(t *testing.T) {
 								StripPath:         kong.Bool(false),
 								ResponseBuffering: kong.Bool(true),
 								RequestBuffering:  kong.Bool(true),
-								Tags:              kong.StringSlice("k8s-name:test-ingress-2", "k8s-namespace:default"),
+								Tags:              kong.StringSlice("k8s-name:test-ingress-2", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Use `util.FromK8sObject` to carry type meta to `Route` in kongstate in sub-translator of ingress. This fixes the issue of missing type meta in checking reference of plugins.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Should fix #6294 (after #6295 merged)

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
