### PR TITLE
fix(log): do not log errors when parentRef kind is not Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@ Adding a new version? You'll need three changes:
 - Fixed Kong client status check causing unnecessary `config update failed` errors
   and `KongConfigurationApplyFailed` events being generated.
   [#6689](https://github.com/Kong/kubernetes-ingress-controller/pull/6689)
+- Do not emit error logs when group and kind of `parentRef` in a route does not
+  point to a `Gateway` as they can point to other kinds of resources like
+  `Service` when used in service mesh solutions.
+  [#6692](https://github.com/Kong/kubernetes-ingress-controller/pull/6692)
 
 ### Added
 

--- a/internal/controllers/gateway/route_predicate_test.go
+++ b/internal/controllers/gateway/route_predicate_test.go
@@ -17,19 +17,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
 )
 
-func testIsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
-	t *testing.T,
-	cl client.Client,
-	gatewayNN controllers.OptionalNamespacedName,
-	route routeT,
-	expectedResult bool,
-) {
-	logger := logr.Discard()
-
-	result := IsRouteAttachedToReconciledGateway[routeT](cl, logger, gatewayNN, route)
-	require.Equal(t, expectedResult, result)
-}
-
 func TestIsRouteAttachedToReconciledGateway(t *testing.T) {
 	type httpRouteTestCase struct {
 		name           string
@@ -214,16 +201,11 @@ func TestIsRouteAttachedToReconciledGateway(t *testing.T) {
 	}
 
 	for _, tc := range httpRouteTestCases {
-
 		cl := fakeclient.NewClientBuilder().WithScheme(lo.Must(scheme.Get())).WithObjects(tc.objects...).Build()
 		t.Run(tc.name, func(t *testing.T) {
-			testIsRouteAttachedToReconciledGateway(
-				t,
-				cl,
-				tc.gatewayNN,
-				tc.route,
-				tc.expectedResult,
-			)
+			logger := logr.Discard()
+			result := IsRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](cl, logger, tc.gatewayNN, tc.route)
+			require.Equal(t, tc.expectedResult, result)
 		},
 		)
 	}

--- a/internal/controllers/gateway/route_predicate_test.go
+++ b/internal/controllers/gateway/route_predicate_test.go
@@ -1,0 +1,230 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
+)
+
+func testIsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
+	t *testing.T,
+	cl client.Client,
+	gatewayNN controllers.OptionalNamespacedName,
+	route routeT,
+	expectedResult bool,
+) {
+	logger := logr.Discard()
+
+	result := IsRouteAttachedToReconciledGateway[routeT](cl, logger, gatewayNN, route)
+	require.Equal(t, expectedResult, result)
+}
+
+func TestIsRouteAttachedToReconciledGateway(t *testing.T) {
+	type httpRouteTestCase struct {
+		name           string
+		objects        []client.Object
+		route          *gatewayapi.HTTPRoute
+		gatewayNN      controllers.OptionalNamespacedName
+		expectedResult bool
+	}
+
+	kongGWClass := &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kong",
+		},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "konghq.com/kic-gateway-controller",
+		},
+	}
+
+	anotherGWClass := &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "another",
+		},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "another",
+		},
+	}
+
+	kongGW := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kong",
+			Namespace: "default",
+		},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: "kong",
+		},
+	}
+
+	anotherGW := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "another",
+			Namespace: "default",
+		},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: "another",
+		},
+	}
+
+	httpRouteTestCases := []httpRouteTestCase{
+		{
+			name: "single parent ref to gateway with expected class",
+			objects: []client.Object{
+				kongGW,
+				kongGWClass,
+			},
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kong-httproute",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Group:     lo.ToPtr(gatewayapi.V1Group),
+								Kind:      lo.ToPtr(gatewayapi.Kind("Gateway")),
+								Namespace: lo.ToPtr(gatewayapi.Namespace("default")),
+								Name:      gatewayapi.ObjectName("kong"),
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "single parent ref to gateway with another class",
+			objects: []client.Object{
+				anotherGW,
+				anotherGWClass,
+			},
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kong-httproute",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Group:     lo.ToPtr(gatewayapi.V1Group),
+								Kind:      lo.ToPtr(gatewayapi.Kind("Gateway")),
+								Namespace: lo.ToPtr(gatewayapi.Namespace("default")),
+								Name:      gatewayapi.ObjectName("another"),
+							},
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "single parent ref to specified gateway",
+			objects: []client.Object{
+				anotherGW,
+				anotherGWClass,
+			},
+			gatewayNN: controllers.NewOptionalNamespacedName(mo.Some(
+				k8stypes.NamespacedName{
+					Namespace: "default",
+					Name:      "another",
+				},
+			)),
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kong-httproute",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  lo.ToPtr(gatewayapi.Kind("Gateway")),
+								Name:  gatewayapi.ObjectName("another"),
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "multiple parent refs with one pointing to reconciled gateway",
+			objects: []client.Object{
+				kongGW,
+				kongGWClass,
+			},
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kong-httproute",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Kind: lo.ToPtr(gatewayapi.Kind("Service")),
+								Name: gatewayapi.ObjectName("kuma"),
+							},
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  lo.ToPtr(gatewayapi.Kind("Gateway")),
+								Name:  gatewayapi.ObjectName("kong"),
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "parent ref pointing to non-exist gateway",
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kong-httproute",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  lo.ToPtr(gatewayapi.Kind("Gateway")),
+								Name:  gatewayapi.ObjectName("non-exist"),
+							},
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range httpRouteTestCases {
+
+		cl := fakeclient.NewClientBuilder().WithScheme(lo.Must(scheme.Get())).WithObjects(tc.objects...).Build()
+		t.Run(tc.name, func(t *testing.T) {
+			testIsRouteAttachedToReconciledGateway(
+				t,
+				cl,
+				tc.gatewayNN,
+				tc.route,
+				tc.expectedResult,
+			)
+		},
+		)
+	}
+}

