### PR TITLE
Fix(controller): Stop reconcilication if KongUpstreamPolicy not referred in reconciled Ingress/HTTPRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,11 @@ Adding a new version? You'll need three changes:
 - Generate one entity for each attached foreign entity if a `KongCustomEntity`
   resource is attached to multiple foreign Kong entities.
   [#6280](https://github.com/Kong/kubernetes-ingress-controller/pull/6280)
+- Only reconcile `KongUpstreamPolicy` referenced by `Services` or
+  `KongServiceFacades`(If `KongServiceFacade` features gate enabled) that are
+  used as backends of any `Ingress` or `HTTPRoute` reconciled by current
+  controller.
+  [#6421](https://github.com/Kong/kubernetes-ingress-controller/pull/6421)
 
 ### Changed
 

--- a/internal/controllers/configuration/kongupstreampolicy_controller_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_controller_test.go
@@ -1,0 +1,184 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+)
+
+func TestIndexIngressesOnBackendServiceName(t *testing.T) {
+	testCases := []struct {
+		name            string
+		object          client.Object
+		expectedIndexes []string
+	}{
+		{
+			name:            "Object not Ingress should return empty index",
+			object:          &corev1.Service{},
+			expectedIndexes: []string{},
+		},
+		{
+			name: "Ingress with single backend",
+			object: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-ingress",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{Name: "svc", Port: netv1.ServiceBackendPort{Number: 80}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIndexes: []string{"test-ns/svc"},
+		},
+		{
+			name: "Ingress with multiple backends and multiple rules",
+			object: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-ingress",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							Host: "foo.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{Name: "svc-1", Port: netv1.ServiceBackendPort{Number: 80}},
+											},
+										},
+										{
+											Path: "/bar",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{Name: "svc-2", Port: netv1.ServiceBackendPort{Number: 80}},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Host: "bar.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{Name: "svc-4", Port: netv1.ServiceBackendPort{Number: 80}},
+											},
+										},
+										{
+											Path: "/bar",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{Name: "svc-3", Port: netv1.ServiceBackendPort{Number: 80}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIndexes: []string{"test-ns/svc-1", "test-ns/svc-2", "test-ns/svc-3", "test-ns/svc-4"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexes := indexIngressesOnBackendServiceName(tc.object)
+			require.ElementsMatch(t, tc.expectedIndexes, indexes, "Should return expected indexes")
+		})
+	}
+}
+
+func TestIndexRoutesOnBackendRefServiceFacadeName(t *testing.T) {
+	testCases := []struct {
+		name            string
+		object          client.Object
+		expectedIndexes []string
+	}{
+		{
+			name:            "Objects not HTTPRoute should return empty index",
+			object:          &netv1.Ingress{},
+			expectedIndexes: []string{},
+		},
+		{
+			name: "HTTPRoute with ServiceFacade backendRef and non-ServiceFacade backendRef",
+			object: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-httproute",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					Rules: []gatewayapi.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayapi.HTTPBackendRef{
+								{
+									BackendRef: gatewayapi.BackendRef{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Name: gatewayapi.ObjectName("svc-1"),
+										},
+									},
+								},
+								{
+									BackendRef: gatewayapi.BackendRef{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Group: lo.ToPtr(gatewayapi.Group("incubator.ingress-controller.konghq.com")),
+											Kind:  lo.ToPtr(gatewayapi.Kind("KongServiceFacade")),
+											Name:  gatewayapi.ObjectName("service-facade-1"),
+										},
+									},
+								},
+								{
+									BackendRef: gatewayapi.BackendRef{
+										BackendObjectReference: gatewayapi.BackendObjectReference{
+											Group:     lo.ToPtr(gatewayapi.Group("incubator.ingress-controller.konghq.com")),
+											Kind:      lo.ToPtr(gatewayapi.Kind("KongServiceFacade")),
+											Namespace: lo.ToPtr(gatewayapi.Namespace("another-ns")),
+											Name:      gatewayapi.ObjectName("service-facade-1"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIndexes: []string{"test-ns/service-facade-1", "another-ns/service-facade-1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexes := indexRoutesOnBackendRefServiceFacadeName(tc.object)
+			require.ElementsMatch(t, tc.expectedIndexes, indexes, "Should return expected indexes")
+		})
+	}
+}

--- a/internal/controllers/configuration/kongupstreampolicy_utils.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils.go
@@ -9,11 +9,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
 	gatewaycontroller "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/utils"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
 	incubatorv1alpha1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/incubator/v1alpha1"
@@ -89,6 +92,7 @@ func (r *KongUpstreamPolicyReconciler) enforceKongUpstreamPolicyStatus(
 	return false, nil
 }
 
+// getServicesReferencingUpstreamPolicy fetches services referencing a KongUpstreamPolicy.
 func (r *KongUpstreamPolicyReconciler) getServicesReferencingUpstreamPolicy(
 	ctx context.Context,
 	upstreamPolicyNN k8stypes.NamespacedName,
@@ -104,6 +108,51 @@ func (r *KongUpstreamPolicyReconciler) getServicesReferencingUpstreamPolicy(
 		return nil, fmt.Errorf("failed listing Services: %w", err)
 	}
 	return services.Items, nil
+}
+
+// getIngressesReferencingService fetches all Ingresses using a Service as its backend.
+func (r *KongUpstreamPolicyReconciler) getIngressesReferencingService(
+	ctx context.Context,
+	serviceNN k8stypes.NamespacedName,
+) ([]netv1.Ingress, error) {
+	ingresses := &netv1.IngressList{}
+	if err := r.List(ctx, ingresses,
+		client.InNamespace(serviceNN.Namespace),
+		client.MatchingFields{routeBackendRefServiceNameIndexKey: serviceNN.String()},
+	); err != nil {
+		return nil, fmt.Errorf("failed listing ingresses: %w", err)
+	}
+	return ingresses.Items, nil
+}
+
+// getHTTPRoutesReferencingService fetches all HTTPRoutes using a service as its backend.
+func (r *KongUpstreamPolicyReconciler) getHTTPRoutesReferencingService(
+	ctx context.Context,
+	serviceNN k8stypes.NamespacedName,
+) ([]gatewayapi.HTTPRoute, error) {
+	httpRoutes := &gatewayapi.HTTPRouteList{}
+	if err := r.List(ctx, httpRoutes,
+		client.InNamespace(serviceNN.Namespace),
+		client.MatchingFields{routeBackendRefServiceNameIndexKey: serviceNN.String()},
+	); err != nil {
+		return nil, fmt.Errorf("failed listing HTTPRoutes referencing services: %w", err)
+	}
+	return httpRoutes.Items, nil
+}
+
+// getHTTPRoutesReferencingServiceFacade fetches all HTTPRoutes using a KongServiceFacade as its backend.
+func (r *KongUpstreamPolicyReconciler) getHTTPRoutesReferencingServiceFacade(
+	ctx context.Context,
+	serviceFacadeNN k8stypes.NamespacedName,
+) ([]gatewayapi.HTTPRoute, error) {
+	httpRoutes := &gatewayapi.HTTPRouteList{}
+	if err := r.List(ctx, httpRoutes,
+		client.InNamespace(serviceFacadeNN.Namespace),
+		client.MatchingFields{routeBackendRefServiceFacadeIndexKey: serviceFacadeNN.String()},
+	); err != nil {
+		return nil, fmt.Errorf("failed listing HTTPRoutes referencing KongServiceFacades: %w", err)
+	}
+	return httpRoutes.Items, nil
 }
 
 // maybeGetServiceFacadesReferencingUpstreamPolicy returns a list of KongServiceFacades that reference the given KongUpstreamPolicy.
@@ -127,6 +176,78 @@ func (r *KongUpstreamPolicyReconciler) maybeGetServiceFacadesReferencingUpstream
 		return nil, fmt.Errorf("failed listing KongServiceFacades: %w", err)
 	}
 	return serviceFacades.Items, nil
+}
+
+// upstreamPolicyUsedByBackendsOfMatchingClass returns true is the KongUpstreamPolicy is referenced in
+// Services or KongServiceFacades that are used in backends of recociled Ingress or HTTPRoute.
+// If it returns false, the reconciliation is terminated and the controller will not update its status and put it into storage
+// because the KongUpstreamPokicy will not be translated into Kong configuration in such situation.
+// This is implmented for preventing races on updating status of KongUpstreamPolicy.
+// Ref:.
+func (r *KongUpstreamPolicyReconciler) upstreamPolicyUsedByBackendsOfMatchingClass(
+	ctx context.Context,
+	upstreamPolicyNN k8stypes.NamespacedName,
+	isDefaultIngressClass bool,
+) (bool, error) {
+	// Fetch Services and ServiceFacades.
+	services, err := r.getServicesReferencingUpstreamPolicy(ctx, upstreamPolicyNN)
+	if err != nil {
+		return false, err
+	}
+	serviceFacades, err := r.maybeGetServiceFacadesReferencingUpstreamPolicy(ctx, upstreamPolicyNN)
+	if err != nil {
+		return false, err
+	}
+	// Check if Ingresses use services referencing reconciled KongUpstreamPolicy as backend.
+	for _, service := range services {
+		ingresses, err := r.getIngressesReferencingService(ctx, k8stypes.NamespacedName{Namespace: service.Namespace, Name: service.Name})
+		if err != nil {
+			return false, err
+		}
+		for _, ingress := range ingresses {
+			if utils.MatchesIngressClass(&ingress, r.IngressClassName, isDefaultIngressClass) {
+				return true, nil
+			}
+		}
+	}
+	// Check if HTTPRoutes use services/KongServiceFacades referencing reconciled KongUpstreamPolicy as backend.
+	if r.HTTPRouteEnabled {
+		for _, service := range services {
+			httpRoutes, err := r.getHTTPRoutesReferencingService(ctx, k8stypes.NamespacedName{Namespace: service.Namespace, Name: service.Name})
+			if err != nil {
+				return false, err
+			}
+			for _, httpRoute := range httpRoutes {
+				attached := r.isRouteAttachedToReconciledGateway(&httpRoute) //nolint:contextcheck
+				if attached {
+					return true, nil
+				}
+			}
+		}
+		for _, serviceFacade := range serviceFacades {
+			httpRoutes, err := r.getHTTPRoutesReferencingServiceFacade(ctx, k8stypes.NamespacedName{Namespace: serviceFacade.Namespace, Name: serviceFacade.Name})
+			if err != nil {
+				return false, err
+			}
+			for _, httpRoute := range httpRoutes {
+				attached := r.isRouteAttachedToReconciledGateway(&httpRoute) //nolint:contextcheck
+				if attached {
+					return true, nil
+				}
+			}
+		}
+	}
+	// If no Ingress or HTTPRoute satisfies, return false.
+	return false, nil
+}
+
+// isRouteAttachedToReconciledGateway returns true if HTTPRoute is attached to any reconciled gateway.
+func (r *KongUpstreamPolicyReconciler) isRouteAttachedToReconciledGateway(httpRoute *gatewayapi.HTTPRoute) bool {
+	return gatewaycontroller.IsRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](
+		r.Client, r.Log,
+		controllers.NewOptionalNamespacedName(mo.Option[k8stypes.NamespacedName]{}),
+		httpRoute,
+	)
 }
 
 // buildAncestorsStatus creates a list of services with their conditions associated.
