### PR TITLE
tests: fix assertions in TestHTTPRouteEssentials

### DIFF
--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -328,14 +328,15 @@ func TestHTTPRouteEssentials(t *testing.T) {
 	_, err = helpers.DeployGatewayClass(ctx, gatewayClient, gatewayClassName)
 	require.NoError(t, err)
 
+	httpRrouteName := httpRoute.Name
+
 	// Set the Port in ParentRef which does not have a matching listener in Gateway.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		httpRoute, err = gatewayClient.GatewayV1().HTTPRoutes(ns.Name).Get(ctx, httpRoute.Name, metav1.GetOptions{})
+		httpRoute, err = gatewayClient.GatewayV1().HTTPRoutes(ns.Name).Get(ctx, httpRrouteName, metav1.GetOptions{})
 		if !assert.NoError(c, err) {
 			return
 		}
-		port81 := gatewayapi.PortNumber(81)
-		httpRoute.Spec.ParentRefs[0].Port = &port81
+		httpRoute.Spec.ParentRefs[0].Port = lo.ToPtr(gatewayapi.PortNumber(81))
 		httpRoute, err = gatewayClient.GatewayV1().HTTPRoutes(ns.Name).Update(ctx, httpRoute, metav1.UpdateOptions{})
 		assert.NoError(c, err)
 	}, time.Minute, time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix assertion in `TestHTTPRouteEssentials` that reuses the HTTPRoute variable incorrectly overwriting the name for the subsequent lookups in case of a failure.

Observed in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11800387959/job/32874484699?pr=6660#step:7:383

```
    httproute_test.go:332: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/httproute_test.go:334
        	            				/opt/hostedtoolcache/go/1.23.2/x64/src/runtime/asm_amd64.s:1700
        	Error:      	Received unexpected error:
        	            	resource name may not be empty
    httproute_test.go:332: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/integration/httproute_test.go:332
        	Error:      	Condition never satisfied
        	Test:       	TestHTTPRouteEssentials
    setup.go:32: Start cleanup for test TestHTTPRouteEssentials
```