### PR TITLE
fix: properly set K8s on Kong Plugins

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,6 +58,11 @@ linters-settings:
     - prefix(github.com/Kong/sdk-konnect-go)
     - prefix(github.com/kong/kubernetes-ingress-controller/v3)
     - prefix(github.com/kong/kubernetes-configuration)
+  govet:
+    enable-all: true # To have checks like e.g. unusedwrite.
+    disable:
+      - fieldalignment
+      - shadow
   importas:
     no-unaliased: true
     alias:

--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -524,9 +524,8 @@ func existsMatchingListenerInStatus[T gatewayapi.RouteT](route T, listener gatew
 			switch any(route).(type) {
 			case *gatewayapi.HTTPRoute:
 				gvk = schema.GroupVersionKind{
-					Group:   gatewayv1.GroupVersion.Group,
-					Version: gatewayv1.GroupVersion.Version,
-					Kind:    "HTTPRoute",
+					Group: gatewayv1.GroupVersion.Group,
+					Kind:  "HTTPRoute",
 				}
 			default:
 				gvk = route.GetObjectKind().GroupVersionKind()

--- a/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/default_golden.yaml
@@ -21,6 +21,12 @@ services:
         replace:
           uri: /new-prefix$(uri_captures[1])
       name: request-transformer
+      tags:
+      - k8s-name:httproute-testing
+      - k8s-namespace:default
+      - k8s-kind:HTTPRoute
+      - k8s-group:gateway.networking.k8s.io
+      - k8s-version:v1
     preserve_host: true
     protocols:
     - http

--- a/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
@@ -18,6 +18,12 @@ services:
         replace:
           uri: /new-prefix$(uri_captures[1])
       name: request-transformer
+      tags:
+      - k8s-name:httproute-testing
+      - k8s-namespace:default
+      - k8s-kind:HTTPRoute
+      - k8s-group:gateway.networking.k8s.io
+      - k8s-version:v1
     preserve_host: true
     priority: 35184422424575
     strip_path: false

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -459,10 +459,10 @@ func generatePluginsFromHTTPRouteFilters(
 	}
 	kongPlugins = append(kongPlugins, transformerPluginsToKongPlugins(transformerPlugins)...)
 
-	for _, p := range kongPlugins {
+	for i := range kongPlugins {
 		// This plugin is derived from an HTTPRoute filter, not a KongPlugin, so we apply tags indicating that
 		// HTTPRoute as the parent Kubernetes resource for these generated transformerPlugins.
-		p.Tags = tags
+		kongPlugins[i].Tags = tags
 	}
 
 	if len(pluginNamesFromExtensionRef) > 0 {

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -1058,6 +1058,13 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 													Headers: []string{"X-Test-Header-1:test-value-1"},
 												},
 											},
+											Tags: []*string{
+												kong.String("k8s-name:basic-httproute"),
+												kong.String("k8s-namespace:default"),
+												kong.String("k8s-kind:HTTPRoute"),
+												kong.String("k8s-group:gateway.networking.k8s.io"),
+												kong.String("k8s-version:v1beta1"),
+											},
 										},
 									},
 								},
@@ -1090,6 +1097,13 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 												"append": subtranslator.TransformerPluginConfig{
 													Headers: []string{"X-Test-Header-2:test-value-2"},
 												},
+											},
+											Tags: []*string{
+												kong.String("k8s-name:basic-httproute"),
+												kong.String("k8s-namespace:default"),
+												kong.String("k8s-kind:HTTPRoute"),
+												kong.String("k8s-group:gateway.networking.k8s.io"),
+												kong.String("k8s-version:v1beta1"),
 											},
 										},
 									},
@@ -1467,6 +1481,13 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 												"append": subtranslator.TransformerPluginConfig{
 													Headers: []string{"X-Test-Header-1:test-value-1"},
 												},
+											},
+											Tags: []*string{
+												kong.String("k8s-name:basic-httproute"),
+												kong.String("k8s-namespace:default"),
+												kong.String("k8s-kind:HTTPRoute"),
+												kong.String("k8s-group:gateway.networking.k8s.io"),
+												kong.String("k8s-version:v1beta1"),
 											},
 										},
 									},
@@ -2307,6 +2328,13 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 						Config: kong.Configuration{
 							"status_code": kong.Int(301),
 						},
+						Tags: []*string{
+							kong.String("k8s-name:httproute-1"),
+							kong.String("k8s-namespace:default"),
+							kong.String("k8s-kind:HTTPRoute"),
+							kong.String("k8s-group:gateway.networking.k8s.io"),
+							kong.String("k8s-version:v1beta1"),
+						},
 					},
 					{
 						Name: kong.String("response-transformer"),
@@ -2314,6 +2342,13 @@ func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
 							"add": subtranslator.TransformerPluginConfig{
 								Headers: []string{"Location: http://bar.com:80/v1/foo"},
 							},
+						},
+						Tags: []*string{
+							kong.String("k8s-name:httproute-1"),
+							kong.String("k8s-namespace:default"),
+							kong.String("k8s-kind:HTTPRoute"),
+							kong.String("k8s-group:gateway.networking.k8s.io"),
+							kong.String("k8s-version:v1beta1"),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Set K8s tags on actual objects from the Kong Plugin list instead of their copies - unused write. Go vet can detect it when properly configured thus this PR enables it. Checks `fieldalignment` and `shadow` report many issues, therefore decide if it is worth enabling them, and let's do it in separate PRs.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

