### PR TITLE
chore(ci): make PR checks workflow runnable for external contributors

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -117,8 +117,28 @@ jobs:
           docker load --input /tmp/image.tar
           docker image ls -a
 
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5
@@ -208,8 +228,28 @@ jobs:
         kubernetes-version: ${{ fromJSON(needs.dependencies-versions.outputs.gke) }}
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5
@@ -319,8 +359,28 @@ jobs:
           docker load --input /tmp/image.tar
           docker image ls -a
 
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -117,25 +117,7 @@ jobs:
           docker load --input /tmp/image.tar
           docker image ls -a
 
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -228,25 +210,7 @@ jobs:
         kubernetes-version: ${{ fromJSON(needs.dependencies-versions.outputs.gke) }}
         test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -359,25 +323,7 @@ jobs:
           docker load --input /tmp/image.tar
           docker image ls -a
 
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -8,8 +8,28 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -8,25 +8,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -143,29 +143,6 @@ jobs:
             enterprise: true
 
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: Kong/kong-license@master
         id: license
         with:
@@ -193,6 +170,11 @@ jobs:
             echo "TEST_KONG_TAG=${kong_oss_tag}" >> $GITHUB_ENV
             echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-oss-effective-version }}" >> $GITHUB_ENV
           fi
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -143,6 +143,29 @@ jobs:
             enterprise: true
 
     steps:
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: Kong/kong-license@master
         id: license
         with:
@@ -170,9 +193,6 @@ jobs:
             echo "TEST_KONG_TAG=${kong_oss_tag}" >> $GITHUB_ENV
             echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-oss-effective-version }}" >> $GITHUB_ENV
           fi
-
-      - name: checkout repository
-        uses: actions/checkout@v4
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -16,25 +16,7 @@ jobs:
           - name: oss
             enterprise: false
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -16,8 +16,28 @@ jobs:
           - name: oss
             enterprise: false
     steps:
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_permission_check.yaml
+++ b/.github/workflows/_permission_check.yaml
@@ -1,0 +1,28 @@
+# The below allows PRs from forks to access the secrets in a secure way
+# https://michaelheap.com/access-secrets-from-forks
+# NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+name: permission check
+
+on:
+  workflow_call:
+
+jobs:
+  check-permission:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -19,28 +19,10 @@ on:
 jobs:
   coverage:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
-    if: ${{ inputs.coverage && !cancelled() }}
     runs-on: ubuntu-latest
