### PR TITLE
feat: handle CP refs in Consumer, ConsumerGroup and Vault reconcilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,12 @@ Adding a new version? You'll need three changes:
   and `ingress_controller_fallback_configuration_push_size` to record size of
   the config sent to a Kong DataPlane by the controller in DB-less mode.
   [#6664](https://github.com/Kong/kubernetes-ingress-controller/pull/6664)
+- Added support for `ControlPlaneRef` in `KongConsumer`, `KongConsumerGroup`,
+  and `KongVault` reconcilers. From now, objects that have `ControlPlaneRef`
+  of type other than `kic` will be ignored by the reconcilers. KIC will still
+  reconcile objects with `ControlPlaneRef` of type `kic` or without an explicit
+  `ControlPlaneRef`.
+  [#6690](https://github.com/Kong/kubernetes-ingress-controller/pull/6690)
 
 ## [3.3.1]
 

--- a/internal/controllers/configuration/zz_generated_controllers.go
+++ b/internal/controllers/configuration/zz_generated_controllers.go
@@ -286,13 +286,17 @@ func (r *NetV1IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&netv1.Ingress{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }
@@ -734,13 +738,17 @@ func (r *KongV1KongClusterPluginReconciler) SetupWithManager(mgr ctrl.Manager) e
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1.KongClusterPlugin{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }
@@ -902,16 +910,23 @@ func (r *KongV1KongConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			),
 		)
 	}
+	cpRefPredicate := ctrlutils.GenerateCPReferenceMatchesPredicate[*kongv1.KongConsumer]()
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+				cpRefPredicate,
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1.KongConsumer{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+			cpRefPredicate,
+		),
 	).
 		Complete(r)
 }
@@ -1088,16 +1103,23 @@ func (r *KongV1Beta1KongConsumerGroupReconciler) SetupWithManager(mgr ctrl.Manag
 			),
 		)
 	}
+	cpRefPredicate := ctrlutils.GenerateCPReferenceMatchesPredicate[*kongv1beta1.KongConsumerGroup]()
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+				cpRefPredicate,
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1beta1.KongConsumerGroup{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+			cpRefPredicate,
+		),
 	).
 		Complete(r)
 }
@@ -1279,13 +1301,17 @@ func (r *KongV1Beta1TCPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1beta1.TCPIngress{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }
@@ -1476,13 +1502,17 @@ func (r *KongV1Beta1UDPIngressReconciler) SetupWithManager(mgr ctrl.Manager) err
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1beta1.UDPIngress{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }
@@ -1732,13 +1762,17 @@ func (r *IncubatorV1Alpha1KongServiceFacadeReconciler) SetupWithManager(mgr ctrl
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&incubatorv1alpha1.KongServiceFacade{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }
@@ -1895,16 +1929,23 @@ func (r *KongV1Alpha1KongVaultReconciler) SetupWithManager(mgr ctrl.Manager) err
 			),
 		)
 	}
+	cpRefPredicate := ctrlutils.GenerateCPReferenceMatchesPredicate[*kongv1alpha1.KongVault]()
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+				cpRefPredicate,
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1alpha1.KongVault{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+			cpRefPredicate,
+		),
 	).
 		Complete(r)
 }
@@ -2063,13 +2104,17 @@ func (r *KongV1Alpha1KongCustomEntityReconciler) SetupWithManager(mgr ctrl.Manag
 	if !r.DisableIngressClassLookups {
 		blder.Watches(&netv1.IngressClass{},
 			handler.EnqueueRequestsFromMapFunc(r.listClassless),
-			builder.WithPredicates(predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass)),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(ctrlutils.IsDefaultIngressClass),
+			),
 		)
 	}
 	preds := ctrlutils.GeneratePredicateFuncsForIngressClassFilter(r.IngressClassName)
 	return blder.Watches(&kongv1alpha1.KongCustomEntity{},
 		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(preds),
+		builder.WithPredicates(
+			preds,
+		),
 	).
 		Complete(r)
 }

--- a/internal/controllers/utils/control_plane_reference.go
+++ b/internal/controllers/utils/control_plane_reference.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kongv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// ObjectWithControlPlaneRef is an interface that represents an object that has a control plane reference.
+type ObjectWithControlPlaneRef interface {
+	GetControlPlaneRef() *kongv1alpha1.ControlPlaneRef
+}
+
+// GenerateCPReferenceMatchesPredicate generates a predicate function that filters out objects that have a control plane
+// reference set to a value other than 'kic'.
+func GenerateCPReferenceMatchesPredicate[T ObjectWithControlPlaneRef]() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(o client.Object) bool {
+		c, ok := o.(T)
+		if !ok {
+			return false
+		}
+		if cpRef := c.GetControlPlaneRef(); cpRef != nil {
+			// If the cpRef is set, reconcile the object only if it is set explicitly to 'kic'.
+			return cpRef.Type == kongv1alpha1.ControlPlaneRefKIC
+		}
+		// If there's no cpRef set, we should reconcile it as by default it's 'kic'.
+		return true
+	})
+}

