### PR TITLE
chore: generate api docs from kubernetes-configuration repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ gotestsum: ## Download gotestsum locally if necessary.
 	@$(MAKE) mise-install DEP_VER=gotestsum@$(GOTESTSUM_VERSION)
 
 CRD_REF_DOCS_VERSION = $(shell yq -ojson -r '.crd-ref-docs' < $(TOOLS_VERSIONS_FILE))
-CRD_REF_DOCS = $(PROJECT_DIR)/bin/installs/go-github-com-elastic-crd-ref-docs/$(CRD_REF_DOCS_VERSION)/bin/crd-ref-docs
+CRD_REF_DOCS = $(PROJECT_DIR)/bin/installs/go-github.com-elastic-crd-ref-docs/$(CRD_REF_DOCS_VERSION)/bin/crd-ref-docs
 .PHONY: crd-ref-docs
 crd-ref-docs: ## Download crd-ref-docs locally if necessary.
 	$(MAKE) mise-install DEP_VER=go:github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ gotestsum: ## Download gotestsum locally if necessary.
 	@$(MAKE) mise-install DEP_VER=gotestsum@$(GOTESTSUM_VERSION)
 
 CRD_REF_DOCS_VERSION = $(shell yq -ojson -r '.crd-ref-docs' < $(TOOLS_VERSIONS_FILE))
-CRD_REF_DOCS = $(PROJECT_DIR)/bin/installs/go-github.com-elastic-crd-ref-docs/$(CRD_REF_DOCS_VERSION)/bin/crd-ref-docs
+CRD_REF_DOCS = $(PROJECT_DIR)/bin/installs/go-github-com-elastic-crd-ref-docs/$(CRD_REF_DOCS_VERSION)/bin/crd-ref-docs
 .PHONY: crd-ref-docs
 crd-ref-docs: ## Download crd-ref-docs locally if necessary.
 	$(MAKE) mise-install DEP_VER=go:github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,10 +25,10 @@ KongClusterPlugin is the Schema for the kongclusterplugins API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongClusterPlugin`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `consumerRef` _string_ | ConsumerRef is a reference to a particular consumer. |
 | `disabled` _boolean_ | Disabled set if the plugin is disabled or not. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
 | `configFrom` _[NamespacedConfigSource](#namespacedconfigsource)_ | ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
 | `configPatches` _[NamespacedConfigPatch](#namespacedconfigpatch) array_ | ConfigPatches represents JSON patches to the configuration of the plugin. Each item means a JSON patch to add something in the configuration, where path is specified in `path` and value is in `valueFrom` referencing a key in a secret. When Config is specified, patches will be applied to the configuration in Config. Otherwise, patches will be applied to an empty object. |
 | `plugin` _string_ | PluginName is the name of the plugin to which to apply the config. |
@@ -50,11 +50,12 @@ KongConsumer is the Schema for the kongconsumers API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongConsumer`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `username` _string_ | Username is a Kong cluster-unique username of the consumer. |
 | `custom_id` _string_ | CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping Kong with users in your existing database. |
 | `credentials` _string array_ | Credentials are references to secrets containing a credential to be provisioned in Kong. |
 | `consumerGroups` _string array_ | ConsumerGroups are references to consumer groups (that consumer wants to be part of) provisioned in Kong. |