+    if: ${{ inputs.coverage && !cancelled() }}
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -67,25 +49,7 @@ jobs:
     if: ${{ inputs.buildpulse && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -22,8 +22,28 @@ jobs:
     if: ${{ inputs.coverage && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: collect test coverage artifacts
         id: download-coverage
@@ -47,8 +67,28 @@ jobs:
     if: ${{ inputs.buildpulse && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: download tests report
         id: download-coverage

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,6 +11,9 @@ on:
   pull_request_target:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
   push:
     branches:
       - 'main'

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
   push:
@@ -20,15 +20,40 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  check-permission:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
+    runs-on: ubuntu-latest
+    steps:
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
   up-to-date:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
+    needs: check-permission
     outputs:
       status: ${{ steps.up-to-date.outputs.status }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Check if PR is up to date, if it is skip workflows for this ref
         id: 'up-to-date'
@@ -36,25 +61,6 @@ jobs:
         uses: Kong/public-shared-actions/pr-previews/up-to-date@v2.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  # This job is used to check if the secrets are available. If they are not, we'll skip jobs that require them.
-  should-run-with-secrets:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
-    runs-on: ubuntu-latest
-    needs:
-    - up-to-date
-    if: needs.up-to-date.outputs.status != 'true'
-    outputs:
-      result: ${{ steps.check.outputs.result }}
-    steps:
-      - name: Check if secrets are available
-        id: check
-        run: |
-          if [ "${{ secrets.PULP_PASSWORD }}" == "" ]; then
-            echo "result=false" >> $GITHUB_OUTPUT
-          else
-            echo "result=true" >> $GITHUB_OUTPUT
-          fi
 
   tools:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
@@ -90,6 +96,7 @@ jobs:
 
   envtest-tests:
     needs:
+    - check-permission
     - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_envtest_tests.yaml
@@ -97,16 +104,17 @@ jobs:
 
   kongintegration-tests:
     needs:
-      - up-to-date
+    - check-permission
+    - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_kongintegration_tests.yaml
     secrets: inherit
 
   integration-tests:
     needs:
-    - should-run-with-secrets
+    - check-permission
     - up-to-date
-    if: needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
+    if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_integration_tests.yaml
     secrets: inherit
     with:
@@ -155,13 +163,13 @@ jobs:
 
   test-reports:
     needs:
-      - should-run-with-secrets
+      - check-permission
       - unit-tests
       - envtest-tests
       - kongintegration-tests
       - integration-tests
       - conformance-tests
       - up-to-date
-    if: always() && needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
+    if: always() && needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_test_reports.yaml
     secrets: inherit

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,27 +21,8 @@ on:
 
 jobs:
   check-permission:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
-    runs-on: ubuntu-latest
-    steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
+    uses: ./.github/workflows/_permission_check.yaml
+    secrets: inherit
 
   up-to-date:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
@@ -96,7 +77,6 @@ jobs:
 
   envtest-tests:
     needs:
-    - check-permission
     - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_envtest_tests.yaml
@@ -104,7 +84,6 @@ jobs:
 
   kongintegration-tests:
     needs:
-    - check-permission
     - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_kongintegration_tests.yaml
@@ -112,7 +91,6 @@ jobs:
 
   integration-tests:
     needs:
-    - check-permission
     - up-to-date
     if: needs.up-to-date.outputs.status != 'true'
     uses: ./.github/workflows/_integration_tests.yaml
@@ -163,7 +141,6 @@ jobs:
 
   test-reports:
     needs:
-      - check-permission
       - unit-tests
       - envtest-tests
       - kongintegration-tests

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -6,10 +6,14 @@ on:
     - labeled
 
 jobs:
+  check-permission:
+    uses: ./.github/workflows/_permission_check.yaml
+    secrets: inherit
   trigger-e2e-tests-targeted:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
-    if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
     runs-on: ubuntu-latest
+    if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
+    needs: check-permission
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
       WORKFLOW: .github/workflows/e2e_targeted.yaml
@@ -17,24 +21,6 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
 
     steps:
-      # The below allows PRs from forks to access the secrets in a secure way
-      # https://michaelheap.com/access-secrets-from-forks
-      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
-      - name: get user permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check user permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
       - name: checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -17,13 +17,34 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
 
     steps:
-    - uses: actions/checkout@v4
-    # Do not run e2e tests on GKE-based clusters for specific PR, because currently
-    # there is no way to use an image built from PR's code for those tests.
-    # https://github.com/Kong/kubernetes-testing-framework/issues/587
-    - run: |
-        gh workflow run ${WORKFLOW} --ref ${BRANCH} \
-          -f run-gke=false \
-          -f run-istio=true \
-          -f all-supported-k8s-versions=true \
-          -f pr-number=${PR_NUMBER}
+      # The below allows PRs from forks to access the secrets in a secure way
+      # https://michaelheap.com/access-secrets-from-forks
+      # NOTE: Reviewer has to check whether the code in PR does not expose secrets!
+      - name: get user permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check user permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      # Do not run e2e tests on GKE-based clusters for specific PR, because currently
+      # there is no way to use an image built from PR's code for those tests.
+      # https://github.com/Kong/kubernetes-testing-framework/issues/587
+      - run: |
+          gh workflow run ${WORKFLOW} --ref ${BRANCH} \
+            -f run-gke=false \
+            -f run-istio=true \
+            -f all-supported-k8s-versions=true \
+            -f pr-number=${PR_NUMBER}

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -1,7 +1,7 @@
 name: trigger e2e (targeted) on label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
     - labeled
 
@@ -35,7 +35,7 @@ jobs:
           echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
-      - name: checkout code
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

It's hard to accept PRs from external contributors, e.g.

- https://github.com/Kong/kubernetes-ingress-controller/pull/6450

because some tests need access to secrets. They can't access them due to GH design. This PR implements the approach described in @mheap [blogpost](https://michaelheap.com/access-secrets-from-forks/) to overcome this limitation. It also makes `should-run-with-secrets` redundant, thus it's removed.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes #3745 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

