### PR TITLE
chore: add more logs data when unparsable Gateway API error is received

### DIFF
--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -52,12 +52,11 @@ func getCertsSNIs(kongCert kong.Certificate) []kong.SNI {
 	for _, sni := range kongCert.SNIs {
 		kongSNI := kong.SNI{
 			Name: sni,
-			Certificate: &kong.Certificate{
-				ID: kongCert.ID,
-			},
 		}
 		if kongCert.ID != nil {
-			kongSNI.Certificate.ID = kongCert.ID
+			kongSNI.Certificate = &kong.Certificate{
+				ID: kongCert.ID,
+			}
 		}
 		snis = append(snis, kongSNI)
 	}

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -116,7 +116,7 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 		raw := flattenedErrorIntoRaw(ee, logger)
 		parsed, err := parseRawResourceError(raw)
 		if err != nil {
-			logger.Error(err, "Entity tags returned in error API error from gateway is missing fields, Kubernetes Event cannot be created without them",
+			logger.Error(err, "API error returned from the gateway for an entity is missing Kubernetes metadata in tags, Kubernetes Event won't be created",
 				"name", ee.Name,
 				"id", ee.ID,
 				"tags", ee.Tags,

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -88,7 +88,6 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 		return nil, nil
 	}
 
-	var resourceErrors []ResourceError //nolint:prealloc
 	var configError ConfigError
 
 	err := json.Unmarshal(body, &configError)
@@ -102,7 +101,7 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 				logger.Error(nil, "Could not fully parse config error", "message", message)
 			}
 		}
-		return resourceErrors, NewResponseParsingError(body)
+		return nil, NewResponseParsingError(body)
 	}
 	if len(configError.Flattened) == 0 {
 		if len(configError.Message) > 0 {
@@ -111,38 +110,19 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 			logger.Error(nil, "Config error missing per-resource and message", "message", configError.Message)
 		}
 	}
