### PR TITLE
fix: unbreak main workflows

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Setup Golang to use go pkg cache which is utilized in Dockerfile's cache mount.
       - name: Setup golang

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup golang
         uses: actions/setup-go@v5

--- a/internal/dataplane/kongstate/credentials_conflicts.go
+++ b/internal/dataplane/kongstate/credentials_conflicts.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
+	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 )
 
 // CredentialConflictsDetector registers all credentials and detects conflicts globally using indices.

--- a/internal/dataplane/kongstate/credentials_conflicts_test.go
+++ b/internal/dataplane/kongstate/credentials_conflicts_test.go
@@ -8,8 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	kongv1 "github.com/kong/kubernetes-ingress-controller/v3/pkg/apis/configuration/v1"
 )
 
 func TestCredentialsConflictsDetector(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes main workflows by:
- fixing a compilation problem that was caused by concurrent merges of https://github.com/Kong/kubernetes-ingress-controller/pull/6619 and https://github.com/Kong/kubernetes-ingress-controller/pull/6585
- checking out PR references in reusable workflows called from `checks.yaml` that uses `pull_request_target` 
