### PR TITLE
chore: predicate.And -> predicate.Or in secret and configmap controllers

### DIFF
--- a/examples/gateway-backendtlspolicy.yaml
+++ b/examples/gateway-backendtlspolicy.yaml
@@ -42,7 +42,6 @@ metadata:
     # NOTE: using the default config map selector.
     konghq.com/configmap: "true"
   name: ca
-  namespace: kong
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy

--- a/internal/controllers/configuration/configmap_controller.go
+++ b/internal/controllers/configuration/configmap_controller.go
@@ -75,7 +75,7 @@ func (r *CoreV1ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&corev1.ConfigMap{},
 			builder.WithPredicates(
-				predicate.And(
+				predicate.Or(
 					predicateFuncs,
 					labelPredicate,
 				)),

--- a/internal/controllers/configuration/secret_controller.go
+++ b/internal/controllers/configuration/secret_controller.go
@@ -79,7 +79,7 @@ func (r *CoreV1SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&corev1.Secret{},
 			builder.WithPredicates(
-				predicate.And(
+				predicate.Or(
 					predicateFuncs,
 					labelPredicate,
 				)),


### PR DESCRIPTION
**What this PR does / why we need it**:

Those predicates should be changed from `And` to `Or` as we don't want to require users to specify e.g. both `konghq.com/ca-cert: "true"` **and** `konghq.com/configmap: "true"`. One will suffice to make KIC ingest the ConfigMap.
