### PR TITLE
fix: resolve panic in resourceErrorFromEntityAction

### DIFF
--- a/internal/dataplane/configfetcher/kongrawstate_test.go
+++ b/internal/dataplane/configfetcher/kongrawstate_test.go
@@ -361,7 +361,7 @@ func extractNotEmptyFieldNames(s kongstate.KongState) []string {
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		v := reflect.ValueOf(s).Field(i)
-		if !f.Anonymous && f.IsExported() && !v.IsZero() {
+		if !f.Anonymous && f.IsExported() && v.IsValid() && !v.IsZero() {
 			fields = append(fields, f.Name)
 		}
 	}

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -206,7 +206,7 @@ func extractNotEmptyFieldNames(s KongState) []string {
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		v := reflect.ValueOf(s).Field(i)
-		if !f.Anonymous && f.IsExported() && !v.IsZero() {
+		if !f.Anonymous && f.IsExported() && v.IsValid() && !v.IsZero() {
 			fields = append(fields, f.Name)
 		}
 	}

--- a/internal/dataplane/sendconfig/dbmode.go
+++ b/internal/dataplane/sendconfig/dbmode.go
@@ -162,7 +162,7 @@ func resourceErrorFromEntityAction(event diff.EntityAction) (ResourceError, erro
 			event.Entity.Kind, event.Entity.Name, reflected.Kind())
 	}
 	tagsValue := reflected.FieldByName("Tags")
-	if tagsValue.IsZero() {
+	if !tagsValue.IsValid() || tagsValue.IsZero() {
 		return ResourceError{}, fmt.Errorf("entity %s/%s of type %s lacks 'Tags' field",
 			event.Entity.Kind, event.Entity.Name, reflect.TypeOf(subj))
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

`TestDeployAllInOneEnterprisePostgres`
- [before](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12218873131/job/34084868994#step:7:1303)
- [after](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12236452121) 

Minimal, interactive example that reproduces the issue - https://go.dev/play/p/BI7vSuUQ996

Go sometimes makes questionable decisions regarding its API, and this is an example of one. Community reported exactly the same case as we encountered, see 

- https://github.com/golang/go/issues/46320

and read details. Any suggestion for improvement was unfortunately rejected, thus we have to live with it. Such rough edges make Go a not-so-safe language, IMHO. But on the other hand, creator discoureages usage of reflections with the proverb - [Reflection is never clear](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=15m22s) 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6797

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

