### PR TITLE
chore(ci): fix typo in conformance report artifact name

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: tests-report-conformance-${{ matrix.name }}
+          name: test-report-conformance-${{ matrix.name }}
           path: ${{ env.JUNIT_REPORT }}
 
   merge-junit-test-reports:


### PR DESCRIPTION
**What this PR does / why we need it**:

#6636 made a type in artifact name. This fixes it 😬 

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11722905565/job/32653776096?pr=6620#step:2:11

```
Error: No artifacts found matching pattern 'test-report-conformance-*'
```