### PR TITLE
feat(HTTPRoute): propagate to Kong tag `k8s-named-route-rule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,8 +203,9 @@ Adding a new version? You'll need three changes:
   where `<hash>` is the hash result of the calculated name, like
   `httproute.default.svc.default.a-long-long-long-service-name.80_combined.00001111222233334444aaaabbbbcccc`.
   [#6711](https://github.com/Kong/kubernetes-ingress-controller/pull/6711)
-- The new tag `k8s-named-route-rules` is added to a Kong Route, in the case when mapped `HTTPRoute` has
-  routes named (filled `spec.rules[*].name` field) that names will be propagated to aforementioned tag.
+- The new tag `k8s-named-route-rule` is added to a Kong Route, in the case when mapped `HTTPRoute` has
+  routes named (filled `spec.rules[*].name` field) that names will be propagated to one or many instances
+  of aforementioned tag.
   [#6759](https://github.com/Kong/kubernetes-ingress-controller/pull/6759)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@ Adding a new version? You'll need three changes:
   where `<hash>` is the hash result of the calculated name, like
   `httproute.default.svc.default.a-long-long-long-service-name.80_combined.00001111222233334444aaaabbbbcccc`.
   [#6711](https://github.com/Kong/kubernetes-ingress-controller/pull/6711)
+- The new tag `k8s-named-route-rules` is added to a Kong Route, in the case when mapped `HTTPRoute` has
+  routes named (filled `spec.rules[*].name` field) that names will be propagated to aforementioned tag.
+  [#6759](https://github.com/Kong/kubernetes-ingress-controller/pull/6759)
+
 
 ## [3.3.1]
 

--- a/internal/dataplane/testdata/golden/httproute-example/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/default_golden.yaml
@@ -1,6 +1,75 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
+  host: httproute.default.httproute-testing.3
+  id: efb4a7d7-791f-504e-b005-0bd38bf1435e
+  name: httproute.default.httproute-testing.3
+  port: 8080
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 80ab997f-3534-58af-a969-300888c6058a
+    name: httproute.default.httproute-testing.3.0
+    path_handling: v0
+    paths:
+    - ~/nginx$
+    - /nginx/
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:nginx
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: httproute.default.httproute-testing.1
+  id: 672dc964-a7f8-5a80-a518-96fc39500cc8
+  name: httproute.default.httproute-testing.1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 4deff45c-4095-55d2-80ab-aea40c0ac7bd
+    name: httproute.default.httproute-testing.1.0
+    path_handling: v0
+    paths:
+    - ~/echo$
+    - /echo/
+    - ~/content$
+    - /content/
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rules:echo;content
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: httproute.default.httproute-testing.0
   id: 4e3cb785-a8d0-5866-aa05-117f7c64f24d
   name: httproute.default.httproute-testing.0
@@ -27,6 +96,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
+    - k8s-named-route-rules:httproute-testing
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default
@@ -35,6 +105,20 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: httproute.default.httproute-testing.3
+  tags:
+  - k8s-name:nginx
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: httproute.default.httproute-testing.1
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
 - algorithm: round-robin
   name: httproute.default.httproute-testing.0
   tags:

--- a/internal/dataplane/testdata/golden/httproute-example/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/default_golden.yaml
@@ -62,7 +62,8 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
-    - k8s-named-route-rules:echo;content
+    - k8s-named-route-rule:echo
+    - k8s-named-route-rule:content
   tags:
   - k8s-name:httpbin
   - k8s-namespace:default
@@ -96,7 +97,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
-    - k8s-named-route-rules:httproute-testing
+    - k8s-named-route-rule:httproute-testing
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default

--- a/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -50,7 +50,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
-    - k8s-named-route-rules:content
+    - k8s-named-route-rule:content
   tags:
   - k8s-name:httpbin
   - k8s-namespace:default
@@ -79,7 +79,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
-    - k8s-named-route-rules:echo
+    - k8s-named-route-rule:echo
   tags:
   - k8s-name:httpbin
   - k8s-namespace:default
@@ -108,7 +108,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
-    - k8s-named-route-rules:httproute-testing
+    - k8s-named-route-rule:httproute-testing
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default

--- a/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -1,6 +1,92 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
+  host: httproute.default.httproute-testing._.3
+  id: 23683d37-44ee-559b-add2-a0b650ad36c0
+  name: httproute.default.httproute-testing._.3
+  port: 8080
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/nginx") || (http.path ^= "/nginx/")
+    https_redirect_status_code: 426
+    id: b4887f46-40a4-568c-a6e4-5bd2f6897c97
+    name: httproute.default.httproute-testing._.3.0
+    preserve_host: true
+    priority: 35184414035967
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+  tags:
+  - k8s-name:nginx
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: httproute.default.httproute-testing._.2
+  id: ff054481-b58a-588f-a8c4-e6cedb6cb489
+  name: httproute.default.httproute-testing._.2
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/content") || (http.path ^= "/content/")
+    https_redirect_status_code: 426
+    id: 73ae1362-1f15-50ab-b106-def677ce7d23
+    name: httproute.default.httproute-testing._.2.0
+    preserve_host: true
+    priority: 35184430813183
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rules:content
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: httproute.default.httproute-testing._.1
+  id: 13be00e6-9c94-561f-9598-8896cd755468
+  name: httproute.default.httproute-testing._.1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/echo") || (http.path ^= "/echo/")
+    https_redirect_status_code: 426
+    id: 88d36cfe-fbb0-5d7a-93c1-df18d1db3a12
+    name: httproute.default.httproute-testing._.1.0
+    preserve_host: true
+    priority: 35184405647359
+    strip_path: true
+    tags:
+    - k8s-name:httproute-testing
+    - k8s-namespace:default
+    - k8s-kind:HTTPRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rules:echo
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: httproute.default.httproute-testing._.0
   id: 2fad71d1-7599-5c6e-9d4f-4afd44f99587
   name: httproute.default.httproute-testing._.0
@@ -22,6 +108,7 @@ services:
     - k8s-kind:HTTPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
+    - k8s-named-route-rules:httproute-testing
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default
@@ -30,6 +117,27 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: httproute.default.httproute-testing._.3
+  tags:
+  - k8s-name:nginx
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: httproute.default.httproute-testing._.2
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
+- algorithm: round-robin
+  name: httproute.default.httproute-testing._.1
+  tags:
+  - k8s-name:httpbin
+  - k8s-namespace:default
+  - k8s-kind:Service
+  - k8s-version:v1
 - algorithm: round-robin
   name: httproute.default.httproute-testing._.0
   tags:

--- a/internal/dataplane/testdata/golden/httproute-example/in.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/in.yaml
@@ -42,7 +42,8 @@ spec:
   parentRefs:
     - name: kong
   rules:
-    - matches:
+    - name: httproute-testing
+      matches:
         - path:
             type: PathPrefix
             value: /httproute-testing
@@ -55,3 +56,29 @@ spec:
           kind: Service
           port: 8080
           weight: 25
+    - name: echo
+      matches:
+        - path:
+            type: PathPrefix
+            value: /echo
+      backendRefs:
+        - name: httpbin
+          kind: Service
+          port: 80
+    - name: content
+      matches:
+        - path:
+            type: PathPrefix
+            value: /content
+      backendRefs:
+        - name: httpbin
+          kind: Service
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /nginx
+      backendRefs:
+        - name: nginx
+          kind: Service
+          port: 8080

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -329,7 +329,7 @@ func translateHTTPRouteRulesMetaToKongstateRoutes(
 			parentRoute := matchGroup[0].parentRoute
 			objectInfo := util.FromK8sObject(parentRoute)
 			matches, optionalNamedRouteRules := matchGroup.httpRouteMatches()
-			tags := util.GenerateTagsForObject(parentRoute, util.AdditionalTagNamedRouteRules(optionalNamedRouteRules...)...)
+			tags := util.GenerateTagsForObject(parentRoute, util.AdditionalTagsK8sNamedRouteRule(optionalNamedRouteRules...)...)
 			routeName := translateToKongRouteName(matchGroup, parentRoute.GetNamespace(), parentRoute.GetName())
 			// Since the grouped matches here are from the same HTTPRoute, it is OK to use the hostnames from the first HTTPRoute.
 			hostnames := getHTTPRouteHostnamesAsSliceOfStringPointers(parentRoute)

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -551,7 +551,7 @@ func KongExpressionRouteFromHTTPRouteMatchWithPriority(
 ) (*kongstate.Route, error) {
 	match := httpRouteMatchWithPriority.Match
 	httproute := httpRouteMatchWithPriority.Match.Source
-	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagNamedRouteRules(match.OptionalNamedRouteRule)...)
+	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagsK8sNamedRouteRule(match.OptionalNamedRouteRule)...)
 
 	// Since we split HTTPRoutes by hostname, rule and match, we generate the route name in
 	// httproute.<namespace>.<name>.<hostname>.<rule index>.<match index> format.

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -257,11 +257,15 @@ func matchersFromParentHTTPRoute(hostnames []string, metaAnnotations map[string]
 }
 
 type SplitHTTPRouteMatch struct {
-	Source     *gatewayapi.HTTPRoute
-	Hostname   string
-	Match      gatewayapi.HTTPRouteMatch
-	RuleIndex  int
-	MatchIndex int
+	Source   *gatewayapi.HTTPRoute
+	Hostname string
+	Match    gatewayapi.HTTPRouteMatch
+	// OptionalNamedRouteRule represents RouteName - an optional name
+	// of the particular route that can be defined in the K8s HTTPRoute,
+	// https://gateway-api.sigs.k8s.io/geps/gep-995/#api.
+	OptionalNamedRouteRule string
+	RuleIndex              int
+	MatchIndex             int
 }
 
 // SplitHTTPRoute splits HTTPRoutes into matches with at most one hostname, and one rule
@@ -271,22 +275,25 @@ func SplitHTTPRoute(httproute *gatewayapi.HTTPRoute) []SplitHTTPRouteMatch {
 	splitHTTPRouteByMatch := func(hostname string) []SplitHTTPRouteMatch {
 		ret := []SplitHTTPRouteMatch{}
 		for ruleIndex, rule := range httproute.Spec.Rules {
+			optionalNamedRouteRule := string(lo.FromPtr(rule.Name))
 			if len(rule.Matches) == 0 {
 				ret = append(ret, SplitHTTPRouteMatch{
-					Source:     httproute,
-					Hostname:   hostname,
-					Match:      gatewayapi.HTTPRouteMatch{},
-					RuleIndex:  ruleIndex,
-					MatchIndex: 0,
+					Source:                 httproute,
+					Hostname:               hostname,
+					Match:                  gatewayapi.HTTPRouteMatch{},
+					OptionalNamedRouteRule: optionalNamedRouteRule,
+					RuleIndex:              ruleIndex,
+					MatchIndex:             0,
 				})
 			}
 			for matchIndex, match := range rule.Matches {
 				ret = append(ret, SplitHTTPRouteMatch{
-					Source:     httproute,
-					Hostname:   hostname,
-					Match:      *match.DeepCopy(),
-					RuleIndex:  ruleIndex,
-					MatchIndex: matchIndex,
+					Source:                 httproute,
+					Hostname:               hostname,
+					Match:                  *match.DeepCopy(),
+					OptionalNamedRouteRule: optionalNamedRouteRule,
+					RuleIndex:              ruleIndex,
+					MatchIndex:             matchIndex,
 				})
 			}
 		}
@@ -544,8 +551,9 @@ func KongExpressionRouteFromHTTPRouteMatchWithPriority(
 ) (*kongstate.Route, error) {
 	match := httpRouteMatchWithPriority.Match
 	httproute := httpRouteMatchWithPriority.Match.Source
-	tags := util.GenerateTagsForObject(httproute)
-	// since we split HTTPRoutes by hostname, rule and match, we generate the route name in
+	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagNamedRouteRules(match.OptionalNamedRouteRule)...)
+
+	// Since we split HTTPRoutes by hostname, rule and match, we generate the route name in
 	// httproute.<namespace>.<name>.<hostname>.<rule index>.<match index> format.
 	hostnameInRouteName := "_"
 	if len(match.Hostname) > 0 {

--- a/internal/dataplane/translator/translate_httproute.go
+++ b/internal/dataplane/translator/translate_httproute.go
@@ -232,7 +232,7 @@ func GenerateKongRouteFromTranslation(
 ) ([]kongstate.Route, error) {
 	// Gather the k8s object information and hostnames from the HTTPRoute.
 	objectInfo := util.FromK8sObject(httproute)
-	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagNamedRouteRules(translation.OptionalNamedRouteRules...)...)
+	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagsK8sNamedRouteRule(translation.OptionalNamedRouteRules...)...)
 
 	// translate to expression based routes when expressionRoutes is enabled.
 	if expressionRoutes {

--- a/internal/dataplane/translator/translate_httproute.go
+++ b/internal/dataplane/translator/translate_httproute.go
@@ -230,9 +230,9 @@ func GenerateKongRouteFromTranslation(
 	translation subtranslator.KongRouteTranslation,
 	expressionRoutes bool,
 ) ([]kongstate.Route, error) {
-	// gather the k8s object information and hostnames from the httproute
+	// Gather the k8s object information and hostnames from the HTTPRoute.
 	objectInfo := util.FromK8sObject(httproute)
-	tags := util.GenerateTagsForObject(httproute)
+	tags := util.GenerateTagsForObject(httproute, util.AdditionalTagNamedRouteRules(translation.OptionalNamedRouteRules...)...)
 
 	// translate to expression based routes when expressionRoutes is enabled.
 	if expressionRoutes {

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -154,13 +154,7 @@ const (
 	K8sKindTagPrefix           = "k8s-kind:"
 	K8sGroupTagPrefix          = "k8s-group:"
 	K8sVersionTagPrefix        = "k8s-version:"
-	K8sNamedRouteRuleTagPrefix = "k8s-named-route-rules:"
-
-	// ValuesInTagSeparator represents separator used for values of tags.
-	// Validation for tags in Kong Gateway enforces:
-	// "expected printable ascii (except `,` and `/`) or valid utf-8 sequences"
-	// thus ; is a sensible choice for a separator.
-	ValuesInTagSeparator = ";"
+	K8sNamedRouteRuleTagPrefix = "k8s-named-route-rule:"
 )
 
 type KongTag struct {
@@ -172,19 +166,18 @@ func (kt KongTag) String() string {
 	return kt.Prefix + kt.Value
 }
 
-func AdditionalTagNamedRouteRules(optionalNamedRouteRules ...string) []KongTag {
+// AdditionalTagsK8sNamedRouteRule returns a slice of KongTag with the given named route rules.
+// It filters out empty strings.
+func AdditionalTagsK8sNamedRouteRule(optionalNamedRouteRules ...string) []KongTag {
 	optionalNamedRouteRules = lo.Filter(optionalNamedRouteRules, func(s string, _ int) bool {
 		return strings.TrimSpace(s) != ""
 	})
-	if len(optionalNamedRouteRules) == 0 {
-		return nil
-	}
-	return []KongTag{
-		{
+	return lo.Map(optionalNamedRouteRules, func(s string, _ int) KongTag {
+		return KongTag{
 			Prefix: K8sNamedRouteRuleTagPrefix,
-			Value:  strings.Join(optionalNamedRouteRules, ValuesInTagSeparator),
-		},
-	}
+			Value:  s,
+		}
+	})
 }
 
 // GenerateTagsForObject returns a subset of an object's metadata as a slice of prefixed string pointers.

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -18,11 +18,12 @@ package util
 
 import (
 	"context"
+	"slices"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -264,8 +265,20 @@ func TestGenerateTagsForObject(t *testing.T) {
 		},
 	}
 
-	tags := GenerateTagsForObject(testObj)
-	if diff := cmp.Diff(expectedTagSet, tags); diff != "" {
-		t.Fatalf("generated tags are not as expected, diff:\n%s", diff)
-	}
+	t.Run("generated tags based on the object", func(t *testing.T) {
+		tags := GenerateTagsForObject(testObj)
+		require.ElementsMatch(t, expectedTagSet, tags, "generated tags are not as expected")
+	})
+
+	t.Run("generated tags based on the object with additional tag k8s-named-route-rules", func(t *testing.T) {
+		expectedTagSetWithAdditional := slices.Concat(
+			expectedTagSet,
+			[]*string{
+				lo.ToPtr(K8sNamedRouteRuleTagPrefix + "test" + ValuesInTagSeparator + "echo"),
+			},
+		)
+
+		tags := GenerateTagsForObject(testObj, AdditionalTagNamedRouteRules("test", "", " ", "echo")...)
+		require.ElementsMatch(t, expectedTagSetWithAdditional, tags, "generated tags are not as expected")
+	})
 }

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -270,15 +270,16 @@ func TestGenerateTagsForObject(t *testing.T) {
 		require.ElementsMatch(t, expectedTagSet, tags, "generated tags are not as expected")
 	})
 
-	t.Run("generated tags based on the object with additional tag k8s-named-route-rules", func(t *testing.T) {
+	t.Run("generated tags based on the object with additional tags k8s-named-route-rule", func(t *testing.T) {
 		expectedTagSetWithAdditional := slices.Concat(
 			expectedTagSet,
 			[]*string{
-				lo.ToPtr(K8sNamedRouteRuleTagPrefix + "test" + ValuesInTagSeparator + "echo"),
+				lo.ToPtr(K8sNamedRouteRuleTagPrefix + "test"),
+				lo.ToPtr(K8sNamedRouteRuleTagPrefix + "echo"),
 			},
 		)
 
-		tags := GenerateTagsForObject(testObj, AdditionalTagNamedRouteRules("test", "", " ", "echo")...)
+		tags := GenerateTagsForObject(testObj, AdditionalTagsK8sNamedRouteRule("test", "", " ", "echo")...)
 		require.ElementsMatch(t, expectedTagSetWithAdditional, tags, "generated tags are not as expected")
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Gateway API 1.2 released named route rules as a GA feature, see [GEP 995](https://gateway-api.sigs.k8s.io/geps/gep-995/#api). The closest equivalent of `HTTPRoute` in Kong is Route. They are translated to them; multiple `HTTPRoute`s can be translated to a single Kong Route, hence introduced tag has a format of 

```
k8s-named-route-rule:route1
# or in case of multiple
k8s-named-route-rule:route1
k8s-named-route-rule:route2
k8s-named-route-rule:route3
```
So it contains single or multiple names (separated with `;`) from optional `spec.rules[*].name` of `HTTPRoute` YAML defined by a user. In case of absence, the tag is not populated at all.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6582 with the same approach presented in this PR separate PRs will address other types of K8s Routes. Docs will be adjusted too. 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
