### PR TITLE
chore(deps): bump gateway-api from 1.1.0 to 1.2.0 and adjust code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+- Bump version of Gateway API to `1.2.0`.
+  [#6571](https://github.com/Kong/kubernetes-ingress-controller/pull/6571)
+
 ## [3.3.1]
 
 > Release date: 2024-08-28

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.22.7
+go 1.23
 
 toolchain go1.23.2
 
@@ -34,7 +34,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.15.0
 	github.com/kong/go-kong v0.59.1
-	github.com/kong/kubernetes-telemetry v0.1.5
+	github.com/kong/kubernetes-telemetry v0.1.7
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -61,7 +61,7 @@ require (
 	k8s.io/component-base v0.31.2
 	sigs.k8s.io/controller-runtime v0.19.1
 	sigs.k8s.io/e2e-framework v0.5.0
-	sigs.k8s.io/gateway-api v1.1.0
+	sigs.k8s.io/gateway-api v1.2.0
 	sigs.k8s.io/kustomize/api v0.18.0
 	sigs.k8s.io/kustomize/kyaml v0.18.1
 	sigs.k8s.io/yaml v1.4.0
@@ -99,7 +99,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
-	github.com/fatih/color v1.16.0 // indirect
+	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -144,7 +144,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/miekg/dns v1.1.58 // indirect
+	github.com/miekg/dns v1.1.62 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -201,7 +201,7 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
-	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0
@@ -209,7 +209,7 @@ require (
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
-	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
+	golang.org/x/tools v0.24.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwC
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
-github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
-github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -240,8 +240,8 @@ github.com/kong/go-database-reconciler v1.15.0 h1:5F5Zzp2H14aiDmqWUCaU4+LGR/lGnv
 github.com/kong/go-database-reconciler v1.15.0/go.mod h1:T5BkBw13PZWub3y2jKAoM7fYD+UmXp2iNqj1YqD0L90=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-telemetry v0.1.5 h1:xHwU1q0IvfEYqpj03po73ZKbVarnFPUwzkoFkdVnr9w=
-github.com/kong/kubernetes-telemetry v0.1.5/go.mod h1:1UXyZ6N3e8Fl6YguToQ6tKNveonkhjSqxzY7HVW+Ba4=
+github.com/kong/kubernetes-telemetry v0.1.7 h1:R4NUpvbF5uZ+5kgSQsIcf/oulRBGQCHsffFRDE4wxV4=
+github.com/kong/kubernetes-telemetry v0.1.7/go.mod h1:USy5pcD1+Mm9NtKuz3Pb/rSx71VN76gHCFhdbAB4/lg=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=
 github.com/kong/kubernetes-testing-framework v0.47.2/go.mod h1:DJ5btl/srdIM03tg3f+jS9Izu7xkRkciAM69Ptqun1I=
 github.com/kong/semver/v4 v4.0.1 h1:DIcNR8W3gfx0KabFBADPalxxsp+q/5COwIFkkhrFQ2Y=
@@ -272,8 +272,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
-github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
+github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
+github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -478,8 +478,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
+golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -541,8 +541,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
+golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -626,8 +626,8 @@ sigs.k8s.io/controller-runtime v0.19.1 h1:Son+Q40+Be3QWb+niBXAg2vFiYWolDjjRfO8hn
 sigs.k8s.io/controller-runtime v0.19.1/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
 sigs.k8s.io/e2e-framework v0.5.0 h1:YLhk8R7EHuTFQAe6Fxy5eBzn5Vb+yamR5u8MH1Rq3cE=
 sigs.k8s.io/e2e-framework v0.5.0/go.mod h1:jJSH8u2RNmruekUZgHAtmRjb5Wj67GErli9UjLSY7Zc=
-sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
-sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
+sigs.k8s.io/gateway-api v1.2.0 h1:LrToiFwtqKTKZcZtoQPTuo3FxhrrhTgzQG0Te+YGSo8=
+sigs.k8s.io/gateway-api v1.2.0/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.24.0 h1:g4y4eu0qa+SCeKESLpESgMmVFBebL0BDa6f777OIWrg=

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -160,15 +160,21 @@ func methodMatcherFromGRPCRegexMethodMatch(service *string, method *string) atc.
 }
 
 func headerMatcherFromGRPCHeaderMatches(headerMatches []gatewayapi.GRPCHeaderMatch) atc.Matcher {
-	// sort headerMatches by names to generate a stable output.
-	sort.Slice(headerMatches, func(i, j int) bool {
+	// Sort headerMatches by names to generate a stable output.
+	sort.SliceStable(headerMatches, func(i, j int) bool {
 		return string(headerMatches[i].Name) < string(headerMatches[j].Name)
 	})
 
 	matchers := make([]atc.Matcher, 0, len(headerMatches))
 	for _, headerMatch := range headerMatches {
+		// For GRPC and HTTP code is common,
+		// due too limitations of generics in Go converting seems to be the best option.
+		var hmt *gatewayapi.HeaderMatchType
+		if headerMatch.Type != nil {
+			hmt = lo.ToPtr(gatewayapi.HeaderMatchType(*headerMatch.Type))
+		}
 		httpHeaderMatch := gatewayapi.HTTPHeaderMatch{
-			Type:  headerMatch.Type,
+			Type:  hmt,
 			Name:  gatewayapi.HTTPHeaderName(headerMatch.Name),
 			Value: headerMatch.Value,
 		}

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -565,12 +565,12 @@ func TestCalculateSplitGRCPRoutePriorityTraits(t *testing.T) {
 				Match: gatewayapi.GRPCRouteMatch{
 					Headers: []gatewayapi.GRPCHeaderMatch{
 						{
-							Type:  lo.ToPtr(gatewayapi.HeaderMatchExact),
+							Type:  lo.ToPtr(gatewayapi.GRPCHeaderMatchExact),
 							Name:  gatewayapi.GRPCHeaderName("key1"),
 							Value: "value1",
 						},
 						{
-							Type:  lo.ToPtr(gatewayapi.HeaderMatchExact),
+							Type:  lo.ToPtr(gatewayapi.GRPCHeaderMatchExact),
 							Name:  gatewayapi.GRPCHeaderName("key2"),
 							Value: "value2",
 						},

--- a/internal/gatewayapi/aliases.go
+++ b/internal/gatewayapi/aliases.go
@@ -33,6 +33,7 @@ type (
 	GatewayStatusAddress      = gatewayv1.GatewayStatusAddress
 	GatewayTLSConfig          = gatewayv1.GatewayTLSConfig
 	Group                     = gatewayv1.Group
+	HeaderMatchType           = gatewayv1.HeaderMatchType
 	HTTPBackendRef            = gatewayv1.HTTPBackendRef
 	HTTPHeader                = gatewayv1.HTTPHeader
 	HTTPHeaderFilter          = gatewayv1.HTTPHeaderFilter
@@ -82,6 +83,7 @@ type (
 	GRPCBackendRef            = gatewayv1.GRPCBackendRef
 	GRPCHeaderMatch           = gatewayv1.GRPCHeaderMatch
 	GRPCHeaderName            = gatewayv1.GRPCHeaderName
+	GRPCHeaderMatchType       = gatewayv1.GRPCHeaderMatchType
 	GRPCMethodMatch           = gatewayv1.GRPCMethodMatch
 	GRPCMethodMatchType       = gatewayv1.GRPCMethodMatchType
 	GRPCRoute                 = gatewayv1.GRPCRoute
@@ -132,6 +134,9 @@ const (
 	HTTPSProtocolType                     = gatewayv1.HTTPSProtocolType
 	HeaderMatchExact                      = gatewayv1.HeaderMatchExact
 	HeaderMatchRegularExpression          = gatewayv1.HeaderMatchRegularExpression
+	GRPCHeaderMatchExact                  = gatewayv1.GRPCHeaderMatchExact
+	GRPCMethodMatchExact                  = gatewayv1.GRPCMethodMatchExact
+	GRPCMethodMatchRegularExpression      = gatewayv1.GRPCMethodMatchRegularExpression
 	HostnameAddressType                   = gatewayv1.HostnameAddressType
 	IPAddressType                         = gatewayv1.IPAddressType
 	ListenerConditionAccepted             = gatewayv1.ListenerConditionAccepted
@@ -173,9 +178,6 @@ const (
 	TLSModeTerminate                      = gatewayv1.TLSModeTerminate
 	TLSProtocolType                       = gatewayv1.TLSProtocolType
 	UDPProtocolType                       = gatewayv1.UDPProtocolType
-
-	GRPCMethodMatchExact             = gatewayv1.GRPCMethodMatchExact
-	GRPCMethodMatchRegularExpression = gatewayv1.GRPCMethodMatchRegularExpression
 
 	PolicyConditionAccepted = gatewayv1alpha2.PolicyConditionAccepted
 	PolicyReasonAccepted    = gatewayv1alpha2.PolicyReasonAccepted

--- a/test/conformance/gateway_conformance_test.go
+++ b/test/conformance/gateway_conformance_test.go
@@ -41,7 +41,7 @@ var skippedTestsForExpressionRoutes = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 }
 
-var traditionalRoutesSupportedFeatures = []features.SupportedFeature{
+var traditionalRoutesSupportedFeatures = []features.FeatureName{
 	// core features
 	features.SupportGateway,
 	features.SupportHTTPRoute,
@@ -55,7 +55,7 @@ var traditionalRoutesSupportedFeatures = []features.SupportedFeature{
 	// suite.SupportHTTPRouteBackendTimeout,
 }
 
-var expressionRoutesSupportedFeatures = []features.SupportedFeature{
+var expressionRoutesSupportedFeatures = []features.FeatureName{
 	// core features
 	features.SupportGateway,
 	features.SupportHTTPRoute,
@@ -78,7 +78,7 @@ func TestGatewayConformance(t *testing.T) {
 	// traditional_compatible and expressions.
 	var (
 		skippedTests      []string
-		supportedFeatures []features.SupportedFeature
+		supportedFeatures []features.FeatureName
 		mode              string
 	)
 	switch rf := testenv.KongRouterFlavor(); rf {

--- a/test/consts/zz_generated_gateway.go
+++ b/test/consts/zz_generated_gateway.go
@@ -4,9 +4,9 @@
 package consts
 
 const (
-	GatewayAPIVersion                   = "v1.1.0"
-	GatewayAPIPackageVersion            = "v1.1.0"
-	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.1.0"
-	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0"
-	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0"
+	GatewayAPIVersion                   = "v1.2.0"
+	GatewayAPIPackageVersion            = "v1.2.0"
+	GatewayStandardCRDsKustomizeURL     = "github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.2.0"
+	GatewayExperimentalCRDsKustomizeURL = "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.2.0"
+	GatewayRawRepoURL                   = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Bumps version of `gateway-api` from `1.1.0` to `1.2.0` and makes required adjustments to make code compile and test pass (bump KTF to [v0.1.7](https://github.com/Kong/kubernetes-telemetry/releases/tag/v0.1.7)).

Furthermore, change the sorting of `headerMatches` by names from `slice.Sort` to `slice.StableSort` to fulfill the code commenter's desire always to have the same order. Bumping the Go version to `1.23` is required to make linitng pass.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Replaces https://github.com/Kong/kubernetes-ingress-controller/pull/6543

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
