### PR TITLE
fix(fallback): check for nil stores in `cacheToGraph` and recovering from fallback config to prevent panics 

### DIFF
--- a/internal/dataplane/fallback/cache_to_graph.go
+++ b/internal/dataplane/fallback/cache_to_graph.go
@@ -24,6 +24,9 @@ func (p DefaultCacheGraphProvider) CacheToGraph(c store.CacheStores) (*ConfigGra
 	g := NewConfigGraph()
 
 	for _, s := range c.ListAllStores() {
+		if s == nil {
+			continue
+		}
 		for _, o := range s.List() {
 			obj, ok := o.(client.Object)
 			if !ok {

--- a/internal/dataplane/fallback/cache_to_graph_test.go
+++ b/internal/dataplane/fallback/cache_to_graph_test.go
@@ -47,6 +47,11 @@ func TestDefaultCacheGraphProvider_CacheToGraph(t *testing.T) {
 			expectedAdjacencyMap: map[string][]string{},
 		},
 		{
+			name:                 "cache with stores being nil",
+			cache:                store.CacheStores{},
+			expectedAdjacencyMap: map[string][]string{},
+		},
+		{
 			name: "cache with Ingress and its dependencies",
 			cache: cacheStoresFromObjs(t,
 				&netv1.Ingress{

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -598,6 +598,9 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 	currentCache store.CacheStores,
 	brokenObjects []fallback.ObjectHash,
 ) error {
+	if !currentCache.Available() {
+		return errors.New("failed to generate fallback configuration: cache snapshot not available")
+	}
 	// Generate a fallback cache snapshot.
 	fallbackCache, generatedCacheMetadata, err := c.generateFallbackCache(currentCache, brokenObjects)
 	if err != nil {

--- a/internal/store/cache_stores.go
+++ b/internal/store/cache_stores.go
@@ -60,3 +60,27 @@ func NewCacheStoresFromObjs(objs ...runtime.Object) (CacheStores, error) {
 	}
 	return c, nil
 }
+
+// CacheStoresLockNotInitializedError is returned when the RW lock in the cache stores is nil.
+// It indicates that the CacheStores may not be correctly initialized.
+type CacheStoresLockNotInitializedError struct{}
+
+var _ error = CacheStoresLockNotInitializedError{}
+
+func (e CacheStoresLockNotInitializedError) Error() string {
+	return "lock of cache stores not initialized"
+}
+
+// Available returns whether the cache is correctly initialized and available for loading/storing objects.
+// When the lock or any of the stores in `nil`, it returns false.
+func (c CacheStores) Available() bool {
+	if c.l == nil {
+		return false
+	}
+	for _, store := range c.ListAllStores() {
+		if store == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/cache_stores_snapshot.go
+++ b/internal/store/cache_stores_snapshot.go
@@ -15,6 +15,9 @@ import (
 
 // TakeSnapshot takes a snapshot of the CacheStores.
 func (c CacheStores) TakeSnapshot() (CacheStores, error) {
+	if c.l == nil {
+		return CacheStores{}, CacheStoresLockNotInitializedError{}
+	}
 	// Create a fresh CacheStores instance to store the snapshot
 	// in the c.takeSnapshot method. It happens here because it's
 	// not required to be guarded by a lock.
@@ -63,6 +66,9 @@ func (c CacheStores) TakeSnapshotIfChanged(previousSnapshotHash SnapshotHash) (
 	newHash SnapshotHash,
 	err error,
 ) {
+	if c.l == nil {
+		return CacheStores{}, "", CacheStoresLockNotInitializedError{}
+	}
 	// Initialize all variables that don't need to be guarded by a lock.
 	snapshot = NewCacheStores()
 	listOfStores := c.ListAllStores()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Check for `lock` and stores in `cacheStores` before using them to prevent panics.
Also added a check in `tryRecoveringWithFallbackConfiguration` to quit generating fallback config if cache is not initialized.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6775
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
