### PR TITLE
fix: set SNI's certificate ID ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ Adding a new version? You'll need three changes:
 
 - Bump version of Gateway API to `1.2.0`.
   [#6571](https://github.com/Kong/kubernetes-ingress-controller/pull/6571)
+- Set SNI's certificate ID ref in generated config
+  [#6660](https://github.com/Kong/kubernetes-ingress-controller/pull/6660)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Adding a new version? You'll need three changes:
 
 - Bump version of Gateway API to `1.2.0`.
   [#6571](https://github.com/Kong/kubernetes-ingress-controller/pull/6571)
-- Set SNI's certificate ID ref in generated config
+- Set SNI's certificate ID ref in the generated config.
   [#6660](https://github.com/Kong/kubernetes-ingress-controller/pull/6660)
 
 ### Fixed

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -43,16 +43,23 @@ func GetFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	if kongCert.Cert != nil {
 		res.Cert = kong.String(*kongCert.Cert)
 	}
-	res.SNIs = getSNIs(kongCert.SNIs)
+	res.SNIs = getCertsSNIs(kongCert)
 	return res
 }
 
-func getSNIs(names []*string) []kong.SNI {
-	snis := make([]kong.SNI, 0, len(names))
-	for _, name := range names {
-		snis = append(snis, kong.SNI{
-			Name: kong.String(*name),
-		})
+func getCertsSNIs(kongCert kong.Certificate) []kong.SNI {
+	snis := make([]kong.SNI, 0, len(kongCert.SNIs))
+	for _, sni := range kongCert.SNIs {
+		kongSNI := kong.SNI{
+			Name: sni,
+			Certificate: &kong.Certificate{
+				ID: kongCert.ID,
+			},
+		}
+		if kongCert.ID != nil {
+			kongSNI.Certificate.ID = kongCert.ID
+		}
+		snis = append(snis, kongSNI)
 	}
 	return snis
 }

--- a/internal/dataplane/sendconfig/inmemory.go
+++ b/internal/dataplane/sendconfig/inmemory.go
@@ -80,6 +80,7 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 		true,
 		true,
 	); reloadConfigErr != nil {
+
 		// If the returned error is an APIError with a 400 status code, we can try to parse the response body to get the
 		// resource errors and produce an UpdateError with them.
 		var apiError *kong.APIError
@@ -88,6 +89,11 @@ func (s UpdateStrategyInMemory) Update(ctx context.Context, targetState ContentW
 			if parseErr != nil {
 				return fmt.Errorf("failed to parse flat entity errors from error response: %w", parseErr)
 			}
+
+			for _, resourceError := range resourceErrors {
+				s.logger.V(logging.DebugLevel).Info("Resource error", "resource_error", resourceError)
+			}
+
 			return NewUpdateErrorWithResponseBody(
 				apiError.Raw(),
 				resourceErrorsToResourceFailures(resourceErrors, s.logger),

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/default_golden.yaml
@@ -2,43 +2,6 @@ _format_version: "3.0"
 certificates:
 - cert: |-
     -----BEGIN CERTIFICATE-----
-    MIIBoTCCAQoCCQCjZq2l6IGAATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
-    b25naHEuY29tMB4XDTIzMDYwMTE3NTMyMVoXDTI0MDUzMTE3NTMyMVowFTETMBEG
-    A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuDsJ
-    xkC+QWHD8UfPBjrUXnM69iq8VRzzKVlxUom7/mXT4WbT7vLIb6pWuWGJXwP7IUec
-    LSAFTwMH9xqeB+IcIwOVRyRwTs8vBrx+rNXBS7gLyAtaeGbWnKl+A95KL5jnaEG+
-    TrxMGpZlRSojOWsc/sE/Yt+WqHJ9QqKKvgKEUtECAwEAATANBgkqhkiG9w0BAQsF
-    AAOBgQCeeXGqFiOpPe4EuFE4O/ydvOMmun8ap3e0VNGwWu7ylN2bxggK3IvZ5rNf
-    03Uc8e1eoKWa30gkw1tyQQ0uo33VbxzJVrbMWQG7syYMocgt/8Czg8rX4ezCOstJ
-    PXXJPGS/3O7JOCUbBUZ2aJ7eVHzMNyn7CiZiqI9kJqEGlU/I8w==
-    -----END CERTIFICATE-----
-  id: 8aade13c-1470-46bd-9849-9a74e349214f
-  key: |-
-    -----BEGIN PRIVATE KEY-----
-    MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALg7CcZAvkFhw/FH
-    zwY61F5zOvYqvFUc8ylZcVKJu/5l0+Fm0+7yyG+qVrlhiV8D+yFHnC0gBU8DB/ca
-    ngfiHCMDlUckcE7PLwa8fqzVwUu4C8gLWnhm1pypfgPeSi+Y52hBvk68TBqWZUUq
-    IzlrHP7BP2LflqhyfUKiir4ChFLRAgMBAAECgYBBJadsMuLUbgUDIniD5HPKvobA
-    HBajJmyaV6WqIUiYSlvlnh4dpj7Yteya+3G/ZsH8X71Le8JE0XaUnBX8Baoa4gWi
-    Ws6CTX5yHVMihJ3Ixh5dGt6pdKPTCbBgNf+0ySVavbCDhfLisWTMNuN6KxHmx0GW
-    PY85RuzRLl68+h7VEQJBANrPJE2MAxTpZ+Qw2r2jPF5yf1njwuyiIkZNlqz7Vmvy
-    ZCXBZfahUXPcR5ka4xKOLgc7oCah+43gNDmq0vDtEP0CQQDXi09XJyLjnD1RpVIi
-    t/cG5JiDBvtuSGjI7s/mI2Ts0fpo/U35WUGajHagma9c2qlYMeVZ7fupxLNaLD6z
-    1MtlAkEA1h/7wL+RjHdVKeP9S7NgsnSN1+Ohr3yC2hW3rBRR4FVWV/RI2e/IC/+3
-    OUcsi84DkSRydxvxVkfgE8btosP76QJABjMWlB4nDb7nsJp9s0vxSfx3OoWP48sn
-    YGgmCKuJ8pnThwOKI5rinSxfGR1ygswzRLsiqqSCsY5bzkMphoifVQJBAIUmrXPj
-    51od3k5VpWo1S+Mg9IiufrnqtpFu/kEEXluxCqrskb1C7mWMkGqy0bHpA014Squ2
-    7InkkRoDnTrU3Ro=
-    -----END PRIVATE KEY-----
-  snis:
-  - certificate:
-      id: 8aade13c-1470-46bd-9849-9a74e349214f
-    name: 3.example.com
-  - certificate:
-      id: 8aade13c-1470-46bd-9849-9a74e349214f
-    name: 4.example.com
-- cert: |-
-    -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
     b25naHEuY29tMB4XDTIzMDYwMTE3NTAwOFoXDTI0MDUzMTE3NTAwOFowFTETMBEG
     A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuyL5
@@ -74,6 +37,23 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+consumers:
+- basicauth_credentials:
+  - password: consumer-1-password
+    tags:
+    - k8s-name:consumer-basic-auth
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+    username: consumer-1
+  id: 7deb6e70-60be-5dd2-b374-06551479ea5e
+  tags:
+  - k8s-name:consumer
+  - k8s-namespace:default
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+  username: consumer
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc
@@ -85,12 +65,19 @@ services:
   read_timeout: 60000
   retries: 5
   routes:
-  - expression: (http.host == "example.com") && (http.path == "/")
+  - hosts:
+    - example.com
     https_redirect_status_code: 426
     id: fc9a8135-0253-5631-b1e0-8712f796a4e2
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
+    path_handling: v0
+    paths:
+    - ~/$
     preserve_host: true
-    priority: 57178899677185
+    protocols:
+    - http
+    - https
+    regex_priority: 0
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
@@ -2,43 +2,6 @@ _format_version: "3.0"
 certificates:
 - cert: |-
     -----BEGIN CERTIFICATE-----
-    MIIBoTCCAQoCCQCjZq2l6IGAATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
-    b25naHEuY29tMB4XDTIzMDYwMTE3NTMyMVoXDTI0MDUzMTE3NTMyMVowFTETMBEG
-    A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuDsJ
-    xkC+QWHD8UfPBjrUXnM69iq8VRzzKVlxUom7/mXT4WbT7vLIb6pWuWGJXwP7IUec
-    LSAFTwMH9xqeB+IcIwOVRyRwTs8vBrx+rNXBS7gLyAtaeGbWnKl+A95KL5jnaEG+
-    TrxMGpZlRSojOWsc/sE/Yt+WqHJ9QqKKvgKEUtECAwEAATANBgkqhkiG9w0BAQsF
-    AAOBgQCeeXGqFiOpPe4EuFE4O/ydvOMmun8ap3e0VNGwWu7ylN2bxggK3IvZ5rNf
-    03Uc8e1eoKWa30gkw1tyQQ0uo33VbxzJVrbMWQG7syYMocgt/8Czg8rX4ezCOstJ
-    PXXJPGS/3O7JOCUbBUZ2aJ7eVHzMNyn7CiZiqI9kJqEGlU/I8w==
-    -----END CERTIFICATE-----
-  id: 8aade13c-1470-46bd-9849-9a74e349214f
-  key: |-
-    -----BEGIN PRIVATE KEY-----
-    MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALg7CcZAvkFhw/FH
-    zwY61F5zOvYqvFUc8ylZcVKJu/5l0+Fm0+7yyG+qVrlhiV8D+yFHnC0gBU8DB/ca
-    ngfiHCMDlUckcE7PLwa8fqzVwUu4C8gLWnhm1pypfgPeSi+Y52hBvk68TBqWZUUq
-    IzlrHP7BP2LflqhyfUKiir4ChFLRAgMBAAECgYBBJadsMuLUbgUDIniD5HPKvobA
-    HBajJmyaV6WqIUiYSlvlnh4dpj7Yteya+3G/ZsH8X71Le8JE0XaUnBX8Baoa4gWi
-    Ws6CTX5yHVMihJ3Ixh5dGt6pdKPTCbBgNf+0ySVavbCDhfLisWTMNuN6KxHmx0GW
-    PY85RuzRLl68+h7VEQJBANrPJE2MAxTpZ+Qw2r2jPF5yf1njwuyiIkZNlqz7Vmvy
-    ZCXBZfahUXPcR5ka4xKOLgc7oCah+43gNDmq0vDtEP0CQQDXi09XJyLjnD1RpVIi
-    t/cG5JiDBvtuSGjI7s/mI2Ts0fpo/U35WUGajHagma9c2qlYMeVZ7fupxLNaLD6z
-    1MtlAkEA1h/7wL+RjHdVKeP9S7NgsnSN1+Ohr3yC2hW3rBRR4FVWV/RI2e/IC/+3
-    OUcsi84DkSRydxvxVkfgE8btosP76QJABjMWlB4nDb7nsJp9s0vxSfx3OoWP48sn
-    YGgmCKuJ8pnThwOKI5rinSxfGR1ygswzRLsiqqSCsY5bzkMphoifVQJBAIUmrXPj
-    51od3k5VpWo1S+Mg9IiufrnqtpFu/kEEXluxCqrskb1C7mWMkGqy0bHpA014Squ2
-    7InkkRoDnTrU3Ro=
-    -----END PRIVATE KEY-----
-  snis:
-  - certificate:
-      id: 8aade13c-1470-46bd-9849-9a74e349214f
-    name: 3.example.com
-  - certificate:
-      id: 8aade13c-1470-46bd-9849-9a74e349214f
-    name: 4.example.com
-- cert: |-
-    -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
     b25naHEuY29tMB4XDTIzMDYwMTE3NTAwOFoXDTI0MDUzMTE3NTAwOFowFTETMBEG
     A1UEAwwKa29uZ2hxLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuyL5
@@ -74,6 +37,23 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+consumers:
+- basicauth_credentials:
+  - password: consumer-1-password
+    tags:
+    - k8s-name:consumer-basic-auth
+    - k8s-namespace:default
+    - k8s-kind:Secret
+    - k8s-version:v1
+    username: consumer-1
+  id: 7deb6e70-60be-5dd2-b374-06551479ea5e
+  tags:
+  - k8s-name:consumer
+  - k8s-namespace:default
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+  username: consumer
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_settings.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/in.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/in.yaml
@@ -1,0 +1,97 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: ing-with-tls
+  namespace: bar-namespace
+  uid: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: foo-svc
+            port:
+              number: 80
+        path: /
+        pathType: Exact
+  tls:
+  - hosts:
+    - 1.example.com
+    - 2.example.com
+    secretName: sooper-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  name: foo-svc
+  namespace: bar-namespace
+  uid: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: consumer
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: kong
+username: consumer
+credentials:
+  - consumer-basic-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consumer-basic-auth
+  namespace: default
+  labels:
+    konghq.com/credential: basic-auth
+data:
+  username: "Y29uc3VtZXItMQ=="
+  password: "Y29uc3VtZXItMS1wYXNzd29yZA=="
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sooper-secret
+  namespace: bar-namespace
+  uid: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+type: kubernetes.io/tls
+data:
+  tls.key: |
+    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkUUlCQURBTkJna3Foa2lHOXcwQkFRRUZB
+    QVNDQWw4d2dnSmJBZ0VBQW9HQkFMc2krZEtPRWNscUdDMEUKMU9jQ3BHRjNNZlp3MkU1L3VqdWxr
+    RDNBOGpuejBKcHZkcjJyZ1N0OHpTVU1aNFN0NlhRaWJQNVl2cXRnYXB3VgptS0JYS2Z3eEV5SGpy
+    c2lPTi9nYVFFWXdCNTdWRE5OcktIM0cwekVSZ052UDdnb0t2dU9pMGc2anhwZWkza2dOCmFYTzVy
+    bk5aaEpwTDVKV0JjME9leG5udUl1VWhBZ01CQUFFQ2dZQVJwdnoxMVp6cjZPd2E0d2ZLT3IrU3lo
+    R1cKYzVLVDVReUdMOW5wV1ZnQUMzV3orNnV4dkluVXRsTUxtWjN5TUEyRGZQUFhFanY2SW9BcjlR
+    V09xbW8xVERvdQp2cGk3bjA2R2xUOHFPTVdPcGJQb1I3aENDYTRubHN4NDhxOFFRK0tubkNoejBB
+    Z05ZdGxJdTlIMWwxYTIwSHV0Ci9xb0VXN1dlL0dQdGJIYkFBUUpCQVBjN3dWVUd0bUhpRnRYSTJO
+    L2JkUmtlZms2N1RneXRNUVZVMWVISWhuaDgKZ2xBVnB1R05ZY3lYWW9EZm9kL3lNcElKNFRvMkZO
+    Z1JOVmFIV2dmT2hRRUNRUURCeGJJdncrUEtydXJOSWJxcgpzdS9mY0RKWGRLWit3ZnVKSlgya1JR
+    ZU1nYTBuVmNxTFVaVjFSQVBtQ2cwWXYrUU5ob3ZxMW91d0xOc1pLcGU1Cnc4QWhBa0JER2FHNExQ
+    RTFFY0syMVNNZlpwV2FjcTgvT1JETzJmYVRCdHBoeENYUzc2QUNrazNQcTZxZWQzdlIKbEdCL3dt
+    RTlSNWNzVUY5SjRTbkR5VXFERWVjQkFrQXZWV1NlaUdKM20xemQrUlJKWnU5empFdXYwMTNzYnVS
+    TAo3eTJPMkJIcy82eFZoSDV5bzk0M2hBTFR5YmJEU2ZTaVhUQ0drQndWVUEvQlNRZEJLSkVoQWtB
+    L1hTVjJKVGxlCmc1Umh4a3VEWnN0M0s4YXVwd1dLQzRFOXp1ZythcmFRa256ak1oNk1TbDZ1MitS
+    TmlmUnJ6MmtUaFEzSFlqMGcKNUdUeWw3WEpteVkvCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+  tls.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJvVENDQVFvQ0NRQy9WNU9mVFh1N3hEQU5C
+    Z2txaGtpRzl3MEJBUXNGQURBVk1STXdFUVlEVlFRRERBcHIKYjI1bmFIRXVZMjl0TUI0WERUSXpN
+    RFl3TVRFM05UQXdPRm9YRFRJME1EVXpNVEUzTlRBd09Gb3dGVEVUTUJFRwpBMVVFQXd3S2EyOXVa
+    Mmh4TG1OdmJUQ0JuekFOQmdrcWhraUc5dzBCQVFFRkFBT0JqUUF3Z1lrQ2dZRUF1eUw1CjBvNFJ5
+    V29ZTFFUVTV3S2tZWGN4OW5EWVRuKzZPNldRUGNEeU9mUFFtbTkydmF1Qkszek5KUXhuaEszcGRD
+    SnMKL2xpK3EyQnFuQldZb0ZjcC9ERVRJZU91eUk0MytCcEFSakFIbnRVTTAyc29mY2JUTVJHQTI4
+    L3VDZ3ErNDZMUwpEcVBHbDZMZVNBMXBjN211YzFtRW1rdmtsWUZ6UTU3R2VlNGk1U0VDQXdFQUFU
+    QU5CZ2txaGtpRzl3MEJBUXNGCkFBT0JnUUJCdngwYmR5RmRXeGE3NVI5YnJ6OHMxR1lMclZtazd6
+    Q1hzcHZ5OXNEeTFSb2FWN1RuWWRXeHYvSFUKOWZ1bXcrMFJvU3N4eXNRUmMxaVdBOHFKNnkycnEz
+    RzdBM0dIdElQcXNESHJqb1M5czlZdEpvNGlUNElOSjNJbQowZkIwUURyMUY0RjVQNlRaeU11MVdq
+    Z3QyQ2hlcWFaSDZUTGE4RW00RnovUXJmYzFBZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -31,8 +31,12 @@ certificates:
     7InkkRoDnTrU3Ro=
     -----END PRIVATE KEY-----
   snis:
-  - name: 3.example.com
-  - name: 4.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 3.example.com
+  - certificate:
+      id: 8aade13c-1470-46bd-9849-9a74e349214f
+    name: 4.example.com
 - cert: |-
     -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
@@ -64,8 +68,12 @@ certificates:
     5GTyl7XJmyY/
     -----END PRIVATE KEY-----
   snis:
-  - name: 1.example.com
-  - name: 2.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 1.example.com
+  - certificate:
+      id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+    name: 2.example.com
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds SNI's certificate ID ref to be set in generated config. This basically means that instead of:

```
{
	"_format_version": "3.0",
	"certificates": [
		{
			"id": "8aade13c-1470-46bd-9849-9a74e349214f",
			"cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
			"key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
			"snis": [
				{
					"name": "3.example.com"
				},
				{
					"name": "4.example.com"
				}
			]
		}
	]
}
```

we generate

```
{
	"_format_version": "3.0",
	"certificates": [
		{
			"id": "8aade13c-1470-46bd-9849-9a74e349214f",
			"cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
			"key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
			"snis": [
				{
					"name": "3.example.com",
					"certificate": {
						"id": "8aade13c-1470-46bd-9849-9a74e349214f"
					}
				},
				{
					"name": "4.example.com"
					"certificate": {
						"id": "8aade13c-1470-46bd-9849-9a74e349214f"
					}
				}
			]
		}
	]
}
```

**Which issue this PR fixes**:

Fixes #6642

**Special notes for your reviewer**:

Related slack thread: https://kongstrong.slack.com/archives/C03CTMSHP6C/p1730991424228489

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
