### PR TITLE
chore: let renovate handle kconf go.mod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: gomod
+  ignore:
+    # Ignore updates for `kong/kubernetes-configuration` as it is handled by Renovate.
+    - dependency-name: github.com/kong/kubernetes-configuration
   directory: /
   schedule:
     interval: daily

--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -1,5 +1,6 @@
-# This workflow will regenerate the manifests, commit&push them on a PR labeled with `renovate/auto-regenerate`.
-# It's to make sure that Renovate-created PRs that update kustomize dependencies also update the manifests.
+# This workflow will regenerate code and manifests, commit&push them on a PR labeled with `renovate/auto-regenerate`.
+# It's to make sure that Renovate-created PRs that update dependencies that might affect generated code/manifests,
+# will have them regenerated automatically.
 name: Regenerate on deps bump
 
 on:
@@ -27,7 +28,7 @@ jobs:
           install: false
 
       - name: regenerate
-        run: make manifests
+        run: make generate manifests
 
       - name: Set github url and credentials
         run: |
@@ -39,8 +40,8 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
-          git add ./test/e2e/manifests
+          git add ./test/e2e/manifests ./config/crd
           git status
           git diff-index --quiet HEAD || \
-          git commit -m "chore: regenerate manifests" && \
+          git commit -m "chore: regenerate" && \
           git push origin ${{ github.event.pull_request.head.ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "configMigration": true,
   "enabledManagers": [
     "custom.regex",
-    "kustomize"
+    "kustomize",
+    "gomod"
   ],
   "automerge": false,
   "separateMinorPatch": true,
@@ -83,6 +84,32 @@
       ],
       "matchDepNames": [
         "/.*@regenerate/"
+      ]
+    },
+    {
+      "description": "Add 'renovate/auto-regenerate' label to a PR if it changes go.mod files to trigger regenerate_on_deps_bump.yaml workflow.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "addLabels": [
+        "renovate/auto-regenerate"
+      ]
+    },
+    {
+      "description": "Ignore all go.mod dependencies as majority of them is handled by dependabot.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Enable go.mod dependencies that are not handled by dependabot.",
+      "matchManagers": [
+          "gomod"
+      ],
+      "enabled": true,
+      "matchPackageNames": [
+        "github.com/kong/kubernetes-configuration"
       ]
     }
   ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables `kong/kubernetes-configuration` go module updates from dependabot. It enables them in Renovate instead because it allows the addition of a custom label to a PR created by the tool. We need to add a `renovate/auto-regenerate` label to a PR to make sure that every time kconf dependency is updated, all generated files depending on it will be up-to-date (i.e. `config/crd/kustomization.yaml`).

Tested on a fork.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Follow up to https://github.com/Kong/kubernetes-ingress-controller/pull/6683#pullrequestreview-2442312936.