--- a/internal/controllers/utils/control_plane_reference_test.go
+++ b/internal/controllers/utils/control_plane_reference_test.go
@@ -1,0 +1,80 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	kongv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+
+	ctrlutils "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/utils"
+)
+
+type objectWithCPRefType struct {
+	client.Object
+	cpRef *kongv1alpha1.ControlPlaneRef
+}
+
+func (o *objectWithCPRefType) GetControlPlaneRef() *kongv1alpha1.ControlPlaneRef {
+	return o.cpRef
+}
+
+func TestGenerateCPReferenceMatchesPredicate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		obj      objectWithCPRefType
+		expected bool
+	}{
+		{
+			name: "control plane reference is nil",
+			obj: objectWithCPRefType{
+				cpRef: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "control plane reference is set to kic",
+			obj: objectWithCPRefType{
+				cpRef: &kongv1alpha1.ControlPlaneRef{
+					Type: kongv1alpha1.ControlPlaneRefKIC,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "control plane reference is set to konnect",
+			obj: objectWithCPRefType{
+				cpRef: &kongv1alpha1.ControlPlaneRef{
+					Type:      kongv1alpha1.ControlPlaneRefKonnectID,
+					KonnectID: lo.ToPtr("konnect-id"),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "control plane reference is set to konnect namespaced reference",
+			obj: objectWithCPRefType{
+				cpRef: &kongv1alpha1.ControlPlaneRef{
+					Type: kongv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+					KonnectNamespacedRef: &kongv1alpha1.KonnectNamespacedRef{
+						Name: "konnect-name",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred := ctrlutils.GenerateCPReferenceMatchesPredicate[*objectWithCPRefType]()
+			actual := pred.Generic(event.GenericEvent{
+				Object: &tc.obj,
+			})
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/test/envtest/consts.go
+++ b/test/envtest/consts.go
@@ -1,0 +1,10 @@
+package envtest
+
+import "time"
+
+const (
+	// waitTime is a time to wait for a condition to be met.
+	waitTime = 3 * time.Second
+	// tickTime is a time to wait between condition's checks.
+	tickTime = 100 * time.Millisecond
+)

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -94,7 +94,8 @@ func TestControlPlaneReferenceHandling(t *testing.T) {
 				},
 				Spec: kongv1alpha1.KongVaultSpec{
 					Backend: "env",
-					Prefix:  "env",
+					// Prefix has to be unique for each Vault object as it's validated by KIC in translation.
+					Prefix: "prefix-" + lo.RandomString(8, lo.LowerCaseLettersCharset),
 				},
 			}
 		}
@@ -175,7 +176,7 @@ func TestControlPlaneReferenceHandling(t *testing.T) {
 					if !assert.NoError(t, ctrlClient.Get(ctx, client.ObjectKeyFromObject(tc.object), tc.object)) {
 						return
 					}
-					assert.Equal(t, tc.expectToBeProgrammed, conditions.Contain(
+					assert.True(t, conditions.Contain(
 						tc.object.GetConditions(),
 						conditions.WithType(string(kongv1.ConditionProgrammed)),
 						conditions.WithStatus(metav1.ConditionTrue),

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -1,0 +1,196 @@
+//go:build envtest
+
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	kongv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	kongv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/conditions"
+)
+
+// TestControlPlaneReferenceHandling tests ControlPlaneReference handling in controllers supporting it.
+// It expects that if an object has a ControlPlaneReference set, it should only be programmed if the reference
+// is set to 'kic'.
+func TestControlPlaneReferenceHandling(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const ingressClassName = "kongenvtest"
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme)
+	ctrlClient := NewControllerClient(t, scheme, envcfg)
+	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
+	logger := zapr.NewLogger(zap.NewNop())
+	ctrl.SetLogger(logger)
+	ns := CreateNamespace(ctx, t, ctrlClient)
+	RunManager(ctx, t, envcfg,
+		AdminAPIOptFns(),
+		WithUpdateStatus(),
+		WithIngressClass(ingressClassName),
+		WithPublishService(ns.Name),
+		WithProxySyncSeconds(0.10),
+	)
+
+	var (
+		kicCPRef = &kongv1alpha1.ControlPlaneRef{
+			Type: kongv1alpha1.ControlPlaneRefKIC,
+		}
+		konnectCPRef = &kongv1alpha1.ControlPlaneRef{
+			Type:      kongv1alpha1.ControlPlaneRefKonnectID,
+			KonnectID: lo.ToPtr("konnect-id"),
+		}
+
+		validConsumer = func() *kongv1.KongConsumer {
+			return &kongv1.KongConsumer{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "consumer-",
+					Namespace:    ns.Name,
+					Annotations: map[string]string{
+						annotations.IngressClassKey: ingressClassName,
+					},
+				},
+				Username: "consumer",
+			}
+		}
+		validConsumerGroup = func() *kongv1beta1.KongConsumerGroup {
+			return &kongv1beta1.KongConsumerGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "consumer-group-",
+					Namespace:    ns.Name,
+					Annotations: map[string]string{
+						annotations.IngressClassKey: ingressClassName,
+					},
+				},
+				Spec: kongv1beta1.KongConsumerGroupSpec{
+					Name: "consumer-group",
+				},
+			}
+		}
+		validVault = func() *kongv1alpha1.KongVault {
+			return &kongv1alpha1.KongVault{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "vault-",
+					Namespace:    ns.Name,
+					Annotations: map[string]string{
+						annotations.IngressClassKey: ingressClassName,
+					},
+				},
+				Spec: kongv1alpha1.KongVaultSpec{
+					Backend: "env",
+					Prefix:  "env",
+				},
+			}
+		}
+	)
+
+	testCases := []struct {
+		name   string
+		object interface {
+			client.Object
+			GetConditions() []metav1.Condition
+			SetControlPlaneRef(*kongv1alpha1.ControlPlaneRef)
+		}
+		controlPlaneRef      *kongv1alpha1.ControlPlaneRef
+		expectToBeProgrammed bool
+	}{
+		{
+			name:                 "KongConsumer - without ControlPlaneRef",
+			object:               validConsumer(),
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongConsumer - with ControlPlaneRef == kic",
+			object:               validConsumer(),
+			controlPlaneRef:      kicCPRef,
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongConsumer - with ControlPlaneRef != kic",
+			object:               validConsumer(),
+			controlPlaneRef:      konnectCPRef,
+			expectToBeProgrammed: false,
+		},
+		{
+			name:                 "KongConsumerGroup - without ControlPlaneRef",
+			object:               validConsumerGroup(),
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongConsumerGroup - with ControlPlaneRef == kic",
+			object:               validConsumerGroup(),
+			controlPlaneRef:      kicCPRef,
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongConsumerGroup - with ControlPlaneRef != kic",
+			object:               validConsumerGroup(),
+			controlPlaneRef:      konnectCPRef,
+			expectToBeProgrammed: false,
+		},
+		{
+			name:                 "KongVault - without ControlPlaneRef",
+			object:               validVault(),
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongVault - with ControlPlaneRef == kic",
+			object:               validVault(),
+			controlPlaneRef:      kicCPRef,
+			expectToBeProgrammed: true,
+		},
+		{
+			name:                 "KongVault - with ControlPlaneRef != kic",
+			object:               validVault(),
+			controlPlaneRef:      konnectCPRef,
+			expectToBeProgrammed: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.controlPlaneRef != nil {
+				tc.object.SetControlPlaneRef(tc.controlPlaneRef)
+			}
+			require.NoError(t, ctrlClient.Create(ctx, tc.object))
+
+			if tc.expectToBeProgrammed {
+				require.EventuallyWithT(t, func(t *assert.CollectT) {
+					if !assert.NoError(t, ctrlClient.Get(ctx, client.ObjectKeyFromObject(tc.object), tc.object)) {
+						return
+					}
+					assert.Equal(t, tc.expectToBeProgrammed, conditions.Contain(
+						tc.object.GetConditions(),
+						conditions.WithType(string(kongv1.ConditionProgrammed)),
+						conditions.WithStatus(metav1.ConditionTrue),
+					))
+				}, waitTime, tickDuration, "expected object to be programmed")
+			} else {
+				require.Never(t, func() bool {
+					err := ctrlClient.Get(ctx, client.ObjectKeyFromObject(tc.object), tc.object)
+					return err == nil && conditions.Contain(
+						tc.object.GetConditions(),
+						conditions.WithType(string(kongv1.ConditionProgrammed)),
+						conditions.WithStatus(metav1.ConditionTrue),
+					)
+				}, waitTime, tickDuration, "expected object not to be programmed")
+			}
+		})
+	}
+}

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -18,11 +18,6 @@ import (
 	ctrllicense "github.com/kong/kubernetes-ingress-controller/v3/controllers/license"
 )
 
-const (
-	waitTime = 3 * time.Second
-	tickTime = 100 * time.Millisecond
-)
-
 func TestKongLicenseController(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	cfg := Setup(t, scheme)


### PR DESCRIPTION
**What this PR does / why we need it**:

Handles CP references in `KongConsumer`, `KongConsumerGroup`, and `KongVault` reconcilers so objects are only reconciled when they do not have a CP ref explicitly set, or it's explicitly set to `kic`. Otherwise, an object will get ignored (e.g. when it has a CP ref of `konnectNamespacedRef` type).

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6581.

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