+| `spec` _[KongConsumerSpec](#kongconsumerspec)_ |  |
 
 
 
@@ -69,7 +70,7 @@ KongIngress is the Schema for the kongingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `upstream` _[KongIngressUpstream](#kongingressupstream)_ | Upstream represents a virtual hostname and can be used to loadbalance incoming requests over multiple targets (e.g. Kubernetes `Services` can be a target, OR `Endpoints` can be targets). |
 | `proxy` _[KongIngressService](#kongingressservice)_ | Proxy defines additional connection options for the routes to be configured in the Kong Gateway, e.g. `connection_timeout`, `retries`, etc. |
 | `route` _[KongIngressRoute](#kongingressroute)_ | Route define rules to match client requests. Each Route is associated with a Service, and a Service may have multiple Routes associated to it. |
@@ -87,10 +88,10 @@ KongPlugin is the Schema for the kongplugins API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongPlugin`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `consumerRef` _string_ | ConsumerRef is a reference to a particular consumer. |
 | `disabled` _boolean_ | Disabled set if the plugin is disabled or not. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
 | `configFrom` _[ConfigSource](#configsource)_ | ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
 | `configPatches` _[ConfigPatch](#configpatch) array_ | ConfigPatches represents JSON patches to the configuration of the plugin. Each item means a JSON patch to add something in the configuration, where path is specified in `path` and value is in `valueFrom` referencing a key in a secret. When Config is specified, patches will be applied to the configuration in Config. Otherwise, patches will be applied to an empty object. |
 | `plugin` _string_ | PluginName is the name of the plugin to which to apply the config. |
@@ -143,6 +144,22 @@ _Appears in:_
 - [KongPlugin](#kongplugin)
 
 
+
+#### KongConsumerSpec
+
+
+KongConsumerSpec defines the specification of the KongConsumer.
+
+
+
+| Field | Description |
+| --- | --- |
+| `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane this Consumer is associated with. |
+| `tags` _[Tags](#tags)_ | Tags is an optional set of tags applied to the consumer. |
+
+
+_Appears in:_
+- [KongConsumer](#kongconsumer)
 
 
 
@@ -327,8 +344,15 @@ IngressClassParameters is the Schema for the IngressClassParameters API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `IngressClassParameters`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[IngressClassParametersSpec](#ingressclassparametersspec)_ | Spec is the IngressClassParameters specification. |
+
+
+
+
+
+
+
 
 
 
@@ -343,8 +367,11 @@ KongCustomEntity defines a "custom" Kong entity that KIC cannot support the enti
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongCustomEntity`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongCustomEntitySpec](#kongcustomentityspec)_ |  |
+
+
+
 
 
 
@@ -359,9 +386,15 @@ KongLicense stores a Kong enterprise license to apply to managed Kong gateway in
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongLicense`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `rawLicenseString` _string_ | RawLicenseString is a string with the raw content of the license. |
 | `enabled` _boolean_ | Enabled is set to true to let controllers (like KIC or KGO) to reconcile it. Default value is true to apply the license by default. |
+
+
+
+
+
+
 
 
 
@@ -378,7 +411,7 @@ See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongVault`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongVaultSpec](#kongvaultspec)_ |  |
 
 
@@ -389,7 +422,7 @@ In this section you will find types that the CRDs rely on.
 #### ControllerReference
 
 
-
+ControllerReference is a reference to a controller that reconciles the KongLicense.
 
 
 
@@ -404,23 +437,10 @@ In this section you will find types that the CRDs rely on.
 _Appears in:_
 - [KongLicenseControllerStatus](#konglicensecontrollerstatus)
 
-#### Group
-_Underlying type:_ `string`
-
-Group refers to a Kubernetes Group. It must either be an empty string or a
-RFC 1123 subdomain.
-
-
-
-
-
-_Appears in:_
-- [ControllerReference](#controllerreference)
-
 #### IngressClassParametersSpec
 
 
-
+IngressClassParametersSpec defines the desired state of IngressClassParameters.
 
 
 
@@ -433,59 +453,23 @@ _Appears in:_
 _Appears in:_
 - [IngressClassParameters](#ingressclassparameters)
 
-#### Kind
-_Underlying type:_ `string`
-
-Kind refers to a Kubernetes kind.
-
-
-
-
-
-_Appears in:_
-- [ControllerReference](#controllerreference)
-
 #### KongCustomEntitySpec
 
 
-
+KongCustomEntitySpec defines the specification of the KongCustomEntity.
 
 
 
 | Field | Description |
 | --- | --- |
 | `type` _string_ | EntityType is the type of the Kong entity. The type is used in generating declarative configuration. |
-| `fields` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ | Fields defines the fields of the Kong entity itself. |
+| `fields` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Fields defines the fields of the Kong entity itself. |
 | `controllerName` _string_ | ControllerName specifies the controller that should reconcile it, like ingress class. |
 | `parentRef` _[ObjectReference](#objectreference)_ | ParentRef references the kubernetes resource it attached to when its scope is "attached". Currently only KongPlugin/KongClusterPlugin allowed. This will make the custom entity to be attached to the entity(service/route/consumer) where the plugin is attached. |
 
 
 _Appears in:_
 - [KongCustomEntity](#kongcustomentity)
-
-
-
-
-
-#### KongLicenseControllerStatus
-
-
-KongLicenseControllerStatus is the status of owning KongLicense being processed
-identified by the controllerName field.
-
-
-
-| Field | Description |
-| --- | --- |
-| `controllerName` _string_ | ControllerName is an identifier of the controller to reconcile this KongLicense. Should be unique in the list of controller statuses. |
-| `controllerRef` _[ControllerReference](#controllerreference)_ | ControllerRef is the reference of the controller to reconcile this KongLicense. It is usually the name of (KIC/KGO) pod that reconciles it. |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#condition-v1-meta) array_ | Conditions describe the current conditions of the KongLicense on the controller. |
-
-
-_Appears in:_
-- [KongLicenseStatus](#konglicensestatus)
-
-
 
 
 
@@ -501,25 +485,15 @@ KongVaultSpec defines specification of a custom Kong vault.
 | `backend` _string_ | Backend is the type of the backend storing the secrets in the vault. The supported backends of Kong is listed here: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/ |
 | `prefix` _string_ | Prefix is the prefix of vault URI for referencing values in the vault. It is immutable after created. |
 | `description` _string_ | Description is the additional information about the vault. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#json-v1-apiextensions-k8s-io)_ | Config is the configuration of the vault. Varies for different backends. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config is the configuration of the vault. Varies for different backends. |
+| `tags` _[Tags](#tags)_ | Tags are the tags associated to the vault for grouping and filtering. |
+| `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a Konnect ControlPlane this KongVault is associated with. |
 
 
 _Appears in:_
 - [KongVault](#kongvault)
 
 
-
-#### Namespace
-_Underlying type:_ `string`
-
-Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
-
-
-
-
-
-_Appears in:_
-- [ControllerReference](#controllerreference)
 
 #### ObjectName
 _Underlying type:_ `string`
@@ -573,7 +547,8 @@ KongConsumerGroup is the Schema for the kongconsumergroups API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `KongConsumerGroup`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[KongConsumerGroupSpec](#kongconsumergroupspec)_ |  |
 
 
 
@@ -600,7 +575,7 @@ used instead. This is to allow reusing the same KongUpstreamPolicy for multiple 
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `KongUpstreamPolicy`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongUpstreamPolicySpec](#kongupstreampolicyspec)_ | Spec contains the configuration of the Kong upstream. |
 
 
@@ -616,7 +591,7 @@ TCPIngress is the Schema for the tcpingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `TCPIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[TCPIngressSpec](#tcpingressspec)_ | Spec is the TCPIngress specification. |
 
 
@@ -632,7 +607,7 @@ UDPIngress is the Schema for the udpingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `UDPIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[UDPIngressSpec](#udpingressspec)_ | Spec is the UDPIngress specification. |
 
 
@@ -716,6 +691,23 @@ IngressTLS describes the transport layer security.
 
 _Appears in:_
 - [TCPIngressSpec](#tcpingressspec)
+
+#### KongConsumerGroupSpec
+
+
+KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
+
+
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ | Name is the name of the ConsumerGroup in Kong. |
+| `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane this ConsumerGroup is associated with. |
+| `tags` _[Tags](#tags)_ | Tags is an optional set of tags applied to the ConsumerGroup. |
+
+
+_Appears in:_
+- [KongConsumerGroup](#kongconsumergroup)
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,10 +25,10 @@ KongClusterPlugin is the Schema for the kongclusterplugins API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongClusterPlugin`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `consumerRef` _string_ | ConsumerRef is a reference to a particular consumer. |
 | `disabled` _boolean_ | Disabled set if the plugin is disabled or not. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
 | `configFrom` _[NamespacedConfigSource](#namespacedconfigsource)_ | ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once. |
 | `configPatches` _[NamespacedConfigPatch](#namespacedconfigpatch) array_ | ConfigPatches represents JSON patches to the configuration of the plugin. Each item means a JSON patch to add something in the configuration, where path is specified in `path` and value is in `valueFrom` referencing a key in a secret. When Config is specified, patches will be applied to the configuration in Config. Otherwise, patches will be applied to an empty object. |
 | `plugin` _string_ | PluginName is the name of the plugin to which to apply the config. |
@@ -50,7 +50,7 @@ KongConsumer is the Schema for the kongconsumers API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongConsumer`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `username` _string_ | Username is a Kong cluster-unique username of the consumer. |
 | `custom_id` _string_ | CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping Kong with users in your existing database. |
 | `credentials` _string array_ | Credentials are references to secrets containing a credential to be provisioned in Kong. |
@@ -70,7 +70,7 @@ KongIngress is the Schema for the kongingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `upstream` _[KongIngressUpstream](#kongingressupstream)_ | Upstream represents a virtual hostname and can be used to loadbalance incoming requests over multiple targets (e.g. Kubernetes `Services` can be a target, OR `Endpoints` can be targets). |
 | `proxy` _[KongIngressService](#kongingressservice)_ | Proxy defines additional connection options for the routes to be configured in the Kong Gateway, e.g. `connection_timeout`, `retries`, etc. |
 | `route` _[KongIngressRoute](#kongingressroute)_ | Route define rules to match client requests. Each Route is associated with a Service, and a Service may have multiple Routes associated to it. |
@@ -88,10 +88,10 @@ KongPlugin is the Schema for the kongplugins API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1`
 | `kind` _string_ | `KongPlugin`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `consumerRef` _string_ | ConsumerRef is a reference to a particular consumer. |
 | `disabled` _boolean_ | Disabled set if the plugin is disabled or not. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#json-v1-apiextensions-k8s-io)_ | Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
 | `configFrom` _[ConfigSource](#configsource)_ | ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once. |
 | `configPatches` _[ConfigPatch](#configpatch) array_ | ConfigPatches represents JSON patches to the configuration of the plugin. Each item means a JSON patch to add something in the configuration, where path is specified in `path` and value is in `valueFrom` referencing a key in a secret. When Config is specified, patches will be applied to the configuration in Config. Otherwise, patches will be applied to an empty object. |
 | `plugin` _string_ | PluginName is the name of the plugin to which to apply the config. |
@@ -344,7 +344,7 @@ IngressClassParameters is the Schema for the IngressClassParameters API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `IngressClassParameters`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[IngressClassParametersSpec](#ingressclassparametersspec)_ | Spec is the IngressClassParameters specification. |
 
 
@@ -367,7 +367,7 @@ KongCustomEntity defines a "custom" Kong entity that KIC cannot support the enti
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongCustomEntity`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongCustomEntitySpec](#kongcustomentityspec)_ |  |
 
 
@@ -386,7 +386,7 @@ KongLicense stores a Kong enterprise license to apply to managed Kong gateway in
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongLicense`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `rawLicenseString` _string_ | RawLicenseString is a string with the raw content of the license. |
 | `enabled` _boolean_ | Enabled is set to true to let controllers (like KIC or KGO) to reconcile it. Default value is true to apply the license by default. |
 
@@ -411,7 +411,7 @@ See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1alpha1`
 | `kind` _string_ | `KongVault`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongVaultSpec](#kongvaultspec)_ |  |
 
 
@@ -463,7 +463,7 @@ KongCustomEntitySpec defines the specification of the KongCustomEntity.
 | Field | Description |
 | --- | --- |
 | `type` _string_ | EntityType is the type of the Kong entity. The type is used in generating declarative configuration. |
-| `fields` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Fields defines the fields of the Kong entity itself. |
+| `fields` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#json-v1-apiextensions-k8s-io)_ | Fields defines the fields of the Kong entity itself. |
 | `controllerName` _string_ | ControllerName specifies the controller that should reconcile it, like ingress class. |
 | `parentRef` _[ObjectReference](#objectreference)_ | ParentRef references the kubernetes resource it attached to when its scope is "attached". Currently only KongPlugin/KongClusterPlugin allowed. This will make the custom entity to be attached to the entity(service/route/consumer) where the plugin is attached. |
 
@@ -485,7 +485,7 @@ KongVaultSpec defines specification of a custom Kong vault.
 | `backend` _string_ | Backend is the type of the backend storing the secrets in the vault. The supported backends of Kong is listed here: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/ |
 | `prefix` _string_ | Prefix is the prefix of vault URI for referencing values in the vault. It is immutable after created. |
 | `description` _string_ | Description is the additional information about the vault. |
-| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Config is the configuration of the vault. Varies for different backends. |
+| `config` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#json-v1-apiextensions-k8s-io)_ | Config is the configuration of the vault. Varies for different backends. |
 | `tags` _[Tags](#tags)_ | Tags are the tags associated to the vault for grouping and filtering. |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a Konnect ControlPlane this KongVault is associated with. |
 
@@ -547,7 +547,7 @@ KongConsumerGroup is the Schema for the kongconsumergroups API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `KongConsumerGroup`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongConsumerGroupSpec](#kongconsumergroupspec)_ |  |
 
 
@@ -575,7 +575,7 @@ used instead. This is to allow reusing the same KongUpstreamPolicy for multiple 
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `KongUpstreamPolicy`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[KongUpstreamPolicySpec](#kongupstreampolicyspec)_ | Spec contains the configuration of the Kong upstream. |
 
 
@@ -591,7 +591,7 @@ TCPIngress is the Schema for the tcpingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `TCPIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[TCPIngressSpec](#tcpingressspec)_ | Spec is the TCPIngress specification. |
 
 
@@ -607,7 +607,7 @@ UDPIngress is the Schema for the udpingresses API.
 | --- | --- |
 | `apiVersion` _string_ | `configuration.konghq.com/v1beta1`
 | `kind` _string_ | `UDPIngress`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[UDPIngressSpec](#udpingressspec)_ | Spec is the UDPIngress specification. |
 
 

--- a/docs/incubator-api-reference.md
+++ b/docs/incubator-api-reference.md
@@ -8,7 +8,63 @@
 
 Package v1alpha1 contains API Schema definitions for the incubator.ingress-controller.konghq.com v1alpha1 API group.
 
+- [KongServiceFacade](#kongservicefacade)
+### KongServiceFacade
+
+
+KongServiceFacade allows creating separate Kong Services for a single Kubernetes
+Service. It can be used as Kubernetes Ingress' backend (via its path's `backend.resource`
+field). It's designed to enable creating two "virtual" Services in Kong that will point
+to the same Kubernetes Service, but will have different configuration (e.g. different
+set of plugins, different load balancing algorithm, etc.).<br /><br />
+KongServiceFacade requires `kubernetes.io/ingress.class` annotation with a value
+matching the ingressClass of the Kong Ingress Controller (`kong` by default) to be reconciled.
+
+<!-- kong_service_facade description placeholder -->
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `incubator.ingress-controller.konghq.com/v1alpha1`
+| `kind` _string_ | `KongServiceFacade`
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[KongServiceFacadeSpec](#kongservicefacadespec)_ |  |
+
+
 
 ### Types
 
 In this section you will find types that the CRDs rely on.
+#### KongServiceFacadeBackend
+
+
+KongServiceFacadeBackend is a reference to a Kubernetes Service
+that is used as a backend for a Kong Service Facade.
+
+
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ | Name is the name of the referenced Kubernetes Service. |
+| `port` _integer_ | Port is the port of the referenced Kubernetes Service. |
+
+
+_Appears in:_
+- [KongServiceFacadeSpec](#kongservicefacadespec)
+
+#### KongServiceFacadeSpec
+
+
+KongServiceFacadeSpec defines the desired state of KongServiceFacade.
+
+
+
+| Field | Description |
+| --- | --- |
+| `backendRef` _[KongServiceFacadeBackend](#kongservicefacadebackend)_ | Backend is a reference to a Kubernetes Service that is used as a backend for this Kong Service Facade. |
+
+
+_Appears in:_
+- [KongServiceFacade](#kongservicefacade)
+
+
+

--- a/docs/incubator-api-reference.md
+++ b/docs/incubator-api-reference.md
@@ -8,63 +8,7 @@
 
 Package v1alpha1 contains API Schema definitions for the incubator.ingress-controller.konghq.com v1alpha1 API group.
 
-- [KongServiceFacade](#kongservicefacade)
-### KongServiceFacade
-
-
-KongServiceFacade allows creating separate Kong Services for a single Kubernetes
-Service. It can be used as Kubernetes Ingress' backend (via its path's `backend.resource`
-field). It's designed to enable creating two "virtual" Services in Kong that will point
-to the same Kubernetes Service, but will have different configuration (e.g. different
-set of plugins, different load balancing algorithm, etc.).<br /><br />
-KongServiceFacade requires `kubernetes.io/ingress.class` annotation with a value
-matching the ingressClass of the Kong Ingress Controller (`kong` by default) to be reconciled.
-
-<!-- kong_service_facade description placeholder -->
-
-| Field | Description |
-| --- | --- |
-| `apiVersion` _string_ | `incubator.ingress-controller.konghq.com/v1alpha1`
-| `kind` _string_ | `KongServiceFacade`
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[KongServiceFacadeSpec](#kongservicefacadespec)_ |  |
-
-
 
 ### Types
 
 In this section you will find types that the CRDs rely on.
-#### KongServiceFacadeBackend
-
-
-KongServiceFacadeBackend is a reference to a Kubernetes Service
-that is used as a backend for a Kong Service Facade.
-
-
-
-| Field | Description |
-| --- | --- |
-| `name` _string_ | Name is the name of the referenced Kubernetes Service. |
-| `port` _integer_ | Port is the port of the referenced Kubernetes Service. |
-
-
-_Appears in:_
-- [KongServiceFacadeSpec](#kongservicefacadespec)
-
-#### KongServiceFacadeSpec
-
-
-KongServiceFacadeSpec defines the desired state of KongServiceFacade.
-
-
-
-| Field | Description |
-| --- | --- |
-| `backendRef` _[KongServiceFacadeBackend](#kongservicefacadebackend)_ | Backend is a reference to a Kubernetes Service that is used as a backend for this Kong Service Facade. |
-
-
-_Appears in:_
-- [KongServiceFacade](#kongservicefacade)
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.15.0
 	github.com/kong/go-kong v0.59.1
-	github.com/kong/kubernetes-configuration v0.0.43
+	github.com/kong/kubernetes-configuration v0.0.44
 	github.com/kong/kubernetes-telemetry v0.1.7
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/lithammer/dedent v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/kong/go-database-reconciler v1.15.0 h1:5F5Zzp2H14aiDmqWUCaU4+LGR/lGnv
 github.com/kong/go-database-reconciler v1.15.0/go.mod h1:T5BkBw13PZWub3y2jKAoM7fYD+UmXp2iNqj1YqD0L90=
 github.com/kong/go-kong v0.59.1 h1:AJZtyCD+Zyqe/mF/m+x3/qN/GPVxAH7jq9zGJTHRfjc=
 github.com/kong/go-kong v0.59.1/go.mod h1:8Vt6HmtgLNgL/7bSwAlz3DIWqBtzG7qEt9+OnMiQOa0=
-github.com/kong/kubernetes-configuration v0.0.43 h1:CzMP38+aMjhRTsE+xwAbq2I3nXgWvLlxhcoUZ4BQ+LY=
-github.com/kong/kubernetes-configuration v0.0.43/go.mod h1:ym++Oygj/wZjaCanK8a+mjZ1jttPF7gPP1OBV0aqI00=
+github.com/kong/kubernetes-configuration v0.0.44 h1:85q8PugPeWQ7AKvEeGXxDoa+XCzTdNMj1qFcHyxHHds=
+github.com/kong/kubernetes-configuration v0.0.44/go.mod h1:ym++Oygj/wZjaCanK8a+mjZ1jttPF7gPP1OBV0aqI00=
 github.com/kong/kubernetes-telemetry v0.1.7 h1:R4NUpvbF5uZ+5kgSQsIcf/oulRBGQCHsffFRDE4wxV4=
 github.com/kong/kubernetes-telemetry v0.1.7/go.mod h1:USy5pcD1+Mm9NtKuz3Pb/rSx71VN76gHCFhdbAB4/lg=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/scripts/apidocs-gen/config.yaml
+++ b/scripts/apidocs-gen/config.yaml
@@ -2,7 +2,6 @@ processor:
   # RE2 regular expressions describing types that should be excluded from the generated documentation.
   ignoreTypes:
     - "List$"
-    # TODO: ignore the types not used in KIC like `KongService`, `KongRoute`.
   # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
   ignoreFields:
     - "status$"
@@ -13,5 +12,5 @@ processor:
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  # NOTE: The type of value here is `number`, so using versions ending with `0` like `1.30` will result in unexpected URL of kubernetes object meta in generated docs.
-  kubernetesVersion: 1.28
+  # NOTE: Quotes are required, otherwise the value will be intepreted as a number so versions ending with `0` like 1.30 would be covreted to "1.3" in results.
+  kubernetesVersion: "1.30"

--- a/scripts/apidocs-gen/config.yaml
+++ b/scripts/apidocs-gen/config.yaml
@@ -9,6 +9,8 @@ processor:
   customMarkers:
     - name: "apireference:kic:include"
       target: type
+    - name: "apireference:kic:exclude"
+      target: "type"
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.

--- a/scripts/apidocs-gen/config.yaml
+++ b/scripts/apidocs-gen/config.yaml
@@ -2,11 +2,16 @@ processor:
   # RE2 regular expressions describing types that should be excluded from the generated documentation.
   ignoreTypes:
     - "List$"
+    # TODO: ignore the types not used in KIC like `KongService`, `KongRoute`.
   # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
   ignoreFields:
     - "status$"
     - "TypeMeta$"
+  customMarkers:
+    - name: "apireference:kic:include"
+      target: type
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.25
+  # NOTE: The type of value here is `number`, so using versions ending with `0` like `1.30` will result in unexpected URL of kubernetes object meta in generated docs.
+  kubernetesVersion: 1.28

--- a/scripts/apidocs-gen/generate.sh
+++ b/scripts/apidocs-gen/generate.sh
@@ -6,11 +6,14 @@ set -o pipefail
 
 SCRIPT_ROOT="$(dirname "${BASH_SOURCE[0]}")/../.."
 CRD_REF_DOCS_BIN="$1"
+# Fetch the version of `kubernetes-configuration` from `go.mod`.
+KUBE_CONF_VERSION=$(grep "github.com/kong/kubernetes-configuration" ${SCRIPT_ROOT}/go.mod   | awk '{print $2}')
+GOPATH=$(go env GOPATH)
 
 generate() {
   echo "INFO: generating API docs for ${1} package, output: ${2}"
   ${CRD_REF_DOCS_BIN} \
-      --source-path="${SCRIPT_ROOT}${1}" \
+      --source-path="${1}" \
       --config="${SCRIPT_ROOT}/scripts/apidocs-gen/config.yaml" \
       --templates-dir="${SCRIPT_ROOT}/scripts/apidocs-gen/template" \
       --renderer=markdown \
@@ -18,7 +21,5 @@ generate() {
       --max-depth=10
 }
 
-# TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/6618
-# Bring the generator back, relying on kong/kubernetes-configuration
-# generate "/configuration" "/docs/api-reference.md"
-# generate "/incubator" "/docs/incubator-api-reference.md"
+generate "${GOPATH}/pkg/mod/github.com/kong/kubernetes-configuration@${KUBE_CONF_VERSION}/api/configuration" "/docs/api-reference.md"
+generate "${GOPATH}/pkg/mod/github.com/kong/kubernetes-configuration@${KUBE_CONF_VERSION}/api/incubator" "/docs/incubator-api-reference.md"

--- a/scripts/apidocs-gen/generate.sh
+++ b/scripts/apidocs-gen/generate.sh
@@ -6,9 +6,10 @@ set -o pipefail
 
 SCRIPT_ROOT="$(dirname "${BASH_SOURCE[0]}")/../.."
 CRD_REF_DOCS_BIN="$1"
-# Fetch the version of `kubernetes-configuration` from `go.mod`.
-KUBE_CONF_VERSION=$(grep "github.com/kong/kubernetes-configuration" ${SCRIPT_ROOT}/go.mod   | awk '{print $2}')
-GOPATH=$(go env GOPATH)
+# Download the `kong/kubernetes-configuration` package and get its path.
+KUBE_CONF_REPO=github.com/kong/kubernetes-configuration
+KUBE_CONF_PATH=$(go mod download -json ${KUBE_CONF_REPO} | jq -rM .Dir)
+echo "Dowloaded ${KUBE_CONF_REPO} in ${KUBE_CONF_PATH}"
 
 generate() {
   echo "INFO: generating API docs for ${1} package, output: ${2}"
@@ -21,5 +22,5 @@ generate() {
       --max-depth=10
 }
 
-generate "${GOPATH}/pkg/mod/github.com/kong/kubernetes-configuration@${KUBE_CONF_VERSION}/api/configuration" "/docs/api-reference.md"
-generate "${GOPATH}/pkg/mod/github.com/kong/kubernetes-configuration@${KUBE_CONF_VERSION}/api/incubator" "/docs/incubator-api-reference.md"
+generate "${KUBE_CONF_PATH}/api/configuration" "/docs/api-reference.md"
+generate "${KUBE_CONF_PATH}/api/incubator" "/docs/incubator-api-reference.md"

--- a/scripts/apidocs-gen/template/gv_details.tpl
+++ b/scripts/apidocs-gen/template/gv_details.tpl
@@ -7,7 +7,11 @@
 
 {{- if $gv.Kinds  }}
 {{- range $gv.SortedKinds }}
+{{- $typ := $gv.TypeForKind . }}
+{{- /* Display only KIC supported kinds */ -}}
+{{- if index $typ.Markers "apireference:kic:include" }}
 - {{ $gv.TypeForKind . | markdownRenderTypeLink }}
+{{- end }}
 {{- end }}
 {{ end }}
 
@@ -15,7 +19,10 @@
 {{- range $gv.SortedKinds -}}
 {{- $typ := $gv.TypeForKind . }}
 {{- $isKind := true -}}
+{{- /* Display only KIC supported kinds */ -}}
+{{- if index $typ.Markers "apireference:kic:include" -}}
 {{ template "type" (dict "type" $typ "isKind" $isKind) }}
+{{- end }}
 {{ end -}}
 
 ### Types
@@ -30,7 +37,8 @@ In this section you will find types that the CRDs rely on.
 {{- $isKind = true -}}
 {{- end -}}
 {{- end -}}
-{{- if not $isKind }}
+{{- /* Display only KIC supported types */ -}}
+{{- if and (not $isKind) (index $typ.Markers "apireference:kic:include") }}
 {{ template "type" (dict "type" $typ "isKind" $isKind) }}
 {{ end -}}
 {{- end }}

--- a/scripts/apidocs-gen/template/type.tpl
+++ b/scripts/apidocs-gen/template/type.tpl
@@ -2,7 +2,6 @@
 {{- $type := $.type -}}
 {{- $isKind := $.isKind -}}
 {{- if markdownShouldRenderType $type -}}
-{{- if not (index $type.Markers "apireference:kic:exclude") -}}
 
 {{- if $isKind -}}
 ### {{ $type.Name }}
@@ -27,7 +26,9 @@
 {{ end -}}
 
 {{ range $type.Members -}}
+{{- if not (index .Markers "apireference:kic:exclude") -}}
 | `{{ .Name  }}` _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} |
+{{ end -}}
 {{ end -}}
 
 {{ end }}
@@ -39,6 +40,5 @@ _Appears in:_
 {{- end }}
 {{- end }}
 
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/scripts/apidocs-gen/template/type.tpl
+++ b/scripts/apidocs-gen/template/type.tpl
@@ -2,6 +2,7 @@
 {{- $type := $.type -}}
 {{- $isKind := $.isKind -}}
 {{- if markdownShouldRenderType $type -}}
+{{- if not (index $type.Markers "apireference:kic:exclude") -}}
 
 {{- if $isKind -}}
 ### {{ $type.Name }}
@@ -38,5 +39,6 @@ _Appears in:_
 {{- end }}
 {{- end }}
 
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Generate apidocs for CRDs from kong/kubernetes-configuration repo.
Dependent on https://github.com/Kong/kubernetes-configuration/pull/155 to include `KongServiceFacade`.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6618

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR~
