### PR TITLE
chore: fix konnect cleanup

### DIFF
--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -196,7 +196,12 @@ func deleteRoles(
 	var errs []error
 	for _, roleID := range rolesIDsToDelete {
 		log.Info("Deleting role", "id", roleID)
-		if _, err := sdk.UsersRemoveRole(ctx, userID, roleID); err != nil {
+		_, err := sdk.UsersRemoveRole(ctx, userID, roleID,
+			// NOTE: Otherwise we use prod server by default.
+			// Related issue: https://github.com/Kong/sdk-konnect-go/issues/20
+			sdkkonnectops.WithServerURL(test.KonnectServerURL()),
+		)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete role %s: %w", roleID, err))
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to https://github.com/Kong/sdk-konnect-go/issues/20 we need to set the URL for each operation that would hit the global endpoint. Otherwise we will get it overwritten with prod's global endpoint which we do not want.

Broke on CI: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11819442161/job/32929360130#step:4:2832