### PR TITLE
test: add case for incorrect reference in remote plugin test

### DIFF
--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
@@ -620,6 +621,13 @@ func TestPluginCrossNamespaceReference(t *testing.T) {
 		return err == nil
 	}, ingressWait, waitTick)
 
+	const (
+		// negativeCheckWait is the duration used in `Never` for verifying that the plugin is not configured
+		// without reference grant or with incorrect reference grant.
+		// Set it to 1 minute since we have to wait until the end in each `Never` if the test is OK.
+		negativeCheckWait = time.Minute
+	)
+
 	t.Logf("validating that plugin %s is not configured without a grant", kongplugin.Name)
 	assert.Never(t, func() bool {
 		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyHTTPURL.String(), "/test_plugin_reference?key=thirtytangas", nil)
@@ -629,10 +637,47 @@ func TestPluginCrossNamespaceReference(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusTeapot
-	}, ingressWait, waitTick)
+	}, negativeCheckWait, waitTick)
+
+	t.Logf("creating a ReferenceGrant that does not permit kongconsumer access to kongplugins")
+	grant := &gatewayapi.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayapi.ReferenceGrantSpec{
+			From: []gatewayapi.ReferenceGrantFrom{
+				{
+					Group:     gatewayapi.Group("configuration.konghq.com"),
+					Kind:      gatewayapi.Kind("KongConsumer"),
+					Namespace: gatewayapi.Namespace(remote.Name),
+				},
+			},
+			To: []gatewayapi.ReferenceGrantTo{
+				{
+					Group: gatewayapi.Group("configuration.konghq.com"),
+					Kind:  gatewayapi.Kind("KongPlugin"),
+				},
+			},
+		},
+	}
+	// Not the namespace as the plugin.
+	_, err = gatewayClient.GatewayV1beta1().ReferenceGrants(remote.Name).Create(ctx, grant, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(grant)
+
+	t.Logf("validating that plugin %s is not configured with an incorrectly configured referencegrant", kongplugin.Name)
+	assert.Never(t, func() bool {
+		req := helpers.MustHTTPRequest(t, http.MethodGet, proxyHTTPURL.String(), "/test_plugin_reference?key=thirtytangas", nil)
+		resp, err := helpers.DefaultHTTPClient(helpers.WithResolveHostTo(proxyHTTPURL.Host)).Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusTeapot
+	}, negativeCheckWait, waitTick)
 
 	t.Logf("creating a ReferenceGrant that permits kongconsumer access from %s to kongplugins in %s", remote.Name, ns.Name)
-	grant := &gatewayapi.ReferenceGrant{
+	grant = &gatewayapi.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: uuid.NewString(),
 		},
@@ -654,6 +699,7 @@ func TestPluginCrossNamespaceReference(t *testing.T) {
 	}
 	_, err = gatewayClient.GatewayV1beta1().ReferenceGrants(ns.Name).Create(ctx, grant, metav1.CreateOptions{})
 	require.NoError(t, err)
+	cleaner.Add(grant)
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Add test case for incorrect `ReferenceGrant` in `TestPluginCrossNamespaceReference`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #6314 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~ Only changing tests
