### PR TITLE
fix: annotation konghq.com/rewrite always works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,17 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
+### Changed
+
 - Bump version of Gateway API to `1.2.0`.
   [#6571](https://github.com/Kong/kubernetes-ingress-controller/pull/6571)
+
+### Fixed
+
+- Fixed annotation `konghq.com/rewrite` that was not being applied sometimes
+  when `Ingress` without annotation and a different `Ingress` with annotation
+  pointed to the same `Service`.
+  [#6569](https://github.com/Kong/kubernetes-ingress-controller/pull/6626)
 
 ## [3.3.1]
 

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -3,6 +3,7 @@ package subtranslator
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -235,7 +236,9 @@ func (i *ingressTranslationIndex) Translate() map[string]kongstate.Service {
 			route := meta.translateIntoKongRoute()
 			kongStateService.Routes = append(kongStateService.Routes, *route)
 		}
-
+		sort.SliceStable(kongStateService.Routes, func(i, j int) bool {
+			return *kongStateService.Routes[i].Name < *kongStateService.Routes[j].Name
+		})
 		kongStateServiceCache[kongServiceName] = kongStateService
 	}
 
@@ -651,7 +654,6 @@ func MaybeRewriteURI(service *kongstate.Service, rewriteURIEnable bool) error {
 				},
 			},
 		})
-
 	}
 	return nil
 }

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -632,12 +632,11 @@ func MaybeRewriteURI(service *kongstate.Service, rewriteURIEnable bool) error {
 
 		rewriteURI, exists := annotations.ExtractRewriteURI(route.Ingress.Annotations)
 		if !exists {
-			return nil
+			continue
 		}
 		if !rewriteURIEnable {
 			return fmt.Errorf("konghq.com/rewrite annotation not supported when rewrite uris disabled")
 		}
-
 		if rewriteURI == "" {
 			rewriteURI = "/"
 		}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -1092,9 +1092,7 @@ func TestIngressRewriteURI(t *testing.T) {
 
 	t.Logf("creating an Ingress for service %s without rewrite annotation", service.Name)
 	const serviceDomainDirect = "direct.example"
-	ingressDirect := generators.NewIngressForService("/", map[string]string{
-		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
-	}, service)
+	ingressDirect := generators.NewIngressForService("/", nil, service)
 	ingressDirect.Name += "-direct"
 	ingressDirect.Spec.IngressClassName = kong.String(consts.IngressClass)
 	for i := range ingressDirect.Spec.Rules {
@@ -1165,7 +1163,6 @@ func TestIngressRewriteURI(t *testing.T) {
 	t.Logf("creating an Ingress for service %s with rewrite annotation", service.Name)
 	const serviceDomainRewrite = "rewrite.example"
 	ingressRewrite := generators.NewIngressForService("/~/foo/(.*)", map[string]string{
-		annotations.AnnotationPrefix + annotations.StripPathKey:  "true",
 		annotations.AnnotationPrefix + annotations.RewriteURIKey: "/image/$1",
 	}, service)
 	ingressRewrite.Name += "-rewrite"
@@ -1177,8 +1174,6 @@ func TestIngressRewriteURI(t *testing.T) {
 	ingressRewrite, err = env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Create(ctx, ingressRewrite, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(ingressRewrite)
-
-	t.Log("rewrite uri feature is enabled")
 
 	t.Log("try to access the ingress with valid capture group")
 	helpers.EventuallyGETPath(t, proxyHTTPURL, serviceDomainRewrite, "/foo/jpeg", nil, http.StatusOK, consts.JPEGMagicNumber, nil, ingressWait, waitTick)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fixes bug reported by user description of the problem and steps to reproduce it robustly are here https://github.com/Kong/kubernetes-ingress-controller/issues/6542#issuecomment-2459793831

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6542
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.


-->

**Special notes for your reviewer**:

This feature was covered with a quite complicated integration test `TestIngressRewriteURI` designed to catch exactly such a bug, but it failed to do so. Why?

- https://github.com/Kong/kubernetes-ingress-controller/pull/6626/commits/8e5f88370d3bc941f0fcc491c75ab58e78842dcc
Changes in the test have no effect (it's just an opportunistic cleanup not to have redundant stuff). The bug was hard to catch due to the order of items in the Go map during iteration - it's random and it even may be [randomized for each iteration](https://go.dev/blog/maps#iteration-order). Hence this commit always enforces the same order for defined routes by sorting them (IMHO KIC should always operate in a consistent and reproducible manner so paying the cost of sorting is worth it). This change leads to the [consistent failure](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11728331106/job/32671606201?pr=6626#step:7:577) of the test `TestIngressRewriteURI` as it is supposed to be.

- https://github.com/Kong/kubernetes-ingress-controller/pull/6626/commits/6898b9c3c957d0e94f9bcadab1f28ba340f6224d
Actual one-line fix `return` -> `continue` to not ignore a rewrite annotation that is not attached to the first item in a list. It resolves the problem (as I said even without changes from the first commit).


<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
