### PR TITLE
feat: Separate channels to notify gateway and Konnect config status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@ Adding a new version? You'll need three changes:
   `ReferenceGrant` in the namespace of the `KongPlugin` to grant permissions
   to `KongCustomEntity` of referring to `KongPlugin`.
   [#6289](https://github.com/Kong/kubernetes-ingress-controller/pull/6289)
+- Konnect configuration updates are now handled separately from gateway
+  updates. This allows the controller to handle sync errors for the gateway and
+  Konnect speparately, and avoids one blocking the other.
+  [#6341](https://github.com/Kong/kubernetes-ingress-controller/pull/6341)
+  [#6349](https://github.com/Kong/kubernetes-ingress-controller/pull/6349)
 
 ### Fixed
 

--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -31,7 +31,7 @@ type GatewayConfigApplyStatus struct {
 }
 
 // KonnectConfigUploadStatus stores the status of uploading configuration to Konnect.
-// REVIEW: should we just make an alias of `bool`?
+
 type KonnectConfigUploadStatus struct {
 	Failed bool
 }

--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -21,33 +21,36 @@ const (
 	ConfigStatusUnknown                                    ConfigStatus = "Unknown"
 )
 
-// CalculateConfigStatusInput aggregates the input to CalculateConfigStatus.
-type CalculateConfigStatusInput struct {
-	// Any error occurred when syncing with Gateways.
-	GatewaysFailed bool
-
-	// Any error occurred when syncing with Konnect,
-	KonnectFailed bool
-
-	// Translation of some of Kubernetes objects failed.
+// GatewayConfigApplyStatus stores the status of building Kong configuration and sending configuration to Kong gateways.
+type GatewayConfigApplyStatus struct {
+	// TranslationFailuresOccurred is true means Translation of some of Kubernetes objects failed.
 	TranslationFailuresOccurred bool
+
+	// Any error occurred when syncing with Gateways.
+	ApplyConfigFailed bool
+}
+
+// KonnectConfigUploadStatus stores the status of uploading configuration to Konnect.
+// REVIEW: should we just make an alias of `bool`?
+type KonnectConfigUploadStatus struct {
+	Failed bool
 }
 
 // CalculateConfigStatus calculates a clients.ConfigStatus that sums up the configuration synchronisation result as
 // a single enumerated value.
-func CalculateConfigStatus(i CalculateConfigStatusInput) ConfigStatus {
+func CalculateConfigStatus(g GatewayConfigApplyStatus, k KonnectConfigUploadStatus) ConfigStatus {
 	switch {
-	case !i.GatewaysFailed && !i.KonnectFailed && !i.TranslationFailuresOccurred:
+	case !g.ApplyConfigFailed && !g.TranslationFailuresOccurred && !k.Failed:
 		return ConfigStatusOK
-	case !i.GatewaysFailed && !i.KonnectFailed && i.TranslationFailuresOccurred:
+	case !g.ApplyConfigFailed && g.TranslationFailuresOccurred && !k.Failed:
 		return ConfigStatusTranslationErrorHappened
-	case i.GatewaysFailed && !i.KonnectFailed: // We don't care about translation failures if we can't apply to gateways.
+	case g.ApplyConfigFailed && !k.Failed: // We don't care about translation failures if we can't apply to gateways.
 		return ConfigStatusApplyFailed
-	case !i.GatewaysFailed && i.KonnectFailed && !i.TranslationFailuresOccurred:
+	case !g.ApplyConfigFailed && !g.TranslationFailuresOccurred && k.Failed:
 		return ConfigStatusOKKonnectApplyFailed
-	case !i.GatewaysFailed && i.KonnectFailed && i.TranslationFailuresOccurred:
+	case !g.ApplyConfigFailed && g.TranslationFailuresOccurred && k.Failed:
 		return ConfigStatusTranslationErrorHappenedKonnectApplyFailed
-	case i.GatewaysFailed && i.KonnectFailed: // We don't care about translation failures if we can't apply to gateways.
+	case g.ApplyConfigFailed && k.Failed: // We don't care about translation failures if we can't apply to gateways.
 		return ConfigStatusApplyFailedKonnectApplyFailed
 	}
 
@@ -56,36 +59,43 @@ func CalculateConfigStatus(i CalculateConfigStatusInput) ConfigStatus {
 }
 
 type ConfigStatusNotifier interface {
-	NotifyConfigStatus(context.Context, ConfigStatus)
+	NotifyGatewayConfigStatus(context.Context, GatewayConfigApplyStatus)
+	NotifyKonnectConfigStatus(context.Context, KonnectConfigUploadStatus)
 }
 
 type ConfigStatusSubscriber interface {
-	SubscribeConfigStatus() chan ConfigStatus
+	SubscribeGatewayConfigStatus() chan GatewayConfigApplyStatus
+	SubscribeKonnectConfigStatus() chan KonnectConfigUploadStatus
 }
 
 type NoOpConfigStatusNotifier struct{}
 
 var _ ConfigStatusNotifier = NoOpConfigStatusNotifier{}
 
-func (n NoOpConfigStatusNotifier) NotifyConfigStatus(_ context.Context, _ ConfigStatus) {
+func (n NoOpConfigStatusNotifier) NotifyGatewayConfigStatus(_ context.Context, _ GatewayConfigApplyStatus) {
+}
+
+func (n NoOpConfigStatusNotifier) NotifyKonnectConfigStatus(_ context.Context, _ KonnectConfigUploadStatus) {
 }
 
 type ChannelConfigNotifier struct {
-	ch     chan ConfigStatus
-	logger logr.Logger
+	gatewayStatusCh chan GatewayConfigApplyStatus
+	konnectStatusCh chan KonnectConfigUploadStatus
+	logger          logr.Logger
 }
 
 var _ ConfigStatusNotifier = &ChannelConfigNotifier{}
 
 func NewChannelConfigNotifier(logger logr.Logger) *ChannelConfigNotifier {
 	return &ChannelConfigNotifier{
-		ch:     make(chan ConfigStatus),
-		logger: logger,
+		gatewayStatusCh: make(chan GatewayConfigApplyStatus),
+		konnectStatusCh: make(chan KonnectConfigUploadStatus),
+		logger:          logger,
 	}
 }
 
-// NotifyConfigStatus sends the status in a separate goroutine. If the notification is not received in 1s, it's dropped.
-func (n *ChannelConfigNotifier) NotifyConfigStatus(ctx context.Context, status ConfigStatus) {
+// NotifyGatewayConfigStatus notifies status of sending configuration to Kong gateway(s).
+func (n *ChannelConfigNotifier) NotifyGatewayConfigStatus(ctx context.Context, status GatewayConfigApplyStatus) {
 	const notifyTimeout = time.Second
 
 	go func() {
@@ -93,16 +103,39 @@ func (n *ChannelConfigNotifier) NotifyConfigStatus(ctx context.Context, status C
 		defer timeout.Stop()
 
 		select {
-		case n.ch <- status:
+		case n.gatewayStatusCh <- status:
 		case <-ctx.Done():
-			n.logger.Info("Context done, not notifying config status", "status", status)
+			n.logger.Info("Context done, not notifying gateway config status", "status", status)
 		case <-timeout.C:
-			n.logger.Info("Timed out notifying config status", "status", status)
+			n.logger.Info("Timed out notifying gateway config status", "status", status)
 		}
 	}()
 }
 
-func (n *ChannelConfigNotifier) SubscribeConfigStatus() chan ConfigStatus {
+// NotifyKonnectConfigStatus notifies status of sending configuration to Konnect.
+func (n *ChannelConfigNotifier) NotifyKonnectConfigStatus(ctx context.Context, status KonnectConfigUploadStatus) {
+	const notifyTimeout = time.Second
+
+	go func() {
+		timeout := time.NewTimer(notifyTimeout)
+		defer timeout.Stop()
+
+		select {
+		case n.konnectStatusCh <- status:
+		case <-ctx.Done():
+			n.logger.Info("Context done, not notifying Konnect config status", "status", status)
+		case <-timeout.C:
+			n.logger.Info("Timed out notifying Konnect config status", "status", status)
+		}
+	}()
+}
+
+func (n *ChannelConfigNotifier) SubscribeGatewayConfigStatus() chan GatewayConfigApplyStatus {
 	// TODO: in case of multiple subscribers, we should use a fan-out pattern.
-	return n.ch
+	return n.gatewayStatusCh
+}
+
+func (n *ChannelConfigNotifier) SubscribeKonnectConfigStatus() chan KonnectConfigUploadStatus {
+	// TODO: in case of multiple subscribers, we should use a fan-out pattern.
+	return n.konnectStatusCh
 }

--- a/internal/clients/config_status_test.go
+++ b/internal/clients/config_status_test.go
@@ -16,11 +16,11 @@ func TestChannelConfigNotifier(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	ch := n.SubscribeConfigStatus()
+	ch := n.SubscribeGatewayConfigStatus()
 
 	// Call NotifyConfigStatus 5 times to make sure that the method is non-blocking.
 	for i := 0; i < 5; i++ {
-		n.NotifyConfigStatus(ctx, clients.ConfigStatusOK)
+		n.NotifyGatewayConfigStatus(ctx, clients.GatewayConfigApplyStatus{})
 	}
 
 	for i := 0; i < 5; i++ {
@@ -90,11 +90,13 @@ func TestCalculateConfigStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := clients.CalculateConfigStatus(clients.CalculateConfigStatusInput{
-				GatewaysFailed:              tc.gatewayFailure,
-				KonnectFailed:               tc.konnectFailure,
+			result := clients.CalculateConfigStatus(clients.GatewayConfigApplyStatus{
+				ApplyConfigFailed:           tc.gatewayFailure,
 				TranslationFailuresOccurred: tc.translationFailures,
-			})
+			}, clients.KonnectConfigUploadStatus{
+				Failed: tc.konnectFailure,
+			},
+			)
 			require.Equal(t, tc.expectedConfigStatus, result)
 		})
 	}

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -641,15 +641,6 @@ func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 			require.Equal(t, tc.expectedStatus, clients.CalculateConfigStatus(
 				gatewayNotifications[0], konnectNotifications[0],
 			))
-
-			// TODO: should we add checks to disable notifications when config status is not changed compared to previous update?
-			/*
-				_ = kongClient.Update(ctx)
-				gatewayNotifications = statusQueue.GatewayConfigStatusNotifications()
-				konnectNotifications = statusQueue.KonnectConfigStatusNotifications()
-				require.Len(t, gatewayNotifications, 1, "No new notifications")
-				require.Len(t, konnectNotifications, 1, "No new notifications")
-			*/
 		})
 	}
 }

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -62,7 +62,7 @@ func TestSynchronizer(t *testing.T) {
 	assert.Equal(t, err.Error(), "server is already running")
 
 	t.Log("verifying that eventually the synchronizer reports as ready for a dbless dataplane")
-	assert.Eventually(t, func() bool { return sync.IsReady() }, testSynchronizerTick*2, testSynchronizerTick)
+	assert.Eventually(t, func() bool { return sync.IsReady() }, testSynchronizerTick*3, testSynchronizerTick)
 
 	t.Log("verifying that the dataplane eventually receieves several successful updates from the synchronizer")
 	assert.Eventually(t, func() bool {

--- a/internal/konnect/node_agent.go
+++ b/internal/konnect/node_agent.go
@@ -193,7 +193,6 @@ func (a *NodeAgent) subscribeConfigStatus(ctx context.Context) {
 			a.logger.Info("Subscribe loop stopped", "message", ctx.Err().Error())
 			return
 		case gatewayConfigStatus := <-gatewayStatusCh:
-			// TODO: add debounce here to prevent updates of nodes being too close or do not trigger an update of nodes immediately?
 			if a.gatewayConfigStatus != gatewayConfigStatus {
 				a.logger.V(logging.DebugLevel).Info("Gateway config status changed")
 				a.gatewayConfigStatus = gatewayConfigStatus

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -465,7 +465,6 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 		},
 	}
 
-	// expectedNodesUpdatesCount := 0
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc.expectedConfigStaus), func(t *testing.T) {
 			configStatusQueue.NotifyGatewayConfigStatus(tc.notifiedGatewayConfigStatus)
@@ -487,11 +486,6 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 
 				return true
 			}, time.Second, time.Millisecond)
-
-			// TODO: when we let node agent to subscribe gateway config status and konnect config status separately,
-			// It will trigger two updates when they are both changed.
-			// expectedNodesUpdatesCount++
-			// require.Equal(t, expectedNodesUpdatesCount, nodeClient.NodesUpdatesCount(), "expected only one more node update")
 		})
 	}
 }

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -70,12 +70,16 @@ func (m *mockManagerInstanceIDProvider) GetID() uuid.UUID {
 }
 
 type mockConfigStatusQueue struct {
-	ch chan clients.ConfigStatus
+	gatewayStatusCh chan clients.GatewayConfigApplyStatus
+	konnetStatusCh  chan clients.KonnectConfigUploadStatus
+	ch              chan clients.ConfigStatus
 }
 
 func newMockConfigStatusNotifier() *mockConfigStatusQueue {
 	return &mockConfigStatusQueue{
-		ch: make(chan clients.ConfigStatus),
+		gatewayStatusCh: make(chan clients.GatewayConfigApplyStatus),
+		konnetStatusCh:  make(chan clients.KonnectConfigUploadStatus),
+		ch:              make(chan clients.ConfigStatus),
 	}
 }
 
@@ -83,8 +87,20 @@ func (m mockConfigStatusQueue) SubscribeConfigStatus() chan clients.ConfigStatus
 	return m.ch
 }
 
-func (m mockConfigStatusQueue) Notify(status clients.ConfigStatus) {
-	m.ch <- status
+func (m mockConfigStatusQueue) SubscribeGatewayConfigStatus() chan clients.GatewayConfigApplyStatus {
+	return m.gatewayStatusCh
+}
+
+func (m mockConfigStatusQueue) SubscribeKonnectConfigStatus() chan clients.KonnectConfigUploadStatus {
+	return m.konnetStatusCh
+}
+
+func (m mockConfigStatusQueue) NotifyGatewayConfigStatus(status clients.GatewayConfigApplyStatus) {
+	m.gatewayStatusCh <- status
+}
+
+func (m mockConfigStatusQueue) NotifyKonnectConfigStatus(status clients.KonnectConfigUploadStatus) {
+	m.konnetStatusCh <- status
 }
 
 func TestNodeAgentUpdateNodes(t *testing.T) {
@@ -100,8 +116,8 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 		name                  string
 		initialNodesInNodeAPI []*nodes.NodeItem
 		// When configStatus is non-nil, notify the status to node agent in the test case.
-		configStatus     *clients.ConfigStatus
-		gatewayInstances []konnect.GatewayInstance
+		gatewayConfigStatus *clients.GatewayConfigApplyStatus
+		gatewayInstances    []konnect.GatewayInstance
 
 		containNodes    []*nodes.NodeItem
 		notContainNodes []*nodes.NodeItem
@@ -111,7 +127,7 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 			name: "create kic node",
 			// no existing nodes
 			initialNodesInNodeAPI: nil,
-			configStatus:          lo.ToPtr(clients.ConfigStatusOK),
+			gatewayConfigStatus:   lo.ToPtr(clients.GatewayConfigApplyStatus{}),
 			containNodes: []*nodes.NodeItem{
 				{
 					Hostname: testHostname,
@@ -134,7 +150,7 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 					Version:  testKicVersion,
 				},
 			},
-			configStatus: lo.ToPtr(clients.ConfigStatusTranslationErrorHappened),
+			gatewayConfigStatus: lo.ToPtr(clients.GatewayConfigApplyStatus{TranslationFailuresOccurred: true}),
 			containNodes: []*nodes.NodeItem{
 				{
 					Hostname: testHostname,
@@ -278,8 +294,8 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 
 			runAgent(t, nodeAgent)
 
-			if tc.configStatus != nil {
-				configStatusQueue.Notify(*tc.configStatus)
+			if tc.gatewayConfigStatus != nil {
+				configStatusQueue.NotifyGatewayConfigStatus(*tc.gatewayConfigStatus)
 			}
 
 			require.Eventually(t, func() bool {
@@ -392,39 +408,68 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 	runAgent(t, nodeAgent)
 
 	testCases := []struct {
-		notifiedConfigStatus    clients.ConfigStatus
-		expectedControllerState nodes.IngressControllerState
+		expectedConfigStaus         clients.ConfigStatus
+		notifiedGatewayConfigStatus clients.GatewayConfigApplyStatus
+		notifiedKonnectConfigStatus clients.KonnectConfigUploadStatus
+		expectedControllerState     nodes.IngressControllerState
 	}{
 		{
-			notifiedConfigStatus:    clients.ConfigStatusOK,
-			expectedControllerState: nodes.IngressControllerStateOperational,
+			expectedConfigStaus:         clients.ConfigStatusOK,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{},
+			expectedControllerState:     nodes.IngressControllerStateOperational,
 		},
 		{
-			notifiedConfigStatus:    clients.ConfigStatusTranslationErrorHappened,
-			expectedControllerState: nodes.IngressControllerStatePartialConfigFail,
+			expectedConfigStaus: clients.ConfigStatusTranslationErrorHappened,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{
+				TranslationFailuresOccurred: true,
+			},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{},
+			expectedControllerState:     nodes.IngressControllerStatePartialConfigFail,
 		},
 		{
-			notifiedConfigStatus:    clients.ConfigStatusApplyFailed,
-			expectedControllerState: nodes.IngressControllerStateInoperable,
+			expectedConfigStaus: clients.ConfigStatusApplyFailed,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{
+				ApplyConfigFailed: true,
+			},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{},
+			expectedControllerState:     nodes.IngressControllerStateInoperable,
 		},
 		{
-			notifiedConfigStatus:    clients.ConfigStatusOKKonnectApplyFailed,
+			expectedConfigStaus:         clients.ConfigStatusOKKonnectApplyFailed,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{
+				Failed: true,
+			},
 			expectedControllerState: nodes.IngressControllerStateOperationalKonnectOutOfSync,
 		},
 		{
-			notifiedConfigStatus:    clients.ConfigStatusTranslationErrorHappenedKonnectApplyFailed,
+			expectedConfigStaus: clients.ConfigStatusTranslationErrorHappenedKonnectApplyFailed,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{
+				TranslationFailuresOccurred: true,
+			},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{
+				Failed: true,
+			},
 			expectedControllerState: nodes.IngressControllerStatePartialConfigFailKonnectOutOfSync,
 		},
 		{
-			notifiedConfigStatus:    clients.ConfigStatusApplyFailedKonnectApplyFailed,
+			expectedConfigStaus: clients.ConfigStatusApplyFailedKonnectApplyFailed,
+			notifiedGatewayConfigStatus: clients.GatewayConfigApplyStatus{
+				ApplyConfigFailed: true,
+			},
+			notifiedKonnectConfigStatus: clients.KonnectConfigUploadStatus{
+				Failed: true,
+			},
 			expectedControllerState: nodes.IngressControllerStateInoperableKonnectOutOfSync,
 		},
 	}
 
-	expectedNodesUpdatesCount := 0
+	// expectedNodesUpdatesCount := 0
 	for _, tc := range testCases {
-		t.Run(fmt.Sprint(tc.notifiedConfigStatus), func(t *testing.T) {
-			configStatusQueue.Notify(tc.notifiedConfigStatus)
+		t.Run(fmt.Sprint(tc.expectedConfigStaus), func(t *testing.T) {
+			configStatusQueue.NotifyGatewayConfigStatus(tc.notifiedGatewayConfigStatus)
+			configStatusQueue.NotifyKonnectConfigStatus(tc.notifiedKonnectConfigStatus)
 
 			require.Eventually(t, func() bool {
 				controllerNode, ok := lo.Find(nodeClient.MustAllNodes(), func(n *nodes.NodeItem) bool {
@@ -443,8 +488,10 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnStatusNotification(t *testin
 				return true
 			}, time.Second, time.Millisecond)
 
-			expectedNodesUpdatesCount++
-			require.Equal(t, expectedNodesUpdatesCount, nodeClient.NodesUpdatesCount(), "expected only one more node update")
+			// TODO: when we let node agent to subscribe gateway config status and konnect config status separately,
+			// It will trigger two updates when they are both changed.
+			// expectedNodesUpdatesCount++
+			// require.Equal(t, expectedNodesUpdatesCount, nodeClient.NodesUpdatesCount(), "expected only one more node update")
 		})
 	}
 }
@@ -469,8 +516,8 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnlyWhenItChanges(t *testing.T
 	runAgent(t, nodeAgent)
 
 	// We'll use these two to toggle between when we want to trigger an update.
-	statusOne := clients.ConfigStatusOK
-	statusTwo := clients.ConfigStatusTranslationErrorHappened
+	statusOne := clients.GatewayConfigApplyStatus{}
+	statusTwo := clients.GatewayConfigApplyStatus{TranslationFailuresOccurred: true}
 
 	nodesUpdatesCountEventuallyEquals := func(count int) {
 		require.Eventually(t, func() bool {
@@ -479,19 +526,19 @@ func TestNodeAgent_ControllerNodeStatusGetsUpdatedOnlyWhenItChanges(t *testing.T
 	}
 
 	// Notify the first status and wait for the node to be updated.
-	configStatusQueue.Notify(statusOne)
+	configStatusQueue.NotifyGatewayConfigStatus(statusOne)
 	nodesUpdatesCountEventuallyEquals(1)
 
 	// Notify the same status again and ensure that the node wasn't updated.
-	configStatusQueue.Notify(statusOne)
+	configStatusQueue.NotifyGatewayConfigStatus(statusOne)
 	nodesUpdatesCountEventuallyEquals(1)
 
 	// Notify the second status and ensure that the node was updated.
-	configStatusQueue.Notify(statusTwo)
+	configStatusQueue.NotifyGatewayConfigStatus(statusTwo)
 	nodesUpdatesCountEventuallyEquals(2)
 
 	// Notify the same status again and ensure that the node wasn't updated.
-	configStatusQueue.Notify(statusTwo)
+	configStatusQueue.NotifyGatewayConfigStatus(statusTwo)
 	nodesUpdatesCountEventuallyEquals(2)
 }
 
@@ -523,7 +570,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() == 1 }, time.Second, time.Microsecond)
 
 		t.Log("trigger update with config status notification")
-		configStatusQueue.Notify(clients.ConfigStatusApplyFailed)
+		configStatusQueue.NotifyGatewayConfigStatus(clients.GatewayConfigApplyStatus{ApplyConfigFailed: true})
 		require.Eventually(t, func() bool { return nodeClient.NodesUpdatesCount() == 2 }, time.Second, time.Microsecond)
 
 		t.Log("let another half of the period pass - no update should be triggered yet because of the notification")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Prerequisite of #6325. Since we want to run sync of Konnect configuration in another loop, the Konnect node agent need to fetch status of sending config to Kong gateways and status of sending to Konnect from different channels. This PR implements the requirement.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6339 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
