### PR TITLE
test: fix `for range` in unit test

### DIFF
--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -595,10 +595,10 @@ func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 			)
 
 			kongClient.SetConfigStatusNotifier(statusQueue)
-			for range tc.gatewayFailuresCount {
+			for i := 0; i < tc.gatewayFailuresCount; i++ {
 				updateStrategyResolver.returnErrorOnUpdate(testGatewayClient.BaseRootURL())
 			}
-			for range tc.konnectFailuresCount {
+			for i := 0; i < tc.konnectFailuresCount; i++ {
 				updateStrategyResolver.returnErrorOnUpdate(testKonnectClient.BaseRootURL())
 			}
 			configBuilder.returnTranslationFailures(tc.translationFailures)
@@ -1095,7 +1095,7 @@ func TestKongClientUpdate_FetchStoreAndPushLastValidConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			updateStrategyResolver := newMockUpdateStrategyResolver(t)
-			for range tc.gatewayFailuresCount {
+			for i := 0; i < tc.gatewayFailuresCount; i++ {
 				updateStrategyResolver.returnSpecificErrorOnUpdate(clientsProvider.gatewayClients[0].BaseRootURL(), tc.errorOnGatewayFailures)
 				updateStrategyResolver.returnSpecificErrorOnUpdate(clientsProvider.gatewayClients[1].BaseRootURL(), tc.errorOnGatewayFailures)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

My IDE was complaining about this unit test and it looks like we were iterating over an int. I don't know why this error wasn't detected in the CI. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
