### PR TITLE
chore: revert go-database-reconciler to 1.16.1 and go-kong to 0.60.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/kong/go-database-reconciler v1.17.0
-	github.com/kong/go-kong v0.61.0
+	github.com/kong/go-database-reconciler v1.16.1
+	github.com/kong/go-kong v0.60.0
 	github.com/kong/kubernetes-configuration v0.0.46
 	github.com/kong/kubernetes-telemetry v0.1.7
 	github.com/kong/kubernetes-testing-framework v0.47.2

--- a/go.sum
+++ b/go.sum
@@ -216,10 +216,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kong/go-database-reconciler v1.17.0 h1:vL/KskveUR8fflbw+r/6QphSHxV8YahjfSDjNe9pDrI=
-github.com/kong/go-database-reconciler v1.17.0/go.mod h1:3L4DP3/YGaDv9Hks4XA1YFm7HfPur2CuBxHI/4+r7NY=
-github.com/kong/go-kong v0.61.0 h1:EWnQVMk1u1gy8//Hvui3NVCJZZ+fBnifVcoaIyLq60A=
-github.com/kong/go-kong v0.61.0/go.mod h1:e0zgpuCnCbOXQN6e0e235TFJr4IYY8dDg9nLQgG9m7A=
+github.com/kong/go-database-reconciler v1.16.1 h1:qcQzEuMGfpNjx3UgulBOKulKA+upmHwqw4dy6TMEV7A=
+github.com/kong/go-database-reconciler v1.16.1/go.mod h1:7CGvStUvUOmUnodUFsWcW3PX2bJgnaKClJ/yhNGEVIE=
+github.com/kong/go-kong v0.60.0 h1:CVrLXRLVE+Gl4IZ3tdvpO7xNDz3c9YLTmra/HvT4oM8=
+github.com/kong/go-kong v0.60.0/go.mod h1:t1eMY8GRS6778uQNzxgzRgnA3YKBXSZOEvYbNocH/aA=
 github.com/kong/kubernetes-configuration v0.0.46 h1:dIxVu9dOtGi9aY2prTlQ1CkiSu8Fk/0oal9m9iiUdSk=
 github.com/kong/kubernetes-configuration v0.0.46/go.mod h1:Bk0H032d+aPgVYakc7C9Zo5nLwiXXm9thKUWF8vvisA=
 github.com/kong/kubernetes-telemetry v0.1.7 h1:R4NUpvbF5uZ+5kgSQsIcf/oulRBGQCHsffFRDE4wxV4=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Passing `enterprise-postgres` against `3.9.0.0-rc.5` with go-kong 0.60.0: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12293996547/job/34308934489

**Which issue this PR fixes**:

Related: #6823

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
