### PR TITLE
Feat(konnect): Start Konnect config syncer to upload config to Konnect in separate loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ Adding a new version? You'll need three changes:
 - Konnect configuration updates are now handled separately from gateway
   updates. This allows the controller to handle sync errors for the gateway and
   Konnect speparately, and avoids one blocking the other.
+  The period of uploading configuration to Konnect can be set by the added flag
+  `--konnect-upload-config-period`.
   [#6341](https://github.com/Kong/kubernetes-ingress-controller/pull/6341)
   [#6349](https://github.com/Kong/kubernetes-ingress-controller/pull/6349)
 - Added `duration` field in logs after successfully sent configuration to Kong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Adding a new version? You'll need three changes:
   `--konnect-upload-config-period`.
   [#6341](https://github.com/Kong/kubernetes-ingress-controller/pull/6341)
   [#6349](https://github.com/Kong/kubernetes-ingress-controller/pull/6349)
+  [#6352](https://github.com/Kong/kubernetes-ingress-controller/pull/6352)
 - Added `duration` field in logs after successfully sent configuration to Kong
   gateway or Konnect.
   [#6360](https://github.com/Kong/kubernetes-ingress-controller/pull/6360)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,8 +111,9 @@ Adding a new version? You'll need three changes:
 - Konnect configuration updates are now handled separately from gateway
   updates. This allows the controller to handle sync errors for the gateway and
   Konnect speparately, and avoids one blocking the other.
-  The period of uploading configuration to Konnect can be set by the added flag
-  `--konnect-upload-config-period`.
+  The period of uploading configuration to Konnect changed to 30 seconds by
+  default. The period can be set by the added flag
+  `--konnect-upload-config-period`, with a minimum period of 10 seconds.
   [#6341](https://github.com/Kong/kubernetes-ingress-controller/pull/6341)
   [#6349](https://github.com/Kong/kubernetes-ingress-controller/pull/6349)
   [#6352](https://github.com/Kong/kubernetes-ingress-controller/pull/6352)

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -77,6 +77,7 @@
 | `--konnect-tls-client-cert-file` | `string` | Konnect TLS client certificate file path. |  |
 | `--konnect-tls-client-key` | `string` | Konnect TLS client key. |  |
 | `--konnect-tls-client-key-file` | `string` | Konnect TLS client key file path. |  |
+| `--konnect-upload-config-period` | `duration` | Period of uploading Kong configuration. | `30s` |
 | `--kubeconfig` | `string` | Path to the kubeconfig file. |  |
 | `--log-format` | `string` | Format of logs of the controller. Allowed values are text and json. | `text` |
 | `--log-level` | `string` | Level of logging for the controller. Allowed values are trace, debug, info, and error. | `info` |

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -26,10 +26,11 @@ type Client struct {
 	pluginSchemaStore   *util.PluginSchemaStore
 	isKonnect           bool
 	konnectControlPlane string
-	lastConfigSHA       []byte
+
 	lastCacheStoresHash store.SnapshotHash
 
-	lock sync.RWMutex
+	lastConfigSHALock sync.RWMutex
+	lastConfigSHA     []byte
 	// podRef (optional) describes the Pod that the Client communicates with.
 	podRef *k8stypes.NamespacedName
 }
@@ -176,15 +177,15 @@ func (c *Client) LastCacheStoresHash() store.SnapshotHash {
 
 // SetLastConfigSHA overrides last config SHA.
 func (c *Client) SetLastConfigSHA(s []byte) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lastConfigSHALock.Lock()
+	defer c.lastConfigSHALock.Unlock()
 	c.lastConfigSHA = s
 }
 
 // LastConfigSHA returns a checksum of the last successful configuration push.
 func (c *Client) LastConfigSHA() []byte {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lastConfigSHALock.RLock()
+	defer c.lastConfigSHALock.RUnlock()
 	return c.lastConfigSHA
 }
 

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -22,6 +22,7 @@ type KonnectConfig struct {
 	ConfigSynchronizationEnabled bool
 	ControlPlaneID               string
 	Address                      string
+	UploadConfigPeriod           time.Duration
 	RefreshNodePeriod            time.Duration
 	TLSClient                    TLSClientConfig
 

--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -31,7 +31,6 @@ type GatewayConfigApplyStatus struct {
 }
 
 // KonnectConfigUploadStatus stores the status of uploading configuration to Konnect.
-
 type KonnectConfigUploadStatus struct {
 	Failed bool
 }

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -488,9 +488,6 @@ func (c *KongClient) Update(ctx context.Context) error {
 	const isFallback = false
 	shas, gatewaysSyncErr := c.sendOutToGatewayClients(ctx, parsingResult.KongState, c.kongConfig, isFallback)
 
-	// TODO: only send Kong configuration to Konnect when applied configuration to gateways successfully(`gatewaysyncErr != nil`)?
-	c.maybeSendOutToKonnectClient(ctx, parsingResult.KongState, c.kongConfig, isFallback)
-
 	// Taking into account the results of syncing configuration with Gateways and Konnect, and potential translation
 	// failures, calculate the config status and update it.
 	c.configStatusNotifier.NotifyGatewayConfigStatus(ctx, clients.GatewayConfigApplyStatus{
@@ -512,6 +509,8 @@ func (c *KongClient) Update(ctx context.Context) error {
 		return gatewaysSyncErr
 	}
 
+	// Send configuration to Konnect ONLY when successfully applied configuration to gateways.
+	c.maybeSendOutToKonnectClient(ctx, parsingResult.KongState, c.kongConfig, isFallback)
 	// Gateways were successfully synced with the current configuration, so we can update the last valid cache snapshot.
 	c.maybePreserveTheLastValidConfigCache(cacheSnapshot)
 

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -180,7 +180,7 @@ type KongClient struct {
 	lastValidCacheSnapshot *store.CacheStores
 
 	// konnectConfigSynchronizer receives latest successfully applied Kong configuration from KongClient
-	// and upload it to Konnect.
+	// and uploads it to Konnect.
 	konnectConfigSynchronizer *konnect.ConfigSynchronizer
 }
 

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -178,13 +178,11 @@ type mockUpdateStrategyResolver struct {
 	updateCalledForURLs       []string
 	lastUpdatedContentForURLs map[string]sendconfig.ContentWithHash
 	errorsToReturnOnUpdate    map[string][]error
-	t                         *testing.T
 	lock                      sync.RWMutex
 }
 
-func newMockUpdateStrategyResolver(t *testing.T) *mockUpdateStrategyResolver {
+func newMockUpdateStrategyResolver() *mockUpdateStrategyResolver {
 	return &mockUpdateStrategyResolver{
-		t:                         t,
 		errorsToReturnOnUpdate:    map[string][]error{},
 		lastUpdatedContentForURLs: map[string]sendconfig.ContentWithHash{},
 	}
@@ -239,17 +237,21 @@ func (f *mockUpdateStrategyResolver) updateCalledForURLCallback(url string) func
 }
 
 // assertUpdateCalledForURLs asserts that the mockUpdateStrategy was called for the given URLs.
-func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLs(urls []string, msgAndArgs ...any) {
+func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLs(t *testing.T, urls []string, msgAndArgs ...any) {
+	t.Helper()
+
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
 	if len(msgAndArgs) == 0 {
 		msgAndArgs = []any{"update was not called for all URLs"}
 	}
-	require.ElementsMatch(f.t, urls, f.updateCalledForURLs, msgAndArgs...)
+	require.ElementsMatch(t, urls, f.updateCalledForURLs, msgAndArgs...)
 }
 
-func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLsWithGivenCount(urlToCount map[string]int, msgAndArgs ...any) {
+func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLsWithGivenCount(t *testing.T, urlToCount map[string]int, msgAndArgs ...any) {
+	t.Helper()
+
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	actualURLToCount := lo.CountValues(f.updateCalledForURLs)
@@ -258,15 +260,17 @@ func (f *mockUpdateStrategyResolver) assertUpdateCalledForURLsWithGivenCount(url
 			fmt.Sprintf("URL %s should receive %d update calls", url, callCount),
 		}
 		m = append(m, msgAndArgs...)
-		require.Equal(f.t, callCount, actualURLToCount[url], m...)
+		require.Equal(t, callCount, actualURLToCount[url], m...)
 	}
 }
 
-func (f *mockUpdateStrategyResolver) assertNoUpdateCalled() {
+func (f *mockUpdateStrategyResolver) assertNoUpdateCalled(t *testing.T) {
+	t.Helper()
+
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
-	require.Empty(f.t, f.updateCalledForURLs, "update was called")
+	require.Empty(t, f.updateCalledForURLs, "update was called")
 }
 
 func (f *mockUpdateStrategyResolver) lastUpdatedContentForURL(url string) (sendconfig.ContentWithHash, bool) {
@@ -277,13 +281,15 @@ func (f *mockUpdateStrategyResolver) lastUpdatedContentForURL(url string) (sendc
 }
 
 func (f *mockUpdateStrategyResolver) eventuallyGetLastUpdatedContentForURL(
-	url string, waitTime, waitTick time.Duration, msgAndArgs ...any,
+	t *testing.T, url string, waitTime, waitTick time.Duration, msgAndArgs ...any,
 ) sendconfig.ContentWithHash {
+	t.Helper()
+
 	var content sendconfig.ContentWithHash
 	if len(msgAndArgs) == 0 {
 		msgAndArgs = []any{"update was not called for URL " + url}
 	}
-	require.Eventually(f.t, func() bool {
+	require.Eventually(t, func() bool {
 		c, ok := f.lastUpdatedContentForURL(url)
 		if ok {
 			content = c
@@ -421,7 +427,7 @@ func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *tes
 				gatewayClients: tc.gatewayClients,
 				konnectClient:  tc.konnectClient,
 			}
-			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			updateStrategyResolver := newMockUpdateStrategyResolver()
 			for _, url := range tc.errorOnUpdateForURLs {
 				updateStrategyResolver.returnErrorOnUpdate(url)
 			}
@@ -449,11 +455,11 @@ func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *tes
 			expectedURLsCalled := lo.SliceToMap(clientsProvider.GatewayClients(), func(c *adminapi.Client) (string, int) {
 				return c.BaseRootURL(), 1
 			})
-			updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(expectedURLsCalled)
+			updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(t, expectedURLsCalled)
 			// Verify that Konnect client is called eventually.
 			if tc.konnectClient != nil {
 				// Should eventually get content in Konnect client if Konnect client enabled.
-				_ = updateStrategyResolver.eventuallyGetLastUpdatedContentForURL(tc.konnectClient.BaseRootURL(), testKonenctUploadWait, testKonnectUploadPeriod)
+				_ = updateStrategyResolver.eventuallyGetLastUpdatedContentForURL(t, tc.konnectClient.BaseRootURL(), testKonenctUploadWait, testKonnectUploadPeriod)
 			}
 		})
 	}
@@ -467,7 +473,7 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 		},
 		konnectClient: mustSampleKonnectClient(t),
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 
 	// no change in config, we'll expect no update to be called
 	configChangeDetector := mockConfigurationChangeDetector{
@@ -482,7 +488,7 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 	err := kongClient.Update(ctx)
 	require.NoError(t, err)
 
-	updateStrategyResolver.assertNoUpdateCalled()
+	updateStrategyResolver.assertNoUpdateCalled(t)
 }
 
 type mockConfigStatusQueue struct {
@@ -663,7 +669,7 @@ func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				kongRawStateGetter     = &mockKongLastValidConfigFetcher{}
-				updateStrategyResolver = newMockUpdateStrategyResolver(t)
+				updateStrategyResolver = newMockUpdateStrategyResolver()
 				statusQueue            = newMockConfigStatusQueue()
 				kongClient             = setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
 			)
@@ -705,7 +711,7 @@ func TestKongClient_ApplyConfigurationEvents(t *testing.T) {
 	clientsProvider := &mockGatewayClientsProvider{
 		gatewayClients: []*adminapi.Client{testGatewayClient},
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
 	configBuilder := newMockKongConfigBuilder()
 
@@ -872,7 +878,7 @@ func TestKongClient_KubernetesEvents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			updateStrategyResolver := newMockUpdateStrategyResolver()
 			configBuilder := newMockKongConfigBuilder()
 			eventRecorder := mocks.NewEventRecorder()
 			lastValidConfigFetcher := &mockKongLastValidConfigFetcher{}
@@ -946,7 +952,7 @@ func TestKongClient_EmptyConfigUpdate(t *testing.T) {
 			konnectClient:  testKonnectClient,
 		}
 
-		updateStrategyResolver = newMockUpdateStrategyResolver(t)
+		updateStrategyResolver = newMockUpdateStrategyResolver()
 		configChangeDetector   = mockConfigurationChangeDetector{hasConfigurationChanged: true}
 		configBuilder          = newMockKongConfigBuilder()
 		kongRawStateGetter     = &mockKongLastValidConfigFetcher{}
@@ -1211,7 +1217,7 @@ func TestKongClientUpdate_FetchStoreAndPushLastValidConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			updateStrategyResolver := newMockUpdateStrategyResolver()
 			for range tc.gatewayFailuresCount {
 				updateStrategyResolver.returnSpecificErrorOnUpdate(clientsProvider.gatewayClients[0].BaseRootURL(), tc.errorOnGatewayFailures)
 				updateStrategyResolver.returnSpecificErrorOnUpdate(clientsProvider.gatewayClients[1].BaseRootURL(), tc.errorOnGatewayFailures)
@@ -1251,7 +1257,7 @@ func TestKongClientUpdate_KonnectUpdatesAreSanitized(t *testing.T) {
 		gatewayClients: []*adminapi.Client{mustSampleGatewayClient(t)},
 		konnectClient:  mustSampleKonnectClient(t),
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
 	configBuilder := newMockKongConfigBuilder()
 	configBuilder.kongState = &kongstate.KongState{
@@ -1278,7 +1284,7 @@ func TestKongClientUpdate_KonnectUpdatesAreSanitized(t *testing.T) {
 	attachKonnectConfigSynchronizer(ctx, t, kongClient, updateStrategyResolver, clientsProvider, configChangeDetector, clients.NoOpConfigStatusNotifier{})
 	require.NoError(t, kongClient.Update(ctx))
 
-	konnectContent := updateStrategyResolver.eventuallyGetLastUpdatedContentForURL(clientsProvider.konnectClient.BaseRootURL(), testKonenctUploadWait, testKonnectUploadPeriod)
+	konnectContent := updateStrategyResolver.eventuallyGetLastUpdatedContentForURL(t, clientsProvider.konnectClient.BaseRootURL(), testKonenctUploadWait, testKonnectUploadPeriod)
 	require.Len(t, konnectContent.Content.Certificates, 1, "expected Konnect to have 1 certificate")
 	cert := konnectContent.Content.Certificates[0]
 	require.NotNil(t, cert.Key, "expected Konnect to have certificate key")
@@ -1317,7 +1323,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			updateStrategyResolver := newMockUpdateStrategyResolver()
 			configBuilder := newMockKongConfigBuilder()
 			fallbackConfigGenerator := newMockFallbackConfigGenerator()
 			gwClient := mustSampleGatewayClient(t)
@@ -1411,6 +1417,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 
 			t.Log("Verifying that the update strategy was called twice for gateway")
 			updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+				t,
 				map[string]int{
 					gwClient.BaseRootURL(): 2,
 				}, "expected update to be called twice: first with the initial config, then with the fallback one",
@@ -1451,7 +1458,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		gatewayClients: []*adminapi.Client{gwClient},
 		konnectClient:  konnectClient,
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
 	configBuilder := newMockKongConfigBuilder()
 	lastValidConfigFetcher := &mockKongLastValidConfigFetcher{}
@@ -1490,7 +1497,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.Len(t, configBuilder.updateCacheCalls, 1)
 
 		t.Log("Verifying that the update strategy was called once for gateway")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{gwClient.BaseRootURL(): 1})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(t, map[string]int{gwClient.BaseRootURL(): 1})
 	})
 
 	t.Run("without clients change, on second update clients are not updated", func(t *testing.T) {
@@ -1501,7 +1508,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.Len(t, configBuilder.updateCacheCalls, 1)
 
 		t.Log("Verifying that the update strategy was not called again")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{gwClient.BaseRootURL(): 1})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(t, map[string]int{gwClient.BaseRootURL(): 1})
 	})
 
 	newGwClient := mustSampleGatewayClient(t)
@@ -1516,10 +1523,12 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.Len(t, configBuilder.updateCacheCalls, 1)
 
 		t.Log("Verifying that the update strategies were called for the client that was added")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{
-			gwClient.BaseRootURL():    2, // First series of updates + Second series of updates
-			newGwClient.BaseRootURL(): 1, // Second series of updates only
-		})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+			t,
+			map[string]int{
+				gwClient.BaseRootURL():    2, // First series of updates + Second series of updates
+				newGwClient.BaseRootURL(): 1, // Second series of updates only
+			})
 	})
 
 	t.Run("when generating fallback, all clients are updated", func(t *testing.T) {
@@ -1538,10 +1547,12 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.Error(t, kongClient.Update(ctx))
 
 		t.Log("Verifying that the update strategy was called again for all gateways")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{
-			gwClient.BaseRootURL():    4, // First series of updates + Second series of updates + rejected/fallback
-			newGwClient.BaseRootURL(): 3, // Second series of updates + rejected/fallback
-		})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+			t,
+			map[string]int{
+				gwClient.BaseRootURL():    4, // First series of updates + Second series of updates + rejected/fallback
+				newGwClient.BaseRootURL(): 3, // Second series of updates + rejected/fallback
+			})
 	})
 
 	anotherNewGwClient := mustSampleGatewayClient(t)
@@ -1559,10 +1570,12 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.Error(t, kongClient.Update(ctx))
 
 		t.Log("Verifying that the update strategy was called again for all gateways")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{
-			gwClient.BaseRootURL():    6, // First series of updates + Second series of updates + rejected/fallback * 2
-			newGwClient.BaseRootURL(): 5, // Second series of updates + rejected/fallback * 2
-		})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+			t,
+			map[string]int{
+				gwClient.BaseRootURL():    6, // First series of updates + Second series of updates + rejected/fallback * 2
+				newGwClient.BaseRootURL(): 5, // Second series of updates + rejected/fallback * 2
+			})
 	})
 
 	t.Run("after fallback, when new config is correct, all clients are updated", func(t *testing.T) {
@@ -1573,10 +1586,12 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		require.NoError(t, kongClient.Update(ctx))
 
 		t.Log("Verifying that the update strategy was called again for all gateways")
-		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{
-			gwClient.BaseRootURL():    7, // First series of updates + Second series of updates + rejected/fallback * 2 + third update
-			newGwClient.BaseRootURL(): 6, // Second series of updates + rejected/fallback + rejected/fallback * 2 + third update
-		})
+		updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+			t,
+			map[string]int{
+				gwClient.BaseRootURL():    7, // First series of updates + Second series of updates + rejected/fallback * 2 + third update
+				newGwClient.BaseRootURL(): 6, // Second series of updates + rejected/fallback + rejected/fallback * 2 + third update
+			})
 	})
 }
 
@@ -1588,7 +1603,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 		gatewayClients: []*adminapi.Client{gwClient},
 		konnectClient:  konnectClient,
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
 	configBuilder := newMockKongConfigBuilder()
 	lastValidConfigFetcher := &mockKongLastValidConfigFetcher{}
@@ -1636,7 +1651,9 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 	require.Error(t, err)
 
 	t.Log("Verifying that the update strategy was called twice for gateway")
-	updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(map[string]int{gwClient.BaseRootURL(): 2},
+	updateStrategyResolver.assertUpdateCalledForURLsWithGivenCount(
+		t,
+		map[string]int{gwClient.BaseRootURL(): 2},
 		"expected update to be called twice: first with the initial config, then with the fallback one")
 
 	t.Log("Verifying that the last valid config is empty")
@@ -1659,7 +1676,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 func TestKongClient_LastValidCacheSnapshot(t *testing.T) {
 	var (
 		ctx                     = context.Background()
-		updateStrategyResolver  = newMockUpdateStrategyResolver(t)
+		updateStrategyResolver  = newMockUpdateStrategyResolver()
 		configChangeDetector    = mockConfigurationChangeDetector{hasConfigurationChanged: true}
 		configBuilder           = newMockKongConfigBuilder()
 		lastValidConfigFetcher  = &mockKongLastValidConfigFetcher{}
@@ -1760,7 +1777,7 @@ func TestKongClient_ConfigDumpSanitization(t *testing.T) {
 		},
 		konnectClient: mustSampleKonnectClient(t),
 	}
-	updateStrategyResolver := newMockUpdateStrategyResolver(t)
+	updateStrategyResolver := newMockUpdateStrategyResolver()
 	configChangeDetector := mockConfigurationChangeDetector{hasConfigurationChanged: true}
 	configBuilder := newMockKongConfigBuilder()
 	kongRawStateGetter := &mockKongLastValidConfigFetcher{}
@@ -1894,7 +1911,7 @@ func TestKongClient_RecoveringFromGatewaySyncError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Preparing %d gateway clients", len(tc.errorsFromGateways))
-			updateStrategyResolver := newMockUpdateStrategyResolver(t)
+			updateStrategyResolver := newMockUpdateStrategyResolver()
 			gwClients := make([]*adminapi.Client, len(tc.errorsFromGateways))
 			for i := range gwClients {
 				gwClients[i] = mustSampleGatewayClient(t)
@@ -1960,7 +1977,7 @@ func TestKongClient_RecoveringFromGatewaySyncError(t *testing.T) {
 				expectedUpdatedURLs = slices.Concat(expectedUpdatedURLs, expectedUpdatedURLs)
 			}
 			t.Logf("Ensuring that the update strategy was called %d times", len(expectedUpdatedURLs))
-			updateStrategyResolver.assertUpdateCalledForURLs(expectedUpdatedURLs)
+			updateStrategyResolver.assertUpdateCalledForURLs(t, expectedUpdatedURLs)
 
 			expectedContent := func(consumerUsername string) *file.Content {
 				return &file.Content{

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -669,6 +669,9 @@ func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 			)
 
 			attachKonnectConfigSynchronizer(ctx, t, kongClient, updateStrategyResolver, clientsProvider, configChangeDetector, statusQueue)
+			// Set an initial content in Konnect syncer to avoid that failure on gateway update causing no target content saved in Konnect config syncer
+			// thus uploading config to Konnect is not triggered.
+			kongClient.konnectConfigSynchronizer.SetTargetContent(&file.Content{})
 			kongClient.SetConfigStatusNotifier(statusQueue)
 			for range tc.gatewayFailuresCount {
 				updateStrategyResolver.returnErrorOnUpdate(testGatewayClient.BaseRootURL())

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -30,6 +30,7 @@ type ConfigSynchronizer struct {
 	prometheusMetrics      *metrics.CtrlFuncMetrics
 	updateStrategyResolver sendconfig.UpdateStrategyResolver
 	configChangeDetector   sendconfig.ConfigurationChangeDetector
+	configStatusNotifier   clients.ConfigStatusNotifier
 
 	targetContent *file.Content
 
@@ -43,6 +44,7 @@ func NewConfigSynchronizer(
 	clientsProvider clients.AdminAPIClientsProvider,
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configChangeDetector sendconfig.ConfigurationChangeDetector,
+	configStatusNotifier clients.ConfigStatusNotifier,
 ) *ConfigSynchronizer {
 	return &ConfigSynchronizer{
 		logger:                 logger,
@@ -52,6 +54,7 @@ func NewConfigSynchronizer(
 		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
 		updateStrategyResolver: updateStrategyResolver,
 		configChangeDetector:   configChangeDetector,
+		configStatusNotifier:   configStatusNotifier,
 	}
 }
 
@@ -105,6 +108,9 @@ func (s *ConfigSynchronizer) runKonnectUpdateServer(ctx context.Context) {
 				s.logger.Error(err, "failed to upload configuration to Konnect")
 				logKonnectErrors(s.logger, err)
 			}
+			s.configStatusNotifier.NotifyKonnectConfigStatus(ctx, clients.KonnectConfigUploadStatus{
+				Failed: err != nil,
+			})
 		}
 	}
 }

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -18,8 +18,12 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 )
 
-// DefaultConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
-var DefaultConfigUploadPeriod = 30 * time.Second
+const (
+	// MinConfigUploadPeriod is the minimum period between operations to upload Kong configuration to Konnect.
+	MinConfigUploadPeriod = 10 * time.Second
+	// DefaultConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
+	DefaultConfigUploadPeriod = 30 * time.Second
+)
 
 // ConfigSynchronizer runs a loop to upload the traslated Kong configuration to Konnect in the given period.
 type ConfigSynchronizer struct {

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
@@ -186,6 +187,7 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
 		updateStrategyResolver: resolver,
 		configChangeDetector:   mockConfigurationChangeDetector{},
+		configStatusNotifier:   clients.NoOpConfigStatusNotifier{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -233,6 +233,13 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 		return assert.ObjectsAreEqual(content, contentWithHash.Content)
 	}, 10*sendConfigPeriod, sendConfigPeriod, "Should send expected configuration in time after received configuration")
 
+	t.Logf("Verifying that update is not called when config not changed")
+	l := len(resolver.getUpdateCalledForURLs())
+	s.SetTargetContent(content)
+	require.Never(t, func() bool {
+		return len(resolver.getUpdateCalledForURLs()) != l
+	}, 10*sendConfigPeriod, sendConfigPeriod)
+
 	t.Logf("Verifying that new config are not sent after context cancelled")
 	cancel()
 	<-ctx.Done()

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -312,6 +312,7 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.StringVar(&c.Konnect.TLSClient.CertFile, "konnect-tls-client-cert-file", "", "Konnect TLS client certificate file path.")
 	flagSet.StringVar(&c.Konnect.TLSClient.Key, "konnect-tls-client-key", "", "Konnect TLS client key.")
 	flagSet.StringVar(&c.Konnect.TLSClient.KeyFile, "konnect-tls-client-key-file", "", "Konnect TLS client key file path.")
+	flagSet.DurationVar(&c.Konnect.UploadConfigPeriod, "konnect-upload-config-period", konnect.DefaultConfigUploadPeriod, "Period of uploading Kong configuration.")
 	flagSet.DurationVar(&c.Konnect.RefreshNodePeriod, "konnect-refresh-node-period", konnect.DefaultRefreshNodePeriod, "Period of uploading status of KIC and controlled Kong instances.")
 	flagSet.BoolVar(&c.Konnect.ConsumersSyncDisabled, "konnect-disable-consumers-sync", false, "Disable synchronization of consumers with Konnect.")
 

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 )
@@ -156,6 +158,7 @@ func TestConfigValidate(t *testing.T) {
 						Cert: "not-empty-cert",
 						Key:  "not-empty-key",
 					},
+					UploadConfigPeriod: konnect.DefaultConfigUploadPeriod,
 				},
 			}
 		}
@@ -217,6 +220,12 @@ func TestConfigValidate(t *testing.T) {
 			c := validEnabled()
 			c.KongAdminSvc = manager.OptionalNamespacedName{}
 			require.ErrorContains(t, c.Validate(), "--kong-admin-svc has to be set when using --konnect-sync-enabled")
+		})
+
+		t.Run("enabled with too small upload config period is rejected", func(t *testing.T) {
+			c := validEnabled()
+			c.Konnect.UploadConfigPeriod = time.Second
+			require.ErrorContains(t, c.Validate(), "cannot set upload config period to be smaller than 10s")
 		})
 	})
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -282,6 +282,7 @@ func Run(
 		konnectConfigSynchronizer, err := setupKonnectConfigSynchronizer(
 			ctx,
 			mgr,
+			c.Konnect.UploadConfigPeriod,
 			kongConfig,
 			clientsManager,
 			updateStrategyResolver,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -480,16 +480,22 @@ func setupLicenseGetter(
 func setupKonnectConfigSynchronizer(
 	ctx context.Context,
 	mgr manager.Manager,
+	configUploadPeriod time.Duration,
 	kongConfig sendconfig.Config,
 	clientsProvider clients.AdminAPIClientsProvider,
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configStatusNotifier clients.ConfigStatusNotifier,
 ) (*konnect.ConfigSynchronizer, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
+	if configUploadPeriod < konnect.MinConfigUploadPeriod {
+		logger.Info("Cannot set config upload period to be smaller than the minimum upload period; use the minimum upload period instead",
+			"upload_period", configUploadPeriod, "minimum_upload_period", konnect.MinConfigUploadPeriod)
+		configUploadPeriod = konnect.MinConfigUploadPeriod
+	}
 	s := konnect.NewConfigSynchronizer(
 		ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer"),
 		kongConfig,
-		konnect.DefaultConfigUploadPeriod,
+		configUploadPeriod,
 		clientsProvider,
 		updateStrategyResolver,
 		sendconfig.NewDefaultConfigurationChangeDetector(logger),

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -488,12 +488,6 @@ func setupKonnectConfigSynchronizer(
 	configStatusNotifier clients.ConfigStatusNotifier,
 ) (*konnect.ConfigSynchronizer, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
-	if configUploadPeriod < konnect.MinConfigUploadPeriod {
-		logger.Info("Cannot set config upload period to be smaller than the minimum upload period; use the minimum upload period instead",
-			"upload_period", configUploadPeriod, "minimum_upload_period", konnect.MinConfigUploadPeriod,
-		)
-		configUploadPeriod = konnect.MinConfigUploadPeriod
-	}
 	s := konnect.NewConfigSynchronizer(
 		ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer"),
 		kongConfig,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -477,6 +477,7 @@ func setupLicenseGetter(
 	return nil, nil
 }
 
+// setupKonnectConfigSynchronizer sets up Konnect config sychronizer and adds it to the manager runnables.
 func setupKonnectConfigSynchronizer(
 	ctx context.Context,
 	mgr manager.Manager,
@@ -489,7 +490,8 @@ func setupKonnectConfigSynchronizer(
 	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
 	if configUploadPeriod < konnect.MinConfigUploadPeriod {
 		logger.Info("Cannot set config upload period to be smaller than the minimum upload period; use the minimum upload period instead",
-			"upload_period", configUploadPeriod, "minimum_upload_period", konnect.MinConfigUploadPeriod)
+			"upload_period", configUploadPeriod, "minimum_upload_period", konnect.MinConfigUploadPeriod,
+		)
 		configUploadPeriod = konnect.MinConfigUploadPeriod
 	}
 	s := konnect.NewConfigSynchronizer(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Add a `konnect.ConfigSynchronizer` to manager in startup to run a separate loop for uploading config to Konnect.
Also added a `--konnect-upload-config-period` CLI flag to set the period of uploading config to Konnect.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6338 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
