### PR TITLE
fix: fix panic when handling KongConsumer without username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ Adding a new version? You'll need three changes:
   kubernetes event with `KongConfigurationTranslationFailed` will be reported
   for each involved `KongConsumer`.
   [#6585](https://github.com/Kong/kubernetes-ingress-controller/pull/6585)
+- Fix panic when handling `KongConsumer` without `username` specified
+  [#6665](https://github.com/Kong/kubernetes-ingress-controller/pull/6665)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@ Adding a new version? You'll need three changes:
   kubernetes event with `KongConfigurationTranslationFailed` will be reported
   for each involved `KongConsumer`.
   [#6585](https://github.com/Kong/kubernetes-ingress-controller/pull/6585)
-- Fix panic when handling `KongConsumer` without `username` specified
+- Fix panic when handling `KongConsumer` without `username` specified.
   [#6665](https://github.com/Kong/kubernetes-ingress-controller/pull/6665)
 
 ### Added

--- a/examples/kong-consumer-key-auth.yaml
+++ b/examples/kong-consumer-key-auth.yaml
@@ -13,8 +13,8 @@ kind: KongConsumer
 metadata:
   name: consumer1
   annotations:
-      kubernetes.io/ingress.class: kong
-# username: consumer1
+    kubernetes.io/ingress.class: kong
+username: consumer1
 credentials:
 - consumer1-auth
 ---

--- a/internal/dataplane/deckgen/consumer_cmp.go
+++ b/internal/dataplane/deckgen/consumer_cmp.go
@@ -1,0 +1,50 @@
+package deckgen
+
+import (
+	"strings"
+
+	"github.com/kong/go-database-reconciler/pkg/file"
+)
+
+type fConsumerByUsernameAndCustomID []file.FConsumer
+
+func (f fConsumerByUsernameAndCustomID) Len() int      { return len(f) }
+func (f fConsumerByUsernameAndCustomID) Swap(i, j int) { f[i], f[j] = f[j], f[i] }
+func (f fConsumerByUsernameAndCustomID) Less(i, j int) bool {
+	if f[i].Username == nil && f[j].Username != nil {
+		return true
+	}
+	if f[i].Username != nil && f[j].Username == nil {
+		return false
+	}
+	if f[i].Username != nil && f[j].Username != nil {
+		switch cmp := strings.Compare(*f[i].Username, *f[j].Username); cmp {
+		case -1:
+			return true
+		case 1:
+			return false
+		case 0:
+			break
+		}
+	}
+
+	// Both usernames are equal, compare custom_id.
+	if f[i].CustomID == nil && f[j].CustomID != nil {
+		return true
+	}
+	if f[i].CustomID != nil && f[j].CustomID == nil {
+		return false
+	}
+	if f[i].CustomID != nil && f[j].CustomID != nil {
+		switch cmp := strings.Compare(*f[i].CustomID, *f[j].CustomID); cmp {
+		case -1:
+			return true
+		case 1:
+			return false
+		case 0:
+			break
+		}
+	}
+
+	return false
+}

--- a/internal/dataplane/deckgen/consumer_cmp.go
+++ b/internal/dataplane/deckgen/consumer_cmp.go
@@ -46,5 +46,10 @@ func (f fConsumerByUsernameAndCustomID) Less(i, j int) bool {
 		}
 	}
 
+	// NOTE: Here both username and custom_id are empty which is not expected to happen
+	// as we enforce either of those field being present in CRD CEL validation rules.
+	// Since this function is only concerned with sorting, we can return false here
+	// as there are no means to propagate the error otherwise (which should be handled
+	// elsewhere prior to this point).
 	return false
 }

--- a/internal/dataplane/deckgen/consumer_cmp.go
+++ b/internal/dataplane/deckgen/consumer_cmp.go
@@ -28,7 +28,7 @@ func (f fConsumerByUsernameAndCustomID) Less(i, j int) bool {
 		}
 	}
 
-	// Both usernames are equal, compare custom_id.
+	// Both usernames are empty or equal, compare custom_id.
 	if f[i].CustomID == nil && f[j].CustomID != nil {
 		return true
 	}

--- a/internal/dataplane/deckgen/consumer_cmp_test.go
+++ b/internal/dataplane/deckgen/consumer_cmp_test.go
@@ -1,0 +1,111 @@
+package deckgen
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsumerCmp(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []file.FConsumer
+		expected []file.FConsumer
+	}{
+		{
+			name: "sort by username",
+			input: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("b"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("a"),
+					},
+				},
+			},
+			expected: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("a"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("b"),
+					},
+				},
+			},
+		},
+		{
+			name: "sort by custom_id",
+			input: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						CustomID: kong.String("b"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						CustomID: kong.String("a"),
+					},
+				},
+			},
+			expected: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						CustomID: kong.String("a"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						CustomID: kong.String("b"),
+					},
+				},
+			},
+		},
+		{
+			name: "sort by username and custom_id",
+			input: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("b"),
+						CustomID: kong.String("b"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("a"),
+						CustomID: kong.String("a"),
+					},
+				},
+			},
+			expected: []file.FConsumer{
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("a"),
+						CustomID: kong.String("a"),
+					},
+				},
+				{
+					Consumer: kong.Consumer{
+						Username: kong.String("b"),
+						CustomID: kong.String("b"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sort.Sort(fConsumerByUsernameAndCustomID(tc.input))
+			assert.Equal(t, tc.expected, tc.input)
+		})
+	}
+}

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -449,8 +449,23 @@ func (ks *KongState) getPluginRelations(cacheStore store.Storer, log logr.Logger
 	}
 
 	for _, c := range ks.Consumers {
+		if c.Username == nil && c.CustomID == nil {
+			// Either Custom ID or username has to be filled so this shouldn't
+			// happen but let's log here just in case.
+			log.Error(nil, "no username or custom_id specified", "consumer", c.K8sKongConsumer.Name)
+			break
+		}
+
+		var identifier string
+		switch {
+		case c.Username != nil:
+			identifier = *c.Username
+		case c.CustomID != nil:
+			identifier = *c.CustomID
+		}
+
 		for _, plugin := range metadata.ExtractPluginsNamespacedNames(&c.K8sKongConsumer) {
-			addRelation(&c.K8sKongConsumer, plugin, *c.Username, ConsumerRelation)
+			addRelation(&c.K8sKongConsumer, plugin, identifier, ConsumerRelation)
 		}
 	}
 

