### PR TITLE
Feat(gateway discovery): Add config for gateway readiness check intervals and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,13 @@ Adding a new version? You'll need three changes:
   Error level to enable correlating Konnect-side logs and traces with customer-side
   KIC logs. Successful responses are logged with Trace level.
   [#6420](https://github.com/Kong/kubernetes-ingress-controller/pull/6420)
+- Added flags `--gateway-discovery-readiness-check-interval` and
+  `--gateway-discovery-readiness-check-timeout` to configure interval of
+  reconciliation to check readiness of gateways and timeouts of readiness
+  checks of a gateway instance.
+  Their default values are `10s` and `5s` and the readiness check timeout must
+  be less than the reconciliation interval.
+  [#6434](https://github.com/Kong/kubernetes-ingress-controller/pull/6434)
 
 ### Fixed
 
@@ -146,7 +153,6 @@ Adding a new version? You'll need three changes:
   [#6280](https://github.com/Kong/kubernetes-ingress-controller/pull/6280)
 
 ### Changed
-
 
 - Promote `KongCustomEntity` feature gate to beta thus it is enabled by default.
   [#6387](https://github.com/Kong/kubernetes-ingress-controller/pull/6387)

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -42,6 +42,8 @@
 | `--feature-gates` | `list of string=bool` | A set of comma separated key=value pairs that describe feature gates for alpha/beta/experimental features. See the Feature Gates documentation for information and available options: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md. |  |
 | `--gateway-api-controller-name` | `string` | The controller name to match on Gateway API resources. | `konghq.com/kic-gateway-controller` |
 | `--gateway-discovery-dns-strategy` | `dns-strategy` | DNS strategy to use when creating Gateway's Admin API addresses. One of: ip, service, pod. | `"ip"` |
+| `--gateway-discovery-readiness-check-interval` | `duration` | Interval of readiness checks on gateway admin API clients for discovery. | `10s` |
+| `--gateway-discovery-readiness-check-timeout` | `duration` | Timeout of readiness checks on gateway admin clients. | `5s` |
 | `--gateway-to-reconcile` | `namespaced-name` | Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway. |  |
 | `--health-probe-bind-address` | `string` | The address the probe endpoint binds to. | `:10254` |
 | `--ingress-class` | `string` | Name of the ingress class to route through this controller. | `kong` |

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -63,6 +63,8 @@ type AdminAPIClientsManager struct {
 	// configured.
 	pendingGatewayClients map[string]adminapi.DiscoveredAdminAPI
 
+	readinessReconciliationInterval time.Duration
+
 	// readinessChecker is used to check readiness of the clients.
 	readinessChecker ReadinessChecker
 
@@ -90,7 +92,17 @@ func WithReadinessReconciliationTicker(ticker Ticker) AdminAPIClientsManagerOpti
 
 // WithDBMode allows to set the DBMode of the Kong gateway instances behind the admin API service.
 func (c *AdminAPIClientsManager) WithDBMode(dbMode dpconf.DBMode) *AdminAPIClientsManager {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.dbMode = dbMode
+	return c
+}
+
+// WithReconciliationInterval allows to set the Reconciliation interval to check readiness of clients.
+func (c *AdminAPIClientsManager) WithReconciliationInterval(d time.Duration) *AdminAPIClientsManager {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.readinessReconciliationInterval = d
 	return c
 }
 
@@ -109,14 +121,15 @@ func NewAdminAPIClientsManager(
 		return c.BaseRootURL(), c
 	})
 	c := &AdminAPIClientsManager{
-		readyGatewayClients:           readyClients,
-		pendingGatewayClients:         make(map[string]adminapi.DiscoveredAdminAPI),
-		readinessChecker:              readinessChecker,
-		readinessReconciliationTicker: clock.NewTicker(),
-		discoveredAdminAPIsNotifyChan: make(chan []adminapi.DiscoveredAdminAPI),
-		ctx:                           ctx,
-		runningChan:                   make(chan struct{}),
-		logger:                        logger,
+		readyGatewayClients:             readyClients,
+		pendingGatewayClients:           make(map[string]adminapi.DiscoveredAdminAPI),
+		readinessReconciliationInterval: DefaultReadinessReconciliationInterval,
+		readinessChecker:                readinessChecker,
+		readinessReconciliationTicker:   clock.NewTicker(),
+		discoveredAdminAPIsNotifyChan:   make(chan []adminapi.DiscoveredAdminAPI),
+		ctx:                             ctx,
+		runningChan:                     make(chan struct{}),
+		logger:                          logger,
 	}
 
 	for _, opt := range opts {
@@ -239,7 +252,7 @@ func (c *AdminAPIClientsManager) SubscribeToGatewayClientsChanges() (<-chan stru
 // - discoveredAdminAPIsNotifyChan - triggered on every Notify() call.
 // - readinessReconciliationTicker - triggered on every readinessReconciliationTicker tick.
 func (c *AdminAPIClientsManager) gatewayClientsReconciliationLoop() {
-	c.readinessReconciliationTicker.Reset(DefaultReadinessReconciliationInterval)
+	c.readinessReconciliationTicker.Reset(c.readinessReconciliationInterval)
 	defer c.readinessReconciliationTicker.Stop()
 
 	close(c.runningChan)
@@ -340,7 +353,7 @@ func (c *AdminAPIClientsManager) adjustGatewayClients(discoveredAdminAPIs []admi
 func (c *AdminAPIClientsManager) reconcileGatewayClientsReadiness() bool {
 	// Reset the ticker after each readiness reconciliation despite the trigger (whether it was a tick or a notification).
 	// It's to ensure that the readiness is not reconciled too often when we receive a lot of notifications.
-	defer c.readinessReconciliationTicker.Reset(DefaultReadinessReconciliationInterval)
+	defer c.readinessReconciliationTicker.Reset(c.readinessReconciliationInterval)
 
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -15,9 +15,13 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
 )
 
-// DefaultReadinessReconciliationInterval is the interval at which the manager will run readiness reconciliation loop.
-// It's the same as the default interval of a Kubernetes container's readiness probe.
-const DefaultReadinessReconciliationInterval = 10 * time.Second
+const (
+	// DefaultReadinessReconciliationInterval is the interval at which the manager will run readiness reconciliation loop.
+	// It's the same as the default interval of a Kubernetes container's readiness probe.
+	DefaultReadinessReconciliationInterval = 10 * time.Second
+	// MinReadinessReconciliationInterval is the minimum interval of readiness reconciliation loop.
+	MinReadinessReconciliationInterval = 3 * time.Second
+)
 
 // ClientFactory is responsible for creating Admin API clients.
 type ClientFactory interface {

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// DefaultReadinessCheckTimeout is the default timeout of readiness check.
+	// When a readiness check request did not get response within the timeout, the gateway instance will turn into `Pending` status.
 	DefaultReadinessCheckTimeout = 5 * time.Second
 )
 

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	readinessCheckTimeout = 5 * time.Second
+	DefaultReadinessCheckTimeout = 5 * time.Second
 )
 
 // ReadinessCheckResult represents the result of a readiness check.
@@ -54,14 +54,16 @@ type AlreadyCreatedClient interface {
 }
 
 type DefaultReadinessChecker struct {
-	factory ClientFactory
-	logger  logr.Logger
+	factory               ClientFactory
+	readinessCheckTimeout time.Duration
+	logger                logr.Logger
 }
 
-func NewDefaultReadinessChecker(factory ClientFactory, logger logr.Logger) DefaultReadinessChecker {
+func NewDefaultReadinessChecker(factory ClientFactory, timeout time.Duration, logger logr.Logger) DefaultReadinessChecker {
 	return DefaultReadinessChecker{
-		factory: factory,
-		logger:  logger,
+		factory:               factory,
+		readinessCheckTimeout: timeout,
+		logger:                logger,
 	}
 }
 
@@ -129,7 +131,7 @@ func (c DefaultReadinessChecker) checkPendingClient(
 	ctx context.Context,
 	pendingClient adminapi.DiscoveredAdminAPI,
 ) (client *adminapi.Client) {
-	ctx, cancel := context.WithTimeout(ctx, readinessCheckTimeout)
+	ctx, cancel := context.WithTimeout(ctx, c.readinessCheckTimeout)
 	defer cancel()
 
 	logger := c.logger.WithValues("address", pendingClient.Address)
@@ -203,7 +205,7 @@ func (c DefaultReadinessChecker) checkAlreadyExistingClients(ctx context.Context
 func (c DefaultReadinessChecker) checkAlreadyCreatedClient(ctx context.Context, client AlreadyCreatedClient) (ready bool) {
 	logger := c.logger.WithValues("address", client.BaseRootURL())
 
-	ctx, cancel := context.WithTimeout(ctx, readinessCheckTimeout)
+	ctx, cancel := context.WithTimeout(ctx, c.readinessCheckTimeout)
 	defer cancel()
 	if err := client.IsReady(ctx); err != nil {
 		// Despite the error reason we still want to keep the client in the pending list to retry later.

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -254,7 +254,7 @@ func TestDefaultReadinessChecker(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			factory := newMockClientFactory(t, tc.pendingClientsReadiness)
-			checker := clients.NewDefaultReadinessChecker(factory, logr.Discard())
+			checker := clients.NewDefaultReadinessChecker(factory, clients.DefaultReadinessCheckTimeout, logr.Discard())
 			result := checker.CheckReadiness(context.Background(), tc.alreadyCreatedClients, tc.pendingClients)
 
 			turnedPending := lo.Map(result.ClientsTurnedPending, func(c adminapi.DiscoveredAdminAPI, _ int) string { return c.Address })

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -75,7 +75,7 @@ type Config struct {
 	KongAdminURLs                          []string
 	KongAdminSvc                           OptionalNamespacedName
 	GatewayDiscoveryDNSStrategy            cfgtypes.DNSStrategy
-	GatewayDiscoveryReadinessCheckInterval time.Duration // REVIEW(naming): the name seems too long. Any idea to shorten it?
+	GatewayDiscoveryReadinessCheckInterval time.Duration
 	GatewayDiscoveryReadinessCheckTimeout  time.Duration
 	KongAdminSvcPortNames                  []string
 	ProxySyncSeconds                       float32

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -131,10 +131,10 @@ func (c *Config) validateGatewayDiscovery() error {
 	if _, ok := c.KongAdminSvc.Get(); !ok {
 		return nil
 	}
-	// REVIEW: Should the reconciliation interval has a miniumum value and should it be the same as default interval?
-	if c.GatewayDiscoveryReadinessCheckInterval < clients.DefaultReadinessReconciliationInterval {
+
+	if c.GatewayDiscoveryReadinessCheckInterval < clients.MinReadinessReconciliationInterval {
 		return fmt.Errorf("Readiness check reconciliation interval cannot be less than %s",
-			clients.DefaultReadinessReconciliationInterval)
+			clients.MinReadinessReconciliationInterval)
 	}
 	if c.GatewayDiscoveryReadinessCheckTimeout >= c.GatewayDiscoveryReadinessCheckInterval {
 		return fmt.Errorf("Readiness check timeout must be less than readiness check recociliation interval")

--- a/internal/manager/config_validation.go
+++ b/internal/manager/config_validation.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config/types"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
@@ -75,6 +76,9 @@ func (c *Config) Validate() error {
 	if err := c.validateFallbackConfiguration(); err != nil {
 		return fmt.Errorf("invalid fallback config settings: %w", err)
 	}
+	if err := c.validateGatewayDiscovery(); err != nil {
+		return fmt.Errorf("invalid gateway discovery configuration: %w", err)
+	}
 
 	return nil
 }
@@ -118,6 +122,22 @@ func (c *Config) validateFallbackConfiguration() error {
 			"--use-last-valid-config-for-fallback or CONTROLLER_USE_LAST_VALID_CONFIG_FOR_FALLBACK can only be used with %s feature gate enabled",
 			featuregates.FallbackConfiguration,
 		)
+	}
+	return nil
+}
+
+func (c *Config) validateGatewayDiscovery() error {
+	// Skip validation if gateway discovery is not enabled.
+	if _, ok := c.KongAdminSvc.Get(); !ok {
+		return nil
+	}
+	// REVIEW: Should the reconciliation interval has a miniumum value and should it be the same as default interval?
+	if c.GatewayDiscoveryReadinessCheckInterval < clients.DefaultReadinessReconciliationInterval {
+		return fmt.Errorf("Readiness check reconciliation interval cannot be less than %s",
+			clients.DefaultReadinessReconciliationInterval)
+	}
+	if c.GatewayDiscoveryReadinessCheckTimeout >= c.GatewayDiscoveryReadinessCheckInterval {
+		return fmt.Errorf("Readiness check timeout must be less than readiness check recociliation interval")
 	}
 	return nil
 }

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -11,6 +11,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
@@ -160,6 +161,7 @@ func TestConfigValidate(t *testing.T) {
 					},
 					UploadConfigPeriod: konnect.DefaultConfigUploadPeriod,
 				},
+				GatewayDiscoveryReadinessCheckInterval: clients.DefaultReadinessReconciliationInterval,
 			}
 		}
 
@@ -327,6 +329,38 @@ func TestConfigValidate(t *testing.T) {
 				},
 			}
 			require.NoError(t, c.Validate())
+		})
+	})
+
+	t.Run("gateway discovery", func(t *testing.T) {
+		validEnabled := func() *manager.Config {
+			return &manager.Config{
+				KongAdminSvc:                           mo.Some(k8stypes.NamespacedName{Name: "admin-svc", Namespace: "ns"}),
+				GatewayDiscoveryReadinessCheckInterval: clients.DefaultReadinessReconciliationInterval,
+				GatewayDiscoveryReadinessCheckTimeout:  clients.DefaultReadinessCheckTimeout,
+			}
+		}
+
+		t.Run("disabled should not check other fields to set", func(t *testing.T) {
+			c := &manager.Config{}
+			require.NoError(t, c.Validate())
+		})
+
+		t.Run("enabled with valid configuration should pass", func(t *testing.T) {
+			c := validEnabled()
+			require.NoError(t, c.Validate())
+		})
+
+		t.Run("too small reconciliation interval should not pass", func(t *testing.T) {
+			c := validEnabled()
+			c.GatewayDiscoveryReadinessCheckInterval = 6 * time.Second
+			require.ErrorContains(t, c.Validate(), "Readiness check reconciliation interval cannot be less than 10s")
+		})
+
+		t.Run("readiness check timeout must be less than reconciliation interval", func(t *testing.T) {
+			c := validEnabled()
+			c.GatewayDiscoveryReadinessCheckTimeout = clients.DefaultReadinessReconciliationInterval
+			require.ErrorContains(t, c.Validate(), "Readiness check timeout must be less than readiness check recociliation interval")
 		})
 	})
 }

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -353,8 +353,9 @@ func TestConfigValidate(t *testing.T) {
 
 		t.Run("too small reconciliation interval should not pass", func(t *testing.T) {
 			c := validEnabled()
-			c.GatewayDiscoveryReadinessCheckInterval = 6 * time.Second
-			require.ErrorContains(t, c.Validate(), "Readiness check reconciliation interval cannot be less than 10s")
+			c.GatewayDiscoveryReadinessCheckInterval = 2 * time.Second
+			c.GatewayDiscoveryReadinessCheckTimeout = time.Second
+			require.ErrorContains(t, c.Validate(), "Readiness check reconciliation interval cannot be less than 3s")
 		})
 
 		t.Run("readiness check timeout must be less than reconciliation interval", func(t *testing.T) {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -153,7 +153,7 @@ func Run(
 		eventRecorder = &record.FakeRecorder{}
 	}
 
-	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, setupLog.WithName("readiness-checker"))
+	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, c.GatewayDiscoveryReadinessCheckTimeout, setupLog.WithName("readiness-checker"))
 	clientsManager, err := clients.NewAdminAPIClientsManager(
 		ctx,
 		logger,
@@ -164,6 +164,7 @@ func Run(
 		return fmt.Errorf("failed to create AdminAPIClientsManager: %w", err)
 	}
 	clientsManager = clientsManager.WithDBMode(dbMode)
+	clientsManager = clientsManager.WithReconciliationInterval(c.GatewayDiscoveryReadinessCheckInterval)
 
 	if c.KongAdminSvc.IsPresent() {
 		setupLog.Info("Running AdminAPIClientsManager loop")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Add flags `--gateway-discovery-readiness-check-interval` and `--gateway-discovery-readiness-check-timeout` to configure reconciliation interval and timeout of readiness checks.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6425 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
Naming problem: should we change `ReconciliationInterval` to `ReconciliationPeriod` to align with other `***Period`s?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
