### PR TITLE
feat(translator): combine services across httproutes expression router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@ Adding a new version? You'll need three changes:
   where `<hash>` is the hash result of the calculated name, like
   `httproute.default.svc.default.a-long-long-long-service-name.80_combined.00001111222233334444aaaabbbbcccc`.
   [#6711](https://github.com/Kong/kubernetes-ingress-controller/pull/6711)
+  [#6766](https://github.com/Kong/kubernetes-ingress-controller/pull/6766)
 - The new tag `k8s-named-route-rule` is added to a Kong Route, in the case when mapped `HTTPRoute`, `GRPCRoute`,
   `TCPRoute`, `TLSRoute` or `UDPRoute` has one or many route rules named (filled `spec.rules[*].name` field),
   those names will be propagated to one or many instances of aforementioned tag.

--- a/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -1,9 +1,9 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: httproute.default.httproute-testing._.3
-  id: 23683d37-44ee-559b-add2-a0b650ad36c0
-  name: httproute.default.httproute-testing._.3
+  host: httproute.default.httproute-testing.3
+  id: efb4a7d7-791f-504e-b005-0bd38bf1435e
+  name: httproute.default.httproute-testing.3
   port: 8080
   protocol: http
   read_timeout: 60000
@@ -29,9 +29,9 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: httproute.default.httproute-testing._.2
-  id: ff054481-b58a-588f-a8c4-e6cedb6cb489
-  name: httproute.default.httproute-testing._.2
+  host: httproute.default.httproute-testing.1
+  id: 672dc964-a7f8-5a80-a518-96fc39500cc8
+  name: httproute.default.httproute-testing.1
   port: 80
   protocol: http
   read_timeout: 60000
@@ -51,21 +51,6 @@ services:
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
     - k8s-named-route-rule:content
-  tags:
-  - k8s-name:httpbin
-  - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
-  write_timeout: 60000
-- connect_timeout: 60000
-  host: httproute.default.httproute-testing._.1
-  id: 13be00e6-9c94-561f-9598-8896cd755468
-  name: httproute.default.httproute-testing._.1
-  port: 80
-  protocol: http
-  read_timeout: 60000
-  retries: 5
-  routes:
   - expression: (http.path == "/echo") || (http.path ^= "/echo/")
     https_redirect_status_code: 426
     id: 88d36cfe-fbb0-5d7a-93c1-df18d1db3a12
@@ -87,9 +72,9 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 - connect_timeout: 60000
-  host: httproute.default.httproute-testing._.0
-  id: 2fad71d1-7599-5c6e-9d4f-4afd44f99587
-  name: httproute.default.httproute-testing._.0
+  host: httproute.default.httproute-testing.0
+  id: 4e3cb785-a8d0-5866-aa05-117f7c64f24d
+  name: httproute.default.httproute-testing.0
   port: 8080
   protocol: http
   read_timeout: 60000
@@ -118,28 +103,21 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: httproute.default.httproute-testing._.3
+  name: httproute.default.httproute-testing.3
   tags:
   - k8s-name:nginx
   - k8s-namespace:default
   - k8s-kind:Service
   - k8s-version:v1
 - algorithm: round-robin
-  name: httproute.default.httproute-testing._.2
+  name: httproute.default.httproute-testing.1
   tags:
   - k8s-name:httpbin
   - k8s-namespace:default
   - k8s-kind:Service
   - k8s-version:v1
 - algorithm: round-robin
-  name: httproute.default.httproute-testing._.1
-  tags:
-  - k8s-name:httpbin
-  - k8s-namespace:default
-  - k8s-kind:Service
-  - k8s-version:v1
-- algorithm: round-robin
-  name: httproute.default.httproute-testing._.0
+  name: httproute.default.httproute-testing.0
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default

--- a/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
@@ -1,9 +1,9 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
-  host: httproute.default.httproute-testing._.0
-  id: 2fad71d1-7599-5c6e-9d4f-4afd44f99587
-  name: httproute.default.httproute-testing._.0
+  host: httproute.default.httproute-testing.0
+  id: 4e3cb785-a8d0-5866-aa05-117f7c64f24d
+  name: httproute.default.httproute-testing.0
   port: 8080
   protocol: http
   read_timeout: 60000
@@ -42,7 +42,7 @@ services:
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
-  name: httproute.default.httproute-testing._.0
+  name: httproute.default.httproute-testing.0
   tags:
   - k8s-name:httproute-testing
   - k8s-namespace:default

--- a/internal/dataplane/translator/subtranslator/httproute.go
+++ b/internal/dataplane/translator/subtranslator/httproute.go
@@ -70,7 +70,7 @@ func TranslateHTTPRoutesToKongstateServices(
 	// When feature flag expression routes is enabled, we need first split the matches and assign priorities to them
 	// to set proper priorities to the translated Kong routes for satisfying the specification of priorities of HTTPRoute matches:
 	// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule
-	ruleToSplitMatchesWithPriorities := make(splitHTTPRouteMatchesWithPrioritiesGroupedByRule)
+	var ruleToSplitMatchesWithPriorities splitHTTPRouteMatchesWithPrioritiesGroupedByRule
 	if expressionRoutes {
 		ruleToSplitMatchesWithPriorities = groupHTTPRouteMatchesWithPrioritiesByRule(logger, routes)
 	}
@@ -87,7 +87,7 @@ func TranslateHTTPRoutesToKongstateServices(
 			return rulesMeta[i].getRuleKey() < rulesMeta[j].getRuleKey()
 		})
 
-		matchesWithPriorities := []SplitHTTPRouteMatchToKongRoutePriority{}
+		var matchesWithPriorities []SplitHTTPRouteMatchToKongRoutePriority
 		if expressionRoutes {
 			for _, ruleMeta := range rulesMeta {
 				ruleKey := ruleMeta.getRuleKey()
@@ -272,15 +272,13 @@ func translateHTTPRouteRulesMetaToKongstateService(
 		if err != nil {
 			return kongstate.Service{}, err
 		}
-		service.Routes = make([]kongstate.Route, 0, len(routes))
-		service.Routes = append(service.Routes, routes...)
+		service.Routes = routes
 	} else {
 		routes, err := translateHTTPRouteRulesMetaToKongstateRoutes(rulesMeta)
 		if err != nil {
 			return kongstate.Service{}, err
 		}
-		service.Routes = make([]kongstate.Route, 0, len(routes))
-		service.Routes = append(service.Routes, routes...)
+		service.Routes = routes
 	}
 
 	return service, nil

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -611,7 +611,6 @@ func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 func groupHTTPRouteMatchesWithPrioritiesByRule(
 	logger logr.Logger, routes []*gatewayapi.HTTPRoute,
 ) splitHTTPRouteMatchesWithPrioritiesGroupedByRule {
-	//
 	splitHTTPRouteMatches := []SplitHTTPRouteMatch{}
 	for _, route := range routes {
 		splitHTTPRouteMatches = append(splitHTTPRouteMatches, SplitHTTPRoute(route)...)
@@ -634,12 +633,13 @@ func groupHTTPRouteMatchesWithPrioritiesByRule(
 func translateSplitHTTPRouteMatchesToKongstateRoutesWithExpression(
 	matchesWithPriorities []SplitHTTPRouteMatchToKongRoutePriority,
 ) ([]kongstate.Route, error) {
-	routes := []kongstate.Route{}
+	routes := make([]kongstate.Route, 0, len(matchesWithPriorities))
 	for _, matchWithPriority := range matchesWithPriorities {
 		// Since each match is assigned a deterministic priority, we have to generate one route for each split match
 		// because every match have a different priority.
 		// TODO: update the algorithm to assign priorities to matches to make it possible to consolidate some matches.
-		// For example, we can assign the same priority to multiple matches from the same rule if they tie on the priority from the fixed fields.
+		// For example, we can assign the same priority to multiple matches from the same rule if they tie on the priority from the fixed fields:
+		// https://github.com/Kong/kubernetes-ingress-controller/issues/6807
 		route, err := kongExpressionRouteFromHTTPRouteMatchWithPriority(matchWithPriority)
 		if err != nil {
 			return []kongstate.Route{}, err

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -175,9 +175,6 @@ func pathMatcherFromHTTPPathMatch(pathMatch *gatewayapi.HTTPPathMatch) atc.Match
 			atc.NewPredicateHTTPPath(atc.OpPrefixMatch, path+"/"),
 		)
 	case gatewayapi.PathMatchRegularExpression:
-		// TODO: for compatibility with kong traditional routes, here we append the ^ prefix to match the path from beginning.
-		// Could we allow the regex to match any part of the path?
-		// https://github.com/Kong/kubernetes-ingress-controller/issues/3983
 		return atc.NewPredicateHTTPPath(atc.OpRegexMatch, appendRegexBeginIfNotExist(path))
 	}
 

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -451,14 +451,14 @@ func (t HTTPRoutePriorityTraits) EncodeToPriority() RoutePriorityType {
 	return priority
 }
 
-// AssignRoutePriorityToSplitHTTPRouteMatches assigns priority to
+// assignRoutePriorityToSplitHTTPRouteMatches assigns priority to
 // ALL split matches from ALL HTTPRoutes in the cache.
 // Firstly assign "fixed" bits by the following fields of the match:
 // hostname, path type, path length, method match, number of header matches, number of query param matches.
 // If ties exists in the first step, where multiple matches has the same priority
 // calculated from the fields, we run a sort for the matches in the tie
 // and assign the bits for "relative order" according to the sorting result of these matches.
-func AssignRoutePriorityToSplitHTTPRouteMatches(
+func assignRoutePriorityToSplitHTTPRouteMatches(
 	logger logr.Logger,
 	splitHTTPRouteMatches []SplitHTTPRouteMatch,
 ) []SplitHTTPRouteMatchToKongRoutePriority {
@@ -541,9 +541,9 @@ func compareSplitHTTPRouteMatchesRelativePriority(match1, match2 SplitHTTPRouteM
 	return true
 }
 
-// KongExpressionRouteFromHTTPRouteMatchWithPriority translates a split HTTPRoute match into expression
+// kongExpressionRouteFromHTTPRouteMatchWithPriority translates a split HTTPRoute match into expression
 // based kong route with assigned priority.
-func KongExpressionRouteFromHTTPRouteMatchWithPriority(
+func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 	httpRouteMatchWithPriority SplitHTTPRouteMatchToKongRoutePriority,
 ) (*kongstate.Route, error) {
 	match := httpRouteMatchWithPriority.Match
@@ -607,20 +607,44 @@ func KongExpressionRouteFromHTTPRouteMatchWithPriority(
 	return r, nil
 }
 
-// KongServiceNameFromSplitHTTPRouteMatch generates service name from split HTTPRoute match.
-// since one HTTPRoute may be split by hostname and rule, the service name will be generated
-// in the format "httproute.<namespace>.<name>.<hostname>.<rule index>".
-// For example: `httproute.default.example.foo.com.0`.
-func KongServiceNameFromSplitHTTPRouteMatch(match SplitHTTPRouteMatch) string {
-	httproute := match.Source
-	hostname := "_"
-	if len(match.Hostname) > 0 {
-		hostname = strings.ReplaceAll(match.Hostname, "*", "_")
+// groupHTTPRouteMatchesWithPrioritiesByRule groups split HTTPRoute matches that has priorities assigned by the source HTTPRoute rule,.
+func groupHTTPRouteMatchesWithPrioritiesByRule(
+	logger logr.Logger, routes []*gatewayapi.HTTPRoute,
+) splitHTTPRouteMatchesWithPrioritiesGroupedByRule {
+	//
+	splitHTTPRouteMatches := []SplitHTTPRouteMatch{}
+	for _, route := range routes {
+		splitHTTPRouteMatches = append(splitHTTPRouteMatches, SplitHTTPRoute(route)...)
 	}
-	return fmt.Sprintf("httproute.%s.%s.%s.%d",
-		httproute.Namespace,
-		httproute.Name,
-		hostname,
-		match.RuleIndex,
-	)
+	// assign priorities to split HTTPRoutes.
+	splitHTTPRouteMatchesWithPriorities := assignRoutePriorityToSplitHTTPRouteMatches(logger, splitHTTPRouteMatches)
+
+	// group the matches with priorities by its source HTTPRoute rule.
+	ruleToSplitMatchesWithPriorities := splitHTTPRouteMatchesWithPrioritiesGroupedByRule{}
+	for _, matchWithPriority := range splitHTTPRouteMatchesWithPriorities {
+		sourceRoute := matchWithPriority.Match.Source
+		ruleKey := fmt.Sprintf("%s/%s.%d", sourceRoute.Namespace, sourceRoute.Name, matchWithPriority.Match.RuleIndex)
+		ruleToSplitMatchesWithPriorities[ruleKey] = append(ruleToSplitMatchesWithPriorities[ruleKey], matchWithPriority)
+	}
+	return ruleToSplitMatchesWithPriorities
+}
+
+// translateSplitHTTPRouteMatchesToKongstateRoutesWithExpression translates a list of split HTTPRoute matches with assigned priorities
+// that are poiting to the same service to list of kongstate route with expressions.
+func translateSplitHTTPRouteMatchesToKongstateRoutesWithExpression(
+	matchesWithPriorities []SplitHTTPRouteMatchToKongRoutePriority,
+) ([]kongstate.Route, error) {
+	routes := []kongstate.Route{}
+	for _, matchWithPriority := range matchesWithPriorities {
+		// Since each match is assigned a deterministic priority, we have to generate one route for each split match
+		// because every match have a different priority.
+		// TODO: update the algorithm to assign priorities to matches to make it possible to consolidate some matches.
+		// For example, we can assign the same priority to multiple matches from the same rule if they tie on the priority from the fixed fields.
+		route, err := kongExpressionRouteFromHTTPRouteMatchWithPriority(matchWithPriority)
+		if err != nil {
+			return []kongstate.Route{}, err
+		}
+		routes = append(routes, *route)
+	}
+	return routes, nil
 }

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -1722,7 +1722,6 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 }
 
 func TestTranslateHTTPRouteRulesMetaToKongstateRoutes(t *testing.T) {
-
 	httpRouteTypeMeta := metav1.TypeMeta{
 		APIVersion: "gateway.networking.k8s.io/v1",
 		Kind:       "HTTPRoute",

--- a/internal/dataplane/translator/translate_httproute.go
+++ b/internal/dataplane/translator/translate_httproute.go
@@ -3,7 +3,6 @@ package translator
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -40,56 +39,8 @@ func (t *Translator) ingressRulesFromHTTPRoutes() ingressRules {
 		httpRoutesToTranslate = append(httpRoutesToTranslate, httproute)
 	}
 
-	if t.featureFlags.ExpressionRoutes {
-		t.ingressRulesFromHTTPRoutesUsingExpressionRoutes(httpRoutesToTranslate, &result)
-		return result
-	}
-
 	t.ingressRulesFromHTTPRoutesWithCombinedService(httpRoutesToTranslate, &result)
 	return result
-}
-
-// applyTimeoutsToService applies timeouts from HTTPRoute to the service.
-// If the HTTPRoute has multiple rules, the timeout from the last rule which has specific timeout will be applied to the service.
-// If the HTTPRoute has multiple rules and the first rule doesn't have timeout, the default timeout will be applied to the service.
-func applyTimeoutsToService(httpRoute *gatewayapi.HTTPRoute, rules *ingressRules) {
-	// If the HTTPRoute doesn't have rules, we don't need to apply timeouts to the service.
-	if httpRoute.Spec.Rules == nil {
-		return
-	}
-
-	backendRequestTimeout := DefaultServiceTimeout
-	for _, rule := range httpRoute.Spec.Rules {
-		if rule.Timeouts != nil && rule.Timeouts.BackendRequest != nil {
-			duration, err := time.ParseDuration(string(*rule.Timeouts.BackendRequest))
-			// We ignore the error here because the rule.Timeouts.BackendRequest is validated
-			// to be a strict subset of Golang time.ParseDuration so it should never happen
-			if err != nil {
-				continue
-			}
-			backendRequestTimeout = int(duration.Milliseconds())
-		}
-	}
-
-	// if the backendRequestTimeout is the same as the default timeout, we don't need to apply it to the service.
-	if backendRequestTimeout == DefaultServiceTimeout {
-		return
-	}
-
-	// due rules.ServiceNameToServices is a map, we need to iterate over the map to find the service
-	// which has the same parent as the HTTPRoute.
-	for serviceName, service := range rules.ServiceNameToServices {
-		if service.Parent.GetObjectKind() == httpRoute.GetObjectKind() && service.Parent.GetName() == httpRoute.Name && service.Parent.GetNamespace() == httpRoute.Namespace {
-			// Due to only one field being available in the Gateway API to control this behavior,
-			// when users set `spec.rules[].timeouts` in HTTPRoute,
-			// KIC will also set ReadTimeout, WriteTimeout and ConnectTimeout for the service to this value
-			// https://github.com/Kong/kubernetes-ingress-controller/issues/4914#issuecomment-1813964669
-			service.Service.ReadTimeout = kong.Int(backendRequestTimeout)
-			service.Service.ConnectTimeout = kong.Int(backendRequestTimeout)
-			service.Service.WriteTimeout = kong.Int(backendRequestTimeout)
-			rules.ServiceNameToServices[serviceName] = service
-		}
-	}
 }
 
 func validateHTTPRoute(httproute *gatewayapi.HTTPRoute, featureFlags FeatureFlags) error {
@@ -131,6 +82,7 @@ func (t *Translator) ingressRulesFromHTTPRoutesWithCombinedService(httpRoutes []
 		t.storer,
 		httpRoutes,
 		t.featureFlags.CombinedServicesFromDifferentHTTPRoutes,
+		t.featureFlags.ExpressionRoutes,
 	)
 	for serviceName, service := range translationResult.ServiceNameToKongstateService {
 		result.ServiceNameToServices[serviceName] = service
@@ -151,52 +103,6 @@ func (t *Translator) ingressRulesFromHTTPRoutesWithCombinedService(httpRoutes []
 			continue
 		}
 		// Register HTTPRoute successfully translated if no translation error found.
-		t.registerSuccessfullyTranslatedObject(httproute)
-	}
-}
-
-// ingressRulesFromHTTPRoutesUsingExpressionRoutes translates HTTPRoutes to expression based routes
-// when ExpressionRoutes feature flag is enabled.
-// Because we need to assign different priorities based on the hostname and match in the specification of HTTPRoutes,
-// We need to split the HTTPRoutes into ones with only one hostname and one match, then assign priority to them
-// and finally translate the split HTTPRoutes into Kong services and routes with assigned priorities.
-func (t *Translator) ingressRulesFromHTTPRoutesUsingExpressionRoutes(httpRoutes []*gatewayapi.HTTPRoute, result *ingressRules) {
-	// first, split HTTPRoutes by hostnames and matches.
-	splitHTTPRouteMatches := []subtranslator.SplitHTTPRouteMatch{}
-	for _, httproute := range httpRoutes {
-		splitHTTPRouteMatches = append(splitHTTPRouteMatches, subtranslator.SplitHTTPRoute(httproute)...)
-	}
-	// assign priorities to split HTTPRoutes.
-	splitHTTPRoutesWithPriorities := subtranslator.AssignRoutePriorityToSplitHTTPRouteMatches(t.logger, splitHTTPRouteMatches)
-	httpRouteNameToTranslationFailure := map[k8stypes.NamespacedName][]error{}
-
-	// translate split HTTPRoute matches to ingress rules, including services, routes, upstreams.
-	for _, httpRouteWithPriority := range splitHTTPRoutesWithPriorities {
-		err := t.ingressRulesFromSplitHTTPRouteMatchWithPriority(result, httpRouteWithPriority)
-		if err != nil {
-			nsName := k8stypes.NamespacedName{
-				Namespace: httpRouteWithPriority.Match.Source.Namespace,
-				Name:      httpRouteWithPriority.Match.Source.Name,
-			}
-			httpRouteNameToTranslationFailure[nsName] = append(httpRouteNameToTranslationFailure[nsName], err)
-		}
-	}
-	// Register successful translated objects and translation failures.
-	// Because one HTTPRoute may be split into multiple HTTPRoutes, we need to de-duplicate by namespace and name.
-	for _, httproute := range httpRoutes {
-		nsName := k8stypes.NamespacedName{
-			Namespace: httproute.Namespace,
-			Name:      httproute.Name,
-		}
-		if translationFailures, ok := httpRouteNameToTranslationFailure[nsName]; !ok {
-			applyTimeoutsToService(httproute, result)
-		} else {
-			t.registerTranslationFailure(
-				fmt.Sprintf("HTTPRoute can't be routed: %v", errors.Join(translationFailures...)),
-				httproute,
-			)
-			continue
-		}
 		t.registerSuccessfullyTranslatedObject(httproute)
 	}
 }
@@ -248,7 +154,6 @@ func GenerateKongRouteFromTranslation(
 
 	// get the hostnames from the HTTPRoute
 	hostnames := getHTTPRouteHostnamesAsSliceOfStringPointers(httproute)
-
 	return subtranslator.GenerateKongRoutesFromHTTPRouteMatches(
 		translation.Name,
 		translation.Matches,
@@ -257,59 +162,4 @@ func GenerateKongRouteFromTranslation(
 		hostnames,
 		tags,
 	)
-}
-
-func httpBackendRefsToBackendRefs(httpBackendRef []gatewayapi.HTTPBackendRef) []gatewayapi.BackendRef {
-	backendRefs := make([]gatewayapi.BackendRef, 0, len(httpBackendRef))
-
-	for _, hRef := range httpBackendRef {
-		backendRefs = append(backendRefs, hRef.BackendRef)
-	}
-	return backendRefs
-}
-
-// ingressRulesFromSplitHTTPRouteMatchWithPriority translates a single match split from HTTPRoute
-// to ingress rule, including Kong service and Kong route.
-func (t *Translator) ingressRulesFromSplitHTTPRouteMatchWithPriority(
-	rules *ingressRules,
-	httpRouteMatchWithPriority subtranslator.SplitHTTPRouteMatchToKongRoutePriority,
-) error {
-	match := httpRouteMatchWithPriority.Match
-	httpRoute := httpRouteMatchWithPriority.Match.Source
-	if match.RuleIndex >= len(httpRoute.Spec.Rules) {
-		t.logger.Error(nil, "Split match has rule out of bound of rules in source HTTPRoute",
-			"rule_index", match.RuleIndex, "rule_count", len(httpRoute.Spec.Rules))
-		return nil
-	}
-
-	rule := httpRoute.Spec.Rules[match.RuleIndex]
-	backendRefs := httpBackendRefsToBackendRefs(rule.BackendRefs)
-	serviceName := subtranslator.KongServiceNameFromSplitHTTPRouteMatch(httpRouteMatchWithPriority.Match)
-
-	kongService, err := generateKongServiceFromBackendRefWithName(
-		t.logger,
-		t.storer,
-		rules,
-		serviceName,
-		httpRoute,
-		"http",
-		backendRefs...,
-	)
-	if err != nil {
-		return err
-	}
-
-	additionalRoutes, err := subtranslator.KongExpressionRouteFromHTTPRouteMatchWithPriority(httpRouteMatchWithPriority)
-	if err != nil {
-		return err
-	}
-
-	kongService.Routes = append(
-		kongService.Routes,
-		*additionalRoutes,
-	)
-	// cache the service to avoid duplicates in further loop iterations
-	rules.ServiceNameToServices[serviceName] = kongService
-	rules.ServiceNameToParent[serviceName] = httpRoute
-	return nil
 }

--- a/internal/dataplane/translator/translate_httproute.go
+++ b/internal/dataplane/translator/translate_httproute.go
@@ -73,9 +73,8 @@ func validateHTTPRoute(httproute *gatewayapi.HTTPRoute, featureFlags FeatureFlag
 // When the feature flag CombinedServicesFromDifferentHTTPRoutes is true, it combines rules with same backends
 // to a single Kong gateway service across different HTTPRoutes in the same namespace.
 // When the feature flag is false, it combines rules with same backends in an HTTPRoute to a Kong gateway service.
-// TODO: This would be the common entrance for translating to Kong services in both traditional and expression routes after
-// https://github.com/Kong/kubernetes-ingress-controller/issues/6727 is finished.
-// They would share the code for translation of service names, backends and fields other then routes in Kong services.
+// When the feature flag ExpressionRoutes is set to true, expression based Kong routes will be translated from matches of HTTPRoutes.
+// Otherwise, traditional Kong routes are translated.
 func (t *Translator) ingressRulesFromHTTPRoutesWithCombinedService(httpRoutes []*gatewayapi.HTTPRoute, result *ingressRules) {
 	translationResult := subtranslator.TranslateHTTPRoutesToKongstateServices(
 		t.logger,

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -3,18 +3,16 @@ package translator
 import (
 	"testing"
 
-	"github.com/go-logr/zapr"
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
@@ -2353,7 +2351,10 @@ func TestIngressRulesFromHTTPRoutes_RegexPrefix(t *testing.T) {
 }
 
 func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
-	httpRouteTypeMeta := metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayv1beta1.GroupVersion.String()}
+	httpRouteTypeMeta := metav1.TypeMeta{
+		APIVersion: string(gatewayapi.V1Group) + "/" + gatewayapi.V1GroupVersion,
+		Kind:       "HTTPRoute",
+	}
 
 	testCases := []struct {
 		name                 string
@@ -2399,7 +2400,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.svc.default.service-1.80"),
+						Name: kong.String("httproute.default.httproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("service-1").
@@ -2410,7 +2411,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.svc.default.service-1.80": {
+				"httproute.default.httproute-1.0": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.0.0"),
@@ -2484,7 +2485,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.svc.default.service-1.80"),
+						Name: kong.String("httproute.default.httproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("service-1").
@@ -2495,7 +2496,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.svc.default.service-2.80"),
+						Name: kong.String("httproute.default.httproute-1.1"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("service-2").
@@ -2506,7 +2507,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.svc.default.service-1.80": {
+				"httproute.default.httproute-1.0": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.0.0"),
@@ -2524,7 +2525,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						ExpressionRoutes: true,
 					},
 				},
-				"httproute.default.svc.default.service-2.80": {
+				"httproute.default.httproute-1.1": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.1.0"),
@@ -2587,7 +2588,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.svc.default.service-1.80"),
+						Name: kong.String("httproute.default.httproute-1.0"),
 					},
 					Backends: []kongstate.ServiceBackend{
 						builder.NewKongstateServiceBackend("service-1").
@@ -2598,7 +2599,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.svc.default.service-1.80": {
+				"httproute.default.httproute-1.0": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.0.0"),
@@ -2653,7 +2654,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name:           kong.String("httproute.default.svc.default.service-1.80"),
+						Name:           kong.String("httproute.default.httproute-1.0"),
 						ConnectTimeout: kong.Int(500),
 						ReadTimeout:    kong.Int(500),
 						WriteTimeout:   kong.Int(500),
@@ -2667,7 +2668,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.svc.default.service-1.80": {
+				"httproute.default.httproute-1.0": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.0.0"),
@@ -2695,10 +2696,387 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakestore)
 			translator.featureFlags.ExpressionRoutes = true
-			translator.failuresCollector = failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
+			translator.failuresCollector = failures.NewResourceFailuresCollector(logr.Discard())
 
 			result := newIngressRules()
 			translator.ingressRulesFromHTTPRoutesWithCombinedService(tc.httpRoutes, &result)
+			// check services
+			require.Equal(t, len(tc.expectedKongServices), len(result.ServiceNameToServices),
+				"should have expected number of services")
+			for _, expectedKongService := range tc.expectedKongServices {
+				kongService, ok := result.ServiceNameToServices[*expectedKongService.Name]
+				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
+				require.Equal(t, expectedKongService.Backends, kongService.Backends)
+				// check routes
+				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
+				require.Equal(t, len(expectedKongRoutes), len(kongService.Routes))
+
+				kongRouteNameToRoute := lo.SliceToMap(kongService.Routes, func(r kongstate.Route) (string, kongstate.Route) {
+					return *r.Name, r
+				})
+				for _, expectedRoute := range expectedKongRoutes {
+					routeName := expectedRoute.Name
+					r, ok := kongRouteNameToRoute[*routeName]
+					require.Truef(t, ok, "should find route %s", *routeName)
+					require.Equal(t, *expectedRoute.Expression, *r.Expression)
+				}
+			}
+		})
+	}
+}
+
+func TestIngressRulesFromHTTPRoutesUsingExpressionRoutesAndCombinedServices(t *testing.T) {
+	var (
+		serviceTypeMeta = metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		}
+		httpRouteTypeMeta = metav1.TypeMeta{
+			APIVersion: string(gatewayapi.V1Group) + "/" + gatewayapi.V1GroupVersion,
+			Kind:       "HTTPRoute",
+		}
+
+		fakeService = &corev1.Service{
+			TypeMeta: serviceTypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-service",
+				Namespace: "default",
+			},
+		}
+		fakeService2 = &corev1.Service{
+			TypeMeta: serviceTypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-service-2",
+				Namespace: "default",
+			},
+		}
+	)
+
+	testCases := []struct {
+		name                 string
+		httpRoutes           []*gatewayapi.HTTPRoute
+		expectedKongServices []kongstate.Service
+		expectedKongRoutes   map[string][]kongstate.Route
+		fakeObjects          store.FakeObjects
+	}{
+		{
+			name: "single HTTPRoute with no hostname and multiple matches",
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				{
+					TypeMeta: httpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "httproute-1",
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								Matches: []gatewayapi.HTTPRouteMatch{
+									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
+									builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").Build(),
+								},
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					fakeService,
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name: kong.String("httproute.default.svc.default.fake-service.80"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("fake-service").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"httproute.default.svc.default.fake-service.80": {
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.0.0"),
+							Expression:   kong.String(`http.path == "/v1/foo"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.0.1"),
+							Expression:   kong.String(`http.path == "/v1/barr"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+				},
+			},
+		},
+		{
+			name: "single HTTPRoute with single rule, multiple hostnames and no matches",
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				{
+					TypeMeta: httpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "httproute-1",
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Hostnames: []gatewayapi.Hostname{
+							gatewayapi.Hostname("foo.com"),
+							gatewayapi.Hostname("bar.com"),
+						},
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					fakeService,
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name: kong.String("httproute.default.svc.default.fake-service.80"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("fake-service").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"httproute.default.svc.default.fake-service.80": {
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1.foo.com.0.0"),
+							Expression:   kong.String(`http.host == "foo.com"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1.bar.com.0.0"),
+							Expression:   kong.String(`http.host == "bar.com"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+				},
+			},
+		},
+		{
+			name: "single HTTPRoute with multiple rules pointing to the same backends",
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				{
+					TypeMeta: httpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "httproute-1",
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								Matches: builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").ToSlice(),
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+							{
+								Matches:     builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").ToSlice(),
+								BackendRefs: builder.NewHTTPBackendRef("fake-service").WithPort(80).ToSlice(),
+							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					fakeService,
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name: kong.String("httproute.default.svc.default.fake-service.80"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("fake-service").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"httproute.default.svc.default.fake-service.80": {
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.0.0"),
+							Expression:   kong.String(`http.path == "/v1/foo"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.1.0"),
+							Expression:   kong.String(`http.path == "/v1/barr"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple HTTPRoutes in the same namespace, where some rules are pointing to the same backends",
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				{
+					TypeMeta: httpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "httproute-1",
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								Matches: builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").ToSlice(),
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+							{
+								Matches:     builder.NewHTTPRouteMatch().WithPathExact("/v2/foo").ToSlice(),
+								BackendRefs: builder.NewHTTPBackendRef("fake-service-2").WithPort(80).ToSlice(),
+							},
+						},
+					},
+				},
+				{
+					TypeMeta: httpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "httproute-2",
+					},
+					Spec: gatewayapi.HTTPRouteSpec{
+						Rules: []gatewayapi.HTTPRouteRule{
+							{
+								Matches: builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").ToSlice(),
+								BackendRefs: []gatewayapi.HTTPBackendRef{
+									builder.NewHTTPBackendRef("fake-service").WithPort(80).Build(),
+								},
+							},
+							{
+								Matches:     builder.NewHTTPRouteMatch().WithPathExact("/v2/barr").ToSlice(),
+								BackendRefs: builder.NewHTTPBackendRef("fake-service-2").WithPort(80).ToSlice(),
+							},
+						},
+					},
+				},
+			},
+			fakeObjects: store.FakeObjects{
+				Services: []*corev1.Service{
+					fakeService,
+					fakeService2,
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name: kong.String("httproute.default.svc.default.fake-service.80"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("fake-service").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+				{
+					Service: kong.Service{
+						Name: kong.String("httproute.default.svc.default.fake-service-2.80"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("fake-service-2").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"httproute.default.svc.default.fake-service.80": {
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.0.0"),
+							Expression:   kong.String(`http.path == "/v1/foo"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-2._.0.0"),
+							Expression:   kong.String(`http.path == "/v1/barr"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+				},
+				"httproute.default.svc.default.fake-service-2.80": {
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-1._.1.0"),
+							Expression:   kong.String(`http.path == "/v2/foo"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+					{
+						Route: kong.Route{
+							Name:         kong.String("httproute.default.httproute-2._.1.0"),
+							Expression:   kong.String(`http.path == "/v2/barr"`),
+							PreserveHost: kong.Bool(true),
+						},
+						ExpressionRoutes: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakestore, err := store.NewFakeStore(tc.fakeObjects)
+			require.NoError(t, err)
+			tr := mustNewTranslator(t, fakestore)
+			tr.featureFlags.ExpressionRoutes = true
+			tr.featureFlags.CombinedServicesFromDifferentHTTPRoutes = true
+			tr.failuresCollector = failures.NewResourceFailuresCollector(logr.Discard())
+
+			result := newIngressRules()
+			tr.ingressRulesFromHTTPRoutesWithCombinedService(tc.httpRoutes, &result)
 			// check services
 			require.Equal(t, len(tc.expectedKongServices), len(result.ServiceNameToServices),
 				"should have expected number of services")

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -2379,7 +2379,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").Build(),
 								},
 								BackendRefs: []gatewayapi.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									builder.NewHTTPBackendRef("service-1").WithPort(80).Build(),
 								},
 							},
 						},
@@ -2391,7 +2391,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
-							Name:      "service1",
+							Name:      "service-1",
 						},
 					},
 				},
@@ -2399,10 +2399,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1._.0"),
+						Name: kong.String("httproute.default.svc.default.service-1.80"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").
+						builder.NewKongstateServiceBackend("service-1").
 							WithNamespace("default").
 							WithPortNumber(80).
 							MustBuild(),
@@ -2410,7 +2410,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.httproute-1._.0": {
+				"httproute.default.svc.default.service-1.80": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.0.0"),
@@ -2450,7 +2450,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
 								},
 								BackendRefs: []gatewayapi.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									builder.NewHTTPBackendRef("service-1").WithPort(80).Build(),
 								},
 							},
 							{
@@ -2458,7 +2458,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").Build(),
 								},
 								BackendRefs: []gatewayapi.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service2").WithPort(80).Build(),
+									builder.NewHTTPBackendRef("service-2").WithPort(80).Build(),
 								},
 							},
 						},
@@ -2470,13 +2470,13 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
-							Name:      "service1",
+							Name:      "service-1",
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
-							Name:      "service2",
+							Name:      "service-2",
 						},
 					},
 				},
@@ -2484,10 +2484,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1.foo.com.0"),
+						Name: kong.String("httproute.default.svc.default.service-1.80"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").
+						builder.NewKongstateServiceBackend("service-1").
 							WithNamespace("default").
 							WithPortNumber(80).
 							MustBuild(),
@@ -2495,32 +2495,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1._.bar.com.0"),
+						Name: kong.String("httproute.default.svc.default.service-2.80"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").
-							WithNamespace("default").
-							WithPortNumber(80).
-							MustBuild(),
-					},
-				},
-				{
-					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1.foo.com.1"),
-					},
-					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").
-							WithNamespace("default").
-							WithPortNumber(80).
-							MustBuild(),
-					},
-				},
-				{
-					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1._.bar.com.1"),
-					},
-					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service2").
+						builder.NewKongstateServiceBackend("service-2").
 							WithNamespace("default").
 							WithPortNumber(80).
 							MustBuild(),
@@ -2528,7 +2506,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.httproute-1.foo.com.0": {
+				"httproute.default.svc.default.service-1.80": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.0.0"),
@@ -2537,8 +2515,6 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					},
-				},
-				"httproute.default.httproute-1._.bar.com.0": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.bar.com.0.0"),
@@ -2548,7 +2524,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						ExpressionRoutes: true,
 					},
 				},
-				"httproute.default.httproute-1.foo.com.1": {
+				"httproute.default.svc.default.service-2.80": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.1.0"),
@@ -2557,8 +2533,6 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 						},
 						ExpressionRoutes: true,
 					},
-				},
-				"httproute.default.httproute-1._.bar.com.1": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.bar.com.1.0"),
@@ -2593,7 +2567,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
 								},
 								BackendRefs: []gatewayapi.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									builder.NewHTTPBackendRef("service-1").WithPort(80).Build(),
 								},
 							},
 						},
@@ -2605,7 +2579,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
-							Name:      "service1",
+							Name:      "service-1",
 						},
 					},
 				},
@@ -2613,10 +2587,10 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name: kong.String("httproute.default.httproute-1.foo.com.0"),
+						Name: kong.String("httproute.default.svc.default.service-1.80"),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").
+						builder.NewKongstateServiceBackend("service-1").
 							WithNamespace("default").
 							WithPortNumber(80).
 							MustBuild(),
@@ -2624,7 +2598,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.httproute-1.foo.com.0": {
+				"httproute.default.svc.default.service-1.80": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1.foo.com.0.0"),
@@ -2653,7 +2627,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 									builder.NewHTTPRouteMatch().WithPathExact("/v1/barr").Build(),
 								},
 								BackendRefs: []gatewayapi.HTTPBackendRef{
-									builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
+									builder.NewHTTPBackendRef("service-1").WithPort(80).Build(),
 								},
 								Timeouts: func() *gatewayapi.HTTPRouteTimeouts {
 									timeout := gatewayapi.Duration("500ms")
@@ -2671,7 +2645,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
-							Name:      "service1",
+							Name:      "service-1",
 						},
 					},
 				},
@@ -2679,13 +2653,13 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			expectedKongServices: []kongstate.Service{
 				{
 					Service: kong.Service{
-						Name:           kong.String("httproute.default.httproute-1._.0"),
+						Name:           kong.String("httproute.default.svc.default.service-1.80"),
 						ConnectTimeout: kong.Int(500),
 						ReadTimeout:    kong.Int(500),
 						WriteTimeout:   kong.Int(500),
 					},
 					Backends: []kongstate.ServiceBackend{
-						builder.NewKongstateServiceBackend("service1").
+						builder.NewKongstateServiceBackend("service-1").
 							WithNamespace("default").
 							WithPortNumber(80).
 							MustBuild(),
@@ -2693,7 +2667,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 				},
 			},
 			expectedKongRoutes: map[string][]kongstate.Route{
-				"httproute.default.httproute-1._.0": {
+				"httproute.default.svc.default.service-1.80": {
 					{
 						Route: kong.Route{
 							Name:         kong.String("httproute.default.httproute-1._.0.0"),
@@ -2724,7 +2698,7 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 			translator.failuresCollector = failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
 
 			result := newIngressRules()
-			translator.ingressRulesFromHTTPRoutesUsingExpressionRoutes(tc.httpRoutes, &result)
+			translator.ingressRulesFromHTTPRoutesWithCombinedService(tc.httpRoutes, &result)
 			// check services
 			require.Equal(t, len(tc.expectedKongServices), len(result.ServiceNameToServices),
 				"should have expected number of services")
@@ -2746,388 +2720,6 @@ func TestIngressRulesFromHTTPRoutesUsingExpressionRoutes(t *testing.T) {
 					require.Equal(t, *expectedRoute.Expression, *r.Expression)
 				}
 			}
-		})
-	}
-}
-
-func TestIngressRulesFromSplitHTTPRouteMatchWithPriority(t *testing.T) {
-	httpRouteTypeMeta := metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayv1beta1.GroupVersion.String()}
-
-	testCases := []struct {
-		name                string
-		matchWithPriority   subtranslator.SplitHTTPRouteMatchToKongRoutePriority
-		storeObjects        store.FakeObjects
-		expectedKongService kongstate.Service
-		expectedKongRoute   kongstate.Route
-		expectedError       error
-	}{
-		{
-			name: "no hostname",
-			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: subtranslator.SplitHTTPRouteMatch{
-					Source: &gatewayapi.HTTPRoute{
-						TypeMeta: httpRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-1",
-						},
-						Spec: gatewayapi.HTTPRouteSpec{
-							Rules: []gatewayapi.HTTPRouteRule{
-								{
-									Matches: []gatewayapi.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-									},
-									BackendRefs: []gatewayapi.HTTPBackendRef{
-										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
-									},
-								},
-							},
-						},
-					},
-					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-					RuleIndex:  0,
-					MatchIndex: 0,
-				},
-				Priority: 1024,
-			},
-			storeObjects: store.FakeObjects{
-				Services: []*corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service1",
-						},
-					},
-				},
-			},
-			expectedKongService: kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String("httproute.default.httproute-1._.0"),
-				},
-				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
-				},
-			},
-			expectedKongRoute: kongstate.Route{
-				Route: kong.Route{
-					Name:         kong.String("httproute.default.httproute-1._.0.0"),
-					Expression:   kong.String(`http.path == "/v1/foo"`),
-					PreserveHost: kong.Bool(true),
-					StripPath:    kong.Bool(false),
-					Priority:     kong.Uint64(1024),
-				},
-				ExpressionRoutes: true,
-			},
-		},
-		{
-			name: "precise hostname and filter",
-			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: subtranslator.SplitHTTPRouteMatch{
-					Source: &gatewayapi.HTTPRoute{
-						TypeMeta: httpRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-1",
-						},
-						Spec: gatewayapi.HTTPRouteSpec{
-							Hostnames: []gatewayapi.Hostname{
-								"foo.com",
-							},
-							Rules: []gatewayapi.HTTPRouteRule{
-								{
-									Matches: []gatewayapi.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/foo").Build(),
-										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-									},
-									BackendRefs: []gatewayapi.HTTPBackendRef{
-										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
-									},
-									Filters: []gatewayapi.HTTPRouteFilter{
-										builder.NewHTTPRouteRequestRedirectFilter().
-											WithRequestRedirectStatusCode(301).
-											WithRequestRedirectHost("bar.com").
-											Build(),
-									},
-								},
-							},
-						},
-					},
-					Hostname:   "foo.com",
-					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-					RuleIndex:  0,
-					MatchIndex: 1,
-				},
-				Priority: 1024,
-			},
-			storeObjects: store.FakeObjects{
-				Services: []*corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service1",
-						},
-					},
-				},
-			},
-			expectedKongService: kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String("httproute.default.httproute-1.foo.com.0"),
-				},
-				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
-				},
-			},
-			expectedKongRoute: kongstate.Route{
-				Route: kong.Route{
-					Name:         kong.String("httproute.default.httproute-1.foo.com.0.1"),
-					Expression:   kong.String(`(http.host == "foo.com") && (http.path == "/v1/foo")`),
-					PreserveHost: kong.Bool(true),
-					StripPath:    kong.Bool(false),
-					Priority:     kong.Uint64(1024),
-				},
-				Plugins: []kong.Plugin{
-					{
-						Name: kong.String("request-termination"),
-						Config: kong.Configuration{
-							"status_code": kong.Int(301),
-						},
-						Tags: []*string{
-							kong.String("k8s-name:httproute-1"),
-							kong.String("k8s-namespace:default"),
-							kong.String("k8s-kind:HTTPRoute"),
-							kong.String("k8s-group:gateway.networking.k8s.io"),
-							kong.String("k8s-version:v1beta1"),
-						},
-					},
-					{
-						Name: kong.String("response-transformer"),
-						Config: kong.Configuration{
-							"add": subtranslator.TransformerPluginConfig{
-								Headers: []string{"Location: http://bar.com:80/v1/foo"},
-							},
-						},
-						Tags: []*string{
-							kong.String("k8s-name:httproute-1"),
-							kong.String("k8s-namespace:default"),
-							kong.String("k8s-kind:HTTPRoute"),
-							kong.String("k8s-group:gateway.networking.k8s.io"),
-							kong.String("k8s-version:v1beta1"),
-						},
-					},
-				},
-				ExpressionRoutes: true,
-			},
-		},
-		{
-			name: "wildcard hostname with multiple backends",
-			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: subtranslator.SplitHTTPRouteMatch{
-					Source: &gatewayapi.HTTPRoute{
-						TypeMeta: httpRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-1",
-						},
-						Spec: gatewayapi.HTTPRouteSpec{
-							Hostnames: []gatewayapi.Hostname{
-								"*.foo.com",
-							},
-							Rules: []gatewayapi.HTTPRouteRule{
-								{
-									Matches: []gatewayapi.HTTPRouteMatch{
-										builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-									},
-									BackendRefs: []gatewayapi.HTTPBackendRef{
-										builder.NewHTTPBackendRef("service1").WithPort(80).WithWeight(10).Build(),
-										builder.NewHTTPBackendRef("service2").WithPort(80).WithWeight(20).Build(),
-									},
-								},
-							},
-						},
-					},
-					Hostname:   "*.foo.com",
-					Match:      builder.NewHTTPRouteMatch().WithPathExact("/v1/foo").Build(),
-					RuleIndex:  0,
-					MatchIndex: 0,
-				},
-				Priority: 1024,
-			},
-			storeObjects: store.FakeObjects{
-				Services: []*corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service1",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service2",
-						},
-					},
-				},
-			},
-			expectedKongService: kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String("httproute.default.httproute-1._.foo.com.0"),
-				},
-				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).WithWeight(10).MustBuild(),
-					builder.NewKongstateServiceBackend("service2").WithPortNumber(80).WithWeight(20).MustBuild(),
-				},
-			},
-			expectedKongRoute: kongstate.Route{
-				Route: kong.Route{
-					Name:         kong.String("httproute.default.httproute-1._.foo.com.0.0"),
-					Expression:   kong.String(`(http.host =^ ".foo.com") && (http.path == "/v1/foo")`),
-					PreserveHost: kong.Bool(true),
-					StripPath:    kong.Bool(false),
-					Priority:     kong.Uint64(1024),
-				},
-				ExpressionRoutes: true,
-			},
-		},
-		{
-			name: "precise hostname and no match",
-			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: subtranslator.SplitHTTPRouteMatch{
-					Source: &gatewayapi.HTTPRoute{
-						TypeMeta: httpRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-1",
-						},
-						Spec: gatewayapi.HTTPRouteSpec{
-							Hostnames: []gatewayapi.Hostname{
-								"a.foo.com",
-							},
-							Rules: []gatewayapi.HTTPRouteRule{
-								{
-									BackendRefs: []gatewayapi.HTTPBackendRef{
-										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
-									},
-								},
-							},
-						},
-					},
-					Hostname:   "a.foo.com",
-					Match:      builder.NewHTTPRouteMatch().Build(),
-					RuleIndex:  0,
-					MatchIndex: 0,
-				},
-				Priority: 1024,
-			},
-			storeObjects: store.FakeObjects{
-				Services: []*corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service1",
-						},
-					},
-				},
-			},
-			expectedKongService: kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String("httproute.default.httproute-1.a.foo.com.0"),
-				},
-				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
-				},
-			},
-			expectedKongRoute: kongstate.Route{
-				Route: kong.Route{
-					Name:         kong.String("httproute.default.httproute-1.a.foo.com.0.0"),
-					Expression:   kong.String(`http.host == "a.foo.com"`),
-					PreserveHost: kong.Bool(true),
-					StripPath:    kong.Bool(false),
-					Priority:     kong.Uint64(1024),
-				},
-				ExpressionRoutes: true,
-			},
-		},
-		{
-			name: "no hostname and no match",
-			matchWithPriority: subtranslator.SplitHTTPRouteMatchToKongRoutePriority{
-				Match: subtranslator.SplitHTTPRouteMatch{
-					Source: &gatewayapi.HTTPRoute{
-						TypeMeta: httpRouteTypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "httproute-1",
-						},
-						Spec: gatewayapi.HTTPRouteSpec{
-							Rules: []gatewayapi.HTTPRouteRule{
-								{
-									BackendRefs: []gatewayapi.HTTPBackendRef{
-										builder.NewHTTPBackendRef("service1").WithPort(80).Build(),
-									},
-								},
-							},
-						},
-					},
-					Hostname:   "",
-					Match:      builder.NewHTTPRouteMatch().Build(),
-					RuleIndex:  0,
-					MatchIndex: 0,
-				},
-				Priority: 1024,
-			},
-			storeObjects: store.FakeObjects{
-				Services: []*corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "service1",
-						},
-					},
-				},
-			},
-			expectedKongService: kongstate.Service{
-				Service: kong.Service{
-					Name: kong.String("httproute.default.httproute-1._.0"),
-				},
-				Backends: []kongstate.ServiceBackend{
-					builder.NewKongstateServiceBackend("service1").WithPortNumber(80).MustBuild(),
-				},
-			},
-			expectedKongRoute: kongstate.Route{
-				Route: kong.Route{
-					Name:         kong.String("httproute.default.httproute-1._.0.0"),
-					Expression:   kong.String(subtranslator.CatchAllHTTPExpression),
-					PreserveHost: kong.Bool(true),
-					StripPath:    kong.Bool(false),
-					Priority:     kong.Uint64(1024),
-				},
-				ExpressionRoutes: true,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			fakestore, err := store.NewFakeStore(tc.storeObjects)
-			require.NoError(t, err)
-			translator := mustNewTranslator(t, fakestore)
-			translator.featureFlags.ExpressionRoutes = true
-
-			match := tc.matchWithPriority.Match
-			tc.expectedKongRoute.Tags = util.GenerateTagsForObject(match.Source)
-			tc.expectedKongRoute.Ingress = util.FromK8sObject(match.Source)
-
-			res := newIngressRules()
-			err = translator.ingressRulesFromSplitHTTPRouteMatchWithPriority(&res, tc.matchWithPriority)
-			if tc.expectedError != nil {
-				require.ErrorAs(t, err, tc.expectedError)
-				return
-			}
-			require.NoError(t, err)
-			kongService, ok := res.ServiceNameToServices[*tc.expectedKongService.Name]
-			require.Truef(t, ok, "should find service %s", *tc.expectedKongService.Name)
-			require.Equal(t, tc.expectedKongService.Backends, kongService.Backends)
-			require.Len(t, kongService.Routes, 1)
-			require.Equal(t, tc.expectedKongRoute, kongService.Routes[0])
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Second part of #5801. Generate combined Kong services for rules sharing the same bakends when expression based routes are used.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

Fixes #6727

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
