### PR TITLE
feat(prometheus): Add translation duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ Adding a new version? You'll need three changes:
 - `KongCustomEntity` is now included in last valid configuration retrieved from
   Kong gateways.
   [#6305](https://github.com/Kong/kubernetes-ingress-controller/pull/6305)
+- Added Prometheus metrics `ingress_controller_translation_duration_milliseconds`
+  and `ingress_controller_fallback_translation_duration_milliseconds` to
+  record duration of translating Kubernetes resources to Kong state in normal
+  state and fallback mode.
+  [#6366](https://github.com/Kong/kubernetes-ingress-controller/pull/6366)
 
 ### Fixed
 

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -160,12 +160,12 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 		prometheus.HistogramOpts{
 			Name: MetricNameTranslationDuration,
 			Help: fmt.Sprintf(
-				"Duration of  translating Kubernetes resources intoo Kong state. "+
+				"Duration of  translating Kubernetes resources into Kong state. "+
 					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`). "+
 					"Unrecoverable error in this case means KIC wasn't able to translate a Kubernetes object to Kong model.",
 				SuccessKey, SuccessFalse, SuccessTrue,
 			),
-			Buckets: prometheus.ExponentialBucketsRange(1, float64(time.Hour.Milliseconds()), 30),
+			Buckets: prometheus.ExponentialBucketsRange(1, float64(time.Minute.Milliseconds()), 30),
 		},
 		[]string{SuccessKey},
 	)
@@ -231,12 +231,12 @@ func NewCtrlFuncMetrics() *CtrlFuncMetrics {
 		prometheus.HistogramOpts{
 			Name: MetricNameFallbackTranslationDuration,
 			Help: fmt.Sprintf(
-				"Duration of translating Kubernetes resources intoo Kong state in fallback mode. "+
+				"Duration of translating Kubernetes resources into Kong state in fallback mode. "+
 					"`%s` describes whether there were unrecoverable errors (`%s`) or not (`%s`). "+
 					"Unrecoverable error in this case means KIC wasn't able to translate a Kubernetes object to Kong model.",
 				SuccessKey, SuccessFalse, SuccessTrue,
 			),
-			Buckets: prometheus.ExponentialBucketsRange(1, float64(time.Hour.Milliseconds()), 30),
+			Buckets: prometheus.ExponentialBucketsRange(1, float64(time.Minute.Milliseconds()), 30),
 		},
 		[]string{SuccessKey},
 	)

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -54,13 +54,13 @@ func TestRecordTranslation(t *testing.T) {
 	m := NewCtrlFuncMetrics()
 	t.Run("recording translation success works", func(t *testing.T) {
 		require.NotPanics(t, func() {
-			m.RecordTranslationSuccess()
+			m.RecordTranslationSuccess(10 * time.Millisecond)
 			m.RecordTranslationBrokenResources(0)
 		})
 	})
 	t.Run("recording translation failure works", func(t *testing.T) {
 		require.NotPanics(t, func() {
-			m.RecordTranslationFailure()
+			m.RecordTranslationFailure(10 * time.Millisecond)
 			m.RecordTranslationBrokenResources(9)
 		})
 	})

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -47,6 +47,7 @@ func TestMetricsAreServed(t *testing.T) {
 				metrics.MetricNameConfigPushCount,
 				metrics.MetricNameConfigPushBrokenResources,
 				metrics.MetricNameTranslationCount,
+				metrics.MetricNameTranslationDuration,
 				metrics.MetricNameTranslationBrokenResources,
 				metrics.MetricNameConfigPushDuration,
 
@@ -67,6 +68,7 @@ func TestMetricsAreServed(t *testing.T) {
 				metrics.MetricNameConfigPushCount,
 				metrics.MetricNameConfigPushBrokenResources,
 				metrics.MetricNameTranslationCount,
+				metrics.MetricNameTranslationDuration,
 				metrics.MetricNameTranslationBrokenResources,
 				metrics.MetricNameConfigPushDuration,
 				metrics.MetricNameConfigPushSuccessTime,

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -53,6 +53,7 @@ func TestMetricsAreServed(t *testing.T) {
 
 				metrics.MetricNameFallbackTranslationBrokenResources,
 				metrics.MetricNameFallbackTranslationCount,
+				metrics.MetricNameFallbackTranslationDuration,
 				metrics.MetricNameFallbackConfigPushCount,
 				metrics.MetricNameFallbackConfigPushSuccessTime,
 				metrics.MetricNameFallbackConfigPushDuration,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Adds `ingress_controller_translation_duration_milliseconds` to collect duration of translating k8s resources to Kong configuration.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
Part of #6191 
Fixes #6363 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

Should we also add a metric for duration of translating fallback configuration?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