+
+	resourceErrors := make([]ResourceError, 0, len(configError.Flattened))
 	for _, ee := range configError.Flattened {
-		raw := rawResourceError{
-			Name:     ee.Name,
-			ID:       ee.ID,
-			Tags:     ee.Tags,
-			Problems: map[string]string{},
-		}
-		for _, p := range ee.Errors {
-			if len(p.Message) > 0 && len(p.Messages) > 0 {
-				logger.Error(nil, "Entity has both single and array errors for field",
-					"name", ee.Name, "field", p.Field)
-				continue
-			}
-			if len(p.Message) > 0 {
-				switch p.Type {
-				case FlatErrorTypeField:
-					// If the error is associated with a single field, store it in the map under the field name.
-					raw.Problems[p.Field] = p.Message
-				case FlatErrorTypeEntity:
-					// If the error is associated with a whole entity, store it in the map under the entity type and name.
-					raw.Problems[fmt.Sprintf("%s:%s", ee.Type, ee.Name)] = p.Message
-				}
-			}
-			for i, message := range p.Messages {
-				if len(message) > 0 {
-					raw.Problems[fmt.Sprintf("%s[%d]", p.Field, i)] = message
-				}
-			}
-		}
+		raw := flattenedErrorIntoRaw(ee, logger)
 		parsed, err := parseRawResourceError(raw)
 		if err != nil {
-			logger.Error(err, "Entity tags missing fields", "name", ee.Name)
+			logger.Error(err, "Entity tags returned in error API error from gateway is missing fields, Kubernetes Event cannot be created without them",
+				"name", ee.Name,
+				"id", ee.ID,
+				"tags", ee.Tags,
+				"type", ee.Type,
+				"raw_error", ee,
+			)
 			continue
 		}
 		resourceErrors = append(resourceErrors, parsed)
@@ -150,46 +130,86 @@ func parseFlatEntityErrors(body []byte, logger logr.Logger) ([]ResourceError, er
 	return resourceErrors, nil
 }
 
+func flattenedErrorIntoRaw(ee FlatEntityError, logger logr.Logger) rawResourceError {
+	raw := rawResourceError{
+		Name:     ee.Name,
+		ID:       ee.ID,
+		Tags:     ee.Tags,
+		Problems: map[string]string{},
+	}
+	for _, p := range ee.Errors {
+		if len(p.Message) > 0 && len(p.Messages) > 0 {
+			logger.Error(nil, "Entity has both single and array errors for field",
+				"name", ee.Name, "field", p.Field)
+			continue
+		}
+		if len(p.Message) > 0 {
+			switch p.Type {
+			case FlatErrorTypeField:
+				// If the error is associated with a single field, store it in the map under the field name.
+				raw.Problems[p.Field] = p.Message
+			case FlatErrorTypeEntity:
+				// If the error is associated with a whole entity, store it in the map under the entity type and name.
+				raw.Problems[fmt.Sprintf("%s:%s", ee.Type, ee.Name)] = p.Message
+			}
+		}
+		for i, message := range p.Messages {
+			if len(message) > 0 {
+				raw.Problems[fmt.Sprintf("%s[%d]", p.Field, i)] = message
+			}
+		}
+	}
+	return raw
+}
+
 // parseRawResourceError takes a raw resource error and parses its tags into Kubernetes metadata. If critical tags are
 // missing, it returns an error indicating the missing tag.
 func parseRawResourceError(raw rawResourceError) (ResourceError, error) {
-	re := ResourceError{}
-	re.Problems = raw.Problems
+	re := ResourceError{
+		Problems: raw.Problems,
+	}
+
 	var gvk schema.GroupVersionKind
 	for _, tag := range raw.Tags {
 		if strings.HasPrefix(tag, util.K8sNameTagPrefix) {
 			re.Name = strings.TrimPrefix(tag, util.K8sNameTagPrefix)
+			continue
 		}
 		if strings.HasPrefix(tag, util.K8sNamespaceTagPrefix) {
 			re.Namespace = strings.TrimPrefix(tag, util.K8sNamespaceTagPrefix)
+			continue
 		}
 		if strings.HasPrefix(tag, util.K8sKindTagPrefix) {
 			gvk.Kind = strings.TrimPrefix(tag, util.K8sKindTagPrefix)
+			continue
 		}
 		if strings.HasPrefix(tag, util.K8sVersionTagPrefix) {
 			gvk.Version = strings.TrimPrefix(tag, util.K8sVersionTagPrefix)
+			continue
 		}
 		// this will not set anything for core resources
 		if strings.HasPrefix(tag, util.K8sGroupTagPrefix) {
 			gvk.Group = strings.TrimPrefix(tag, util.K8sGroupTagPrefix)
+			continue
 		}
 		if strings.HasPrefix(tag, util.K8sUIDTagPrefix) {
 			re.UID = strings.TrimPrefix(tag, util.K8sUIDTagPrefix)
+			continue
 		}
 	}
 
 	re.APIVersion, re.Kind = gvk.ToAPIVersionAndKind()
 	if re.Name == "" {
-		return re, fmt.Errorf("no name")
+		return re, fmt.Errorf("resource error has no name tag")
 	}
 	if re.Namespace == "" && !gvkIsClusterScoped(gvk) {
-		return re, fmt.Errorf("no namespace")
+		return re, fmt.Errorf("resource error has no namespace tag, name: %s", raw.Name)
 	}
 	if re.Kind == "" {
-		return re, fmt.Errorf("no kind")
+		return re, fmt.Errorf("resource error has not enough kind, group, version tags, name: %s", raw.Name)
 	}
 	if re.UID == "" {
-		return re, fmt.Errorf("no uid")
+		return re, fmt.Errorf("resource error has no uid tag, name: %s", raw.Name)
 	}
 	return re, nil
 }

--- a/internal/dataplane/sendconfig/inmemory_error_handling.go
+++ b/internal/dataplane/sendconfig/inmemory_error_handling.go
@@ -171,30 +171,19 @@ func parseRawResourceError(raw rawResourceError) (ResourceError, error) {
 
 	var gvk schema.GroupVersionKind
 	for _, tag := range raw.Tags {
-		if strings.HasPrefix(tag, util.K8sNameTagPrefix) {
+		switch {
+		case strings.HasPrefix(tag, util.K8sNameTagPrefix):
 			re.Name = strings.TrimPrefix(tag, util.K8sNameTagPrefix)
-			continue
-		}
-		if strings.HasPrefix(tag, util.K8sNamespaceTagPrefix) {
+		case strings.HasPrefix(tag, util.K8sNamespaceTagPrefix):
 			re.Namespace = strings.TrimPrefix(tag, util.K8sNamespaceTagPrefix)
-			continue
-		}
-		if strings.HasPrefix(tag, util.K8sKindTagPrefix) {
+		case strings.HasPrefix(tag, util.K8sKindTagPrefix):
 			gvk.Kind = strings.TrimPrefix(tag, util.K8sKindTagPrefix)
-			continue
-		}
-		if strings.HasPrefix(tag, util.K8sVersionTagPrefix) {
+		case strings.HasPrefix(tag, util.K8sVersionTagPrefix):
 			gvk.Version = strings.TrimPrefix(tag, util.K8sVersionTagPrefix)
-			continue
-		}
-		// this will not set anything for core resources
-		if strings.HasPrefix(tag, util.K8sGroupTagPrefix) {
+		case strings.HasPrefix(tag, util.K8sGroupTagPrefix):
 			gvk.Group = strings.TrimPrefix(tag, util.K8sGroupTagPrefix)
-			continue
-		}
-		if strings.HasPrefix(tag, util.K8sUIDTagPrefix) {
+		case strings.HasPrefix(tag, util.K8sUIDTagPrefix):
 			re.UID = strings.TrimPrefix(tag, util.K8sUIDTagPrefix)
-			continue
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the `Entity tags missing fields {"name": "", "error": "no name"}` errors, have a bit more context so that they are actually helpful in debugging:

```
2024-11-14T16:37:44+01:00	error	Entity tags returned in error API error from gateway is missing fields, Kubernetes Event cannot be created without them	{"name": "", "id": "c021ae7d-f985-40ad-9908-6c517a1d49d8", "tags": [], "type": "certificate", "raw_error": {"entity_id":"c021ae7d-f985-40ad-9908-6c517a1d49d8","entity_type":"certificate","errors":[{"message":"required field missing","type":"entity"}]}, "error": "resource error has no name tag"}
```

Related to #6660 