### PR TITLE
ci: only run benchmarks on main and labeled PRs

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -2,7 +2,13 @@ name: Go Benchmarks
 on:
   push:
     branches:
+    - 'main'
+  pull_request:
+    branches:
     - '**'
+    types:
+    - labeled
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -12,6 +18,10 @@ jobs:
   benchmark:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Run Go benchmarks
+    if: |
+      contains(github.event.*.labels.*.name, 'ci/run-benchmarks') ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -41,6 +51,7 @@ jobs:
         alert-comment-cc-users: '@Kong/k8s-maintainers'
         comment-always: false
         comment-on-alert: true
+        max-items-in-chart: 50
 
         # Enable Job Summary for PRs
         summary-always: true


### PR DESCRIPTION
**What this PR does / why we need it**:

To reduce the noise a little bit, let's run benchmarks only 
- on `main`
- on PRs with `ci/run-benchmarks` label

Additionally limit the data points stored (and rendered at https://kong.github.io/kubernetes-ingress-controller/dev/bench/) to 50.