### PR TITLE
 chore(tests): migrate TestTCPIngressEssentials to isolated

### DIFF
--- a/test/integration/isolated/tcpingress_test.go
+++ b/test/integration/isolated/tcpingress_test.go
@@ -1,0 +1,161 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1beta1"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/clientset"
+	"github.com/kong/kubernetes-ingress-controller/v3/test"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestTCPIngressEssentials(t *testing.T) {
+	const tcpIngressName = "tcp-ingress-essentials"
+	const servicePort = ktfkong.DefaultTCPServicePort
+	const serviceName = "tcpecho"
+	testUUID := uuid.NewString()
+
+	f := features.
+		New("essentials").
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyIngress).
+		WithLabel(testlabels.Kind, testlabels.KindKongTCPIngress).
+		Setup(SkipIfRouterNotExpressions).
+		WithSetup("deploy kong addon into cluster", featureSetup()).
+		WithSetup("configure a tcpecho Deployment and Service",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Log("setting up the TCPIngress tests")
+
+				kongClient, err := clientset.NewForConfig(cfg.Client().RESTConfig())
+				assert.NoError(t, err)
+				ctx = SetInCtxForT(ctx, t, kongClient)
+
+				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+				namespace := GetNamespaceForT(ctx, t)
+				cluster := GetClusterFromCtx(ctx)
+
+				t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
+				container := generators.NewContainer(serviceName, test.HTTPBinImage, test.HTTPBinPort)
+				// App go-echo sends a "Running on Pod <UUID>." immediately on connecting.
+				container.Env = []corev1.EnvVar{
+					{
+						Name:  "POD_NAME",
+						Value: testUUID,
+					},
+				}
+				deployment := generators.NewDeploymentForContainer(container)
+				deployment, err = cluster.Client().AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+				assert.NoError(t, err)
+				cleaner.Add(deployment)
+
+				t.Logf("exposing deployment %s/%s via service", deployment.Namespace, deployment.Name)
+				service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+				service.Name = serviceName
+				// Use the same port as the default TCP port from the Kong Gateway deployment
+				// to the tcpecho port, as this is what will be used to route the traffic at the Gateway.
+				service.Spec.Ports = []corev1.ServicePort{{
+					Name:       "tcp",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       servicePort,
+					TargetPort: intstr.FromInt(test.HTTPBinPort),
+				}}
+				service, err = cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+				assert.NoError(t, err)
+				cleaner.Add(service)
+
+				t.Logf("creating a TCPIngress to access deployment %s via kong", deployment.Name)
+				tcpIngress := &kongv1beta1.TCPIngress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tcpIngressName,
+						Annotations: map[string]string{
+							annotations.IngressClassKey: GetIngressClassFromCtx(ctx),
+						},
+					},
+					Spec: kongv1beta1.TCPIngressSpec{Rules: []kongv1beta1.IngressRule{
+						{
+							Port: ktfkong.DefaultTCPServicePort,
+							Backend: kongv1beta1.IngressBackend{
+								ServiceName: service.Name,
+								ServicePort: servicePort,
+							},
+						},
+					}},
+				}
+				_, err = kongClient.ConfigurationV1beta1().TCPIngresses(namespace).Create(ctx, tcpIngress, metav1.CreateOptions{})
+				assert.NoError(t, err)
+
+				return ctx
+			}).
+		Assess("basic test - status and connectivity", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			tcpGatewayURL := GetTCPURLFromCtx(ctx)
+			ingressClient := GetFromCtxForT[*clientset.Clientset](ctx, t).ConfigurationV1beta1().TCPIngresses(GetNamespaceForT(ctx, t))
+
+			t.Logf("verifying that TCPIngress becomes routable at %s", tcpGatewayURL)
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				configuredIngress, err := ingressClient.Get(ctx, tcpIngressName, metav1.GetOptions{})
+				assert.NoError(c, err)
+				assert.NotNil(c, configuredIngress)
+				for _, ingress := range configuredIngress.Status.LoadBalancer.Ingress {
+					ipReportedByIngress := ingress.IP
+					assert.NotEmpty(c, ipReportedByIngress)
+					ipOfKong, _, err := net.SplitHostPort(tcpGatewayURL)
+					assert.NoError(c, err)
+					assert.Equal(c, ipOfKong, ipReportedByIngress, "TCPIngress is not ready to redirect traffic")
+				}
+			}, consts.StatusWait, consts.WaitTick)
+
+			tcpProxyURL := fmt.Sprintf("http://%s", tcpGatewayURL)
+			t.Logf("verifying that the TCPIngress %s is responding ready", tcpProxyURL)
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				resp, err := helpers.DefaultHTTPClient().Get(tcpProxyURL)
+				if assert.NoError(c, err) && assert.NotNil(c, resp) {
+					// the assert.EventuallyWithT will collect all errors,
+					// so the Close() can only be called if the response is not nil
+					defer resp.Body.Close()
+					assert.Equal(c, http.StatusOK, resp.StatusCode)
+					// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
+					// Expected: "<title>httpbin.org</title>"
+					b := new(bytes.Buffer)
+					n, err := b.ReadFrom(resp.Body)
+					assert.NoError(c, err)
+					assert.Greater(c, n, int64(0))
+					assert.Contains(c, b.String(), "<title>httpbin.org</title>")
+				}
+			}, consts.StatusWait, consts.WaitTick)
+
+			return ctx
+		}).
+		Assess("test teardown - TCPIngress deletion", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			ingressClient := GetFromCtxForT[*clientset.Clientset](ctx, t).ConfigurationV1beta1().TCPIngresses(GetNamespaceForT(ctx, t))
+
+			t.Log("deleting TCPIngress")
+			assert.NoError(t, ingressClient.Delete(ctx, tcpIngressName, metav1.DeleteOptions{}))
+			t.Logf("verifying that traffic is no longer routed")
+			assertEventuallyNoResponseTCP(t, GetTCPURLFromCtx(ctx))
+
+			return ctx
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -3,12 +3,10 @@
 package integration
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -35,112 +33,6 @@ var (
 	tcpMutex sync.Mutex
 	tlsMutex sync.Mutex
 )
-
-func TestTCPIngressEssentials(t *testing.T) {
-	ctx := context.Background()
-	RunWhenKongExpressionRouter(ctx, t)
-
-	t.Parallel()
-	// Ensure no other TCP tests run concurrently to avoid fights over the port
-	t.Log("locking TCP port")
-	tcpMutex.Lock()
-	t.Cleanup(func() {
-		t.Log("unlocking TCP port")
-		tcpMutex.Unlock()
-	})
-
-	ns, cleaner := helpers.Setup(ctx, t, env)
-
-	t.Log("setting up the TCPIngress tests")
-	const testName = "tcpingress"
-	gatewayClient, err := clientset.NewForConfig(env.Cluster().Config())
-	require.NoError(t, err)
-
-	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
-	deployment := generators.NewDeploymentForContainer(generators.NewContainer(testName, test.HTTPBinImage, test.HTTPBinPort))
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(ns.Name).Create(ctx, deployment, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(deployment)
-
-	t.Logf("exposing deployment %s via service", deployment.Name)
-	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	service, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(service)
-
-	t.Logf("routing to service %s via TCPIngress", service.Name)
-	tcp := &kongv1beta1.TCPIngress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: ns.Name,
-			Annotations: map[string]string{
-				annotations.IngressClassKey: consts.IngressClass,
-			},
-		},
-		Spec: kongv1beta1.TCPIngressSpec{
-			Rules: []kongv1beta1.IngressRule{
-				{
-					Port: ktfkong.DefaultTCPServicePort,
-					Backend: kongv1beta1.IngressBackend{
-						ServiceName: service.Name,
-						ServicePort: 80,
-					},
-				},
-			},
-		},
-	}
-	tcp, err = gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Create(ctx, tcp, metav1.CreateOptions{})
-	require.NoError(t, err)
-	cleaner.Add(tcp)
-
-	t.Logf("checking tcpingress %s status readiness.", tcp.Name)
-	ingCli := gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name)
-	assert.Eventually(t, func() bool {
-		curIng, err := ingCli.Get(ctx, tcp.Name, metav1.GetOptions{})
-		if err != nil || curIng == nil {
-			return false
-		}
-		ingresses := curIng.Status.LoadBalancer.Ingress
-		for _, ingress := range ingresses {
-			if len(ingress.Hostname) > 0 || len(ingress.IP) > 0 {
-				t.Logf("tcpingress hostname %s or ip %s is ready to redirect traffic.", ingress.Hostname, ingress.IP)
-				return true
-			}
-		}
-		return false
-	}, statusWait, waitTick, true)
-
-	t.Logf("verifying TCP Ingress %s operational", tcp.Name)
-	tcpProxyURL := fmt.Sprintf("http://%s:", proxyTCPURL)
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(tcpProxyURL)
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			// now that the ingress backend is routable, make sure the contents we're getting back are what we expect
-			// Expected: "<title>httpbin.org</title>"
-			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
-			return strings.Contains(b.String(), "<title>httpbin.org</title>")
-		}
-		return false
-	}, ingressWait, waitTick)
-
-	t.Logf("tearing down TCPIngress %s and ensuring that the relevant backend routes are removed", tcp.Name)
-	require.NoError(t, gatewayClient.ConfigurationV1beta1().TCPIngresses(ns.Name).Delete(ctx, tcp.Name, metav1.DeleteOptions{}))
-	require.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient().Get(tcpProxyURL)
-		if err != nil {
-			return true
-		}
-		defer resp.Body.Close()
-		return false
-	}, ingressWait, waitTick)
-}
 
 func TestTCPIngressTLS(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Migrate test integration `TestTCPIngressEssentials` to isolated. Avoiding locking a port cuts execution time.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
#5757

<!--**Special notes for your reviewer**:
-->

<!-- Here you can add any open questions or notes that you might have for reviewers -->

