### PR TITLE
feat(log): log duration after sent config successfully to gateway or Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ Adding a new version? You'll need three changes:
   Konnect speparately, and avoids one blocking the other.
   [#6341](https://github.com/Kong/kubernetes-ingress-controller/pull/6341)
   [#6349](https://github.com/Kong/kubernetes-ingress-controller/pull/6349)
+- Added `duration` field in logs after successfully sent configuration to Kong
+  gateway or Konnect.
+  [#6360](https://github.com/Kong/kubernetes-ingress-controller/pull/6360)
 
 ### Fixed
 

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -106,9 +106,9 @@ func PerformUpdate(
 	}
 
 	if client.IsKonnect() {
-		logger.V(logging.InfoLevel).Info("Successfully synced configuration to Konnect")
+		logger.V(logging.InfoLevel).Info("Successfully synced configuration to Konnect", "duration", duration.Truncate(time.Millisecond).String())
 	} else {
-		logger.V(logging.InfoLevel).Info("Successfully synced configuration to Kong")
+		logger.V(logging.InfoLevel).Info("Successfully synced configuration to Kong", "duration", duration.Truncate(time.Millisecond).String())
 	}
 
 	return newSHA, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Adds `duration` field in logs after sent config to gateway or Konnect successfully.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
Part of #6191
Fixes #6362

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Used `Truncate()` to avoid the duration being too long and having unnecessary precision.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
