### PR TITLE
feat: improve robustness of extracting comma-delimited annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,15 @@ Adding a new version? You'll need three changes:
   [#6571](https://github.com/Kong/kubernetes-ingress-controller/pull/6571)
 - Set SNI's certificate ID ref in the generated config.
   [#6660](https://github.com/Kong/kubernetes-ingress-controller/pull/6660)
+- Improved robustness of extracting comma-delimited annotations by trimming whitespace
+  in every value and discarding empty values. Affects following annotations:
+  - `konghq.com/protocols`
+  - `konghq.com/methods`
+  - `konghq.com/snis`
+  - `konghq.com/host-aliases`
+  - `konghq.com/publish-service`
+  - `konghq.com/tags`
+  [#6729](https://github.com/Kong/kubernetes-ingress-controller/pull/6729)
 
 ### Fixed
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -414,22 +414,29 @@ func extractCommaDelimitedStrings(s string, sanitizeFns ...func(string) string) 
 		return nil
 	}
 
-	// Split by comma.
-	out := strings.Split(s, ",")
+	// Split values by comma.
+	values := strings.Split(s, ",")
 
-	// Apply trimming and sanitization functions in place.
-	for i := range out {
-		// Trim spaces.
-		out[i] = strings.TrimSpace(out[i])
+	// Allocate an output slice with the same capacity as the input slice.
+	// This may be a bit more than needed as we'll filter out empty strings later.
+	out := make([]string, 0, len(values))
+
+	// Trim and sanitize each value.
+	for _, v := range values {
+		sanitized := strings.TrimSpace(v)
+		if sanitized == "" {
+			// Discard empty strings.
+			continue
+		}
 
 		// Apply optional sanitization functions (e.g. upper-casing).
 		for _, sanitizeFn := range sanitizeFns {
-			out[i] = sanitizeFn(out[i])
+			sanitized = sanitizeFn(sanitized)
 		}
+
+		// Append to the output slice.
+		out = append(out, sanitized)
 	}
 
-	// Filter out empty strings.
-	return lo.Filter(out, func(s string, _ int) bool {
-		return s != ""
-	})
+	return out
 }

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -151,10 +151,7 @@ func ExtractProtocolName(anns map[string]string) string {
 // ExtractProtocolNames extracts the protocols supplied in the annotation.
 func ExtractProtocolNames(anns map[string]string) []string {
 	val := anns[AnnotationPrefix+ProtocolsKey]
-	if len(val) == 0 {
-		return nil
-	}
-	return strings.Split(val, ",")
+	return extractCommaDelimitedStrings(val)
 }
 
 // ExtractClientCertificate extracts the secret name containing the
@@ -215,19 +212,13 @@ func ExtractHostHeader(anns map[string]string) string {
 // ExtractMethods extracts the methods annotation value.
 func ExtractMethods(anns map[string]string) []string {
 	val := anns[AnnotationPrefix+MethodsKey]
-	if val == "" {
-		return nil
-	}
-	return strings.Split(val, ",")
+	return extractCommaDelimitedStrings(val, strings.ToUpper)
 }
 
 // ExtractSNIs extracts the route SNI match criteria annotation value.
 func ExtractSNIs(anns map[string]string) ([]string, bool) {
 	val, exists := anns[AnnotationPrefix+SNIsKey]
-	if val == "" {
-		return nil, exists
-	}
-	return strings.Split(val, ","), exists
+	return extractCommaDelimitedStrings(val), exists
 }
 
 // ExtractRequestBuffering extracts the boolean annotation indicating
@@ -253,7 +244,7 @@ func ExtractHostAliases(anns map[string]string) ([]string, bool) {
 	if val == "" {
 		return nil, false
 	}
-	return strings.Split(val, ","), true
+	return extractCommaDelimitedStrings(val), true
 }
 
 // ExtractConnectTimeout extracts the connection timeout annotation value.
@@ -345,11 +336,8 @@ func ExtractGatewayPublishService(anns map[string]string) []string {
 	if anns == nil {
 		return []string{}
 	}
-	publish, ok := anns[AnnotationPrefix+GatewayPublishServiceKey]
-	if !ok {
-		return []string{}
-	}
-	return strings.Split(publish, ",")
+	publish := anns[AnnotationPrefix+GatewayPublishServiceKey]
+	return extractCommaDelimitedStrings(publish)
 }
 
 // UpdateGatewayPublishService updates the value of the annotation konghq.com/gatewayclass-unmanaged.
@@ -360,12 +348,7 @@ func UpdateGatewayPublishService(anns map[string]string, services []string) {
 // ExtractUserTags extracts a set of tags from a comma-separated string.
 func ExtractUserTags(anns map[string]string) []string {
 	val := anns[AnnotationPrefix+UserTagKey]
-	// If the annotation is not present, the map provides an empty value, and splitting that will create a slice
-	// containing a single empty string tag. These aren't valid, hence this special case.
-	if len(val) == 0 {
-		return []string{}
-	}
-	return strings.Split(val, ",")
+	return extractCommaDelimitedStrings(val)
 }
 
 // ExtractRewriteURI extracts the rewrite annotation value.
@@ -424,8 +407,8 @@ func ExtractCACertificates(anns map[string]string) []string {
 
 // extractCommaDelimitedStrings extracts a list of non-empty strings from a comma-separated string.
 // It trims spaces from the strings.
-// TODO: consider using it in other places where we extract comma-separated strings.
-func extractCommaDelimitedStrings(s string) []string {
+// It accepts optional sanitization functions to apply to each string.
+func extractCommaDelimitedStrings(s string, sanitizeFns ...func(string) string) []string {
 	// If it's an empty string, return nil.
 	if strings.TrimSpace(s) == "" {
 		return nil
@@ -434,9 +417,15 @@ func extractCommaDelimitedStrings(s string) []string {
 	// Split by comma.
 	out := strings.Split(s, ",")
 
-	// Trim spaces in place.
+	// Apply trimming and sanitization functions in place.
 	for i := range out {
+		// Trim spaces.
 		out[i] = strings.TrimSpace(out[i])
+
+		// Apply optional sanitization functions (e.g. upper-casing).
+		for _, sanitizeFn := range sanitizeFns {
+			out[i] = sanitizeFn(out[i])
+		}
 	}
 
 	// Filter out empty strings.

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -203,6 +203,24 @@ func TestExtractProtocolNames(t *testing.T) {
 			},
 			want: []string{"foo", "bar"},
 		},
+		{
+			name: "non-empty with spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/protocols": " foo, bar",
+				},
+			},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "non-empty with a single protocol empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/protocols": "foo,",
+				},
+			},
+			want: []string{"foo"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -497,6 +515,33 @@ func TestExtractMethods(t *testing.T) {
 			},
 			want: []string{"POST", "GET"},
 		},
+		{
+			name: "non-empty with spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/methods": " POST, GET",
+				},
+			},
+			want: []string{"POST", "GET"},
+		},
+		{
+			name: "non-empty with a single method empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/methods": "POST,",
+				},
+			},
+			want: []string{"POST"},
+		},
+		{
+			name: "lowercase methods",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/methods": "post,Get",
+				},
+			},
+			want: []string{"POST", "GET"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -528,6 +573,24 @@ func TestExtractSNIs(t *testing.T) {
 				},
 			},
 			want: []string{"hrodna.kong.example", "katowice.kong.example"},
+		},
+		{
+			name: "non-empty with spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/snis": " hrodna.kong.example, katowice.kong.example",
+				},
+			},
+			want: []string{"hrodna.kong.example", "katowice.kong.example"},
+		},
+		{
+			name: "non-empty with a single sni empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/snis": "hrodna.kong.example,",
+				},
+			},
+			want: []string{"hrodna.kong.example"},
 		},
 	}
 	for _, tt := range tests {
@@ -646,6 +709,24 @@ func TestExtractHostAliases(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "non-empty with spaces",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/host-aliases": " foo.kong.com, bar.kong.com",
+				},
+			},
+			want: []string{"foo.kong.com", "bar.kong.com"},
+		},
+		{
+			name: "non-empty with a single alias empty",
+			args: args{
+				anns: map[string]string{
+					"konghq.com/host-aliases": "foo.kong.com,",
+				},
+			},
+			want: []string{"foo.kong.com"},
 		},
 	}
 	for _, tt := range tests {
@@ -1038,5 +1119,45 @@ func TestExtractCACertificates(t *testing.T) {
 	assert.Equal(t, []string{"foo", "bar", "baz"}, v, "expected to trim spaces")
 
 	v = ExtractCACertificates(map[string]string{AnnotationPrefix + CACertificatesKey: "foo, bar,  "})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to ignore empty values")
+}
+
+func TestExtractGatewayPublishService(t *testing.T) {
+	v := ExtractGatewayPublishService(nil)
+	assert.Empty(t, v)
+
+	v = ExtractGatewayPublishService(map[string]string{})
+	assert.Empty(t, v)
+
+	v = ExtractGatewayPublishService(map[string]string{AnnotationPrefix + GatewayPublishServiceKey: "foo"})
+	assert.Equal(t, []string{"foo"}, v)
+
+	v = ExtractGatewayPublishService(map[string]string{AnnotationPrefix + GatewayPublishServiceKey: "foo,bar"})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to split by comma")
+
+	v = ExtractGatewayPublishService(map[string]string{AnnotationPrefix + GatewayPublishServiceKey: " foo, bar "})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to trim spaces")
+
+	v = ExtractGatewayPublishService(map[string]string{AnnotationPrefix + GatewayPublishServiceKey: "foo, bar, "})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to ignore empty values")
+}
+
+func TestExtractUserTags(t *testing.T) {
+	v := ExtractUserTags(nil)
+	assert.Empty(t, v)
+
+	v = ExtractUserTags(map[string]string{})
+	assert.Empty(t, v)
+
+	v = ExtractUserTags(map[string]string{AnnotationPrefix + UserTagKey: "foo"})
+	assert.Equal(t, []string{"foo"}, v)
+
+	v = ExtractUserTags(map[string]string{AnnotationPrefix + UserTagKey: "foo,bar"})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to split by comma")
+
+	v = ExtractUserTags(map[string]string{AnnotationPrefix + UserTagKey: " foo, bar "})
+	assert.Equal(t, []string{"foo", "bar"}, v, "expected to trim spaces")
+
+	v = ExtractUserTags(map[string]string{AnnotationPrefix + UserTagKey: "foo, bar, "})
 	assert.Equal(t, []string{"foo", "bar"}, v, "expected to ignore empty values")
 }

--- a/internal/dataplane/kongstate/route.go
+++ b/internal/dataplane/kongstate/route.go
@@ -189,9 +189,8 @@ func (r *Route) overrideMethods(logger logr.Logger, anns map[string]string) {
 	}
 	var methods []*string
 	for _, method := range annMethods {
-		sanitizedMethod := strings.TrimSpace(strings.ToUpper(method))
-		if validMethods.MatchString(sanitizedMethod) {
-			methods = append(methods, kong.String(sanitizedMethod))
+		if validMethods.MatchString(method) {
+			methods = append(methods, kong.String(method))
 		} else {
 			// if any method is invalid (not an uppercase alpha string),
 			// discard everything
@@ -214,9 +213,8 @@ func (r *Route) overrideSNIs(logger logr.Logger, anns map[string]string) {
 	}
 	var snis []*string
 	for _, sni := range annSNIs {
-		sanitizedSNI := strings.TrimSpace(sni)
-		if validSNIs.MatchString(sanitizedSNI) {
-			snis = append(snis, kong.String(sanitizedSNI))
+		if validSNIs.MatchString(sni) {
+			snis = append(snis, kong.String(sni))
 		} else {
 			// SNI is not a valid hostname
 			logger.Error(nil, "Invalid SNI", "route_name", r.Name, "sni", sni)
@@ -305,21 +303,20 @@ func (r *Route) overrideHosts(logger logr.Logger, anns map[string]string) {
 	}
 
 	// avoid allowing duplicate hosts or host-aliases from being added
-	appendIfMissing := func(hosts []*string, sanitizedHost string) []*string {
+	appendIfMissing := func(hosts []*string, host string) []*string {
 		for _, uniqueHost := range hosts {
-			if *uniqueHost == sanitizedHost {
+			if *uniqueHost == host {
 				return hosts
 			}
 		}
-		return append(hosts, kong.String(sanitizedHost))
+		return append(hosts, kong.String(host))
 	}
 
 	// Merge hosts and host-aliases
 	hosts = append(hosts, r.Hosts...)
 	for _, hostAlias := range annHostAliases {
-		sanitizedHost := strings.TrimSpace(hostAlias)
-		if validHosts.MatchString(sanitizedHost) {
-			hosts = appendIfMissing(hosts, sanitizedHost)
+		if validHosts.MatchString(hostAlias) {
+			hosts = appendIfMissing(hosts, hostAlias)
 		} else {
 			// Host Alias is not a valid hostname
 			logger.Error(nil, "Invalid host alias", "value", hostAlias, "kongroute", r.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses a common `extractCommaDelimitedStrings ` function to extract values from a comma-delimited list of strings. Beside just splitting by a comma, it also sanitizes the output values by trimming whitespace and discarding empty values.

**Which issue this PR fixes**:

Follow up to https://github.com/Kong/kubernetes-ingress-controller/pull/6707#discussion_r1858292972.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

