### PR TITLE
fix: use KongConsumer from kubernetes-configuration

### DIFF
--- a/internal/dataplane/kongstate/credentials_conflicts.go
+++ b/internal/dataplane/kongstate/credentials_conflicts.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 )
 
 // CredentialConflictsDetector registers all credentials and detects conflicts globally using indices.

--- a/internal/dataplane/kongstate/credentials_conflicts_test.go
+++ b/internal/dataplane/kongstate/credentials_conflicts_test.go
@@ -8,8 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
 
 func TestCredentialsConflictsDetector(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a compilation problem that was caused by concurrent merges of https://github.com/Kong/kubernetes-ingress-controller/pull/6619 and https://github.com/Kong/kubernetes-ingress-controller/pull/6585.