--- a/internal/dataplane/testdata/golden/consumer-group-example-ee/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/consumer-group-example-ee/default_golden.yaml
@@ -1,11 +1,11 @@
 _format_version: "3.0"
 consumer_group_consumers:
+- consumer: consumer-1
+  consumer_group: consumer-group-1
 - consumer: consumer-2
   consumer_group: consumer-group-1
 - consumer: consumer-2
   consumer_group: consumer-group-2
-- consumer: consumer-1
-  consumer_group: consumer-group-1
 consumer_groups:
 - id: 876a1c78-f75a-570e-a918-26506344add0
   name: consumer-group-2
@@ -22,13 +22,6 @@ consumer_groups:
   - k8s-group:configuration.konghq.com
   - k8s-version:v1beta1
 consumers:
-- id: 71168e5f-1d0b-5465-8bb9-a3b032fbc4c4
-  tags:
-  - k8s-name:consumer-2
-  - k8s-kind:KongConsumer
-  - k8s-group:configuration.konghq.com
-  - k8s-version:v1
-  username: consumer-2
 - id: e23d9ef8-1cc4-5b55-abd1-db89aa90346c
   tags:
   - k8s-name:consumer-1
@@ -36,3 +29,10 @@ consumers:
   - k8s-group:configuration.konghq.com
   - k8s-version:v1
   username: consumer-1
+- id: 71168e5f-1d0b-5465-8bb9-a3b032fbc4c4
+  tags:
+  - k8s-name:consumer-2
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1
+  username: consumer-2

--- a/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/default_golden.yaml
@@ -1,0 +1,9 @@
+_format_version: "3.0"
+consumers:
+- custom_id: 1234-1234
+  tags:
+  - k8s-name:consumer
+  - k8s-namespace:consumer-namespace
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1

--- a/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/expression-routes-on_golden.yaml
@@ -1,0 +1,9 @@
+_format_version: "3.0"
+consumers:
+- custom_id: 1234-1234
+  tags:
+  - k8s-name:consumer
+  - k8s-namespace:consumer-namespace
+  - k8s-kind:KongConsumer
+  - k8s-group:configuration.konghq.com
+  - k8s-version:v1

--- a/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/expression-routes-on_settings.yaml
+++ b/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/expression-routes-on_settings.yaml
@@ -1,0 +1,2 @@
+feature_flags:
+  ExpressionRoutes: true

--- a/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/in.yaml
+++ b/internal/dataplane/testdata/golden/kongconsumer-with-custom-id/in.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongConsumer
+metadata:
+  name: consumer
+  namespace: consumer-namespace
+  annotations:
+    kubernetes.io/ingress.class: kong
+custom_id: "1234-1234"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix handling `KongConsumer` without `username` specified. Currently we allow to [set just the `custom_id` on the consumer](https://github.com/Kong/kubernetes-ingress-controller/blob/5bcd583300191c5b36daf18c32d22fae0c58d0c4/pkg/apis/configuration/v1/kongconsumer_types.go#L32) (as an alternative to setting just the `username`).

This PR fixes the former case where `username` is not specified.

**Which issue this PR fixes**:

Fixes #6552 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