--- a/internal/controllers/gateway/route_predicates.go
+++ b/internal/controllers/gateway/route_predicates.go
@@ -87,8 +87,6 @@ func IsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 				return true
 			}
 		}
-		// REVIEW: should we directly return false here if parentRef points to a non-Gateway object (like `Service`)?
-		// This means we do not reconcile the route when it is attaching to some non-Gateway parent, like using it for service mesh.
 	}
 
 	return false

--- a/internal/controllers/gateway/route_predicates.go
+++ b/internal/controllers/gateway/route_predicates.go
@@ -67,9 +67,8 @@ func IsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 		if parentRef.Group != nil {
 			group = string(*parentRef.Group)
 		}
-
-		switch {
-		case kind == "Gateway" && group == gatewayapi.GroupVersion.Group:
+		// Check the parent gateway if the parentRef points to a gateway that is possible to be controlled by KIC.
+		if kind == "Gateway" && group == gatewayapi.GroupVersion.Group {
 			var gateway gatewayapi.Gateway
 			err := cl.Get(context.Background(), k8stypes.NamespacedName{Namespace: namespace, Name: string(parentRef.Name)}, &gateway)
 			if err != nil {
@@ -87,13 +86,9 @@ func IsRouteAttachedToReconciledGateway[routeT gatewayapi.RouteT](
 			if isGatewayClassControlled(&gatewayClass) {
 				return true
 			}
-		default:
-			log.Error(
-				fmt.Errorf("unsupported parentRef kind %s and group %s", kind, group),
-				"Got an unexpected kind and group when checking route's parentRefs",
-			)
-			return false
 		}
+		// REVIEW: should we directly return false here if parentRef points to a non-Gateway object (like `Service`)?
+		// This means we do not reconcile the route when it is attaching to some non-Gateway parent, like using it for service mesh.
 	}
 
 	return false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Do not log errors when a `parentRef` item is not referencing a `Gateway`. It is possibly that the route is managed by some other controllers, like using service mesh.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6584 
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
