### PR TITLE
feat: check Gateway pending clients readiness concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ Adding a new version? You'll need three changes:
   resource is attached to multiple foreign Kong entities.
   [#6280](https://github.com/Kong/kubernetes-ingress-controller/pull/6280)
 
+### Changed
+
+- Check Kong Gateway readiness concurrently. This greatly reduces the time which
+  is required to check all Gateway instances readiness, especially when there's many
+  of them.
+  [#6347](https://github.com/Kong/kubernetes-ingress-controller/pull/6347)
+  [#6357](https://github.com/Kong/kubernetes-ingress-controller/pull/6357)
+
 ## 3.2.3
 
 > Release date: 2024-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ Adding a new version? You'll need three changes:
 
 - Check Kong Gateway readiness concurrently. This greatly reduces the time which
   is required to check all Gateway instances readiness, especially when there's many
-  of them.
+  of them. Increased individual readiness check timeout from 1s to 5s.
   [#6347](https://github.com/Kong/kubernetes-ingress-controller/pull/6347)
   [#6357](https://github.com/Kong/kubernetes-ingress-controller/pull/6357)
 

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -86,6 +86,11 @@ func intoTurnedPending(urls ...string) []adminapi.DiscoveredAdminAPI {
 }
 
 func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+		testURL2 = "http://localhost:8002"
+	)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -240,6 +245,11 @@ func TestAdminAPIClientsManager_Clients_DBMode(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+		testURL2 = "http://localhost:8002"
+	)
+
 	t.Parallel()
 
 	readinessChecker := &mockReadinessChecker{}
@@ -330,6 +340,10 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+	)
+
 	readinessChecker := &mockReadinessChecker{}
 	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL1)})
 	testClient, err := adminapi.NewTestClient(testURL1)
@@ -365,6 +379,11 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_GatewayClientsChanges(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+		testURL2 = "http://localhost:8002"
+	)
+
 	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 
@@ -459,6 +478,11 @@ func TestAdminAPIClientsManager_GatewayClientsChanges(t *testing.T) {
 }
 
 func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+		testURL2 = "http://localhost:8002"
+	)
+
 	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -15,34 +16,27 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 )
 
-const (
-	testURL1 = "http://localhost:8001"
-	testURL2 = "http://localhost:8002"
-)
-
-var testPodRef = k8stypes.NamespacedName{
-	Namespace: "default",
-	Name:      "mock",
-}
-
 type mockClientFactory struct {
 	ready      map[string]bool // Maps address to readiness.
-	callsCount map[string]int  // Maps address to number of CreateAdminAPIClient calls.
+	lock       sync.RWMutex
+	callsCount map[string]int // Maps address to number of CreateAdminAPIClient calls.
 	t          *testing.T
 }
 
