### PR TITLE
tests: fix Konnect ControlPlane role cleanup code

### DIFF
--- a/hack/cleanup/konnect_control_planes.go
+++ b/hack/cleanup/konnect_control_planes.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	konnectControlPlanesLimit       = int64(100)
-	createdInTestsControlPlaneLabel = "created_in_tests"
-	timeUntilControlPlaneOrphaned   = time.Hour
+	konnectControlPlanesLimit     = int64(100)
+	timeUntilControlPlaneOrphaned = time.Hour
 )
 
 // cleanupKonnectControlPlanes deletes orphaned control planes created by the tests and their roles.
@@ -91,7 +90,7 @@ func findOrphanedControlPlanes(
 
 	var orphanedControlPlanes []string
 	for _, ControlPlane := range response.ListControlPlanesResponse.Data {
-		if ControlPlane.Labels[createdInTestsControlPlaneLabel] != "true" {
+		if ControlPlane.Labels[test.KonnectControlPlaneLabelCreatedInTests] != "true" {
 			log.Info("Control plane was not created by the tests, skipping", "name", ControlPlane.Name)
 			continue
 		}

--- a/test/konnect.go
+++ b/test/konnect.go
@@ -2,6 +2,12 @@ package test
 
 import "os"
 
+const (
+	// KonnectControlPlaneLabelCreatedInTests is the label that is set on all
+	// Konnect control planes created by tests.
+	KonnectControlPlaneLabelCreatedInTests = "created_in_tests"
+)
+
 // KonnectServerURL returns the Konnect server URL to be used for Konnect API
 // requests in tests and CI.
 // It is driven by the TEST_KONG_KONNECT_SERVER_URL environment variable.


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR prevents failures in `kongintegration` tests like the one that hapenned in here: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11823753971/job/32943857263#step:9:534

```
    control_plane.go:114: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/internal/helpers/konnect/control_plane.go:114
        	            				/opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1176
        	            				/opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1354
        	            				/opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1684
        	Error:      	Received unexpected error:
        	            	{"status":404,"title":"Not Found","instance":"konnect:trace:4146916054452603185","detail":"The requested assigned role was not found"}
        	Test:       	TestKongClientGoldenTestsOutputs_Konnect
        	Messages:   	failed to cleanup a control plane role: "42a4ddd6-1271-4f5b-800b-39a2033b40c4"
```

The change basically makes the cleanup code ignore the not found errors (as those basically indicate that the role that we wanted to delete no longer exists).