### PR TITLE
chore(HTTPRoute): change level from ERROR to DEBUG for missing backend and enhance status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,9 @@ Adding a new version? You'll need three changes:
   - `konghq.com/publish-service`
   - `konghq.com/tags`
   [#6729](https://github.com/Kong/kubernetes-ingress-controller/pull/6729)
+- Log `Object requested backendRef to target, but it does not exist, skipping...`
+  as `DEBUG` instead of `ERROR`, enhance `HTTPRoute` status with detailed message.
+  [#6746](https://github.com/Kong/kubernetes-ingress-controller/pull/6746)
 
 ### Fixed
 

--- a/internal/dataplane/translator/backendref.go
+++ b/internal/dataplane/translator/backendref.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
@@ -57,9 +58,9 @@ func backendRefsToKongStateBackends(
 		}
 		if err != nil {
 			if errors.As(err, &store.NotFoundError{}) {
-				logger.Error(err, "Object requested backendRef to target, but it does not exist, skipping...")
+				logger.V(logging.DebugLevel).Info("Object requested backendRef to target, but it does not exist, skipping...")
 			} else {
-				logger.Error(err, "Object requested backendRef to target, but an error occurred, skipping...")
+				logger.Error(err, "Object requested backendRef to target, but an unexpected error occurred, skipping...")
 			}
 			continue
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

One of the cases mentioned in the original issue https://github.com/Kong/kubernetes-ingress-controller/issues/6540:

> When a resource is missing in the cluster, like a Service on which an HTTPRoute points

For verification, the below configuration was used

```yml
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: kong
  annotations:
    konghq.com/gatewayclass-unmanaged: "true"
spec:
  controllerName: konghq.com/kic-gateway-controller
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kong
spec:
  gatewayClassName: kong
  listeners:
    - name: http
      protocol: HTTP
      port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: rewrite-path-full
spec:
  parentRefs:
    - name: kong
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /full-path-prefix
      backendRefs:
        - name: echo
          kind: Service
          port: 80
```

### Result

there are no redundant `INFO` log entries; there is something like this, an `ERROR` level log

```log
[ingress-controller] 2024-11-29T14:05:54Z        error   Object requested backendRef to target, but it does not exist, skipping...       {"object_name": "gateway.networking.k8s.io/v1, Kind=HTTPRoute default/rewrite-path-full", "target_kind": "Service", "target_namespace": "default", "target_name": "echo", "error": "Service default/echo not found"}
```

and properly set status without additional information

```yml
...
  status:
    parents:
    - conditions:
      - lastTransitionTime: "2024-11-29T15:30:49Z"
        message: ""
        observedGeneration: 1
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2024-11-29T15:30:49Z"
        message: ""
        observedGeneration: 1
        reason: BackendNotFound
        status: "False"
        type: ResolvedRefs
      - lastTransitionTime: "2024-11-29T15:30:49Z"
        message: ""
        observedGeneration: 1
        reason: ConfiguredInGateway
        status: "True"
        type: Programmed
      controllerName: konghq.com/kic-gateway-controller
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: kong
        namespace: default
```

### Proposed improvement

It shouldn't be logged as an error because it's a user error that may be transitive (e.g., order of YAMLs application) and it's reported in `HTTPRoute` status. Furthermore, this PR enhances status by filling a field `Message` to make it more useful.

So after changes

```log
[ingress-controller] 2024-11-29T15:22:22Z        debug   Object requested backendRef to target, but it does not exist, skipping...       {"object_name": "gateway.networking.k8s.io/v1, Kind=HTTPRoute default/rewrite-path-full", "target_kind": "Service", "target_namespace": "default", "target_name": "echo", "v": 1}
```

```yml
...
  status:
    parents:
    - conditions:
      - lastTransitionTime: "2024-11-29T15:22:22Z"
        message: ""
        observedGeneration: 1
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2024-11-29T15:22:22Z"
        message: target default/echo of type Service does not exist
        observedGeneration: 1
        reason: BackendNotFound
        status: "False"
        type: ResolvedRefs
      - lastTransitionTime: "2024-11-29T15:22:22Z"
        message: ""
        observedGeneration: 1
        reason: ConfiguredInGateway
        status: "True"
        type: Programmed
      controllerName: konghq.com/kic-gateway-controller
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: kong
        namespace: default
```


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6540

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
