### PR TITLE
chore(ci): migrate actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
-          JUNIT_REPORT: conformance-tests.xml
+          JUNIT_REPORT: conformance-tests-${{ matrix.name }}.xml
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
           TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
 
@@ -74,5 +74,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: tests-report-conformance-${{ matrix.name }}
-          path: conformance-tests.xml
+          name: tests-report-conformance
+          path: conformance-tests-${{ matrix.name }}.xml

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -146,7 +146,7 @@ jobs:
             GOCACHE=${{ env.GOCACHE}}
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kic-image
           path: /tmp/image.tar

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kic-image
           path: /tmp
@@ -165,6 +165,8 @@ jobs:
         with:
           install: false
 
+      - run: echo "GOTESTSUM_JUNITFILE=e2e-kind-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml" >> $GITHUB_ENV
+
       - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
@@ -180,21 +182,26 @@ jobs:
           TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          GOTESTSUM_JUNITFILE: "e2e-${{ matrix.test }}${{ matrix.kubernetes-version }}-tests.xml"
+          GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
+
+      - run: |
+          if [ "${{ steps.split.outputs.kong-image }}" != "" ]; then
+            echo "KONG_IMAGE_ARTIFACT=kongimage-$( echo ${{ steps.split.outputs.kong-image }} | awk '{gsub(/[:.\/]/, "-")};$1' )-${{ steps.split.outputs.kong-tag }}" >> $GITHUB_ENV
+          fi
 
       - name: upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: "diagnostics-e2e-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
