### PR TITLE
chore(makefile): support setting path of staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ setup-envtest: mise ## Download setup-envtest locally if necessary.
 	@$(MAKE) mise-install DEP_VER=setup-envtest@$(SETUP_ENVTEST_VERSION)
 
 STATICCHECK_VERSION = $(shell yq -ojson -r '.staticcheck' < $(TOOLS_VERSIONS_FILE))
-STATICCHECK = $(PROJECT_DIR)/bin/installs/staticcheck/$(STATICCHECK_VERSION)/bin/staticcheck
+STATICCHECK ?= $(PROJECT_DIR)/bin/installs/staticcheck/$(STATICCHECK_VERSION)/bin/staticcheck
 .PHONY: staticcheck.download
 staticcheck.download: ## Download staticcheck locally if necessary.
 	@$(MAKE) mise-plugin-install DEP=staticcheck


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When I update golang to 1.23, `staticcheck` cannot run with the following errors:
```
 (0, 0)  compile  /home/yitao/go1.23/go/src/maps/iter.go:51:20: cannot range over seq (variable of type iter.Seq2[K, V])
  (0, 0)  compile  /home/yitao/go1.23/go/src/slices/iter.go:50:17: cannot range over seq (variable of type iter.Seq[E])
  (0, 0)  compile  module requires at least go1.22.7, but Staticcheck was built with go1.22.6
  (0, 0)  compile  module requires at least go1.23, but Staticcheck was built with go1.22.6
```
However, the makefile does not support setting path of `staticcheck` to use own version of `staticcheck` so I cannot run `make lint` correctly.
The PR supports specifying path of `staticcheck` by environment variable `STATICCHECK`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
