### PR TITLE
feat(konnect): Add Konnect config syncer

### DIFF
--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -30,8 +30,7 @@ type ConfigSynchronizer struct {
 	prometheusMetrics      *metrics.CtrlFuncMetrics
 	updateStrategyResolver sendconfig.UpdateStrategyResolver
 	configChangeDetector   sendconfig.ConfigurationChangeDetector
-	// REVIEW: use *file.Content to pass Kong configuration because it has Deepcopy method
-	// so we can easily copy config to prevent data race and long term locks.
+
 	targetContent *file.Content
 
 	lock sync.RWMutex
@@ -46,11 +45,10 @@ func NewConfigSynchronizer(
 	configChangeDetector sendconfig.ConfigurationChangeDetector,
 ) *ConfigSynchronizer {
 	return &ConfigSynchronizer{
-		logger:          logger,
-		syncTicker:      time.NewTicker(configUploadPeriod),
-		kongConfig:      kongConfig,
-		clientsProvider: clientsProvider,
-		// REVIEW: can we run metrics.NewCtrlFuncMetrics() more than once?
+		logger:                 logger,
+		syncTicker:             time.NewTicker(configUploadPeriod),
+		kongConfig:             kongConfig,
+		clientsProvider:        clientsProvider,
 		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
 		updateStrategyResolver: updateStrategyResolver,
 		configChangeDetector:   configChangeDetector,

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -1,0 +1,165 @@
+package konnect
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/kong/go-kong/kong"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckerrors"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+)
+
+// DefaultConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
+var DefaultConfigUploadPeriod = 30 * time.Second
+
+// ConfigSynchronizer runs a loop to upload the traslated Kong configuration to Konnect in the given period.
+type ConfigSynchronizer struct {
+	logger                 logr.Logger
+	syncTicker             *time.Ticker
+	kongConfig             sendconfig.Config
+	clientsProvider        clients.AdminAPIClientsProvider
+	prometheusMetrics      *metrics.CtrlFuncMetrics
+	updateStrategyResolver sendconfig.UpdateStrategyResolver
+	configChangeDetector   sendconfig.ConfigurationChangeDetector
+	// REVIEW: use *file.Content to pass Kong configuration because it has Deepcopy method
+	// so we can easily copy config to prevent data race and long term locks.
+	targetContent *file.Content
+
+	lock sync.RWMutex
+}
+
+func NewConfigSynchronizer(
+	logger logr.Logger,
+	kongConfig sendconfig.Config,
+	configUploadPeriod time.Duration,
+	clientsProvider clients.AdminAPIClientsProvider,
+	updateStrategyResolver sendconfig.UpdateStrategyResolver,
+	configChangeDetector sendconfig.ConfigurationChangeDetector,
+) *ConfigSynchronizer {
+	return &ConfigSynchronizer{
+		logger:          logger,
+		syncTicker:      time.NewTicker(configUploadPeriod),
+		kongConfig:      kongConfig,
+		clientsProvider: clientsProvider,
+		// REVIEW: can we run metrics.NewCtrlFuncMetrics() more than once?
+		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		updateStrategyResolver: updateStrategyResolver,
+		configChangeDetector:   configChangeDetector,
+	}
+}
+
+var _ manager.Runnable = &ConfigSynchronizer{}
+
+// Start starts the loop to receive configuration and uplaod configuration to Konnect.
+func (s *ConfigSynchronizer) Start(ctx context.Context) error {
+	s.logger.Info("Started Konnect configuration synchronizer")
+	go s.runKonnectUpdateServer(ctx)
+	return nil
+}
+
+// SetTargetContent stores the latest configuration in `file.Content` format.
+// REVIEW: should we use channel to receive the configuration?
+func (s *ConfigSynchronizer) SetTargetContent(targetContent *file.Content) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.targetContent = targetContent
+}
+
+// GetTargetContentCopy returns a copy of the latest configuration in `file.Content` format
+// to prevent data race and long duration of occupying lock.
+func (s *ConfigSynchronizer) GetTargetContentCopy() *file.Content {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.targetContent.DeepCopy()
+}
+
+// runKonnectUpdateServer starts the loop to receive configuration and send configuration to Konenct.
+func (s *ConfigSynchronizer) runKonnectUpdateServer(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("Context done: shutting down the Konnect update server")
+			s.syncTicker.Stop()
+		case <-s.syncTicker.C:
+			s.logger.Info("Start uploading to Konnect")
+			client := s.clientsProvider.KonnectClient()
+			if client == nil {
+				s.logger.Info("Konnect client not ready, skipping")
+				continue
+			}
+			// Copy target content to upload here because uploading full configuration to Konnect may cost too much time.
+			targetContent := s.GetTargetContentCopy()
+			if targetContent == nil {
+				s.logger.Info("No target content received, skipping")
+				continue
+			}
+			err := s.uploadConfig(ctx, client, targetContent)
+			if err != nil {
+				s.logger.Error(err, "failed to upload configuration to Konnect")
+				logKonnectErrors(s.logger, err)
+			}
+		}
+	}
+}
+
+// uploadConfig sends the given configuration to Konnect.
+func (s *ConfigSynchronizer) uploadConfig(ctx context.Context, client *adminapi.KonnectClient, targetContent *file.Content) error {
+	const isFallback = false
+	// Remove consumers in target content if consumer sync is disabled.
+	if client.ConsumersSyncDisabled() {
+		targetContent.Consumers = []file.FConsumer{}
+	}
+
+	newSHA, err := sendconfig.PerformUpdate(
+		ctx,
+		s.logger,
+		client,
+		s.kongConfig,
+		targetContent,
+		// Konnect client does not upload custom entities.
+		sendconfig.CustomEntitiesByType{},
+		s.prometheusMetrics,
+		s.updateStrategyResolver,
+		s.configChangeDetector,
+		isFallback,
+	)
+	if err != nil {
+		return err
+	}
+	client.SetLastConfigSHA(newSHA)
+	return nil
+}
+
+// logKonnectErrors logs details of each error response returned from Konnect API.
+// TODO: This is copied from internal/dataplane package.
+// Remove the definition in dataplane package after using separate loop to upload config to Konnect:
+// https://github.com/Kong/kubernetes-ingress-controller/issues/6338
+func logKonnectErrors(logger logr.Logger, err error) {
+	if crudActionErrors := deckerrors.ExtractCRUDActionErrors(err); len(crudActionErrors) > 0 {
+		for _, actionErr := range crudActionErrors {
+			apiErr := &kong.APIError{}
+			if errors.As(actionErr.Err, &apiErr) {
+				logger.Error(actionErr, "Failed to send request to Konnect",
+					"operation_type", actionErr.OperationType.String(),
+					"entity_kind", actionErr.Kind,
+					"entity_name", actionErr.Name,
+					"details", apiErr.Details())
+			} else {
+				logger.Error(actionErr, "Failed to send request to Konnect",
+					"operation_type", actionErr.OperationType.String(),
+					"entity_kind", actionErr.Kind,
+					"entity_name", actionErr.Name,
+				)
+			}
+		}
+	}
+}

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -1,0 +1,262 @@
+package konnect
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+)
+
+func TestConfigSynchronizer_GetTargetContentCopy(t *testing.T) {
+	content := &file.Content{
+		FormatVersion: "3.0",
+		Services: []file.FService{
+			{
+				Service: kong.Service{
+					Name: kong.String("service1"),
+					Host: kong.String("example.com"),
+				},
+				Routes: []*file.FRoute{
+					{
+						Route: kong.Route{
+							Name:       kong.String("route1"),
+							Expression: kong.String("http.path == \"/foo\""),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := &ConfigSynchronizer{}
+	s.SetTargetContent(content)
+	copiedContent := s.GetTargetContentCopy()
+	require.Equal(t, content, copiedContent, "Copied content should have values with same fields with original content")
+	require.NotSame(t, content, copiedContent, "Copied content should not point to the same object with the original content")
+}
+
+// ----------------------------------------------------------------------------
+// Mocks: Mock interfaces to run sendconfig.PerformUpdate in tests.
+// TODO: These are (mostly) copied from internal/dataplane package, but there are also differences because we do not need so man features for the tests here.
+// Should we extract the mock interfaces for sendconfig.PerformUpdate to common packages?
+// ----------------------------------------------------------------------------
+
+// mockGatewayClientsProvider is a mock implementation of dataplane.AdminAPIClientsProvider.
+type mockGatewayClientsProvider struct {
+	gatewayClients []*adminapi.Client
+	konnectClient  *adminapi.KonnectClient
+	dbMode         dpconf.DBMode
+}
+
+func (p *mockGatewayClientsProvider) KonnectClient() *adminapi.KonnectClient {
+	return p.konnectClient
+}
+
+func (p *mockGatewayClientsProvider) GatewayClients() []*adminapi.Client {
+	return p.gatewayClients
+}
+
+func (p *mockGatewayClientsProvider) GatewayClientsToConfigure() []*adminapi.Client {
+	if p.dbMode.IsDBLessMode() {
+		return p.gatewayClients
+	}
+	if len(p.gatewayClients) == 0 {
+		return []*adminapi.Client{}
+	}
+	return p.gatewayClients[:1]
+}
+
+// mockUpdateStrategy is a mock implementation of sendconfig.UpdateStrategyResolver.
+type mockUpdateStrategyResolver struct {
+	updateCalledForURLs       []string
+	lastUpdatedContentForURLs map[string]sendconfig.ContentWithHash
+	lock                      sync.RWMutex
+}
+
+func newMockUpdateStrategyResolver() *mockUpdateStrategyResolver {
+	return &mockUpdateStrategyResolver{
+		lastUpdatedContentForURLs: map[string]sendconfig.ContentWithHash{},
+	}
+}
+
+func (f *mockUpdateStrategyResolver) ResolveUpdateStrategy(c sendconfig.UpdateClient) sendconfig.UpdateStrategy {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	url := c.AdminAPIClient().BaseRootURL()
+	return &mockUpdateStrategy{onUpdate: f.updateCalledForURLCallback(url)}
+}
+
+// updateCalledForURLCallback returns a function that will be called when the mockUpdateStrategy is called.
+// That enables us to track which URLs were called.
+func (f *mockUpdateStrategyResolver) updateCalledForURLCallback(url string) func(sendconfig.ContentWithHash) error {
+	return func(content sendconfig.ContentWithHash) error {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		f.updateCalledForURLs = append(f.updateCalledForURLs, url)
+		f.lastUpdatedContentForURLs[url] = content
+		return nil
+	}
+}
+
+// getUpdateCalledForURLs returns the called URLs.
+func (f *mockUpdateStrategyResolver) getUpdateCalledForURLs() []string {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	urls := make([]string, 0, len(f.updateCalledForURLs))
+	urls = append(urls, f.updateCalledForURLs...)
+	return urls
+}
+
+func (f *mockUpdateStrategyResolver) lastUpdatedContentForURL(url string) (sendconfig.ContentWithHash, bool) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	c, ok := f.lastUpdatedContentForURLs[url]
+	return c, ok
+}
+
+// mockUpdateStrategy is a mock implementation of sendconfig.UpdateStrategy.
+type mockUpdateStrategy struct {
+	onUpdate func(content sendconfig.ContentWithHash) error
+}
+
+func (m *mockUpdateStrategy) Update(_ context.Context, targetContent sendconfig.ContentWithHash) (err error) {
+	return m.onUpdate(targetContent)
+}
+
+func (m *mockUpdateStrategy) MetricsProtocol() metrics.Protocol {
+	return metrics.ProtocolDBLess
+}
+
+func (m *mockUpdateStrategy) Type() string {
+	return "Mock"
+}
+
+// mockConfigurationChangeDetector is a mock implementation of sendconfig.ConfigurationChangeDetector.
+type mockConfigurationChangeDetector struct{}
+
+func (m mockConfigurationChangeDetector) HasConfigurationChanged(
+	_ context.Context, oldSHA []byte, newSHA []byte, _ *file.Content, _ sendconfig.KonnectAwareClient, _ sendconfig.StatusClient,
+) (bool, error) {
+	return !bytes.Equal(oldSHA, newSHA), nil
+}
+
+func mustSampleKonnectClient(t *testing.T) *adminapi.KonnectClient {
+	t.Helper()
+
+	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), &http.Client{})
+	require.NoError(t, err)
+
+	rgID := uuid.NewString()
+	return adminapi.NewKonnectClient(c, rgID, false)
+}
+
+// ----------------------------------------------------------------------------
+// End of Mocks
+// ----------------------------------------------------------------------------
+
+func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
+	sendConfigPeriod := 10 * time.Millisecond
+	testKonnectClient := mustSampleKonnectClient(t)
+	resolver := newMockUpdateStrategyResolver()
+
+	s := &ConfigSynchronizer{
+		logger:     logr.Discard(),
+		syncTicker: time.NewTicker(sendConfigPeriod),
+		clientsProvider: &mockGatewayClientsProvider{
+			konnectClient: testKonnectClient,
+		},
+		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		updateStrategyResolver: resolver,
+		configChangeDetector:   mockConfigurationChangeDetector{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := s.Start(ctx)
+	require.NoError(t, err)
+
+	t.Logf("Verifying that no URL are updated when no configuration received")
+	require.Never(t, func() bool {
+		return len(resolver.getUpdateCalledForURLs()) != 0
+	}, 10*sendConfigPeriod, sendConfigPeriod, "Should not update any URL when no configuration received")
+
+	t.Logf("Verifying that the new config updated when received")
+	content := &file.Content{
+		FormatVersion: "3.0",
+		Services: []file.FService{
+			{
+				Service: kong.Service{
+					Name: kong.String("service1"),
+					Host: kong.String("example.com"),
+				},
+				Routes: []*file.FRoute{
+					{
+						Route: kong.Route{
+							Name:       kong.String("route1"),
+							Expression: kong.String("http.path == \"/foo\""),
+						},
+					},
+				},
+			},
+		},
+	}
+	s.SetTargetContent(content)
+	require.Eventually(t, func() bool {
+		urls := resolver.getUpdateCalledForURLs()
+		if len(urls) != 1 {
+			return false
+		}
+		url := urls[0]
+		contentWithHash, ok := resolver.lastUpdatedContentForURL(url)
+		if !ok {
+			return false
+		}
+		return assert.ObjectsAreEqual(content, contentWithHash.Content)
+	}, 10*sendConfigPeriod, sendConfigPeriod, "Should send expected configuration in time after received configuration")
+
+	t.Logf("Verifying that new config are not sent after context cancelled")
+	cancel()
+	<-ctx.Done()
+	// modify content
+	newContent := content.DeepCopy()
+	newContent.Consumers = []file.FConsumer{
+		{
+			Consumer: kong.Consumer{
+				Username: kong.String("consumer-1"),
+			},
+		},
+	}
+	s.SetTargetContent(newContent)
+	// The latest updated content should always be the content in the previous update
+	// because it should not update new content after context cancelled.
+	require.Never(t, func() bool {
+		urls := resolver.getUpdateCalledForURLs()
+		l := len(urls)
+		if l == 0 {
+			return false
+		}
+		url := urls[l-1]
+		contentWithHash, ok := resolver.lastUpdatedContentForURL(url)
+		if !ok {
+			return false
+		}
+		return !(assert.ObjectsAreEqual(content, contentWithHash.Content))
+	}, 10*sendConfigPeriod, sendConfigPeriod, "Should not send new updates after context cancelled")
+}

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -253,6 +253,9 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 			return false
 		}
 		url := urls[l-1]
+		if url != testKonnectClient.BaseRootURL() {
+			return false
+		}
 		contentWithHash, ok := resolver.lastUpdatedContentForURL(url)
 		if !ok {
 			return false

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -36,6 +36,18 @@ func TestRecordPush(t *testing.T) {
 			m.RecordPushFailure(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080", 5, fmt.Errorf("custom error"))
 		})
 	})
+	// Verify that multiple call of NewCtrlFuncMetrics keeps all created metrics work.
+	m2 := NewCtrlFuncMetrics()
+	t.Run("recording push success works for old metrics", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			m.RecordPushSuccess(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080")
+		})
+	})
+	t.Run("recording push success works for new metrics", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			m2.RecordPushSuccess(ProtocolDBLess, time.Millisecond, "https://10.0.0.2:8080")
+		})
+	})
 }
 
 func TestRecordTranslation(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Add a Konnect configuration syncer that receives Kong configuration in `file.Content` format and runs a loop to upload the received configuration to Konnect in period. It also adds unit tests to verify the implementation of the methods.

This is the first step for #6325.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #6337 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
