### PR TITLE
ci: fix assigning duplicated instance names to plugins bound to different entity types (e.g. route and consumer group)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,11 @@ Adding a new version? You'll need three changes:
 - Fixed an issue where `KongPlugin` used as `HTTPRoute`'s `ExtensionRef` filter
   would produce an invalid configuration.
   [#6762](https://github.com/Kong/kubernetes-ingress-controller/pull/6762)
+- Fixed an issue of assigning duplicated instance names to plugins where
+  `KongPlugin`s would be bound to multiple entities, e.g.:
+  - route R1 and consumer group CG
+  - route R2 and consumer group CG
+  [#6786](https://github.com/Kong/kubernetes-ingress-controller/pull/6786)
 
 ### Added
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -1,6 +1,7 @@
 package kongstate
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"strconv"
@@ -575,31 +576,31 @@ func buildPlugins(
 		for _, rel := range relations.GetCombinations() {
 			plugin := plugin.DeepCopy()
 
-			var toHash string
+			var toHash bytes.Buffer
 
 			// ID is populated because that is read by decK and in_memory translator too
 			if rel.Service != "" {
 				plugin.Service = &kong.Service{ID: kong.String(rel.Service)}
-				toHash += "_service-" + rel.Service
+				toHash.WriteString("_service-" + rel.Service)
 			}
 			if rel.Route != "" {
 				plugin.Route = &kong.Route{ID: kong.String(rel.Route)}
-				toHash += "_route-" + rel.Route
+				toHash.WriteString("_route-" + rel.Route)
 			}
 			if rel.Consumer != "" {
 				plugin.Consumer = &kong.Consumer{ID: kong.String(rel.Consumer)}
-				toHash += "_consumer-" + rel.Consumer
+				toHash.WriteString("_consumer-" + rel.Consumer)
 			}
 			if rel.ConsumerGroup != "" {
 				plugin.ConsumerGroup = &kong.ConsumerGroup{ID: kong.String(rel.ConsumerGroup)}
-				toHash += "_group-" + rel.ConsumerGroup
+				toHash.WriteString("_group-" + rel.ConsumerGroup)
 			}
-
-			sha := sha256.Sum256([]byte(toHash))
 
 			// instance_name must be unique. Using the same KongPlugin on multiple resources will result in duplicates
 			// unless we add some sort of suffix.
 			if plugin.InstanceName != nil {
+
+				sha := sha256.Sum256(toHash.Bytes())
 				suffix := fmt.Sprintf("%x", sha)
 				short := suffix[:9]
 				suffixed := fmt.Sprintf("%s-%s", *plugin.InstanceName, short)

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -574,25 +574,29 @@ func buildPlugins(
 		usedInstanceNames := sets.New[string]()
 		for _, rel := range relations.GetCombinations() {
 			plugin := plugin.DeepCopy()
-			var sha [32]byte
-			// ID is populated because that is read by decK and in_memory
-			// translator too
+
+			var toHash string
+
+			// ID is populated because that is read by decK and in_memory translator too
 			if rel.Service != "" {
 				plugin.Service = &kong.Service{ID: kong.String(rel.Service)}
-				sha = sha256.Sum256([]byte("service-" + rel.Service))
+				toHash += "_service-" + rel.Service
 			}
 			if rel.Route != "" {
 				plugin.Route = &kong.Route{ID: kong.String(rel.Route)}
-				sha = sha256.Sum256([]byte("route-" + rel.Route))
+				toHash += "_route-" + rel.Route
 			}
 			if rel.Consumer != "" {
 				plugin.Consumer = &kong.Consumer{ID: kong.String(rel.Consumer)}
-				sha = sha256.Sum256([]byte("consumer-" + rel.Consumer))
+				toHash += "_consumer-" + rel.Consumer
 			}
 			if rel.ConsumerGroup != "" {
 				plugin.ConsumerGroup = &kong.ConsumerGroup{ID: kong.String(rel.ConsumerGroup)}
-				sha = sha256.Sum256([]byte("group-" + rel.ConsumerGroup))
+				toHash += "_group-" + rel.ConsumerGroup
 			}
+
+			sha := sha256.Sum256([]byte(toHash))
+
 			// instance_name must be unique. Using the same KongPlugin on multiple resources will result in duplicates
 			// unless we add some sort of suffix.
 			if plugin.InstanceName != nil {

--- a/internal/dataplane/testdata/golden/kongplugin-instance-name/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/kongplugin-instance-name/default_golden.yaml
@@ -2,7 +2,7 @@ _format_version: "3.0"
 plugins:
 - config:
     header_name: kong-id
-  instance_name: example-7d9f28edc
+  instance_name: example-21a1f5b5f
   name: correlation-id
   route: default.httpbin.httpbin..80
   tags:
@@ -13,7 +13,7 @@ plugins:
   - k8s-version:v1
 - config:
     header_name: kong-id
-  instance_name: example-76ac9ccd1
+  instance_name: example-2bc7f3de3
   name: correlation-id
   route: default.httpbin-other.httpbin..80
   tags:
@@ -24,7 +24,7 @@ plugins:
   - k8s-version:v1
 - config:
     header_name: kong-id
-  instance_name: example-b8b9400c0
+  instance_name: example-6c322b5f5
   name: correlation-id
   route: default.httpbin-other.httpbin-other..80
   tags:


### PR DESCRIPTION
**What this PR does / why we need it**:

#4588 introduced assigning instance names to plugins and handling collisions in generates names.

This missed the fact that plugins can be bound to multiple entities, e.g. routes **and** consumer groups.

This PR fixes it.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
