### PR TITLE
chore: make CA certificate annotations use plural form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,8 +205,10 @@ Adding a new version? You'll need three changes:
     upstream connections of a `Service`.
   - `konghq.com/tls-verify-depth`: set to an integer to specify the maximum
     depth of the certificate chain that will be verified.
-  - `konghq.com/ca-certificates`: set to a comma-delimited list of CA
-    certificates' names to use for verification.
+  - `konghq.com/ca-certificates-secrets`: set to a comma-delimited list of CA
+    certificate Secrets' names to use for verification.
+  - `konghq.com/ca-certificates-configmaps`: set to a comma-delimited list of CA
+    certificate ConfigMaps' names to use for verification.
   [#6707](https://github.com/Kong/kubernetes-ingress-controller/pull/6707)
 - Combine Kong gateway services from rules of `HTTPRoute` sharing the same
   backends (same combination of group, kind, namespace, name, port and weight)

--- a/examples/ingress-upstream-tls.yaml
+++ b/examples/ingress-upstream-tls.yaml
@@ -42,10 +42,10 @@ metadata:
     app: goecho
   name: goecho
   annotations:
-    konghq.com/tls-verify: "true"           # Enable TLS verification of the upstream.
-    konghq.com/ca-certificates-secret: "ca" # The CA root certificate secret used for verification.
-    konghq.com/protocol: "https"            # Has to be either https or tls when TLS verification is enabled.
-    konghq.com/host-header: "goecho"        # This will make Kong use `goecho` server name when validating server-presented TLS certificate.
+    konghq.com/tls-verify: "true"            # Enable TLS verification of the upstream.
+    konghq.com/ca-certificates-secrets: "ca" # The CA root certificate secret used for verification.
+    konghq.com/protocol: "https"             # Has to be either https or tls when TLS verification is enabled.
+    konghq.com/host-header: "goecho"         # This will make Kong use `goecho` server name when validating server-presented TLS certificate.
 spec:
   ports:
   - port: 443

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -69,8 +69,8 @@ const (
 	RewriteURIKey               = "/rewrite"
 	TLSVerifyKey                = "/tls-verify"
 	TLSVerifyDepthKey           = "/tls-verify-depth"
-	CACertificatesSecretsKey    = "/ca-certificates-secret"
-	CACertificatesConfigMapsKey = "/ca-certificates-configmap"
+	CACertificatesSecretsKey    = "/ca-certificates-secrets"
+	CACertificatesConfigMapsKey = "/ca-certificates-configmaps"
 
 	// GatewayClassUnmanagedKey is an annotation used on a Gateway resource to
 	// indicate that the GatewayClass should be reconciled according to unmanaged


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes `konghq.com/ca-certificates-secret` and `konghq.com/ca-certificates-configmap` to use plural forms (secrets and configmaps) as they represent a list of CA certificates.
