### PR TITLE
chore(ci): fix conformance test reports re-using the same artifact name

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -52,12 +52,14 @@ jobs:
         with:
           install: false
 
+      - run: echo "JUNIT_REPORT=conformance-tests-${{ matrix.name }}.xml" >> $GITHUB_ENV
+
       - name: run conformance tests
         run: make test.conformance
         env:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
-          JUNIT_REPORT: conformance-tests-${{ matrix.name }}.xml
+          JUNIT_REPORT: ${{ env.JUNIT_REPORT }}
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
           TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
 
@@ -74,5 +76,17 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: tests-report-conformance
-          path: conformance-tests-${{ matrix.name }}.xml
+          name: tests-report-conformance-${{ matrix.name }}
+          path: ${{ env.JUNIT_REPORT }}
+
+  merge-junit-test-reports:
+    runs-on: ubuntu-latest
+    needs:
+    - conformance-tests
+    steps:
+      - name: Merge Junit test reports
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: test-report-conformance
+          pattern: test-report-conformance-*
+          delete-merged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

GitHub's `actions/upload` doesn't allow uploading artifacts with the same name.

This PR fixes the problem for conformance tests workflow where this would happen.

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11720599834/job/32646382112?pr=6620

```
Run actions/upload-artifact@v4
  with:
    name: tests-report-conformance
    path: conformance-tests-expressions-router.xml
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    TEST_KONG_HELM_CHART_VERSION: [2](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11720599834/job/32646382112?pr=6620#step:7:2).42.0
    MISE_LOG_LEVEL: info
    MISE_TRUSTED_CONFIG_PATHS: /home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller
    MISE_YES: 1
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: ([4](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11720599834/job/32646382112?pr=6620#step:7:4)09) Conflict: an artifact with this name already exists on the workflow run
```

Additionally this PR would merge all the reports into 1 artifact: `test-report-conformance` using https://github.com/actions/upload-artifact/blob/main/merge/README.md