### PR TITLE
chore(ci): remove redundant pull_request trigger and fix e2e trigger (#6462)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,9 +11,6 @@ on:
   pull_request_target:
     branches:
       - '**'
-  pull_request:
-    branches:
-      - '**'
   push:
     branches:
       - 'main'

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   check-permission:
     uses: ./.github/workflows/_permission_check.yaml
+    if: contains(github.event.*.labels.*.name, 'ci/run-e2e')
     secrets: inherit
   trigger-e2e-tests-targeted:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to GH limitation that `pull_request_target` can be triggered only for workflows that are already in `main` redundant trigger `pull_request` can be only removed after merging of 

- https://github.com/Kong/kubernetes-ingress-controller/pull/6459

to `main` so this PR does it. Furthermore, it makes running permission checks for e2e only when triggered by corresponding label
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Followup for https://github.com/Kong/kubernetes-ingress-controller/issues/3745
