### PR TITLE
fix(log): get rid of `No targets found to create upstream ...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,10 +150,10 @@ Adding a new version? You'll need three changes:
   [#6585](https://github.com/Kong/kubernetes-ingress-controller/pull/6585)
 - Fix panic when handling `KongConsumer` without `username` specified.
   [#6665](https://github.com/Kong/kubernetes-ingress-controller/pull/6665)
-- Get rid of redundant log `info  No targets found to create upstream ...` for
-  `HTTPRoute` with `RequestRedirect` or when `request-termination` Kong Plugin
-  is used.
-  [#6687](https://github.com/Kong/kubernetes-ingress-controller/pull/6686).
+- Get rid of redundant log `info  No targets found to create upstream ...` because
+  such misconfiguration is reported to user with Kubernetes events or in the `status`
+  field of an affected object.
+  [#6781](https://github.com/Kong/kubernetes-ingress-controller/pull/6781)
 - Fixed Kong client status check causing unnecessary `config update failed` errors
   and `KongConfigurationApplyFailed` events being generated.
   [#6689](https://github.com/Kong/kubernetes-ingress-controller/pull/6689)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

The first attempt to fix it https://github.com/Kong/kubernetes-ingress-controller/pull/6687 was unsuccessful, see https://github.com/Kong/kubernetes-ingress-controller/issues/6535#issuecomment-2517305897 and https://github.com/Kong/kubernetes-ingress-controller/issues/6535#issuecomment-2517981672.

It can be triggered with such configuration. 

```yml
---
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: kong
  annotations:
    konghq.com/gatewayclass-unmanaged: "true"
spec:
  controllerName: konghq.com/kic-gateway-controller
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kong
spec:
  gatewayClassName: kong
  listeners:
    - name: http
      protocol: HTTP
      port: 80
---
apiVersion: configuration.konghq.com/v1
config:
  message: OK
  status_code: 200
kind: KongClusterPlugin
metadata:
  annotations:
    kubernetes.io/ingress.class: kong
  name: request-termination
plugin: request-termination
---
apiVersion: configuration.konghq.com/v1
config:
  message: OK
  status_code: 200
kind: KongClusterPlugin
metadata:
  annotations:
    kubernetes.io/ingress.class: kong
  name: request-terminate-200
plugin: request-termination
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  annotations:
    konghq.com/plugins: request-termination
  name: kong-kong-status-test
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: kong
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /kong/test
```

Logging it properly is challenging (this is why first atempt was wrong) because that field with Plugis for a Service is filled later; see 

https://github.com/Kong/kubernetes-ingress-controller/blob/1cb9b6db2730528b352bcdbce8d2d57ea9f2e0ab/internal/dataplane/configfetcher/kongrawstate.go#L65

furthermore, for `KongClusterPlugin` it works differently.

**But first of all, that log entry is redundant in the first place.** The desired way to communicate such stuff to a user is through Kubernetes Events or filling the `status` of a particular object, and it happens in case of missing backend
- https://github.com/Kong/kubernetes-ingress-controller/pull/6746





<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6535

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
