### PR TITLE
chore(tests): migrate TestExampleTCPRoute and TestIngressExample to isolated

### DIFF
--- a/examples/gateway-tcproute.yaml
+++ b/examples/gateway-tcproute.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: kong
+  name: example-tcproute
   annotations:
     konghq.com/gatewayclass-unmanaged: "true"
 spec:
@@ -51,9 +51,9 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: kong
+  name: example-tcproute
 spec:
-  gatewayClassName: kong
+  gatewayClassName: example-tcproute
   listeners:
   - name: http
     protocol: HTTP
@@ -68,7 +68,7 @@ metadata:
   name: tcpecho
 spec:
   parentRefs:
-  - name: kong
+  - name: example-tcproute
   rules:
   - backendRefs:
     - name: tcpecho

--- a/test/integration/isolated/examples_ingress_test.go
+++ b/test/integration/isolated/examples_ingress_test.go
@@ -1,0 +1,70 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestIngressExample(t *testing.T) {
+	ingressExampleManifests := examplesManifestPath("ingress.yaml")
+
+	replaceIngressClassAnnotationInManifests := func(manifests string, ingressClass string) string {
+		return strings.ReplaceAll(manifests, "ingressClassName: kong", fmt.Sprintf("ingressClassName: %s", ingressClass))
+	}
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyIngress).
+		WithLabel(testlabels.Kind, testlabels.KindIngress).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
+		)).
+		Assess("deploying to cluster works and HTTP traffic is routed to the service",
+			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+				cluster := GetClusterFromCtx(ctx)
+				proxyURL := GetHTTPURLFromCtx(ctx)
+
+				t.Logf("applying yaml manifest %s", ingressExampleManifests)
+				b, err := os.ReadFile(ingressExampleManifests)
+				assert.NoError(t, err)
+				manifest := replaceIngressClassAnnotationInManifests(string(b), GetIngressClassFromCtx(ctx))
+				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, manifest))
+				cleaner.AddManifest(manifest)
+
+				t.Logf("verifying that the Ingress routes traffic properly")
+				helpers.EventuallyGETPath(
+					t,
+					proxyURL,
+					proxyURL.Host,
+					"/",
+					nil,
+					http.StatusOK,
+					"<title>httpbin.org</title>",
+					nil,
+					consts.IngressWait,
+					consts.WaitTick,
+				)
+
+				return ctx
+			}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}

--- a/test/integration/isolated/examples_tcproute_test.go
+++ b/test/integration/isolated/examples_tcproute_test.go
@@ -16,34 +16,34 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
 )
 
-func TestExampleUDPRoute(t *testing.T) {
-	udpRouteExampleManifests := examplesManifestPath("gateway-udproute.yaml")
+func TestExampleTCPRoute(t *testing.T) {
+	tcpRouteExampleManifests := examplesManifestPath("gateway-tcproute.yaml")
 
 	f := features.
 		New("example").
 		WithLabel(testlabels.Example, testlabels.ExampleTrue).
 		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyGatewayAPI).
-		WithLabel(testlabels.Kind, testlabels.KindUDPRoute).
+		WithLabel(testlabels.Kind, testlabels.KindTCPRoute).
 		Setup(SkipIfRouterNotExpressions).
 		WithSetup("deploy kong addon into cluster", featureSetup(
 			withControllerManagerOpts(helpers.ControllerManagerOptAdditionalWatchNamespace("default")),
 		)).
-		Assess("deploying to cluster works and udp traffic is routed to the service",
+		Assess("deploying to cluster works and tcp traffic is routed to the service",
 			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
 				cluster := GetClusterFromCtx(ctx)
-				proxyUDPURL := GetUDPURLFromCtx(ctx)
+				proxyTCPURL := GetTCPURLFromCtx(ctx)
 
-				t.Logf("applying yaml manifest %s", udpRouteExampleManifests)
-				b, err := os.ReadFile(udpRouteExampleManifests)
+				t.Logf("applying yaml manifest %s", tcpRouteExampleManifests)
+				b, err := os.ReadFile(tcpRouteExampleManifests)
 				assert.NoError(t, err)
 
 				s := string(b)
 				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, s))
 				cleaner.AddManifest(s)
 
-				t.Logf("verifying that the UDPRoute becomes routable")
-				assertEventuallyResponseUDP(t, proxyUDPURL, "udproute-example-manifest")
+				t.Logf("verifying that the TCPRoute becomes routable")
+				assertEventuallyResponseTCP(t, proxyTCPURL, "tcproute-example-manifest")
 
 				return ctx
 			}).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

All integration tests should be migrated to isolated one (furthermore we want to get rid of those two mutexes), this PR migrates
- `TestExampleTCPRoute`
- `TestIngressExample`

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5757

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
