### PR TITLE
tests: fix  TestAdmissionWebhook by using Eventually()

### DIFF
--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -673,7 +673,7 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			// admission webhook "kongclusterplugins.validation.ingress-controller.konghq.com" denied
 			// the request: could not parse plugin configuration: Secret "cluster-conf-secret-valid-patch" not found
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				require.NoError(t, ctrlClientGlobal.Create(ctx, tc.kongClusterPlugin))
+				assert.NoError(t, ctrlClientGlobal.Create(ctx, tc.kongClusterPlugin))
 			}, waitTime, tickTime,
 			)
 			t.Cleanup(func() {

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -656,6 +656,11 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 			errorContains: "Change on secret will generate invalid configuration for KongClusterPlugin",
 		},
 	}
+
+	const (
+		waitTime = 30 * time.Second
+		tickTime = 100 * time.Millisecond
+	)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, ctrlClient.Create(ctx, tc.secretBefore))
@@ -663,7 +668,14 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 				require.NoError(t, ctrlClient.Delete(ctx, tc.secretBefore))
 			})
 
-			require.NoError(t, ctrlClientGlobal.Create(ctx, tc.kongClusterPlugin))
+			// NOTE: We create the KongClusterPlugin with 'eventually' to avoid
+			// flaky errors like:
+			// admission webhook "kongclusterplugins.validation.ingress-controller.konghq.com" denied
+			// the request: could not parse plugin configuration: Secret "cluster-conf-secret-valid-patch" not found
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				require.NoError(t, ctrlClientGlobal.Create(ctx, tc.kongClusterPlugin))
+			}, waitTime, tickTime,
+			)
 			t.Cleanup(func() {
 				require.NoError(t, ctrlClientGlobal.Delete(ctx, tc.kongClusterPlugin))
 			})
@@ -678,7 +690,8 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 				} else if !assert.NoError(c, err) {
 					t.Logf("Error: %v", err)
 				}
-			}, 30*time.Second, 100*time.Millisecond)
+			}, waitTime, tickTime,
+			)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fix the flake that was observed in https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11857806653/job/33047028189?pr=6677#step:6:256

```
      admission_webhook_envtest_test.go:666: 
          	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/envtest/admission_webhook_envtest_test.go:666
          	Error:      	Received unexpected error:
          	            	admission webhook "kongclusterplugins.validation.ingress-controller.konghq.com" denied the request: could not parse plugin configuration: Secret "cluster-conf-secret-valid-patch" not found
          	Test:       	TestAdmissionWebhook_KongClusterPlugins/should_pass_the_validation_if_the_secret_in_ConfigPatches_of_KongClusterPlugin_generates_valid_configuration
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
