### PR TITLE
fix(log): false positive `No targets found to create upstream ...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ Adding a new version? You'll need three changes:
   [#6585](https://github.com/Kong/kubernetes-ingress-controller/pull/6585)
 - Fix panic when handling `KongConsumer` without `username` specified.
   [#6665](https://github.com/Kong/kubernetes-ingress-controller/pull/6665)
+- Get rid of redundant log `info  No targets found to create upstream ...` for
+  `HTTPRoute` with `RequestRedirect` or when `request-termination` Kong Plugin
+  is used.
+  [#6687](https://github.com/Kong/kubernetes-ingress-controller/pull/6686).
 
 ### Added
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Reported by a user in 

- https://github.com/Kong/kubernetes-ingress-controller/issues/6535

Steps to reproduce - apply the YAML:

```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: kong
  annotations:
    konghq.com/gatewayclass-unmanaged: "true"
spec:
  controllerName: konghq.com/kic-gateway-controller
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kong
spec:
  gatewayClassName: kong
  listeners:
    - name: http
      protocol: HTTP
      port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: route-name
spec:
  hostnames:
    - app.domain.example
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: kong
  rules:
    - filters:
        - requestRedirect:
            hostname: app.domain.example
            path:
              replaceFullPath: /chat
              type: ReplaceFullPath
            port: 443
            scheme: https
            statusCode: 302
          type: RequestRedirect
      matches:
        - path:
            type: PathPrefix
            value: /
```

and observe logs, there is the entry

```log
[ingress-controller] 2024-11-18T14:26:09Z. info  No targets found to create upstream     {"v": 0, "service_name": "httproute.default.route-name.app.domain.example.0"}
```

which does not make sense when the target may be outside of the K8s cluster (not a `Service` or `ServiceFacade`). This PR fixes it to not log it when Kong Plugin `request-termination` is used (configured by a user or as a result of implementing `RequestRedirect` filter by KIC&Kong).

Debug message 
```log
[ingress-controller] 2024-11-18T14:26:06Z  debug  Service has zero k8sServices backends, cannot generate tags for it properly     {"v": 1, "service": "httproute.default.route-name.app.domain.example.0"}
```
is still present in both cases.


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6535

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
