### PR TITLE
chore(deps): update e2e tests deps

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -3,6 +3,8 @@ e2e:
     # renovate: datasource=docker depName=kindest/node versioning=docker
     - 'v1.32.0'
     # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
+    - 'v1.31.4'
+    # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.30.8'
     # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node versioning=docker
     - 'v1.29.12'
@@ -14,21 +16,21 @@ e2e:
   # used directly in the test matrix `include` section.
   istio:
     - # renovate: datasource=docker depName=kindest/node versioning=docker
-      kind: 'v1.32.0'
+      kind: 'v1.31.4'
       # renovate: datasource=docker depName=istio/istioctl versioning=docker
       istio: '1.24.1'
     - # renovate: datasource=docker depName=kindest/node@only-patch versioning=docker
-      kind: 'v1.30.3'
+      kind: 'v1.30.8'
+      # renovate: datasource=docker depName=istio/istioctl@only-patch versioning=docker
+      istio: '1.23.3'
+    - # renovate: datasource=docker depName=kindest/node@only-patch versioning=docker
+      kind: 'v1.30.8'
       # renovate: datasource=docker depName=istio/istioctl@only-patch versioning=docker
       istio: '1.22.3'
     - # renovate: datasource=docker depName=kindest/node@only-patch versioning=docker
-      kind: 'v1.29.4'
+      kind: 'v1.29.12'
       # renovate: datasource=docker depName=istio/istioctl@only-patch versioning=docker
       istio: '1.21.2'
-    - # renovate: datasource=docker depName=kindest/node@only-patch versioning=docker
-      kind: 'v1.29.8'
-      # renovate: datasource=docker depName=istio/istioctl@only-patch versioning=docker
-      istio: '1.20.7'
 
   # renovate: datasource=helm depName=kuma registryUrl=https://kumahq.github.io/charts versioning=helm
   kuma: '2.9.2'


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `test_dependencies.yaml` manually:
- edits `e2e.kind` so it includes `v1.31.x` (still leaving `v1.29.x` as it's not reached EOL yet)
- aligns `e2e.istio` matrix to match https://istio.io/latest/docs/releases/supported-releases/
