### PR TITLE
chore(ci): renovate update kubernetes-configuration to unstable versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -103,14 +103,15 @@
       "enabled": false
     },
     {
-      "description": "Enable go.mod dependencies that are not handled by dependabot.",
+      "description": "Enable go dependency - github.com/kong/kubernetes-configuration - which is not handled by dependabot.",
       "matchManagers": [
           "gomod"
       ],
       "enabled": true,
       "matchPackageNames": [
         "github.com/kong/kubernetes-configuration"
-      ]
+      ],
+      "ignoreUnstable": false
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

[`ignoreUnstable`](https://docs.renovatebot.com/configuration-options/#ignoreunstable) by default is `true` so it doesn't update to `rc`, `beta` etc.

This PR changes it so that KIC can automatically get a new version of https://github.com/Kong/kubernetes-configuration.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
