### PR TITLE
chore(ci): disable exportloopref, loopvar and enable copyloopvar linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,13 +12,13 @@ linters:
   - asciicheck
   - bodyclose
   - contextcheck
+  - copyloopvar
   - dogsled
   - durationcheck
   - errcheck
   - errname
   - errorlint
   - exhaustive
-  - exportloopref
   - forbidigo
   - gci
   - gocritic

--- a/controllers/license/konglicense_controller_test.go
+++ b/controllers/license/konglicense_controller_test.go
@@ -53,7 +53,6 @@ func TestCompareLicense(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expectedResult,
 				compareKongLicense(tc.license1, tc.license2),
@@ -103,7 +102,6 @@ func TestKongLicenseController_pickLicense(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			r := &KongV1Alpha1KongLicenseReconciler{
 				LicenseCache: NewLicenseCache(),

--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -490,8 +490,6 @@ func TestDiscoverer_AddressesFromEndpointSlice(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(fmt.Sprintf("dnsstrategy_%s/%s", tt.dnsStrategy, tt.name), func(t *testing.T) {
 			discoverer, err := NewDiscoverer(tt.portNames, tt.dnsStrategy)
 			require.NoError(t, err)
@@ -702,7 +700,6 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("dnsstrategy_%s/%s", tt.dnsStrategy, tt.name), func(t *testing.T) {
 			require.NoError(t, tt.dnsStrategy.Validate())
 

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -397,7 +397,6 @@ func TestHandleSecret(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			validator := KongFakeValidator{
 				Result:  tc.validatorOK,

--- a/internal/admission/response_builder_test.go
+++ b/internal/admission/response_builder_test.go
@@ -89,7 +89,6 @@ func TestResponseBuilder(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			builder := admission.NewResponseBuilder(someUID)
 

--- a/internal/admission/server_test.go
+++ b/internal/admission/server_test.go
@@ -360,7 +360,6 @@ func TestValidationWebhook(t *testing.T) {
 				},
 			},
 		} {
-			tt := tt
 			t.Run(fmt.Sprintf("%s/%s", apiVersion, tt.name), func(t *testing.T) {
 				// arrange
 				assert := assert.New(t)

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -212,7 +212,6 @@ func validateWithKongGateway(
 	}
 	// Validate by using feature of Kong Gateway.
 	for _, kg := range kongRoutes {
-		kg := kg
 		ok, msg, err := routesValidator.Validate(ctx, &kg)
 		if err != nil {
 			return false, fmt.Sprintf("Unable to validate HTTPRoute schema: %s", err.Error())

--- a/internal/admission/validation/ingress/ingress.go
+++ b/internal/admission/validation/ingress/ingress.go
@@ -39,7 +39,6 @@ func ValidateIngress(
 	}
 
 	for _, kg := range ingressToKongRoutesForValidation(translatorFeatures, ingress, failuresCollector, storer) {
-		kg := kg
 		// Validate by using feature of Kong Gateway.
 		ok, msg, err := routesValidator.Validate(ctx, &kg)
 		if err != nil {

--- a/internal/admission/validator.go
+++ b/internal/admission/validator.go
@@ -527,9 +527,7 @@ func (validator KongHTTPValidator) listManagedConsumers(ctx context.Context) ([]
 	// Reduce the consumer set to consumers managed by this controller.
 	managedConsumers := make([]*kongv1.KongConsumer, 0)
 	for _, consumer := range consumers {
-		consumer := consumer
-		if !validator.ingressClassMatcher(&consumer.ObjectMeta, annotations.IngressClassKey,
-			annotations.ExactClassMatch) {
+		if !validator.ingressClassMatcher(&consumer.ObjectMeta, annotations.IngressClassKey, annotations.ExactClassMatch) {
 			// ignore consumers (and subsequently secrets) that are managed by other controllers
 			continue
 		}

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -993,7 +993,6 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 			require.NoError(t, testk8sclient.AddToScheme(scheme))
@@ -1389,7 +1388,6 @@ func TestValidator_ValidateVault(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			storer := lo.Must(store.NewFakeStore(tc.storerObjects))
 			validator := KongHTTPValidator{

--- a/internal/controllers/configuration/kongupstreampolicy_utils.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils.go
@@ -278,7 +278,6 @@ func (r *KongUpstreamPolicyReconciler) buildAncestorsStatus(
 	// Build the status for each ancestor (Services and KongServiceFacades).
 	ancestorsStatus := make([]ancestorStatus, 0, len(services)+len(serviceFacades))
 	for _, service := range services {
-		service := service
 		acceptedCondition := acceptedCondition
 		programmedCondition := programmedCondition
 
@@ -307,7 +306,6 @@ func (r *KongUpstreamPolicyReconciler) buildAncestorsStatus(
 		})
 	}
 	for _, serviceFacade := range serviceFacades {
-		serviceFacade := serviceFacade
 		programmedCondition := programmedCondition
 		if !r.DataplaneClient.KubernetesObjectIsConfigured(&serviceFacade) {
 			// If the KongServiceFacade is not configured, we change it to False.

--- a/internal/controllers/configuration/kongupstreampolicy_utils_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils_test.go
@@ -681,7 +681,6 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tc.inputObjects = append(tc.inputObjects, &tc.kongUpstreamPolicy)
 			fakeClient := fakectrlruntimeclient.

--- a/internal/controllers/configuration/object_references_test.go
+++ b/internal/controllers/configuration/object_references_test.go
@@ -57,7 +57,6 @@ func TestListCoreV1ServiceReferredSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			secretNames := listCoreV1ServiceReferredSecrets(tc.service)
 			require.Len(t, secretNames, tc.secretNum)
@@ -119,7 +118,6 @@ func TestListIngressReferredSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			secretNames := listNetV1IngressReferredSecrets(tc.ingress)
 			require.Len(t, secretNames, tc.secretNum)

--- a/internal/controllers/gateway/gateway_controller_test.go
+++ b/internal/controllers/gateway/gateway_controller_test.go
@@ -143,7 +143,6 @@ func TestSetGatewayCondtion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			setGatewayCondition(tc.gw, tc.condition)
 			t.Logf("checking conditions of gateway after setting")
@@ -342,7 +341,6 @@ func TestIsGatewayControlled(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expectedResult, isGatewayClassControlled(tc.GatewayClass))
@@ -371,7 +369,6 @@ func TestIsGatewayUnmanaged(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expectedResult, isGatewayClassUnmanaged(tc.GatewayClassAnnotations))

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -701,7 +701,6 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 
 	var attachedRoutes int32
 	for _, route := range httpRouteList.Items {
-		route := route
 		acceptedByGateway := lo.ContainsBy(route.Status.Parents, func(parentStatus gatewayapi.RouteParentStatus) bool {
 			parentRef := parentStatus.ParentRef
 			if parentRef.Group != nil && *parentRef.Group != gatewayapi.V1Group {

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -109,7 +109,6 @@ func TestGetListenerSupportedRouteKinds(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got, reason := getListenerSupportedRouteKinds(tc.listener)
 			require.Equal(t, tc.expectedSupportedKinds, got)
@@ -256,7 +255,6 @@ func TestGetListenerStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			statuses, err := getListenerStatus(ctx, tc.gateway, tc.kongListens, nil, client)
 			require.NoError(t, err)

--- a/internal/controllers/gateway/gatewayclass_controller_test.go
+++ b/internal/controllers/gateway/gatewayclass_controller_test.go
@@ -93,7 +93,6 @@ func TestSetGatewayClassCondtion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			setGatewayClassCondition(tc.gwc, tc.condition)
 			t.Logf("checking conditions of gateway after setting")

--- a/internal/controllers/gateway/grpcroute_controller.go
+++ b/internal/controllers/gateway/grpcroute_controller.go
@@ -449,7 +449,6 @@ func (r *GRPCRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
-		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayapi.RouteParentStatus{
 			ParentRef: gatewayapi.ParentReference{

--- a/internal/controllers/gateway/httproute_controller.go
+++ b/internal/controllers/gateway/httproute_controller.go
@@ -539,7 +539,6 @@ func (r *HTTPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Cont
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
-		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayapi.RouteParentStatus{
 			ParentRef: gatewayapi.ParentReference{

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -574,7 +574,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				fakeClient := fakeclient.
 					NewClientBuilder().
@@ -845,7 +844,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				fakeClient := fakeclient.
 					NewClientBuilder().
@@ -1080,7 +1078,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				fakeClient := fakeclient.
 					NewClientBuilder().
@@ -1302,7 +1299,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				fakeClient := fakeclient.
 					NewClientBuilder().
@@ -1437,7 +1433,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				fakeClient := fakeclient.
 					NewClientBuilder().
@@ -2043,8 +2038,6 @@ func TestEnsureParentsProgrammedCondition(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				var (
 					ctx       = context.Background()

--- a/internal/controllers/gateway/tcproute_controller.go
+++ b/internal/controllers/gateway/tcproute_controller.go
@@ -458,7 +458,6 @@ func (r *TCPRouteReconciler) ensureGatewayReferenceStatusAdded(
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
-		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayapi.RouteParentStatus{
 			ParentRef: gatewayapi.ParentReference{

--- a/internal/controllers/gateway/tlsroute_controller.go
+++ b/internal/controllers/gateway/tlsroute_controller.go
@@ -439,7 +439,6 @@ func (r *TLSRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
-		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayapi.RouteParentStatus{
 			ParentRef: gatewayapi.ParentReference{

--- a/internal/controllers/gateway/udproute_controller.go
+++ b/internal/controllers/gateway/udproute_controller.go
@@ -449,7 +449,6 @@ func (r *UDPRouteReconciler) ensureGatewayReferenceStatusAdded(ctx context.Conte
 	// overlay the parent ref statuses for all new gateway references
 	statusChangesWereMade := false
 	for _, gateway := range gateways {
-		gateway := gateway
 		// build a new status for the parent Gateway
 		gatewayParentStatus := &gatewayapi.RouteParentStatus{
 			ParentRef: gatewayapi.ParentReference{

--- a/internal/controllers/reference/indexer_test.go
+++ b/internal/controllers/reference/indexer_test.go
@@ -83,7 +83,6 @@ func TestSetObjectReference(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
@@ -128,7 +127,6 @@ func TestDeleteObjectReference(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(testRefService1, testRefSecret1)
@@ -170,7 +168,6 @@ func TestObjectReferred(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
@@ -208,7 +205,6 @@ func TestListReferredObjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)
@@ -246,7 +242,6 @@ func TestDeleteReferencesByReferrer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(testRefService1, testRefSecret1)
@@ -288,7 +283,6 @@ func TestListReferrerObjectsByReferent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewCacheIndexers(logr.Discard())
 			err := c.SetObjectReference(tc.addReferrer, tc.addReferent)

--- a/internal/dataplane/configfetcher/config_fetcher_test.go
+++ b/internal/dataplane/configfetcher/config_fetcher_test.go
@@ -74,7 +74,6 @@ func TestTryFetchingValidConfigFromGateways(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fetcher := NewDefaultKongLastGoodConfigFetcher(false, "")
 			state, ok := fetcher.LastValidConfig()

--- a/internal/dataplane/deckerrors/api_test.go
+++ b/internal/dataplane/deckerrors/api_test.go
@@ -52,7 +52,6 @@ func TestExtractAPIErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			out := deckerrors.ExtractAPIErrors(tc.input)
 			require.Equal(t, tc.expected, out)
@@ -104,7 +103,6 @@ func TestExtractCRUDActionErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			out := deckerrors.ExtractCRUDActionErrors(tc.input)
 			require.Equal(t, tc.expected, out)

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -109,7 +109,6 @@ func ToDeckContent(
 	})
 
 	for _, u := range k8sState.Upstreams {
-		u := u
 		fillUpstream(&u.Upstream)
 		upstream := file.FUpstream{Upstream: u.Upstream}
 		for _, t := range u.Targets {
@@ -162,7 +161,6 @@ func ToDeckContent(
 		}
 
 		for _, cg := range c.ConsumerGroups {
-			cg := cg
 			consumer.Groups = append(consumer.Groups, &cg)
 		}
 
@@ -171,31 +169,24 @@ func ToDeckContent(
 		}
 
 		for _, v := range c.KeyAuths {
-			v := v
 			consumer.KeyAuths = append(consumer.KeyAuths, &v.KeyAuth)
 		}
 		for _, v := range c.HMACAuths {
-			v := v
 			consumer.HMACAuths = append(consumer.HMACAuths, &v.HMACAuth)
 		}
 		for _, v := range c.BasicAuths {
-			v := v
 			consumer.BasicAuths = append(consumer.BasicAuths, &v.BasicAuth)
 		}
 		for _, v := range c.JWTAuths {
-			v := v
 			consumer.JWTAuths = append(consumer.JWTAuths, &v.JWTAuth)
 		}
 		for _, v := range c.ACLGroups {
-			v := v
 			consumer.ACLGroups = append(consumer.ACLGroups, &v.ACLGroup)
 		}
 		for _, v := range c.Oauth2Creds {
-			v := v
 			consumer.Oauth2Creds = append(consumer.Oauth2Creds, &v.Oauth2Credential)
 		}
 		for _, v := range c.MTLSAuths {
-			v := v
 			consumer.MTLSAuths = append(consumer.MTLSAuths, &v.MTLSAuth)
 		}
 		content.Consumers = append(content.Consumers, consumer)

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -323,7 +323,6 @@ func (c *KongClient) Listeners(ctx context.Context) ([]kong.ProxyListener, []kon
 	// SetLastConfigSHA() method. It's not ideal but it should do for now.
 	c.lock.RLock()
 	for _, cl := range c.clientsProvider.GatewayClients() {
-		cl := cl
 		errg.Go(func() error {
 			listeners, streamListeners, err := cl.AdminAPIClient().Listeners(ctx)
 			if err != nil {

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -122,7 +122,6 @@ func TestUniqueObjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			translationFailures := []failures.ResourceFailure{}
 			for _, failedObjs := range tc.failedObjs {
@@ -421,7 +420,6 @@ func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *tes
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			clientsProvider := &mockGatewayClientsProvider{
 				gatewayClients: tc.gatewayClients,

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -785,9 +785,7 @@ func TestFillConsumersAndCredentials(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			store, _ := store.NewFakeStore(store.FakeObjects{
 				Secrets:       secrets,
 				KongConsumers: tc.k8sConsumers,
@@ -1382,7 +1380,6 @@ func TestFillVaults(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			s, err := store.NewFakeStore(store.FakeObjects{
 				KongVaults: tc.kongVaults,

--- a/internal/dataplane/kongstate/route_test.go
+++ b/internal/dataplane/kongstate/route_test.go
@@ -304,9 +304,7 @@ func TestOverrideExpressionRoute(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			tc.inRoute.override(zapr.NewLogger(zap.NewNop()))
 			assert.Equal(t, tc.outRoute, tc.inRoute, "should be the same as expected after overriding")
 		})
@@ -513,7 +511,6 @@ func TestOverrideRouteStripPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideStripPath(tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
@@ -917,7 +914,6 @@ func TestOverrideRequestBuffering(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideRequestBuffering(zapr.NewLogger(zap.NewNop()), tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {
@@ -991,7 +987,6 @@ func TestOverrideResponseBuffering(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.route.overrideResponseBuffering(zapr.NewLogger(zap.NewNop()), tt.args.anns)
 			if !reflect.DeepEqual(tt.args.route.Route, tt.want) {

--- a/internal/dataplane/kongstate/service_test.go
+++ b/internal/dataplane/kongstate/service_test.go
@@ -171,8 +171,6 @@ func TestOverrideService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			service := tc.inService
 			for _, k8sSvc := range service.K8sServices {

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -96,7 +96,6 @@ func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
 		dpconf.DBModeOff,
 		dpconf.DBModePostgres,
 	} {
-		dbMode := dbMode
 		t.Run(fmt.Sprintf("dbmode=%s", dbMode), func(t *testing.T) {
 			c := &fakeDataplaneClient{dbmode: dbMode, t: t}
 			l, err := zap.NewDevelopment()

--- a/internal/dataplane/translator/atc/expression_test.go
+++ b/internal/dataplane/translator/atc/expression_test.go
@@ -181,7 +181,6 @@ func TestGenerateExpression(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			exp := tc.matcher.Expression()
 			require.Equal(t, tc.expression, exp)

--- a/internal/dataplane/translator/atc/predicate_test.go
+++ b/internal/dataplane/translator/atc/predicate_test.go
@@ -60,7 +60,6 @@ func TestNewPredicate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			predicate, err := NewPredicate(tc.lhs, tc.op, tc.rhs)
 			if tc.expectedError == nil {

--- a/internal/dataplane/translator/ingressclassparemeters_test.go
+++ b/internal/dataplane/translator/ingressclassparemeters_test.go
@@ -127,7 +127,6 @@ func TestGetIngressClassParameters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ingressClass := &netv1.IngressClass{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/dataplane/translator/ingressrules_test.go
+++ b/internal/dataplane/translator/ingressrules_test.go
@@ -639,8 +639,6 @@ func TestPopulateServices(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			ingressRules := newIngressRules()
 			fakeStore, err := store.NewFakeStore(store.FakeObjects{

--- a/internal/dataplane/translator/subtranslator/atc_utils_test.go
+++ b/internal/dataplane/translator/subtranslator/atc_utils_test.go
@@ -35,7 +35,6 @@ func TestHostMatcherFromHosts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := hostMatcherFromHosts(tc.hosts)
 			require.Equal(t, tc.expression, matcher.Expression())

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -218,7 +218,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule}, nil)
 			routes := GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute, 0)
@@ -269,7 +268,6 @@ func TestMethodMatcherFromGRPCMethodMatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expression, methodMatcherFromGRPCMethodMatch(&tc.match).Expression())
 		})
@@ -505,9 +503,7 @@ func TestSplitGRPCRoute(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
-		indexStr := strconv.Itoa(i)
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			splitMatches := SplitGRPCRoute(tc.grpcRoute)
 			require.Len(t, splitMatches, len(tc.expectedSplitMatches), "should have same number of split matches with expected")
 			for i, splitGRPCRoute := range tc.expectedSplitMatches {
@@ -591,9 +587,7 @@ func TestCalculateSplitGRCPRoutePriorityTraits(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
-		indexStr := strconv.Itoa(i)
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			traits := CalculateGRCPRouteMatchPriorityTraits(tc.match)
 			require.Equal(t, tc.expectedTraits, traits)
 		})
@@ -629,9 +623,7 @@ func TestGRPCRouteTraitsEncodeToPriority(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
-		indexStr := strconv.Itoa(i)
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			priority := tc.traits.EncodeToPriority()
 			require.Equal(t, tc.exprectedPriority, priority)
 		})
@@ -1058,9 +1050,7 @@ func TestAssignRoutePriorityToSplitGRPCRouteMatches(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			splitMatchesWithPriorities := AssignRoutePriorityToSplitGRPCRouteMatches(logr.Discard(), tc.splitGRPCRouteMatches)
 			require.Lenf(t, splitMatchesWithPriorities, len(tc.priorities),
 				"should have expeceted number of results")
@@ -1259,9 +1249,7 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			r := KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(tc.splitGRPCMatchWithPriority)
 			grpcRoute := tc.splitGRPCMatchWithPriority.Match.Source
 			tc.expectedRoute.Route.Tags = util.GenerateTagsForObject(grpcRoute)

--- a/internal/dataplane/translator/subtranslator/grpcroute_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_test.go
@@ -344,7 +344,6 @@ func TestGenerateKongRoutesFromGRPCRouteRule(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			grpcroute := makeTestGRPCRoute(tc.objectName, "default", tc.annotations, tc.hostnames, []gatewayapi.GRPCRouteRule{tc.rule}, tc.parentRef)
 			routes := GenerateKongRoutesFromGRPCRouteRule(grpcroute, 0, tc.storer)

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -245,7 +245,6 @@ func (m *httpRouteRuleMeta) matches() httpRouteMatchMetaList {
 	matches := make([]httpRouteMatchMeta, 0, len(m.Rule.Matches))
 
 	for matchNumber, match := range m.Rule.Matches {
-		match := match
 		matches = append(matches, httpRouteMatchMeta{
 			Match:       &match,
 			RuleNumber:  m.RuleNumber,
@@ -482,7 +481,6 @@ func mergePluginsOfTheSameType(plugins []transformerPlugin) ([]transformerPlugin
 		return p.Type // Name is effectively a plugin type.
 	})
 	for pluginName, plugins := range pluginsByName {
-		plugins := plugins
 		// If we produced multiple plugins of the same type, we need to merge their configurations now.
 		if len(plugins) > 1 {
 			mergedPlugin := transformerPlugin{}

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -249,7 +249,6 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			routes, err := GenerateKongExpressionRoutesFromHTTPRouteMatches(
 				KongRouteTranslation{
@@ -326,7 +325,6 @@ func TestGenerateMatcherFromHTTPRouteMatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expression, generateMatcherFromHTTPRouteMatch(tc.match).Expression())
 		})
@@ -461,7 +459,6 @@ func TestCalculateHTTPRoutePriorityTraits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			traits := CalculateHTTPRouteMatchPriorityTraits(tc.match)
 			require.Equal(t, tc.expectedTraits, traits)
@@ -517,7 +514,6 @@ func TestEncodeHTTPRoutePriorityFromTraits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expectedPriority, tc.traits.EncodeToPriority())
 		})
@@ -707,9 +703,7 @@ func TestSplitHTTPRoutes(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			splitHTTPRouteMatches := SplitHTTPRoute(tc.httpRoute)
 			require.Len(t, splitHTTPRouteMatches, len(tc.expectedSplitMatches), "should have same number of split matched with expected")
 			for i, expectedMatch := range tc.expectedSplitMatches {
@@ -720,7 +714,6 @@ func TestSplitHTTPRoutes(t *testing.T) {
 				assert.Equal(t, expectedMatch.MatchIndex, splitHTTPRouteMatches[i].MatchIndex)
 			}
 		})
-
 	}
 }
 
@@ -1046,7 +1039,6 @@ func TestAssignRoutePriorityToSplitHTTPRouteMatches(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			splitHTTPRoutesWithPriorities := AssignRoutePriorityToSplitHTTPRouteMatches(logr.Discard(), tc.matches)
 			require.Equal(t, len(tc.priorities), len(splitHTTPRoutesWithPriorities), "should have required number of results")

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -270,7 +270,6 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := generatePluginsFromHTTPRouteFilters(tc.filters, tc.path, nil, false)
 			require.Equal(t, tc.expectedErr, err)

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -136,7 +136,6 @@ func (i *ingressTranslationIndex) Add(ingress *netv1.Ingress, addRegexPrefix add
 		}
 
 		for _, httpIngressPath := range ingressRule.HTTP.Paths {
-			httpIngressPath := httpIngressPath
 			httpIngressPath.Path = flattenMultipleSlashes(httpIngressPath.Path)
 
 			if httpIngressPath.Path == "" {

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -415,7 +415,6 @@ func TestTranslateIngressATC(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			failuresCollector := failures.NewResourceFailuresCollector(logr.Discard())
 			storer := lo.Must(store.NewFakeStore(store.FakeObjects{
@@ -557,7 +556,6 @@ func TestCalculateIngressRoutePriorityTraits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			traits := calculateIngressRoutePriorityTraits(
 				tc.paths, tc.regexPathPrefix, tc.ingressHost, tc.ingressAnnotations,
@@ -617,7 +615,6 @@ func TestEncodeIngressRoutePriorityFromTraits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			priority := tc.traits.EncodeToPriority()
 			require.Equal(t, tc.expectedPriority, priority)
@@ -699,7 +696,6 @@ func TestPathMatcherFromIngressPath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			regexPrefix := tc.regexPrefix
 			if regexPrefix == "" {
@@ -758,7 +754,6 @@ func TestHeaderMatcherFromHeaders(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := headerMatcherFromHeaders(tc.headers)
 			require.Equal(t, tc.expression, matcher.Expression())
@@ -790,7 +785,6 @@ func TestMethodMatcherFromMethods(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		matcher := methodMatcherFromMethods(tc.methods)
 		require.Equal(t, tc.expression, matcher.Expression())
 	}
@@ -825,7 +819,6 @@ func TestSNIMatcherFromSNIs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		matcher := sniMatcherFromSNIs(tc.snis)
 		require.Equal(t, tc.expression, matcher.Expression())
 	}

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -1559,7 +1559,6 @@ func TestTranslateIngress(t *testing.T) {
 	}
 
 	for _, tt := range tts {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			checkOnlyIngressMeta := cmp.Transformer("checkOnlyIngressMeta", func(i *netv1.Ingress) *netv1.Ingress {
 				// In the result we only care about ingresses' metadata being equal.
@@ -2084,7 +2083,6 @@ func TestMaybeRewriteURI(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := MaybeRewriteURI(&tc.service, true)
 			require.Equal(t, tc.expectedError, err)

--- a/internal/dataplane/translator/subtranslator/l4route_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/l4route_atc_test.go
@@ -95,7 +95,6 @@ func TestApplyExpressionToL4KongRoute(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			wrapped := kongstate.Route{Route: tc.route}
 			ApplyExpressionToL4KongRoute(&wrapped)

--- a/internal/dataplane/translator/translate_grpcroute_test.go
+++ b/internal/dataplane/translator/translate_grpcroute_test.go
@@ -422,9 +422,7 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		indexStr := strconv.Itoa(i)
-		tc := tc
-		t.Run(indexStr+"-"+tc.name, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
 			failureCollector := failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
 
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
@@ -463,6 +461,5 @@ func TestIngressRulesFromGRPCRoutesUsingExpressionRoutes(t *testing.T) {
 			translationFailures := failureCollector.PopResourceFailures()
 			require.Empty(t, translationFailures)
 		})
-
 	}
 }

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -141,7 +141,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			featureFlags := FeatureFlags{
 				ExpressionRoutes: tc.expressionRoutes,
@@ -2133,7 +2132,6 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(tc.fakeObjects)
 			require.NoError(t, err)
@@ -2510,7 +2508,6 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(tc.storeObjects)
 			require.NoError(t, err)

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -344,7 +344,6 @@ func TestGetDefaultBackendService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			storer := lo.Must(store.NewFakeStore(tc.storerObjects))
 			failuresCollector := failures.NewResourceFailuresCollector(logr.Discard())

--- a/internal/dataplane/translator/translate_routes_helpers_test.go
+++ b/internal/dataplane/translator/translate_routes_helpers_test.go
@@ -116,7 +116,6 @@ func TestGenerateKongRoutesFromRouteRule_TCP(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, tc.gwPorts, 0, tc.routeRule)
 			require.NoError(t, err)
@@ -229,7 +228,6 @@ func TestGenerateKongRoutesFromRouteRule_UDP(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, tc.gwPorts, 0, tc.routeRule)
 			require.NoError(t, err)
@@ -317,7 +315,6 @@ func TestGenerateKongRoutesFromRouteRule_TLS(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// TLSRoute matches based on hostname with Gateway listener thus passing gwPorts is pointless.
 			kongRoutes, err := generateKongRoutesFromRouteRule(tc.route, nil, 0, tc.routeRule)

--- a/internal/dataplane/translator/translate_tcproute_test.go
+++ b/internal/dataplane/translator/translate_tcproute_test.go
@@ -373,7 +373,6 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeStore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,

--- a/internal/dataplane/translator/translate_tlsroute_test.go
+++ b/internal/dataplane/translator/translate_tlsroute_test.go
@@ -209,7 +209,6 @@ func TestIngressRulesFromTLSRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
 				TLSRoutes: tc.tcpRoutes,

--- a/internal/dataplane/translator/translate_udproute_test.go
+++ b/internal/dataplane/translator/translate_udproute_test.go
@@ -485,7 +485,6 @@ func TestIngressRulesFromUDPRoutes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,
@@ -990,7 +989,6 @@ func TestIngressRulesFromUDPRoutesUsingExpressionRoutes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakestore, err := store.NewFakeStore(store.FakeObjects{
 				Gateways:  tc.gateways,

--- a/internal/dataplane/translator/translate_upstreams.go
+++ b/internal/dataplane/translator/translate_upstreams.go
@@ -151,7 +151,6 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 			}, nil
 		}
 		for _, port := range svc.Spec.Ports {
-			port := port
 			if port.Port == wantPort.Number {
 				return &port, nil
 			}
@@ -162,7 +161,6 @@ func findPort(svc *corev1.Service, wantPort kongstate.PortDef) (*corev1.ServiceP
 			return nil, fmt.Errorf("rules with an ExternalName service must specify numeric ports")
 		}
 		for _, port := range svc.Spec.Ports {
-			port := port
 			if port.Name == wantPort.Name {
 				return &port, nil
 			}

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -274,7 +274,6 @@ func TestNodeAgentUpdateNodes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			nodeClient := newMockNodeClient(tc.initialNodesInNodeAPI)
 			configStatusQueue := newMockConfigStatusNotifier()

--- a/internal/manager/health_check_test.go
+++ b/internal/manager/health_check_test.go
@@ -55,7 +55,6 @@ func TestHealthCheckServer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			h := &healthCheckServer{}
 			h.setHealthzCheck(tc.healthzChecker)

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -178,7 +178,6 @@ func TestCreateManager_GatewayDiscoverySpecifics(t *testing.T) {
 	k8sclient := testk8sclient.NewSimpleClientset()
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/manager/utils/kongconfig/root.go
+++ b/internal/manager/utils/kongconfig/root.go
@@ -201,8 +201,6 @@ func GetRoots(
 	eg, ctx := errgroup.WithContext(ctx)
 
 	for _, client := range kongClients {
-		client := client
-
 		eg.Go(func() error {
 			return retry.Do(
 				func() error {

--- a/internal/manager/utils/kongconfig/root_test.go
+++ b/internal/manager/utils/kongconfig/root_test.go
@@ -36,7 +36,6 @@ func TestValidateRoots(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var root Root
 			require.NoError(t, json.Unmarshal([]byte(tc.configStr), &root))

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -134,7 +134,6 @@ func TestPushFailureReason(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/util/conditions_test.go
+++ b/internal/util/conditions_test.go
@@ -87,7 +87,6 @@ func TestCheckCondition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			ok := util.CheckCondition(
 				givenConditions,

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -172,7 +172,6 @@ func ensureConformanceTestsNamespacesAreNotPresent(ctx context.Context, client *
 	g.SetLimit(3) //nolint:gomnd
 
 	for _, namespace := range []string{"gateway-conformance-infra", "gateway-conformance-web-backend", "gateway-conformance-app-backend"} {
-		namespace := namespace
 		g.Go(func() error {
 			return ensureNamespaceDeleted(ctx, namespace, client)
 		})

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -346,7 +346,6 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 
 	wg := sync.WaitGroup{}
 	for _, pod := range pods {
-		pod := pod
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -28,7 +28,6 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 
 	routerFlavors := []string{"expressions", "traditional_compatible", "traditional"}
 	for _, rf := range routerFlavors {
-		rf := rf
 		t.Run(rf, func(t *testing.T) {
 			deploy := ManifestDeploy{
 				Path: dblessPath,
@@ -96,7 +95,6 @@ func ensureGatewayDeployedWithRouterFlavor(
 
 		allPodsMatch := true
 		for _, pod := range podList.Items {
-			pod := pod
 			proxyContainer := getContainerInPodSpec(&pod.Spec, proxyContainerName)
 			if proxyContainer == nil {
 				t.Logf("proxy container not found for Pod %s", pod.Name)

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -324,7 +324,6 @@ func requireAllProxyReplicasIDsConsistentWithKonnect(
 	t.Logf("ensuring all %d proxy replicas have consistent IDs assigned in Node API", len(pods))
 	wg := sync.WaitGroup{}
 	for _, pod := range pods {
-		pod := pod
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -43,7 +43,6 @@ func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThro
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(fmt.Sprintf("%dx%d", tc.subnetC, tc.subnetD), func(t *testing.T) {
 			t.Parallel()
 

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -656,7 +656,6 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, ctrlClient.Create(ctx, tc.secretBefore))
 			t.Cleanup(func() {
@@ -990,7 +989,6 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, credential := range tc.credentials {
 				require.NoError(t, ctrlClient.Create(ctx, credential))
@@ -1359,7 +1357,6 @@ func createKongConsumers(ctx context.Context, t *testing.T, cl client.Client, co
 
 	errg := errgroup.Group{}
 	for i := 0; i < count; i++ {
-		i := i
 		errg.Go(func() error {
 			consumerName := fmt.Sprintf("background-noise-consumer-%d", i)
 

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -185,7 +185,6 @@ func TestCRDValidations(t *testing.T) {
 			name: "KongUpstreamPolicy - only one of spec.hashOn.(cookie|header|uriCapture|queryArg) can be set",
 			scenario: func(ctx context.Context, t *testing.T, ns string) {
 				for i, invalidHashOn := range generateInvalidHashOns() {
-					invalidHashOn := invalidHashOn
 					t.Run(fmt.Sprintf("invalidHashOn[%d]", i), func(t *testing.T) {
 						err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
 							HashOn: &invalidHashOn,
@@ -203,7 +202,6 @@ func TestCRDValidations(t *testing.T) {
 					return hashOn.Cookie != nil
 				})
 				for i, invalidHashOn := range invalidHashOns {
-					invalidHashOn := invalidHashOn
 					t.Run(fmt.Sprintf("invalidHashOn[%d]", i), func(t *testing.T) {
 						err := createKongUpstreamPolicy(ctx, ctrlClient, ns, kongv1beta1.KongUpstreamPolicySpec{
 							HashOnFallback: &invalidHashOn,
@@ -823,7 +821,6 @@ func TestCRDValidations(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ns := CreateNamespace(ctx, t, ctrlClient)
 			tc.scenario(ctx, t, ns.Name)

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -317,7 +317,6 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/envtest/manager_debugendpoints_test.go
+++ b/test/envtest/manager_debugendpoints_test.go
@@ -63,7 +63,6 @@ func TestDebugEndpoints(t *testing.T) {
 	}
 
 	for _, u := range urls {
-		u := u
 		t.Run(u.name, func(t *testing.T) {
 			url := fmt.Sprintf("http://localhost:%d/%s", u.port, u.name)
 			eventuallHTTPGet(t, http.DefaultClient, url, waitTime, tickTime)

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -105,7 +105,6 @@ func TestMetricsAreServed(t *testing.T) {
 			t.Logf("waiting for metrics to be available at %q", metricsURL)
 
 			for _, metric := range wantMetrics {
-				metric := metric
 				t.Run(metric, func(t *testing.T) {
 					require.NoError(t,
 						retry.Do(func() error {

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -84,7 +84,6 @@ func TestGatewayValidationWebhook(t *testing.T) {
 			wantCreateErr: false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotCreateErr := gatewayClient.GatewayV1().Gateways(ns.Name).Create(ctx, &tt.createdGW, metav1.CreateOptions{})
 			if tt.wantCreateErr {

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -86,14 +86,12 @@ func TestIngressRegexMatchPath(t *testing.T) {
 	cleaner.Add(service)
 
 	for i, tc := range testCases {
-		index := i
-		tc := tc
-		t.Run(fmt.Sprintf("case-%d: %s", index, tc.pathRegex), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case-%d: %s", i, tc.pathRegex), func(t *testing.T) {
 			t.Log("create an ingress")
 			ingress := &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns.Name,
-					Name:      "ingress-regex-path-" + strconv.Itoa(index),
+					Name:      "ingress-regex-path-" + strconv.Itoa(i),
 					Annotations: map[string]string{
 						"konghq.com/strip-path": "true",
 					},
@@ -179,14 +177,12 @@ func TestIngressRegexMatchHeader(t *testing.T) {
 	cleaner.Add(service)
 
 	for i, tc := range testCases {
-		index := i
-		tc := tc
-		t.Run(fmt.Sprintf("case-%d: %s", index, tc.headerRegex), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case-%d: %s", i, tc.headerRegex), func(t *testing.T) {
 			t.Log("create an ingress")
 			ingress := &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns.Name,
-					Name:      "ingress-regex-header-" + strconv.Itoa(index),
+					Name:      "ingress-regex-header-" + strconv.Itoa(i),
 					Annotations: map[string]string{
 						"konghq.com/strip-path":                                 "true",
 						"konghq.com/headers." + strings.ToLower(matchHeaderKey): headerRegexPrefix + tc.headerRegex,

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -250,7 +250,6 @@ func TestTranslationFailures(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/internal/helpers/controller_manager_flag_opts_test.go
+++ b/test/internal/helpers/controller_manager_flag_opts_test.go
@@ -34,7 +34,6 @@ func TestControllerManagerOptAdditionalWatchNamespace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actual := ControllerManagerOptAdditionalWatchNamespace(tt.ns)(tt.input)
 

--- a/test/kongintegration/expression_router_test.go
+++ b/test/kongintegration/expression_router_test.go
@@ -93,7 +93,6 @@ func TestExpressionsRouterMatchers_GenerateValidExpressions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			r := &kong.Route{
 				StripPath: kong.Bool(true),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Get rid of 

```log
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```

during execution of 

```
make lint
```

Since [Go 1.22](https://tip.golang.org/doc/go1.22#language) the weird behavior of variables in `for range` loops is no longer a problem.

