### PR TITLE
fix: fix panic in KongUpstreamPolicyReconciler when using with Ingress having a nil HTTP rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,9 @@ Adding a new version? You'll need three changes:
 - Fixed annotation `konghq.com/rewrite` that was not being applied sometimes
   when `Ingress` without annotation and a different `Ingress` with annotation
   pointed to the same `Service`.
-  [#6569](https://github.com/Kong/kubernetes-ingress-controller/pull/6626)
+  [#6626](https://github.com/Kong/kubernetes-ingress-controller/pull/6626)
+- Fix panic in `KongUpstreamPolicyReconciler` when using with Ingress having a nil HTTP rule
+  [#6651](https://github.com/Kong/kubernetes-ingress-controller/pull/6651)
 
 ## [3.3.1]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix panic in KongUpstreamPolicyReconciler when using with Ingress having a nil HTTP rule

**Which issue this PR fixes**:

Fixes #6649

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
