### PR TITLE
fix: fix ExtensionRef plugins for HTTPRoutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@ Adding a new version? You'll need three changes:
   to make sure the order of ancestors in the status is deterministic to fix
   the issue where the status of `KongUpstreamPolicy` is continuously updated.
   [#6767](https://github.com/Kong/kubernetes-ingress-controller/pull/6767)
+- Fixed an issue where `KongPlugin` used as `HTTPRoute`'s `ExtensionRef` filter
+  would produce an invalid configuration.
+  [#6762](https://github.com/Kong/kubernetes-ingress-controller/pull/6762)
 
 ### Added
 

--- a/internal/util/builder/httproutefilter.go
+++ b/internal/util/builder/httproutefilter.go
@@ -94,3 +94,25 @@ func (b *HTTPRouteFilterBuilder) WithRequestHeaderRemove(headerNames []string) *
 	b.httpRouteFilter.RequestHeaderModifier.Remove = headerNames
 	return b
 }
+
+// NewHTTPRouteExtensionRefFilter builds an extension ref HTTPRoute filter.
+func NewHTTPRouteExtensionRefFilter() *HTTPRouteFilterBuilder {
+	filter := gatewayapi.HTTPRouteFilter{
+		Type:         gatewayapi.HTTPRouteFilterExtensionRef,
+		ExtensionRef: &gatewayapi.LocalObjectReference{},
+	}
+	return &HTTPRouteFilterBuilder{httpRouteFilter: filter}
+}
+
+// WithExtensionRef sets the extension reference of the filter.
+func (b *HTTPRouteFilterBuilder) WithExtensionRef(apiGroup, kind, name string) *HTTPRouteFilterBuilder {
+	if b.httpRouteFilter.Type != gatewayapi.HTTPRouteFilterExtensionRef ||
+		b.httpRouteFilter.ExtensionRef == nil {
+		return b
+	}
+
+	b.httpRouteFilter.ExtensionRef.Group = (gatewayapi.Group)(apiGroup)
+	b.httpRouteFilter.ExtensionRef.Kind = (gatewayapi.Kind)(kind)
+	b.httpRouteFilter.ExtensionRef.Name = (gatewayapi.ObjectName)(name)
+	return b
+}

--- a/internal/util/builder/httproutefilter.go
+++ b/internal/util/builder/httproutefilter.go
@@ -94,4 +94,3 @@ func (b *HTTPRouteFilterBuilder) WithRequestHeaderRemove(headerNames []string) *
 	b.httpRouteFilter.RequestHeaderModifier.Remove = headerNames
 	return b
 }
-

--- a/internal/util/builder/httproutefilter.go
+++ b/internal/util/builder/httproutefilter.go
@@ -95,24 +95,3 @@ func (b *HTTPRouteFilterBuilder) WithRequestHeaderRemove(headerNames []string) *
 	return b
 }
 
-// NewHTTPRouteExtensionRefFilter builds an extension ref HTTPRoute filter.
-func NewHTTPRouteExtensionRefFilter() *HTTPRouteFilterBuilder {
-	filter := gatewayapi.HTTPRouteFilter{
-		Type:         gatewayapi.HTTPRouteFilterExtensionRef,
-		ExtensionRef: &gatewayapi.LocalObjectReference{},
-	}
-	return &HTTPRouteFilterBuilder{httpRouteFilter: filter}
-}
-
-// WithExtensionRef sets the extension reference of the filter.
-func (b *HTTPRouteFilterBuilder) WithExtensionRef(apiGroup, kind, name string) *HTTPRouteFilterBuilder {
-	if b.httpRouteFilter.Type != gatewayapi.HTTPRouteFilterExtensionRef ||
-		b.httpRouteFilter.ExtensionRef == nil {
-		return b
-	}
-
-	b.httpRouteFilter.ExtensionRef.Group = (gatewayapi.Group)(apiGroup)
-	b.httpRouteFilter.ExtensionRef.Kind = (gatewayapi.Kind)(kind)
-	b.httpRouteFilter.ExtensionRef.Name = (gatewayapi.ObjectName)(name)
-	return b
-}

--- a/internal/util/objectmeta.go
+++ b/internal/util/objectmeta.go
@@ -31,7 +31,7 @@ func FromK8sObject(obj client.Object) K8sObjectInfo {
 	return K8sObjectInfo{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
-		// We return a deep copy here because translator functions may modify annotations
+		// We return a copy of annotations map here because translator functions may modify annotations
 		// and that change would then be stored in store which is not desired.
 		Annotations:      maps.Clone(obj.GetAnnotations()),
 		GroupVersionKind: obj.GetObjectKind().GroupVersionKind(),

--- a/internal/util/objectmeta.go
+++ b/internal/util/objectmeta.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"maps"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,9 +29,11 @@ func (k K8sObjectInfo) GetNamespace() string {
 // calling FromK8sObject will have an effect on the original object.
 func FromK8sObject(obj client.Object) K8sObjectInfo {
 	return K8sObjectInfo{
-		Name:             obj.GetName(),
-		Namespace:        obj.GetNamespace(),
-		Annotations:      obj.GetAnnotations(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		// We return a deep copy here because translator functions may modify annotations
+		// and that change would then be stored in store which is not desired.
+		Annotations:      maps.Clone(obj.GetAnnotations()),
 		GroupVersionKind: obj.GetObjectKind().GroupVersionKind(),
 	}
 }
@@ -40,9 +44,4 @@ func TypeMetaFromGVK(gvk schema.GroupVersionKind) metav1.TypeMeta {
 		APIVersion: gvk.GroupVersion().String(),
 		Kind:       gvk.Kind,
 	}
-}
-
-// TypeMetaFromK8sObject returns the typemeta of a client Object by its GVK.
-func TypeMetaFromK8sObject(obj client.Object) metav1.TypeMeta {
-	return TypeMetaFromGVK(obj.GetObjectKind().GroupVersionKind())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue when declaring an `ExtensionRef` plugin on `HTTPRoute`.

**Which issue this PR fixes**:

Fixes #6761

**Special notes for your reviewer**:

Open to suggestions how to test this one further.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
