### PR TITLE
feat(KongPlugin): generate K8s Events for misconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@ Adding a new version? You'll need three changes:
   any needed information is reported in the status of the affected object or
   with Kubernetes events.
   [#6790](https://github.com/Kong/kubernetes-ingress-controller/pull/6790)
+- Do not log `ERROR` when referenced `KongPlugin` or `KongClusterPlugin` does not exist,
+  instead generate a Kubernetes Event - `KongConfigurationTranslationFailed` for object
+  that references it.
+  [#6814](https://github.com/Kong/kubernetes-ingress-controller/pull/6814)
 - From now on, upstreams produced by KIC from `Service`s that are configured as
   upstream services (either by `ingress.kubernetes.io/service-upstream` annotation
   or through `IngressClassNamespacedParameters`'s `serviceUpstream` field), will use

--- a/internal/dataplane/deckgen/generate.go
+++ b/internal/dataplane/deckgen/generate.go
@@ -246,7 +246,7 @@ func fillPlugin(ctx context.Context, plugin *file.FPlugin, schemas PluginSchemaS
 	}
 	schema, err := schemas.Schema(ctx, *plugin.Name)
 	if err != nil {
-		return fmt.Errorf("error retrieveing schema for plugin %s: %w", *plugin.Name, err)
+		return fmt.Errorf("error retrieving schema for plugin %s: %w", *plugin.Name, err)
 	}
 	if plugin.Config == nil {
 		plugin.Config = make(kong.Configuration)

--- a/internal/dataplane/kongstate/customentity.go
+++ b/internal/dataplane/kongstate/customentity.go
@@ -393,19 +393,19 @@ func findCustomEntityForeignFields(
 			foreignRelations.Service = getServiceIDFromPluginRels(logger, rels, pluginRelEntities.RouteAttachedService, workspace)
 		case string(kong.EntityTypeRoutes):
 			foreignRouteFields = append(foreignRouteFields, fieldName)
-			foreignRelations.Route = lo.FilterMap(rels.Routes, func(r *Route, _ int) (string, bool) {
+			foreignRelations.Route = lo.FilterMap(rels.Routes, func(r *Route, _ int) (util.FR, bool) {
 				if err := r.FillID(workspace); err != nil {
-					return "", false
+					return util.FR{}, false
 				}
-				return *r.ID, true
+				return util.FR{Identifier: *r.ID, Referer: k8sEntity}, true
 			})
 		case string(kong.EntityTypeConsumers):
 			foreignConsumerFields = append(foreignConsumerFields, fieldName)
-			foreignRelations.Consumer = lo.FilterMap(rels.Consumers, func(c *Consumer, _ int) (string, bool) {
+			foreignRelations.Consumer = lo.FilterMap(rels.Consumers, func(c *Consumer, _ int) (util.FR, bool) {
 				if err := c.FillID(workspace); err != nil {
-					return "", false
+					return util.FR{}, false
 				}
-				return *c.ID, true
+				return util.FR{Identifier: *c.ID, Referer: k8sEntity}, true
 			})
 		} // end of switch
 	}
@@ -419,21 +419,21 @@ func findCustomEntityForeignFields(
 			foreignFieldValues = append(foreignFieldValues, entityForeignFieldValue{
 				fieldName:         fieldName,
 				foreignEntityType: kong.EntityTypeServices,
-				foreignEntityID:   combination.Service,
+				foreignEntityID:   combination.Service.Identifier,
 			})
 		}
 		for _, fieldName := range foreignRouteFields {
 			foreignFieldValues = append(foreignFieldValues, entityForeignFieldValue{
 				fieldName:         fieldName,
 				foreignEntityType: kong.EntityTypeRoutes,
-				foreignEntityID:   combination.Route,
+				foreignEntityID:   combination.Route.Identifier,
 			})
 		}
 		for _, fieldName := range foreignConsumerFields {
 			foreignFieldValues = append(foreignFieldValues, entityForeignFieldValue{
 				fieldName:         fieldName,
 				foreignEntityType: kong.EntityTypeConsumers,
-				foreignEntityID:   combination.Consumer,
+				foreignEntityID:   combination.Consumer.Identifier,
 			})
 		}
 		ret = append(ret, foreignFieldValues)

--- a/internal/util/relations.go
+++ b/internal/util/relations.go
@@ -1,11 +1,29 @@
 package util
 
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// FR represents a foreign relation.
+type FR struct {
+	Identifier string
+	// Referer represents K8s object that references a Plugin.
+	Referer client.Object
+}
+
+func (fr FR) IsEmpty() bool {
+	return fr == FR{}
+}
+
 type ForeignRelations struct {
-	Consumer, ConsumerGroup, Route, Service []string
+	Consumer, ConsumerGroup, Route, Service []FR
 }
 
 type Rel struct {
-	Consumer, ConsumerGroup, Route, Service string
+	Consumer, ConsumerGroup, Route, Service FR
+}
+
+// ToList returns a list of FRs of Consumer, ConsumerGroup, Route, Service as one list.
+func (r Rel) ToList() [4]FR {
+	return [4]FR{r.Consumer, r.ConsumerGroup, r.Route, r.Service}
 }
 
 func (relations *ForeignRelations) GetCombinations() []Rel {

--- a/internal/util/relations_test.go
+++ b/internal/util/relations_test.go
@@ -26,15 +26,15 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on consumer only",
 			args: args{
 				relations: ForeignRelations{
-					Consumer: []string{"foo", "bar"},
+					Consumer: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Consumer: "foo",
+					Consumer: FR{Identifier: "foo"},
 				},
 				{
-					Consumer: "bar",
+					Consumer: FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -42,15 +42,15 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on consumer group only",
 			args: args{
 				relations: ForeignRelations{
-					ConsumerGroup: []string{"foo", "bar"},
+					ConsumerGroup: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					ConsumerGroup: "foo",
+					ConsumerGroup: FR{Identifier: "foo"},
 				},
 				{
-					ConsumerGroup: "bar",
+					ConsumerGroup: FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -58,15 +58,15 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on service only",
 			args: args{
 				relations: ForeignRelations{
-					Service: []string{"foo", "bar"},
+					Service: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Service: "foo",
+					Service: FR{Identifier: "foo"},
 				},
 				{
-					Service: "bar",
+					Service: FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -74,15 +74,15 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on routes only",
 			args: args{
 				relations: ForeignRelations{
-					Route: []string{"foo", "bar"},
+					Route: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Route: "foo",
+					Route: FR{Identifier: "foo"},
 				},
 				{
-					Route: "bar",
+					Route: FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -90,22 +90,22 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on service and routes only",
 			args: args{
 				relations: ForeignRelations{
-					Route:   []string{"foo", "bar"},
-					Service: []string{"foo", "bar"},
+					Route:   []FR{{Identifier: "foo"}, {Identifier: "bar"}},
+					Service: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Service: "foo",
+					Service: FR{Identifier: "foo"},
 				},
 				{
-					Service: "bar",
+					Service: FR{Identifier: "bar"},
 				},
 				{
-					Route: "foo",
+					Route: FR{Identifier: "foo"},
 				},
 				{
-					Route: "bar",
+					Route: FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -113,26 +113,26 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on combination of route and consumer",
 			args: args{
 				relations: ForeignRelations{
-					Route:    []string{"foo", "bar"},
-					Consumer: []string{"foo", "bar"},
+					Route:    []FR{{Identifier: "foo"}, {Identifier: "bar"}},
+					Consumer: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Consumer: "foo",
-					Route:    "foo",
+					Consumer: FR{Identifier: "foo"},
+					Route:    FR{Identifier: "foo"},
 				},
 				{
-					Consumer: "foo",
-					Route:    "bar",
+					Consumer: FR{Identifier: "foo"},
+					Route:    FR{Identifier: "bar"},
 				},
 				{
-					Consumer: "bar",
-					Route:    "foo",
+					Consumer: FR{Identifier: "bar"},
+					Route:    FR{Identifier: "foo"},
 				},
 				{
-					Consumer: "bar",
-					Route:    "bar",
+					Consumer: FR{Identifier: "bar"},
+					Route:    FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -140,26 +140,26 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on combination of service and consumer",
 			args: args{
 				relations: ForeignRelations{
-					Service:  []string{"foo", "bar"},
-					Consumer: []string{"foo", "bar"},
+					Service:  []FR{{Identifier: "foo"}, {Identifier: "bar"}},
+					Consumer: []FR{{Identifier: "foo"}, {Identifier: "bar"}},
 				},
 			},
 			want: []Rel{
 				{
-					Consumer: "foo",
-					Service:  "foo",
+					Consumer: FR{Identifier: "foo"},
+					Service:  FR{Identifier: "foo"},
 				},
 				{
-					Consumer: "foo",
-					Service:  "bar",
+					Consumer: FR{Identifier: "foo"},
+					Service:  FR{Identifier: "bar"},
 				},
 				{
-					Consumer: "bar",
-					Service:  "foo",
+					Consumer: FR{Identifier: "bar"},
+					Service:  FR{Identifier: "foo"},
 				},
 				{
-					Consumer: "bar",
-					Service:  "bar",
+					Consumer: FR{Identifier: "bar"},
+					Service:  FR{Identifier: "bar"},
 				},
 			},
 		},
@@ -167,43 +167,43 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on combination of service,route and consumer",
 			args: args{
 				relations: ForeignRelations{
-					Consumer: []string{"c1", "c2"},
-					Route:    []string{"r1", "r2"},
-					Service:  []string{"s1", "s2"},
+					Consumer: []FR{{Identifier: "c1"}, {Identifier: "c2"}},
+					Route:    []FR{{Identifier: "r1"}, {Identifier: "r2"}},
+					Service:  []FR{{Identifier: "s1"}, {Identifier: "s2"}},
 				},
 			},
 			want: []Rel{
 				{
-					Consumer: "c1",
-					Service:  "s1",
+					Consumer: FR{Identifier: "c1"},
+					Service:  FR{Identifier: "s1"},
 				},
 				{
-					Consumer: "c1",
-					Service:  "s2",
+					Consumer: FR{Identifier: "c1"},
+					Service:  FR{Identifier: "s2"},
 				},
 				{
-					Consumer: "c1",
-					Route:    "r1",
+					Consumer: FR{Identifier: "c1"},
+					Route:    FR{Identifier: "r1"},
 				},
 				{
-					Consumer: "c1",
-					Route:    "r2",
+					Consumer: FR{Identifier: "c1"},
+					Route:    FR{Identifier: "r2"},
 				},
 				{
-					Consumer: "c2",
-					Service:  "s1",
+					Consumer: FR{Identifier: "c2"},
+					Service:  FR{Identifier: "s1"},
 				},
 				{
-					Consumer: "c2",
-					Service:  "s2",
+					Consumer: FR{Identifier: "c2"},
+					Service:  FR{Identifier: "s2"},
 				},
 				{
-					Consumer: "c2",
-					Route:    "r1",
+					Consumer: FR{Identifier: "c2"},
+					Route:    FR{Identifier: "r1"},
 				},
 				{
-					Consumer: "c2",
-					Route:    "r2",
+					Consumer: FR{Identifier: "c2"},
+					Route:    FR{Identifier: "r2"},
 				},
 			},
 		},
@@ -211,43 +211,43 @@ func TestGetCombinations(t *testing.T) {
 			name: "plugins on combination of service,route and consumer group",
 			args: args{
 				relations: ForeignRelations{
-					Route:         []string{"r1", "r2"},
-					Service:       []string{"s1", "s2"},
-					ConsumerGroup: []string{"cg1", "cg2"},
+					Route:         []FR{{Identifier: "r1"}, {Identifier: "r2"}},
+					Service:       []FR{{Identifier: "s1"}, {Identifier: "s2"}},
+					ConsumerGroup: []FR{{Identifier: "cg1"}, {Identifier: "cg2"}},
 				},
 			},
 			want: []Rel{
 				{
-					ConsumerGroup: "cg1",
-					Service:       "s1",
+					ConsumerGroup: FR{Identifier: "cg1"},
+					Service:       FR{Identifier: "s1"},
 				},
 				{
-					ConsumerGroup: "cg1",
-					Service:       "s2",
+					ConsumerGroup: FR{Identifier: "cg1"},
+					Service:       FR{Identifier: "s2"},
 				},
 				{
-					ConsumerGroup: "cg1",
-					Route:         "r1",
+					ConsumerGroup: FR{Identifier: "cg1"},
+					Route:         FR{Identifier: "r1"},
 				},
 				{
-					ConsumerGroup: "cg1",
-					Route:         "r2",
+					ConsumerGroup: FR{Identifier: "cg1"},
+					Route:         FR{Identifier: "r2"},
 				},
 				{
-					ConsumerGroup: "cg2",
-					Service:       "s1",
+					ConsumerGroup: FR{Identifier: "cg2"},
+					Service:       FR{Identifier: "s1"},
 				},
 				{
-					ConsumerGroup: "cg2",
-					Service:       "s2",
+					ConsumerGroup: FR{Identifier: "cg2"},
+					Service:       FR{Identifier: "s2"},
 				},
 				{
-					ConsumerGroup: "cg2",
-					Route:         "r1",
+					ConsumerGroup: FR{Identifier: "cg2"},
+					Route:         FR{Identifier: "r1"},
 				},
 				{
-					ConsumerGroup: "cg2",
-					Route:         "r2",
+					ConsumerGroup: FR{Identifier: "cg2"},
+					Route:         FR{Identifier: "r2"},
 				},
 			},
 		},
@@ -263,9 +263,9 @@ func BenchmarkGetCombinations(b *testing.B) {
 	b.Run("consumer groups", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			relations := ForeignRelations{
-				Route:         []string{"r1", "r2"},
-				Service:       []string{"s1", "s2"},
-				ConsumerGroup: []string{"cg1", "cg2"},
+				Route:         []FR{{Identifier: "r1"}, {Identifier: "r2"}},
+				Service:       []FR{{Identifier: "s1"}, {Identifier: "s2"}},
+				ConsumerGroup: []FR{{Identifier: "cg1"}, {Identifier: "cg2"}},
 			}
 
 			rels := relations.GetCombinations()
@@ -275,9 +275,9 @@ func BenchmarkGetCombinations(b *testing.B) {
 	b.Run("consumers", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			relations := ForeignRelations{
-				Route:    []string{"r1", "r2"},
-				Service:  []string{"s1", "s2"},
-				Consumer: []string{"c1", "c2", "c3"},
+				Route:    []FR{{Identifier: "r1"}, {Identifier: "r2"}},
+				Service:  []FR{{Identifier: "s1"}, {Identifier: "s2"}},
+				Consumer: []FR{{Identifier: "c1"}, {Identifier: "c2"}, {Identifier: "c3"}},
 			}
 
 			rels := relations.GetCombinations()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

One of the cases mentioned in the original issue https://github.com/Kong/kubernetes-ingress-controller/issues/6540:

`a Plugin on which an HTTPRoute depends`

can be extrapolated to any plugin attachment referring to a nonexisting plugin leads to a logs message, but no K8s Event is sent.

Status for `HTTPRoute` that references non-existing plugin is

```yml
...
  status:
    parents:
    - conditions:
      - lastTransitionTime: "2024-12-12T16:06:22Z"
        message: ""
        observedGeneration: 1
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2024-12-12T16:06:22Z"
        message: ""
        observedGeneration: 1
        reason: ResolvedRefs
        status: "True"
        type: ResolvedRefs
      - lastTransitionTime: "2024-12-12T16:06:22Z"
        message: ""
        observedGeneration: 1
        reason: Unknown
        status: Unknown
        type: Programmed
      controllerName: konghq.com/kic-gateway-controller
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: kong
        namespace: default
```

and respective K8s Events are presented

```log
default              2m51s       Warning   KongConfigurationTranslationFailed   httproute/httproute-testing                           referenced KongPlugin or KongClusterPlugin "my-amazing" does not exist
default              2m51s       Warning   KongConfigurationTranslationFailed   httproute/httproute-testing                           referenced KongPlugin or KongClusterPlugin "second" does not exist
```


The mechanism for setting appropriate status is implemented only for generated controllers with the helper [EnsureProgrammedCondition](https://github.com/Kong/kubernetes-ingress-controller/blob/67c8a9596a3ec1c8d1d87a269c12eb491dbf25da/internal/controllers/utils/conditions.go#L36-L107), for make them robust, I'm suggesting creating a dedicated issue.

There are still logs that should be events and statuses related to plugins like in [this helper](https://github.com/Kong/kubernetes-ingress-controller/blob/67c8a9596a3ec1c8d1d87a269c12eb491dbf25da/internal/dataplane/kongstate/kongstate.go#L392-L429) for cross-namespace access, but it can be handled in a separate PR or issue .




<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

https://github.com/Kong/kubernetes-ingress-controller/issues/6540

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

I wonder whether performance and/or memory consumption will be significantly damaged...

I'm going to create an issue for the enhancement of statuses and removing those other logs for missing/misconfigured Plugins

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