@@ -410,4 +531,22 @@ func isSupportedHTTPRouteBackendRef(br gatewayapi.BackendRef) bool {
 	// For Kind nil case should never happen as it defaults on the API level to 'Service'. We can safely consider
 	// nil to be treated as 'Service' if it would happen for any reason.
 	return groupIsCoreOrNilOrEmpty && kindIsServiceOrNil
+}
+
+// backendRefToServiceFacadeRef returns the key of KongServiceFacade in namespace/name format
+// if the backendRef points to a ServiceFacade.
+func backendRefToServiceFacadeRef(routeNamespace string, br gatewayapi.BackendRef) serviceKey {
+	if !backendRefIsServiceFacade(br) {
+		return ""
+	}
+	namespace := routeNamespace
+	if br.Namespace != nil {
+		namespace = string(*br.Namespace)
+	}
+	return buildServiceReference(namespace, string(br.Name))
+}
+
+func backendRefIsServiceFacade(br gatewayapi.BackendRef) bool {
+	return br.Group != nil && *br.Group == gatewayapi.Group(incubatorv1alpha1.GroupVersion.Group) &&
+		br.Kind != nil && *br.Kind == "KongServiceFacade"
 }

--- a/internal/controllers/configuration/kongupstreampolicy_utils.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils.go
@@ -132,7 +132,6 @@ func (r *KongUpstreamPolicyReconciler) getHTTPRoutesReferencingService(
 ) ([]gatewayapi.HTTPRoute, error) {
 	httpRoutes := &gatewayapi.HTTPRouteList{}
 	if err := r.List(ctx, httpRoutes,
-		client.InNamespace(serviceNN.Namespace),
 		client.MatchingFields{routeBackendRefServiceNameIndexKey: serviceNN.String()},
 	); err != nil {
 		return nil, fmt.Errorf("failed listing HTTPRoutes referencing services: %w", err)
@@ -147,7 +146,6 @@ func (r *KongUpstreamPolicyReconciler) getHTTPRoutesReferencingServiceFacade(
 ) ([]gatewayapi.HTTPRoute, error) {
 	httpRoutes := &gatewayapi.HTTPRouteList{}
 	if err := r.List(ctx, httpRoutes,
-		client.InNamespace(serviceFacadeNN.Namespace),
 		client.MatchingFields{routeBackendRefServiceFacadeIndexKey: serviceFacadeNN.String()},
 	); err != nil {
 		return nil, fmt.Errorf("failed listing HTTPRoutes referencing KongServiceFacades: %w", err)
@@ -181,9 +179,9 @@ func (r *KongUpstreamPolicyReconciler) maybeGetServiceFacadesReferencingUpstream
 // upstreamPolicyUsedByBackendsOfMatchingClass returns true is the KongUpstreamPolicy is referenced in
 // Services or KongServiceFacades that are used in backends of recociled Ingress or HTTPRoute.
 // If it returns false, the reconciliation is terminated and the controller will not update its status and put it into storage
-// because the KongUpstreamPokicy will not be translated into Kong configuration in such situation.
-// This is implmented for preventing races on updating status of KongUpstreamPolicy.
-// Ref:.
+// because the KongUpstreamPolicy will not be translated into Kong configuration in such situation.
+// This is implemented to prevent races on updating the status of KongUpstreamPolicy.
+// Ref: https://github.com/Kong/kubernetes-ingress-controller/issues/6270.
 func (r *KongUpstreamPolicyReconciler) upstreamPolicyUsedByBackendsOfMatchingClass(
 	ctx context.Context,
 	upstreamPolicyNN k8stypes.NamespacedName,
@@ -237,7 +235,7 @@ func (r *KongUpstreamPolicyReconciler) upstreamPolicyUsedByBackendsOfMatchingCla
 			}
 		}
 	}
-	// If no Ingress or HTTPRoute satisfies, return false.
+	// If no Ingress or HTTPRoute satisfied, return false.
 	return false, nil
 }
 

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -112,13 +112,13 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false // we don't need to enqueue from generic
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.GRPCRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 			}),
 		).

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -137,13 +137,13 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false // we don't need to enqueue from generic
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 			}),
 		).

