### PR TITLE
fix: fix Kong client's status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ Adding a new version? You'll need three changes:
   `HTTPRoute` with `RequestRedirect` or when `request-termination` Kong Plugin
   is used.
   [#6687](https://github.com/Kong/kubernetes-ingress-controller/pull/6686).
+- Fixed Kong client status check causing unnecessary `config update failed` errors
+  and `KongConfigurationApplyFailed` events being generated.
+  [#6689](https://github.com/Kong/kubernetes-ingress-controller/pull/6689)
 
 ### Added
 

--- a/internal/adminapi/kong_test.go
+++ b/internal/adminapi/kong_test.go
@@ -105,56 +105,100 @@ func TestMakeHTTPClientWithTLSOptsAndFilePaths(t *testing.T) {
 }
 
 func TestNewKongClientForWorkspace(t *testing.T) {
-	const testWorkspace = "workspace"
+	const workspace = "workspace"
 
 	testCases := []struct {
 		name            string
 		adminAPIReady   bool
 		adminAPIVersion string
+		workspace       string
 		workspaceExists bool
 		expectError     error
 	}{
 		{
+			name:          "admin api is ready for default workspace",
+			adminAPIReady: true,
+			workspace:     "",
+		},
+		{
 			name:            "admin api is ready and workspace exists",
 			adminAPIReady:   true,
+			workspace:       workspace,
 			workspaceExists: true,
 		},
 		{
 			name:            "admin api is ready and workspace doesn't exist",
 			adminAPIReady:   true,
+			workspace:       workspace,
 			workspaceExists: false,
 		},
 		{
 			name:          "admin api is not ready",
 			adminAPIReady: false,
+			workspace:     "",
 			expectError:   adminapi.KongClientNotReadyError{},
+		},
+		{
+			name:            "admin api is not ready for an existing workspace",
+			adminAPIReady:   false,
+			workspace:       workspace,
+			workspaceExists: true,
+			expectError:     adminapi.KongClientNotReadyError{},
 		},
 		{
 			name:            "admin api is in too old version",
 			adminAPIReady:   true,
 			adminAPIVersion: "3.4.0",
+			workspace:       "",
 			expectError:     adminapi.KongGatewayUnsupportedVersionError{},
 		},
 		{
 			name:            "admin api is in supported OSS version",
 			adminAPIReady:   true,
+			workspace:       "",
 			adminAPIVersion: versions.KICv3VersionCutoff.String(),
 		},
 		{
 			name:            "admin api has malformed version",
 			adminAPIReady:   true,
 			adminAPIVersion: "3-malformed-version",
+			workspace:       "",
+			expectError:     adminapi.KongGatewayUnsupportedVersionError{},
+		},
+		{
+			name:            "admin api has malformed version for workspace",
+			adminAPIReady:   true,
+			adminAPIVersion: "3-malformed-version",
+			workspace:       workspace,
+			workspaceExists: true,
 			expectError:     adminapi.KongGatewayUnsupportedVersionError{},
 		},
 		{
 			name:            "admin api has enterprise version",
 			adminAPIReady:   true,
+			workspace:       "",
+			adminAPIVersion: "3.4.1.2",
+		},
+		{
+			name:            "admin api has enterprise version for workspace",
+			adminAPIReady:   true,
+			workspace:       workspace,
+			workspaceExists: true,
 			adminAPIVersion: "3.4.1.2",
 		},
 		{
 			name:            "admin api has too old enterprise version",
 			adminAPIReady:   true,
 			adminAPIVersion: "3.4.0.2",
+			workspace:       "",
+			expectError:     adminapi.KongGatewayUnsupportedVersionError{},
+		},
+		{
+			name:            "admin api has too old enterprise version for workspace",
+			adminAPIReady:   true,
+			adminAPIVersion: "3.4.0.2",
+			workspace:       workspace,
+			workspaceExists: true,
 			expectError:     adminapi.KongGatewayUnsupportedVersionError{},
 		},
 	}
@@ -173,7 +217,7 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 			client, err := adminapi.NewKongClientForWorkspace(
 				context.Background(),
 				adminAPIServer.URL,
-				testWorkspace,
+				tc.workspace,
 				adminAPIServer.Client(),
 			)
 
@@ -184,11 +228,11 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, client)
 
-			if !tc.workspaceExists {
+			if tc.workspace != "" && !tc.workspaceExists {
 				require.True(t, adminAPIHandler.WasWorkspaceCreated(), "expected workspace to be created")
 			}
 
-			require.Equal(t, client.AdminAPIClient().Workspace(), testWorkspace)
+			require.Equal(t, client.AdminAPIClient().Workspace(), tc.workspace)
 			_, ok := client.PodReference()
 			require.False(t, ok, "expected no pod reference to be attached to the client")
 		})

--- a/internal/dataplane/configfetcher/config_fetcher.go
+++ b/internal/dataplane/configfetcher/config_fetcher.go
@@ -152,6 +152,9 @@ func (cf *DefaultKongLastGoodConfigFetcher) TryFetchingValidConfigFromGateways(
 		}
 		cf.lastValidState = goodKongState
 		logger.V(logging.DebugLevel).Info("Last good configuration fetched from Kong node", "url", clientUsed.BaseRootURL())
+		// If we've found at least one good configuration, we can return early without an error.
+		// We got what we wanted, which is the last good configuration.
+		return nil
 	}
 	return errs
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:


