### PR TITLE
fix(controller): Do not update existing Programmed condition to Unknown

### DIFF
--- a/hack/generators/controllers/networking/main.go
+++ b/hack/generators/controllers/networking/main.go
@@ -727,11 +727,6 @@ func (r *{{.PackageAlias}}{{.Kind}}Reconciler) Reconcile(ctx context.Context, re
 		{{- if .ProgrammedCondition.UpdatesEnabled }}
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status",configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx,client.ObjectKeyFromObject(obj),obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w",err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus, 
 			obj.Generation, 

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -1018,11 +1018,6 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -1209,11 +1204,6 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -1845,11 +1835,6 @@ func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) Reconcile(ctx context.Con
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -2016,11 +2001,6 @@ func (r *KongV1Alpha1KongVaultReconciler) Reconcile(ctx context.Context, req ctr
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -2186,11 +2166,6 @@ func (r *KongV1Alpha1KongCustomEntityReconciler) Reconcile(ctx context.Context, 
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
 		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
-		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
-		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -1016,8 +1016,13 @@ func (r *KongV1KongConsumerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 	// if status updates are enabled report the status for the object
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
+		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
+		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -1202,8 +1207,13 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) Reconcile(ctx context.Context, 
 	}
 	// if status updates are enabled report the status for the object
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
+		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
+		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -1833,8 +1843,13 @@ func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) Reconcile(ctx context.Con
 	}
 	// if status updates are enabled report the status for the object
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
+		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
+		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -1999,8 +2014,13 @@ func (r *KongV1Alpha1KongVaultReconciler) Reconcile(ctx context.Context, req ctr
 	}
 	// if status updates are enabled report the status for the object
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
+		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
+		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,
@@ -2164,8 +2184,13 @@ func (r *KongV1Alpha1KongCustomEntityReconciler) Reconcile(ctx context.Context, 
 	}
 	// if status updates are enabled report the status for the object
 	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name)
 		configurationStatus := r.DataplaneClient.KubernetesObjectConfigurationStatus(obj)
+		log.V(logging.DebugLevel).Info("Updating programmed condition status", "namespace", req.Namespace, "name", req.Name, "configuration_status", configurationStatus)
+		// REVIEW: Should we try to fetch the latest version of updated object to reduce probalility of race on update?
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch the latest object to update status: %w", err)
+		}
 		conditions, updateNeeded := ctrlutils.EnsureProgrammedCondition(
 			configurationStatus,
 			obj.Generation,

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -94,6 +94,10 @@ func EnsureProgrammedCondition(
 	if !ok {
 		conditions = append(conditions, desiredCondition)
 	} else {
+		// Do not update existing "Programmed" condition to Unknown to prevent races on updating status when new instance starts.
+		if configurationStatus == object.ConfigurationStatusUnknown {
+			return conditions, false
+		}
 		conditions[idx] = desiredCondition
 	}
 

--- a/internal/controllers/utils/conditions_test.go
+++ b/internal/controllers/utils/conditions_test.go
@@ -84,16 +84,23 @@ func TestEnsureProgrammedCondition(t *testing.T) {
 		},
 		{
 			name:                "condition present with correct observed generation but different reason",
-			configurationStatus: object.ConfigurationStatusUnknown,
+			configurationStatus: object.ConfigurationStatusFailed,
 			conditions: []metav1.Condition{
 				func() metav1.Condition {
-					cond := expectedProgrammedConditionUnknown
-					cond.Reason = string(kongv1.ReasonInvalid)
+					cond := expectedProgrammedConditionFalse
+					cond.Reason = string("SomeOtherReason")
 					return cond
 				}(),
 			},
-			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionUnknown},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionFalse},
 			expectedUpdateNeeded:      true,
+		},
+		{
+			name:                      "Unknown status should not modify existing Programmed condition",
+			configurationStatus:       object.ConfigurationStatusUnknown,
+			conditions:                []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdatedConditions: []metav1.Condition{expectedProgrammedConditionTrue},
+			expectedUpdateNeeded:      false,
 		},
 		{
 			name:                      "empty conditions",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
In sidecar deployment mode, when new pod KIC pod is up to reconcile resources like `KongConsumers`, the programmed condition in status would be `Unknown` before the first successful applying configuration to Kong gateway. This will cause flips of status of `KongConsumer` and races on updates. thus producing excessive reconciliation requests and heavy load to API server.

The PR ignores the update of `Programmed` condition when the status is `Unknown` and there are existing `Programmed` condition in the status. 
**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6386 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
I did not update the changelog in the PR to prevent from conflicts on automatically created backport PRs.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