--- a/internal/controllers/gateway/route_predicates.go
+++ b/internal/controllers/gateway/route_predicates.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 )
 
-func isRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
+func IsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 	cl client.Client, log logr.Logger, gatewayNN controllers.OptionalNamespacedName, obj client.Object,
 ) bool {
 	route, ok := obj.(routeT)
@@ -103,6 +103,6 @@ func isOrWasRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 	cl client.Client, log logr.Logger, gatewayNN controllers.OptionalNamespacedName, e event.UpdateEvent,
 ) bool {
 	oldObj, newObj := e.ObjectOld, e.ObjectNew
-	return isRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, oldObj) ||
-		isRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, newObj)
+	return IsRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, oldObj) ||
+		IsRouteAttachedToReconciledGateway[routeT](cl, log, gatewayNN, newObj)
 }

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -108,13 +108,13 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false // we don't need to enqueue from generic
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.TCPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 			}),
 		).

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -103,13 +103,13 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false // we don't need to enqueue from generic
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.TLSRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 			}),
 		).

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -107,13 +107,13 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false // We don't need to enqueue from generic.
 				},
 				CreateFunc: func(e event.CreateEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return isOrWasRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
-					return isRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
+					return IsRouteAttachedToReconciledGateway[*gatewayapi.UDPRoute](r.Client, mgr.GetLogger(), r.GatewayNN, e.Object)
 				},
 			}),
 		).

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -268,6 +268,8 @@ func setupControllers(
 					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "httproutes",
 				}),
