### PR TITLE
feat((TLS|TCP|UDP|GRPC)Route): propagate to Kong tag `k8s-named-route-rule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,10 +206,11 @@ Adding a new version? You'll need three changes:
   where `<hash>` is the hash result of the calculated name, like
   `httproute.default.svc.default.a-long-long-long-service-name.80_combined.00001111222233334444aaaabbbbcccc`.
   [#6711](https://github.com/Kong/kubernetes-ingress-controller/pull/6711)
-- The new tag `k8s-named-route-rule` is added to a Kong Route, in the case when mapped `HTTPRoute` has
-  routes named (filled `spec.rules[*].name` field) that names will be propagated to one or many instances
-  of aforementioned tag.
+- The new tag `k8s-named-route-rule` is added to a Kong Route, in the case when mapped `HTTPRoute`, `GRPCRoute`,
+  `TCPRoute`, `TLSRoute` or `UDPRoute` has one or many route rules named (filled `spec.rules[*].name` field),
+  those names will be propagated to one or many instances of aforementioned tag.
   [#6759](https://github.com/Kong/kubernetes-ingress-controller/pull/6759)
+  [#6780](https://github.com/Kong/kubernetes-ingress-controller/pull/6780)
 
 
 ## [3.3.1]

--- a/internal/dataplane/testdata/golden/grpcroute-example/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/grpcroute-example/default_golden.yaml
@@ -1,6 +1,86 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
+  host: grpcroute.default.grpcbin.2
+  id: 20d53c70-e92e-57d7-85a4-265209989fd2
+  name: grpcroute.default.grpcbin.2
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    id: f036508e-e749-5b7c-ac09-70e771daff5f
+    name: grpcroute.default.grpcbin.2.0
+    path_handling: v0
+    paths:
+    - ~/grpcbin.GRPCBin/Get
+    protocols:
+    - grpc
+    - grpcs
+    tags:
+    - k8s-name:grpcbin
+    - k8s-namespace:default
+    - k8s-kind:GRPCRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.1
+  id: 5a5c3a90-aad9-5e89-93e6-53741e27b8fa
+  name: grpcroute.default.grpcbin.1
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - hosts:
+    - example.com
+    https_redirect_status_code: 426
+    id: b3572b0c-972a-5f08-9d2e-e0e57de804e1
+    name: grpcroute.default.grpcbin.1.0
+    path_handling: v0
+    paths:
+    - ~/grpcbin.GRPCBin/Default
+    protocols:
+    - grpc
+    - grpcs
+    tags:
+    - k8s-name:grpcbin
+    - k8s-namespace:default
+    - k8s-kind:GRPCRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: grpcroute.default.grpcbin.0
   id: 21a5e729-c47e-5086-a236-0551b9a11bda
   name: grpcroute.default.grpcbin.0
@@ -30,6 +110,8 @@ services:
     - k8s-kind:GRPCRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -39,6 +121,24 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.2
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.1
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
 - algorithm: round-robin
   name: grpcroute.default.grpcbin.0
   tags:

--- a/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -1,6 +1,76 @@
 _format_version: "3.0"
 services:
 - connect_timeout: 60000
+  host: grpcroute.default.grpcbin.example.com.2
+  id: 3ffe4b8d-2338-5124-ae9f-8dccbb3af27b
+  name: grpcroute.default.grpcbin.example.com.2
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/grpcbin.GRPCBin/Get") && (http.host == "example.com")
+    https_redirect_status_code: 426
+    id: 22f4a0b8-634d-558a-99fb-3cf82f273636
+    name: grpcroute.default.grpcbin.example.com.2.0
+    preserve_host: true
+    priority: 26766487871743
+    tags:
+    - k8s-name:grpcbin
+    - k8s-namespace:default
+    - k8s-kind:GRPCRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
+  host: grpcroute.default.grpcbin.example.com.1
+  id: 4d9f08e3-4be4-5155-85df-879454f38400
+  name: grpcroute.default.grpcbin.example.com.1
+  plugins:
+  - config:
+      message: no existing backendRef provided
+      status_code: 500
+    name: request-termination
+  protocol: grpcs
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - expression: (http.path == "/grpcbin.GRPCBin/Default") && (http.host == "example.com")
+    https_redirect_status_code: 426
+    id: c0838597-8475-5f04-b4f9-42f0bf2f40cb
+    name: grpcroute.default.grpcbin.example.com.1.0
+    preserve_host: true
+    priority: 26766487904511
+    tags:
+    - k8s-name:grpcbin
+    - k8s-namespace:default
+    - k8s-kind:GRPCRoute
+    - k8s-group:gateway.networking.k8s.io
+    - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+  write_timeout: 60000
+- connect_timeout: 60000
   host: grpcroute.default.grpcbin.example.com.0
   id: e3750232-74d7-5496-bf14-1c266ec17184
   name: grpcroute.default.grpcbin.example.com.0
@@ -25,6 +95,8 @@ services:
     - k8s-kind:GRPCRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1
+    - k8s-named-route-rule:grpcbin-dummy-unary
+    - k8s-named-route-rule:grpcbin-default
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN
@@ -34,6 +106,24 @@ services:
   - k8s-version:v1
   write_timeout: 60000
 upstreams:
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.example.com.2
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
+- algorithm: round-robin
+  name: grpcroute.default.grpcbin.example.com.1
+  tags:
+  - k8s-name:UNKNOWN
+  - k8s-namespace:UNKNOWN
+  - k8s-kind:Service
+  - k8s-uid:00000000-0000-0000-0000-000000000000
+  - k8s-group:core
+  - k8s-version:v1
 - algorithm: round-robin
   name: grpcroute.default.grpcbin.example.com.0
   tags:

--- a/internal/dataplane/testdata/golden/grpcroute-example/in.yaml
+++ b/internal/dataplane/testdata/golden/grpcroute-example/in.yaml
@@ -9,13 +9,29 @@ spec:
   hostnames:
   - "example.com"
   rules:
-  - backendRefs:
+  - name: grpcbin-dummy-unary
+    backendRefs:
     - name: grpcbin
       port: 443
     matches:
     - method:
         service: "grpcbin.GRPCBin"
         method: "DummyUnary"
+  - name: grpcbin-default
+    backendRefs:
+    - name: grpcbin
+      port: 443
+    matches:
+    - method:
+        service: "grpcbin.GRPCBin"
+        method: "Default"
+  - backendRefs:
+    - name: grpcbin
+      port: 443
+    matches:
+    - method:
+        service: "grpcbin.GRPCBin"
+        method: "Get"
 ---
 apiVersion: v1
 kind: Service

--- a/internal/dataplane/testdata/golden/tcproute-example/in.yaml
+++ b/internal/dataplane/testdata/golden/tcproute-example/in.yaml
@@ -19,7 +19,8 @@ spec:
   - name: example-tcp-gateway
     namespace: tcp-example
   rules:
-  - backendRefs:
+  - rule: rule-echo
+    backendRefs:
     - name: echo
       port: 1025
 ---

--- a/internal/dataplane/testdata/golden/tlsroute-example/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/tlsroute-example/default_golden.yaml
@@ -27,6 +27,7 @@ services:
     - k8s-kind:TLSRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1alpha2
+    - k8s-named-route-rule:rule-echo
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/internal/dataplane/testdata/golden/tlsroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/tlsroute-example/expression-routes-on_golden.yaml
@@ -26,6 +26,7 @@ services:
     - k8s-kind:TLSRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1alpha2
+    - k8s-named-route-rule:rule-echo
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/internal/dataplane/testdata/golden/tlsroute-example/in.yaml
+++ b/internal/dataplane/testdata/golden/tlsroute-example/in.yaml
@@ -10,7 +10,8 @@ spec:
   hostnames:
     - tls9443.kong.example
   rules:
-    - backendRefs:
+    - name: rule-echo
+      backendRefs:
       - name: echo
         port: 1025
 ---

--- a/internal/dataplane/testdata/golden/udproute-example/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/udproute-example/default_golden.yaml
@@ -27,6 +27,7 @@ services:
     - k8s-kind:UDPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1alpha2
+    - k8s-named-route-rule:rule-tftp
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/internal/dataplane/testdata/golden/udproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/udproute-example/expression-routes-on_golden.yaml
@@ -26,6 +26,7 @@ services:
     - k8s-kind:UDPRoute
     - k8s-group:gateway.networking.k8s.io
     - k8s-version:v1alpha2
+    - k8s-named-route-rule:rule-tftp
   tags:
   - k8s-name:UNKNOWN
   - k8s-namespace:UNKNOWN

--- a/internal/dataplane/testdata/golden/udproute-example/in.yaml
+++ b/internal/dataplane/testdata/golden/udproute-example/in.yaml
@@ -19,7 +19,8 @@ spec:
   - name: example-udp-gateway
     namespace: udp-example
   rules:
-  - backendRefs:
+  - name: rule-tftp
+    backendRefs:
     - name: tftp
       port: 9999
 ---

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -458,7 +458,7 @@ func KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(
 	matchWithPriority SplitGRPCRouteMatchToPriority,
 ) kongstate.Route {
 	grpcRoute := matchWithPriority.Match.Source
-	tags := util.GenerateTagsForObject(grpcRoute)
+	tags := generateTagsForGRPCRoute(grpcRoute)
 	// since we split GRPCRoute by hostname, rule and match, we generate the route name in
 	// grpcroute.<namespace>.<name>.<hostname>.<rule index>.<match index> format.
 	hostname := matchWithPriority.Match.Hostname


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Gateway API 1.2 released named route rules as a GA feature, see [GEP 995](https://gateway-api.sigs.k8s.io/geps/gep-995/#api). The closest equivalent of HTTPRoute in Kong is Route. This PR introduces `k8s-named-route-rule` for `TLSRoute`, `TCPRoute` `UDPRoute`, and `GRPCRoute` in the same as it has been done for `HTTPRoute` in https://github.com/Kong/kubernetes-ingress-controller/pull/6759 (check for more details)

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6582 

There is no documentation to add because those propagated tags haven't been officially documented yet; whether we should is a separate question.


<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Unfortunately, some code duplication is required due to the limitations of Go generics - a field can't be accessed on a generic type.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