-func newMockClientFactory(t *testing.T, ready map[string]bool) mockClientFactory {
-	return mockClientFactory{
+func newMockClientFactory(t *testing.T, ready map[string]bool) *mockClientFactory {
+	return &mockClientFactory{
 		ready:      ready,
 		callsCount: map[string]int{},
 		t:          t,
 	}
 }
 
-func (cf mockClientFactory) CreateAdminAPIClient(_ context.Context, adminAPI adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
+func (cf *mockClientFactory) CreateAdminAPIClient(_ context.Context, adminAPI adminapi.DiscoveredAdminAPI) (*adminapi.Client, error) {
 	address := adminAPI.Address
 
+	cf.lock.Lock()
 	cf.callsCount[address]++
+	cf.lock.Unlock()
 
 	ready, ok := cf.ready[address]
 	if !ok {
@@ -55,9 +49,16 @@ func (cf mockClientFactory) CreateAdminAPIClient(_ context.Context, adminAPI adm
 	return adminapi.NewTestClient(address)
 }
 
+func (cf *mockClientFactory) CallsForAddress(address string) int {
+	cf.lock.RLock()
+	defer cf.lock.RUnlock()
+	return cf.callsCount[address]
+}
+
 type mockAlreadyCreatedClient struct {
 	url     string
 	isReady bool
+	podRef  k8stypes.NamespacedName
 }
 
 func (m mockAlreadyCreatedClient) IsReady(context.Context) error {
@@ -68,7 +69,7 @@ func (m mockAlreadyCreatedClient) IsReady(context.Context) error {
 }
 
 func (m mockAlreadyCreatedClient) PodReference() (k8stypes.NamespacedName, bool) {
-	return testPodRef, true
+	return m.podRef, true
 }
 
 func (m mockAlreadyCreatedClient) BaseRootURL() string {
@@ -76,6 +77,18 @@ func (m mockAlreadyCreatedClient) BaseRootURL() string {
 }
 
 func TestDefaultReadinessChecker(t *testing.T) {
+	const (
+		testURL1 = "http://localhost:8001"
+		testURL2 = "http://localhost:8002"
+		testURL3 = "http://localhost:8003"
+		testURL4 = "http://localhost:8004"
+	)
+
+	testPodRef := k8stypes.NamespacedName{
+		Namespace: "default",
+		Name:      "mock",
+	}
+
 	testCases := []struct {
 		name string
 
@@ -90,6 +103,7 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			name: "ready turning pending",
 			alreadyCreatedClients: []clients.AlreadyCreatedClient{
 				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
 					url:     testURL1,
 					isReady: false,
 				},
@@ -113,8 +127,14 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			name: "ready turning pending, pending turning ready at once",
 			alreadyCreatedClients: []clients.AlreadyCreatedClient{
 				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
 					url:     testURL1,
 					isReady: false,
+				},
+				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
+					url:     testURL3,
+					isReady: true,
 				},
 			},
 			pendingClients: []adminapi.DiscoveredAdminAPI{
@@ -126,13 +146,18 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			pendingClientsReadiness: map[string]bool{
 				testURL2: true,
 			},
-			expectedTurnedReady:   []string{testURL2},
-			expectedTurnedPending: []string{testURL1},
+			expectedTurnedReady: []string{
+				testURL2,
+			},
+			expectedTurnedPending: []string{
+				testURL1,
+			},
 		},
 		{
 			name: "no changes",
 			alreadyCreatedClients: []clients.AlreadyCreatedClient{
 				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
 					url:     testURL1,
 					isReady: true,
 				},
@@ -158,10 +183,12 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			name: "multiple ready, one turning pending",
 			alreadyCreatedClients: []clients.AlreadyCreatedClient{
 				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
 					url:     testURL1,
 					isReady: true,
 				},
 				mockAlreadyCreatedClient{
+					podRef:  testPodRef,
 					url:     testURL2,
 					isReady: false, // This one will turn pending.
 				},
@@ -191,6 +218,37 @@ func TestDefaultReadinessChecker(t *testing.T) {
 				testURL2,
 			},
 		},
+		{
+			name: "multiple pending, two turning ready",
+			pendingClients: []adminapi.DiscoveredAdminAPI{
+				{
+					Address: testURL1,
+					PodRef:  testPodRef,
+				},
+				{
+					Address: testURL2,
+					PodRef:  testPodRef,
+				},
+				{
+					Address: testURL3,
+					PodRef:  testPodRef,
+				},
+				{
+					Address: testURL4,
+					PodRef:  testPodRef,
+				},
+			},
+			pendingClientsReadiness: map[string]bool{
+				testURL1: false,
+				testURL2: true, // This one will turn ready.
+				testURL3: false,
+				testURL4: true, // This one will turn ready.
+			},
+			expectedTurnedReady: []string{
+				testURL2,
+				testURL4,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -207,12 +265,12 @@ func TestDefaultReadinessChecker(t *testing.T) {
 
 			// For every pending client turning ready we expect exactly one call to CreateAdminAPIClient.
 			for _, url := range tc.pendingClients {
-				require.Equal(t, 1, factory.callsCount[url.Address])
+				require.Equal(t, 1, factory.CallsForAddress(url.Address))
 			}
 
 			// For every already created client we expect NO calls to CreateAdminAPIClient.
 			for _, url := range tc.alreadyCreatedClients {
-				require.Zero(t, factory.callsCount[url.BaseRootURL()])
+				require.Zero(t, factory.CallsForAddress(url.BaseRootURL()))
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds to what #6347 has done:

- check pending clients concurrently
- check pending clients and already created clients lists in parallel

Since the readiness is checked concurrently now, this PR also increases the readiness timeout from 1s to 5s.

NOTE: Gateway client readiness is checked every [10s by default](https://github.com/Kong/kubernetes-ingress-controller/blob/8593248e3214144fa6a6a83d21d4448cdac3d70c/internal/clients/manager.go#L18-L20) (not configurable).

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
