### PR TITLE
chore(Makefile): fix target debug.skaffold

### DIFF
--- a/config/variants/multi-gw/debug/kustomization.yaml
+++ b/config/variants/multi-gw/debug/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: kong
 
 resources:
 - ../base/
-- ../../../crd/incubator
 
 patchesStrategicMerge:
 - manager_debug.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Running

```
make debug.skaffold
```

leads to 

```log
...
Checking cache...
 - kic-placeholder: Found Locally
WARN[0001] Failed to render :running [kubectl --context kind-kong-test kustomize /Users/jakub.warczarek@konghq.com/Documents/work/kubernetes-ingress-controller/config/variants/multi-gw/debug]
 - stdout: ""
 - stderr: "# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.\nerror: accumulating resources: accumulation err='accumulating resources from '../../../crd/incubator': '/Users/jakub.warczarek@konghq.com/Documents/work/kubernetes-ingress-controller/config/crd/incubator' must resolve to a file': recursed merging from path '/Users/jakub.warczarek@konghq.com/Documents/work/kubernetes-ingress-controller/config/crd/incubator': may not add resource with an already registered id: CustomResourceDefinition.v1.apiextensions.k8s.io/kongservicefacades.incubator.ingress-controller.konghq.com.[noNs]\n"
 - cause: exit status 1, please fix the error and press any key to continue.  subtask=-1 task=DevLoop
 ```
 
 this PR fixes it. It seems that removing it was omitted by mistake previously

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

