### PR TITLE
fix(controller): set creationTimestamp of ancestors of KongUpstreamPolicy status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,10 @@ Adding a new version? You'll need three changes:
   point to a `Gateway` as they can point to other kinds of resources like
   `Service` when used in service mesh solutions.
   [#6692](https://github.com/Kong/kubernetes-ingress-controller/pull/6692)
+- Set creationTimestamp of ancestor in ancestor status of `KongUpstreamPolicy`
+  to make sure the order of ancestors in the status is deterministic to fix
+  the issue where the status of `KongUpstreamPolicy` is continuously updated.
+  [#6767](https://github.com/Kong/kubernetes-ingress-controller/pull/6767)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ Adding a new version? You'll need three changes:
   point to a `Gateway` as they can point to other kinds of resources like
   `Service` when used in service mesh solutions.
   [#6692](https://github.com/Kong/kubernetes-ingress-controller/pull/6692)
-- Set creationTimestamp of ancestor in ancestor status of `KongUpstreamPolicy`
+- Set `creationTimestamp` of ancestor in ancestor status of `KongUpstreamPolicy`
   to make sure the order of ancestors in the status is deterministic to fix
   the issue where the status of `KongUpstreamPolicy` is continuously updated.
   [#6767](https://github.com/Kong/kubernetes-ingress-controller/pull/6767)

--- a/internal/controllers/configuration/kongupstreampolicy_utils.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils.go
@@ -423,7 +423,6 @@ func (r *KongUpstreamPolicyReconciler) buildPolicyStatus(
 		if !ancestorsStatus[i].creationTimestamp.Equal(&ancestorsStatus[j].creationTimestamp) {
 			return ancestorsStatus[i].creationTimestamp.Before(&ancestorsStatus[j].creationTimestamp)
 		}
-		// REVIEW: the condition will make KongServiceFacade be prior to Service. Should we customize the comparing of kinds here?
 		if ancestorsStatus[i].ancestorKind != ancestorsStatus[j].ancestorKind {
 			return ancestorsStatus[i].ancestorKind < ancestorsStatus[j].ancestorKind
 		}

--- a/internal/controllers/configuration/kongupstreampolicy_utils_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils_test.go
@@ -35,6 +35,8 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 		testNamespace     = "test"
 	)
 
+	now := metav1.Now()
+
 	testCases := []struct {
 		name                             string
 		kongUpstreamPolicy               kongv1beta1.KongUpstreamPolicy
@@ -44,7 +46,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 		updated                          bool
 	}{
 		{
-			name: "2 services referencing the same policy, all accepted. Status update.",
+			name: "3 services referencing the same policy, all accepted. Status update.",
 			kongUpstreamPolicy: kongv1beta1.KongUpstreamPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      policyName,
@@ -59,7 +61,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&corev1.Service{
@@ -70,7 +72,19 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
 						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
+							Time: now.Add(10 * time.Second),
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-3",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
+						},
+						CreationTimestamp: metav1.Time{
+							Time: now.Add(5 * time.Second),
 						},
 					},
 				},
@@ -97,6 +111,13 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 											},
 										},
 									},
+									{
+										BackendRef: gatewayapi.BackendRef{
+											BackendObjectReference: gatewayapi.BackendObjectReference{
+												Name: "svc-3",
+											},
+										},
+									},
 								},
 							},
 						},
@@ -106,12 +127,34 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 			objectsConfiguredInDataPlane: true,
 			expectedKongUpstreamPolicyStatus: gatewayapi.PolicyStatus{
 				Ancestors: []gatewayapi.PolicyAncestorStatus{
+					// Order of ancestors should be svc-1 - svc-3 - svc-2 for the order of creationTimestamp.
 					{
 						AncestorRef: gatewayapi.ParentReference{
 							Group:     lo.ToPtr(gatewayapi.Group("core")),
 							Kind:      lo.ToPtr(gatewayapi.Kind("Service")),
 							Namespace: lo.ToPtr(gatewayapi.Namespace(testNamespace)),
 							Name:      gatewayapi.ObjectName("svc-1"),
+						},
+						ControllerName: gatewaycontroller.GetControllerName(),
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayapi.PolicyConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.PolicyReasonAccepted),
+							},
+							{
+								Type:   string(gatewayapi.GatewayConditionProgrammed),
+								Status: metav1.ConditionTrue,
+								Reason: string(gatewayapi.GatewayReasonProgrammed),
+							},
+						},
+					},
+					{
+						AncestorRef: gatewayapi.ParentReference{
+							Group:     lo.ToPtr(gatewayapi.Group("core")),
+							Kind:      lo.ToPtr(gatewayapi.Kind("Service")),
+							Namespace: lo.ToPtr(gatewayapi.Namespace(testNamespace)),
+							Name:      gatewayapi.ObjectName("svc-3"),
 						},
 						ControllerName: gatewaycontroller.GetControllerName(),
 						Conditions: []metav1.Condition{
@@ -214,7 +257,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&corev1.Service{
@@ -224,9 +267,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
-						},
+						CreationTimestamp: now,
 					},
 				},
 				&gatewayapi.HTTPRoute{
@@ -323,7 +364,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&corev1.Service{
@@ -334,7 +375,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: anotherPolicyName,
 						},
 						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
+							Time: now.Add(10 * time.Second),
 						},
 					},
 				},
@@ -411,7 +452,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&corev1.Service{
@@ -422,7 +463,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: anotherPolicyName,
 						},
 						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
+							Time: now.Add(10 * time.Second),
 						},
 					},
 				},
@@ -503,7 +544,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&incubatorv1alpha1.KongServiceFacade{
@@ -514,7 +555,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
 						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
+							Time: now.Add(10 * time.Second),
 						},
 					},
 				},
@@ -599,7 +640,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 						Annotations: map[string]string{
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
-						CreationTimestamp: metav1.Now(),
+						CreationTimestamp: now,
 					},
 				},
 				&incubatorv1alpha1.KongServiceFacade{
@@ -610,7 +651,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 							kongv1beta1.KongUpstreamPolicyAnnotationKey: policyName,
 						},
 						CreationTimestamp: metav1.Time{
-							Time: metav1.Now().Add(10 * time.Second),
+							Time: now.Add(10 * time.Second),
 						},
 					},
 				},
@@ -949,6 +990,23 @@ func TestBuildPolicyStatus(t *testing.T) {
 					serviceFacadeExpectedPolicyAncestorStatus("svc-facade-1"),
 					serviceExpectedPolicyAncestorStatus("svc-2"),
 					serviceExpectedPolicyAncestorStatus("svc-1"),
+				},
+			},
+		},
+		{
+			name: "ordered by kind, namespace and name if their creationTimestamp is the same",
+			ancestorsStatuses: []ancestorStatus{
+				serviceStatus("svc-1", now),
+				serviceStatus("svc-2", now),
+				serviceFacadeStatus("svc-facade-1", now),
+				serviceFacadeStatus("svc-facade-2", now),
+			},
+			expected: gatewayapi.PolicyStatus{
+				Ancestors: []gatewayapi.PolicyAncestorStatus{
+					serviceFacadeExpectedPolicyAncestorStatus("svc-facade-1"),
+					serviceFacadeExpectedPolicyAncestorStatus("svc-facade-2"),
+					serviceExpectedPolicyAncestorStatus("svc-1"),
+					serviceExpectedPolicyAncestorStatus("svc-2"),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Set creationTimestamp of ancestor status in `KongUpstreamPolicy` to fix the sorting of ancestors in `KongUpstreamPolicy` status.
This fixes an issue where status of `KongUpstreamPolicy` is continuously updated even nothing changed.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6757 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
