### PR TITLE
fix(credentials): ignore missing secret field on secret validation for JWT credentials with non HMAC algo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,9 @@ Adding a new version? You'll need three changes:
 - Check referenced `KongCustomEntity`'s `parentRef` and verify if referenced
   `KongPlugin` or `KongClusterPlugin` exists.
   [#6791](https://github.com/Kong/kubernetes-ingress-controller/pull/6791)
+- Fixed validation of JWT credentials using non HMAC algorithms where `secret`
+  field was incorrectly required.
+  [#6848](https://github.com/Kong/kubernetes-ingress-controller/pull/6848)
 
 ### Added
 

--- a/internal/admission/validation/consumers/credentials/validation.go
+++ b/internal/admission/validation/consumers/credentials/validation.go
@@ -36,12 +36,19 @@ func ValidateCredentials(secret *corev1.Secret) error {
 	algo, hasAlgo := secret.Data["algorithm"]
 	ignoreMissingRSAPublicKey := credentialType == "jwt" && hasAlgo && algoIsHMAC(string(algo))
 
+	ignoreMissingSecretKey := credentialType == "jwt" && hasAlgo && !algoIsHMAC(string(algo))
+
 	// verify that all required fields are present
 	var missingFields []string
 	var missingDataFields []string
 	for _, field := range CredTypeToFields[credentialType] {
 		// Ignore missing rsa_public_key for jwt credentials with HMAC algorithm
 		if field == "rsa_public_key" && ignoreMissingRSAPublicKey {
+			continue
+		}
+
+		// Ignore missing secret for jwt credentials with non HMAC algorithm
+		if field == "secret" && ignoreMissingSecretKey {
 			continue
 		}
 

--- a/internal/admission/validation/consumers/credentials/validation_test.go
+++ b/internal/admission/validation/consumers/credentials/validation_test.go
@@ -102,7 +102,7 @@ func TestValidateCredentials(t *testing.T) {
 					"algorithm": []byte("RS256"),
 				},
 			},
-			wantErr: fmt.Errorf("missing required field(s): rsa_public_key, key, secret"),
+			wantErr: fmt.Errorf("missing required field(s): rsa_public_key, key"),
 		},
 		{
 			name: "valid jwt credential with RS256",
@@ -117,11 +117,10 @@ func TestValidateCredentials(t *testing.T) {
 				Data: map[string][]byte{
 					"algorithm":      []byte("RS256"),
 					"key":            []byte(""),
-					"secret":         []byte(""),
 					"rsa_public_key": []byte(""),
 				},
 			},
-			wantErr: fmt.Errorf("some fields were invalid due to missing data: rsa_public_key, key, secret"),
+			wantErr: fmt.Errorf("some fields were invalid due to missing data: rsa_public_key, key"),
 		},
 		{
 			name: "invalid credential type",
@@ -183,6 +182,91 @@ func TestValidateCredentials(t *testing.T) {
 				},
 			},
 			wantErr: fmt.Errorf("some fields were invalid due to missing data: key"),
+		},
+		{
+			name: "invalid jwt credential with HS256 missing secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS256"),
+					"key":       []byte("key-name"),
+				},
+			},
+			wantErr: fmt.Errorf("missing required field(s): secret"),
+		},
+		{
+			name: "invalid jwt credential with HS384 missing secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS384"),
+					"key":       []byte("key-name"),
+				},
+			},
+			wantErr: fmt.Errorf("missing required field(s): secret"),
+		},
+		{
+			name: "invalid jwt credential with HS512 missing secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm": []byte("HS512"),
+					"key":       []byte("key-name"),
+				},
+			},
+			wantErr: fmt.Errorf("missing required field(s): secret"),
+		},
+		{
+			name: "valid jwt credential with RS256 missing secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm":      []byte("RS256"),
+					"key":            []byte("key-name"),
+					"rsa_public_key": []byte("-----BEGIN PUBLIC KEY----- AXAXAXAAXA... -----END PUBLIC KEY-----"),
+				},
+			},
+		},
+		{
+			name: "valid jwt credential with RS512 missing secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+					Labels: map[string]string{
+						labels.CredentialTypeLabel: "jwt",
+					},
+				},
+				Data: map[string][]byte{
+					"algorithm":      []byte("RS512"),
+					"key":            []byte("key-name"),
+					"rsa_public_key": []byte("-----BEGIN PUBLIC KEY----- AXAXAXAAXA... -----END PUBLIC KEY-----"),
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -1157,7 +1157,7 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 					"algorithm": "RS256",
 				},
 			}),
-			"missing required field(s): rsa_public_key, key, secret",
+			"missing required field(s): rsa_public_key, key",
 		)
 
 		hmacAlgos := []string{"HS256", "HS384", "HS512"}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes JWT credential validation a bit more correct, not requiring `secret` field for credentials with algorithms different than HS256, HS384 or HS512.

This will also allow to make the guide at https://docs.konghq.com/hub/kong-inc/jwt/#create-a-jwt-credential cleaner (not requiring the note to add a dummy value for `secret` for other  algos)

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