+          name: diagnostics-e2e-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}-${{ env.KONG_IMAGE_ARTIFACT }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
       - name: collect test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
-          path: "*-tests.xml"
+          name: tests-report-e2e-kind-${{ matrix.test }}-${{ matrix.kubernetes-version }}-${{ env.KONG_IMAGE_ARTIFACT }}
+          path: ${{ env.GOTESTSUM_JUNITFILE }}
 
   gke:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
@@ -261,6 +268,8 @@ jobs:
         with:
           install: false
 
+      - run: echo "GOTESTSUM_JUNITFILE=e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml" >> $GITHUB_ENV
+
       - name: run ${{ matrix.test }}
         run: make test.e2e
         env:
@@ -280,25 +289,36 @@ jobs:
           KONG_CLUSTER_VERSION: ${{ matrix.kubernetes-version }}
           KONG_CLUSTER_PROVIDER: gke
           E2E_TEST_RUN: ${{ matrix.test }}
-          GOTESTSUM_JUNITFILE: "e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-tests.xml"
+          GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
           TEST_GKE_CLUSTER_RELEASE_CHANNEL: "rapid"
 
+      - run: |
+          if [ "${{ steps.split.outputs.kong-image }}" != "" ]; then
+            echo "KONG_IMAGE_ARTIFACT=kongimage-$( echo ${{ steps.split.outputs.kong-image }} | awk '{gsub(/[:.\/]/, "-")};$1' )-${{ steps.split.outputs.kong-tag }}" >> $GITHUB_ENV
+          fi
+
       - name: upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: "diagnostics-e2e-gke-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}"
+          # NOTE: we add the kong image suffix here because actions/upload-artifact@v4
+          # only allows to have 1 artifact with the same name and we run this workflow
+          # in parallel for different kong images (specifically for nightly).
+          name: diagnostics-e2e-gke-tests-${{ matrix.test }}-${{ matrix.kubernetes-version }}-${{ env.KONG_IMAGE_ARTIFACT }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
       - name: collect test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
-          path: "*-tests.xml"
+          # NOTE: we add the kong image suffix here because actions/upload-artifact@v4
+          # only allows to have 1 artifact with the same name and we run this workflow
+          # in parallel for different kong images (specifically for nightly).
+          name: tests-report-e2e-gke-${{ matrix.test }}-${{ matrix.kubernetes-version }}-${{ env.KONG_IMAGE_ARTIFACT }}
+          path: ${{ env.GOTESTSUM_JUNITFILE }}
 
   istio:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
@@ -312,7 +332,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kic-image
           path: /tmp
@@ -361,6 +381,8 @@ jobs:
         with:
           install: false
 
+      - run: echo "GOTESTSUM_JUNITFILE=e2e-istio-${{ matrix.kind }}-${{ matrix.istio }}-tests.xml" >> $GITHUB_ENV
+
       - name: run Istio tests
         run: make test.istio
         env:
@@ -376,18 +398,29 @@ jobs:
           ISTIO_VERSION: ${{ matrix.istio }}
           NCPU: 1 # it was found that github actions (specifically) did not seem to perform well when spawning
           # multiple kind clusters within a single job, so only 1 is allowed at a time.
-          GOTESTSUM_JUNITFILE: "istio-${{ matrix.kubernetes-version }}-${{ matrix.istio-version }}-tests.xml"
+          GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
+
+      - run: |
+          if [ "${{ steps.split.outputs.kong-image }}" != "" ]; then
+            echo "KONG_IMAGE_ARTIFACT=kongimage-$( echo ${{ steps.split.outputs.kong-image }} | awk '{gsub(/[:.\/]/, "-")};$1' )-${{ steps.split.outputs.kong-tag }}" >> $GITHUB_ENV
+          fi
 
       - name: upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: diagnostics-e2e-tests
+          # NOTE: we add the kong image suffix here because actions/upload-artifact@v4
+          # only allows to have 1 artifact with the same name and we run this workflow
+          # in parallel for different kong images (specifically for nightly).
+          name: diagnostics-e2e-tests-istio-${{ matrix.kind }}-${{ matrix.istio }}-${{ env.KONG_IMAGE_ARTIFACT }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
       - name: collect test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
-          path: "*-tests.xml"
+          # NOTE: we add the kong image suffix here because actions/upload-artifact@v4
+          # only allows to have 1 artifact with the same name and we run this workflow
+          # in parallel for different kong images (specifically for nightly).
+          name: tests-report-e2e-istio-k8s-${{ matrix.kind }}-istio-${{ matrix.istio }}-${{ env.KONG_IMAGE_ARTIFACT }}
+          path: ${{ env.GOTESTSUM_JUNITFILE }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -206,7 +206,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.name }}
+          name: coverage-integration-${{ matrix.name }}
           path: coverage.*.out
 
       - name: upload diagnostics

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -47,12 +47,14 @@ jobs:
         with:
           install: false
 
+      - run: echo "GOTESTSUM_JUNITFILE=kongintegration-${{ matrix.name }}-tests.xml" >> $GITHUB_ENV
+
       - name: run kong integration tests
         run: make test.kongintegration
         env:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
-          GOTESTSUM_JUNITFILE: kongintegration-${{ matrix.name }}-tests.xml
+          GOTESTSUM_JUNITFILE: ${{ env.GOTESTSUM_JUNITFILE }}
           TEST_KONG_KONNECT_ACCESS_TOKEN: ${{ secrets.K8S_TEAM_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
@@ -61,11 +63,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-kongintegration-${{ matrix.name }}
-          path: "coverage.*.out"
+          path: coverage.*.out
 
       - name: collect test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report-kongintegration
-          path: kongintegration-tests.xml
+          name: tests-report-kongintegration-${{ matrix.name }}
+          path: ${{ env.GOTESTSUM_JUNITFILE }}

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kic-image
           path: /tmp
@@ -101,22 +101,22 @@ jobs:
 
       - name: upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: diagnostics-performance-tests
+          name: diagnostics-performance-tests-${{ matrix.resource-number }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
       - name: collect test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
+          name: tests-report-performance-${{ matrix.resource-number }}
           path: "*-tests.xml"
 
       - name: collect performance test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: performance-tests-results
+          name: performance-tests-results-${{ matrix.resource-number }}
           path: "/tmp/kic-perf/*.txt"
           if-no-files-found: ignore
 
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Download built image artifact
         if: ${{ inputs.load-local-image }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kic-image
           path: /tmp
@@ -190,21 +190,21 @@ jobs:
 
       - name: upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: diagnostics-performance-tests
+          name: diagnostics-performance-target-tests-${{ inputs.res-number-for-perf }}
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
       - name: collect test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tests-report
+          name: tests-report-performance-target-tests-${{ inputs.res-number-for-perf }}
           path: "*-tests.xml"
 
       - name: collect performance test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: performance-tests-results
+          name: performance-target-tests-results-${{ inputs.res-number-for-perf }}
           path: "/tmp/kic-perf/*.txt"
           if-no-files-found: ignore

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: collect test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-report-unit
           path: unit-tests.xml

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -60,7 +60,7 @@ jobs:
       # in future when experimental becomes stable autamate creating PR (add to release workflow).
       # See: https://github.com/Kong/kubernetes-ingress-controller/issues/4654
       - name: Collect conformance tests report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kong-kubernetes-ingress-controller.yaml
           path: kong-kubernetes-ingress-controller.yaml

--- a/.github/workflows/performance_nightly.yaml
+++ b/.github/workflows/performance_nightly.yaml
@@ -44,7 +44,7 @@ jobs:
           gem install youplot
 
       - name: download performance test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: performance-tests-results
           path: perf-results

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -104,7 +104,7 @@ jobs:
           gem install youplot
 
       - name: download performance test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: performance-tests-results
           path: perf-results

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -73,14 +73,14 @@ jobs:
 
 
     - name: collect test coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-integration-tests-enterprise-postgres-nightly
         path: coverage.enterprisepostgres.out
 
     - name: upload diagnostics
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: diagnostics-integration-tests-enterprise-postgres-nightly
         path: /tmp/ktf-diag*
@@ -116,14 +116,14 @@ jobs:
         TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
     - name: collect test coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-integration-tests-enterprise-dbless-nightly
         path: coverage.enterprisedbless.out
 
     - name: upload diagnostics
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: diagnostics-integration-tests-enterprise-dbless-nightly
         path: /tmp/ktf-diag*
@@ -150,14 +150,14 @@ jobs:
         TEST_KONG_EFFECTIVE_VERSION: ${{ env.kong-gateway-oss-effective-version }}
 
     - name: collect test coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-integration-tests-postgres-nightly
         path: coverage.postgres.out
 
     - name: upload diagnostics
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: diagnostics-integration-tests-postgres-nightly
         path: /tmp/ktf-diag*
@@ -185,14 +185,14 @@ jobs:
         TEST_KONG_EFFECTIVE_VERSION: ${{ env.kong-gateway-oss-effective-version }}
 
     - name: collect test coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-integration-tests-dbless-nightly
         path: coverage.dbless.out
 
     - name: upload diagnostics
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: diagnostics-integration-tests-dbless-nightly
         path: /tmp/ktf-diag*


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up from https://github.com/Kong/kubernetes-ingress-controller/pull/5843

Fixes #5357
