### PR TITLE
feat(client): use another goroutine to send config to Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ Adding a new version? You'll need three changes:
   flag `--konnect-disable-consumers-sync`.
   [#6313](https://github.com/Kong/kubernetes-ingress-controller/pull/6313)
 
+### Changed
+
+- Spawn a goroutine to send configuration to Konnect. This prevents the process
+  of sending configuration to Konnect to block the syncing to Kong gateways.
+  [#6320](https://github.com/Kong/kubernetes-ingress-controller/pull/6320)
+
 ### Fixed
 
 - Services using `Secret`s containing the same certificate as client certificates

--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -33,6 +33,14 @@ type CalculateConfigStatusInput struct {
 	TranslationFailuresOccurred bool
 }
 
+func (i CalculateConfigStatusInput) SetKonnectFailed(failed bool) (CalculateConfigStatusInput, bool) {
+	if i.KonnectFailed != failed {
+		i.KonnectFailed = failed
+		return i, true
+	}
+	return i, false
+}
+
 // CalculateConfigStatus calculates a clients.ConfigStatus that sums up the configuration synchronisation result as
 // a single enumerated value.
 func CalculateConfigStatus(i CalculateConfigStatusInput) ConfigStatus {

--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -33,14 +33,6 @@ type CalculateConfigStatusInput struct {
 	TranslationFailuresOccurred bool
 }
 
-func (i CalculateConfigStatusInput) SetKonnectFailed(failed bool) (CalculateConfigStatusInput, bool) {
-	if i.KonnectFailed != failed {
-		i.KonnectFailed = failed
-		return i, true
-	}
-	return i, false
-}
-
 // CalculateConfigStatus calculates a clients.ConfigStatus that sums up the configuration synchronisation result as
 // a single enumerated value.
 func CalculateConfigStatus(i CalculateConfigStatusInput) ConfigStatus {

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -740,6 +740,12 @@ func (c *KongClient) sendToClient(
 		AppendStubEntityWhenConfigEmpty: !client.IsKonnect() && config.InMemory,
 	}
 	targetContent := deckgen.ToDeckContent(ctx, logger, s, deckGenParams)
+	// Remove consumers in target content when we send to Konnect if `--disable-consumers-sync` flag is set.
+	// REVIEW: add an option to `deckGenParams` to omit them in `ToDeckContent` to reduce the cost filling the contents?
+	if client.IsKonnect() && config.KonnectConsumersDisabled {
+		targetContent.Consumers = nil
+	}
+
 	customEntities := make(sendconfig.CustomEntitiesByType)
 	for entityType, collection := range s.CustomEntities {
 		for _, entity := range collection.Entities {

--- a/internal/dataplane/kong_client_konnect.go
+++ b/internal/dataplane/kong_client_konnect.go
@@ -43,9 +43,8 @@ func (c *KongClient) sendOutToKonnectClient(
 ) {
 	// In case users have many consumers, konnect sync can be very slow and cause dataplane sync issues.
 	// For this reason, if the --disable-consumers-sync flag is set, we do not send consumers to Konnect.
-	// TODO: modify the implementation here not to modify the shared `Consumers`.
 	if konnectClient.ConsumersSyncDisabled() {
-		s.Consumers = nil
+		config.KonnectConsumersDisabled = true
 	}
 
 	if _, err := c.sendToClient(ctx, konnectClient, s, config, isFallback); err != nil {

--- a/internal/dataplane/kong_client_konnect.go
+++ b/internal/dataplane/kong_client_konnect.go
@@ -1,0 +1,104 @@
+package dataplane
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-kong/kong"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckerrors"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+)
+
+// maybeSendOutToKonnectClient sends out the configuration to Konnect when KonnectClient is provided.
+// It's a noop when Konnect integration is not enabled.
+func (c *KongClient) maybeSendOutToKonnectClient(
+	ctx context.Context,
+	s *kongstate.KongState,
+	config sendconfig.Config,
+	isFallback bool,
+) {
+	konnectClient := c.clientsProvider.KonnectClient()
+	// There's no KonnectClient configured, that's totally fine.
+	if konnectClient == nil {
+		return
+	}
+
+	// send Kong configuration to Konnect client in a new goroutine
+	go c.sendOutToKonnectClient(
+		ctx, konnectClient, s, config, isFallback,
+	)
+}
+
+func (c *KongClient) sendOutToKonnectClient(
+	ctx context.Context,
+	konnectClient *adminapi.KonnectClient,
+	s *kongstate.KongState,
+	config sendconfig.Config,
+	isFallback bool,
+) {
+	// In case users have many consumers, konnect sync can be very slow and cause dataplane sync issues.
+	// For this reason, if the --disable-consumers-sync flag is set, we do not send consumers to Konnect.
+	// TODO: modify the implementation here not to modify the shared `Consumers`.
+	if konnectClient.ConsumersSyncDisabled() {
+		s.Consumers = nil
+	}
+
+	if _, err := c.sendToClient(ctx, konnectClient, s, config, isFallback); err != nil {
+		// In case of an error, we only log it since we don't want the Konnect to affect the basic functionality
+		// of the controller.
+		if errors.As(err, &sendconfig.UpdateSkippedDueToBackoffStrategyError{}) {
+			c.logger.Info("Skipped pushing configuration to Konnect due to backoff strategy", "explanation", err.Error())
+		}
+
+		c.logger.Error(err, "Failed pushing configuration to Konnect")
+		logKonnectErrors(c.logger, err)
+		if isFallback {
+			// If Konnect sync fails, we should log the error and carry on as it's not a critical error.
+			c.logger.Error(err, "Failed to sync fallback configuration with Konnect")
+		}
+		// If we got any error, set Konnect failed to true.
+		c.setSendToKonnectFailed(ctx, true)
+		return
+	}
+	// If configuration is correctly sent to Konnect, set Konnect failed to false.
+	c.setSendToKonnectFailed(ctx, false)
+}
+
+// setSendToKonnectFailed sets the current status of sending configuration to Konnect
+// and update the general config status if the status is changed.
+func (c *KongClient) setSendToKonnectFailed(ctx context.Context, failed bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.currentConfigStatusAttributes.KonnectFailed != failed {
+		c.currentConfigStatusAttributes.KonnectFailed = failed
+		c.updateConfigStatus(ctx, clients.CalculateConfigStatus(c.currentConfigStatusAttributes))
+	}
+}
+
+// logKonnectErrors logs details of each error response returned from Konnect API.
+func logKonnectErrors(logger logr.Logger, err error) {
+	if crudActionErrors := deckerrors.ExtractCRUDActionErrors(err); len(crudActionErrors) > 0 {
+		for _, actionErr := range crudActionErrors {
+			apiErr := &kong.APIError{}
+			if errors.As(actionErr.Err, &apiErr) {
+				logger.Error(actionErr, "Failed to send request to Konnect",
+					"operation_type", actionErr.OperationType.String(),
+					"entity_kind", actionErr.Kind,
+					"entity_name", actionErr.Name,
+					"details", apiErr.Details())
+			} else {
+				logger.Error(actionErr, "Failed to send request to Konnect",
+					"operation_type", actionErr.OperationType.String(),
+					"entity_kind", actionErr.Kind,
+					"entity_name", actionErr.Name,
+				)
+			}
+		}
+	}
+}

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -623,8 +623,7 @@ func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 				notifications := statusQueue.Notifications()
 				l = len(notifications)
 				return l > 0 && notifications[l-1] == tc.expectedStatus
-			}, urlUpdatedWait, urlUpdatedWaitTick, "the latest notification should be equal to expected status %s: actual %s",
-				tc.expectedStatus, statusQueue.Notifications()[l-1])
+			}, urlUpdatedWait, urlUpdatedWaitTick, "the latest notification should be equal to expected status %s", tc.expectedStatus)
 
 			_ = kongClient.Update(ctx)
 			notifications := statusQueue.Notifications()

--- a/internal/dataplane/sendconfig/kong.go
+++ b/internal/dataplane/sendconfig/kong.go
@@ -34,6 +34,9 @@ type Config struct {
 	// SanitizeKonnectConfigDumps indicates whether to sanitize Konnect config dumps.
 	SanitizeKonnectConfigDumps bool
 
+	// KonnectConsumersDisabled indicates whether to omit consumers in Konnect config dumps.
+	KonnectConsumersDisabled bool
+
 	// FallbackConfiguration indicates whether to generate fallback configuration in the case of entity
 	// errors returned by the Kong Admin API.
 	FallbackConfiguration bool


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Spawn a goroutine to send configuration to Konnect in `KongClient.maybeSendOutToKonnectClient`. This should make sending to Konnect not to block syncing configuration to Kong gateways.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6188

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

There are LOTS of potential concurrency issues because we have written some code and tests based on the current implementation that uploading to Konnect is run in serial after sending config to gateways and they are protected by the same `lock`. For example, the logic of config status should be changed and we need to use `Eventually` in test cases for checking if a certain client is updated.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
