### PR TITLE
chore(ci): fix performance tests artifacts

### DIFF
--- a/.github/workflows/performance_nightly.yaml
+++ b/.github/workflows/performance_nightly.yaml
@@ -46,8 +46,9 @@ jobs:
       - name: download performance test results
         uses: actions/download-artifact@v4
         with:
-          name: performance-tests-results
+          pattern: performance-tests-results-*
           path: perf-results
+          merge-multiple: true
 
       - name: drawing
         run: |

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -106,8 +106,9 @@ jobs:
       - name: download performance test results
         uses: actions/download-artifact@v4
         with:
-          name: performance-tests-results
+          pattern: performance-tests-results-*
           path: perf-results
+          merge-multiple: true
 
       - name: drawing
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Migrating to `actions/upload-artifact@v4` and `actions/download-artifact@v4` missed the performance reports artifacts. This PR fixes it.

Working workflow run can be found in: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12163549394, specifically: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12163549394/job/33924218511#step:5:1

Failing workflow run in nightly: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12153705270/job/33892614064#step:5:10