+				IngressClassName:           c.IngressClassName,
+				DisableIngressClassLookups: !c.IngressClassNetV1Enabled,
 			},
 		},
 		{

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -197,7 +197,7 @@ func TestKongUpstreamPolicyWithoutHTTPRoute(t *testing.T) {
 			return false
 		}
 		upstream := config.Upstreams[0]
-		return upstream.Algorithm != nil && *upstream.Algorithm == "round-robin"
+		return upstream.Algorithm != nil && *upstream.Algorithm == "round-robin" && upstream.Slots != nil && *upstream.Slots == 32
 	}, waitTime, tickTime)
 
 	t.Logf("verify that ancestor status of KongUpstreamPolicy is updated correctly")

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -154,7 +154,7 @@ func installKongCRDs(t *testing.T, scheme *k8sruntime.Scheme, cfg *rest.Config) 
 	require.NoError(t, err)
 }
 
-func deployIngressClass(ctx context.Context, t *testing.T, name string, client ctrlclient.Client) { //nolint:unparam
+func deployIngressClass(ctx context.Context, t *testing.T, name string, client ctrlclient.Client) {
 	t.Helper()
 
 	ingress := &netv1.IngressClass{


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Stop the reconciliation of `KongUpstreamPolicy` if it is not eventually used in `Ingress` or `HTTPRoute` with matching class. These `KongUpstreamPolicy`s are not loaded into config storage and their status are not updated to prevent races on updating status if there are multiple instances with different ingress classes/controller names are reconciling.  

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #6270 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

This may not resolve the problem that in sidecar mode, multiple instances are reconciling the same `KongUpstreamPolicy`. Maybe we should use the similar thing done to other resources like #6395 ?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
