### PR TITLE
chore: cover credentials in KongClient golden tests

### DIFF
--- a/internal/dataplane/testdata/golden/credentials/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/credentials/default_golden.yaml
@@ -1,0 +1,47 @@
+_format_version: "3.0"
+consumers:
+- acls:
+  - group: group
+    tags:
+    - k8s-name:consumer-acl
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+  basicauth_credentials:
+  - password: consumer-1-password
+    tags:
+    - k8s-name:consumer-basic-auth
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+    username: consumer-1
+  hmacauth_credentials:
+  - tags:
+    - k8s-name:consumer-hmac-auth
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+    username: consumer-1
+  id: 7deb6e70-60be-5dd2-b374-06551479ea5e
+  jwt_secrets:
+  - algorithm: HS256
+    key: key
+    tags:
+    - k8s-name:consumer-jwt
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+  keyauth_credentials:
+  - key: key
+    tags:
+    - k8s-name:consumer-key-auth
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+  tags:
+  - k8s-name:consumer
+  - k8s-namespace:default
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+  username: consumer

--- a/internal/dataplane/testdata/golden/credentials/in.yaml
+++ b/internal/dataplane/testdata/golden/credentials/in.yaml
@@ -1,0 +1,65 @@
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: consumer
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: kong
+username: consumer
+credentials:
+  - consumer-basic-auth
+  - consumer-key-auth
+  - consumer-hmac-auth
+  - consumer-jwt
+  - consumer-acl
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-key-auth
+  namespace: default
+  labels:
+    konghq.com/credential: key-auth
+data:
+  key: "a2V5"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-basic-auth
+  namespace: default
+  labels:
+    konghq.com/credential: basic-auth
+data:
+  username: "Y29uc3VtZXItMQ=="
+  password: "Y29uc3VtZXItMS1wYXNzd29yZA=="
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-hmac-auth
+  namespace: default
+  labels:
+    konghq.com/credential: hmac-auth
+data:
+  username: "Y29uc3VtZXItMQ=="
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-jwt
+  namespace: default
+  labels:
+    konghq.com/credential: jwt
+data:
+  key: "a2V5"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-acl
+  namespace: default
+  labels:
+    konghq.com/credential: acl
+data:
+  group: "Z3JvdXA="


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/Kong/kubernetes-ingress-controller/issues/6574 we suspected KIC doesn't set Kubernetes metadata tags for credential entities. This PR proves it's not the case by adding a KongClient golden test case that covers all credential types.

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6574. 

