### PR TITLE
tests(envtest): disable metrics by default

### DIFF
--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -95,14 +96,16 @@ func TestMetricsAreServed(t *testing.T) {
 					mocks.WithConfigPostErrorOnlyOnFirstRequest(),
 				)
 			}
-			cfg, _ := RunManager(ctx, t, envcfg,
+			addr := fmt.Sprintf("localhost:%d", helpers.GetFreePort(t))
+			_, _ = RunManager(ctx, t, envcfg,
 				AdminAPIOptFns(adminAPIOpts...),
 				func(cfg *manager.Config) {
 					cfg.FeatureGates[featuregates.FallbackConfiguration] = tc.fallbackConfigurationEnabled
 				},
+				WithMetricsAddr(addr),
 			)
 
-			metricsURL := fmt.Sprintf("http://%s/metrics", cfg.MetricsAddr)
+			metricsURL := fmt.Sprintf("http://%s/metrics", addr)
 			t.Logf("waiting for metrics to be available at %q", metricsURL)
 
 			for _, metric := range tc.expectedMetrics {

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/cmd/rootcmd"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
-	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -59,8 +58,7 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 	cfg.ProxySyncSeconds = 0.1
 	cfg.InitCacheSyncDuration = 0
 
-	p := helpers.GetFreePort(t)
-	cfg.MetricsAddr = fmt.Sprintf("localhost:%d", p)
+	cfg.MetricsAddr = "0"
 
 	// And other settings which are irrelevant here.
 	cfg.Konnect.ConfigSynchronizationEnabled = false
@@ -181,6 +179,12 @@ func WithAdmissionWebhookEnabled(key, cert []byte, addr string) func(cfg *manage
 		cfg.AdmissionServer.ListenAddr = addr
 		cfg.AdmissionServer.Key = string(key)
 		cfg.AdmissionServer.Cert = string(cert)
+	}
+}
+
+func WithMetricsAddr(addr string) func(cfg *manager.Config) {
+	return func(cfg *manager.Config) {
+		cfg.MetricsAddr = addr
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable metrics by default in `envtest` suite to prevent ports exhaustion.

Add `WithMetricsAddr()` option to enable enabling them.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
