### PR TITLE
tests: fix data race in TestSpecificGatewayNN

### DIFF
--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -53,6 +53,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 
 	t.Run("configured specific gateway gets its listener status filled", func(t *testing.T) {
 		require.Eventually(t, func() bool {
+			var gw gatewayapi.Gateway
 			if err := ctrlClient.Get(ctx, nn, &gw); err != nil {
 				t.Logf("Failed to get gateway %s: %v", nn, err)
 				return false
@@ -93,6 +94,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	t.Run("not configured gateway does not gets its listener status filled and HTTPRoute attached to it doesn't get its status parent filled", func(t *testing.T) {
 		require.Never(t, func() bool {
 			t.Logf("Checking if Gateway %s is ignored (does not get status listeners filled)", nnIgnored)
+			var gwIgnored gatewayapi.Gateway
 			if err := ctrlClient.Get(ctx, nnIgnored, &gwIgnored); err != nil {
 				t.Logf("Failed to get gateway %s: %v", nnIgnored, err)
 				return true
@@ -134,6 +136,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 				return true
 			}
 
+			var gwIgnored gatewayapi.Gateway
 			t.Logf("Checking if Gateway %s is ignored (does not get status listeners filled)", nnIgnored)
 			if err := ctrlClient.Get(ctx, nnIgnored, &gwIgnored); err != nil {
 				t.Logf("Failed to get gateway %s: %v", nnIgnored, err)
@@ -164,6 +167,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 				return true
 			}
 
+			var gwIgnored gatewayapi.Gateway
 			t.Logf("Checking if Gateway %s is ignored (does not get status listeners filled)", gwIgnored.Name)
 			if err := ctrlClient.Get(ctx, nnIgnored, &gwIgnored); err != nil {
 				t.Logf("Failed to get gateway %s: %v", nnIgnored, err)
@@ -187,14 +191,14 @@ func TestSpecificGatewayNN(t *testing.T) {
 		refGrant := gatewayapi.ReferenceGrant{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "refgrant-1",
-				Namespace: gwIgnored.Namespace,
+				Namespace: nnIgnored.Namespace,
 			},
 			Spec: gatewayapi.ReferenceGrantSpec{
 				From: []gatewayapi.ReferenceGrantFrom{
 					{
 						Group:     gatewayapi.V1Group,
 						Kind:      "Gateway",
-						Namespace: gatewayapi.Namespace(gwIgnored.Namespace),
+						Namespace: gatewayapi.Namespace(nnIgnored.Namespace),
 					},
 				},
 				To: []gatewayapi.ReferenceGrantTo{
@@ -215,6 +219,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 				return true
 			}
 
+			var gwIgnored gatewayapi.Gateway
 			t.Logf("Checking if Gateway %s is ignored (does not get status listeners filled)", nnIgnored)
 			if err := ctrlClient.Get(ctx, nnIgnored, &gwIgnored); err != nil {
 				t.Logf("Failed to get gateway %s: %v", nnIgnored, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a data race detected in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11691112734/job/32557672213?pr=6620

```
==================
  WARNING: DATA RACE
  Write at 0x00c002944830 by goroutine 21544:
    reflect.Value.SetString()
        /opt/hostedtoolcache/go/1.23.2/x64/src/reflect/value.go:2516 +0x87
    sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:1070 +0x108e
    sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:415 +0x224
    sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0x1993
    sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0xae
    sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).unmarshal()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:188 +0x2a5
    sigs.k8s.io/json/internal/golang/encoding/json.Unmarshal()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:113 +0x2d9
    sigs.k8s.io/json.UnmarshalCaseSensitivePreserveInts()
        /home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/json.go:62 +0x25b
    k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).unmarshal()
        /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/runtime/serializer/json/json.go:258 +0x1ad
    k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode()
        /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/runtime/serializer/json/json.go:206 +0x9af
    sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Get()
        /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/client/typed_client.go:147 +0x524
    sigs.k8s.io/controller-runtime/pkg/client.(*client).Get()
        /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/client/client.go:351 +0x350
    github.com/kong/kubernetes-ingress-controller/v3/test/envtest.TestSpecificGatewayNN.func4.1()
        /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/envtest/specific_gateway_envtest_test.go:138 +0x58d
    github.com/stretchr/testify/assert.Never.func1()
        /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:2019 +0x33
  
  Goroutine 21544 (running) created at:
    github.com/stretchr/testify/assert.Never()
        /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:2019 +0x3d5
    github.com/stretchr/testify/require.Never()
        /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/require/require.go:1274 +0xd1
    github.com/kong/kubernetes-ingress-controller/v3/test/envtest.TestSpecificGatewayNN.func5()
        /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/envtest/specific_gateway_envtest_test.go:158 +0x2fd
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1743 +0x44
  
  Goroutine 21500 (finished) created at:
    github.com/stretchr/testify/assert.Never()
        /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:2019 +0x3d5
    github.com/stretchr/testify/require.Never()
        /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/require/require.go:1274 +0xd1
    github.com/kong/kubernetes-ingress-controller/v3/test/envtest.TestSpecificGatewayNN.func4()
        /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/envtest/specific_gateway_envtest_test.go:129 +0x2a9
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1743 +0x44
  ==================
```
