### PR TITLE
feat(custom_entity): introduce schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,9 @@ Adding a new version? You'll need three changes:
   and their timestamps are listed under the `available` section of the
   response.
   [#6131](https://github.com/Kong/kubernetes-ingress-controller/pull/6131)
+- Added schema validation for `KongCustomEntity`. Kubernetes event will be created for
+  each validation error for `KongCustomEntity` objects.
+  [#6802](https://github.com/Kong/kubernetes-ingress-controller/pull/6802)
 
 ## [3.3.1]
 

--- a/internal/dataplane/kongstate/customentity.go
+++ b/internal/dataplane/kongstate/customentity.go
@@ -190,7 +190,7 @@ func (ks *KongState) FillCustomEntities(
 			continue
 		}
 		// Fetch the entity schema.
-		schema, err := ks.fetchEntitySchema(schemaService, entity.Spec.EntityType)
+		schema, err := ks.fetchEntitySchema(ctx, schemaService, entity.Spec.EntityType)
 		if err != nil {
 			failuresCollector.PushResourceFailure(
 				fmt.Sprintf("failed to fetch entity schema for entity type %s: %v", entity.Spec.EntityType, err),
@@ -256,13 +256,13 @@ func (ks *KongState) CustomEntityTypes() []string {
 
 // fetchEntitySchema fetches schema of an entity by its type and stores the schema in its custom entity collection
 // as a cache to avoid excessive calling of Kong admin APIs.
-func (ks *KongState) fetchEntitySchema(schemaGetter SchemaService, entityType string) (EntitySchema, error) {
+func (ks *KongState) fetchEntitySchema(ctx context.Context, schemaGetter SchemaService, entityType string) (EntitySchema, error) {
 	collection, ok := ks.CustomEntities[entityType]
 	if ok {
 		return collection.Schema, nil
 	}
 	// Use `context.Background()` here because `BuildKongConfig` does not provide a context.
-	schema, err := schemaGetter.Get(context.Background(), entityType)
+	schema, err := schemaGetter.Get(ctx, entityType)
 	if err != nil {
 		return EntitySchema{}, err
 	}

--- a/internal/dataplane/kongstate/customentity.go
+++ b/internal/dataplane/kongstate/customentity.go
@@ -256,13 +256,13 @@ func (ks *KongState) CustomEntityTypes() []string {
 
 // fetchEntitySchema fetches schema of an entity by its type and stores the schema in its custom entity collection
 // as a cache to avoid excessive calling of Kong admin APIs.
-func (ks *KongState) fetchEntitySchema(ctx context.Context, schemaGetter SchemaService, entityType string) (EntitySchema, error) {
+func (ks *KongState) fetchEntitySchema(ctx context.Context, schemaService SchemaService, entityType string) (EntitySchema, error) {
 	collection, ok := ks.CustomEntities[entityType]
 	if ok {
 		return collection.Schema, nil
 	}
 	// Use `context.Background()` here because `BuildKongConfig` does not provide a context.
-	schema, err := schemaGetter.Get(ctx, entityType)
+	schema, err := schemaService.Get(ctx, entityType)
 	if err != nil {
 		return EntitySchema{}, err
 	}

--- a/internal/dataplane/kongstate/customentity.go
+++ b/internal/dataplane/kongstate/customentity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/go-kong/kong/custom"
 	"github.com/samber/lo"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kongv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 
@@ -143,10 +144,12 @@ type CustomEntity struct {
 	ForeignEntityIDs map[kong.EntityType]string
 }
 
-// SchemaGetter is the interface to fetch the schema of a Kong entity by its type.
+// SchemaService is the interface to fetch the schema of a Kong entity by its type.
 // Used for fetching schema of custom entity for filling "foreign" field referring to other entities.
-type SchemaGetter interface {
+// It can also validate an entity against its schema.
+type SchemaService interface {
 	Get(ctx context.Context, entityType string) (kong.Schema, error)
+	Validate(ctx context.Context, entityType kong.EntityType, entity interface{}) (bool, string, error)
 }
 
 type entityForeignFieldValue struct {
@@ -157,10 +160,11 @@ type entityForeignFieldValue struct {
 
 // FillCustomEntities fills custom entities in KongState.
 func (ks *KongState) FillCustomEntities(
+	ctx context.Context,
 	logger logr.Logger,
 	s store.Storer,
 	failuresCollector *failures.ResourceFailuresCollector,
-	schemaGetter SchemaGetter,
+	schemaService SchemaService,
 	workspace string,
 ) {
 	entities := s.ListKongCustomEntities()
@@ -186,11 +190,25 @@ func (ks *KongState) FillCustomEntities(
 			continue
 		}
 		// Fetch the entity schema.
-		schema, err := ks.fetchEntitySchema(schemaGetter, entity.Spec.EntityType)
+		schema, err := ks.fetchEntitySchema(schemaService, entity.Spec.EntityType)
 		if err != nil {
 			failuresCollector.PushResourceFailure(
 				fmt.Sprintf("failed to fetch entity schema for entity type %s: %v", entity.Spec.EntityType, err),
 				entity,
+			)
+			continue
+		}
+
+		valid, msg, err := schemaService.Validate(ctx, kong.EntityType(entity.Spec.EntityType), entity.Spec.Fields)
+		if err != nil {
+			failuresCollector.PushResourceFailure(
+				fmt.Sprintf("failed validating entity %s: %v", client.ObjectKeyFromObject(entity), err), entity,
+			)
+			continue
+		}
+		if !valid {
+			failuresCollector.PushResourceFailure(
+				fmt.Sprintf("entity %s failed validation: %s", client.ObjectKeyFromObject(entity), msg), entity,
 			)
 			continue
 		}
@@ -238,7 +256,7 @@ func (ks *KongState) CustomEntityTypes() []string {
 
 // fetchEntitySchema fetches schema of an entity by its type and stores the schema in its custom entity collection
 // as a cache to avoid excessive calling of Kong admin APIs.
-func (ks *KongState) fetchEntitySchema(schemaGetter SchemaGetter, entityType string) (EntitySchema, error) {
+func (ks *KongState) fetchEntitySchema(schemaGetter SchemaService, entityType string) (EntitySchema, error) {
 	collection, ok := ks.CustomEntities[entityType]
 	if ok {
 		return collection.Schema, nil

--- a/internal/dataplane/kongstate/customentity_test.go
+++ b/internal/dataplane/kongstate/customentity_test.go
@@ -1,6 +1,7 @@
 package kongstate
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -1101,9 +1102,10 @@ func TestKongState_FillCustomEntities(t *testing.T) {
 
 			ks := tc.initialState
 			ks.FillCustomEntities(
+				context.Background(),
 				logr.Discard(), s,
 				failuresCollector,
-				&fakeSchemaGetter{schemas: tc.schemas}, "",
+				&fakeSchemaService{schemas: tc.schemas}, "",
 			)
 			for entityType, expectedObjectList := range tc.expectedCustomEntities {
 				require.NotNil(t, ks.CustomEntities[entityType])

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -1931,18 +1931,22 @@ func TestFillOverrides_ServiceFailures(t *testing.T) {
 	}
 }
 
-type fakeSchemaGetter struct {
+type fakeSchemaService struct {
 	schemas map[string]kong.Schema
 }
 
-var _ SchemaGetter = &fakeSchemaGetter{}
+var _ SchemaService = &fakeSchemaService{}
 
-func (s *fakeSchemaGetter) Get(_ context.Context, entityType string) (kong.Schema, error) {
+func (s *fakeSchemaService) Get(_ context.Context, entityType string) (kong.Schema, error) {
 	schema, ok := s.schemas[entityType]
 	if !ok {
 		return nil, fmt.Errorf("schema not found")
 	}
 	return schema, nil
+}
+
+func (s *fakeSchemaService) Validate(ctx context.Context, entityType kong.EntityType, entity interface{}) (bool, string, error) {
+	return true, "", nil
 }
 
 func TestIsRemotePluginReferenceAllowed(t *testing.T) {

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -1945,7 +1945,7 @@ func (s *fakeSchemaService) Get(_ context.Context, entityType string) (kong.Sche
 	return schema, nil
 }
 
-func (s *fakeSchemaService) Validate(ctx context.Context, entityType kong.EntityType, entity interface{}) (bool, string, error) {
+func (s *fakeSchemaService) Validate(_ context.Context, _ kong.EntityType, _ interface{}) (bool, string, error) {
 	return true, "", nil
 }
 

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -157,6 +157,8 @@ func (t *Translator) UpdateCache(c store.CacheStores) {
 // BuildKongConfig creates a Kong configuration from Ingress and Custom resources
 // defined in Kubernetes.
 func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
+	ctx := context.Background()
+
 	// Translate and merge all rules together from all Kubernetes API sources
 	ingressRules := mergeIngressRules(
 		t.ingressRulesFromIngressV1(),
@@ -218,7 +220,7 @@ func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
 
 	// process custom entities
 	if t.featureFlags.KongCustomEntity {
-		result.FillCustomEntities(t.logger, t.storer, t.failuresCollector, t.schemaServiceProvider.GetSchemaService(), t.workspace)
+		result.FillCustomEntities(ctx, t.logger, t.storer, t.failuresCollector, t.schemaServiceProvider.GetSchemaService(), t.workspace)
 		// Register successcully translated KCEs to set the status of these KCEs.
 		for _, collection := range result.CustomEntities {
 			for i := range collection.Entities {

--- a/test/integration/isolated/custom_entity_test.go
+++ b/test/integration/isolated/custom_entity_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,8 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -198,54 +200,64 @@ func TestCustomEntityExample(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("should apply last valid configuration with custom entities", func(ctx context.Context, t *testing.T, conf *envconf.Config) context.Context {
+		Assess("entities not passing schema validation are excluded from config and produce KongConfigurationTranslationFailed events", func(ctx context.Context, t *testing.T, conf *envconf.Config) context.Context {
 			c, err := clientset.NewForConfig(conf.Client().RESTConfig())
 			require.NoError(t, err)
 			kceClient := c.ConfigurationV1alpha1().KongCustomEntities("default")
 			customEntity, err := kceClient.Get(ctx, "degraphql-route-example", metav1.GetOptions{})
 			require.NoError(t, err)
-			t.Logf("update the custom entity to build invalid Kong configuration")
+			t.Logf("update the custom entity with invalid field, failing validation and thus being excluded from config")
 			customEntity.Spec.Fields = apiextensionsv1.JSON{
 				Raw: []byte(`{"uri":"/contacts","query":"aaaa","foo":"bar"}`),
 			}
 			_, err = kceClient.Update(ctx, customEntity, metav1.UpdateOptions{})
 			require.NoError(t, err)
 
-			t.Log("Deleting existing pod and wait for pod re-create and check if last valid config is applied")
-			kongNamespace := GetNamespaceForT(ctx, t)
-			k8sClient, err := k8sclient.NewForConfig(conf.Client().RESTConfig())
+			cl, err := client.NewWithWatch(conf.Client().RESTConfig(), client.Options{})
 			require.NoError(t, err)
-			podList, err := k8sClient.CoreV1().Pods(kongNamespace).List(ctx, metav1.ListOptions{
-				LabelSelector: "app.kubernetes.io/name=kong",
+
+			var events corev1.EventList
+			fs := fields.SelectorFromSet(fields.Set{
+				"involvedObject.kind":      "KongCustomEntity",
+				"involvedObject.name":      "degraphql-route-example",
+				"involvedObject.namespace": "default",
+				"reason":                   "KongConfigurationTranslationFailed",
+			})
+			w, err := cl.Watch(ctx, &events, &client.ListOptions{
+				Namespace:     "default",
+				FieldSelector: fs,
 			})
 			require.NoError(t, err)
-			require.Len(t, podList.Items, 1)
-			existingPod := podList.Items[0]
-			t.Logf("Deleting existing Kong gateway pod %s/%s", kongNamespace, existingPod.Name)
-			require.NoError(t,
-				k8sClient.CoreV1().Pods(kongNamespace).Delete(ctx, existingPod.Name, metav1.DeleteOptions{}),
-			)
-			t.Logf("Waiting for new Kong gateway pod to be re-created")
-			require.Eventually(t, func() bool {
-				podList, err := k8sClient.CoreV1().Pods(kongNamespace).List(ctx, metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/name=kong",
-				})
-				require.NoError(t, err)
-				if len(podList.Items) != 1 {
-					return false
-				}
-				newPod := podList.Items[0]
-				if newPod.Name != existingPod.Name && newPod.Status.Phase == corev1.PodRunning {
-					t.Logf("Recreated new pod %s/%s", kongNamespace, newPod.Name)
-					return true
-				}
-				return false
-			}, consts.StatusWait, consts.WaitTick)
+			defer w.Stop()
 
-			t.Log("verifying degraphQL plugin and degraphql_routes entity still works with last valid config")
+			timer := time.NewTimer(consts.StatusWait)
+			defer timer.Stop()
+		forLoop:
+			for {
+				select {
+				case e := <-w.ResultChan():
+					event := e.Object.(*corev1.Event)
+					// Just perform the assertions and break out of the loop. There shouldn't be more than one event at this point.
+					assert.Contains(t, event.Message, "entity default/degraphql-route-example failed validation:")
+					assert.Contains(t, event.Message, "schema violation")
+					assert.Equal(t, "KongConfigurationTranslationFailed", event.Reason)
+					break forLoop
+
+				case <-timer.C:
+					t.Logf("timeout waiting for KongConfigurationTranslationFailed Event")
+					t.Fail()
+					return ctx
+				case <-ctx.Done():
+					t.Logf("timeout waiting for KongConfigurationTranslationFailed Event")
+					t.Fail()
+					return ctx
+				}
+			}
+
+			t.Log("verifying degraphQL plugin was excluded from the configuration as it was failing schema validation")
 			proxyURL := GetHTTPURLFromCtx(ctx)
 			// The ingress providing graphQL service has a different host, so we need to set the `Host` header.
-			helpers.EventuallyGETPath(t, proxyURL, "graphql.service.example", "/contacts", nil, http.StatusOK, `"name":"Alice"`, map[string]string{"Host": "graphql.service.example"}, consts.IngressWait, consts.WaitTick)
+			helpers.EventuallyGETPath(t, proxyURL, "graphql.service.example", "/contacts", nil, http.StatusNotFound, `{"message":"Not Found"}`, map[string]string{"Host": "graphql.service.example"}, consts.IngressWait, consts.WaitTick)
 
 			return ctx
 		}).


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently users cannot rely KIC for their custom entities schema validation.

This PR introduces feature.

When an invalid custom entity is created e.g. :

```
apiVersion: configuration.konghq.com/v1
kind: KongPlugin
metadata:
  namespace: default
  name: degraphql-example
plugin: degraphql
config:
  graphql_server_path: /v1/graphql
---
apiVersion: configuration.konghq.com/v1alpha1
kind: KongCustomEntity
metadata:
  namespace: default
  name: degraphql-route-example
  annotations:
    a: a
spec:
  type: degraphql_routes
  fields:
    uri: /contacts
    queryy: "query{ contacts { name } }" # invalid key, missing required "query"
  controllerName: kong
  parentRef:
    group: configuration.konghq.com
    kind: KongPlugin
    name: degraphql-example
```

Events with validation failures will be created.

**Which issue this PR fixes**:

Closes #6793
Closes #6794

**Special notes for your reviewer**:

This changes how `KongCustomEntity` resources are excluded from final config. When they fail the schema validation they are excluded so last valid configuration does not kick in.

Instead of last valid config we generate a `KongConfigurationTranslationFailed` event for each schema violation, setting the `involvedObject` to said `KongCustomEntity`.

See the adjusted test for changes in behavior.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