This PR fixes an invalid status check in kong client which causes the client to report that it's ready while in reality it's not. The problem arises from an invalid check in `NewKongClientForWorkspace()`

```
	if wsName == "" {
		return NewClient(client), nil
	}
```

which short circuits when the workspace is empty and [does not perform the checks that follow](https://github.com/Kong/kubernetes-ingress-controller/blob/c393bb5fcc88c9f924be48190ae79a304fa71845/internal/adminapi/kong.go#L71-L110).

The above causes the client manager to think that this client is ready to receive config where it's not.

This behavior can easily be tested with using Gateway Discovery and scaling up the Kong `Deployment`. This also prevents the `KongConfigurationApplyFailed` event from being created.

```
2024-11-18T16:57:50+01:00	info	controllers.KongAdminAPIService	Reconciling Admin API EndpointSlice	{"v": 0, "namespace": "kong", "name": "kong-kong-admin-skgmz"}
2024-11-18T16:57:50+01:00	debug	controllers.KongAdminAPIService	Notifying about newly detected Admin APIs	{"v": 1, "admin_apis": ["https://10.244.0.27:8444", "https://10.244.0.185:8444"]}
2024-11-18T16:57:50+01:00	debug	Received notification about Admin API addresses change	{"v": 1}
2024-11-18T16:57:50+01:00	debug	setup.readiness-checker	Checked readiness of pending client	{"address": "https://10.244.0.185:8444", "v": 1, "ok": true}
2024-11-18T16:57:50+01:00	debug	controllers.EndpointSlice	Reconciling resource	{"DiscoveryV1EndpointSlice": {"name":"kong-kong-proxy-rsfsw","namespace":"kong"}, "v": 1, "namespace": "kong", "name": "kong-kong-proxy-rsfsw"}
2024-11-18T16:57:50+01:00	debug	setup.readiness-checker	Already created client is ready	{"address": "https://10.244.0.27:8444", "v": 1}
2024-11-18T16:57:50+01:00	debug	Notifying subscribers about gateway clients change	{"v": 1}
2024-11-18T16:57:51+01:00	debug	controllers.KongLicense	Get license from KongLicense resource	{"v": 1, "name": "kong-license"}
2024-11-18T16:57:51+01:00	debug	New configuration snapshot detected	{"v": 1, "hash": "L4QTCQCY47VAEMJYAZSJTGEF23XIL23BKP3PN5DDX4ZJKDYGDPEQ===="}
2024-11-18T16:57:51+01:00	debug	Parsing kubernetes objects into data-plane configuration	{"v": 1}
2024-11-18T16:57:51+01:00	debug	controllers.KongLicense	Get license from KongLicense resource	{"v": 1, "name": "kong-license"}
2024-11-18T16:57:51+01:00	debug	Successfully built data-plane configuration	{"v": 1, "duration": "392.667µs"}
2024-11-18T16:57:51+01:00	debug	Sending configuration to gateway clients	{"v": 1, "urls": ["https://10.244.0.27:8444", "https://10.244.0.185:8444"]}
2024-11-18T16:57:51+01:00	debug	Shipping config to diagnostic server	{"url": "https://10.244.0.185:8444", "v": 1}
2024-11-18T16:57:51+01:00	debug	events	failed to apply Kong configuration to https://10.244.0.185:8444: config update failed: failed to reload declarative configuration: failed posting new config to /config: making HTTP request: Post "https://10.244.0.185:8444/config?check_hash=1&flatten_errors=1": dial tcp 10.244.0.185:8444: connect: connection refused	{"v": 1, "type": "Warning", "object": {"kind":"Pod","namespace":"kong","name":"local","apiVersion":"v1"}, "reason": "KongConfigurationApplyFailed"}
2024-11-18T16:57:51+01:00	debug	No configuration change, skipping sync to Kong	{"url": "https://10.244.0.27:8444", "v": 1}
2024-11-18T16:57:51+01:00	debug	Shipping config to diagnostic server	{"url": "https://10.244.0.27:8444", "v": 1}
2024-11-18T16:57:51+01:00	debug	Skipping recovery from gateways sync error - not enough details to recover	{"v": 1, "error": "performing update for https://10.244.0.185:8444 failed: config update failed: failed to reload declarative configuration: failed posting new config to /config: making HTTP request: Post \"https://10.244.0.185:8444/config?check_hash=1&flatten_errors=1\": dial tcp 10.244.0.185:8444: connect: connection refused"}
2024-11-18T16:57:51+01:00	error	dataplane-synchronizer	Could not update kong admin	{"error": "performing update for https://10.244.0.185:8444 failed: config update failed: failed to reload declarative configuration: failed posting new config to /config: making HTTP request: Post \"https://10.244.0.185:8444/config?check_hash=1&flatten_errors=1\": dial tcp 10.244.0.185:8444: connect: connection refused"}
2024-11-18T16:57:51+01:00	debug	events	successfully applied Kong configuration to https://10.244.0.27:8444	{"v": 1, "type": "Normal", "object": {"kind":"Pod","namespace":"kong","name":"local","apiVersion":"v1"}, "reason": "KongConfigurationSucceeded"}
2024-11-18T16:57:52+01:00	debug	controllers.EndpointSlice	Reconciling resource	{"DiscoveryV1EndpointSlice": {"name":"kong-kong-proxy-rsfsw","namespace":"kong"}, "v": 1, "namespace": "kong", "name": "kong-kong-proxy-rsfsw"}
2024-11-18T16:57:52+01:00	debug	controllers.EndpointSlice	Reconciling resource	{"DiscoveryV1EndpointSlice": {"name":"kong-kong-manager-zw2v2","namespace":"kong"}, "v": 1, "namespace": "kong", "name": "kong-kong-manager-zw2v2"}
2024-11-18T16:57:52+01:00	debug	controllers.EndpointSlice	Reconciling resource	{"DiscoveryV1EndpointSlice": {"name":"kong-kong-admin-skgmz","namespace":"kong"}, "v": 1, "namespace": "kong", "name": "kong-kong-admin-skgmz"}
2024-11-18T16:57:52+01:00	info	controllers.KongAdminAPIService	Reconciling Admin API EndpointSlice	{"v": 0, "namespace": "kong", "name": "kong-kong-admin-skgmz"}
2024-11-18T16:57:54+01:00	debug	controllers.KongLicense	Get license from KongLicense resource	{"v": 1, "name": "kong-license"}
2024-11-18T16:57:54+01:00	debug	New configuration snapshot detected	{"v": 1, "hash": "CEE2CSUNBAWL5TVBC7UGGKH4RFOEATG7WGRW6CCC7UEU5VN4TJGA===="}
2024-11-18T16:57:54+01:00	debug	Parsing kubernetes objects into data-plane configuration	{"v": 1}
2024-11-18T16:57:54+01:00	debug	controllers.KongLicense	Get license from KongLicense resource	{"v": 1, "name": "kong-license"}
2024-11-18T16:57:54+01:00	debug	Successfully built data-plane configuration	{"v": 1, "duration": "70.292µs"}
2024-11-18T16:57:54+01:00	debug	Sending configuration to gateway clients	{"v": 1, "urls": ["https://10.244.0.27:8444", "https://10.244.0.185:8444"]}
2024-11-18T16:57:54+01:00	debug	No configuration change, skipping sync to Kong	{"url": "https://10.244.0.27:8444", "v": 1}
2024-11-18T16:57:54+01:00	debug	Shipping config to diagnostic server	{"url": "https://10.244.0.27:8444", "v": 1}
2024-11-18T16:57:54+01:00	debug	events	successfully applied Kong configuration to https://10.244.0.27:8444	{"v": 1, "type": "Normal", "object": {"kind":"Pod","namespace":"kong","name":"local","apiVersion":"v1"}, "reason": "KongConfigurationSucceeded"}
2024-11-18T16:57:54+01:00	info	Successfully synced configuration to Kong	{"url": "https://10.244.0.185:8444", "update_strategy": "InMemory", "v": 0, "duration": "202ms"}
2024-11-18T16:57:54+01:00	debug	Shipping config to diagnostic server	{"url": "https://10.244.0.185:8444", "v": 1}
2024-11-18T16:57:54+01:00	debug	Triggering report for configured Kubernetes objects	{"v": 1, "count": 0}
2024-11-18T16:57:54+01:00	debug	events	successfully applied Kong configuration to https://10.244.0.185:8444	{"v": 1, "type": "Normal", "object": {"kind":"Pod","namespace":"kong","name":"local","apiVersion":"v1"}, "reason": "KongConfigurationSucceeded"}
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
