### PR TITLE
Test(e2e): List entities instead of dump.Get to fetch Kong config in e2e tests

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -363,6 +363,5 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 			t.Logf("proxy pod %s/%s: got the config", pod.Namespace, pod.Name)
 		}()
 	}
-
 	wg.Wait()
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -528,7 +528,9 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 
 	require.Eventually(t, func() bool {
 		start := time.Now()
-		defer t.Logf("Try fetching config from %q started at %s, duration %v", kongClient.BaseRootURL(), start.Format(time.RFC3339), time.Since(start))
+		defer func() {
+			t.Logf("Fetched config from %q, started at %s, duration %v", kongClient.BaseRootURL(), start.Format(time.RFC3339), time.Since(start))
+		}()
 
 		services, err := kongClient.Services.ListAll(ctx)
 		if err != nil {
@@ -536,7 +538,7 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 			return false
 		}
 		if len(services) != 1 || services[0].ID == nil {
-			t.Log("still no service found...")
+			t.Logf("%d services found, expected 1", len(services))
 			return false
 		}
 
@@ -546,7 +548,7 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 			return false
 		}
 		if len(routes) != 1 {
-			t.Log("still no route found...")
+			t.Logf("%d routes found under service %s, expected 1", len(routes), *services[0].ID)
 			return false
 		}
 
@@ -556,7 +558,7 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 			return false
 		}
 		if len(upstreams) != 1 || upstreams[0].ID == nil {
-			t.Logf("still no upstreams found...")
+			t.Logf("%d upstreams found, expected 1", len(upstreams))
 			return false
 		}
 
@@ -566,7 +568,7 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 			return false
 		}
 		if len(targets) != noReplicas {
-			t.Log("still no targets found...")
+			t.Logf("%d targets found, expected %d", len(targets), noReplicas)
 			return false
 		}
 		return true

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
-	"github.com/kong/go-database-reconciler/pkg/dump"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
@@ -528,31 +527,46 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 	t.Helper()
 
 	require.Eventually(t, func() bool {
-		d, err := dump.Get(ctx, kongClient, dump.Config{})
+		start := time.Now()
+		defer t.Logf("Try fetching config from %q started at %s, duration %v", kongClient.BaseRootURL(), start.Format(time.RFC3339), time.Since(start))
+
+		services, err := kongClient.Services.ListAll(ctx)
 		if err != nil {
-			t.Logf("failed dumping config: %s", err)
+			t.Logf("failed to list services: %v", err)
 			return false
 		}
-		if len(d.Services) != 1 {
+		if len(services) != 1 || services[0].ID == nil {
 			t.Log("still no service found...")
 			return false
 		}
-		if len(d.Routes) != 1 {
+
+		routes, _, err := kongClient.Routes.ListForService(ctx, services[0].ID, &kong.ListOpt{Size: 10})
+		if err != nil {
+			t.Logf("failed to list routes for service %s: %v", *services[0].ID, err)
+			return false
+		}
+		if len(routes) != 1 {
 			t.Log("still no route found...")
 			return false
 		}
-		if d.Services[0].ID == nil ||
-			d.Routes[0].Service.ID == nil ||
-			*d.Services[0].ID != *d.Routes[0].Service.ID {
-			t.Log("still no matching service found...")
+
+		upstreams, err := kongClient.Upstreams.ListAll(ctx)
+		if err != nil {
+			t.Logf("failed to list upstreams: %v", err)
 			return false
 		}
-		if len(d.Targets) != noReplicas {
-			t.Log("still no target found...")
+		if len(upstreams) != 1 || upstreams[0].ID == nil {
+			t.Logf("still no upstreams found...")
 			return false
 		}
-		if len(d.Upstreams) != 1 {
-			t.Log("still no upstream found...")
+
+		targets, err := kongClient.Targets.ListAll(ctx, upstreams[0].ID)
+		if err != nil {
+			t.Logf("failed to list targets for upstream %s: %v", *upstreams[0].ID, err)
+			return false
+		}
+		if len(targets) != noReplicas {
+			t.Log("still no targets found...")
 			return false
 		}
 		return true

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -542,7 +542,7 @@ func verifyIngressWithEchoBackendsInAdminAPI(
 			return false
 		}
 
-		routes, _, err := kongClient.Routes.ListForService(ctx, services[0].ID, &kong.ListOpt{Size: 10})
+		routes, _, err := kongClient.Routes.ListForService(ctx, services[0].ID, &kong.ListOpt{})
 		if err != nil {
 			t.Logf("failed to list routes for service %s: %v", *services[0].ID, err)
 			return false

--- a/test/helpers/ports.go
+++ b/test/helpers/ports.go
@@ -17,19 +17,18 @@ func GetFreePort(t *testing.T) int {
 		freePort    int
 		retriesLeft = 100
 	)
+	freePortLock.Lock()
+	defer freePortLock.Unlock()
 	for {
 		// Get a random free port, but do not use it yet...
 		var err error
-		freePortLock.Lock()
 		freePort, err = freeport.GetFreePort()
 		if err != nil {
-			freePortLock.Unlock()
 			continue
 		}
 
 		// ... First, check if the port has been used in this test run already to reduce chances of a race condition.
 		_, wasUsed := usedPorts.LoadOrStore(freePort, true)
-		freePortLock.Unlock()
 
 		// The port hasn't been used in this test run - we can use it. It was stored in usedPorts, so it will not be
 		// used again during this test run.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
List `Services`, `Routes`, `Upstreams` and `Targets` to verify Kong configuration in gateway pods in `verifyIngressWithEchoBackendsInAdminAPI` instead of `dump.Get`. This could reduce the concurrency of streams to forwarded ports.

e2e run passes: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/10173800539. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Fixes #6317 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~  No need to update changelog.
