### PR TITLE
fix(controller): reconcile secrets having kongCredType in data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- Reconcile `Secret`s with `kongCredType` in data implying that the secrets are
+  used as Kong credentials.
+
 ## [2.12.5]
 
 > Release date: 2024-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Adding a new version? You'll need three changes:
 
 - Reconcile `Secret`s with `kongCredType` in data implying that the secrets are
   used as Kong credentials.
+  [#6400](https://github.com/Kong/kubernetes-ingress-controller/pull/6400)
 
 ## [2.12.5]
 

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -87,6 +87,11 @@ func (r *CoreV1SecretReconciler) shouldReconcileSecret(obj client.Object) bool {
 		return true
 	}
 
+	// reconcile secrets used as Kong credentials.
+	if _, ok := secret.Data["kongCredType"]; ok {
+		return true
+	}
+
 	referred, err := r.ReferenceIndexers.ObjectReferred(secret)
 	if err != nil {
 		r.Log.Error(err, "failed to check whether secret referred",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Reconcile `Secret`s with `kongCredType` in data, which are used as Kong credentials. This is only for 2.12.x because in later versions, `kongCredType` in data is deprecated and removed.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6398 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Should mitigate FTI-6157 where secret may not get reconciled at the first rounds of reconciling.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
