### PR TITLE
feat: Add the flag `--secret-label-selector` to set the label selector for `Secrets` to ingest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,10 @@ Adding a new version? You'll need three changes:
   those names will be propagated to one or many instances of aforementioned tag.
   [#6759](https://github.com/Kong/kubernetes-ingress-controller/pull/6759)
   [#6780](https://github.com/Kong/kubernetes-ingress-controller/pull/6780)
+- Added the flag `--secret-label-selector` to set the label selector for `Secrets` to ingest.
+  By setting this flag, the secrets that are ingested will be limited to those having this label set to "true".
+  This can reduce the memory usage in scenarios with a large number of giant secrets.
+  [#6795](https://github.com/Kong/kubernetes-ingress-controller/pull/6795)
 
 
 ## [3.3.1]

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -92,6 +92,7 @@
 | `--publish-service-udp` | `namespaced-name` | Service fronting UDP routing resources in "namespace/name" format. The controller will update UDP route status information with this Service's endpoints. If omitted, the same Service will be used for both TCP and UDP routes. |  |
 | `--publish-status-address` | `strings` | Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service" when that Service lacks useful address information (for example, in bare-metal environments). | `[]` |
 | `--publish-status-address-udp` | `strings` | Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service-udp" when that Service lacks useful address information (for example, in bare-metal environments). | `[]` |
+| `--secret-label-selector` | `string` | Limits the secrets ingested to those having this label set to "true". If not specified, all secrets are ingested. |  |
 | `--skip-ca-certificates` | `bool` | Disable syncing CA certificate syncing (for use with multi-workspace environments). | `false` |
 | `--sync-period` | `duration` | Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime. | `10h0m0s` |
 | `--term-delay` | `duration` | The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller. | `0s` |

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -2,18 +2,19 @@ package configuration
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -41,6 +42,7 @@ type CoreV1SecretReconciler struct {
 	CacheSyncTimeout time.Duration
 
 	ReferenceIndexers ctrlref.CacheIndexers
+	LabelSelector     string
 }
 
 var _ controllers.Reconciler = &CoreV1SecretReconciler{}
@@ -51,6 +53,22 @@ func (r *CoreV1SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// we should always try to delete secrets in caches when they are deleted in cluster.
 	predicateFuncs.DeleteFunc = func(_ event.DeleteEvent) bool { return true }
 
+	var (
+		labelPredicate predicate.Predicate
+		labelSelector  metav1.LabelSelector
+		err            error
+	)
+	if r.LabelSelector != "" {
+		labelSelector = metav1.LabelSelector{
+			MatchLabels: map[string]string{r.LabelSelector: "true"},
+		}
+	}
+
+	labelPredicate, err = predicate.LabelSelectorPredicate(labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to create secret label selector predicate: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("CoreV1Secret").
 		WithOptions(controller.Options{
@@ -59,9 +77,12 @@ func (r *CoreV1SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 			CacheSyncTimeout: r.CacheSyncTimeout,
 		}).
-		Watches(&corev1.Secret{},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicateFuncs),
+		For(&corev1.Secret{},
+			builder.WithPredicates(
+				predicate.And(
+					predicateFuncs,
+					labelPredicate,
+				)),
 		).
 		Complete(r)
 }

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -131,8 +131,11 @@ type Config struct {
 	GatewayAPIReferenceGrantController bool
 	GatewayAPIGRPCRouteController      bool
 
-	// KIC can only reconciling the specified Gateway.
+	// GatewayToReconcile specifies the Gateway to be reconciled.
 	GatewayToReconcile OptionalNamespacedName
+
+	// SecretLabelSelector specifies the label which will be used to limit the ingestion of secrets. Only those that have this label set to "true" will be ingested.
+	SecretLabelSelector string
 
 	// Admission Webhook server config
 	AdmissionServer admission.ServerConfig
@@ -280,6 +283,8 @@ func (c *Config) FlagSet() *pflag.FlagSet {
 	flagSet.BoolVar(&c.GatewayAPIGRPCRouteController, "enable-controller-gwapi-grpcroute", true, "Enable the Gateway API GRPCRoute controller.")
 	flagSet.Var(flags.NewValidatedValue(&c.GatewayToReconcile, namespacedNameFromFlagValue, nnTypeNameOverride), "gateway-to-reconcile",
 		`Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway.`)
+	flagSet.StringVar(&c.SecretLabelSelector, "secret-label-selector", "",
+		`Limits the secrets ingested to those having this label set to "true". If not specified, all secrets are ingested.`)
 	flagSet.BoolVar(&c.KongServiceFacadeEnabled, "enable-controller-kong-service-facade", true, "Enable the KongServiceFacade controller.")
 	flagSet.BoolVar(&c.KongVaultEnabled, "enable-controller-kong-vault", true, "Enable the KongVault controller.")
 	flagSet.BoolVar(&c.KongLicenseEnabled, "enable-controller-kong-license", true, "Enable the KongLicense controller.")

--- a/internal/manager/config_validation_test.go
+++ b/internal/manager/config_validation_test.go
@@ -114,6 +114,15 @@ func TestConfigValidatedVars(t *testing.T) {
 				ExpectedErrorContains: "namespace cannot be empty",
 			},
 		},
+		"--secret-label-selector": {
+			{
+				Input: "konghq.com/label-for-caching",
+				ExtractValueFn: func(c manager.Config) any {
+					return c.SecretLabelSelector
+				},
+				ExpectedValue: "konghq.com/label-for-caching",
+			},
+		},
 	}
 
 	for flag, flagTestCases := range testCasesGroupedByFlag {

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -142,6 +142,7 @@ func setupControllers(
 				DataplaneClient:   dataplaneClient,
 				CacheSyncTimeout:  c.CacheSyncTimeout,
 				ReferenceIndexers: referenceIndexers,
+				LabelSelector:     c.SecretLabelSelector,
 			},
 		},
 		// ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->


As #6576 mentioned, we received a report about KIC's high memory usage.

We can reproduce this issue by the following steps:

* Create 300 secret resources with a size of 1M.

```
$ dd if=/dev/urandom bs=756439 count=1 | base64 > output.txt
$ for i in `seq 0 300`; do kubectl create secret generic "foo-${i}" --from-file=key=output.txt ; done
```

**Before this change:**

KIC will consume over 1G of memory within the first 3-5 minutes, but after 10 minutes, KIC's memory consumption will stay around 400M.

**With this change:**


KIC will consume over 1G of memory within the first 3-5 minutes, but after 10 minutes, KIC's memory consumption will stay around 360M.





**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes: https://github.com/Kong/kubernetes-ingress-controller/issues/6576

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->


In this PR, I added a `--secret-label-for-caching` flag. Users can control whether KIC should cache it by specifying a label for the secret resources.

This is achieved by setting a [LabelSelectorPredicate](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate#LabelSelectorPredicate).

Of course, as I mentioned earlier, this approach only alleviates some of the memory usage pressure. A more thorough way we have is not to cache, which will greatly increase the pressure on the API server.



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
